### PR TITLE
feat: custom-fields UI in the item dialog + distinct field keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
 - Full CRUD for Items and Locations via WebSocket; optimistic concurrency with versioning;
   Areas integration; real-time subscriptions (items, locations, stats); documented persistence.
 - `haventory/distinct_values` returns distinct categories and tags with usage counts
-  (categories grouped case-insensitively) — powers category/tag autocomplete and browser views.
+  (categories grouped case-insensitively) plus distinct custom-field keys — powers
+  category/tag autocomplete, the browser views, and custom-field key suggestions.
 
 ### ✅ Phase 2: Frontend Lovelace Card (Complete)
 - Lit 3 + TypeScript components (`haventory-card`, `hv-search-bar`, `hv-inventory-list`,
@@ -233,6 +234,9 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
 - **Column selection** (header → "Columns"): choose which optional columns (quantity,
   category, location, tags, due date) show in the standard vs expanded view; the choice is
   persisted in `localStorage` (`haventory:columns:v1`, per browser).
+- **Custom fields UI** in the item dialog: define/edit/remove typed fields
+  (string/number/boolean/date) with type-appropriate inputs; existing field keys across the
+  dataset are offered as suggestions.
 
 ### 🚧 Phase 3: Polish & HACS (Planned)
 - HACS publication; release automation (release-please); additional optimizations.

--- a/cards/haventory-card/src/components/hv-item-dialog.custom-fields.test.ts
+++ b/cards/haventory-card/src/components/hv-item-dialog.custom-fields.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './hv-item-dialog';
+import type { Item } from '../store/types';
+
+type Dialog = HTMLElement & {
+  open: boolean;
+  item: Item | null;
+  customFieldKeys: string[];
+  updateComplete?: Promise<unknown>;
+};
+
+function makeItem(custom_fields: Record<string, string | number | boolean>): Item {
+  return {
+    id: '1', name: 'Thing', description: null, quantity: 1, checked_out: false,
+    due_date: null, inspection_date: null, location_id: null, tags: [], category: null,
+    low_stock_threshold: null, custom_fields, created_at: '', updated_at: '', version: 1,
+    location_path: { id_path: [], name_path: [], display_path: '', sort_key: '' },
+  };
+}
+
+async function mount(props: Partial<Dialog>): Promise<Dialog> {
+  const el = document.createElement('hv-item-dialog') as Dialog;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await customElements.whenDefined('hv-item-dialog');
+  el.open = true;
+  if (el.updateComplete) await el.updateComplete;
+  return el;
+}
+
+function setName(sr: ShadowRoot, name: string) {
+  const nameInput = sr.querySelector('input[type="text"]') as HTMLInputElement;
+  nameInput.value = name;
+  nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function addField(el: Dialog) {
+  const sr = el.shadowRoot as ShadowRoot;
+  (sr.querySelector('[data-testid="cf-add"]') as HTMLButtonElement).click();
+  if (el.updateComplete) await el.updateComplete;
+}
+
+function rows(sr: ShadowRoot): HTMLElement[] {
+  return Array.from(sr.querySelectorAll('[data-testid="cf-row"]'));
+}
+
+async function fillRow(el: Dialog, row: HTMLElement, key: string, type: string, value: string) {
+  const keyInput = row.querySelector('[data-testid="cf-key"]') as HTMLInputElement;
+  keyInput.value = key;
+  keyInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+  const typeSel = row.querySelector('[data-testid="cf-type"]') as HTMLSelectElement;
+  typeSel.value = type;
+  typeSel.dispatchEvent(new Event('change', { bubbles: true }));
+  if (el.updateComplete) await el.updateComplete;
+
+  // Re-query the row (value input type may have changed after the type switch).
+  const freshRow = rows(el.shadowRoot as ShadowRoot).find(
+    (r) => (r.querySelector('[data-testid="cf-key"]') as HTMLInputElement).value === key,
+  ) as HTMLElement;
+  const valInput = freshRow.querySelector('[data-testid="cf-value"]') as HTMLInputElement;
+  if (type === 'boolean') {
+    valInput.checked = value === 'true';
+    valInput.dispatchEvent(new Event('change', { bubbles: true }));
+  } else {
+    valInput.value = value;
+    valInput.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  if (el.updateComplete) await el.updateComplete;
+}
+
+function save(sr: ShadowRoot) {
+  (sr.querySelector('button[aria-label="Save item"]') as HTMLButtonElement).click();
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('hv-item-dialog custom fields', () => {
+  it('adds a typed custom field on create', async () => {
+    const el = await mount({});
+    const sr = el.shadowRoot as ShadowRoot;
+    setName(sr, 'Gadget');
+
+    await addField(el);
+    await fillRow(el, rows(sr)[0], 'color', 'string', 'red');
+
+    let detail: any = null;
+    el.addEventListener('save', (e: any) => { detail = e.detail; });
+    save(sr);
+
+    expect(detail.custom_fields).toEqual({ color: 'red' });
+    // Create path: no *_set / *_unset keys.
+    expect('custom_fields_set' in detail).toBe(false);
+  });
+
+  it('stores number, boolean, and date fields with correct types', async () => {
+    const el = await mount({});
+    const sr = el.shadowRoot as ShadowRoot;
+    setName(sr, 'Gadget');
+
+    await addField(el);
+    await fillRow(el, rows(sr)[0], 'voltage', 'number', '18');
+    await addField(el);
+    await fillRow(el, rows(sr)[1], 'active', 'boolean', 'true');
+    await addField(el);
+    await fillRow(el, rows(sr)[2], 'bought', 'date', '2026-08-01');
+
+    let detail: any = null;
+    el.addEventListener('save', (e: any) => { detail = e.detail; });
+    save(sr);
+
+    expect(detail.custom_fields).toEqual({ voltage: 18, active: true, bought: '2026-08-01' });
+  });
+
+  it('rejects a non-numeric number field with a validation error', async () => {
+    const el = await mount({});
+    const sr = el.shadowRoot as ShadowRoot;
+    setName(sr, 'Gadget');
+    await addField(el);
+    await fillRow(el, rows(sr)[0], 'weight', 'number', 'heavy');
+
+    let saved = false;
+    el.addEventListener('save', () => { saved = true; });
+    save(sr);
+    if (el.updateComplete) await el.updateComplete;
+
+    expect(saved).toBe(false);
+    expect((sr.textContent || '').toLowerCase()).toContain('must be a number');
+  });
+
+  it('pre-populates rows from an existing item with inferred types', async () => {
+    const el = await mount({ item: makeItem({ note: 'hi', count: 3, flag: true, when: '2026-01-02' }) });
+    const sr = el.shadowRoot as ShadowRoot;
+    const typeByKey: Record<string, string> = {};
+    for (const r of rows(sr)) {
+      const key = (r.querySelector('[data-testid="cf-key"]') as HTMLInputElement).value;
+      typeByKey[key] = (r.querySelector('[data-testid="cf-type"]') as HTMLSelectElement).value;
+    }
+    expect(typeByKey).toEqual({ note: 'string', count: 'number', flag: 'boolean', when: 'date' });
+  });
+
+  it('emits custom_fields_set and custom_fields_unset when editing', async () => {
+    const el = await mount({ item: makeItem({ a: 'x', n: 5 }) });
+    const sr = el.shadowRoot as ShadowRoot;
+
+    // Remove the row for key 'a'.
+    const rowA = rows(sr).find(
+      (r) => (r.querySelector('[data-testid="cf-key"]') as HTMLInputElement).value === 'a',
+    ) as HTMLElement;
+    (rowA.querySelector('[data-testid="cf-remove"]') as HTMLButtonElement).click();
+    if (el.updateComplete) await el.updateComplete;
+
+    let detail: any = null;
+    el.addEventListener('save', (e: any) => { detail = e.detail; });
+    save(sr);
+
+    expect(detail.custom_fields_set).toEqual({ n: 5 });
+    expect(detail.custom_fields_unset).toEqual(['a']);
+    expect('custom_fields' in detail).toBe(false);
+  });
+
+  it('offers existing field keys as datalist suggestions', async () => {
+    const el = await mount({ customFieldKeys: ['serial', 'warranty'] });
+    const sr = el.shadowRoot as ShadowRoot;
+    const opts = Array.from(sr.querySelectorAll('#cf-key-suggestions option')).map((o) => o.getAttribute('value'));
+    expect(opts).toEqual(['serial', 'warranty']);
+  });
+});

--- a/cards/haventory-card/src/components/hv-item-dialog.ts
+++ b/cards/haventory-card/src/components/hv-item-dialog.ts
@@ -1,7 +1,18 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { nextZBase } from '../utils/zindex';
-import type { Item, Location } from '../store/types';
+import type { Item, Location, ScalarValue } from '../store/types';
+
+type CustomFieldType = 'string' | 'number' | 'boolean' | 'date';
+interface CustomFieldRow {
+  id: number;
+  key: string;
+  type: CustomFieldType;
+  /** Raw string form; booleans use 'true'/'false'. */
+  value: string;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 @customElement('hv-item-dialog')
 export class HVItemDialog extends LitElement {
@@ -190,6 +201,54 @@ export class HVItemDialog extends LitElement {
       background: var(--primary-color, #03a9f4);
       color: var(--text-primary-color, #fff);
     }
+    /* Custom fields */
+    .cf-section { margin: 8px 0; }
+    .cf-heading { font-weight: 600; margin: 8px 0 4px; }
+    .cf-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1.4fr) 90px minmax(0, 1.6fr) 32px;
+      gap: 8px;
+      align-items: center;
+      margin: 4px 0;
+    }
+    .cf-row input[type="text"],
+    .cf-row input[type="number"],
+    .cf-row input[type="date"],
+    .cf-row select {
+      background: var(--input-fill-color, var(--secondary-background-color, #f5f5f5));
+      color: var(--primary-text-color, #212121);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 4px;
+      padding: 8px;
+      box-sizing: border-box;
+      font: inherit;
+      width: 100%;
+      min-width: 0;
+    }
+    .cf-row input:focus, .cf-row select:focus {
+      outline: 2px solid var(--primary-color, #03a9f4);
+      outline-offset: -1px;
+    }
+    .cf-bool { display: flex; align-items: center; }
+    .cf-bool input[type="checkbox"] { accent-color: var(--primary-color, #03a9f4); width: 18px; height: 18px; }
+    .cf-remove {
+      background: transparent;
+      color: var(--error-color, #db4437);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 4px;
+      padding: 6px;
+      cursor: pointer;
+    }
+    .cf-add {
+      background: transparent;
+      color: var(--primary-color, #03a9f4);
+      border: 1px dashed var(--primary-color, #03a9f4);
+      border-radius: 4px;
+      padding: 6px 10px;
+      margin-top: 4px;
+      cursor: pointer;
+      font: inherit;
+    }
   `;
 
   @property({ type: Boolean, reflect: true }) open: boolean = false;
@@ -203,6 +262,8 @@ export class HVItemDialog extends LitElement {
   @property({ attribute: false }) tagSuggestions: string[] = [];
   /** Debounce delay (ms) before recomputing autocomplete suggestions. */
   @property({ type: Number }) debounceMs: number = 120;
+  /** Existing custom-field keys across the dataset (suggestions). */
+  @property({ attribute: false }) customFieldKeys: string[] = [];
 
   @state() private _name: string = '';
   @state() private _description: string = '';
@@ -220,6 +281,8 @@ export class HVItemDialog extends LitElement {
   @state() private _acField: 'category' | 'tags' | null = null;
   @state() private _acSuggestions: string[] = [];
   @state() private _acIndex: number = -1;
+  @state() private _customFields: CustomFieldRow[] = [];
+  private _cfCounter = 0;
   private _acTimer: number | undefined;
   private static readonly _AC_MAX = 8;
 
@@ -236,6 +299,7 @@ export class HVItemDialog extends LitElement {
       this._checkedOut = !!it?.checked_out;
       this._dueDate = it?.due_date ?? '';
       this._inspectionDate = it?.inspection_date ?? '';
+      this._customFields = this._rowsFromItem(it);
       this._validation = null;
       this._closeSuggestions();
     }
@@ -265,23 +329,104 @@ export class HVItemDialog extends LitElement {
       this._validation = 'Low-stock threshold must be ≥ 0 or empty.';
       return;
     }
+    const built = this._buildCustomFields();
+    if (built === null) return; // validation error already set
     this._validation = null;
-    this.dispatchEvent(new CustomEvent('save', {
-      detail: {
-        name,
-        description: this._description || null,
-        quantity: this._quantity,
-        low_stock_threshold: this._lowStock,
-        category: this._category || null,
-        tags: this._tags.split(',').map((t) => t.trim()).filter(Boolean),
-        location_id: this._location,
-        checked_out: this._checkedOut,
 
-        due_date: this._checkedOut ? (this._dueDate || null) : null,
-        inspection_date: this._inspectionDate || null,
-      },
-      bubbles: true, composed: true,
+    const detail: Record<string, unknown> = {
+      name,
+      description: this._description || null,
+      quantity: this._quantity,
+      low_stock_threshold: this._lowStock,
+      category: this._category || null,
+      tags: this._tags.split(',').map((t) => t.trim()).filter(Boolean),
+      location_id: this._location,
+      checked_out: this._checkedOut,
+      due_date: this._checkedOut ? (this._dueDate || null) : null,
+      inspection_date: this._inspectionDate || null,
+    };
+
+    if (this.item) {
+      // Editing: send the full desired map as *_set, and unset removed keys.
+      const original = this.item.custom_fields ?? {};
+      detail.custom_fields_set = built;
+      detail.custom_fields_unset = Object.keys(original).filter((k) => !(k in built));
+    } else {
+      detail.custom_fields = built;
+    }
+
+    this.dispatchEvent(new CustomEvent('save', { detail, bubbles: true, composed: true }));
+  }
+
+  // ---------- Custom fields ----------
+
+  private _rowsFromItem(it: Item | null): CustomFieldRow[] {
+    const cf = it?.custom_fields ?? {};
+    return Object.entries(cf).map(([key, value]) => ({
+      id: this._cfCounter++,
+      key,
+      type: this._inferType(value),
+      value: this._valueToString(value),
     }));
+  }
+
+  private _inferType(value: ScalarValue): CustomFieldType {
+    if (typeof value === 'boolean') return 'boolean';
+    if (typeof value === 'number') return 'number';
+    if (typeof value === 'string' && DATE_RE.test(value)) return 'date';
+    return 'string';
+  }
+
+  private _valueToString(value: ScalarValue): string {
+    if (typeof value === 'boolean') return value ? 'true' : 'false';
+    return String(value);
+  }
+
+  /** Build the custom_fields map, or null (and set a validation error) if invalid. */
+  private _buildCustomFields(): Record<string, ScalarValue> | null {
+    const out: Record<string, ScalarValue> = {};
+    for (const row of this._customFields) {
+      const key = row.key.trim();
+      if (!key) continue; // skip incomplete rows
+      if (row.type === 'number') {
+        const n = Number(row.value);
+        if (row.value.trim() === '' || !Number.isFinite(n)) {
+          this._validation = `Custom field "${key}" must be a number.`;
+          return null;
+        }
+        out[key] = n;
+      } else if (row.type === 'boolean') {
+        out[key] = row.value === 'true';
+      } else {
+        out[key] = row.value; // string or date (stored as a string)
+      }
+    }
+    return out;
+  }
+
+  private _addCustomField = () => {
+    this._customFields = [
+      ...this._customFields,
+      { id: this._cfCounter++, key: '', type: 'string', value: '' },
+    ];
+  };
+
+  private _removeCustomField(id: number) {
+    this._customFields = this._customFields.filter((r) => r.id !== id);
+  }
+
+  private _updateCustomField(id: number, patch: Partial<CustomFieldRow>) {
+    this._customFields = this._customFields.map((r) => {
+      if (r.id !== id) return r;
+      const next = { ...r, ...patch };
+      // When the type changes, keep the value only if it fits the new type.
+      if (patch.type && patch.type !== r.type) {
+        if (patch.type === 'boolean' && next.value !== 'true' && next.value !== 'false') next.value = 'false';
+        if (patch.type === 'number' && next.value.trim() !== '' && !Number.isFinite(Number(next.value))) next.value = '';
+        if (patch.type === 'date' && !DATE_RE.test(next.value)) next.value = '';
+      }
+      return next;
+    });
   }
 
   private onOpenLocationSelector() {
@@ -456,6 +601,78 @@ export class HVItemDialog extends LitElement {
     `;
   }
 
+  private _renderCustomFieldValue(row: CustomFieldRow) {
+    const set = (v: string) => this._updateCustomField(row.id, { value: v });
+    if (row.type === 'boolean') {
+      return html`<label class="cf-bool"><input
+        type="checkbox"
+        data-testid="cf-value"
+        .checked=${row.value === 'true'}
+        @change=${(e: Event) => set((e.target as HTMLInputElement).checked ? 'true' : 'false')}
+        aria-label="Custom field value"
+      /></label>`;
+    }
+    const inputType = row.type === 'number' ? 'number' : row.type === 'date' ? 'date' : 'text';
+    return html`<input
+      class="cf-value"
+      data-testid="cf-value"
+      type=${inputType}
+      .value=${row.value}
+      @input=${(e: Event) => set((e.target as HTMLInputElement).value)}
+      aria-label="Custom field value"
+    />`;
+  }
+
+  private _renderCustomFieldRow(row: CustomFieldRow) {
+    return html`
+      <div class="cf-row" data-testid="cf-row">
+        <input
+          class="cf-key"
+          data-testid="cf-key"
+          type="text"
+          placeholder="Key"
+          list="cf-key-suggestions"
+          .value=${row.key}
+          @input=${(e: Event) => this._updateCustomField(row.id, { key: (e.target as HTMLInputElement).value })}
+          aria-label="Custom field key"
+        />
+        <select
+          class="cf-type"
+          data-testid="cf-type"
+          .value=${row.type}
+          @change=${(e: Event) => this._updateCustomField(row.id, { type: (e.target as HTMLSelectElement).value as CustomFieldType })}
+          aria-label="Custom field type"
+        >
+          <option value="string" ?selected=${row.type === 'string'}>Text</option>
+          <option value="number" ?selected=${row.type === 'number'}>Number</option>
+          <option value="boolean" ?selected=${row.type === 'boolean'}>Boolean</option>
+          <option value="date" ?selected=${row.type === 'date'}>Date</option>
+        </select>
+        ${this._renderCustomFieldValue(row)}
+        <button
+          type="button"
+          class="cf-remove"
+          data-testid="cf-remove"
+          @click=${() => this._removeCustomField(row.id)}
+          aria-label="Remove custom field"
+        >✕</button>
+      </div>
+    `;
+  }
+
+  private _renderCustomFields() {
+    return html`
+      <div class="cf-section">
+        <div class="cf-heading">Custom fields</div>
+        <datalist id="cf-key-suggestions">
+          ${this.customFieldKeys.map((k) => html`<option value=${k}></option>`)}
+        </datalist>
+        ${this._customFields.map((row) => this._renderCustomFieldRow(row))}
+        <button type="button" class="cf-add" data-testid="cf-add" @click=${this._addCustomField}>+ Add field</button>
+      </div>
+    `;
+  }
+
   render() {
     if (!this.open) return null;
     return html`
@@ -580,6 +797,7 @@ export class HVItemDialog extends LitElement {
               />
             </label>
           </div>
+          ${this._renderCustomFields()}
           <div class="actions">
             <div>
               ${this.item ? html`<button class="btn-danger" @click=${this.onDelete} aria-label="Delete item">Delete…</button>` : null}

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -224,6 +224,7 @@ export class HAventoryCard extends LitElement {
         .areas=${st?.areasCache?.areas ?? []}
         .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
         .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
+        .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
         @open-location-selector=${() => { this._locationSelectorOpen = true; this.requestUpdate(); }}
         @delete-item=${(e: CustomEvent) => {
           const { itemId, name } = e.detail as { itemId: string; name: string };

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -120,6 +120,8 @@ export interface DistinctValue {
 export interface DistinctValues {
   categories: DistinctValue[];
   tags: DistinctValue[];
+  /** Distinct custom-field keys across all items (sorted, case-insensitive). */
+  custom_field_keys: string[];
 }
 
 /** Result of haventory/health: storage/index integrity as seen by the backend. */

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -84,7 +84,16 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
           const tags = Array.from(tagGroups.entries())
             .map(([value, ids]) => ({ value, count: ids.size }))
             .sort((a, b) => a.value.toLowerCase().localeCompare(b.value.toLowerCase()));
-          return { categories, tags } as unknown as T;
+          const customKeys = new Set<string>();
+          for (const it of items) {
+            for (const k of Object.keys(it.custom_fields ?? {})) {
+              if (k.trim()) customKeys.add(k);
+            }
+          }
+          const custom_field_keys = Array.from(customKeys).sort((a, b) =>
+            a.toLowerCase().localeCompare(b.toLowerCase()),
+          );
+          return { categories, tags, custom_field_keys } as unknown as T;
         }
         case 'haventory/location/tree': {
           return [] as unknown as T;

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -1067,15 +1067,18 @@ class Repository:
             "locations_total": len(self._locations_by_id),
         }
 
-    def get_distinct_field_values(self) -> dict[str, list[dict[str, object]]]:
-        """Return distinct categories and tags with per-value usage counts.
+    def get_distinct_field_values(self) -> dict[str, object]:
+        """Return distinct categories, tags, and custom-field keys.
 
         Categories are grouped case-insensitively (matching the case-insensitive
         category index); each entry's ``value`` is a representative display label
         — the most frequent original casing among the items using it, ties broken
         alphabetically — and ``count`` is the number of items in that group. Tags
         are already normalized (lowercase) at ingress, so each key maps directly
-        to one entry. Both lists are sorted case-insensitively by value.
+        to one entry. ``custom_field_keys`` is the sorted, distinct set of keys
+        used across all items' ``custom_fields`` (keys are case-sensitive; sorted
+        case-insensitively). The two value lists are sorted case-insensitively by
+        value.
         """
 
         categories: list[dict[str, object]] = []
@@ -1098,7 +1101,18 @@ class Repository:
         ]
         tags.sort(key=lambda t: str(t["value"]).casefold())
 
-        return {"categories": categories, "tags": tags}
+        custom_keys: set[str] = set()
+        for item in self._items_by_id.values():
+            for cf_key in item.custom_fields:
+                if isinstance(cf_key, str) and cf_key.strip():
+                    custom_keys.add(cf_key)
+        custom_field_keys = sorted(custom_keys, key=lambda k: k.casefold())
+
+        return {
+            "categories": categories,
+            "tags": tags,
+            "custom_field_keys": custom_field_keys,
+        }
 
     # -----------------------------
     # Public API — Location operations

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -45,8 +45,8 @@ Handlers map domain exceptions to these codes and log with context; `conflict` a
 
 - `haventory/distinct_values`
   - Request: `{id, type: "haventory/distinct_values"}` (no payload; extra fields → `validation_error`)
-  - Result: `{categories: DistinctValue[], tags: DistinctValue[]}` (see data shapes)
-  - `categories` are grouped case-insensitively; each `value` is a representative display label (most frequent original casing, ties broken alphabetically) and `count` is the number of items using that category. `tags` are already normalized (lowercase); each maps to one entry. Both lists are sorted case-insensitively by `value`.
+  - Result: `{categories: DistinctValue[], tags: DistinctValue[], custom_field_keys: string[]}` (see data shapes)
+  - `categories` are grouped case-insensitively; each `value` is a representative display label (most frequent original casing, ties broken alphabetically) and `count` is the number of items using that category. `tags` are already normalized (lowercase); each maps to one entry. Both lists are sorted case-insensitively by `value`. `custom_field_keys` is the sorted, distinct set of keys used across all items' `custom_fields` (case-sensitive keys, sorted case-insensitively).
   - Read-only: emits no events and does not mutate state.
 
 - `haventory/health`

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -128,17 +128,19 @@ Counts object used in `stats` results and events:
 
 ### Distinct values
 
-Result of `distinct_values`, used by category/tag autocomplete and browser views:
+Result of `distinct_values`, used by category/tag autocomplete, the browser views, and custom-field key suggestions:
 ```json
 {
   "categories": [ { "value": "Books", "count": 1 }, { "value": "Tools", "count": 2 } ],
-  "tags": [ { "value": "blue", "count": 2 }, { "value": "red", "count": 2 } ]
+  "tags": [ { "value": "blue", "count": 2 }, { "value": "red", "count": 2 } ],
+  "custom_field_keys": [ "serial", "Voltage", "warranty_until" ]
 }
 ```
 
 - `DistinctValue`: `{ value: string, count: number }` where `count` is the number of items using that value.
 - Categories are grouped case-insensitively; `value` is a representative display label (most frequent original casing, ties broken alphabetically). Tags are already normalized (lowercase), so `value` is the tag itself.
-- Both lists are sorted case-insensitively by `value`. Items with no category (or no tags) contribute nothing to the respective list.
+- Both value lists are sorted case-insensitively by `value`. Items with no category (or no tags) contribute nothing to the respective list.
+- `custom_field_keys` is the sorted, distinct set of keys used across all items' `custom_fields` (keys are case-sensitive; sorted case-insensitively). Empty when no item has custom fields.
 
 ### Events
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -163,6 +163,8 @@ haventory-card (main container)
 - `categorySuggestions`: `string[]` of existing category values (autocomplete source)
 - `tagSuggestions`: `string[]` of existing tag values (autocomplete source)
 - `debounceMs`: debounce delay before recomputing suggestions (default 120)
+- `customFieldKeys`: `string[]` of existing custom-field keys across the dataset
+  (from `distinct_values.custom_field_keys`), offered as key suggestions
 
 **Fields**:
 - **Name*** (required)
@@ -175,6 +177,18 @@ haventory-card (main container)
 - **Location** (opens `hv-location-selector`)
 - **Checked-out** (checkbox)
 - **Due date** (enabled only when checked out)
+- **Custom fields** (define/edit/remove; see below)
+
+**Custom fields**: A repeatable editor of `{key, type, value}` rows. Types are
+`string` / `number` / `boolean` / `date`, each with a type-appropriate value
+input (text / number / checkbox / date). Types are inferred when loading an
+existing item (booleans, numbers, and `YYYY-MM-DD` strings → `date`, else
+`string`); `date` values are stored as strings since the backend only persists
+scalars. Rows with an empty key are ignored; a non-numeric `number` field blocks
+save with an inline error. Key inputs offer a `<datalist>` of existing keys
+(`customFieldKeys`). On save: **create** sends `custom_fields`; **edit** sends
+`custom_fields_set` (the full desired map) plus `custom_fields_unset` (keys
+removed relative to the original item).
 
 **Autocomplete**: The Category and Tags inputs render a suggestion dropdown
 (`role="listbox"`) sourced from `haventory/distinct_values` via

--- a/tests/test_ws_distinct_values_offline.py
+++ b/tests/test_ws_distinct_values_offline.py
@@ -69,6 +69,8 @@ async def test_distinct_values_returns_categories_and_tags_with_counts() -> None
     # Deterministic, case-insensitive alphabetical ordering.
     assert [c["value"] for c in result["categories"]] == ["Books", "Tools"]
     assert [t["value"] for t in result["tags"]] == ["blue", "red"]
+    # No custom fields on any item yet.
+    assert result["custom_field_keys"] == []
 
 
 @pytest.mark.asyncio
@@ -94,12 +96,37 @@ async def test_distinct_values_groups_categories_case_insensitively() -> None:
 
 @pytest.mark.asyncio
 async def test_distinct_values_empty_repository() -> None:
-    """An empty repository yields empty category and tag lists."""
+    """An empty repository yields empty category, tag, and custom-field lists."""
 
     hass = _fresh_hass()
     res = await _send(hass, 1, "haventory/distinct_values")
     assert res["success"] is True
-    assert res["result"] == {"categories": [], "tags": []}
+    assert res["result"] == {"categories": [], "tags": [], "custom_field_keys": []}
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_returns_custom_field_keys() -> None:
+    """Distinct custom-field keys across all items are returned, sorted."""
+
+    hass = _fresh_hass()
+    await _send(
+        hass,
+        1,
+        "haventory/item/create",
+        name="Drill",
+        custom_fields={"Voltage": 18, "warranty_until": "2027-01-01"},
+    )
+    await _send(
+        hass,
+        2,
+        "haventory/item/create",
+        name="Saw",
+        custom_fields={"Voltage": 20, "serial": "abc"},
+    )
+
+    res = await _send(hass, 3, "haventory/distinct_values")
+    # Distinct keys, sorted case-insensitively; "Voltage" appears once.
+    assert res["result"]["custom_field_keys"] == ["serial", "Voltage", "warranty_until"]
 
 
 def test_distinct_values_schema_rejects_unknown_field() -> None:


### PR DESCRIPTION
## Summary

WP3 feature #6 (final). Adds a UI to define/edit/remove typed custom fields per item, plus the backend support needed to suggest existing field keys across the whole dataset.

**Backend**
- `repository.get_distinct_field_values()` now also returns **`custom_field_keys`** — the sorted, distinct set of keys used across all items' `custom_fields` (case-sensitive keys, sorted case-insensitively).
- The `haventory/distinct_values` result gains `custom_field_keys` (docs + `data_shapes.md` updated). Offline tests cover it (empty repo → `[]`, and distinct keys across items).

**Frontend**
- **`hv-item-dialog`** — a repeatable custom-fields editor with per-row **key / type / value**:
  - Types `string` / `number` / `boolean` / `date`, each with a type-appropriate value input (text / number / checkbox / date).
  - Types are **inferred** when loading an existing item (booleans, numbers, and `YYYY-MM-DD` strings → `date`, else `string`). `date` persists as a string since the backend stores scalars only.
  - Rows with an empty key are ignored; a non-numeric `number` field blocks save with an inline error.
  - Key inputs offer a `<datalist>` of existing keys (`customFieldKeys`).
  - On save: **create** sends `custom_fields`; **edit** sends `custom_fields_set` (the full desired map) plus `custom_fields_unset` (keys removed relative to the original item) — matching the existing WS update contract.
- `DistinctValues` type + the test mock gain `custom_field_keys`; the container passes `customFieldKeys` to the dialog from `distinctValuesCache`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Frontend (`cards/haventory-card`): `npx eslint .` (clean), `npx vitest run` (**150 passed**), `npm run build` (OK). New tests in `hv-item-dialog.custom-fields.test.ts`: add typed field on create, number/boolean/date value typing, non-numeric number validation, type inference when editing, `custom_fields_set` + `custom_fields_unset` on edit, and datalist key suggestions.
- [x] Backend: `uv run ruff check .` → green. `pytest` couldn't run natively here (no CPython 3.14 — the python-build-standalone download is blocked by egress policy, and the source uses 3.14-only PEP 758 syntax). As a substitute, the **full offline suite (180 tests, all passing)** was run against a byte-identical shadow copy on CPython 3.13 with only the two `except A, B:` lines rewritten to parenthesized form; this includes the new `custom_field_keys` distinct-values tests. CI runs the real 3.14 gate.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`, `docs/frontend_architecture.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync (the `distinct_values` result shape change is reflected in both docs).
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — the backend change is a read-only additive field; custom-field writes use the existing `custom_fields_set`/`unset` contract.

## Screenshots (card / UI changes)

Not captured in this environment (no running HA). The editor reuses the dialog's existing input/theme styling.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_