### PR TITLE
feat(card): user-selectable list columns, persisted

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
   counts and drills down to the items filed under each.
 - Dedicated **tag browser** (header → "Tags"): lists used tags with item counts and drills
   down to the items carrying each.
+- **Column selection** (header → "Columns"): choose which optional columns (quantity,
+  category, location, tags, due date) show in the standard vs expanded view; the choice is
+  persisted in `localStorage` (`haventory:columns:v1`, per browser).
 
 ### 🚧 Phase 3: Polish & HACS (Planned)
 - HACS publication; release automation (release-please); additional optimizations.

--- a/cards/haventory-card/src/components/hv-column-picker.test.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './hv-column-picker';
+import type { ColumnKey } from '../store/columns';
+
+type Picker = HTMLElement & {
+  open: boolean;
+  columns: ColumnKey[];
+  heading: string;
+  updateComplete?: Promise<unknown>;
+};
+
+async function mount(props: Partial<Picker>): Promise<Picker> {
+  const el = document.createElement('hv-column-picker') as Picker;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await customElements.whenDefined('hv-column-picker');
+  el.open = true;
+  if (el.updateComplete) await el.updateComplete;
+  return el;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('hv-column-picker', () => {
+  it('reflects the current selection as checked boxes', async () => {
+    const el = await mount({ columns: ['quantity', 'location'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const boxes = Array.from(sr.querySelectorAll('[data-testid="column-option"]')) as HTMLInputElement[];
+    const checked = boxes.filter((b) => b.checked).map((b) => b.getAttribute('data-key'));
+    expect(checked).toEqual(['quantity', 'location']);
+  });
+
+  it('emits change with the added column (canonical order) when a box is checked', async () => {
+    const el = await mount({ columns: ['location'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let received: ColumnKey[] | null = null;
+    el.addEventListener('change', (e: any) => { received = e.detail.columns; });
+
+    const qty = sr.querySelector('[data-testid="column-option"][data-key="quantity"]') as HTMLInputElement;
+    qty.checked = true;
+    qty.dispatchEvent(new Event('change', { bubbles: true }));
+    // canonical order: quantity before location
+    expect(received).toEqual(['quantity', 'location']);
+  });
+
+  it('emits change removing a column when unchecked', async () => {
+    const el = await mount({ columns: ['quantity', 'category'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let received: ColumnKey[] | null = null;
+    el.addEventListener('change', (e: any) => { received = e.detail.columns; });
+
+    const cat = sr.querySelector('[data-testid="column-option"][data-key="category"]') as HTMLInputElement;
+    cat.checked = false;
+    cat.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(received).toEqual(['quantity']);
+  });
+
+  it('closes on Done and on Escape', async () => {
+    const el = await mount({ columns: [] });
+    const sr = el.shadowRoot as ShadowRoot;
+    let cancels = 0;
+    el.addEventListener('cancel', () => { cancels += 1; });
+    (sr.querySelector('[data-testid="column-picker-done"]') as HTMLButtonElement).click();
+    expect(cancels).toBe(1);
+    expect(el.open).toBe(false);
+  });
+});

--- a/cards/haventory-card/src/components/hv-column-picker.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.ts
@@ -1,0 +1,118 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { nextZBase } from '../utils/zindex';
+import type { ColumnKey } from '../store/columns';
+import { COLUMN_DEFS, normalizeColumns } from '../store/columns';
+
+/**
+ * Small modal to choose which optional columns show in a given view.
+ *
+ * Presentational: it reflects `columns` (the current selection) and emits a
+ * `change` event with the new selection whenever a column is toggled. The
+ * container owns persistence.
+ */
+@customElement('hv-column-picker')
+export class HVColumnPicker extends LitElement {
+  static styles = css`
+    :host { display: block; }
+    .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 9998; }
+    .panel-wrap { position: fixed; inset: 0; display: grid; place-items: center; z-index: 9999; }
+    .panel {
+      background: var(--card-background-color, var(--ha-card-background, #fff));
+      color: var(--primary-text-color, #212121);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 8px;
+      padding: 16px;
+      max-width: 320px;
+      width: calc(100vw - 32px);
+      box-sizing: border-box;
+      font: inherit;
+    }
+    h2 { font-size: 1.1em; margin: 0 0 8px; }
+    ul { list-style: none; margin: 0; padding: 0; }
+    li { margin: 0; }
+    label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 4px;
+      cursor: pointer;
+    }
+    input[type="checkbox"] { accent-color: var(--primary-color, #03a9f4); }
+    .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+    .actions button {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      border: none;
+      border-radius: 4px;
+      padding: 8px 16px;
+      cursor: pointer;
+      font: inherit;
+    }
+    .actions button:hover { opacity: 0.9; }
+  `;
+
+  @property({ type: Boolean, reflect: true }) open: boolean = false;
+  @property({ attribute: false }) columns: ColumnKey[] = [];
+  @property({ type: String }) heading: string = 'Columns';
+
+  @state() private _zBase: number | null = null;
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has('open') && this.open) {
+      this._zBase = nextZBase();
+    }
+  }
+
+  private _onCancel = () => {
+    this.dispatchEvent(new CustomEvent('cancel', { bubbles: true, composed: true }));
+    this.open = false;
+  };
+
+  private _toggle(key: ColumnKey, checked: boolean) {
+    const current = new Set(normalizeColumns(this.columns));
+    if (checked) current.add(key);
+    else current.delete(key);
+    const next = normalizeColumns([...current]);
+    this.dispatchEvent(new CustomEvent('change', { detail: { columns: next }, bubbles: true, composed: true }));
+  }
+
+  render() {
+    if (!this.open) return null;
+    const selected = new Set(normalizeColumns(this.columns));
+    return html`
+      <div class="backdrop" role="presentation" style="z-index: ${this._zBase ?? 9998};" @click=${this._onCancel}></div>
+      <div class="panel-wrap" role="none" style="z-index: ${(this._zBase ?? 9998) + 1};">
+        <div class="panel" role="dialog" aria-modal="true" aria-label="Column selection"
+          @keydown=${(e: KeyboardEvent) => { if (e.key === 'Escape') { e.preventDefault(); this._onCancel(); } }}>
+          <h2>${this.heading}</h2>
+          <ul data-testid="column-options">
+            ${COLUMN_DEFS.map((c) => html`
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    data-testid="column-option"
+                    data-key=${c.key}
+                    .checked=${selected.has(c.key)}
+                    @change=${(e: Event) => this._toggle(c.key, (e.target as HTMLInputElement).checked)}
+                  />
+                  <span>${c.label}</span>
+                </label>
+              </li>
+            `)}
+          </ul>
+          <div class="actions">
+            <button data-testid="column-picker-done" @click=${this._onCancel}>Done</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hv-column-picker': HVColumnPicker;
+  }
+}

--- a/cards/haventory-card/src/components/hv-inventory-list.ts
+++ b/cards/haventory-card/src/components/hv-inventory-list.ts
@@ -2,26 +2,14 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import type { Item } from '../store/types';
+import type { ColumnKey } from '../store/columns';
+import { COLUMN_DEFS, DEFAULT_COLUMN_PREFS, gridTemplateFor, normalizeColumns } from '../store/columns';
 
 @customElement('hv-inventory-list')
 export class HVInventoryList extends LitElement {
   static styles = css`
     :host {
       display: block;
-      /* Define grid columns as CSS custom property for header/row alignment */
-      /* Full mode: Name, Qty, Category, Location, Actions (4 buttons ~160px) */
-      --hv-col-name: minmax(120px, 2fr);
-      --hv-col-qty: 50px;
-      --hv-col-category: minmax(80px, 1fr);
-      --hv-col-location: minmax(100px, 2fr);
-      --hv-col-actions: 160px;
-      --hv-grid-columns: var(--hv-col-name) var(--hv-col-qty) var(--hv-col-category) var(--hv-col-location) var(--hv-col-actions);
-      /* Compact mode: Name (flex), Qty (fixed), Actions (3 buttons ~120px) */
-      --hv-col-actions-compact: 120px;
-      --hv-grid-columns-compact: 1fr 50px var(--hv-col-actions-compact);
-    }
-    :host([compact]) {
-      --hv-grid-columns: var(--hv-grid-columns-compact);
     }
     /* Fill mode: stretch to fill parent container (expanded view) */
     :host([fill]) {
@@ -32,7 +20,6 @@ export class HVInventoryList extends LitElement {
     }
     .header {
       display: grid;
-      grid-template-columns: var(--hv-grid-columns);
       gap: 8px;
       align-items: center;
       font-weight: 600;
@@ -41,9 +28,6 @@ export class HVInventoryList extends LitElement {
       flex-shrink: 0;
       box-sizing: border-box;
     }
-    .header .hide-compact { display: block; }
-    :host([compact]) .header .hide-compact { display: none; }
-
     .empty-state { padding: 32px 16px; text-align: center; color: #666; }
     .empty-state p { margin: 8px 0; }
     .empty-state .hint { font-size: 0.9em; opacity: 0.8; }
@@ -73,6 +57,8 @@ export class HVInventoryList extends LitElement {
   @property({ attribute: false }) locations: Array<{ id: string; area_id: string | null }> = [];
   @property({ type: Boolean, reflect: true }) compact: boolean = false;
   @property({ type: Boolean, reflect: true }) fill: boolean = false;
+  /** Optional middle columns to display (Name + Actions are always shown). */
+  @property({ attribute: false }) columns: ColumnKey[] = [...DEFAULT_COLUMN_PREFS.expanded];
 
   private onRowEvent(type: string, e: CustomEvent) {
     e.stopPropagation();
@@ -93,6 +79,7 @@ export class HVInventoryList extends LitElement {
         .item=${it}
         .areas=${this.areas}
         .locations=${this.locations}
+        .columns=${this._cols()}
         ?compact=${this.compact}
         @decrement=${(e: CustomEvent) => this.onRowEvent('decrement', e)}
         @increment=${(e: CustomEvent) => this.onRowEvent('increment', e)}
@@ -102,13 +89,18 @@ export class HVInventoryList extends LitElement {
     `;
   }
 
+  private _cols(): ColumnKey[] {
+    return normalizeColumns(this.columns);
+  }
+
   private renderHeader() {
+    const cols = this._cols();
+    const template = gridTemplateFor(cols, { compact: this.compact });
+    const labelFor = (k: ColumnKey) => COLUMN_DEFS.find((c) => c.key === k)?.label ?? k;
     return html`
-      <div class="header" role="row">
+      <div class="header" role="row" style="grid-template-columns: ${template};">
         <div role="columnheader">Name</div>
-        <div role="columnheader">Qty</div>
-        <div role="columnheader" class="hide-compact">Category</div>
-        <div role="columnheader" class="hide-compact">Location</div>
+        ${cols.map((k) => html`<div role="columnheader">${labelFor(k)}</div>`)}
         <div role="columnheader" aria-hidden="true"></div>
       </div>
     `;

--- a/cards/haventory-card/src/components/hv-item-row.columns.test.ts
+++ b/cards/haventory-card/src/components/hv-item-row.columns.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './hv-item-row';
+import './hv-inventory-list';
+import type { Item } from '../store/types';
+import type { ColumnKey } from '../store/columns';
+
+function makeItem(overrides?: Partial<Item>): Item {
+  const now = new Date().toISOString();
+  return {
+    id: '1', name: 'Drill', description: null, quantity: 4, checked_out: false,
+    due_date: '2026-08-01', inspection_date: null, location_id: 'loc1',
+    tags: ['power', 'metal'], category: 'Tools', low_stock_threshold: null,
+    custom_fields: {}, created_at: now, updated_at: now, version: 1,
+    location_path: { id_path: ['g'], name_path: ['Garage'], display_path: 'Garage', sort_key: 'garage' },
+    ...overrides,
+  };
+}
+
+async function mountRow(columns: ColumnKey[], compact = false) {
+  const el = document.createElement('hv-item-row') as HTMLElement & { updateComplete?: Promise<unknown> };
+  (el as any).item = makeItem();
+  (el as any).columns = columns;
+  (el as any).compact = compact;
+  document.body.appendChild(el);
+  await customElements.whenDefined('hv-item-row');
+  if (el.updateComplete) await el.updateComplete;
+  return el;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('hv-item-row configurable columns', () => {
+  it('renders only the selected columns', async () => {
+    const el = await mountRow(['quantity', 'tags']);
+    const sr = el.shadowRoot as ShadowRoot;
+    const text = sr.textContent || '';
+    expect(text).toContain('4');            // quantity
+    expect(text).toContain('power, metal'); // tags
+    expect(text).not.toContain('Tools');    // category not selected
+    expect(text).not.toContain('Garage');   // location not selected
+  });
+
+  it('renders the due date column when selected', async () => {
+    const el = await mountRow(['due_date']);
+    const sr = el.shadowRoot as ShadowRoot;
+    expect(sr.textContent || '').toContain('2026-08-01');
+  });
+
+  it('compact mode omits the check-out button; full mode includes it', async () => {
+    const compact = await mountRow(['quantity'], true);
+    const compactBtns = Array.from((compact.shadowRoot as ShadowRoot).querySelectorAll('button')).map((b) => b.textContent);
+    expect(compactBtns).not.toContain('Out');
+
+    const full = await mountRow(['quantity'], false);
+    const fullBtns = Array.from((full.shadowRoot as ShadowRoot).querySelectorAll('button')).map((b) => b.textContent?.trim());
+    expect(fullBtns).toContain('Out');
+  });
+});
+
+describe('hv-inventory-list configurable columns', () => {
+  it('renders headers for the selected columns only', async () => {
+    const el = document.createElement('hv-inventory-list') as HTMLElement & { updateComplete?: Promise<unknown> };
+    (el as any).items = [makeItem()];
+    (el as any).columns = ['quantity', 'due_date'];
+    document.body.appendChild(el);
+    await customElements.whenDefined('hv-inventory-list');
+    if (el.updateComplete) await el.updateComplete;
+
+    const headers = Array.from((el.shadowRoot as ShadowRoot).querySelectorAll('[role="columnheader"]'))
+      .map((h) => h.textContent?.trim())
+      .filter((t) => t);
+    expect(headers).toEqual(['Name', 'Qty', 'Due']);
+  });
+});

--- a/cards/haventory-card/src/components/hv-item-row.ts
+++ b/cards/haventory-card/src/components/hv-item-row.ts
@@ -1,6 +1,8 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { Item } from '../store/types';
+import type { ColumnKey } from '../store/columns';
+import { DEFAULT_COLUMN_PREFS, gridTemplateFor, normalizeColumns } from '../store/columns';
 
 @customElement('hv-item-row')
 export class HVItemRow extends LitElement {
@@ -13,8 +15,6 @@ export class HVItemRow extends LitElement {
     }
     .row {
       display: grid;
-      /* Use inherited grid columns from hv-inventory-list for alignment */
-      grid-template-columns: var(--hv-grid-columns, minmax(120px, 2fr) 50px minmax(80px, 1fr) minmax(100px, 2fr) 160px);
       gap: 8px;
       align-items: center;
       padding: 6px 8px;
@@ -52,6 +52,8 @@ export class HVItemRow extends LitElement {
   @property({ attribute: false }) areas: { id: string; name: string }[] = [];
   @property({ attribute: false }) locations: Array<{ id: string; area_id: string | null }> = [];
   @property({ type: Boolean }) compact: boolean = false;
+  /** Which optional middle columns to render (Name + Actions are always shown). */
+  @property({ attribute: false }) columns: ColumnKey[] = [...DEFAULT_COLUMN_PREFS.expanded];
 
   private resolveAreaName(): string | null {
     // First try item's effective_area_id (inherited from location hierarchy)
@@ -120,49 +122,57 @@ export class HVItemRow extends LitElement {
     return typeof thr === 'number' && this.item.quantity <= thr;
   }
 
+  private renderCell(key: ColumnKey) {
+    const item = this.item;
+    switch (key) {
+      case 'quantity':
+        return html`<div role="cell">${item.quantity}</div>`;
+      case 'category':
+        return html`<div role="cell" class="cell-text" title=${item.category ?? ''}>${item.category ?? ''}</div>`;
+      case 'location': {
+        const path = this.getFullLocationPath();
+        return html`<div role="cell" class="cell-text" title=${path}>${path}</div>`;
+      }
+      case 'tags': {
+        const tags = (item.tags ?? []).join(', ');
+        return html`<div role="cell" class="cell-text" title=${tags}>${tags}</div>`;
+      }
+      case 'due_date':
+        return html`<div role="cell" class="cell-text">${item.due_date ?? ''}</div>`;
+    }
+  }
+
   render() {
     const item = this.item;
+    const cols = normalizeColumns(this.columns);
     const areaName = this.compact ? null : this.resolveAreaName();
+    const template = gridTemplateFor(cols, { compact: this.compact });
 
-    // Compact mode: Name, Qty, and essential buttons only
-    if (this.compact) {
-      return html`
-        <div class="row" role="row" tabindex="0" @keydown=${this.onKeyDown} aria-label=${`Item ${item.name}`}>
-        <div class="name" role="cell">
-          <span>${item.name}</span>
-          ${this.isLow ? html`<span class="badge" aria-label="Low stock">LOW</span>` : null}
-        </div>
-          <div role="cell">${item.quantity}</div>
-          <div class="actions" role="cell">
-            <button @click=${this.onDecrement} aria-label="Decrease quantity">−</button>
-            <button @click=${this.onIncrement} aria-label="Increase quantity">+</button>
-            <button @click=${this.onEdit} aria-label="Edit item">Edit</button>
-          </div>
-        </div>
-      `;
-    }
-
-    // Full mode: All columns and buttons
     return html`
-      <div class="row" role="row" tabindex="0" @keydown=${this.onKeyDown} aria-label=${`Item ${item.name}`}>
+      <div
+        class="row"
+        role="row"
+        tabindex="0"
+        style="grid-template-columns: ${template};"
+        @keydown=${this.onKeyDown}
+        aria-label=${`Item ${item.name}`}
+      >
         <div class="name" role="cell">
           <span>${item.name}</span>
           ${this.isLow ? html`<span class="badge" aria-label="Low stock">LOW</span>` : null}
           ${areaName ? html`<span class="area">[${areaName}]</span>` : null}
         </div>
-        <div role="cell">${item.quantity}</div>
-        <div role="cell" class="cell-text" title=${item.category ?? ''}>${item.category ?? ''}</div>
-        <div role="cell" class="cell-text" title=${this.getFullLocationPath()}>${this.getFullLocationPath()}</div>
+        ${cols.map((k) => this.renderCell(k))}
         <div class="actions" role="cell">
           <button @click=${this.onDecrement} aria-label="Decrease quantity">−</button>
           <button @click=${this.onIncrement} aria-label="Increase quantity">+</button>
-          <button
-            class=${`btn-checkout${item.checked_out ? ' btn-danger' : ''}`}
-            @click=${this.onToggleCheckout}
-            aria-label="Toggle check out/in"
-          >
-            ${item.checked_out ? 'In' : 'Out'}
-          </button>
+          ${this.compact
+            ? null
+            : html`<button
+                class=${`btn-checkout${item.checked_out ? ' btn-danger' : ''}`}
+                @click=${this.onToggleCheckout}
+                aria-label="Toggle check out/in"
+              >${item.checked_out ? 'In' : 'Out'}</button>`}
           <button @click=${this.onEdit} aria-label="Edit item">Edit</button>
         </div>
       </div>

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -3,6 +3,8 @@ import type { HassLike, Item } from './store/types';
 import type { HVLocationSelector } from './components/hv-location-selector';
 import { getDefaultOrderFor } from './store/sort';
 import { Store } from './store/store';
+import type { ColumnKey, ColumnPrefs } from './store/columns';
+import { loadColumnPrefs, saveColumnPrefs } from './store/columns';
 import './components/hv-search-bar';
 import './components/hv-inventory-list';
 import './components/hv-item-row';
@@ -10,6 +12,7 @@ import './components/hv-item-dialog';
 import './components/hv-location-selector';
 import './components/hv-category-browser';
 import './components/hv-tag-browser';
+import './components/hv-column-picker';
 
 export class HAventoryCard extends LitElement {
   static styles = css`
@@ -89,6 +92,9 @@ export class HAventoryCard extends LitElement {
   private _browseTag: string | null = null;
   private _browseTagItems: Item[] = [];
   private _browseTagLoading = false;
+  private _columnPrefs: ColumnPrefs = loadColumnPrefs();
+  private _columnPickerOpen = false;
+  private _columnPickerScope: 'standard' | 'expanded' = 'standard';
 
   // Lovelace interface: called by HA when the card is created/configured
   public setConfig(cfg: unknown): void {
@@ -156,6 +162,7 @@ export class HAventoryCard extends LitElement {
           }} aria-label="Add item" title="Add item">Add item</button>
           <button data-testid="browse-categories" @click=${() => this._openCategoryBrowser()} aria-label="Browse categories" title="Browse categories">Categories</button>
           <button data-testid="browse-tags" @click=${() => this._openTagBrowser()} aria-label="Browse tags" title="Browse tags">Tags</button>
+          <button data-testid="columns-standard" @click=${() => this._openColumnPicker('standard')} aria-label="Choose columns" title="Choose columns">Columns</button>
           <button data-testid="expand-toggle" @click=${() => this._toggleExpanded()} aria-expanded=${String(this.expanded)} aria-label=${this.expanded ? 'Collapse' : 'Expand'}>
             ${this.expanded ? '⤢ Collapse' : '⇱ Expand'}
           </button>
@@ -182,6 +189,7 @@ export class HAventoryCard extends LitElement {
           .items=${st?.items ?? []}
           .areas=${st?.areasCache?.areas ?? []}
           .locations=${st?.locationsFlatCache ?? []}
+          .columns=${this._columnPrefs.standard}
           @near-end=${(e: CustomEvent) => {
             const ratio = e.detail?.ratio ?? 0;
             void this.store?.prefetchIfNeeded(ratio);
@@ -345,8 +353,28 @@ export class HAventoryCard extends LitElement {
         @cancel=${() => { this._tagBrowserOpen = false; this._browseTag = null; this._browseTagItems = []; this.requestUpdate(); }}
       ></hv-tag-browser>
 
+      <hv-column-picker
+        .open=${this._columnPickerOpen}
+        .columns=${this._columnPrefs[this._columnPickerScope]}
+        .heading=${this._columnPickerScope === 'standard' ? 'Standard view columns' : 'Expanded view columns'}
+        @change=${(e: CustomEvent) => this._setColumns(this._columnPickerScope, e.detail.columns as ColumnKey[])}
+        @cancel=${() => { this._columnPickerOpen = false; this.requestUpdate(); }}
+      ></hv-column-picker>
+
       ${this.expanded ? this._renderOverlayTemplate() : null}
     `;
+  }
+
+  private _openColumnPicker(scope: 'standard' | 'expanded') {
+    this._columnPickerScope = scope;
+    this._columnPickerOpen = true;
+    this.requestUpdate();
+  }
+
+  private _setColumns(scope: 'standard' | 'expanded', columns: ColumnKey[]) {
+    this._columnPrefs = { ...this._columnPrefs, [scope]: columns };
+    saveColumnPrefs(this._columnPrefs);
+    this.requestUpdate();
   }
 
   private _openCategoryBrowser() {
@@ -527,6 +555,7 @@ export class HAventoryCard extends LitElement {
                 this.requestUpdate();
               }}
             >Add location</button>
+            <button class="btn-add" data-testid="columns-expanded" @click=${() => this._openColumnPicker('expanded')} aria-label="Choose columns">Columns</button>
             <button data-testid="expand-toggle" @click=${this._onOverlayCollapseClick} aria-label="Collapse">⤢ Collapse</button>
           </div>
         </div>
@@ -629,6 +658,7 @@ export class HAventoryCard extends LitElement {
                   .items=${st?.items ?? []}
                   .areas=${st?.areasCache?.areas ?? []}
                   .locations=${st?.locationsFlatCache ?? []}
+                  .columns=${this._columnPrefs.expanded}
                   @near-end=${(e: CustomEvent) => { const ratio = e.detail?.ratio ?? 0; void this.store?.prefetchIfNeeded(ratio); }}
                   @decrement=${(e: CustomEvent) => this.store?.adjustQuantity(e.detail.itemId, -1)}
                   @increment=${(e: CustomEvent) => this.store?.adjustQuantity(e.detail.itemId, +1)}

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  COLUMN_PREFS_STORAGE_KEY,
+  DEFAULT_COLUMN_PREFS,
+  gridTemplateFor,
+  loadColumnPrefs,
+  normalizeColumns,
+  saveColumnPrefs,
+} from './columns';
+
+describe('columns model', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('normalizes to canonical order, dedupes, and drops unknown keys', () => {
+    expect(normalizeColumns(['location', 'quantity', 'quantity', 'bogus', 'tags']))
+      .toEqual(['quantity', 'location', 'tags']);
+    expect(normalizeColumns('nope')).toEqual([]);
+    expect(normalizeColumns(undefined)).toEqual([]);
+  });
+
+  it('builds a grid template with name + columns + actions', () => {
+    expect(gridTemplateFor(['quantity'], { compact: true }))
+      .toBe('minmax(120px, 2fr) 50px 120px');
+    expect(gridTemplateFor(['quantity', 'category', 'location'], { compact: false }))
+      .toBe('minmax(120px, 2fr) 50px minmax(80px, 1fr) minmax(100px, 2fr) 160px');
+  });
+
+  it('returns defaults when nothing is stored', () => {
+    expect(loadColumnPrefs()).toEqual(DEFAULT_COLUMN_PREFS);
+  });
+
+  it('round-trips saved preferences (normalized)', () => {
+    saveColumnPrefs({ standard: ['category', 'quantity'], expanded: ['tags', 'due_date'] });
+    expect(loadColumnPrefs()).toEqual({
+      standard: ['quantity', 'category'],
+      expanded: ['tags', 'due_date'],
+    });
+  });
+
+  it('falls back to defaults on corrupt stored JSON', () => {
+    localStorage.setItem(COLUMN_PREFS_STORAGE_KEY, '{not valid json');
+    expect(loadColumnPrefs()).toEqual(DEFAULT_COLUMN_PREFS);
+  });
+
+  it('fills a missing view from defaults and sanitizes unknown keys', () => {
+    localStorage.setItem(
+      COLUMN_PREFS_STORAGE_KEY,
+      JSON.stringify({ standard: ['bogus', 'tags'] }),
+    );
+    const prefs = loadColumnPrefs();
+    expect(prefs.standard).toEqual(['tags']);
+    expect(prefs.expanded).toEqual(DEFAULT_COLUMN_PREFS.expanded);
+  });
+});

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -1,0 +1,101 @@
+/**
+ * Configurable inventory-list columns.
+ *
+ * The Name column and the trailing Actions column are always shown; the columns
+ * defined here are the optional, user-selectable middle columns. Users pick a
+ * set for the standard (card) view and a separate set for the expanded view;
+ * the choice is persisted in localStorage (per browser).
+ */
+
+export type ColumnKey = 'quantity' | 'category' | 'location' | 'tags' | 'due_date';
+
+export interface ColumnDef {
+  key: ColumnKey;
+  label: string;
+  /** grid-template-columns sizing for this column. */
+  size: string;
+}
+
+/** Canonical column order. Selections are normalized to this order. */
+export const COLUMN_DEFS: readonly ColumnDef[] = [
+  { key: 'quantity', label: 'Qty', size: '50px' },
+  { key: 'category', label: 'Category', size: 'minmax(80px, 1fr)' },
+  { key: 'location', label: 'Location', size: 'minmax(100px, 2fr)' },
+  { key: 'tags', label: 'Tags', size: 'minmax(80px, 1fr)' },
+  { key: 'due_date', label: 'Due', size: '110px' },
+];
+
+const COLUMN_ORDER: ColumnKey[] = COLUMN_DEFS.map((c) => c.key);
+const COLUMN_SIZE: Record<ColumnKey, string> = Object.fromEntries(
+  COLUMN_DEFS.map((c) => [c.key, c.size]),
+) as Record<ColumnKey, string>;
+
+export interface ColumnPrefs {
+  standard: ColumnKey[];
+  expanded: ColumnKey[];
+}
+
+/** Defaults mirror the pre-column-selection layout. */
+export const DEFAULT_COLUMN_PREFS: ColumnPrefs = {
+  standard: ['quantity'],
+  expanded: ['quantity', 'category', 'location'],
+};
+
+export const COLUMN_PREFS_STORAGE_KEY = 'haventory:columns:v1';
+
+/** Filter to known keys, dedupe, and enforce the canonical order. */
+export function normalizeColumns(keys: unknown): ColumnKey[] {
+  if (!Array.isArray(keys)) return [];
+  const wanted = new Set(keys.filter((k): k is ColumnKey => COLUMN_ORDER.includes(k as ColumnKey)));
+  return COLUMN_ORDER.filter((k) => wanted.has(k));
+}
+
+/** Build a grid-template-columns value: name + selected columns + actions. */
+export function gridTemplateFor(columns: ColumnKey[], opts: { compact: boolean }): string {
+  const nameCol = 'minmax(120px, 2fr)';
+  const actionsCol = opts.compact ? '120px' : '160px';
+  const middle = normalizeColumns(columns).map((k) => COLUMN_SIZE[k]);
+  return [nameCol, ...middle, actionsCol].join(' ');
+}
+
+function safeLocalStorage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    // Access to localStorage can throw (e.g. disabled cookies / sandboxed iframe).
+    return null;
+  }
+}
+
+/** Load persisted column preferences, falling back to defaults on any problem. */
+export function loadColumnPrefs(): ColumnPrefs {
+  const store = safeLocalStorage();
+  if (!store) return { ...DEFAULT_COLUMN_PREFS };
+  try {
+    const raw = store.getItem(COLUMN_PREFS_STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_COLUMN_PREFS };
+    const parsed = JSON.parse(raw) as Partial<ColumnPrefs>;
+    return {
+      standard: 'standard' in parsed ? normalizeColumns(parsed.standard) : [...DEFAULT_COLUMN_PREFS.standard],
+      expanded: 'expanded' in parsed ? normalizeColumns(parsed.expanded) : [...DEFAULT_COLUMN_PREFS.expanded],
+    };
+  } catch {
+    return { ...DEFAULT_COLUMN_PREFS };
+  }
+}
+
+/** Persist column preferences (best-effort; ignores storage failures). */
+export function saveColumnPrefs(prefs: ColumnPrefs): void {
+  const store = safeLocalStorage();
+  if (!store) return;
+  try {
+    const normalized: ColumnPrefs = {
+      standard: normalizeColumns(prefs.standard),
+      expanded: normalizeColumns(prefs.expanded),
+    };
+    store.setItem(COLUMN_PREFS_STORAGE_KEY, JSON.stringify(normalized));
+  } catch {
+    // Best-effort; ignore quota/serialization errors.
+  }
+}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -24,7 +24,8 @@ haventory-card (main container)
 ├── hv-item-dialog (add/edit modal)
 ├── hv-location-selector (location picker modal)
 ├── hv-category-browser (browse-by-category modal)
-└── hv-tag-browser (browse-by-tag modal)
+├── hv-tag-browser (browse-by-tag modal)
+└── hv-column-picker (column-selection modal)
 ```
 
 ---
@@ -93,12 +94,16 @@ haventory-card (main container)
 - `items`: Array of items to display
 - `areas`: Passed through to rows
 - `locations`: Passed through to rows
+- `columns`: `ColumnKey[]` — the optional middle columns to show (Name and
+  Actions are always present). Passed through to rows; also drives the header
+  and the shared grid template (`gridTemplateFor`).
 
 **Features**:
 - Uses `@lit-labs/virtualizer` with `lit-virtualizer` element
 - Fixed height: 420px with overflow scroll
 - Renders only visible rows + buffer
-- Header row with column labels (Name, Qty, Category, Location path, Actions)
+- Header row with column labels; the middle columns are user-selectable (see
+  `hv-column-picker` and Column preferences below)
 
 **Events**:
 - `near-end`: Emitted on scroll with `{ratio}` (triggers prefetch at ~70%)
@@ -285,6 +290,45 @@ drill-down of the items carrying the selected tag (fetched via
 > this codebase's per-component modal convention (see also `hv-item-dialog` /
 > `hv-location-selector`). A future refactor could unify them into one
 > value-browser parameterized by kind.
+
+---
+
+### `hv-column-picker`
+
+**Purpose**: Small modal to choose which optional columns are shown, opened from
+the "Columns" button in the card header (standard view) and in the expanded
+overlay header (expanded view).
+
+**Properties**:
+- `open`: Boolean visibility
+- `columns`: `ColumnKey[]` — the current selection for the scope being edited
+- `heading`: label (e.g. "Standard view columns" / "Expanded view columns")
+
+**Events**:
+- `change`: `{columns}` — emitted on every toggle with the new, canonically
+  ordered selection (the container persists it)
+- `cancel`: close the picker
+
+---
+
+## Column preferences (`store/columns.ts`)
+
+The optional middle columns are `quantity`, `category`, `location`, `tags`,
+`due_date` (Name and Actions are always shown). Users pick an independent set
+for the **standard** (card) view and the **expanded** view.
+
+- `COLUMN_DEFS` — canonical order + labels + grid sizing.
+- `normalizeColumns()` — filter to known keys, dedupe, enforce canonical order.
+- `gridTemplateFor(columns, {compact})` — the shared `grid-template-columns`
+  value (name + selected columns + actions) used by both the list header and the
+  rows so they stay aligned.
+- `DEFAULT_COLUMN_PREFS` — `{ standard: ['quantity'], expanded: ['quantity',
+  'category', 'location'] }`, mirroring the pre-feature layout.
+
+**Persistence**: choices are stored in **`localStorage`** under
+`haventory:columns:v1` (per browser). This was chosen over card config so users
+can change columns live without editing the dashboard YAML; loads/saves are
+best-effort and fall back to defaults if storage is unavailable or corrupt.
 
 ---
 


### PR DESCRIPTION
## Summary

WP3 feature #5. Lets users choose which optional columns show in the **standard** (card) view vs the **expanded** view, persisted across sessions.

- **`store/columns.ts`** — a small columns model:
  - Optional columns: `quantity`, `category`, `location`, `tags`, `due_date` (Name and Actions are always shown).
  - `normalizeColumns()` (filter unknown keys, dedupe, canonical order), `gridTemplateFor()` (the single source of truth for the `grid-template-columns` used by both the header and the rows, so they stay aligned), `DEFAULT_COLUMN_PREFS` mirroring the previous layout.
  - **Persistence in `localStorage`** under `haventory:columns:v1` — `loadColumnPrefs()` / `saveColumnPrefs()`, best-effort with fallback to defaults on missing/corrupt data or unavailable storage.
- **`hv-item-row` / `hv-inventory-list`** now render a dynamic column set + matching grid template. Defaults preserve the exact prior layout (standard = qty; expanded = qty/category/location), so all existing row/list tests pass unchanged.
- **`hv-column-picker`** — a modal with a checkbox per column; emits `change` with the new canonical selection.
- **Container** — a "Columns" button in the standard header and in the expanded overlay header opens the picker scoped to that view; the choice is saved and applied live.

**Persistence choice:** `localStorage` over card config, so users can change columns live without editing dashboard YAML (documented in `docs/frontend_architecture.md` and README).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Frontend (`cards/haventory-card`): `npx eslint .` (clean), `npx vitest run` (**144 passed**), `npm run build` (OK). New tests: `store/columns.test.ts` (normalize, grid template, load/save round-trip, corrupt-JSON + unknown-key + missing-view fallbacks), `hv-column-picker.test.ts` (reflects selection, add/remove emits canonical `change`, Done closes), and `hv-item-row.columns.test.ts` (renders only selected columns, due-date column, compact vs full action set, list header reflects columns). Existing row/list tests pass unchanged (defaults preserve prior layout).
- [x] Backend: `uv run ruff check .` → green. No Python changed; `pytest`/`mypy` behavior is identical to `main` (native 3.14 gate runs in CI — the sandbox can't provision CPython 3.14 because the python-build-standalone download is blocked by egress policy).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs updated (`README.md`, `docs/frontend_architecture.md`).
- [x] WebSocket API changes keep `ws.py` + docs in sync — N/A, frontend-only; no backend change.
- [x] Load-bearing invariants preserved — frontend-only, no backend behavior changed.

## Screenshots (card / UI changes)

Not captured in this environment (no running HA). The picker reuses the card's existing modal/theme styling; column layout uses the same grid sizing as before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_