### PR TITLE
feat(card): dedicated category browser with drill-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
   updates with conflict resolution; Vite build → `www/haventory/haventory-card.js`.
 - Item dialog offers debounced, keyboard-navigable category/tag autocomplete sourced from
   `haventory/distinct_values`.
+- Dedicated **category browser** (header → "Categories"): lists used categories with item
+  counts and drills down to the items filed under each.
 
 ### 🚧 Phase 3: Polish & HACS (Planned)
 - HACS publication; release automation (release-please); additional optimizations.

--- a/cards/haventory-card/src/components/hv-category-browser.test.ts
+++ b/cards/haventory-card/src/components/hv-category-browser.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './hv-category-browser';
+import type { DistinctValue, Item } from '../store/types';
+
+type Browser = HTMLElement & {
+  open: boolean;
+  categories: DistinctValue[];
+  selectedCategory: string | null;
+  items: Item[];
+  loading: boolean;
+  updateComplete?: Promise<unknown>;
+};
+
+function makeItem(partial: Partial<Item>): Item {
+  return {
+    id: 'i', name: 'Item', description: null, quantity: 1, checked_out: false,
+    due_date: null, inspection_date: null, location_id: null, tags: [], category: null,
+    low_stock_threshold: null, custom_fields: {}, created_at: '', updated_at: '', version: 1,
+    location_path: { id_path: [], name_path: [], display_path: '', sort_key: '' },
+    ...partial,
+  };
+}
+
+async function mount(props: Partial<Browser>): Promise<Browser> {
+  const el = document.createElement('hv-category-browser') as Browser;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await customElements.whenDefined('hv-category-browser');
+  el.open = true;
+  if (el.updateComplete) await el.updateComplete;
+  return el;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('hv-category-browser', () => {
+  it('lists categories with counts', async () => {
+    const el = await mount({ categories: [{ value: 'Books', count: 3 }, { value: 'Tools', count: 5 }] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const rows = Array.from(sr.querySelectorAll('[data-testid="category-row"]'));
+    expect(rows.map((r) => r.getAttribute('data-value'))).toEqual(['Books', 'Tools']);
+    expect(rows.map((r) => r.querySelector('.count')?.textContent)).toEqual(['3', '5']);
+  });
+
+  it('filters the category list', async () => {
+    const el = await mount({ categories: [{ value: 'Books', count: 1 }, { value: 'Tools', count: 1 }, { value: 'Toys', count: 1 }] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const filter = sr.querySelector('[data-testid="category-filter"]') as HTMLInputElement;
+    filter.value = 'to';
+    filter.dispatchEvent(new Event('input', { bubbles: true }));
+    if (el.updateComplete) await el.updateComplete;
+    const rows = Array.from(sr.querySelectorAll('[data-testid="category-row"]'));
+    expect(rows.map((r) => r.getAttribute('data-value'))).toEqual(['Tools', 'Toys']);
+  });
+
+  it('emits select-category when a category is clicked', async () => {
+    const el = await mount({ categories: [{ value: 'Tools', count: 2 }] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let picked: string | null = null;
+    el.addEventListener('select-category', (e: any) => { picked = e.detail.category; });
+    (sr.querySelector('[data-testid="category-row"]') as HTMLButtonElement).click();
+    expect(picked).toBe('Tools');
+  });
+
+  it('shows the drill-down items and a back button when a category is selected', async () => {
+    const el = await mount({
+      categories: [{ value: 'Tools', count: 2 }],
+      selectedCategory: 'Tools',
+      items: [
+        makeItem({ id: '1', name: 'Hammer', quantity: 2, location_path: { id_path: [], name_path: [], display_path: 'Garage', sort_key: '' } }),
+        makeItem({ id: '2', name: 'Wrench', quantity: 1 }),
+      ],
+    });
+    const sr = el.shadowRoot as ShadowRoot;
+    const rows = Array.from(sr.querySelectorAll('[data-testid="item-row"]'));
+    expect(rows.map((r) => r.querySelector('.grow')?.textContent)).toEqual(['Hammer', 'Wrench']);
+    expect(sr.querySelector('.header h2')?.textContent).toBe('Tools');
+    expect(sr.querySelector('[data-testid="browser-back"]')).toBeTruthy();
+
+    let cleared = false;
+    el.addEventListener('clear-category', () => { cleared = true; });
+    (sr.querySelector('[data-testid="browser-back"]') as HTMLButtonElement).click();
+    expect(cleared).toBe(true);
+  });
+
+  it('emits open-item when a drill-down item is clicked', async () => {
+    const el = await mount({
+      selectedCategory: 'Tools',
+      items: [makeItem({ id: 'abc', name: 'Hammer' })],
+    });
+    const sr = el.shadowRoot as ShadowRoot;
+    let openedId: string | null = null;
+    el.addEventListener('open-item', (e: any) => { openedId = e.detail.itemId; });
+    (sr.querySelector('[data-testid="item-row"]') as HTMLButtonElement).click();
+    expect(openedId).toBe('abc');
+  });
+
+  it('shows loading and empty states in the drill-down', async () => {
+    const el = await mount({ selectedCategory: 'Tools', loading: true, items: [] });
+    let sr = el.shadowRoot as ShadowRoot;
+    expect(sr.querySelector('[data-testid="browser-loading"]')).toBeTruthy();
+
+    (el as Browser).loading = false;
+    if (el.updateComplete) await el.updateComplete;
+    sr = el.shadowRoot as ShadowRoot;
+    expect(sr.querySelector('[data-testid="browser-empty"]')?.textContent).toContain('No items');
+  });
+
+  it('shows an empty state when there are no categories', async () => {
+    const el = await mount({ categories: [] });
+    const sr = el.shadowRoot as ShadowRoot;
+    expect(sr.querySelector('[data-testid="browser-empty"]')?.textContent).toContain('No categories');
+  });
+
+  it('Escape steps back when drilled in, and closes at the top level', async () => {
+    const el = await mount({ categories: [{ value: 'Tools', count: 1 }], selectedCategory: 'Tools', items: [] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const panel = sr.querySelector('[role="dialog"]') as HTMLElement;
+
+    let cleared = false; let cancelled = false;
+    el.addEventListener('clear-category', () => { cleared = true; });
+    el.addEventListener('cancel', () => { cancelled = true; });
+
+    panel.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(cleared).toBe(true);
+    expect(cancelled).toBe(false);
+
+    // Back at the top level, Escape closes.
+    (el as Browser).selectedCategory = null;
+    if (el.updateComplete) await el.updateComplete;
+    (sr.querySelector('[role="dialog"]') as HTMLElement)
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(cancelled).toBe(true);
+    expect(el.open).toBe(false);
+  });
+
+  it('closes on backdrop click', async () => {
+    const el = await mount({ categories: [] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let cancelled = false;
+    el.addEventListener('cancel', () => { cancelled = true; });
+    (sr.querySelector('.backdrop') as HTMLElement).click();
+    expect(cancelled).toBe(true);
+    expect(el.open).toBe(false);
+  });
+});

--- a/cards/haventory-card/src/components/hv-category-browser.ts
+++ b/cards/haventory-card/src/components/hv-category-browser.ts
@@ -1,0 +1,241 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { nextZBase } from '../utils/zindex';
+import type { DistinctValue, Item } from '../store/types';
+
+/**
+ * Dedicated modal for browsing items by category.
+ *
+ * Two levels:
+ *  1. A list of all used categories with item counts (filterable).
+ *  2. Drill-down: the items filed under the selected category.
+ *
+ * The component is presentational — it renders `categories` (from
+ * `haventory/distinct_values`) and, once a category is picked, the `items` the
+ * container fetches for it. It emits events; the container owns the data.
+ */
+@customElement('hv-category-browser')
+export class HVCategoryBrowser extends LitElement {
+  static styles = css`
+    :host { display: block; }
+    .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 9998; }
+    .panel-wrap { position: fixed; inset: 0; display: grid; place-items: center; z-index: 9999; }
+    .panel {
+      background: var(--card-background-color, var(--ha-card-background, #fff));
+      color: var(--primary-text-color, #212121);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 8px;
+      padding: 16px;
+      max-width: 460px;
+      width: calc(100vw - 32px);
+      box-sizing: border-box;
+      font: inherit;
+    }
+    .header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+    .header h2 { font-size: 1.1em; margin: 0; flex: 1; }
+    .back {
+      background: transparent;
+      color: var(--primary-color, #03a9f4);
+      border: 1px solid var(--primary-color, #03a9f4);
+      border-radius: 4px;
+      padding: 4px 8px;
+      cursor: pointer;
+      font: inherit;
+    }
+    input[type="search"] {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--input-fill-color, var(--secondary-background-color, #f5f5f5));
+      color: var(--primary-text-color, #212121);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 4px;
+      padding: 8px;
+      font: inherit;
+      margin-bottom: 8px;
+    }
+    input[type="search"]:focus { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: -1px; }
+    ul { list-style: none; margin: 0; padding: 0; max-height: 360px; overflow: auto; }
+    li { margin: 0; }
+    .row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      text-align: left;
+      background: transparent;
+      color: inherit;
+      border: none;
+      border-bottom: 1px solid var(--divider-color, #eee);
+      padding: 8px 6px;
+      cursor: pointer;
+      font: inherit;
+    }
+    .row:hover, .row:focus-visible {
+      background: var(--secondary-background-color, #f5f5f5);
+      outline: none;
+    }
+    .grow { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .count {
+      flex: 0 0 auto;
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      border-radius: 10px;
+      padding: 0 8px;
+      font-size: 0.85em;
+      min-width: 20px;
+      text-align: center;
+    }
+    .qty { flex: 0 0 auto; color: var(--secondary-text-color, #666); }
+    .loc { flex: 0 0 auto; color: var(--secondary-text-color, #666); font-size: 0.85em; }
+    .empty { padding: 16px 6px; color: var(--secondary-text-color, #666); }
+    .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+    .actions button {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      border: none;
+      border-radius: 4px;
+      padding: 8px 16px;
+      cursor: pointer;
+      font: inherit;
+    }
+    .actions button:hover { opacity: 0.9; }
+  `;
+
+  @property({ type: Boolean, reflect: true }) open: boolean = false;
+  @property({ attribute: false }) categories: DistinctValue[] = [];
+  @property({ type: String }) selectedCategory: string | null = null;
+  @property({ attribute: false }) items: Item[] = [];
+  @property({ type: Boolean }) loading: boolean = false;
+
+  @state() private _filter: string = '';
+  @state() private _zBase: number | null = null;
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has('open') && this.open) {
+      this._zBase = nextZBase();
+      this._filter = '';
+    }
+  }
+
+  private _emit(type: string, detail?: unknown) {
+    this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+  }
+
+  private _onCancel = () => {
+    this._emit('cancel');
+    this.open = false;
+  };
+
+  private _onBack = () => {
+    this._emit('clear-category');
+  };
+
+  private _onKeydown = (e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    e.preventDefault();
+    // Drilled in → step back to the category list; otherwise close.
+    if (this.selectedCategory !== null) this._onBack();
+    else this._onCancel();
+  };
+
+  private _filteredCategories(): DistinctValue[] {
+    const q = this._filter.trim().toLowerCase();
+    if (!q) return this.categories;
+    return this.categories.filter((c) => c.value.toLowerCase().includes(q));
+  }
+
+  private _locationLabel(item: Item): string {
+    return item.location_path?.display_path || '';
+  }
+
+  private _renderCategoryList() {
+    const cats = this._filteredCategories();
+    return html`
+      <input
+        type="search"
+        placeholder="Filter categories…"
+        data-testid="category-filter"
+        aria-label="Filter categories"
+        .value=${this._filter}
+        @input=${(e: Event) => { this._filter = (e.target as HTMLInputElement).value; }}
+      />
+      ${this.categories.length === 0
+        ? html`<div class="empty" data-testid="browser-empty">No categories yet.</div>`
+        : cats.length === 0
+          ? html`<div class="empty" data-testid="browser-empty">No matching categories.</div>`
+          : html`
+            <ul data-testid="category-list" role="listbox" aria-label="Categories">
+              ${cats.map((c) => html`
+                <li>
+                  <button
+                    class="row"
+                    role="option"
+                    data-testid="category-row"
+                    data-value=${c.value}
+                    @click=${() => this._emit('select-category', { category: c.value })}
+                  >
+                    <span class="grow">${c.value}</span>
+                    <span class="count" aria-label="${c.count} items">${c.count}</span>
+                  </button>
+                </li>
+              `)}
+            </ul>
+          `}
+    `;
+  }
+
+  private _renderItemList() {
+    if (this.loading) {
+      return html`<div class="empty" data-testid="browser-loading">Loading…</div>`;
+    }
+    if (this.items.length === 0) {
+      return html`<div class="empty" data-testid="browser-empty">No items in this category.</div>`;
+    }
+    return html`
+      <ul data-testid="item-list">
+        ${this.items.map((it) => html`
+          <li>
+            <button
+              class="row"
+              data-testid="item-row"
+              data-item-id=${it.id}
+              @click=${() => this._emit('open-item', { itemId: it.id })}
+            >
+              <span class="grow">${it.name}</span>
+              <span class="qty">×${it.quantity}</span>
+              ${this._locationLabel(it) ? html`<span class="loc">${this._locationLabel(it)}</span>` : null}
+            </button>
+          </li>
+        `)}
+      </ul>
+    `;
+  }
+
+  render() {
+    if (!this.open) return null;
+    const drilled = this.selectedCategory !== null;
+    return html`
+      <div class="backdrop" role="presentation" style="z-index: ${this._zBase ?? 9998};" @click=${this._onCancel}></div>
+      <div class="panel-wrap" role="none" style="z-index: ${(this._zBase ?? 9998) + 1};">
+        <div class="panel" role="dialog" aria-modal="true" aria-label="Category browser" @keydown=${this._onKeydown}>
+          <div class="header">
+            ${drilled
+              ? html`<button class="back" data-testid="browser-back" @click=${this._onBack} aria-label="Back to categories">‹ Categories</button>`
+              : null}
+            <h2>${drilled ? this.selectedCategory : 'Browse by category'}</h2>
+          </div>
+          ${drilled ? this._renderItemList() : this._renderCategoryList()}
+          <div class="actions">
+            <button data-testid="browser-close" @click=${this._onCancel}>Close</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hv-category-browser': HVCategoryBrowser;
+  }
+}

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -1,5 +1,5 @@
 import { LitElement, css, html } from 'lit';
-import type { HassLike } from './store/types';
+import type { HassLike, Item } from './store/types';
 import type { HVLocationSelector } from './components/hv-location-selector';
 import { getDefaultOrderFor } from './store/sort';
 import { Store } from './store/store';
@@ -8,6 +8,7 @@ import './components/hv-inventory-list';
 import './components/hv-item-row';
 import './components/hv-item-dialog';
 import './components/hv-location-selector';
+import './components/hv-category-browser';
 
 export class HAventoryCard extends LitElement {
   static styles = css`
@@ -79,6 +80,10 @@ export class HAventoryCard extends LitElement {
   private _prevFocusEl: HTMLElement | null = null;
   private _locationSelectorOpen = false;
   private _locationSelectorCreateMode = false;
+  private _categoryBrowserOpen = false;
+  private _browseCategory: string | null = null;
+  private _browseItems: Item[] = [];
+  private _browseLoading = false;
 
   // Lovelace interface: called by HA when the card is created/configured
   public setConfig(cfg: unknown): void {
@@ -144,6 +149,7 @@ export class HAventoryCard extends LitElement {
               dialog.open = true;
             }
           }} aria-label="Add item" title="Add item">Add item</button>
+          <button data-testid="browse-categories" @click=${() => this._openCategoryBrowser()} aria-label="Browse categories" title="Browse categories">Categories</button>
           <button data-testid="expand-toggle" @click=${() => this._toggleExpanded()} aria-expanded=${String(this.expanded)} aria-label=${this.expanded ? 'Collapse' : 'Expand'}>
             ${this.expanded ? '⤢ Collapse' : '⇱ Expand'}
           </button>
@@ -309,8 +315,54 @@ export class HAventoryCard extends LitElement {
         }}
       ></hv-location-selector>
 
+      <hv-category-browser
+        .open=${this._categoryBrowserOpen}
+        .categories=${st?.distinctValuesCache?.categories ?? []}
+        .selectedCategory=${this._browseCategory}
+        .items=${this._browseItems}
+        .loading=${this._browseLoading}
+        @select-category=${(e: CustomEvent) => { void this._openCategory(e.detail.category as string); }}
+        @clear-category=${() => { this._browseCategory = null; this._browseItems = []; this._browseLoading = false; this.requestUpdate(); }}
+        @open-item=${(e: CustomEvent) => this._openBrowseItem(e.detail.itemId as string)}
+        @cancel=${() => { this._categoryBrowserOpen = false; this._browseCategory = null; this._browseItems = []; this.requestUpdate(); }}
+      ></hv-category-browser>
+
       ${this.expanded ? this._renderOverlayTemplate() : null}
     `;
+  }
+
+  private _openCategoryBrowser() {
+    this._categoryBrowserOpen = true;
+    this._browseCategory = null;
+    this._browseItems = [];
+    this._browseLoading = false;
+    this.requestUpdate();
+  }
+
+  private async _openCategory(category: string) {
+    this._browseCategory = category;
+    this._browseItems = [];
+    this._browseLoading = true;
+    this.requestUpdate();
+    try {
+      this._browseItems = (await this.store?.fetchItemsByCategory(category)) ?? [];
+    } catch {
+      this._browseItems = [];
+    } finally {
+      this._browseLoading = false;
+      this.requestUpdate();
+    }
+  }
+
+  private _openBrowseItem(itemId: string) {
+    const item = this._browseItems.find((i) => i.id === itemId);
+    if (!item) return;
+    const dialog = this.shadowRoot?.querySelector('hv-item-dialog') as
+      (HTMLElement & { open: boolean; item: unknown }) | null;
+    if (dialog) {
+      dialog.item = item;
+      dialog.open = true;
+    }
   }
 
   private async _toggleExpanded() {

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -413,4 +413,21 @@ describe('Store', () => {
       { value: 'Tools', count: 1 },
     ]);
   });
+
+  it('fetchItemsByCategory returns only items in that category', async () => {
+    const items = [
+      makeItem({ id: '1', name: 'Hammer', category: 'Tools' }),
+      makeItem({ id: '2', name: 'Novel', category: 'Books' }),
+      makeItem({ id: '3', name: 'Wrench', category: 'tools' }), // case-insensitive
+    ];
+    const hass = makeMockHass({ items });
+    const store = new Store(hass);
+    await store.init();
+
+    const tools = await store.fetchItemsByCategory('Tools');
+    expect(tools.map((i) => i.id).sort()).toEqual(['1', '3']);
+
+    const books = await store.fetchItemsByCategory('Books');
+    expect(books.map((i) => i.name)).toEqual(['Novel']);
+  });
 });

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -19,6 +19,9 @@ import type {
 import { WSClient } from './ws';
 import { DEFAULT_SORT } from './sort';
 
+/** Max items fetched for a single-category/tag browse drill-down (snapshot). */
+const BROWSE_PAGE_LIMIT = 500;
+
 /** A very small reactive wrapper using a Proxy; components can subscribe to `onChange`. */
 export interface Observable<T> {
   readonly value: T;
@@ -229,6 +232,16 @@ export class Store {
 
     this.inflight.set(key, p);
     return p as Promise<void>;
+  }
+
+  /**
+   * Fetch items filed under a single category, sorted by name. Used by the
+   * dedicated category browser (drill-down). Returns a snapshot (first page,
+   * capped) independent of the main list's filters/pagination.
+   */
+  async fetchItemsByCategory(category: string): Promise<Item[]> {
+    const res = await this.ws.listItems({ category }, { field: 'name', order: 'asc' }, BROWSE_PAGE_LIMIT);
+    return res.items;
   }
 
   async prefetchIfNeeded(scrollRatio: number) {

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -145,13 +145,25 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
         case 'haventory/item/list': {
           const limit = (typeof msg.limit === 'number' ? (msg.limit as number) : 50) || 50;
           const cursor = (msg.cursor as string | undefined) || undefined;
-          const page1 = items.slice(0, limit);
+          const filter = (msg.filter as Record<string, unknown> | undefined) ?? {};
+          // Apply the subset of filters the browsers rely on (category, tags_any),
+          // case-insensitively, mirroring the backend indexes.
+          let filtered = items;
+          const cat = typeof filter.category === 'string' ? filter.category.trim().toLowerCase() : '';
+          if (cat) {
+            filtered = filtered.filter((i) => (i.category ?? '').trim().toLowerCase() === cat);
+          }
+          const tagsAny = Array.isArray(filter.tags_any) ? (filter.tags_any as string[]).map((t) => t.toLowerCase()) : [];
+          if (tagsAny.length) {
+            filtered = filtered.filter((i) => (i.tags ?? []).some((t) => tagsAny.includes(t.toLowerCase())));
+          }
+          const page1 = filtered.slice(0, limit);
           if (!cursor) {
-            const next_cursor = items.length > limit ? 'cursor-2' : null;
+            const next_cursor = filtered.length > limit ? 'cursor-2' : null;
             return { items: page1, next_cursor } as unknown as T;
           }
           if (cursor === 'cursor-2') {
-            return { items: items.slice(limit, limit * 2), next_cursor: null } as unknown as T;
+            return { items: filtered.slice(limit, limit * 2), next_cursor: null } as unknown as T;
           }
           return { items: [], next_cursor: null } as unknown as T;
         }

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -22,7 +22,8 @@ haventory-card (main container)
 ├── hv-inventory-list (virtualized list)
 │   └── hv-item-row (individual item rows) × N
 ├── hv-item-dialog (add/edit modal)
-└── hv-location-selector (location picker modal)
+├── hv-location-selector (location picker modal)
+└── hv-category-browser (browse-by-category modal)
 ```
 
 ---
@@ -225,6 +226,36 @@ tags can follow.
 
 **Keyboard**:
 - `Esc`: Close selector
+
+---
+
+### `hv-category-browser`
+
+**Purpose**: Dedicated modal for browsing items by category, opened from the
+card header ("Categories" button).
+
+**Properties**:
+- `open`: Boolean visibility
+- `categories`: `DistinctValue[]` (value + count) from `store.distinctValuesCache`
+- `selectedCategory`: `string | null` — the drilled-in category (null = list level)
+- `items`: `Item[]` — items filed under `selectedCategory` (fetched by the container)
+- `loading`: Boolean — drill-down fetch in progress
+
+**Two levels**:
+1. **Category list** — all used categories with item counts, filterable via a
+   search box. Empty states for "no categories" and "no matches".
+2. **Drill-down** — the items in the selected category (name, quantity, location),
+   fetched by the container via `store.fetchItemsByCategory()` (a snapshot, first
+   page capped at 500). A "‹ Categories" button returns to the list.
+
+**Events**:
+- `select-category`: `{category}` — a category was chosen (container fetches items)
+- `clear-category`: return to the category list
+- `open-item`: `{itemId}` — a drill-down item was clicked (container opens the item dialog)
+- `cancel`: close the browser
+
+**Keyboard**:
+- `Esc`: step back to the category list when drilled in; otherwise close
 
 ---
 


### PR DESCRIPTION
## Summary

WP3 feature #3. A dedicated **browse-by-category** view, opened from the card header ("Categories" button).

- **`hv-category-browser`** — a modal with two levels:
  1. A **filterable list** of all used categories with item counts (from `haventory/distinct_values` via `store.distinctValuesCache`), with empty states for "no categories" and "no matches".
  2. A **drill-down** showing the items filed under the selected category (name, quantity, location), with a "‹ Categories" back button.
  - Emits `select-category` / `clear-category` / `open-item` / `cancel`. `Esc` steps back from the drill-down, or closes at the top level.
- **`Store.fetchItemsByCategory()`** — fetches a snapshot of the items in one category via `item/list`'s case-insensitive `category` filter (name-sorted, first page capped at 500; documented). Independent of the main list's filters/pagination.
- **Container** wires it up: header button opens the browser; selecting a category fetches its items; clicking a drill-down item opens the existing item dialog on top.
- The mock `hass` `item/list` now honors the `category`/`tags_any` filters so the drill-down is exercised in tests.

Snapshot semantics: the drill-down list is fetched on selection and does not live-update while open (re-selecting refetches). Noted as acceptable for a browse view.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Frontend (`cards/haventory-card`): `npx eslint .` (clean), `npx vitest run` (**120 passed**), `npm run build` (OK). New tests: `hv-category-browser.test.ts` (list + counts, filter, select, drill-down + back, open-item, loading/empty states, Esc behavior, backdrop) and `store.fetchItemsByCategory`.
- [x] Backend: `uv run ruff check .` → green. No Python changed; `pytest`/`mypy` behavior is identical to `main` (native 3.14 gate runs in CI — the sandbox can't provision CPython 3.14 because the python-build-standalone download is blocked by egress policy).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs updated (`README.md`, `docs/frontend_architecture.md`).
- [x] WebSocket API changes keep `ws.py` + docs in sync — N/A, reuses existing `distinct_values` and `item/list`; no backend change.
- [x] Load-bearing invariants preserved — frontend-only, no backend behavior changed.

## Screenshots (card / UI changes)

Not captured in this environment (no running HA). The modal reuses the card's existing panel/theme styling.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_