### PR TITLE
fix(ci): pin scorecard/codeql actions to real commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: "24"
 
-      - uses: github/codeql-action/init@c54b30b7df092240050e69945842bc67aee0f0f4  # v4.37.3
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           languages: ${{ matrix.language }}
 
@@ -47,4 +47,4 @@ jobs:
         working-directory: cards/haventory-card
         run: npm ci --no-audit --no-fund
 
-      - uses: github/codeql-action/analyze@c54b30b7df092240050e69945842bc67aee0f0f4  # v4.37.3
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -39,6 +39,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@c54b30b7df092240050e69945842bc67aee0f0f4  # v4.37.3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

The OpenSSF **Scorecard** run on `main` (after #76 merged) failed. The analysis itself succeeded (score 6.0) — the failure was in the **publish** step:

```
error sending scorecard results to webapp: http response 400
imposter commit: 99c09fe975337306107572b4fdf4db224cf8e2f2 does not belong to ossf/scorecard-action
```

**Root cause:** the action SHAs in #76 were fetched with `git ls-remote --tags --refs`, and `--refs` strips the peeled `^{}` entries — so for **annotated** tags I pinned the tag *object* SHA instead of the release *commit* SHA. The action still ran (GitHub dereferences on download), but OpenSSF's publish webapp verifies the ref against real release commits and rejected it.

**Fix** — re-pin to the peeled commit SHAs (verified via `git ls-remote … refs/tags/<tag>^{}`):

| Action | Before (tag object) | After (commit) |
|---|---|---|
| `ossf/scorecard-action` v2.4.3 | `99c09fe` | `4eaacf0` |
| `github/codeql-action` v4.37.3 | `c54b30b` | `e4fba86` |

The other three pinned actions (`labeler`, `release-please`, `semantic-pull-request`) used lightweight tags and were already correct.

## Type of change

- [x] Bug fix (CI/tooling)

## How was this tested?

- `actionlint 1.7.12` clean on all workflows.
- New SHAs confirmed to be the real release commits of each action (peeled tag targets).
- The Scorecard workflow re-runs on push to `main`; the publish 400 should be gone.

## Note

This branch was restarted from `main` after #76 merged (its head branch was auto-deleted on merge), so this is a fresh, single-commit follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_