### PR TITLE
feat(card): category/tag autocomplete in the item dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
 - Lit 3 + TypeScript components (`haventory-card`, `hv-search-bar`, `hv-inventory-list`,
   `hv-item-row`, `hv-item-dialog`, `hv-location-selector`); real-time sync; optimistic
   updates with conflict resolution; Vite build → `www/haventory/haventory-card.js`.
+- Item dialog offers debounced, keyboard-navigable category/tag autocomplete sourced from
+  `haventory/distinct_values`.
 
 ### 🚧 Phase 3: Polish & HACS (Planned)
 - HACS publication; release automation (release-please); additional optimizations.

--- a/cards/haventory-card/src/components/hv-item-dialog.autocomplete.test.ts
+++ b/cards/haventory-card/src/components/hv-item-dialog.autocomplete.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import './hv-item-dialog';
+
+type Dialog = HTMLElement & {
+  open: boolean;
+  updateComplete?: Promise<unknown>;
+  categorySuggestions: string[];
+  tagSuggestions: string[];
+  debounceMs: number;
+};
+
+async function mount(props: Partial<Dialog>): Promise<Dialog> {
+  const el = document.createElement('hv-item-dialog') as Dialog;
+  el.debounceMs = 0;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await customElements.whenDefined('hv-item-dialog');
+  el.open = true;
+  if (el.updateComplete) await el.updateComplete;
+  return el;
+}
+
+function inputByLabel(sr: ShadowRoot, label: string): HTMLInputElement {
+  return Array.from(sr.querySelectorAll('input[type="text"]')).find(
+    (inp) => inp.closest('label')?.textContent?.includes(label),
+  ) as HTMLInputElement;
+}
+
+function setName(sr: ShadowRoot, name: string) {
+  const nameInput = sr.querySelector('input[type="text"]') as HTMLInputElement;
+  nameInput.value = name;
+  nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/** Type into a field and open its suggestion dropdown synchronously (via focus). */
+async function typeAndFocus(el: Dialog, input: HTMLInputElement, value: string) {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.dispatchEvent(new Event('focus', { bubbles: true }));
+  if (el.updateComplete) await el.updateComplete;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+describe('hv-item-dialog autocomplete', () => {
+  it('filters category suggestions by substring and selects on click', async () => {
+    const el = await mount({ categorySuggestions: ['Books', 'Tools', 'Toys'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    setName(sr, 'X');
+
+    const catInput = inputByLabel(sr, 'Category');
+    await typeAndFocus(el, catInput, 'to');
+
+    const list = sr.querySelector('[data-testid="category-suggestions"]') as HTMLElement;
+    expect(list).toBeTruthy();
+    const options = Array.from(list.querySelectorAll('[role="option"]')).map((o) => o.textContent);
+    expect(options).toEqual(['Tools', 'Toys']);
+
+    // Select via mousedown (click would blur-close before firing).
+    const firstOption = list.querySelector('[role="option"]') as HTMLElement;
+    firstOption.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    if (el.updateComplete) await el.updateComplete;
+
+    // Dropdown closes after selection.
+    expect(sr.querySelector('[data-testid="category-suggestions"]')).toBe(null);
+
+    let saveDetail: any = null;
+    el.addEventListener('save', (e: any) => { saveDetail = e.detail; });
+    (sr.querySelector('button[aria-label="Save item"]') as HTMLButtonElement).click();
+    expect(saveDetail.category).toBe('Tools');
+  });
+
+  it('navigates category suggestions with the keyboard and selects on Enter', async () => {
+    const el = await mount({ categorySuggestions: ['Alpha', 'Beta', 'Gamma'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    setName(sr, 'X');
+
+    const catInput = inputByLabel(sr, 'Category');
+    await typeAndFocus(el, catInput, 'a'); // all three contain 'a'
+
+    catInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    if (el.updateComplete) await el.updateComplete;
+    catInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    if (el.updateComplete) await el.updateComplete;
+
+    let saveDetail: any = null;
+    el.addEventListener('save', (e: any) => { saveDetail = e.detail; });
+    (sr.querySelector('button[aria-label="Save item"]') as HTMLButtonElement).click();
+    expect(saveDetail.category).toBe('Beta');
+  });
+
+  it('autocompletes the last tag token and preserves earlier tags', async () => {
+    const el = await mount({ tagSuggestions: ['red', 'green', 'blue'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    setName(sr, 'X');
+
+    const tagsInput = inputByLabel(sr, 'Tags');
+    await typeAndFocus(el, tagsInput, 'red, gr');
+
+    const list = sr.querySelector('[data-testid="tags-suggestions"]') as HTMLElement;
+    const options = Array.from(list.querySelectorAll('[role="option"]')).map((o) => o.textContent);
+    expect(options).toEqual(['green']); // only the last token 'gr' is matched
+
+    tagsInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    if (el.updateComplete) await el.updateComplete;
+
+    let saveDetail: any = null;
+    el.addEventListener('save', (e: any) => { saveDetail = e.detail; });
+    (sr.querySelector('button[aria-label="Save item"]') as HTMLButtonElement).click();
+    expect(saveDetail.tags).toEqual(['red', 'green']);
+  });
+
+  it('excludes already-chosen tags from suggestions', async () => {
+    const el = await mount({ tagSuggestions: ['red', 'green', 'blue'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const tagsInput = inputByLabel(sr, 'Tags');
+    await typeAndFocus(el, tagsInput, 'red, '); // empty last token, 'red' committed
+
+    const list = sr.querySelector('[data-testid="tags-suggestions"]') as HTMLElement;
+    const options = Array.from(list.querySelectorAll('[role="option"]')).map((o) => o.textContent);
+    expect(options).toEqual(['green', 'blue']); // 'red' excluded, order preserved
+  });
+
+  it('Escape closes the dropdown without closing the dialog', async () => {
+    const el = await mount({ categorySuggestions: ['Books'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const catInput = inputByLabel(sr, 'Category');
+    await typeAndFocus(el, catInput, 'boo');
+    expect(sr.querySelector('[data-testid="category-suggestions"]')).toBeTruthy();
+
+    let cancelled = false;
+    el.addEventListener('cancel', () => { cancelled = true; });
+
+    catInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    if (el.updateComplete) await el.updateComplete;
+
+    expect(sr.querySelector('[data-testid="category-suggestions"]')).toBe(null);
+    expect(cancelled).toBe(false);
+    expect(el.open).toBe(true);
+  });
+
+  it('debounces suggestion computation while typing', async () => {
+    vi.useFakeTimers();
+    const el = document.createElement('hv-item-dialog') as Dialog;
+    el.categorySuggestions = ['Books', 'Tools'];
+    el.debounceMs = 120;
+    document.body.appendChild(el);
+    await customElements.whenDefined('hv-item-dialog');
+    el.open = true;
+    if (el.updateComplete) await el.updateComplete;
+    const sr = el.shadowRoot as ShadowRoot;
+
+    const catInput = inputByLabel(sr, 'Category');
+    catInput.value = 'boo';
+    catInput.dispatchEvent(new Event('input', { bubbles: true })); // no focus → debounced only
+    if (el.updateComplete) await el.updateComplete;
+
+    // Before the debounce elapses, no dropdown.
+    expect(sr.querySelector('[data-testid="category-suggestions"]')).toBe(null);
+
+    vi.advanceTimersByTime(120);
+    if (el.updateComplete) await el.updateComplete;
+
+    const list = sr.querySelector('[data-testid="category-suggestions"]') as HTMLElement;
+    expect(list).toBeTruthy();
+    expect(Array.from(list.querySelectorAll('[role="option"]')).map((o) => o.textContent)).toEqual(['Books']);
+  });
+});

--- a/cards/haventory-card/src/components/hv-item-dialog.ts
+++ b/cards/haventory-card/src/components/hv-item-dialog.ts
@@ -160,6 +160,36 @@ export class HVItemDialog extends LitElement {
       color: var(--primary-text-color, #212121);
       border: 1px solid var(--divider-color, #ddd);
     }
+    /* Autocomplete */
+    .ac-wrap { position: relative; }
+    .ac-list {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      z-index: 1;
+      margin: 2px 0 0;
+      padding: 4px 0;
+      list-style: none;
+      max-height: 200px;
+      overflow-y: auto;
+      background: var(--card-background-color, var(--ha-card-background, #fff));
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 4px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    }
+    .ac-option {
+      padding: 6px 10px;
+      cursor: pointer;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .ac-option:hover,
+    .ac-option.active {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+    }
   `;
 
   @property({ type: Boolean, reflect: true }) open: boolean = false;
@@ -167,6 +197,12 @@ export class HVItemDialog extends LitElement {
   @property({ attribute: false }) locations: Location[] | null = null;
   @property({ attribute: false }) areas: { id: string; name: string }[] = [];
   @property({ type: String }) error: string | null = null;
+  /** Existing category values for autocomplete (sourced from distinct_values). */
+  @property({ attribute: false }) categorySuggestions: string[] = [];
+  /** Existing tag values for autocomplete (sourced from distinct_values). */
+  @property({ attribute: false }) tagSuggestions: string[] = [];
+  /** Debounce delay (ms) before recomputing autocomplete suggestions. */
+  @property({ type: Number }) debounceMs: number = 120;
 
   @state() private _name: string = '';
   @state() private _description: string = '';
@@ -180,6 +216,12 @@ export class HVItemDialog extends LitElement {
   @state() private _inspectionDate: string = '';
   @state() private _validation: string | null = null;
   @state() private _zBase: number | null = null;
+  /** Which field's suggestion dropdown is currently open, if any. */
+  @state() private _acField: 'category' | 'tags' | null = null;
+  @state() private _acSuggestions: string[] = [];
+  @state() private _acIndex: number = -1;
+  private _acTimer: number | undefined;
+  private static readonly _AC_MAX = 8;
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has('item')) {
@@ -195,9 +237,13 @@ export class HVItemDialog extends LitElement {
       this._dueDate = it?.due_date ?? '';
       this._inspectionDate = it?.inspection_date ?? '';
       this._validation = null;
+      this._closeSuggestions();
     }
-    if (changed.has('open') && this.open) {
-      this._zBase = nextZBase();
+    if (changed.has('open')) {
+      this._closeSuggestions();
+      if (this.open) {
+        this._zBase = nextZBase();
+      }
     }
   }
 
@@ -289,6 +335,127 @@ export class HVItemDialog extends LitElement {
     this._lowStock = Math.max(0, Math.round(base + delta));
   }
 
+  // ---------- Autocomplete (category + tags) ----------
+
+  private _closeSuggestions() {
+    if (this._acTimer !== undefined) {
+      window.clearTimeout(this._acTimer);
+      this._acTimer = undefined;
+    }
+    this._acField = null;
+    this._acSuggestions = [];
+    this._acIndex = -1;
+  }
+
+  /** The in-progress (last, comma-separated) tag token the user is typing. */
+  private _lastTagToken(): string {
+    const parts = this._tags.split(',');
+    return (parts[parts.length - 1] ?? '').trim();
+  }
+
+  /** Tags already committed (everything before the last comma), normalized. */
+  private _committedTags(): string[] {
+    return this._tags
+      .split(',')
+      .slice(0, -1)
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
+  private _onFieldInput(field: 'category' | 'tags', e: Event) {
+    const value = (e.target as HTMLInputElement).value;
+    if (field === 'category') this._category = value;
+    else this._tags = value;
+    this._scheduleSuggestions(field);
+  }
+
+  private _scheduleSuggestions(field: 'category' | 'tags') {
+    if (this._acTimer !== undefined) window.clearTimeout(this._acTimer);
+    this._acTimer = window.setTimeout(() => {
+      this._acTimer = undefined;
+      this._computeSuggestions(field);
+    }, Math.max(0, this.debounceMs));
+  }
+
+  private _computeSuggestions(field: 'category' | 'tags') {
+    const source = field === 'category' ? this.categorySuggestions : this.tagSuggestions;
+    const query = (field === 'category' ? this._category.trim() : this._lastTagToken()).toLowerCase();
+    const exclude = new Set(
+      field === 'category'
+        ? [this._category.trim().toLowerCase()]
+        : this._committedTags().map((t) => t.toLowerCase()),
+    );
+    const matches: string[] = [];
+    for (const candidate of source) {
+      const lc = candidate.toLowerCase();
+      if (exclude.has(lc)) continue;
+      if (query !== '' && !lc.includes(query)) continue;
+      if (!matches.includes(candidate)) matches.push(candidate);
+      if (matches.length >= HVItemDialog._AC_MAX) break;
+    }
+    this._acField = field;
+    this._acSuggestions = matches;
+    this._acIndex = matches.length > 0 ? 0 : -1;
+  }
+
+  private _selectSuggestion(field: 'category' | 'tags', value: string) {
+    if (field === 'category') {
+      this._category = value;
+    } else {
+      const next = [...this._committedTags(), value];
+      // Trailing separator lets the user keep adding tags.
+      this._tags = next.join(', ') + ', ';
+    }
+    this._closeSuggestions();
+  }
+
+  private _onFieldKeydown(field: 'category' | 'tags', e: KeyboardEvent) {
+    if (this._acField !== field || this._acSuggestions.length === 0) return;
+    const len = this._acSuggestions.length;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this._acIndex = (this._acIndex + 1) % len;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        this._acIndex = (this._acIndex - 1 + len) % len;
+        break;
+      case 'Enter': {
+        e.preventDefault();
+        const idx = this._acIndex >= 0 ? this._acIndex : 0;
+        this._selectSuggestion(field, this._acSuggestions[idx]);
+        break;
+      }
+      case 'Escape':
+        // Close the dropdown only; don't let the dialog's Escape handler fire.
+        e.preventDefault();
+        e.stopPropagation();
+        this._closeSuggestions();
+        break;
+      case 'Tab':
+        this._closeSuggestions();
+        break;
+    }
+  }
+
+  private _renderSuggestions(field: 'category' | 'tags') {
+    if (this._acField !== field || this._acSuggestions.length === 0) return null;
+    return html`
+      <ul class="ac-list" role="listbox" id="${field}-suggestions" data-testid="${field}-suggestions">
+        ${this._acSuggestions.map((s, i) => html`
+          <li
+            role="option"
+            id="ac-${field}-${i}"
+            class="ac-option ${i === this._acIndex ? 'active' : ''}"
+            aria-selected=${i === this._acIndex}
+            @mousedown=${(e: Event) => { e.preventDefault(); this._selectSuggestion(field, s); }}
+          >${s}</li>
+        `)}
+      </ul>
+    `;
+  }
+
   render() {
     if (!this.open) return null;
     return html`
@@ -334,8 +501,38 @@ export class HVItemDialog extends LitElement {
               </div>
             </label>
           </div>
-          <div class="row"><label class="full-width">Category <input type="text" .value=${this._category} @input=${(e: Event) => this._category = (e.target as HTMLInputElement).value} /></label></div>
-          <div class="row"><label class="full-width">Tags <input type="text" .value=${this._tags} @input=${(e: Event) => this._tags = (e.target as HTMLInputElement).value} /></label></div>
+          <div class="row"><label class="full-width ac-wrap">Category
+            <input
+              type="text"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded=${this._acField === 'category'}
+              aria-controls="category-suggestions"
+              aria-activedescendant=${this._acField === 'category' && this._acIndex >= 0 ? `ac-category-${this._acIndex}` : ''}
+              .value=${this._category}
+              @input=${(e: Event) => this._onFieldInput('category', e)}
+              @focus=${() => this._computeSuggestions('category')}
+              @keydown=${(e: KeyboardEvent) => this._onFieldKeydown('category', e)}
+              @blur=${() => this._closeSuggestions()}
+            />
+            ${this._renderSuggestions('category')}
+          </label></div>
+          <div class="row"><label class="full-width ac-wrap">Tags
+            <input
+              type="text"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded=${this._acField === 'tags'}
+              aria-controls="tags-suggestions"
+              aria-activedescendant=${this._acField === 'tags' && this._acIndex >= 0 ? `ac-tags-${this._acIndex}` : ''}
+              .value=${this._tags}
+              @input=${(e: Event) => this._onFieldInput('tags', e)}
+              @focus=${() => this._computeSuggestions('tags')}
+              @keydown=${(e: KeyboardEvent) => this._onFieldKeydown('tags', e)}
+              @blur=${() => this._closeSuggestions()}
+            />
+            ${this._renderSuggestions('tags')}
+          </label></div>
           <div class="row location-row">
             <span>Location</span>
             <div class="location-controls">

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -202,6 +202,8 @@ export class HAventoryCard extends LitElement {
       <hv-item-dialog
         .locations=${st?.locationsFlatCache ?? null}
         .areas=${st?.areasCache?.areas ?? []}
+        .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
+        .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
         @open-location-selector=${() => { this._locationSelectorOpen = true; this.requestUpdate(); }}
         @delete-item=${(e: CustomEvent) => {
           const { itemId, name } = e.detail as { itemId: string; name: string };

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -373,4 +373,44 @@ describe('Store', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(listCalls).toBe(2);
   });
+
+  it('caches distinct categories and tags with counts on init', async () => {
+    const items = [
+      makeItem({ id: '1', category: 'Tools', tags: ['red'] }),
+      makeItem({ id: '2', category: 'Tools', tags: ['red', 'blue'] }),
+      makeItem({ id: '3', category: 'Books', tags: ['blue'] }),
+    ];
+    const hass = makeMockHass({ items });
+    const store = new Store(hass);
+    await store.init();
+
+    const distinct = store.state.value.distinctValuesCache;
+    expect(distinct).toBeTruthy();
+    expect(distinct!.categories).toEqual([
+      { value: 'Books', count: 1 },
+      { value: 'Tools', count: 2 },
+    ]);
+    expect(distinct!.tags).toEqual([
+      { value: 'blue', count: 2 },
+      { value: 'red', count: 2 },
+    ]);
+  });
+
+  it('refreshes distinct values after an item is created', async () => {
+    const hass = makeMockHass({ items: [] });
+    const store = new Store(hass);
+    await store.init();
+    expect(store.state.value.distinctValuesCache?.categories).toEqual([]);
+
+    await store.createItem({ name: 'Drill', category: 'Tools' });
+    // The items subscription event triggers a distinct-values refresh.
+    hass.__emit('items', 'created', {
+      item: makeItem({ id: '99', name: 'Drill', category: 'Tools' }),
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(store.state.value.distinctValuesCache?.categories).toEqual([
+      { value: 'Tools', count: 1 },
+    ]);
+  });
 });

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -1,6 +1,7 @@
 import type {
   AreasListResult,
   AnyEventPayload,
+  DistinctValues,
   HassLike,
   HealthResult,
   Item,
@@ -76,6 +77,7 @@ export class Store {
       locationsFlatCache: null,
       statsCounts: null,
       healthCache: null,
+      distinctValuesCache: null,
       connected: { items: false, stats: false },
     };
     this.stateObs = createObservable<StoreState>(initial);
@@ -93,6 +95,7 @@ export class Store {
       this.refreshAreas(),
       this.refreshLocationTree(),
       this.refreshLocationsFlat(),
+      this.refreshDistinctValues(),
     ]);
     await this.listItems(true);
     this.subscribeTopics();
@@ -136,6 +139,11 @@ export class Store {
       }
     }
     this.stateObs.set({ items });
+    // Category/tag distributions can change on create/update/delete — keep the
+    // autocomplete source fresh. Other actions (quantity, check-out) can't.
+    if (evt.action === 'created' || evt.action === 'updated' || evt.action === 'deleted') {
+      void this.refreshDistinctValues().catch(() => undefined);
+    }
   }
 
   private onStatsEvent(evt: AnyEventPayload) {
@@ -167,6 +175,12 @@ export class Store {
   async refreshAreas() {
     const areas = await this.ws.listAreas();
     this.stateObs.set({ areasCache: areas as AreasListResult });
+  }
+
+  /** Refresh distinct categories/tags with counts (source for autocomplete). */
+  async refreshDistinctValues() {
+    const distinct = await this.ws.distinctValues();
+    this.stateObs.set({ distinctValuesCache: distinct as DistinctValues });
   }
 
   async refreshLocationTree() {

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -110,6 +110,18 @@ export interface AreasListResult {
   areas: { id: string; name: string }[];
 }
 
+/** A distinct field value with its usage count (see haventory/distinct_values). */
+export interface DistinctValue {
+  value: string;
+  count: number;
+}
+
+/** Result of haventory/distinct_values: distinct categories and tags with counts. */
+export interface DistinctValues {
+  categories: DistinctValue[];
+  tags: DistinctValue[];
+}
+
 /** Result of haventory/health: storage/index integrity as seen by the backend. */
 export interface HealthResult {
   healthy: boolean;
@@ -192,6 +204,8 @@ export interface StoreState {
   locationsFlatCache: Location[] | null;
   statsCounts: StatsCounts | null;
   healthCache: HealthResult | null;
+  // Distinct categories/tags with counts, sourcing category/tag autocomplete.
+  distinctValuesCache: DistinctValues | null;
   connected: { items: boolean; stats: boolean };
 }
 

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -1,5 +1,6 @@
 import type {
   AreasListResult,
+  DistinctValues,
   HassLike,
   HealthResult,
   Item,
@@ -38,6 +39,10 @@ export class WSClient {
 
   health() {
     return this.hass.callWS<HealthResult>({ type: 'haventory/health' });
+  }
+
+  distinctValues() {
+    return this.hass.callWS<DistinctValues>({ type: 'haventory/distinct_values' });
   }
 
   // ---------- Items ----------

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -58,6 +58,34 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
         case 'haventory/areas/list': {
           return { areas: [] } as unknown as T;
         }
+        case 'haventory/distinct_values': {
+          // Mirror the backend: distinct categories (case-insensitive) and tags,
+          // each with a usage count, sorted case-insensitively by value.
+          const catGroups = new Map<string, { display: string; ids: Set<string> }>();
+          for (const it of items) {
+            const raw = (it.category ?? '').trim();
+            if (!raw) continue;
+            const key = raw.toLowerCase();
+            const group = catGroups.get(key) ?? { display: raw, ids: new Set<string>() };
+            group.ids.add(it.id);
+            catGroups.set(key, group);
+          }
+          const categories = Array.from(catGroups.values())
+            .map((g) => ({ value: g.display, count: g.ids.size }))
+            .sort((a, b) => a.value.toLowerCase().localeCompare(b.value.toLowerCase()));
+          const tagGroups = new Map<string, Set<string>>();
+          for (const it of items) {
+            for (const tag of it.tags ?? []) {
+              const set = tagGroups.get(tag) ?? new Set<string>();
+              set.add(it.id);
+              tagGroups.set(tag, set);
+            }
+          }
+          const tags = Array.from(tagGroups.entries())
+            .map(([value, ids]) => ({ value, count: ids.size }))
+            .sort((a, b) => a.value.toLowerCase().localeCompare(b.value.toLowerCase()));
+          return { categories, tags } as unknown as T;
+        }
         case 'haventory/location/tree': {
           return [] as unknown as T;
         }

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -153,16 +153,30 @@ haventory-card (main container)
 - `open`: Boolean visibility
 - `item`: Item object (null for create mode)
 - `error`: Error message string
+- `categorySuggestions`: `string[]` of existing category values (autocomplete source)
+- `tagSuggestions`: `string[]` of existing tag values (autocomplete source)
+- `debounceMs`: debounce delay before recomputing suggestions (default 120)
 
 **Fields**:
 - **Name*** (required)
 - **Quantity** (default 1)
 - **Low-stock threshold**
-- **Category**
-- **Tags** (comma-separated, converted to array)
+- **Category** (autocomplete against `categorySuggestions`)
+- **Tags** (comma-separated, converted to array; autocomplete against
+  `tagSuggestions`, matching only the last comma-separated token and excluding
+  tags already entered)
 - **Location** (opens `hv-location-selector`)
 - **Checked-out** (checkbox)
 - **Due date** (enabled only when checked out)
+
+**Autocomplete**: The Category and Tags inputs render a suggestion dropdown
+(`role="listbox"`) sourced from `haventory/distinct_values` via
+`store.distinctValuesCache`. Matching is case-insensitive substring, debounced by
+`debounceMs`, capped at 8 results. Keyboard: `ArrowUp`/`ArrowDown` move the
+highlight, `Enter` accepts the highlighted suggestion, `Esc` closes the dropdown
+only (without closing the dialog). Selecting a category replaces the field;
+selecting a tag replaces the in-progress token and appends a separator so more
+tags can follow.
 
 **Validation**:
 - Name required (non-empty after trim)
@@ -177,7 +191,7 @@ haventory-card (main container)
 - `open-location-selector`: Open location picker
 
 **Keyboard**:
-- `Esc`: Close dialog
+- `Esc`: Close dialog (or, when a suggestion dropdown is open, close the dropdown only)
 
 ---
 


### PR DESCRIPTION
## Summary

WP3 feature #2. Suggests **existing categories and tags while typing** in the item dialog, sourced from the `haventory/distinct_values` command added in #81.

- **Data**: `WSClient.distinctValues()` + `DistinctValues`/`DistinctValue` types. The store caches `distinctValuesCache` — fetched on `init()` and refreshed on item `created`/`updated`/`deleted` events so suggestions stay fresh (other actions like quantity/check-out can't change the category/tag distribution, so they don't trigger a refresh).
- **UI**: `hv-item-dialog` renders a debounced (120 ms), keyboard-navigable suggestion dropdown (`role="listbox"`) below the Category and Tags inputs:
  - `ArrowUp`/`ArrowDown` move the highlight, `Enter` accepts, `Esc` closes the **dropdown only** (without closing the dialog).
  - Case-insensitive substring match, capped at 8 results.
  - Tags match only the in-progress (last comma-separated) token and exclude tags already entered; accepting one appends a separator so more tags can follow.
  - Implemented inline (native `<input>` retained) so it degrades gracefully and keeps existing dialog behavior/tests intact.
- The container passes `categorySuggestions`/`tagSuggestions` from the store cache.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Frontend (`cards/haventory-card`): `npx eslint .` (clean), `npx vitest run` (**110 passed**), `npm run build` (OK). New tests: `hv-item-dialog.autocomplete.test.ts` (substring filter, keyboard nav + Enter, last-tag-token handling, exclusion of chosen tags, Esc-closes-dropdown-not-dialog, debounce via fake timers) and store distinct-values caching/refresh in `store.test.ts`.
- [x] Backend: `uv run ruff check .` → green. No Python changed in this PR, so `pytest`/`mypy` behavior is identical to `main` (the native 3.14 gate runs in CI; the sandbox can't provision CPython 3.14 because the python-build-standalone download is blocked by egress policy).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs updated (`README.md`, `docs/frontend_architecture.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — N/A, consumes the existing `distinct_values` command; no backend change.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — frontend-only, no backend behavior changed.

## Screenshots (card / UI changes)

Not captured in this environment (no running HA). The dropdown reuses the card's existing input/token styling and theme variables.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_