### PR TITLE
Revival & toolchain

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# HAventory SessionStart hook: bootstrap a fresh Claude Code session.
+#
+# Idempotent — safe to re-run when dependencies already exist:
+#   * creates .venv (preferring python3.12, the project target) if missing,
+#     then pip-installs backend dev deps (pip skips already-satisfied ones)
+#   * runs `npm ci` in cards/haventory-card only when node_modules is absent
+#
+# Runs synchronously so tests/lint/build are ready before the agent starts.
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$PROJECT_DIR"
+
+log() { printf '[session-start] %s\n' "$1" >&2; }
+
+# --- Backend: Python venv + dev dependencies -------------------------------
+if [ ! -d .venv ]; then
+  PYTHON_BIN=""
+  for candidate in python3.12 python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      break
+    fi
+  done
+  if [ -z "$PYTHON_BIN" ]; then
+    log "no python interpreter found; skipping backend bootstrap"
+  else
+    log "creating .venv with $PYTHON_BIN"
+    "$PYTHON_BIN" -m venv .venv
+  fi
+fi
+
+if [ -x .venv/bin/pip ]; then
+  log "installing backend dev dependencies"
+  .venv/bin/python -m pip install --quiet --upgrade pip
+  .venv/bin/pip install --quiet -r requirements-dev.txt
+else
+  log "no .venv/bin/pip; skipping backend dependency install"
+fi
+
+# --- Frontend: npm dependencies --------------------------------------------
+CARD_DIR="cards/haventory-card"
+if command -v npm >/dev/null 2>&1; then
+  if [ ! -d "$CARD_DIR/node_modules" ]; then
+    log "installing frontend dependencies (npm ci)"
+    (cd "$CARD_DIR" && npm ci)
+  else
+    log "frontend node_modules present; skipping npm ci"
+  fi
+else
+  log "npm not found; skipping frontend bootstrap"
+fi
+
+log "bootstrap complete"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,50 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ruff check:*)",
+      "Bash(ruff format:*)",
+      "Bash(ruff --version)",
+      "Bash(pytest:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(.venv/bin/pytest:*)",
+      "Bash(.venv/bin/python -m pytest:*)",
+      "Bash(python --version)",
+      "Bash(python3 --version)",
+      "Bash(pip install -r requirements-dev.txt)",
+      "Bash(pip install --quiet -r requirements-dev.txt)",
+      "Bash(pre-commit run:*)",
+      "Bash(npm ci)",
+      "Bash(npm install:*)",
+      "Bash(npm run build)",
+      "Bash(npm run test:*)",
+      "Bash(npm test:*)",
+      "Bash(npx eslint:*)",
+      "Bash(npx vitest run:*)",
+      "Bash(node --version)",
+      "Bash(npm --version)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git fetch:*)",
+      "Bash(git stash list)",
+      "Bash(git ls-files:*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in the HAventory repository.
+
+## What this is
+
+HAventory is a Home Assistant **custom integration** (domain `haventory`) for household
+inventory tracking, plus a Lovelace **card** frontend. Local-push, single-instance, HA
+`Store`-backed persistence — no external services.
+
+Targets: minimum Home Assistant is a recent stable release (2026.x era; no legacy support),
+Python 3.12 (`pyproject.toml` ruff `target-version = py312`, CI Python 3.12), Node 20
+(`engines: node >=20 <23`). Version 0.0.1, unreleased.
+
+## Architecture & key files
+
+### Backend — `custom_components/haventory/`
+- `__init__.py` — integration setup/teardown, `hass.data[DOMAIN]` wiring, persistence helpers
+  (`async_persist_repo`, `async_persist_immediate`, `async_request_persist`), Lovelace resource
+  registration.
+- `models.py` — `Item` / `Location` dataclasses, validation, serializers. Items carry a
+  denormalized `location_path` (rebuilt on location changes) and a `version` int (starts at 1,
+  bumped on each mutation) for **optimistic concurrency**.
+- `repository.py` — in-memory indexed repository (the source of truth at runtime). Owns the
+  search indexes; **search is case-insensitive** (casefold + NFKD accent-stripping) — see
+  `_normalize_for_search`. Maintains a generation counter for optimistic locking / debugging.
+- `storage.py` — HA `Store` persistence with schema versioning (`CURRENT_SCHEMA_VERSION`,
+  `STORAGE_KEY = "haventory_store"`), plus `asyncio.Lock`-serialized writes.
+- `migrations.py` — forward-only, **idempotent** schema migrations (`migrate_N_to_N+1`).
+- `ws.py` — WebSocket-first CRUD API (`websocket_api` decorators) and subscriptions
+  (items / locations / stats). This is the primary API surface.
+- `services.py` / `services.yaml` — HA services (`haventory.*`) with voluptuous schemas; handlers
+  re-raise validation/repository/storage errors so HA surfaces them.
+- `areas.py` — HA area registry integration (read-only; never auto-creates areas).
+- `config_flow.py` — single-instance config flow. `const.py`, `exceptions.py`, `manifest.json`,
+  `strings.json`, `translations/`.
+
+### Frontend — `cards/haventory-card/`
+Lit 3 + TypeScript + Vite Lovelace card. Source in `src/` (`haventory-card` container,
+`hv-*` components, `store/` for WS client + state). Builds to `www/haventory/haventory-card.js`
+(git-ignored; produced in CI and by `npm run build`).
+
+### Docs — `docs/` (link here, don't duplicate)
+- `backend_api_contract.md` — WebSocket envelope, error taxonomy, command catalog, events.
+- `data_shapes.md` — canonical Item/Location/filter/sort/event shapes.
+- `frontend_architecture.md` — card component architecture.
+
+## Running tests / lint / build (Linux)
+
+Backend (repo root, venv activated):
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
+ruff check .
+```
+
+Frontend (in `cards/haventory-card`):
+```bash
+npx eslint .
+npx vitest run
+npm run build
+```
+
+Bootstrap a fresh session (also run automatically by the SessionStart hook):
+```bash
+python3.12 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt
+(cd cards/haventory-card && npm ci)
+```
+
+Online smoke tests (`tests/*_online.py`) are opt-in and need a real HA instance plus
+`RUN_ONLINE=1`, `HA_BASE_URL`, `HA_TOKEN` — see the README. Offline tests stub HA via
+`tests/conftest.py`.
+
+> The `scripts/*.ps1` files are **legacy** PowerShell tooling, slated for replacement in WP1.
+> Develop and document for Linux/bash; leave the `.ps1` scripts (and the `windows-latest` CI
+> job) untouched for now.
+
+## Conventions
+
+- **TDD**: every feature/fix ships with tests — happy path plus at least one edge/error case.
+- **Gate before each commit**: run the backend gate *and* the frontend gate+build above; both
+  must be green.
+- **Offline-first testing**: default to offline tests with the plugin autoload disabled; HA is
+  stubbed. Async tests use `@pytest.mark.asyncio`.
+- **WebSocket API contract lives in `docs/`** — keep `ws.py`, `docs/backend_api_contract.md`,
+  and `docs/data_shapes.md` in sync when the API changes.
+- **Case-insensitive search** and **denormalized `location_path`** on items are load-bearing
+  invariants — preserve them.
+- **Optimistic concurrency** via the item `version` field — mutations expect/return it.
+- **Conventional Commits**; small, focused commits. Update `README.md` when behavior changes.
+- **Persistence**: WS and service handlers save immediately (errors propagate as
+  `storage_error`); shutdown/unload flushes immediately; debounced saves are for internal/batch
+  work only.
+- **Logging**: avoid reserved `LogRecord` keys in `extra=` — use `item_name` / `location_name`,
+  not `name`.
+- Naming: domain/package `haventory`, services `haventory.*`, built assets `www/haventory/`,
+  calendar entity `calendar.haventory`.
+- Report out-of-scope findings under a "Follow-ups" note rather than fixing them.
+
+See the README "Developer Checklist" for the full backend/frontend/CI checklist.


### PR DESCRIPTION
## Overview

Infrastructure arc for HAventory's revival. This PR accumulates the whole toolchain/enablement work across **WP0–WP1.5** on a single branch and is intended to **merge after WP1.5 lands**. Kept as a **draft** until then.

No integration behavior changes in this arc — it's repo baseline, tooling, and developer enablement only.

## Work packages

- [x] **WP0 — Claude enablement + repo baseline** (this commit)
- [ ] WP1 — (pending)
- [ ] WP1.5 — (pending)

## Changes so far (WP0)

- **`CLAUDE.md`** (repo root): architecture & key-file map (verified against the code), Linux test/lint/build commands, and project conventions — TDD, Conventional Commits, offline-first testing, WebSocket API contract in `docs/`, case-insensitive search, denormalized `location_path`, optimistic concurrency via the item `version` field. Links to `docs/` instead of duplicating. Notes the `scripts/*.ps1` tooling as legacy (slated for WP1 replacement).
- **`.claude/settings.json`**: permission allowlist for safe commands only (ruff, pytest, npm/npx/node, read-only git). No secrets, no destructive commands. Registers the SessionStart hook.
- **`.claude/hooks/session-start.sh`**: idempotent SessionStart bootstrap — creates `.venv` (python3.12) and installs `requirements-dev.txt`; runs `npm ci` in `cards/haventory-card` only when `node_modules` is absent. Safe to re-run.

## Validation (WP0)

Both gates and the build are green:

| Check | Result |
|---|---|
| Backend `pytest -q` | 168 passed, 22 skipped |
| Backend `ruff check .` | clean |
| Frontend `npx eslint .` | clean |
| Frontend `npx vitest run` | 87 passed |
| Frontend `npm run build` | built `haventory-card.js` |
| SessionStart hook | bootstraps cold; idempotent on re-run |

## Notes

- Linux-first per repo rules; the legacy `.ps1` scripts and the `windows-latest` CI job are left untouched (WP1 replaces them).
- Follow-ups (out of scope): README developer checklist still states the pre-WP0.5 targets (Windows-first / HA ≥ 2024.8) — reconciliation is WP1 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_