### PR TITLE
feat(ws): add distinct_values command for categories and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
 ### ✅ Phase 1: Backend & WebSocket API (Complete)
 - Full CRUD for Items and Locations via WebSocket; optimistic concurrency with versioning;
   Areas integration; real-time subscriptions (items, locations, stats); documented persistence.
+- `haventory/distinct_values` returns distinct categories and tags with usage counts
+  (categories grouped case-insensitively) — powers category/tag autocomplete and browser views.
 
 ### ✅ Phase 2: Frontend Lovelace Card (Complete)
 - Lit 3 + TypeScript components (`haventory-card`, `hv-search-bar`, `hv-inventory-list`,

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -1067,6 +1067,39 @@ class Repository:
             "locations_total": len(self._locations_by_id),
         }
 
+    def get_distinct_field_values(self) -> dict[str, list[dict[str, object]]]:
+        """Return distinct categories and tags with per-value usage counts.
+
+        Categories are grouped case-insensitively (matching the case-insensitive
+        category index); each entry's ``value`` is a representative display label
+        — the most frequent original casing among the items using it, ties broken
+        alphabetically — and ``count`` is the number of items in that group. Tags
+        are already normalized (lowercase) at ingress, so each key maps directly
+        to one entry. Both lists are sorted case-insensitively by value.
+        """
+
+        categories: list[dict[str, object]] = []
+        for key, item_ids in self._category_to_item_ids.items():
+            originals: dict[str, int] = {}
+            for item_id in item_ids:
+                item = self._items_by_id.get(item_id)
+                if item is None:
+                    continue
+                raw = (item.category or "").strip()
+                if raw:
+                    originals[raw] = originals.get(raw, 0) + 1
+            display = max(sorted(originals), key=lambda o: originals[o]) if originals else key
+            categories.append({"value": display, "count": len(item_ids)})
+        categories.sort(key=lambda c: str(c["value"]).casefold())
+
+        tags = [
+            {"value": tag, "count": len(item_ids)}
+            for tag, item_ids in self._tags_to_item_ids.items()
+        ]
+        tags.sort(key=lambda t: str(t["value"]).casefold())
+
+        return {"categories": categories, "tags": tags}
+
     # -----------------------------
     # Public API — Location operations
     # -----------------------------

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -511,6 +511,14 @@ async def ws_stats(hass: HomeAssistant, conn, msg):
     conn.send_message(websocket_api.result_message(msg.get("id", 0), counts))
 
 
+@websocket_api.websocket_command({"type": "haventory/distinct_values"})
+@websocket_api.async_response
+@ws_guard("distinct_values", ())
+async def ws_distinct_values(hass: HomeAssistant, conn, msg):
+    result = _repo(hass).get_distinct_field_values()
+    conn.send_message(websocket_api.result_message(msg.get("id", 0), result))
+
+
 def _health_indexes(repo: Repository) -> dict[str, object]:
     idx = repo._debug_get_internal_indexes()  # type: ignore[attr-defined]
     return idx
@@ -1427,6 +1435,7 @@ def setup(hass: HomeAssistant) -> None:
         ws_ping,
         ws_version,
         ws_stats,
+        ws_distinct_values,
         ws_health,
         ws_subscribe,
         ws_unsubscribe,

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -43,6 +43,12 @@ Handlers map domain exceptions to these codes and log with context; `conflict` a
 - `haventory/stats`
   - Result: `{items_total: number, low_stock_count: number, checked_out_count: number, locations_total: number}`
 
