### PR TITLE
WP0.5 — HA compatibility &amp; redundancy review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,5 +172,21 @@ is partial and confined to primitives (counters, to-do due dates, labels/categor
 calendar) plus the one strong overlap: **HA Areas** (which HAventory already integrates
 with). HA has **no** nested/multi-level location tree (hard-capped at floor → area).
 
-**Per-item redundancy decisions: PENDING owner calls.** Do NOT rework any pillar until the
-owner has answered the WP0.5 decision table. Record the answers here when given.
+### Per-item decisions (DECIDED by owner, 2026-07-22)
+
+| # | Pillar | Nearest HA-native (since) | Overlap | Decision |
+|---|---|---|---|---|
+| 1 | Quantity + low-stock threshold | `counter` / `input_number` helpers | weak (no threshold logic) | **Keep as-is** |
+| 2 | Categories + tags | Labels + Categories registries (2024.4) | partial (target HA entities, not item objects) | **Keep as-is** |
+| 3 | Custom fields | none | none | **Keep as-is** |
+| 4 | Check-out + due dates | `todo` due dates (2024.1) | none (primitive only; no borrow/return) | **Keep as-is** |
+| 5 | Inspection dates | `todo` / `calendar` primitive | none | **Keep as-is** |
+| 6 | Multi-level location tree | Floors → Areas (2024.4) = one level only | none (major gap; a differentiator) | **Keep as-is** |
+| 7 | Areas integration | Area registry (0.87), Floors (2024.4) | strong | **Keep as-is** (already rides native Areas) |
+| 8 | JSON import/export (planned) | none | none | **Keep / build as planned** |
+| 9 | Reminders / calendar (post-1.0) | Local Calendar (2022.12) + `todo` + automations | partial | **Rework onto HA-native**: implement the roadmap's `CalendarEntity` (`calendar.haventory`) + HA automations rather than a bespoke reminder scheduler. Effort M, post-1.0. |
+
+Net: HAventory keeps all pillars; only the post-1.0 reminders/calendar work is to be built on
+HA-native primitives (`CalendarEntity` + automations) rather than a custom scheduler. Do NOT
+start that rework here — it is post-1.0 and out of WP0.5 scope; this table just fixes the
+direction. Everything else stays as implemented (no core-HA equivalent to migrate onto).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ Targets: minimum Home Assistant is a recent stable release (2026.x era; no legac
 Python 3.12 (`pyproject.toml` ruff `target-version = py312`, CI Python 3.12), Node 20
 (`engines: node >=20 <23`). Version 0.0.1, unreleased.
 
+> **Superseded by WP0.5 (2026-07-22):** the Python target is now **3.14** (forced by HA
+> ≥ 2026.3) and the min HA is **2026.7** — see the "HA / Python compatibility baseline"
+> section below. The `py312` / CI-3.12 values above describe the *current* toolchain; the
+> bump to 3.14 lands in WP1.
+
 ## Architecture & key files
 
 ### Backend — `custom_components/haventory/`
@@ -97,3 +102,75 @@ Online smoke tests (`tests/*_online.py`) are opt-in and need a real HA instance 
 - Report out-of-scope findings under a "Follow-ups" note rather than fixing them.
 
 See the README "Developer Checklist" for the full backend/frontend/CI checklist.
+
+---
+
+## HA / Python compatibility baseline (WP0.5, established 2026-07-22)
+
+Established empirically (real HA installed in a throwaway venv + integration smoke-tested)
+and by inspecting `home-assistant/core` at the `2026.7.3` tag. Sources: PyPI
+`homeassistant` per-version `requires_python`; HA release blog 2026.1–2026.7; HA developer
+blog.
+
+- **Current stable HA:** `2026.7.3` (2026.7 series, released 2026-07-01).
+- **HA Python floor:** **Python `>=3.14.2`**, bumped from 3.13 → **3.14 in HA 2026.3**
+  (2026-03-04). Every HA release from 2026.3 onward requires Python 3.14. This is not
+  optional: declaring a min HA of 2026.3+ forces Python 3.14 on the toolchain.
+
+### Decisions to adopt at release (min HA + Python)
+
+- **Minimum supported HA:** **`2026.7`** (current stable at review time; policy = "a recent
+  stable release"). Re-confirm against whatever is current stable on the actual release date.
+- **Python:** **`3.14`** (forced by HA ≥ 2026.3). Non-negotiable given the min-HA choice.
+
+> Status: RECOMMENDED, pending owner confirmation of the exact min-HA number. The Python
+> floor is determined by the min-HA choice and is not a free variable.
+
+### Toolchain targets for WP1 (record now, change lands in WP1 — not WP0.5)
+
+The min-HA/Python decision above implies these toolchain edits (do them in WP1):
+
+- CI `.github/workflows/ci.yml` → `actions/setup-python` `python-version: '3.12'` → `'3.14'`.
+- `pyproject.toml` `[tool.ruff]` `target-version = "py312"` → `"py314"`.
+- mypy (when configured) `python_version = "3.14"`.
+- Note: the offline test suite stubs HA and does not import real `homeassistant`, so the
+  suite itself does not require Python 3.14 to run — but the declared support target does.
+
+---
+
+## HA compatibility review — findings (WP0.5)
+
+Full report is in the WP0.5 session; the durable conclusions:
+
+- **No breaking incompatibility** with current stable (2026.7.3) in any touch point.
+  Verified compatible: `websocket_api` command registration + `@websocket_command` /
+  `@async_response` decorators; `helpers.storage.Store(hass, version, key)`; config-entry
+  lifecycle (`async_setup_entry` / `async_unload_entry`); `helpers.area_registry.async_get`;
+  Lovelace resource auto-registration (`LOVELACE_DATA` + resource collection API unchanged
+  despite the 2026.1 & 2026.6 dashboard overhauls); `manifest.json` keys (no newly-required
+  key). Empirical smoke against real HA 2026.2.3 (last 3.13-compatible release): import +
+  `async_setup_entry` + WS command + `async_unload_entry` all pass, 0 deprecation warnings.
+- **Not affected** by the two 2026.6 config-entry deprecations: HAventory registers no
+  config-entry update listener and uses no advanced-mode config flow.
+- **Fixed (mechanical):** `config_flow.py` now annotates the flow step with
+  `ConfigFlowResult` (HA's recommended type since 2024.4) instead of importing `FlowResult`.
+- **Flagged for WP1 (not fixed — needs a small guarded change):** `storage.py` uses bare
+  `asyncio.create_task(...)` for the debounced persist. HA guidance is to use hass/entry
+  tracked task helpers (`hass.async_create_background_task(coro, name=...)`). Not a
+  deprecation and not broken (the task ref is held in `hass.data`, so no GC), but tracked
+  tasks are cancelled/awaited on shutdown. Effort: S.
+- **Optional nice-to-haves (not required):** add `"single_config_entry": true` to
+  `manifest.json` (matches the flow's single-instance guard); frontend card could opt into
+  the 2026.6 picker via `getEntitySuggestion`. Neither affects current functionality.
+
+---
+
+## Redundancy review vs. core HA (WP0.5, Part B)
+
+Core HA has shipped **no** first-party inventory/pantry/stock feature as of 2026.7. Overlap
+is partial and confined to primitives (counters, to-do due dates, labels/categories, local
+calendar) plus the one strong overlap: **HA Areas** (which HAventory already integrates
+with). HA has **no** nested/multi-level location tree (hard-capped at floor → area).
+
+**Per-item redundancy decisions: PENDING owner calls.** Do NOT rework any pillar until the
+owner has answered the WP0.5 decision table. Record the answers here when given.

--- a/custom_components/haventory/config_flow.py
+++ b/custom_components/haventory/config_flow.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigFlowResult
 
 
 class HAventoryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -15,7 +17,7 @@ class HAventoryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step.
 
         Single-instance setup for now. Create entry immediately.


### PR DESCRIPTION
## Overview

**WP0.5** of the revival arc: a two-sweep review of HAventory against current-stable Home Assistant, following the merged **#72 "Revival &amp; toolchain" (WP0)**. Review-mostly — no feature work, no reworks. Only trivial mechanical fixes are applied; everything larger is recorded as a finding.

## Method

Verified **empirically, not just from changelogs**: installed real Home Assistant into a throwaway venv and inspected `home-assistant/core` at the `2026.7.3` tag.

- Ran the integration against **real HA 2026.2.3** (last Python-3.13-compatible release): import + `async_setup_entry` + a live WS command (`haventory/version`, `item/create`) + `async_unload_entry` — all pass, **0 deprecation warnings** from our code. Also exercised the debounced `asyncio.create_task` persist path (clean).
- Current stable **2026.7.3 requires Python ≥3.14.2**, which isn't runnable in this environment, so every touch point was additionally confirmed against the **2026.7.3 source**.

## Changes

- **`config_flow.py`** — annotate the flow step with **`ConfigFlowResult`** (HA's recommended config-flow return type since 2024.4) instead of importing `FlowResult`. `TYPE_CHECKING`-only import ⇒ zero runtime change; offline stubs untouched.
- **`CLAUDE.md`** — extend the #72 enablement doc (non-destructively — #72's content is kept verbatim) with the WP0.5 HA/Python compatibility baseline, review findings, WP1 toolchain targets, and the **decided** Part-B redundancy table.

## Compatibility findings

**No breaking incompatibility with current stable (2026.7.3) in any touch point.** Verified compatible: `websocket_api` command registration + decorators; `Store(hass, version, key)`; config-entry lifecycle; `area_registry.async_get`; Lovelace `LOVELACE_DATA` + resource collection API (unchanged despite the 2026.1 &amp; 2026.6 dashboard overhauls); `manifest.json` keys (none newly required). Not affected by the two 2026.6 config-entry deprecations (no update listener, no advanced-mode flow).

**Flagged for WP1 (not fixed here):** `storage.py` uses a bare `asyncio.create_task(...)` for the debounced persist. HA guidance is to use `hass.async_create_background_task(coro, name=...)`. Not a deprecation and not broken (task ref is held in `hass.data`, so no GC), but tracked tasks are cancelled/awaited on shutdown. Effort: **S**.

## Recommended min HA + Python

- **Min HA: `2026.7`** (current stable; policy = a recent stable release — re-confirm at actual release date).
- **Python: `3.14`** — *forced* by HA ≥ 2026.3 (Python floor bumped 3.13 → 3.14.2 in 2026.3). WP1 toolchain edits (CI `setup-python`, ruff `target-version`, mypy) are recorded in `CLAUDE.md`; the changes themselves land in WP1.

## Part-B redundancy decisions (DECIDED)

Owner's call: **keep all pillars as-is except #9**. Core HA still ships no first-party inventory feature; overlap is limited to generic primitives plus the one strong overlap (Areas, already integrated). Pillar **9 (reminders/calendar, post-1.0)** is to be built on HA-native primitives — the roadmap's `CalendarEntity` (`calendar.haventory`) + automations rather than a bespoke scheduler (effort M, post-1.0). No rework performed in this PR — direction only; full table in `CLAUDE.md`.

## Validation

| Check | Result |
|---|---|
| Backend `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` | 168 passed, 22 skipped |
| Backend `ruff check .` | clean |
| Empirical smoke (real HA 2026.2.3): setup/unload + WS commands | pass, 0 deprecation warnings |
| Frontend gate | n/a — no frontend files changed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
_Generated by [Claude Code](https://claude.ai/code)_