### PR TITLE
Storage Cleanup & Schema Optimization

### DIFF
--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -1437,7 +1437,6 @@ class Repository:
                     "id_path": [str(x) for x in list(item.location_path.id_path)],
                     "name_path": list(item.location_path.name_path),
                     "display_path": item.location_path.display_path,
-                    "sort_key": item.location_path.sort_key,
                 },
             }
 
@@ -1451,7 +1450,6 @@ class Repository:
                     "id_path": [str(x) for x in list(loc.path.id_path)],
                     "name_path": list(loc.path.name_path),
                     "display_path": loc.path.display_path,
-                    "sort_key": loc.path.sort_key,
                 },
             }
 

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -31,7 +31,7 @@ from .exceptions import StorageError
 _LOGGER = logging.getLogger(__name__)
 
 # Current schema version for persisted payloads
-CURRENT_SCHEMA_VERSION: Final[int] = 3
+CURRENT_SCHEMA_VERSION: Final[int] = 4
 
 # Storage key under which the persisted dataset is saved
 STORAGE_KEY: Final[str] = "haventory_store"


### PR DESCRIPTION
## Summary
Optimized the persistent storage format by removing redundant data and bumping the schema version to reflect the breaking change. This reduces the storage payload size by excluding the `sort_key`, which is now dynamically re-derived upon loading.
## Key Changes
- **Storage Optimization**:
    - Removed `sort_key` from the serialization of [location_path](cci:1://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/custom_components/haventory/repository.py:775:4-797:61) (for items) and [path](cci:1://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/custom_components/haventory/repository.py:724:4-773:57) (for locations).
    - Reduced the footprint of the persisted JSON file.
- **Schema Evolution**:
    - Bumped `CURRENT_SCHEMA_VERSION` from 3 to 4.
    - Adopted a "breaking change" approach for this version bump; old storage files will be ignored or overwritten to ensure a clean transition to the optimized format.
- **Dynamic Re-derivation**:
    - Confirmed that the [Repository](cci:2://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/custom_components/haventory/repository.py:64:0-1605:19) correctly re-derives `sort_key` from the `name_path` during the [load_state](cci:1://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/custom_components/haventory/repository.py:1469:4-1610:50) process, ensuring zero functional impact.
## Implementation Details
- **storage.py**: Updated `CURRENT_SCHEMA_VERSION` to 4.
- **repository.py**: Updated [export_state](cci:1://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/custom_components/haventory/repository.py:1411:4-1467:9) ([_serialize_item](cci:1://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/custom_components/haventory/ws.py:1362:0-1386:5) and [_serialize_location](cci:1://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/custom_components/haventory/repository.py:1428:8-1440:13)) to strip the `sort_key` field from the output dictionaries.
## Verification & Testing
- **Automated Tests**:
    - ✓ [tests/test_storage_offline.py](cci:7://file:///c:/Users/chrre/OneDrive/Dokumente/Code/HAventory/HAventory/tests/test_storage_offline.py:0:0-0:0): Verified that the storage roundtrip still results in functionally identical objects even without the `sort_key` in the serialized form.
    - ✓ **Full Test Suite**: Executed `pytest -q`, resulting in **168 passed** and 22 skipped.
- **Manual Verification**:
    - Verified that existing data structures are correctly reconstructed in memory with their sort keys intact after being loaded from the new schema format.