+- `haventory/distinct_values`
+  - Request: `{id, type: "haventory/distinct_values"}` (no payload; extra fields → `validation_error`)
+  - Result: `{categories: DistinctValue[], tags: DistinctValue[]}` (see data shapes)
+  - `categories` are grouped case-insensitively; each `value` is a representative display label (most frequent original casing, ties broken alphabetically) and `count` is the number of items using that category. `tags` are already normalized (lowercase); each maps to one entry. Both lists are sorted case-insensitively by `value`.
+  - Read-only: emits no events and does not mutate state.
+
 - `haventory/health`
   - Result: `{healthy: boolean, issues: string[], counts: <stats shape>, generation: number}`
 

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -126,6 +126,20 @@ Counts object used in `stats` results and events:
 { "items_total": 0, "low_stock_count": 0, "checked_out_count": 0, "locations_total": 0 }
 ```
 
+### Distinct values
+
+Result of `distinct_values`, used by category/tag autocomplete and browser views:
+```json
+{
+  "categories": [ { "value": "Books", "count": 1 }, { "value": "Tools", "count": 2 } ],
+  "tags": [ { "value": "blue", "count": 2 }, { "value": "red", "count": 2 } ]
+}
+```
+
+- `DistinctValue`: `{ value: string, count: number }` where `count` is the number of items using that value.
+- Categories are grouped case-insensitively; `value` is a representative display label (most frequent original casing, ties broken alphabetically). Tags are already normalized (lowercase), so `value` is the tag itself.
+- Both lists are sorted case-insensitively by `value`. Items with no category (or no tags) contribute nothing to the respective list.
+
 ### Events
 
 Common envelope inside HA WS event wrapper:

--- a/tests/test_ws_distinct_values_offline.py
+++ b/tests/test_ws_distinct_values_offline.py
@@ -1,0 +1,122 @@
+"""Offline tests for the haventory distinct-values WebSocket command.
+
+Scenarios:
+- distinct_values returns distinct categories and tags with usage counts
+- categories are grouped case-insensitively with a representative display label
+- an empty repository yields empty lists
+- unknown/extra request fields are rejected by the voluptuous schema
+  (vol.PREVENT_EXTRA, matching real Home Assistant command validation)
+"""
+
+from __future__ import annotations
+
+import pytest
+import voluptuous as vol
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.ws import setup as ws_setup
+from custom_components.haventory.ws import ws_distinct_values
+from homeassistant.core import HomeAssistant
+
+
+async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
+    handlers = hass.data.get("__ws_commands__", [])
+    for h in handlers:
+        schema = getattr(h, "_ws_schema", None)
+        if not callable(h) or not isinstance(schema, dict):
+            continue
+        if schema.get("type") != type_:
+            continue
+        req = {"id": _id, "type": type_}
+        req.update(payload)
+        return await h(hass, None, req)
+    raise AssertionError("No handler responded for type " + type_)
+
+
+def _fresh_hass() -> HomeAssistant:
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_returns_categories_and_tags_with_counts() -> None:
+    """distinct_values returns distinct categories and tags with usage counts."""
+
+    hass = _fresh_hass()
+
+    await _send(hass, 1, "haventory/item/create", name="Hammer", category="Tools", tags=["red"])
+    await _send(
+        hass, 2, "haventory/item/create", name="Wrench", category="Tools", tags=["red", "blue"]
+    )
+    await _send(hass, 3, "haventory/item/create", name="Novel", category="Books", tags=["blue"])
+    # An item with neither category nor tags must not contribute to either list.
+    await _send(hass, 4, "haventory/item/create", name="Mystery Box")
+
+    res = await _send(hass, 5, "haventory/distinct_values")
+    assert res["success"] is True
+    result = res["result"]
+
+    categories = {c["value"]: c["count"] for c in result["categories"]}
+    tags = {t["value"]: t["count"] for t in result["tags"]}
+
+    assert categories == {"Books": 1, "Tools": 2}
+    assert tags == {"blue": 2, "red": 2}
+
+    # Deterministic, case-insensitive alphabetical ordering.
+    assert [c["value"] for c in result["categories"]] == ["Books", "Tools"]
+    assert [t["value"] for t in result["tags"]] == ["blue", "red"]
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_groups_categories_case_insensitively() -> None:
+    """Categories differing only by case collapse into one entry, count summed."""
+
+    hass = _fresh_hass()
+
+    await _send(hass, 1, "haventory/item/create", name="A", category="Books")
+    await _send(hass, 2, "haventory/item/create", name="B", category="Books")
+    await _send(hass, 3, "haventory/item/create", name="C", category="books")
+
+    res = await _send(hass, 4, "haventory/distinct_values")
+    categories = res["result"]["categories"]
+
+    expected_grouped_count = 3
+    assert len(categories) == 1
+    entry = categories[0]
+    assert entry["count"] == expected_grouped_count
+    # Representative label is the most frequent original casing ("Books", 2 > 1).
+    assert entry["value"] == "Books"
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_empty_repository() -> None:
+    """An empty repository yields empty category and tag lists."""
+
+    hass = _fresh_hass()
+    res = await _send(hass, 1, "haventory/distinct_values")
+    assert res["success"] is True
+    assert res["result"] == {"categories": [], "tags": []}
+
+
+def test_distinct_values_schema_rejects_unknown_field() -> None:
+    """Unknown request fields are rejected (vol.PREVENT_EXTRA, as in real HA).
+
+    The offline stub does not apply the command schema, so we reconstruct the
+    schema exactly as Home Assistant does (extending a base that requires `id`
+    and defaults to PREVENT_EXTRA) and assert an extra field is rejected.
+    """
+
+    schema_dict = ws_distinct_values._ws_schema
+    assert isinstance(schema_dict, dict)
+    full = vol.Schema({vol.Required("id"): int, **schema_dict})
+
+    # Valid request passes.
+    full({"id": 1, "type": "haventory/distinct_values"})
+
+    # Unknown field is rejected.
+    with pytest.raises(vol.Invalid):
+        full({"id": 1, "type": "haventory/distinct_values", "bogus": 1})


### PR DESCRIPTION
## Summary

Adds a read-only WebSocket command `haventory/distinct_values` returning **distinct categories and tags with per-value usage counts**. This is WP3 feature #1 — the data source that the upcoming category/tag autocomplete and dedicated browser views build on.

- `repository.get_distinct_field_values()` computes the grouped counts:
  - **Categories** are grouped case-insensitively (matching the case-insensitive category index). Each entry's `value` is a representative display label — the most frequent original casing among items using it, ties broken alphabetically — and `count` is the number of items in that group.
  - **Tags** are already normalized (lowercase) at ingress, so each key maps directly to one entry.
  - Both lists are sorted case-insensitively by `value`; items with no category/tags contribute nothing.
- `ws_distinct_values` handler registered alongside the other utility commands (schema-validated with `vol.PREVENT_EXTRA` like the rest; unknown fields → `validation_error`).
- Emits no events and does not mutate state.

Result shape:
```json
{
  "categories": [ { "value": "Books", "count": 1 }, { "value": "Tools", "count": 2 } ],
  "tags": [ { "value": "blue", "count": 2 }, { "value": "red", "count": 2 } ]
}
```

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

New offline tests in `tests/test_ws_distinct_values_offline.py` cover: counts across categories/tags, case-insensitive category grouping with representative label, empty repository, and an invalid-field (`vol.PREVENT_EXTRA`) case.

- [x] Backend: `uv run ruff check .` → green (pinned ruff `0.15.22`).
- [~] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` / `uv run mypy` — **could not run natively in this sandbox**: provisioning CPython 3.14 requires a python-build-standalone download that the environment's egress policy blocks (403), and the source uses 3.14-only PEP 758 syntax so it won't parse on ≤3.13. As a substitute, the **full offline suite (179 tests, all passing)** was run against a byte-identical shadow copy on CPython 3.13 with only the two unparenthesized `except A, B:` lines rewritten to parenthesized form; the new command's logic was also validated in isolation. CI (Python 3.14) will run the real gate.
- [ ] Frontend (`cards/haventory-card`) — untouched by this backend-only change.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + invalid-field/edge cases).
- [x] Docs updated (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — read-only command, no mutations.

## Screenshots (card / UI changes)

N/A — backend-only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_