### PR TITLE
ci: show Ruff version; fix hassfest step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         shell: pwsh
         run: |
           .\.venv\Scripts\Activate.ps1
+          ruff --version
           ruff check --no-cache .
       - name: Test (pytest offline w/ coverage)
         shell: pwsh
@@ -91,8 +92,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Hassfest
         uses: home-assistant/actions/hassfest@master
-        with:
-          path: "./custom_components"
       - name: HACS validation
         uses: hacs/action@main
         with:


### PR DESCRIPTION
Show Ruff version from venv during lint; remove unsupported hassfest input.