### PR TITLE
fix: make the list_items post-filter accent-insensitive (NFKD)

### DIFF
--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -220,6 +220,21 @@ def normalize_text_for_sort(text: str) -> str:
     return collapsed.casefold()
 
 
+def normalize_search_text(text: str) -> str:
+    """Normalize text for search matching (lowercase, strip accents).
+
+    Uses NFKD normalization to separate accents from characters, then keeps only ASCII.
+    Shared by the repository search indexes and the post-filter in ``_item_matches_q``
+    so both layers agree on what "case-insensitive, accent-insensitive" means.
+    """
+
+    if not text:
+        return ""
+    nfkd = unicodedata.normalize("NFKD", text)
+    ascii_text = nfkd.encode("ascii", "ignore").decode("ascii")
+    return ascii_text.casefold().strip()
+
+
 def normalize_tags(tags: list[str] | None) -> list[str]:
     """Lowercase, trim, and de-duplicate a list of tags, preserving order."""
 
@@ -577,8 +592,8 @@ def _item_matches_q(item: Item, q: str) -> bool:
     if not q:
         return True
 
-    # Normalize query: split into words
-    query_words = q.casefold().split()
+    # Normalize query (casefold + NFKD accent-stripping): split into words
+    query_words = normalize_search_text(q).split()
     if not query_words:
         return True
 
@@ -593,15 +608,17 @@ def _item_matches_q(item: Item, q: str) -> bool:
 
     # Optimization: construct a single searchable string for the item
     # doing this per-item is O(field_len).
-    searchable_text = " ".join(
-        [
-            item.name or "",
-            item.description or "",
-            item.category or "",
-            item.location_path.display_path or "",
-            " ".join(item.tags),
-        ]
-    ).casefold()
+    searchable_text = normalize_search_text(
+        " ".join(
+            [
+                item.name or "",
+                item.description or "",
+                item.category or "",
+                item.location_path.display_path or "",
+                " ".join(item.tags),
+            ]
+        )
+    )
 
     for word in query_words:
         if word not in searchable_text:

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -16,7 +16,6 @@ import bisect
 import json
 import logging
 import re
-import unicodedata
 import uuid
 from collections import deque
 from collections.abc import Iterable
