### PR TITLE
ci(dependabot): remove invalid labels from .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: [ "deps", "actions" ]
 
   - package-ecosystem: "npm"
     directory: "/cards/haventory-card"
     schedule:
       interval: "weekly"
-    labels: [ "deps", "npm" ]
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: [ "deps", "python" ]
     allow:
       - dependency-type: "direct"


### PR DESCRIPTION
Dependabot reported missing labels ("actions", "deps", "npm", "python"). Removed label assignments so future Dependabot PRs open without errors.