### PR TITLE
feat(card): dedicated tag browser with drill-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
   `haventory/distinct_values`.
 - Dedicated **category browser** (header → "Categories"): lists used categories with item
   counts and drills down to the items filed under each.
+- Dedicated **tag browser** (header → "Tags"): lists used tags with item counts and drills
+  down to the items carrying each.
 
 ### 🚧 Phase 3: Polish & HACS (Planned)
 - HACS publication; release automation (release-please); additional optimizations.

--- a/cards/haventory-card/src/components/hv-tag-browser.test.ts
+++ b/cards/haventory-card/src/components/hv-tag-browser.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './hv-tag-browser';
+import type { DistinctValue, Item } from '../store/types';
+
+type Browser = HTMLElement & {
+  open: boolean;
+  tags: DistinctValue[];
+  selectedTag: string | null;
+  items: Item[];
+  loading: boolean;
+  updateComplete?: Promise<unknown>;
+};
+
+function makeItem(partial: Partial<Item>): Item {
+  return {
+    id: 'i', name: 'Item', description: null, quantity: 1, checked_out: false,
+    due_date: null, inspection_date: null, location_id: null, tags: [], category: null,
+    low_stock_threshold: null, custom_fields: {}, created_at: '', updated_at: '', version: 1,
+    location_path: { id_path: [], name_path: [], display_path: '', sort_key: '' },
+    ...partial,
+  };
+}
+
+async function mount(props: Partial<Browser>): Promise<Browser> {
+  const el = document.createElement('hv-tag-browser') as Browser;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await customElements.whenDefined('hv-tag-browser');
+  el.open = true;
+  if (el.updateComplete) await el.updateComplete;
+  return el;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('hv-tag-browser', () => {
+  it('lists tags with counts', async () => {
+    const el = await mount({ tags: [{ value: 'blue', count: 2 }, { value: 'red', count: 4 }] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const rows = Array.from(sr.querySelectorAll('[data-testid="tag-row"]'));
+    expect(rows.map((r) => r.getAttribute('data-value'))).toEqual(['blue', 'red']);
+    expect(rows.map((r) => r.querySelector('.count')?.textContent)).toEqual(['2', '4']);
+  });
+
+  it('filters the tag list', async () => {
+    const el = await mount({ tags: [{ value: 'blue', count: 1 }, { value: 'red', count: 1 }, { value: 'green', count: 1 }] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const filter = sr.querySelector('[data-testid="tag-filter"]') as HTMLInputElement;
+    filter.value = 'e';
+    filter.dispatchEvent(new Event('input', { bubbles: true }));
+    if (el.updateComplete) await el.updateComplete;
+    const rows = Array.from(sr.querySelectorAll('[data-testid="tag-row"]'));
+    expect(rows.map((r) => r.getAttribute('data-value'))).toEqual(['blue', 'red', 'green']
+      .filter((v) => v.includes('e')));
+  });
+
+  it('emits select-tag when a tag is clicked', async () => {
+    const el = await mount({ tags: [{ value: 'red', count: 2 }] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let picked: string | null = null;
+    el.addEventListener('select-tag', (e: any) => { picked = e.detail.tag; });
+    (sr.querySelector('[data-testid="tag-row"]') as HTMLButtonElement).click();
+    expect(picked).toBe('red');
+  });
+
+  it('shows drill-down items and a back button when a tag is selected', async () => {
+    const el = await mount({
+      tags: [{ value: 'red', count: 2 }],
+      selectedTag: 'red',
+      items: [makeItem({ id: '1', name: 'Hammer', quantity: 2 }), makeItem({ id: '2', name: 'Wrench' })],
+    });
+    const sr = el.shadowRoot as ShadowRoot;
+    const rows = Array.from(sr.querySelectorAll('[data-testid="item-row"]'));
+    expect(rows.map((r) => r.querySelector('.grow')?.textContent)).toEqual(['Hammer', 'Wrench']);
+    expect(sr.querySelector('.header h2')?.textContent).toBe('#red');
+
+    let cleared = false;
+    el.addEventListener('clear-tag', () => { cleared = true; });
+    (sr.querySelector('[data-testid="browser-back"]') as HTMLButtonElement).click();
+    expect(cleared).toBe(true);
+  });
+
+  it('emits open-item when a drill-down item is clicked', async () => {
+    const el = await mount({ selectedTag: 'red', items: [makeItem({ id: 'xyz', name: 'Hammer' })] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let openedId: string | null = null;
+    el.addEventListener('open-item', (e: any) => { openedId = e.detail.itemId; });
+    (sr.querySelector('[data-testid="item-row"]') as HTMLButtonElement).click();
+    expect(openedId).toBe('xyz');
+  });
+
+  it('shows loading and empty drill-down states', async () => {
+    const el = await mount({ selectedTag: 'red', loading: true, items: [] });
+    let sr = el.shadowRoot as ShadowRoot;
+    expect(sr.querySelector('[data-testid="browser-loading"]')).toBeTruthy();
+
+    (el as Browser).loading = false;
+    if (el.updateComplete) await el.updateComplete;
+    sr = el.shadowRoot as ShadowRoot;
+    expect(sr.querySelector('[data-testid="browser-empty"]')?.textContent).toContain('No items');
+  });
+
+  it('shows an empty state when there are no tags', async () => {
+    const el = await mount({ tags: [] });
+    const sr = el.shadowRoot as ShadowRoot;
+    expect(sr.querySelector('[data-testid="browser-empty"]')?.textContent).toContain('No tags');
+  });
+
+  it('Escape steps back when drilled in, and closes at the top level', async () => {
+    const el = await mount({ tags: [{ value: 'red', count: 1 }], selectedTag: 'red', items: [] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let cleared = false; let cancelled = false;
+    el.addEventListener('clear-tag', () => { cleared = true; });
+    el.addEventListener('cancel', () => { cancelled = true; });
+
+    (sr.querySelector('[role="dialog"]') as HTMLElement)
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(cleared).toBe(true);
+    expect(cancelled).toBe(false);
+
+    (el as Browser).selectedTag = null;
+    if (el.updateComplete) await el.updateComplete;
+    (sr.querySelector('[role="dialog"]') as HTMLElement)
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(cancelled).toBe(true);
+    expect(el.open).toBe(false);
+  });
+
+  it('closes on backdrop click', async () => {
+    const el = await mount({ tags: [] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let cancelled = false;
+    el.addEventListener('cancel', () => { cancelled = true; });
+    (sr.querySelector('.backdrop') as HTMLElement).click();
+    expect(cancelled).toBe(true);
+    expect(el.open).toBe(false);
+  });
+});

--- a/cards/haventory-card/src/components/hv-tag-browser.ts
+++ b/cards/haventory-card/src/components/hv-tag-browser.ts
@@ -1,0 +1,237 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { nextZBase } from '../utils/zindex';
+import type { DistinctValue, Item } from '../store/types';
+
+/**
+ * Dedicated modal for browsing items by tag.
+ *
+ * Mirrors hv-category-browser: a filterable list of all used tags with item
+ * counts (from `haventory/distinct_values`), drilling down to the items
+ * carrying the selected tag. Presentational — the container owns the data.
+ */
+@customElement('hv-tag-browser')
+export class HVTagBrowser extends LitElement {
+  static styles = css`
+    :host { display: block; }
+    .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 9998; }
+    .panel-wrap { position: fixed; inset: 0; display: grid; place-items: center; z-index: 9999; }
+    .panel {
+      background: var(--card-background-color, var(--ha-card-background, #fff));
+      color: var(--primary-text-color, #212121);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 8px;
+      padding: 16px;
+      max-width: 460px;
+      width: calc(100vw - 32px);
+      box-sizing: border-box;
+      font: inherit;
+    }
+    .header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+    .header h2 { font-size: 1.1em; margin: 0; flex: 1; }
+    .back {
+      background: transparent;
+      color: var(--primary-color, #03a9f4);
+      border: 1px solid var(--primary-color, #03a9f4);
+      border-radius: 4px;
+      padding: 4px 8px;
+      cursor: pointer;
+      font: inherit;
+    }
+    input[type="search"] {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--input-fill-color, var(--secondary-background-color, #f5f5f5));
+      color: var(--primary-text-color, #212121);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 4px;
+      padding: 8px;
+      font: inherit;
+      margin-bottom: 8px;
+    }
+    input[type="search"]:focus { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: -1px; }
+    ul { list-style: none; margin: 0; padding: 0; max-height: 360px; overflow: auto; }
+    li { margin: 0; }
+    .row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      text-align: left;
+      background: transparent;
+      color: inherit;
+      border: none;
+      border-bottom: 1px solid var(--divider-color, #eee);
+      padding: 8px 6px;
+      cursor: pointer;
+      font: inherit;
+    }
+    .row:hover, .row:focus-visible {
+      background: var(--secondary-background-color, #f5f5f5);
+      outline: none;
+    }
+    .grow { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .tag-name::before { content: '#'; opacity: 0.6; }
+    .count {
+      flex: 0 0 auto;
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      border-radius: 10px;
+      padding: 0 8px;
+      font-size: 0.85em;
+      min-width: 20px;
+      text-align: center;
+    }
+    .qty { flex: 0 0 auto; color: var(--secondary-text-color, #666); }
+    .loc { flex: 0 0 auto; color: var(--secondary-text-color, #666); font-size: 0.85em; }
+    .empty { padding: 16px 6px; color: var(--secondary-text-color, #666); }
+    .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+    .actions button {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      border: none;
+      border-radius: 4px;
+      padding: 8px 16px;
+      cursor: pointer;
+      font: inherit;
+    }
+    .actions button:hover { opacity: 0.9; }
+  `;
+
+  @property({ type: Boolean, reflect: true }) open: boolean = false;
+  @property({ attribute: false }) tags: DistinctValue[] = [];
+  @property({ type: String }) selectedTag: string | null = null;
+  @property({ attribute: false }) items: Item[] = [];
+  @property({ type: Boolean }) loading: boolean = false;
+
+  @state() private _filter: string = '';
+  @state() private _zBase: number | null = null;
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has('open') && this.open) {
+      this._zBase = nextZBase();
+      this._filter = '';
+    }
+  }
+
+  private _emit(type: string, detail?: unknown) {
+    this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+  }
+
+  private _onCancel = () => {
+    this._emit('cancel');
+    this.open = false;
+  };
+
+  private _onBack = () => {
+    this._emit('clear-tag');
+  };
+
+  private _onKeydown = (e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    e.preventDefault();
+    if (this.selectedTag !== null) this._onBack();
+    else this._onCancel();
+  };
+
+  private _filteredTags(): DistinctValue[] {
+    const q = this._filter.trim().toLowerCase();
+    if (!q) return this.tags;
+    return this.tags.filter((t) => t.value.toLowerCase().includes(q));
+  }
+
+  private _locationLabel(item: Item): string {
+    return item.location_path?.display_path || '';
+  }
+
+  private _renderTagList() {
+    const tags = this._filteredTags();
+    return html`
+      <input
+        type="search"
+        placeholder="Filter tags…"
+        data-testid="tag-filter"
+        aria-label="Filter tags"
+        .value=${this._filter}
+        @input=${(e: Event) => { this._filter = (e.target as HTMLInputElement).value; }}
+      />
+      ${this.tags.length === 0
+        ? html`<div class="empty" data-testid="browser-empty">No tags yet.</div>`
+        : tags.length === 0
+          ? html`<div class="empty" data-testid="browser-empty">No matching tags.</div>`
+          : html`
+            <ul data-testid="tag-list" role="listbox" aria-label="Tags">
+              ${tags.map((t) => html`
+                <li>
+                  <button
+                    class="row"
+                    role="option"
+                    data-testid="tag-row"
+                    data-value=${t.value}
+                    @click=${() => this._emit('select-tag', { tag: t.value })}
+                  >
+                    <span class="grow tag-name">${t.value}</span>
+                    <span class="count" aria-label="${t.count} items">${t.count}</span>
+                  </button>
+                </li>
+              `)}
+            </ul>
+          `}
+    `;
+  }
+
+  private _renderItemList() {
+    if (this.loading) {
+      return html`<div class="empty" data-testid="browser-loading">Loading…</div>`;
+    }
+    if (this.items.length === 0) {
+      return html`<div class="empty" data-testid="browser-empty">No items with this tag.</div>`;
+    }
+    return html`
+      <ul data-testid="item-list">
+        ${this.items.map((it) => html`
+          <li>
+            <button
+              class="row"
+              data-testid="item-row"
+              data-item-id=${it.id}
+              @click=${() => this._emit('open-item', { itemId: it.id })}
+            >
+              <span class="grow">${it.name}</span>
+              <span class="qty">×${it.quantity}</span>
+              ${this._locationLabel(it) ? html`<span class="loc">${this._locationLabel(it)}</span>` : null}
+            </button>
+          </li>
+        `)}
+      </ul>
+    `;
+  }
+
+  render() {
+    if (!this.open) return null;
+    const drilled = this.selectedTag !== null;
+    return html`
+      <div class="backdrop" role="presentation" style="z-index: ${this._zBase ?? 9998};" @click=${this._onCancel}></div>
+      <div class="panel-wrap" role="none" style="z-index: ${(this._zBase ?? 9998) + 1};">
+        <div class="panel" role="dialog" aria-modal="true" aria-label="Tag browser" @keydown=${this._onKeydown}>
+          <div class="header">
+            ${drilled
+              ? html`<button class="back" data-testid="browser-back" @click=${this._onBack} aria-label="Back to tags">‹ Tags</button>`
+              : null}
+            <h2>${drilled ? `#${this.selectedTag}` : 'Browse by tag'}</h2>
+          </div>
+          ${drilled ? this._renderItemList() : this._renderTagList()}
+          <div class="actions">
+            <button data-testid="browser-close" @click=${this._onCancel}>Close</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hv-tag-browser': HVTagBrowser;
+  }
+}

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -9,6 +9,7 @@ import './components/hv-item-row';
 import './components/hv-item-dialog';
 import './components/hv-location-selector';
 import './components/hv-category-browser';
+import './components/hv-tag-browser';
 
 export class HAventoryCard extends LitElement {
   static styles = css`
@@ -84,6 +85,10 @@ export class HAventoryCard extends LitElement {
   private _browseCategory: string | null = null;
   private _browseItems: Item[] = [];
   private _browseLoading = false;
+  private _tagBrowserOpen = false;
+  private _browseTag: string | null = null;
+  private _browseTagItems: Item[] = [];
+  private _browseTagLoading = false;
 
   // Lovelace interface: called by HA when the card is created/configured
   public setConfig(cfg: unknown): void {
@@ -150,6 +155,7 @@ export class HAventoryCard extends LitElement {
             }
           }} aria-label="Add item" title="Add item">Add item</button>
           <button data-testid="browse-categories" @click=${() => this._openCategoryBrowser()} aria-label="Browse categories" title="Browse categories">Categories</button>
+          <button data-testid="browse-tags" @click=${() => this._openTagBrowser()} aria-label="Browse tags" title="Browse tags">Tags</button>
           <button data-testid="expand-toggle" @click=${() => this._toggleExpanded()} aria-expanded=${String(this.expanded)} aria-label=${this.expanded ? 'Collapse' : 'Expand'}>
             ${this.expanded ? '⤢ Collapse' : '⇱ Expand'}
           </button>
@@ -327,6 +333,18 @@ export class HAventoryCard extends LitElement {
         @cancel=${() => { this._categoryBrowserOpen = false; this._browseCategory = null; this._browseItems = []; this.requestUpdate(); }}
       ></hv-category-browser>
 
+      <hv-tag-browser
+        .open=${this._tagBrowserOpen}
+        .tags=${st?.distinctValuesCache?.tags ?? []}
+        .selectedTag=${this._browseTag}
+        .items=${this._browseTagItems}
+        .loading=${this._browseTagLoading}
+        @select-tag=${(e: CustomEvent) => { void this._openTag(e.detail.tag as string); }}
+        @clear-tag=${() => { this._browseTag = null; this._browseTagItems = []; this._browseTagLoading = false; this.requestUpdate(); }}
+        @open-item=${(e: CustomEvent) => this._openBrowseItem(e.detail.itemId as string)}
+        @cancel=${() => { this._tagBrowserOpen = false; this._browseTag = null; this._browseTagItems = []; this.requestUpdate(); }}
+      ></hv-tag-browser>
+
       ${this.expanded ? this._renderOverlayTemplate() : null}
     `;
   }
@@ -354,8 +372,31 @@ export class HAventoryCard extends LitElement {
     }
   }
 
+  private _openTagBrowser() {
+    this._tagBrowserOpen = true;
+    this._browseTag = null;
+    this._browseTagItems = [];
+    this._browseTagLoading = false;
+    this.requestUpdate();
+  }
+
+  private async _openTag(tag: string) {
+    this._browseTag = tag;
+    this._browseTagItems = [];
+    this._browseTagLoading = true;
+    this.requestUpdate();
+    try {
+      this._browseTagItems = (await this.store?.fetchItemsByTag(tag)) ?? [];
+    } catch {
+      this._browseTagItems = [];
+    } finally {
+      this._browseTagLoading = false;
+      this.requestUpdate();
+    }
+  }
+
   private _openBrowseItem(itemId: string) {
-    const item = this._browseItems.find((i) => i.id === itemId);
+    const item = [...this._browseItems, ...this._browseTagItems].find((i) => i.id === itemId);
     if (!item) return;
     const dialog = this.shadowRoot?.querySelector('hv-item-dialog') as
       (HTMLElement & { open: boolean; item: unknown }) | null;

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -430,4 +430,21 @@ describe('Store', () => {
     const books = await store.fetchItemsByCategory('Books');
     expect(books.map((i) => i.name)).toEqual(['Novel']);
   });
+
+  it('fetchItemsByTag returns only items carrying that tag', async () => {
+    const items = [
+      makeItem({ id: '1', name: 'Hammer', tags: ['red', 'metal'] }),
+      makeItem({ id: '2', name: 'Novel', tags: ['blue'] }),
+      makeItem({ id: '3', name: 'Wrench', tags: ['red'] }),
+    ];
+    const hass = makeMockHass({ items });
+    const store = new Store(hass);
+    await store.init();
+
+    const red = await store.fetchItemsByTag('red');
+    expect(red.map((i) => i.id).sort()).toEqual(['1', '3']);
+
+    const blue = await store.fetchItemsByTag('blue');
+    expect(blue.map((i) => i.name)).toEqual(['Novel']);
+  });
 });

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -244,6 +244,16 @@ export class Store {
     return res.items;
   }
 
+  /**
+   * Fetch items carrying a single tag, sorted by name. Used by the dedicated
+   * tag browser (drill-down). Returns a snapshot (first page, capped) independent
+   * of the main list's filters/pagination.
+   */
+  async fetchItemsByTag(tag: string): Promise<Item[]> {
+    const res = await this.ws.listItems({ tags_any: [tag] }, { field: 'name', order: 'asc' }, BROWSE_PAGE_LIMIT);
+    return res.items;
+  }
+
   async prefetchIfNeeded(scrollRatio: number) {
     if (scrollRatio < 0.7) return;
     if (!this.state.value.cursor) return;

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -23,7 +23,8 @@ haventory-card (main container)
 │   └── hv-item-row (individual item rows) × N
 ├── hv-item-dialog (add/edit modal)
 ├── hv-location-selector (location picker modal)
-└── hv-category-browser (browse-by-category modal)
+├── hv-category-browser (browse-by-category modal)
+└── hv-tag-browser (browse-by-tag modal)
 ```
 
 ---
@@ -256,6 +257,34 @@ card header ("Categories" button).
 
 **Keyboard**:
 - `Esc`: step back to the category list when drilled in; otherwise close
+
+---
+
+### `hv-tag-browser`
+
+**Purpose**: Dedicated modal for browsing items by tag, opened from the card
+header ("Tags" button). Mirrors `hv-category-browser`.
+
+**Properties**:
+- `open`: Boolean visibility
+- `tags`: `DistinctValue[]` (value + count) from `store.distinctValuesCache`
+- `selectedTag`: `string | null` — the drilled-in tag (null = list level)
+- `items`: `Item[]` — items carrying `selectedTag` (fetched by the container)
+- `loading`: Boolean — drill-down fetch in progress
+
+**Two levels**: a filterable list of all used tags with item counts, and a
+drill-down of the items carrying the selected tag (fetched via
+`store.fetchItemsByTag()`, a snapshot capped at 500).
+
+**Events**: `select-tag` `{tag}`, `clear-tag`, `open-item` `{itemId}`, `cancel`.
+
+**Keyboard**:
+- `Esc`: step back to the tag list when drilled in; otherwise close
+
+> The category and tag browsers are deliberately parallel components, matching
+> this codebase's per-component modal convention (see also `hv-item-dialog` /
+> `hv-location-selector`). A future refactor could unify them into one
+> value-browser parameterized by kind.
 
 ---
 


### PR DESCRIPTION
## Summary

WP3 feature #4. A dedicated **browse-by-tag** view, opened from the card header ("Tags" button). Mirrors the category browser (#83).

- **`hv-tag-browser`** — a modal with two levels:
  1. A **filterable list** of all used tags with item counts (from `haventory/distinct_values` via `store.distinctValuesCache`), with empty states for "no tags" and "no matches".
  2. A **drill-down** showing the items carrying the selected tag (name, quantity, location), with a "‹ Tags" back button.
  - Emits `select-tag` / `clear-tag` / `open-item` / `cancel`. `Esc` steps back from the drill-down, or closes at the top level.
- **`Store.fetchItemsByTag()`** — fetches a snapshot of the items carrying one tag via `item/list`'s case-insensitive `tags_any` filter (name-sorted, capped at 500).
- **Container** wires it up: header "Tags" button opens the browser; selecting a tag fetches its items; clicking a drill-down item opens the existing item dialog on top (the open-item handler now resolves against both browsers' item lists).

**Design note:** the category and tag browsers are deliberately parallel components, consistent with this codebase's per-component modal convention (`hv-item-dialog`, `hv-location-selector` also carry their own modal styling). A future refactor could unify them into one value-browser parameterized by kind — noted in `docs/frontend_architecture.md` under Follow-ups.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Frontend (`cards/haventory-card`): `npx eslint .` (clean), `npx vitest run` (**130 passed**), `npm run build` (OK). New tests: `hv-tag-browser.test.ts` (list + counts, filter, select, drill-down + back, open-item, loading/empty states, Esc behavior, backdrop) and `store.fetchItemsByTag`.
- [x] Backend: `uv run ruff check .` → green. No Python changed; `pytest`/`mypy` behavior is identical to `main` (native 3.14 gate runs in CI — the sandbox can't provision CPython 3.14 because the python-build-standalone download is blocked by egress policy).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs updated (`README.md`, `docs/frontend_architecture.md`).
- [x] WebSocket API changes keep `ws.py` + docs in sync — N/A, reuses existing `distinct_values` and `item/list`; no backend change.
- [x] Load-bearing invariants preserved — frontend-only, no backend behavior changed.

## Screenshots (card / UI changes)

Not captured in this environment (no running HA). The modal reuses the card's existing panel/theme styling.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_