@@ -39,6 +38,7 @@ from .models import (
     create_item_from_create,
     filter_items,
     new_uuid4,
+    normalize_search_text,
     normalize_tags,
     normalize_text_for_sort,
     parse_uuid4,
@@ -262,13 +262,10 @@ class Repository:
     def _normalize_for_search(self, text: str) -> str:
         """Normalize text for search indexing (lowercase, strip accents).
 
-        Uses NFKD normalization to separate accents from characters, then keeps only ASCII.
+        Delegates to :func:`models.normalize_search_text` so the index path and the
+        ``filter_items`` post-filter always agree on normalization.
         """
-        if not text:
-            return ""
-        nfkd = unicodedata.normalize("NFKD", text)
-        ascii_text = nfkd.encode("ascii", "ignore").decode("ascii")
-        return ascii_text.casefold().strip()
+        return normalize_search_text(text)
 
     def _extract_trigrams(self, text: str) -> set[str]:
         """Extract 3-character trigrams from normalized text."""

--- a/tests/test_models_filter_sort_offline.py
+++ b/tests/test_models_filter_sort_offline.py
@@ -69,6 +69,33 @@ async def test_filter_q_matches_name_description_tags_and_location() -> None:
 
 
 @pytest.mark.asyncio
+async def test_filter_q_is_accent_insensitive() -> None:
+    """q matching folds accents (NFKD) in both the query and the item text.
+
+    Regression: the post-filter used casefold() only, so the unaccented query
+    "cafe" missed an item named "Probe Café" even though the index found it.
+    """
+    a = create_item_from_create({"name": "Probe Café"})
+    b = create_item_from_create({"name": "Plain Mug"})
+
+    # Unaccented query vs accented content (the previously broken direction)
+    out = filter_items([a, b], ItemFilter(q="cafe"))
+    assert [x.name for x in out] == ["Probe Café"]
+
+    out2 = filter_items([a, b], ItemFilter(q="CAFE"))
+    assert [x.name for x in out2] == ["Probe Café"]
+
+    # Accented query vs accented content still works
+    out3 = filter_items([a, b], ItemFilter(q="café"))
+    assert [x.name for x in out3] == ["Probe Café"]
+
+    # Accented query vs unaccented content (the reverse direction)
+    c = create_item_from_create({"name": "Cafe Filter"})
+    out4 = filter_items([b, c], ItemFilter(q="café"))
+    assert [x.name for x in out4] == ["Cafe Filter"]
+
+
+@pytest.mark.asyncio
 async def test_filter_tags_any_and_all() -> None:
     i1 = create_item_from_create({"name": "Box", "tags": ["red", "blue"]})
     i2 = create_item_from_create({"name": "Tape", "tags": ["blue"]})

--- a/tests/test_repository_search_offline.py
+++ b/tests/test_repository_search_offline.py
@@ -71,6 +71,36 @@ async def test_text_search_fuzzy_matching() -> None:
 
 
 @pytest.mark.asyncio
+async def test_text_search_accent_insensitive_end_to_end() -> None:
+    """Accent-insensitive search works through list_items (index + post-filter).
+
+    Regression: the index normalized accents (NFKD) but the filter_items
+    post-filter only casefolded, so "cafe" found the candidate in the index
+    and then discarded it — list_items returned nothing for unaccented queries
+    against accented content.
+    """
+    repo = Repository()
+    i1 = repo.create_item({"name": "Probe Café"})
+    repo.create_item({"name": "Plain Mug"})
+
+    # Unaccented query vs accented content (the previously broken direction)
+    for query in ("cafe", "CAFE", "Cafe"):
+        results = repo.list_items(flt={"q": query})["items"]
+        assert len(results) == 1, f"q={query!r} should match 'Probe Café'"
+        assert results[0].id == i1.id
+
+    # Accented query still works
+    results = repo.list_items(flt={"q": "café"})["items"]
+    assert len(results) == 1
+    assert results[0].id == i1.id
+
+    # Prefix search stays accent-insensitive too
+    results = repo.list_items(flt={"q": "caf"})["items"]  # codespell:ignore caf
+    assert len(results) == 1
+    assert results[0].id == i1.id
+
+
+@pytest.mark.asyncio
 async def test_text_search_multi_word_and_logic() -> None:
     """Multi-word text search uses AND logic."""
     repo = Repository()


### PR DESCRIPTION
## Summary

Live smoke testing against HA 2026.7.3 showed accent-insensitive search broken in one direction: on an item named "Probe Café", `café` → hit, but `cafe`/`CAFE` → miss.

**Root cause** — the two filter layers disagreed on normalization:
- The index path (`repository._normalize_for_search`) does casefold + NFKD accent-stripping, so `cafe` correctly found the candidate.
- `list_items` then re-filters candidates through `filter_items` → `_item_matches_q` (models.py), which used `casefold()` only — `"cafe" not in "probe café"` discarded it.

This violated the documented load-bearing invariant (CLAUDE.md: "search is case-insensitive (casefold + NFKD accent-stripping)").

**Fix** — one shared normalizer so the layers cannot drift again:
- New `models.normalize_search_text()` (NFKD → ascii-fold → casefold), used by `_item_matches_q` on **both** the query and the item haystack.
- `repository._normalize_for_search` now delegates to it (local copy + `unicodedata` import dropped).

## Tests

- `test_filter_q_is_accent_insensitive` — direct against `filter_items` (the broken layer), both directions: unaccented query vs accented content and vice versa.
- `test_text_search_accent_insensitive_end_to_end` — through `repo.list_items` (`cafe`/`CAFE`/`Cafe`/`café`/`caf` prefix), mirroring the live probe that caught the bug.

Gate: backend 170 passed / 22 skipped (online), ruff + mypy clean; frontend eslint clean, 87 vitest passed, build OK. Verified on the live HA 2026.7.3 container after redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)