### PR TITLE
feat: JSON import/export for backup & restore (WP3.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ Included: `tests/test_ws_smoke_online.py`, `tests/test_ws_smoke_advanced_online.
   validation/repository/storage errors so HA surfaces them.
 - Areas via `homeassistant.helpers.area_registry.async_get(hass)`; never auto-create areas.
 - Case-insensitive search; denormalized `location_path` on items; item `version` for optimistic concurrency.
+- **JSON import/export (data safety)** via `haventory/export`, `haventory/import/preview`,
+  and `haventory/import/execute`: back up to a versioned document before a breaking update
+  and restore afterwards. Preview reports would-be adds/updates/conflicts without touching
+  state; execute applies a `merge` / `replace` / `skip` conflict policy and rolls back on
+  failure so a bad import never leaves partial state. This **complements** Home Assistant's
+  own snapshots/backups — the HAventory store file is already captured by an HA backup;
+  import/export adds a portable, human-readable document you can inspect, diff, and restore
+  independently of a full-instance snapshot. See
+  [`docs/backend_api_contract.md`](docs/backend_api_contract.md) and
+  [`docs/data_shapes.md`](docs/data_shapes.md).
 
 ### Frontend (Lovelace card)
 
@@ -181,6 +191,10 @@ Included: `tests/test_ws_smoke_online.py`, `tests/test_ws_smoke_advanced_online.
   **move a whole subtree** to a new parent, with descendant paths updating live.
 - Expanded view includes a diagnostics panel with **storage health**
   (`haventory/health`: status, issues, generation) and a refresh action.
+- **Export / Import** buttons in the card header: Export downloads a JSON backup;
+  Import opens a dialog with a **preview step** (adds/updates/conflicts per policy),
+  `merge` / `replace` / `skip` policy selection, and structured error display before
+  anything is written.
 - Card auto-registered as a Lovelace resource on integration setup.
 - **Note:** after first install, a browser refresh (F5 / Ctrl+Shift+R) is required for the
   card to appear in the picker (standard for all custom cards).

--- a/cards/haventory-card/src/components/hv-import-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-import-dialog.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './hv-import-dialog';
+import type { ImportPreview, ImportSummary } from '../store/types';
+
+type Dialog = HTMLElement & {
+  open: boolean;
+  preview: ImportPreview | null;
+  summary: ImportSummary | null;
+  busy: boolean;
+  errorMessage: string | null;
+  updateComplete?: Promise<unknown>;
+};
+
+async function mount(props: Partial<Dialog> = {}): Promise<Dialog> {
+  const el = document.createElement('hv-import-dialog') as Dialog;
+  document.body.appendChild(el);
+  await customElements.whenDefined('hv-import-dialog');
+  Object.assign(el, props);
+  el.open = true;
+  if (el.updateComplete) await el.updateComplete;
+  return el;
+}
+
+const validDoc = JSON.stringify({
+  haventory_export_version: 1,
+  schema_version: 4,
+  items: [],
+  locations: [],
+});
+
+function validPreview(): ImportPreview {
+  return {
+    valid: true,
+    errors: [],
+    policy: 'merge',
+    document: { haventory_export_version: 1, schema_version: 4, exported_at: null, integration_version: null },
+    items: { add: ['a'], update: [], conflict: [], unchanged: [] },
+    locations: { add: [], update: [], conflict: [], unchanged: [] },
+    counts: {
+      items: { total: 1, add: 1, update: 0, conflict: 0, unchanged: 0 },
+      locations: { total: 0, add: 0, update: 0, conflict: 0, unchanged: 0 },
+    },
+  };
+}
+
+async function type(el: Dialog, text: string) {
+  const ta = el.shadowRoot!.querySelector('[data-testid="import-text"]') as HTMLTextAreaElement;
+  ta.value = text;
+  ta.dispatchEvent(new Event('input', { bubbles: true }));
+  if (el.updateComplete) await el.updateComplete;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('hv-import-dialog', () => {
+  it('emits preview with the parsed document and selected policy', async () => {
+    const el = await mount();
+    let detail: { document: unknown; policy: string } | null = null;
+    el.addEventListener('preview', (e: Event) => { detail = (e as CustomEvent).detail; });
+
+    await type(el, validDoc);
+    // Choose the "replace" policy.
+    const replace = el.shadowRoot!.querySelector('[data-testid="policy-replace"]') as HTMLInputElement;
+    replace.checked = true;
+    replace.dispatchEvent(new Event('change', { bubbles: true }));
+
+    (el.shadowRoot!.querySelector('[data-testid="import-preview"]') as HTMLButtonElement).click();
+
+    expect(detail).not.toBeNull();
+    expect(detail!.policy).toBe('replace');
+    expect(detail!.document).toEqual(JSON.parse(validDoc));
+  });
+
+  it('shows a parse error and does not emit preview for invalid JSON', async () => {
+    const el = await mount();
+    let emitted = false;
+    el.addEventListener('preview', () => { emitted = true; });
+
+    await type(el, '{ not json');
+    (el.shadowRoot!.querySelector('[data-testid="import-preview"]') as HTMLButtonElement).click();
+    if (el.updateComplete) await el.updateComplete;
+
+    expect(emitted).toBe(false);
+    expect(el.shadowRoot!.querySelector('[data-testid="parse-error"]')).not.toBeNull();
+  });
+
+  it('disables Import until a valid preview is present', async () => {
+    const el = await mount();
+    const importBtn = () => el.shadowRoot!.querySelector('[data-testid="import-execute"]') as HTMLButtonElement;
+    expect(importBtn().disabled).toBe(true);
+
+    el.preview = validPreview();
+    if (el.updateComplete) await el.updateComplete;
+    expect(importBtn().disabled).toBe(false);
+
+    // The summary counts are rendered from the preview.
+    expect(el.shadowRoot!.querySelector('[data-testid="preview-summary"]')).not.toBeNull();
+    expect(el.shadowRoot!.querySelector('[data-testid="count-items-add"]')!.textContent).toContain('1 add');
+  });
+
+  it('renders structured errors and keeps Import disabled for an invalid preview', async () => {
+    const el = await mount();
+    el.preview = {
+      ...validPreview(),
+      valid: false,
+      errors: [{ path: 'items[0].id', message: 'must be a UUID v4 string' }],
+    };
+    if (el.updateComplete) await el.updateComplete;
+
+    const errBox = el.shadowRoot!.querySelector('[data-testid="preview-errors"]');
+    expect(errBox).not.toBeNull();
+    expect(errBox!.textContent).toContain('items[0].id');
+    expect((el.shadowRoot!.querySelector('[data-testid="import-execute"]') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('emits execute when Import is clicked with a valid preview', async () => {
+    const el = await mount();
+    await type(el, validDoc);
+    el.preview = validPreview();
+    if (el.updateComplete) await el.updateComplete;
+
+    let detail: { document: unknown; policy: string } | null = null;
+    el.addEventListener('execute', (e: Event) => { detail = (e as CustomEvent).detail; });
+    (el.shadowRoot!.querySelector('[data-testid="import-execute"]') as HTMLButtonElement).click();
+
+    expect(detail).not.toBeNull();
+    expect(detail!.document).toEqual(JSON.parse(validDoc));
+  });
+
+  it('shows a success summary after import completes', async () => {
+    const el = await mount();
+    el.summary = {
+      applied: true,
+      policy: 'merge',
+      items: { total: 2, add: 2, update: 0, conflict: 0, unchanged: 0 },
+      locations: { total: 1, add: 1, update: 0, conflict: 0, unchanged: 0 },
+      totals: { items_total: 2, low_stock_count: 0, checked_out_count: 0, locations_total: 1 },
+    };
+    if (el.updateComplete) await el.updateComplete;
+
+    const banner = el.shadowRoot!.querySelector('[data-testid="import-summary"]');
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain('2 items');
+  });
+
+  it('closes on Cancel', async () => {
+    const el = await mount();
+    let cancels = 0;
+    el.addEventListener('cancel', () => { cancels += 1; });
+    (el.shadowRoot!.querySelector('[data-testid="import-close"]') as HTMLButtonElement).click();
+    expect(cancels).toBe(1);
+    expect(el.open).toBe(false);
+  });
+});

--- a/cards/haventory-card/src/components/hv-import-dialog.ts
+++ b/cards/haventory-card/src/components/hv-import-dialog.ts
@@ -1,0 +1,270 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { nextZBase } from '../utils/zindex';
+import type { ImportPolicy, ImportPreview, ImportSummary } from '../store/types';
+
+/**
+ * Import dialog with a preview step (data safety / restore-from-backup).
+ *
+ * Presentational: the user pastes or loads a JSON backup document and picks a
+ * conflict policy. It emits `preview` (validate + classify without mutating) and
+ * then `execute` (apply). The container performs the WebSocket calls and pushes
+ * results back via the `preview`, `summary`, `busy`, and `errorMessage`
+ * properties — mirroring how `hv-location-selector` receives async outcomes.
+ */
+@customElement('hv-import-dialog')
+export class HVImportDialog extends LitElement {
+  static styles = css`
+    :host { display: block; }
+    .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 9998; }
+    .panel-wrap { position: fixed; inset: 0; display: grid; place-items: center; z-index: 9999; }
+    .panel {
+      background: var(--card-background-color, var(--ha-card-background, #fff));
+      color: var(--primary-text-color, #212121);
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 8px;
+      padding: 16px;
+      max-width: 520px;
+      width: calc(100vw - 32px);
+      max-height: calc(100vh - 48px);
+      overflow: auto;
+      box-sizing: border-box;
+      font: inherit;
+    }
+    h2 { font-size: 1.15em; margin: 0 0 4px; }
+    p.hint { margin: 0 0 12px; color: var(--secondary-text-color, #666); font-size: 0.9em; }
+    label { display: block; margin: 8px 0 4px; font-weight: 600; }
+    textarea {
+      width: 100%;
+      min-height: 120px;
+      box-sizing: border-box;
+      font-family: monospace;
+      font-size: 0.85em;
+      border: 1px solid var(--divider-color, #ddd);
+      border-radius: 4px;
+      padding: 8px;
+      resize: vertical;
+    }
+    .policies { display: flex; gap: 16px; flex-wrap: wrap; margin: 6px 0; }
+    .policies label { display: inline-flex; align-items: center; gap: 6px; font-weight: 400; margin: 0; }
+    input[type="radio"] { accent-color: var(--primary-color, #03a9f4); }
+    .summary-grid { display: grid; grid-template-columns: auto repeat(4, 1fr); gap: 4px 10px; margin: 8px 0; align-items: center; }
+    .summary-grid .head { font-weight: 600; }
+    .errors { margin: 8px 0; padding: 8px 10px; border-radius: 6px; background: #fdecea; color: #611a15; border: 1px solid #f5c6cb; }
+    .errors ul { margin: 4px 0 0; padding-left: 18px; }
+    .errors code { font-family: monospace; }
+    .ok-banner { margin: 8px 0; padding: 8px 10px; border-radius: 6px; background: #e6f4ea; color: #0f5132; border: 1px solid #badbcc; }
+    .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; flex-wrap: wrap; }
+    button {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      border: none;
+      border-radius: 4px;
+      padding: 8px 16px;
+      cursor: pointer;
+      font: inherit;
+    }
+    button.secondary { background: var(--secondary-background-color, #e0e0e0); color: var(--primary-text-color, #212121); }
+    button:hover { opacity: 0.9; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .filename { font-size: 0.85em; color: var(--secondary-text-color, #666); margin-left: 8px; }
+  `;
+
+  @property({ type: Boolean, reflect: true }) open = false;
+  /** Preview report from the container (null until a preview runs). */
+  @property({ attribute: false }) preview: ImportPreview | null = null;
+  /** Success summary from the container (null until an import completes). */
+  @property({ attribute: false }) summary: ImportSummary | null = null;
+  /** True while a WS call is in flight (disables actions). */
+  @property({ type: Boolean }) busy = false;
+  /** Container-level error (e.g. a WS failure) to surface to the user. */
+  @property({ attribute: false }) errorMessage: string | null = null;
+
+  @state() private _rawText = '';
+  @state() private _policy: ImportPolicy = 'merge';
+  @state() private _parseError: string | null = null;
+  @state() private _fileName: string | null = null;
+  @state() private _zBase: number | null = null;
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has('open')) {
+      if (this.open) {
+        this._zBase = nextZBase();
+      } else {
+        // Reset transient state whenever the dialog is closed.
+        this._rawText = '';
+        this._policy = 'merge';
+        this._parseError = null;
+        this._fileName = null;
+        this.preview = null;
+        this.summary = null;
+        this.errorMessage = null;
+      }
+    }
+  }
+
+  private _onCancel = () => {
+    this.dispatchEvent(new CustomEvent('cancel', { bubbles: true, composed: true }));
+    this.open = false;
+  };
+
+  private _parseDocument(): unknown | undefined {
+    const text = this._rawText.trim();
+    if (!text) {
+      this._parseError = 'Paste a backup document or choose a file first.';
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(text);
+      this._parseError = null;
+      return parsed;
+    } catch (e: unknown) {
+      this._parseError = `Not valid JSON: ${(e as Error)?.message ?? 'parse error'}`;
+      return undefined;
+    }
+  }
+
+  private async _onFile(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    this._fileName = file.name;
+    this._rawText = await file.text();
+    // Reset any prior preview when a new document is loaded.
+    this.preview = null;
+    this.summary = null;
+    this._parseError = null;
+  }
+
+  private _onPreview = () => {
+    const document = this._parseDocument();
+    if (document === undefined) return;
+    this.dispatchEvent(
+      new CustomEvent('preview', { detail: { document, policy: this._policy }, bubbles: true, composed: true }),
+    );
+  };
+
+  private _onExecute = () => {
+    const document = this._parseDocument();
+    if (document === undefined) return;
+    this.dispatchEvent(
+      new CustomEvent('execute', { detail: { document, policy: this._policy }, bubbles: true, composed: true }),
+    );
+  };
+
+  private _setPolicy(p: ImportPolicy) {
+    this._policy = p;
+    // Policy changed — a stale preview no longer matches the resolution.
+    this.preview = null;
+    this.summary = null;
+  }
+
+  private _renderCounts(label: string, counts?: { add: number; update: number; conflict: number; unchanged: number }) {
+    const c = counts ?? { add: 0, update: 0, conflict: 0, unchanged: 0 };
+    return html`
+      <span class="head">${label}</span>
+      <span data-testid="count-${label.toLowerCase()}-add">${c.add} add</span>
+      <span data-testid="count-${label.toLowerCase()}-update">${c.update} update</span>
+      <span data-testid="count-${label.toLowerCase()}-conflict">${c.conflict} conflict</span>
+      <span data-testid="count-${label.toLowerCase()}-unchanged">${c.unchanged} unchanged</span>
+    `;
+  }
+
+  render() {
+    if (!this.open) return null;
+    const preview = this.preview;
+    const canImport = !!preview && preview.valid && !this.busy;
+    return html`
+      <div class="backdrop" role="presentation" style="z-index: ${this._zBase ?? 9998};" @click=${this._onCancel}></div>
+      <div class="panel-wrap" role="none" style="z-index: ${(this._zBase ?? 9998) + 1};">
+        <div class="panel" role="dialog" aria-modal="true" aria-label="Import inventory"
+          @keydown=${(e: KeyboardEvent) => { if (e.key === 'Escape') { e.preventDefault(); this._onCancel(); } }}>
+          <h2>Import inventory</h2>
+          <p class="hint">
+            Restore from a HAventory backup. Preview first to see what would change; nothing is
+            written until you choose Import.
+          </p>
+
+          <label for="hv-import-file">Backup file (.json)</label>
+          <div>
+            <input
+              id="hv-import-file"
+              data-testid="import-file"
+              type="file"
+              accept="application/json,.json"
+              @change=${this._onFile}
+            />
+            ${this._fileName ? html`<span class="filename" data-testid="import-filename">${this._fileName}</span>` : null}
+          </div>
+
+          <label for="hv-import-text">…or paste the document</label>
+          <textarea
+            id="hv-import-text"
+            data-testid="import-text"
+            .value=${this._rawText}
+            @input=${(e: Event) => { this._rawText = (e.target as HTMLTextAreaElement).value; this.preview = null; this.summary = null; }}
+            placeholder="{ &quot;haventory_export_version&quot;: 1, ... }"
+          ></textarea>
+
+          <label>On conflict</label>
+          <div class="policies" data-testid="import-policies">
+            ${(['merge', 'replace', 'skip'] as ImportPolicy[]).map((p) => html`
+              <label>
+                <input
+                  type="radio"
+                  name="policy"
+                  data-testid="policy-${p}"
+                  value=${p}
+                  .checked=${this._policy === p}
+                  @change=${() => this._setPolicy(p)}
+                />
+                <span>${p}</span>
+              </label>
+            `)}
+          </div>
+
+          ${this._parseError ? html`<div class="errors" data-testid="parse-error">${this._parseError}</div>` : null}
+
+          ${preview && !preview.valid ? html`
+            <div class="errors" data-testid="preview-errors">
+              <strong>${preview.errors.length} problem${preview.errors.length === 1 ? '' : 's'} — nothing imported:</strong>
+              <ul>
+                ${preview.errors.slice(0, 20).map((err) => html`<li><code>${err.path}</code>: ${err.message}</li>`)}
+              </ul>
+            </div>
+          ` : null}
+
+          ${preview && preview.valid ? html`
+            <div class="summary-grid" data-testid="preview-summary">
+              <span class="head"></span><span class="head">add</span><span class="head">update</span><span class="head">conflict</span><span class="head">unchanged</span>
+              ${this._renderCounts('Items', preview.counts.items)}
+              ${this._renderCounts('Locations', preview.counts.locations)}
+            </div>
+          ` : null}
+
+          ${this.summary ? html`
+            <div class="ok-banner" data-testid="import-summary">
+              Imported with policy <strong>${this.summary.policy}</strong>.
+              Now ${this.summary.totals.items_total} item${this.summary.totals.items_total === 1 ? '' : 's'},
+              ${this.summary.totals.locations_total} location${this.summary.totals.locations_total === 1 ? '' : 's'}.
+            </div>
+          ` : null}
+
+          ${this.errorMessage ? html`<div class="errors" data-testid="import-error">${this.errorMessage}</div>` : null}
+
+          <div class="actions">
+            <button class="secondary" data-testid="import-close" @click=${this._onCancel}>${this.summary ? 'Close' : 'Cancel'}</button>
+            <button data-testid="import-preview" @click=${this._onPreview} ?disabled=${this.busy}>Preview</button>
+            <button data-testid="import-execute" @click=${this._onExecute} ?disabled=${!canImport}>Import</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hv-import-dialog': HVImportDialog;
+  }
+}

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -13,6 +13,8 @@ import './components/hv-location-selector';
 import './components/hv-category-browser';
 import './components/hv-tag-browser';
 import './components/hv-column-picker';
+import './components/hv-import-dialog';
+import type { ImportPolicy, ImportPreview, ImportSummary } from './store/types';
 
 export class HAventoryCard extends LitElement {
   static styles = css`
@@ -95,6 +97,11 @@ export class HAventoryCard extends LitElement {
   private _columnPrefs: ColumnPrefs = loadColumnPrefs();
   private _columnPickerOpen = false;
   private _columnPickerScope: 'standard' | 'expanded' = 'standard';
+  private _importDialogOpen = false;
+  private _importPreview: ImportPreview | null = null;
+  private _importSummary: ImportSummary | null = null;
+  private _importBusy = false;
+  private _importError: string | null = null;
 
   // Lovelace interface: called by HA when the card is created/configured
   public setConfig(cfg: unknown): void {
@@ -163,6 +170,8 @@ export class HAventoryCard extends LitElement {
           <button data-testid="browse-categories" @click=${() => this._openCategoryBrowser()} aria-label="Browse categories" title="Browse categories">Categories</button>
           <button data-testid="browse-tags" @click=${() => this._openTagBrowser()} aria-label="Browse tags" title="Browse tags">Tags</button>
           <button data-testid="columns-standard" @click=${() => this._openColumnPicker('standard')} aria-label="Choose columns" title="Choose columns">Columns</button>
+          <button data-testid="export-btn" @click=${() => { void this._exportDownload(); }} aria-label="Export inventory" title="Download a JSON backup">Export</button>
+          <button data-testid="import-btn" @click=${() => this._openImportDialog()} aria-label="Import inventory" title="Restore from a JSON backup">Import</button>
           <button data-testid="expand-toggle" @click=${() => this._toggleExpanded()} aria-expanded=${String(this.expanded)} aria-label=${this.expanded ? 'Collapse' : 'Expand'}>
             ${this.expanded ? '⤢ Collapse' : '⇱ Expand'}
           </button>
@@ -362,8 +371,96 @@ export class HAventoryCard extends LitElement {
         @cancel=${() => { this._columnPickerOpen = false; this.requestUpdate(); }}
       ></hv-column-picker>
 
+      <hv-import-dialog
+        .open=${this._importDialogOpen}
+        .preview=${this._importPreview}
+        .summary=${this._importSummary}
+        .busy=${this._importBusy}
+        .errorMessage=${this._importError}
+        @preview=${(e: CustomEvent) => this._onImportPreview(e)}
+        @execute=${(e: CustomEvent) => this._onImportExecute(e)}
+        @cancel=${() => { this._importDialogOpen = false; this._resetImportState(); this.requestUpdate(); }}
+      ></hv-import-dialog>
+
       ${this.expanded ? this._renderOverlayTemplate() : null}
     `;
+  }
+
+  private async _exportDownload() {
+    try {
+      const doc = await this.store?.exportDocument();
+      if (!doc) return;
+      const json = JSON.stringify(doc, null, 2);
+      const stamp = (doc.exported_at ?? '').replace(/[:]/g, '-') || 'backup';
+      this._triggerDownload(`haventory-export-${stamp}.json`, json);
+    } catch (err: unknown) {
+      // Surfacing this via the import dialog is overkill for export; log for diagnostics.
+      console.error('HAventory export failed', err);
+    }
+  }
+
+  /** Trigger a browser download of the given text as a JSON file. Isolated for testing. */
+  protected _triggerDownload(filename: string, text: string) {
+    const blob = new Blob([text], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  private _openImportDialog() {
+    this._resetImportState();
+    this._importDialogOpen = true;
+    this.requestUpdate();
+  }
+
+  private _resetImportState() {
+    this._importPreview = null;
+    this._importSummary = null;
+    this._importBusy = false;
+    this._importError = null;
+  }
+
+  private async _onImportPreview(e: CustomEvent) {
+    const { document, policy } = e.detail as { document: unknown; policy: ImportPolicy };
+    this._importBusy = true;
+    this._importError = null;
+    this._importSummary = null;
+    this.requestUpdate();
+    try {
+      this._importPreview = (await this.store?.previewImport(document, policy)) ?? null;
+    } catch (err: unknown) {
+      this._importPreview = null;
+      this._importError = (err as { message?: string })?.message ?? 'Preview failed';
+    } finally {
+      this._importBusy = false;
+      this.requestUpdate();
+    }
+  }
+
+  private async _onImportExecute(e: CustomEvent) {
+    const { document, policy } = e.detail as { document: unknown; policy: ImportPolicy };
+    this._importBusy = true;
+    this._importError = null;
+    this.requestUpdate();
+    try {
+      this._importSummary = (await this.store?.executeImport(document, policy)) ?? null;
+    } catch (err: unknown) {
+      const anyErr = err as { code?: string; message?: string; data?: { errors?: { path: string; message: string }[] } };
+      if (anyErr?.code === 'validation_error' && anyErr.data?.errors?.length) {
+        this._importError = `Import rejected: ${anyErr.data.errors.length} problem(s) in the document.`;
+      } else {
+        this._importError = anyErr?.message ?? 'Import failed';
+      }
+    } finally {
+      this._importBusy = false;
+      this.requestUpdate();
+    }
   }
 
   private _openColumnPicker(scope: 'standard' | 'expanded') {

--- a/cards/haventory-card/src/store/import-export.test.ts
+++ b/cards/haventory-card/src/store/import-export.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { Store } from './store';
+import { makeMockHass, makeItem } from '../test.utils';
+
+describe('Store import/export', () => {
+  it('exports a versioned document of the current inventory', async () => {
+    const items = [makeItem({ id: '1', name: 'Hammer' }), makeItem({ id: '2', name: 'Nails' })];
+    const store = new Store(makeMockHass({ items }));
+    await store.init();
+
+    const doc = await store.exportDocument();
+    expect(doc.haventory_export_version).toBe(1);
+    expect(doc.items.length).toBe(2);
+  });
+
+  it('previews an import without mutating the current list', async () => {
+    const existing = [makeItem({ id: '1', name: 'Existing' })];
+    const store = new Store(makeMockHass({ items: existing }));
+    await store.init();
+
+    const incoming = {
+      haventory_export_version: 1,
+      schema_version: 4,
+      items: [makeItem({ id: 'x', name: 'Fresh' })],
+      locations: [],
+    };
+    const preview = await store.previewImport(incoming, 'merge');
+    expect(preview.valid).toBe(true);
+    expect(preview.counts.items?.add).toBe(1);
+    // The live list is untouched by a preview.
+    expect(store.state.value.items.map((i) => i.id)).toEqual(['1']);
+  });
+
+  it('executes an import and reloads the list to reflect the new dataset', async () => {
+    const store = new Store(makeMockHass({ items: [makeItem({ id: '1', name: 'Old' })] }));
+    await store.init();
+
+    const incoming = {
+      haventory_export_version: 1,
+      schema_version: 4,
+      items: [makeItem({ id: 'a', name: 'Imported A' }), makeItem({ id: 'b', name: 'Imported B' })],
+      locations: [],
+    };
+    const summary = await store.executeImport(incoming, 'replace');
+    expect(summary.applied).toBe(true);
+    expect(summary.totals.items_total).toBe(2);
+    // reloadAll ran: the list now reflects the imported items.
+    const names = store.state.value.items.map((i) => i.name).sort();
+    expect(names).toEqual(['Imported A', 'Imported B']);
+  });
+});

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -2,8 +2,12 @@ import type {
   AreasListResult,
   AnyEventPayload,
   DistinctValues,
+  ExportDocument,
   HassLike,
   HealthResult,
+  ImportPolicy,
+  ImportPreview,
+  ImportSummary,
   Item,
   ItemCreate,
   ItemFilter,
@@ -123,6 +127,12 @@ export class Store {
 
   private onItemsEvent(evt: AnyEventPayload) {
     if (evt.topic !== 'items') return;
+    if (evt.action === 'reloaded') {
+      // An import replaced the dataset wholesale — reload from scratch.
+      void this.listItems(true);
+      void this.refreshDistinctValues().catch(() => undefined);
+      return;
+    }
     const item = (evt as unknown as { item: Item }).item; // narrow by known payload structure
     const items = this.state.value.items.slice();
     const idx = items.findIndex((x) => x.id === item.id);
@@ -156,6 +166,11 @@ export class Store {
 
   private onLocationsEvent(evt: AnyEventPayload) {
     if (evt.topic !== 'locations') return;
+    if (evt.action === 'reloaded') {
+      void Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
+      void this.listItems(true);
+      return;
+    }
     void Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
     // Moving or renaming a location rewrites the denormalized location_path on
     // every item in its subtree — reload the list so rows reflect it live.
@@ -423,6 +438,36 @@ export class Store {
     // Denormalized item location_path values changed for the whole subtree.
     await this.listItems(true);
     return moved;
+  }
+
+  // ---------- Import / export (data safety) ----------
+  /** Build a versioned backup document of the whole inventory. */
+  async exportDocument(): Promise<ExportDocument> {
+    return this.ws.exportDocument();
+  }
+
+  /** Validate + classify an import document without mutating state. */
+  async previewImport(document: unknown, policy: ImportPolicy): Promise<ImportPreview> {
+    return this.ws.importPreview(document, policy);
+  }
+
+  /** Apply an import document, then reload local caches to reflect the new dataset. */
+  async executeImport(document: unknown, policy: ImportPolicy): Promise<ImportSummary> {
+    const summary = await this.ws.importExecute(document, policy);
+    await this.reloadAll();
+    return summary;
+  }
+
+  /** Refresh every derived cache and the item list (used after a wholesale import). */
+  async reloadAll(): Promise<void> {
+    await Promise.all([
+      this.refreshStats(),
+      this.refreshHealth(),
+      this.refreshLocationsFlat(),
+      this.refreshLocationTree(),
+      this.refreshDistinctValues(),
+    ]);
+    await this.listItems(true);
   }
 
   // ---------- Errors ----------

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -132,6 +132,69 @@ export interface HealthResult {
   generation: number;
 }
 
+// ---------- Import / export (data safety) ----------
+
+/** Conflict resolution policy for import/execute and import/preview. */
+export type ImportPolicy = 'merge' | 'replace' | 'skip';
+
+/** A versioned backup document produced by haventory/export. */
+export interface ExportDocument {
+  haventory_export_version: number;
+  schema_version: number;
+  exported_at: string;
+  integration_version: string;
+  items: unknown[];
+  locations: unknown[];
+}
+
+/** A single structured validation problem in an import document. */
+export interface ImportError {
+  path: string;
+  message: string;
+}
+
+/** Per-type classification counts in an import preview. */
+export interface ImportBucketCounts {
+  total: number;
+  add: number;
+  update: number;
+  conflict: number;
+  unchanged: number;
+}
+
+/** Per-type lists of entity ids by classification. */
+export interface ImportBuckets {
+  add: string[];
+  update: string[];
+  conflict: string[];
+  unchanged: string[];
+}
+
+/** Result of haventory/import/preview: validation + classification, no mutation. */
+export interface ImportPreview {
+  valid: boolean;
+  errors: ImportError[];
+  policy: ImportPolicy;
+  document: {
+    haventory_export_version: number | null;
+    schema_version: number | null;
+    exported_at: string | null;
+    integration_version: string | null;
+  };
+  items: ImportBuckets;
+  locations: ImportBuckets;
+  counts: { items?: ImportBucketCounts; locations?: ImportBucketCounts };
+}
+
+/** Result of haventory/import/execute after a successful apply. */
+export interface ImportSummary {
+  applied: boolean;
+  policy: ImportPolicy;
+  items: ImportBucketCounts;
+  locations: ImportBucketCounts;
+  totals: StatsCounts;
+}
+
 // WS subscription event payloads
 export interface BaseEventPayload {
   domain: 'haventory';
@@ -142,7 +205,9 @@ export interface BaseEventPayload {
 
 export interface ItemsEventPayload extends BaseEventPayload {
   topic: 'items';
-  item: Item;
+  // `item` is present for per-item actions; absent for the wholesale `reloaded`
+  // signal emitted after an import replaces the dataset.
+  item?: Item;
   action:
   | 'created'
   | 'updated'
@@ -150,13 +215,14 @@ export interface ItemsEventPayload extends BaseEventPayload {
   | 'deleted'
   | 'checked_out'
   | 'checked_in'
-  | 'quantity_changed';
+  | 'quantity_changed'
+  | 'reloaded';
 }
 
 export interface LocationsEventPayload extends BaseEventPayload {
   topic: 'locations';
-  location: Location;
-  action: 'created' | 'renamed' | 'moved' | 'deleted';
+  location?: Location;
+  action: 'created' | 'renamed' | 'moved' | 'deleted' | 'reloaded';
 }
 
 export interface StatsEventPayload extends BaseEventPayload {

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -1,8 +1,12 @@
 import type {
   AreasListResult,
   DistinctValues,
+  ExportDocument,
   HassLike,
   HealthResult,
+  ImportPolicy,
+  ImportPreview,
+  ImportSummary,
   Item,
   ItemCreate,
   ItemFilter,
@@ -153,6 +157,24 @@ export class WSClient {
 
   listAreas() {
     return this.hass.callWS<AreasListResult>({ type: 'haventory/areas/list' });
+  }
+
+  // ---------- Import / export (data safety) ----------
+  /** Build a versioned backup document (optionally filtered to matching items). */
+  exportDocument(filter?: ItemFilter) {
+    const msg: Record<string, unknown> = { type: 'haventory/export' };
+    if (filter) msg.filter = filter;
+    return this.hass.callWS<ExportDocument>(msg);
+  }
+
+  /** Validate + classify a document without mutating state. */
+  importPreview(document: unknown, policy: ImportPolicy) {
+    return this.hass.callWS<ImportPreview>({ type: 'haventory/import/preview', document, policy });
+  }
+
+  /** Apply a document with the chosen conflict policy (rolls back on failure). */
+  importExecute(document: unknown, policy: ImportPolicy) {
+    return this.hass.callWS<ImportSummary>({ type: 'haventory/import/execute', document, policy });
   }
 
   // ---------- Subscriptions ----------

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -1,4 +1,13 @@
-import type { AnyEventPayload, HassLike, Item, Location, StatsCounts } from './store/types';
+import type {
+  AnyEventPayload,
+  ExportDocument,
+  HassLike,
+  ImportPreview,
+  ImportSummary,
+  Item,
+  Location,
+  StatsCounts,
+} from './store/types';
 
 type SubCb = (msg: { id: number; type: 'event'; event: AnyEventPayload }) => void;
 
@@ -58,6 +67,54 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
         }
         case 'haventory/areas/list': {
           return { areas: [] } as unknown as T;
+        }
+        case 'haventory/export': {
+          const doc: ExportDocument = {
+            haventory_export_version: 1,
+            schema_version: 4,
+            exported_at: new Date().toISOString(),
+            integration_version: '0.0.1',
+            items: items.map((i) => ({ ...i })),
+            locations: locations.map((l) => ({ ...l })),
+          };
+          return doc as unknown as T;
+        }
+        case 'haventory/import/preview': {
+          const doc = ((msg as any).document ?? {}) as { items?: Item[]; locations?: Location[] };
+          const policy = String((msg as any).policy || 'merge');
+          const itemIds = (doc.items ?? []).map((i) => i.id);
+          const locIds = (doc.locations ?? []).map((l) => l.id);
+          const bucket = (ids: string[]) => ({ add: ids, update: [], conflict: [], unchanged: [] });
+          const counts = (ids: string[]) => ({ total: ids.length, add: ids.length, update: 0, conflict: 0, unchanged: 0 });
+          const report: ImportPreview = {
+            valid: true,
+            errors: [],
+            policy: policy as ImportPreview['policy'],
+            document: { haventory_export_version: 1, schema_version: 4, exported_at: null, integration_version: null },
+            items: bucket(itemIds),
+            locations: bucket(locIds),
+            counts: { items: counts(itemIds), locations: counts(locIds) },
+          };
+          return report as unknown as T;
+        }
+        case 'haventory/import/execute': {
+          const doc = ((msg as any).document ?? {}) as { items?: Item[]; locations?: Location[] };
+          const policy = String((msg as any).policy || 'merge');
+          items = (doc.items ?? []).map((i) => ({ ...i }));
+          locations = (doc.locations ?? []).map((l) => ({ ...l }));
+          const summary: ImportSummary = {
+            applied: true,
+            policy: policy as ImportSummary['policy'],
+            items: { total: items.length, add: items.length, update: 0, conflict: 0, unchanged: 0 },
+            locations: { total: locations.length, add: locations.length, update: 0, conflict: 0, unchanged: 0 },
+            totals: {
+              items_total: items.length,
+              low_stock_count: 0,
+              checked_out_count: 0,
+              locations_total: locations.length,
+            },
+          };
+          return summary as unknown as T;
         }
         case 'haventory/distinct_values': {
           // Mirror the backend: distinct categories (case-insensitive) and tags,

--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -1,0 +1,607 @@
+"""JSON import/export for HAventory — data safety (backup & restore).
+
+This module builds versioned export documents from a :class:`Repository` and
+applies import documents back into one. It is framework-agnostic (no Home
+Assistant, no I/O): the WebSocket layer (``ws.py``) wraps it, persists on
+success, and rolls back on failure.
+
+Document shape (``haventory_export_version = 1``)::
+
+    {
+        "haventory_export_version": 1,
+        "schema_version": <int>,
+        "exported_at": "YYYY-MM-DDTHH:MM:SSZ",
+        "integration_version": "0.0.1",
+        "items": [ <ItemDoc>, ... ],
+        "locations": [ <LocationDoc>, ... ]
+    }
+
+``ItemDoc`` / ``LocationDoc`` carry every source-of-truth field plus the
+denormalized paths, so a round-trip (export → import into an empty instance)
+reproduces the data exactly. The document is machine-generated and best treated
+as opaque; hand-editing is supported but paths are recomputed on import.
+
+Import is a three-step contract:
+
+* :func:`plan_import` — validate + classify without mutating; the basis for the
+  ``haventory/import/preview`` command and for ``execute``'s dry run.
+* the caller applies the returned ``target_payload`` via ``Repository.load_state``
+  and persists, rolling back to a snapshot on any failure.
+
+Conflict policies (for ids already present in the repository):
+
+* ``skip`` — keep the existing entity; the incoming one is ignored.
+* ``replace`` — overwrite the existing entity with the incoming one.
+* ``merge`` — overlay incoming onto existing: scalar fields from incoming, item
+  ``tags`` unioned, item ``custom_fields`` merged (incoming wins per key).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from .const import INTEGRATION_VERSION
+from .exceptions import ValidationError
+from .models import (
+    EMPTY_LOCATION_PATH,
+    Item,
+    Location,
+    build_location_path_from_map,
+    iso_utc_now,
+    normalize_tags,
+    parse_uuid4,
+)
+from .repository import Repository
+
+# Version of the export *document envelope* (independent of the storage
+# ``schema_version``, which describes item/location field shapes).
+EXPORT_VERSION: int = 1
+
+Policy = Literal["merge", "replace", "skip"]
+POLICIES: tuple[Policy, ...] = ("merge", "replace", "skip")
+
+# Source-of-truth item fields compared when deciding add/update/conflict/unchanged.
+# Derived fields (location_path) are intentionally excluded — paths are recomputed.
+_ITEM_SOURCE_FIELDS: tuple[str, ...] = (
+    "name",
+    "description",
+    "quantity",
+    "checked_out",
+    "due_date",
+    "inspection_date",
+    "location_id",
+    "tags",
+    "category",
+    "low_stock_threshold",
+    "custom_fields",
+    "created_at",
+    "updated_at",
+    "version",
+)
+_LOCATION_SOURCE_FIELDS: tuple[str, ...] = ("name", "parent_id", "area_id")
+
+
+# -----------------------------
+# Export
+# -----------------------------
+
+
+def _serialize_item_doc(item: Item) -> dict[str, Any]:
+    """Serialize an item to a document entry (all source + path fields)."""
+
+    return {
+        "id": str(item.id),
+        "name": item.name,
+        "description": item.description,
+        "quantity": int(item.quantity),
+        "checked_out": bool(item.checked_out),
+        "due_date": item.due_date,
+        "inspection_date": item.inspection_date,
+        "location_id": str(item.location_id) if item.location_id is not None else None,
+        "tags": list(item.tags),
+        "category": item.category,
+        "low_stock_threshold": item.low_stock_threshold,
+        "custom_fields": dict(item.custom_fields),
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+        "version": int(item.version),
+        "location_path": {
+            "id_path": [str(x) for x in item.location_path.id_path],
+            "name_path": list(item.location_path.name_path),
+            "display_path": item.location_path.display_path,
+            "sort_key": item.location_path.sort_key,
+        },
+    }
+
+
+def _serialize_location_doc(loc: Location) -> dict[str, Any]:
+    """Serialize a location to a document entry (all source + path fields)."""
+
+    return {
+        "id": str(loc.id),
+        "name": loc.name,
+        "parent_id": str(loc.parent_id) if loc.parent_id is not None else None,
+        "area_id": str(loc.area_id) if loc.area_id is not None else None,
+        "path": {
+            "id_path": [str(x) for x in loc.path.id_path],
+            "name_path": list(loc.path.name_path),
+            "display_path": loc.path.display_path,
+            "sort_key": loc.path.sort_key,
+        },
+    }
+
+
+def build_export_document(
+    repo: Repository,
+    *,
+    item_filter: dict[str, Any] | None = None,
+    schema_version: int,
+) -> dict[str, Any]:
+    """Build a versioned export document from ``repo``.
+
+    With no ``item_filter`` this is a full backup: every item and location.
+    With a filter, only the matching items are exported, together with the
+    locations on each item's ancestry (its ``location_path``) so the document
+    stays referentially self-consistent.
+    """
+
+    if item_filter is None:
+        items = list(repo._items_by_id.values())
+        location_ids = set(repo._locations_by_id.keys())
+    else:
+        page = repo.list_items(flt=item_filter, limit=None)  # type: ignore[arg-type]
+        items = list(page["items"])
+        # Keep every location referenced by an exported item's ancestry so the
+        # document remains self-consistent (items always reference a location
+        # that is present in the same document).
+        location_ids = set()
+        for it in items:
+            for lid in it.location_path.id_path:
+                location_ids.add(str(lid))
+            if it.location_id is not None:
+                location_ids.add(str(it.location_id))
+
+    items_docs = [_serialize_item_doc(items[i]) for i in _sorted_index_by_id(items)]
+    locations = [
+        repo._locations_by_id[lid]
+        for lid in sorted(location_ids)
+        if lid in repo._locations_by_id
+    ]
+    locations_docs = [_serialize_location_doc(loc) for loc in locations]
+
+    return {
+        "haventory_export_version": EXPORT_VERSION,
+        "schema_version": int(schema_version),
+        "exported_at": iso_utc_now(),
+        "integration_version": INTEGRATION_VERSION,
+        "items": items_docs,
+        "locations": locations_docs,
+    }
+
+
+def _sorted_index_by_id(items: list[Item]) -> list[int]:
+    """Return indices of ``items`` ordered by their stringified id (stable export)."""
+
+    return sorted(range(len(items)), key=lambda i: str(items[i].id))
+
+
+# -----------------------------
+# Import — validation & planning
+# -----------------------------
+
+
+def _err(path: str, message: str) -> dict[str, str]:
+    return {"path": path, "message": message}
+
+
+def _coerce_entity_list(value: Any) -> list[dict[str, Any]] | None:
+    """Accept the document list form (preferred) or a legacy id->dict mapping."""
+
+    if isinstance(value, list):
+        if all(isinstance(v, dict) for v in value):
+            return list(value)
+        return None
+    if isinstance(value, dict):
+        # Tolerate {id: entity} maps produced by repository.export_state.
+        return [v for v in value.values() if isinstance(v, dict)]
+    return None
+
+
+def _parse_envelope(
+    doc: Any,
+    *,
+    current_schema_version: int | None,
+) -> tuple[list[dict[str, Any]] | None, list[dict[str, Any]] | None, list[dict[str, str]]]:
+    """Validate the document envelope. Returns (items, locations, errors).
+
+    ``items``/``locations`` are ``None`` when the envelope is unusable.
+    """
+
+    errors: list[dict[str, str]] = []
+    if not isinstance(doc, dict):
+        return None, None, [_err("document", "document must be a JSON object")]
+
+    version = doc.get("haventory_export_version")
+    if version is None:
+        errors.append(_err("haventory_export_version", "missing export version"))
+    elif not isinstance(version, int) or isinstance(version, bool):
+        errors.append(_err("haventory_export_version", "export version must be an integer"))
+    elif version > EXPORT_VERSION:
+        errors.append(
+            _err(
+                "haventory_export_version",
+                f"unsupported export version {version} (this build supports {EXPORT_VERSION})",
+            )
+        )
+
+    sv = doc.get("schema_version")
+    if sv is None:
+        errors.append(_err("schema_version", "missing schema_version"))
+    elif not isinstance(sv, int) or isinstance(sv, bool):
+        errors.append(_err("schema_version", "schema_version must be an integer"))
+    elif current_schema_version is not None and sv > current_schema_version:
+        errors.append(
+            _err(
+                "schema_version",
+                f"document schema version {sv} is newer than supported "
+                f"({current_schema_version}); upgrade HAventory before importing",
+            )
+        )
+
+    items = _coerce_entity_list(doc.get("items", []))
+    if items is None:
+        errors.append(_err("items", "items must be an array of objects"))
+    locations = _coerce_entity_list(doc.get("locations", []))
+    if locations is None:
+        errors.append(_err("locations", "locations must be an array of objects"))
+
+    return items, locations, errors
+
+
+def _validate_uuid4(value: Any, path: str, errors: list[dict[str, str]]) -> str | None:
+    if not isinstance(value, str) or not value:
+        errors.append(_err(path, "must be a non-empty UUID v4 string"))
+        return None
+    try:
+        parse_uuid4(value, field_name=path)
+    except ValidationError as exc:
+        errors.append(_err(path, str(exc)))
+        return None
+    return value
+
+
+def _validate_location_doc(
+    idx: int, doc: dict[str, Any], errors: list[dict[str, str]]
+) -> str | None:
+    base = f"locations[{idx}]"
+    lid = _validate_uuid4(doc.get("id"), f"{base}.id", errors)
+    name = doc.get("name")
+    if not isinstance(name, str) or not name.strip():
+        errors.append(_err(f"{base}.name", "name is required and must be a non-empty string"))
+    parent_id = doc.get("parent_id")
+    if parent_id is not None:
+        _validate_uuid4(parent_id, f"{base}.parent_id", errors)
+    area_id = doc.get("area_id")
+    if area_id is not None and not isinstance(area_id, str):
+        errors.append(_err(f"{base}.area_id", "area_id must be a string or null"))
+    return lid
+
+
+def _validate_item_doc(idx: int, doc: dict[str, Any], errors: list[dict[str, str]]) -> str | None:
+    base = f"items[{idx}]"
+    iid = _validate_uuid4(doc.get("id"), f"{base}.id", errors)
+    name = doc.get("name")
+    if not isinstance(name, str) or not name.strip():
+        errors.append(_err(f"{base}.name", "name is required and must be a non-empty string"))
+    qty = doc.get("quantity", 1)
+    if not isinstance(qty, int) or isinstance(qty, bool) or qty < 0:
+        errors.append(_err(f"{base}.quantity", "quantity must be an integer >= 0"))
+    thr = doc.get("low_stock_threshold")
+    if thr is not None and (not isinstance(thr, int) or isinstance(thr, bool) or thr < 0):
+        errors.append(
+            _err(
+                f"{base}.low_stock_threshold",
+                "low_stock_threshold must be an integer >= 0 or null",
+            )
+        )
+    loc_id = doc.get("location_id")
+    if loc_id is not None:
+        _validate_uuid4(loc_id, f"{base}.location_id", errors)
+    tags = doc.get("tags", [])
+    if not isinstance(tags, list) or any(not isinstance(t, str) for t in tags):
+        errors.append(_err(f"{base}.tags", "tags must be an array of strings"))
+    cf = doc.get("custom_fields", {})
+    if not isinstance(cf, dict):
+        errors.append(_err(f"{base}.custom_fields", "custom_fields must be an object"))
+    else:
+        for k, v in cf.items():
+            if not isinstance(k, str) or not k:
+                errors.append(
+                    _err(f"{base}.custom_fields", "custom_fields keys must be non-empty strings")
+                )
+            elif not isinstance(v, str | int | float | bool):
+                errors.append(
+                    _err(f"{base}.custom_fields.{k}", "custom_fields values must be scalar")
+                )
+    return iid
+
+
+def _canonical_item(doc: dict[str, Any]) -> dict[str, Any]:
+    """Normalize an item document to its comparable source-of-truth subset."""
+
+    out: dict[str, Any] = {}
+    for f in _ITEM_SOURCE_FIELDS:
+        if f == "tags":
+            out[f] = normalize_tags(doc.get("tags") or [])
+        elif f == "custom_fields":
+            out[f] = dict(doc.get("custom_fields") or {})
+        else:
+            out[f] = doc.get(f)
+    return out
+
+
+def _canonical_location(doc: dict[str, Any]) -> dict[str, Any]:
+    return {f: doc.get(f) for f in _LOCATION_SOURCE_FIELDS}
+
+
+def _merge_item(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    """Overlay ``incoming`` onto ``existing`` for the ``merge`` policy."""
+
+    merged = dict(existing)
+    for f in _ITEM_SOURCE_FIELDS:
+        if f == "tags":
+            union: list[str] = list(existing.get("tags") or [])
+            for t in normalize_tags(incoming.get("tags") or []):
+                if t not in union:
+                    union.append(t)
+            merged["tags"] = union
+        elif f == "custom_fields":
+            merged["custom_fields"] = {
+                **(existing.get("custom_fields") or {}),
+                **(incoming.get("custom_fields") or {}),
+            }
+        elif f in incoming:
+            merged[f] = incoming[f]
+    merged["id"] = existing["id"]
+    return merged
+
+
+def _recompute_paths(
+    items: dict[str, dict[str, Any]],
+    locations: dict[str, dict[str, Any]],
+    errors: list[dict[str, str]],
+) -> dict[str, Any] | None:
+    """Materialize objects, recompute all denormalized paths, and re-serialize.
+
+    Validates referential integrity as a side effect (item.location_id and
+    location.parent_id must resolve). Returns the storage-shaped payload, or
+    ``None`` when a reference is broken (with ``errors`` populated).
+    """
+
+    loc_objs: dict[str, Location] = {}
+    for lid, d in locations.items():
+        loc_objs[lid] = Location(
+            id=parse_uuid4(str(d["id"]), field_name="location.id"),
+            parent_id=(
+                parse_uuid4(str(d["parent_id"]), field_name="location.parent_id")
+                if d.get("parent_id") is not None
+                else None
+            ),
+            name=str(d["name"]),
+            area_id=str(d["area_id"]) if d.get("area_id") is not None else None,
+            path=EMPTY_LOCATION_PATH,
+        )
+
+    # Recompute location paths (also validates parent references resolve).
+    out_locations: dict[str, Any] = {}
+    for lid, obj in loc_objs.items():
+        try:
+            path = build_location_path_from_map(obj.id, locations_by_id=loc_objs)
+        except ValidationError as exc:
+            errors.append(_err(f"locations[{lid}].parent_id", str(exc)))
+            return None
+        out_locations[lid] = {
+            "id": str(obj.id),
+            "name": obj.name,
+            "parent_id": str(obj.parent_id) if obj.parent_id is not None else None,
+            "area_id": obj.area_id,
+            "path": {
+                "id_path": [str(x) for x in path.id_path],
+                "name_path": list(path.name_path),
+                "display_path": path.display_path,
+                "sort_key": path.sort_key,
+            },
+        }
+
+    out_items: dict[str, Any] = {}
+    for iid, d in items.items():
+        loc_id = d.get("location_id")
+        if loc_id is not None and str(loc_id) not in loc_objs:
+            errors.append(
+                _err(f"items[{iid}].location_id", "location_id must reference an existing location")
+            )
+            return None
+        if loc_id is not None:
+            lp = build_location_path_from_map(
+                parse_uuid4(str(loc_id), field_name="item.location_id"), locations_by_id=loc_objs
+            )
+            location_path = {
+                "id_path": [str(x) for x in lp.id_path],
+                "name_path": list(lp.name_path),
+                "display_path": lp.display_path,
+                "sort_key": lp.sort_key,
+            }
+        else:
+            location_path = {"id_path": [], "name_path": [], "display_path": "", "sort_key": ""}
+        entry = dict(d)
+        entry["tags"] = normalize_tags(d.get("tags") or [])
+        entry["custom_fields"] = dict(d.get("custom_fields") or {})
+        entry["location_path"] = location_path
+        out_items[iid] = entry
+
+    return {"items": out_items, "locations": out_locations}
+
+
+def _empty_bucket() -> dict[str, list[str]]:
+    return {"add": [], "update": [], "conflict": [], "unchanged": []}
+
+
+def _bucket_counts(bucket: dict[str, list[str]]) -> dict[str, int]:
+    total = sum(len(v) for v in bucket.values())
+    return {
+        "total": total,
+        "add": len(bucket["add"]),
+        "update": len(bucket["update"]),
+        "conflict": len(bucket["conflict"]),
+        "unchanged": len(bucket["unchanged"]),
+    }
+
+
+def plan_import(
+    repo: Repository,
+    doc: Any,
+    *,
+    policy: Policy = "merge",
+    current_schema_version: int | None = None,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Validate and classify an import document without mutating ``repo``.
+
+    Returns ``(report, target_payload)``. ``report["valid"]`` is ``False`` when
+    the document is unusable or contains invalid entities, in which case
+    ``target_payload`` is ``None`` and ``report["errors"]`` explains why.
+
+    Classification (per entity, mutually exclusive):
+
+    * ``add`` — id absent from the repository (created under every policy).
+    * ``unchanged`` — id present and content identical to the stored entity.
+    * ``update`` — id present, content differs, and the policy modifies it
+      (``replace``/``merge``).
+    * ``conflict`` — id present, content differs, and the policy leaves it
+      untouched (``skip``).
+    """
+
+    if policy not in POLICIES:
+        raise ValidationError(f"policy must be one of: {', '.join(POLICIES)}")
+
+    items_in, locations_in, errors = _parse_envelope(
+        doc, current_schema_version=current_schema_version
+    )
+    report: dict[str, Any] = {
+        "valid": False,
+        "errors": errors,
+        "policy": policy,
+        "document": _document_meta(doc if isinstance(doc, dict) else {}),
+        "items": _empty_bucket(),
+        "locations": _empty_bucket(),
+        "counts": {},
+    }
+    if items_in is None or locations_in is None or errors:
+        return report, None
+
+    # Per-entity structural validation.
+    loc_ids: list[str] = []
+    for i, d in enumerate(locations_in):
+        loc_ids.append(_validate_location_doc(i, d, errors) or "")
+    item_ids: list[str] = []
+    for i, d in enumerate(items_in):
+        item_ids.append(_validate_item_doc(i, d, errors) or "")
+
+    # Duplicate ids within the document are ambiguous — reject.
+    _check_duplicate_ids(item_ids, "items", errors)
+    _check_duplicate_ids(loc_ids, "locations", errors)
+
+    if errors:
+        report["errors"] = errors
+        return report, None
+
+    existing = repo.export_state()
+    existing_items = existing.get("items", {})
+    existing_locations = existing.get("locations", {})
+
+    target_items = {iid: dict(d) for iid, d in existing_items.items()}
+    target_locations = {lid: dict(d) for lid, d in existing_locations.items()}
+
+    _plan_entities(
+        incoming=locations_in,
+        ids=loc_ids,
+        existing=existing_locations,
+        target=target_locations,
+        bucket=report["locations"],
+        policy=policy,
+        canonical=_canonical_location,
+        merge=lambda ex, inc: {**ex, **inc},  # locations: merge == replace (structural)
+    )
+    _plan_entities(
+        incoming=items_in,
+        ids=item_ids,
+        existing=existing_items,
+        target=target_items,
+        bucket=report["items"],
+        policy=policy,
+        canonical=_canonical_item,
+        merge=_merge_item,
+    )
+
+    payload = _recompute_paths(target_items, target_locations, errors)
+    if payload is None or errors:
+        report["errors"] = errors
+        return report, None
+
+    report["valid"] = True
+    report["counts"] = {
+        "items": _bucket_counts(report["items"]),
+        "locations": _bucket_counts(report["locations"]),
+    }
+    return report, payload
+
+
+def _plan_entities(  # noqa: PLR0913 - cohesive planning parameters
+    *,
+    incoming: list[dict[str, Any]],
+    ids: list[str],
+    existing: dict[str, Any],
+    target: dict[str, dict[str, Any]],
+    bucket: dict[str, list[str]],
+    policy: Policy,
+    canonical,
+    merge,
+) -> None:
+    """Classify each incoming entity and write the resolved form into ``target``."""
+
+    for eid, inc in zip(ids, incoming, strict=True):
+        if eid not in existing:
+            bucket["add"].append(eid)
+            target[eid] = dict(inc)
+            continue
+        if canonical(inc) == canonical(existing[eid]):
+            bucket["unchanged"].append(eid)
+            continue
+        if policy == "skip":
+            bucket["conflict"].append(eid)
+            # keep existing (already in target)
+            continue
+        bucket["update"].append(eid)
+        if policy == "replace":
+            target[eid] = dict(inc)
+        else:  # merge
+            target[eid] = merge(dict(existing[eid]), dict(inc))
+
+
+def _check_duplicate_ids(ids: list[str], label: str, errors: list[dict[str, str]]) -> None:
+    seen: set[str] = set()
+    for eid in ids:
+        if not eid:
+            continue
+        if eid in seen:
+            errors.append(_err(label, f"duplicate id in document: {eid}"))
+        seen.add(eid)
+
+
+def _document_meta(doc: dict[str, Any]) -> dict[str, Any]:
+    sv = doc.get("schema_version")
+    return {
+        "haventory_export_version": doc.get("haventory_export_version"),
+        "schema_version": int(sv) if isinstance(sv, int) and not isinstance(sv, bool) else None,
+        "exported_at": doc.get("exported_at"),
+        "integration_version": doc.get("integration_version"),
+    }

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -15,10 +15,12 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
+from . import import_export
 from . import storage as storage_mod
 from .areas import async_get_area_registry
 from .const import DOMAIN, INTEGRATION_VERSION
 from .exceptions import ConflictError, NotFoundError, StorageError, ValidationError
+from .import_export import POLICIES
 from .models import ItemUpdate, normalize_tags
 from .repository import UNSET, Repository
 from .storage import CURRENT_SCHEMA_VERSION
@@ -1421,6 +1423,132 @@ async def ws_areas_list(hass: HomeAssistant, conn, msg):
 
 
 # -----------------------------
+# Import / Export (data safety)
+# -----------------------------
+
+
+@websocket_api.websocket_command(
+    {vol.Required("type"): "haventory/export", vol.Optional("filter"): dict}
+)
+@websocket_api.async_response
+@ws_guard("export", ())
+async def ws_export(hass: HomeAssistant, conn, msg):
+    if "filter" in msg and not isinstance(msg.get("filter"), dict):
+        raise ValidationError("filter must be an object")
+    item_filter = msg.get("filter") if "filter" in msg else None
+    document = import_export.build_export_document(
+        _repo(hass),
+        item_filter=item_filter,
+        schema_version=_schema_version_from_hass(hass),
+    )
+    conn.send_message(websocket_api.result_message(msg.get("id", 0), document))
+
+
+def _import_policy(msg: dict) -> str:
+    policy = msg.get("policy", "merge")
+    if policy not in POLICIES:
+        raise ValidationError(f"policy must be one of: {', '.join(POLICIES)}")
+    return policy
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "haventory/import/preview",
+        vol.Required("document"): dict,
+        vol.Optional("policy"): str,
+    }
+)
+@websocket_api.async_response
+@ws_guard("import_preview", ())
+async def ws_import_preview(hass: HomeAssistant, conn, msg):
+    policy = _import_policy(msg)
+    report, _target = import_export.plan_import(
+        _repo(hass),
+        msg.get("document"),
+        policy=policy,
+        current_schema_version=_schema_version_from_hass(hass),
+    )
+    conn.send_message(websocket_api.result_message(msg.get("id", 0), report))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "haventory/import/execute",
+        vol.Required("document"): dict,
+        vol.Optional("policy"): str,
+    }
+)
+@websocket_api.async_response
+@ws_guard("import_execute", ())
+async def ws_import_execute(hass: HomeAssistant, conn, msg):
+    policy = _import_policy(msg)
+    repo = _repo(hass)
+    report, target = import_export.plan_import(
+        repo,
+        msg.get("document"),
+        policy=policy,
+        current_schema_version=_schema_version_from_hass(hass),
+    )
+    if not report.get("valid") or target is None:
+        # Invalid document: surface structured errors without mutating state.
+        err = websocket_api.error_message(
+            msg.get("id", 0),
+            "validation_error",
+            "import document is invalid",
+            {"op": "import_execute", "errors": report.get("errors", [])},
+        )
+        LOGGER.warning(
+            "Import rejected: invalid document",
+            extra={
+                "domain": DOMAIN,
+                "op": "import_execute",
+                "error_count": len(report.get("errors", [])),
+            },
+        )
+        conn.send_message(err)
+        return
+
+    # Snapshot for rollback, then swap the whole dataset atomically.
+    snapshot = repo.export_state()
+    repo.load_state(target)
+    try:
+        await _persist_repo(hass)
+    except Exception:
+        # A failed persist must never leave partial in-memory state.
+        repo.load_state(snapshot)
+        LOGGER.error(
+            "Import failed during persist; rolled back",
+            extra={"domain": DOMAIN, "op": "import_execute"},
+            exc_info=True,
+        )
+        raise
+
+    # Tell every subscriber the dataset was replaced wholesale.
+    _broadcast_event(hass, topic="items", action="reloaded", payload=None)
+    _broadcast_event(hass, topic="locations", action="reloaded", payload=None)
+    _broadcast_counts(hass)
+
+    summary = {
+        "applied": True,
+        "policy": policy,
+        "items": report["counts"]["items"],
+        "locations": report["counts"]["locations"],
+        "totals": repo.get_counts(),
+    }
+    LOGGER.info(
+        "Import applied",
+        extra={
+            "domain": DOMAIN,
+            "op": "import_execute",
+            "policy": policy,
+            "items_total": summary["items"]["total"],
+            "locations_total": summary["locations"]["total"],
+        },
+    )
+    conn.send_message(websocket_api.result_message(msg.get("id", 0), summary))
+
+
+# -----------------------------
 # Registration
 # -----------------------------
 
@@ -1462,6 +1590,9 @@ def setup(hass: HomeAssistant) -> None:
         ws_location_tree,
         ws_location_move_subtree,
         ws_areas_list,
+        ws_export,
+        ws_import_preview,
+        ws_import_execute,
     ]
 
     for h in handlers:

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -65,8 +65,8 @@ Handlers map domain exceptions to these codes and log with context; `conflict` a
 
 - Event payloads (inside `event`):
   - Common: `{domain: "haventory", topic: "items"|"locations"|"stats", action: string, ts: string, ...payload}`
-  - Items topic payloads include `{item: <Item>}` and actions: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed`.
-  - Locations topic payloads include `{location: <Location>}` and actions: `created`, `renamed`, `moved`, `deleted`.
+  - Items topic payloads include `{item: <Item>}` and actions: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed`. The `reloaded` action (emitted after `import/execute`) carries **no** `item` and signals a wholesale dataset replacement.
+  - Locations topic payloads include `{location: <Location>}` and actions: `created`, `renamed`, `moved`, `deleted`. The `reloaded` action (emitted after `import/execute`) carries **no** `location`.
   - Stats topic payload `action: "counts"` with `{counts: <stats shape>}`.
   - When `location_id` filter is provided on subscription:
     - Items: if `include_subtree` (default true) match any item whose `location_path.id_path` contains the filter id; otherwise only direct `location_id` matches.
@@ -168,6 +168,47 @@ Handlers map domain exceptions to these codes and log with context; `conflict` a
 - `haventory/location/move_subtree`
   - Payload: `{location_id: string, new_parent_id: string|null}`
   - Result: `<Location>`; emits `locations/moved` and `stats/counts`.
+
+### Import / export (data safety)
+
+Backup-and-restore over WebSocket. Processing is in-memory (add chunking only if
+payload size demands it). The export document embeds `schema_version` plus all items
+and locations; a round-trip (export → import into an empty instance) reproduces the
+data. See `data_shapes.md` for the full document, preview, and summary shapes.
+
+- `haventory/export`
+  - Payload: `{filter?: <ItemFilter>}` (a non-object `filter` → `validation_error`).
+  - Result: `<ExportDocument>`. With no filter this is a full backup; with a filter,
+    only matching items are exported together with the locations on each item's
+    ancestry (so the document stays referentially self-consistent).
+  - Read-only: emits no events and does not mutate state.
+
+- `haventory/import/preview`
+  - Payload: `{document: <ExportDocument>, policy?: "merge"|"replace"|"skip"}` (default
+    `merge`).
+  - Result: `<ImportPreview>` — validates and classifies **without mutating state**.
+    Each incoming entity lands in exactly one bucket: `add` (id absent), `unchanged`
+    (id present, identical), `update` (id present, differs, resolved by the policy), or
+    `conflict` (id present, differs, left untouched by `skip`). Invalid documents return
+    `{valid: false, errors: [{path, message}]}` rather than throwing.
+
+- `haventory/import/execute`
+  - Payload: `{document: <ExportDocument>, policy?: "merge"|"replace"|"skip"}` (default
+    `merge`).
+  - Applies the document with the chosen conflict policy, persists immediately, then
+    emits `items/reloaded`, `locations/reloaded`, and `stats/counts`. Result:
+    `<ImportSummary>`.
+  - An invalid document is rejected with a `validation_error` whose `data.errors` lists
+    the structured problems; **state is not mutated**. If persistence fails after the
+    in-memory swap, the repository is rolled back to its pre-import snapshot and the
+    error surfaces as `storage_error` — a bad import never leaves partial state.
+  - Conflict policies (for ids already present): `skip` keeps the existing entity;
+    `replace` overwrites it with the incoming one; `merge` overlays incoming onto
+    existing (scalar fields from incoming; item `tags` unioned; item `custom_fields`
+    merged, incoming wins per key). For locations, `merge` behaves as `replace`.
+
+Note: a successful import emits `items/reloaded` and `locations/reloaded` (no `item` /
+`location` payload) to tell every subscriber the dataset was replaced wholesale.
 
 ### Versioning and concurrency
 

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -142,6 +142,67 @@ Result of `distinct_values`, used by category/tag autocomplete, the browser view
 - Both value lists are sorted case-insensitively by `value`. Items with no category (or no tags) contribute nothing to the respective list.
 - `custom_field_keys` is the sorted, distinct set of keys used across all items' `custom_fields` (keys are case-sensitive; sorted case-insensitively). Empty when no item has custom fields.
 
+### Import / export (data safety)
+
+`ExportDocument` — the versioned backup produced by `haventory/export` and accepted by
+`haventory/import/preview` / `haventory/import/execute`:
+```json
+{
+  "haventory_export_version": 1,
+  "schema_version": 4,
+  "exported_at": "YYYY-MM-DDTHH:MM:SSZ",
+  "integration_version": "0.0.1",
+  "items": [ <Item>, ... ],
+  "locations": [ <Location>, ... ]
+}
+```
+
+- `haventory_export_version` versions the document envelope; `schema_version` is the
+  storage schema of the embedded item/location shapes.
+- `items` / `locations` are arrays of the canonical `Item` / `Location` shapes above,
+  including the denormalized `location_path` / `path` (with `sort_key`) so a round-trip
+  reproduces the data exactly. The document is machine-generated and best treated as
+  opaque; hand-editing works but paths are recomputed on import.
+
+`ImportPreview` — result of `haventory/import/preview` (no mutation):
+```json
+{
+  "valid": true,
+  "errors": [ { "path": "items[2].id", "message": "must be a UUID v4 string" } ],
+  "policy": "merge",
+  "document": {
+    "haventory_export_version": 1, "schema_version": 4,
+    "exported_at": "…", "integration_version": "0.0.1"
+  },
+  "items":     { "add": ["uuid"], "update": [], "conflict": [], "unchanged": [] },
+  "locations": { "add": [], "update": [], "conflict": [], "unchanged": [] },
+  "counts": {
+    "items":     { "total": 1, "add": 1, "update": 0, "conflict": 0, "unchanged": 0 },
+    "locations": { "total": 0, "add": 0, "update": 0, "conflict": 0, "unchanged": 0 }
+  }
+}
+```
+
+- Buckets are mutually exclusive per entity: `add` (id absent), `unchanged` (present &
+  identical), `update` (present, differs, resolved by `merge`/`replace`), `conflict`
+  (present, differs, left as-is by `skip`). Under `merge`/`replace` `conflict` is empty;
+  under `skip` `update` is empty.
+- When `valid` is `false`, `errors` (each `{path, message}`) explains why and `counts` is
+  empty. Envelope problems (bad/missing versions, malformed `items`/`locations`, a
+  `schema_version` newer than supported), invalid entities, duplicate ids, and broken
+  references (e.g. an item's `location_id` with no matching location) all surface here.
+
+`ImportSummary` — result of a successful `haventory/import/execute`:
+```json
+{
+  "applied": true,
+  "policy": "merge",
+  "items":     { "total": 2, "add": 2, "update": 0, "conflict": 0, "unchanged": 0 },
+  "locations": { "total": 1, "add": 1, "update": 0, "conflict": 0, "unchanged": 0 },
+  "totals": { "items_total": 2, "low_stock_count": 0, "checked_out_count": 0, "locations_total": 1 }
+}
+```
+
 ### Events
 
 Common envelope inside HA WS event wrapper:
@@ -149,8 +210,8 @@ Common envelope inside HA WS event wrapper:
 { "domain": "haventory", "topic": "items|locations|stats", "action": "...", "ts": "ISO8601Z", ... }
 ```
 
-- Items: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed` with `{item: <Item>}`.
-- Locations: `created`, `renamed`, `moved`, `deleted` with `{location: <Location>}`.
+- Items: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed` with `{item: <Item>}`; plus `reloaded` (no `item`) after an import replaces the dataset.
+- Locations: `created`, `renamed`, `moved`, `deleted` with `{location: <Location>}`; plus `reloaded` (no `location`) after an import.
 - Stats: `counts` with `{counts: <Counts>}`.
 
 ### Validation notes

--- a/tests/integration/test_import_export.py
+++ b/tests/integration/test_import_export.py
@@ -1,0 +1,126 @@
+"""Integration: JSON import/export end-to-end through the real websocket_api.
+
+Drives ``haventory/export`` and ``haventory/import/execute`` over a real Home
+Assistant WebSocket connection (``hass_ws_client``). The round-trip test empties
+the instance after exporting, then imports the document back and asserts the data
+is reproduced — the real-HA counterpart to the offline round-trip unit test.
+"""
+
+from __future__ import annotations
+
+from custom_components.haventory.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_export_then_import_into_emptied_instance(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """Export, empty the instance, import the document, and verify data returns."""
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+    quantity = 3
+
+    # Create a location and an item inside it.
+    await client.send_json({"id": 1, "type": "haventory/location/create", "name": "Garage"})
+    loc = await client.receive_json()
+    assert loc["success"] is True, loc
+    location_id = loc["result"]["id"]
+
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "haventory/item/create",
+            "name": "Hammer",
+            "quantity": quantity,
+            "location_id": location_id,
+            "tags": ["tools"],
+        }
+    )
+    created = await client.receive_json()
+    assert created["success"] is True, created
+    item_id = created["result"]["id"]
+
+    # Export the full dataset.
+    await client.send_json({"id": 3, "type": "haventory/export"})
+    exported = await client.receive_json()
+    assert exported["success"] is True, exported
+    document = exported["result"]
+    assert len(document["items"]) == 1
+    assert len(document["locations"]) == 1
+
+    # Empty the instance: delete the item, then its (now empty) location.
+    await client.send_json({"id": 4, "type": "haventory/item/delete", "item_id": item_id})
+    assert (await client.receive_json())["success"] is True
+    await client.send_json(
+        {"id": 5, "type": "haventory/location/delete", "location_id": location_id}
+    )
+    assert (await client.receive_json())["success"] is True
+
+    await client.send_json({"id": 6, "type": "haventory/stats"})
+    stats = await client.receive_json()
+    assert stats["result"]["items_total"] == 0
+    assert stats["result"]["locations_total"] == 0
+
+    # Import the document back into the now-empty instance.
+    await client.send_json(
+        {"id": 7, "type": "haventory/import/execute", "document": document, "policy": "merge"}
+    )
+    applied = await client.receive_json()
+    assert applied["success"] is True, applied
+    assert applied["result"]["applied"] is True
+    assert applied["result"]["totals"]["items_total"] == 1
+
+    # The item is reproduced with its original id and fields.
+    await client.send_json({"id": 8, "type": "haventory/item/get", "item_id": item_id})
+    fetched = await client.receive_json()
+    assert fetched["success"] is True, fetched
+    assert fetched["result"]["name"] == "Hammer"
+    assert fetched["result"]["quantity"] == quantity
+    assert fetched["result"]["location_id"] == location_id
+    assert fetched["result"]["location_path"]["display_path"] == "Garage"
+
+
+async def test_import_preview_reports_errors_without_mutating(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """A structurally invalid document is reported, not applied."""
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    bad_document = {
+        "haventory_export_version": 1,
+        "schema_version": 4,
+        "items": [{"id": "not-a-uuid", "name": ""}],
+        "locations": [],
+    }
+
+    await client.send_json(
+        {"id": 1, "type": "haventory/import/preview", "document": bad_document}
+    )
+    preview = await client.receive_json()
+    assert preview["success"] is True, preview
+    assert preview["result"]["valid"] is False
+    assert preview["result"]["errors"]
+
+    # Executing the same invalid document is a structured validation error.
+    await client.send_json(
+        {"id": 2, "type": "haventory/import/execute", "document": bad_document}
+    )
+    executed = await client.receive_json()
+    assert executed["success"] is False, executed
+    assert executed["error"]["code"] == "validation_error"
+
+    # Nothing was written.
+    await client.send_json({"id": 3, "type": "haventory/stats"})
+    stats = await client.receive_json()
+    assert stats["result"]["items_total"] == 0

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -1,0 +1,395 @@
+"""Offline tests for HAventory JSON import/export (data safety).
+
+Covers the ``import_export`` module and the three WebSocket commands
+(``haventory/export``, ``haventory/import/preview``, ``haventory/import/execute``):
+
+- full and filtered export to a versioned document,
+- round-trip (export → import into an empty instance reproduces the data),
+- preview classification (add / update / conflict / unchanged) per policy,
+- merge / replace / skip conflict resolution,
+- structured errors for invalid documents (envelope, entity, and referential),
+- an invalid-field case for export (matching the suite's convention),
+- execute rollback so a failed persist never leaves partial state.
+"""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.haventory import import_export as ie
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.exceptions import StorageError, ValidationError
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
+from custom_components.haventory.ws import setup as ws_setup
+from homeassistant.core import HomeAssistant
+
+# The `_seed` helper always creates exactly this many items and locations.
+SEEDED_ITEMS = 2
+SEEDED_LOCATIONS = 2
+
+
+async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
+    handlers = hass.data.get("__ws_commands__", [])
+    for h in handlers:
+        schema = getattr(h, "_ws_schema", None)
+        if not callable(h) or not isinstance(schema, dict):
+            continue
+        if schema.get("type") != type_:
+            continue
+        req = {"id": _id, "type": type_}
+        req.update(payload)
+        return await h(hass, None, req)
+    raise AssertionError("No handler responded for type " + type_)
+
+
+def _new_hass() -> HomeAssistant:
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+    return hass
+
+
+def _seed(repo: Repository) -> dict[str, str]:
+    """Populate a repo with a small tree and a couple of items."""
+
+    garage = repo.create_location(name="Garage")
+    shelf = repo.create_location(name="Shelf A", parent_id=str(garage.id))
+    hammer = repo.create_item(
+        {
+            "name": "Hammer",
+            "quantity": 2,
+            "location_id": str(shelf.id),
+            "tags": ["tools", "red"],
+            "category": "Hardware",
+            "custom_fields": {"serial": "H-1"},
+        }
+    )
+    nails = repo.create_item({"name": "Nails", "quantity": 100})
+    return {
+        "garage": str(garage.id),
+        "shelf": str(shelf.id),
+        "hammer": str(hammer.id),
+        "nails": str(nails.id),
+    }
+
+
+# -----------------------------
+# Export (module + WS)
+# -----------------------------
+
+
+def test_build_export_document_full() -> None:
+    repo = Repository()
+    ids = _seed(repo)
+
+    doc = ie.build_export_document(repo, schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert doc["haventory_export_version"] == ie.EXPORT_VERSION
+    assert doc["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert doc["integration_version"]
+    assert doc["exported_at"].endswith("Z")
+    assert {i["id"] for i in doc["items"]} == {ids["hammer"], ids["nails"]}
+    assert {loc["id"] for loc in doc["locations"]} == {ids["garage"], ids["shelf"]}
+    hammer_doc = next(i for i in doc["items"] if i["id"] == ids["hammer"])
+    assert hammer_doc["location_path"]["display_path"] == "Garage / Shelf A"
+
+
+def test_build_export_document_filtered_includes_ancestor_locations() -> None:
+    repo = Repository()
+    ids = _seed(repo)
+
+    # Filter to just the Hammer (search by name); Nails must be excluded.
+    doc = ie.build_export_document(
+        repo, item_filter={"q": "Hammer"}, schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    assert {i["id"] for i in doc["items"]} == {ids["hammer"]}
+    # Both ancestor locations of the Hammer are kept so the doc stays consistent.
+    assert {loc["id"] for loc in doc["locations"]} == {ids["garage"], ids["shelf"]}
+
+
+@pytest.mark.asyncio
+async def test_ws_export_returns_document() -> None:
+    hass = _new_hass()
+    _seed(hass.data[DOMAIN]["repository"])
+
+    res = await _send(hass, 1, "haventory/export")
+    assert res["success"] is True, res
+    doc = res["result"]
+    assert doc["haventory_export_version"] == ie.EXPORT_VERSION
+    assert len(doc["items"]) == SEEDED_ITEMS
+
+
+@pytest.mark.asyncio
+async def test_ws_export_invalid_filter_field() -> None:
+    """Invalid-field case: a non-object filter is rejected as validation_error."""
+
+    hass = _new_hass()
+    res = await _send(hass, 1, "haventory/export", filter="not-an-object")
+    assert res["success"] is False, res
+    assert res["error"]["code"] == "validation_error"
+
+
+# -----------------------------
+# Round-trip guarantee (unit)
+# -----------------------------
+
+
+def test_round_trip_into_empty_reproduces_data() -> None:
+    source = Repository()
+    _seed(source)
+    doc = ie.build_export_document(source, schema_version=CURRENT_SCHEMA_VERSION)
+
+    target = Repository()
+    report, payload = ie.plan_import(
+        target, doc, policy="merge", current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+    assert report["valid"] is True
+    assert payload is not None
+    target.load_state(payload)
+
+    reexport = ie.build_export_document(target, schema_version=CURRENT_SCHEMA_VERSION)
+    assert reexport["items"] == doc["items"]
+    assert reexport["locations"] == doc["locations"]
+
+
+@pytest.mark.asyncio
+async def test_round_trip_via_ws_execute() -> None:
+    """End-to-end round-trip through the export + execute WS commands."""
+
+    src = _new_hass()
+    _seed(src.data[DOMAIN]["repository"])
+    exported = (await _send(src, 1, "haventory/export"))["result"]
+
+    dst = _new_hass()
+    preview = await _send(dst, 2, "haventory/import/preview", document=exported)
+    assert preview["success"] is True
+    assert preview["result"]["valid"] is True
+    assert preview["result"]["counts"]["items"]["add"] == SEEDED_ITEMS
+
+    applied = await _send(dst, 3, "haventory/import/execute", document=exported)
+    assert applied["success"] is True, applied
+    assert applied["result"]["applied"] is True
+    assert applied["result"]["totals"]["items_total"] == SEEDED_ITEMS
+
+    re_export = (await _send(dst, 4, "haventory/export"))["result"]
+    assert re_export["items"] == exported["items"]
+    assert re_export["locations"] == exported["locations"]
+
+
+# -----------------------------
+# Preview classification & policies
+# -----------------------------
+
+
+def _doc_from(repo: Repository) -> dict:
+    return ie.build_export_document(repo, schema_version=CURRENT_SCHEMA_VERSION)
+
+
+def test_preview_reimport_all_unchanged() -> None:
+    repo = Repository()
+    _seed(repo)
+    doc = _doc_from(repo)
+    report, _ = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+    assert report["valid"] is True
+    assert report["counts"]["items"]["unchanged"] == SEEDED_ITEMS
+    assert report["counts"]["items"]["add"] == 0
+    assert report["counts"]["locations"]["unchanged"] == SEEDED_LOCATIONS
+
+
+def test_preview_skip_marks_conflict_replace_marks_update() -> None:
+    repo = Repository()
+    ids = _seed(repo)
+    doc = _doc_from(repo)
+    # Mutate the exported Hammer so its content differs from the stored one.
+    for it in doc["items"]:
+        if it["id"] == ids["hammer"]:
+            it["name"] = "Hammer XL"
+
+    skip_rep, skip_target = ie.plan_import(
+        repo, doc, policy="skip", current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+    assert ids["hammer"] in skip_rep["items"]["conflict"]
+    assert skip_rep["items"]["update"] == []
+    # skip keeps the existing name in the target payload
+    assert skip_target["items"][ids["hammer"]]["name"] == "Hammer"
+
+    repl_rep, repl_target = ie.plan_import(
+        repo, doc, policy="replace", current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+    assert ids["hammer"] in repl_rep["items"]["update"]
+    assert repl_rep["items"]["conflict"] == []
+    assert repl_target["items"][ids["hammer"]]["name"] == "Hammer XL"
+
+
+def test_merge_unions_tags_and_merges_custom_fields() -> None:
+    repo = Repository()
+    ids = _seed(repo)
+    doc = _doc_from(repo)
+    for it in doc["items"]:
+        if it["id"] == ids["hammer"]:
+            it["tags"] = ["blue"]  # differs from stored ["tools","red"]
+            it["custom_fields"] = {"weight": "1kg"}  # stored has {"serial":"H-1"}
+
+    report, target = ie.plan_import(
+        repo, doc, policy="merge", current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+    assert ids["hammer"] in report["items"]["update"]
+    merged = target["items"][ids["hammer"]]
+    assert set(merged["tags"]) == {"tools", "red", "blue"}
+    assert merged["custom_fields"] == {"serial": "H-1", "weight": "1kg"}
+
+
+def test_replace_into_empty_and_add_new_item() -> None:
+    repo = Repository()
+    _seed(repo)
+    doc = _doc_from(repo)
+    # Add a brand-new item id to the document.
+    new_id = "11111111-1111-4111-8111-111111111111"
+    doc["items"].append(
+        {
+            "id": new_id,
+            "name": "Wrench",
+            "quantity": 1,
+            "location_id": None,
+            "tags": [],
+            "custom_fields": {},
+        }
+    )
+    report, target = ie.plan_import(
+        repo, doc, policy="replace", current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+    assert new_id in report["items"]["add"]
+    assert new_id in target["items"]
+
+
+# -----------------------------
+# Invalid documents
+# -----------------------------
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        "not a dict",
+        {"items": [], "locations": []},  # missing versions
+        {"haventory_export_version": 1, "schema_version": 4, "items": {}, "locations": 5},
+        {"haventory_export_version": 99, "schema_version": 4, "items": [], "locations": []},
+    ],
+)
+def test_preview_invalid_envelope_reports_errors(doc) -> None:
+    repo = Repository()
+    report, target = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+    assert report["valid"] is False
+    assert target is None
+    assert report["errors"]
+
+
+def test_preview_invalid_entity_reports_paths() -> None:
+    repo = Repository()
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [{"id": "not-a-uuid", "name": ""}],
+        "locations": [],
+    }
+    report, target = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+    assert report["valid"] is False
+    assert target is None
+    paths = {e["path"] for e in report["errors"]}
+    assert "items[0].id" in paths
+    assert "items[0].name" in paths
+
+
+def test_preview_broken_reference_reports_error() -> None:
+    repo = Repository()
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [
+            {
+                "id": "22222222-2222-4222-8222-222222222222",
+                "name": "Ghost",
+                "quantity": 1,
+                "location_id": "33333333-3333-4333-8333-333333333333",
+                "tags": [],
+                "custom_fields": {},
+            }
+        ],
+        "locations": [],
+    }
+    report, target = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+    assert report["valid"] is False
+    assert target is None
+    assert any("location_id" in e["path"] for e in report["errors"])
+
+
+def test_preview_schema_version_newer_than_supported() -> None:
+    repo = Repository()
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION + 5,
+        "items": [],
+        "locations": [],
+    }
+    report, _ = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+    assert report["valid"] is False
+    assert any(e["path"] == "schema_version" for e in report["errors"])
+
+
+def test_plan_import_rejects_unknown_policy() -> None:
+    repo = Repository()
+    with pytest.raises(ValidationError):
+        ie.plan_import(repo, _doc_from(repo), policy="bogus")  # type: ignore[arg-type]
+
+
+# -----------------------------
+# WS import/execute — errors & rollback
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_import_execute_invalid_document_is_validation_error() -> None:
+    hass = _new_hass()
+    bad = {"haventory_export_version": 1, "schema_version": CURRENT_SCHEMA_VERSION, "items": 3}
+    res = await _send(hass, 1, "haventory/import/execute", document=bad)
+    assert res["success"] is False, res
+    assert res["error"]["code"] == "validation_error"
+    assert res["error"]["data"]["errors"]
+
+
+@pytest.mark.asyncio
+async def test_ws_import_execute_rolls_back_on_persist_failure() -> None:
+    hass = _new_hass()
+    repo: Repository = hass.data[DOMAIN]["repository"]
+    _seed(repo)
+    before_counts = repo.get_counts()
+
+    # A document that would add a fresh item, then make persistence fail.
+    doc = ie.build_export_document(repo, schema_version=CURRENT_SCHEMA_VERSION)
+    doc["items"].append(
+        {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "Screwdriver",
+            "quantity": 1,
+            "location_id": None,
+            "tags": [],
+            "custom_fields": {},
+        }
+    )
+
+    class _FailingStore:
+        schema_version = CURRENT_SCHEMA_VERSION
+
+        async def async_save(self, _payload):
+            raise StorageError("disk full")
+
+    hass.data[DOMAIN]["store"] = _FailingStore()
+
+    res = await _send(hass, 1, "haventory/import/execute", document=doc)
+    assert res["success"] is False, res
+    assert res["error"]["code"] == "storage_error"
+    # State rolled back: the new item must NOT be present and counts unchanged.
+    assert repo.get_counts() == before_counts
+    assert "44444444-4444-4444-8444-444444444444" not in repo._items_by_id


### PR DESCRIPTION
## Summary

Adds versioned JSON **import/export over WebSocket** for data safety — back up the
inventory before a breaking update and restore it afterwards. History logs and CSV are
out of scope (deferred), as specified.

**Backend** (`custom_components/haventory/`)
- New `import_export.py`:
  - `build_export_document` — full or filtered export to a versioned document embedding
    `schema_version` plus all items and locations. A filtered export also keeps every
    location on each exported item's ancestry, so the document stays referentially
    self-consistent.
  - `plan_import` — validate + classify **without mutating** (basis for preview and the
    execute dry run). Each entity is bucketed `add` / `unchanged` / `update` / `conflict`;
    paths are recomputed on import and referential integrity is enforced.
- `ws.py` — three commands (the names reserved by the API design):
  `haventory/export`, `haventory/import/preview`, `haventory/import/execute`.
  Execute snapshots state, swaps atomically via `load_state`, and **rolls back to the
  snapshot on persist failure** so a bad import never leaves partial state. It emits
  `items/reloaded` + `locations/reloaded` + `stats/counts` to keep other live clients in
  sync. Invalid documents are rejected with a structured `validation_error` (`data.errors`
  as `{path, message}`) and no mutation.
- Conflict policies: `merge` (overlay; tags unioned, custom_fields merged) | `replace` |
  `skip`.

**Frontend** (`cards/haventory-card/`)
- Header **Export** button downloads a JSON backup; **Import** button opens a new
  `hv-import-dialog` with a **preview step** (adds/updates/conflicts per policy), policy
  selection, structured error display, and a success summary.
- Store / WS-client methods (`exportDocument`, `previewImport`, `executeImport`) and
  handling of the `reloaded` events to refresh live clients.

**Round-trip guarantee:** export → import into an empty instance reproduces the data
exactly — covered by both a unit test and an in-process HA integration test.

Closes #

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI

## How was this tested?

- [x] Frontend (`cards/haventory-card`): `npx eslint .` (0 errors), `npm run typecheck`,
  `npx vitest run` (163 passed, incl. new `hv-import-dialog` + store import/export specs),
  `npm run build` (ok).
- [x] Backend lint: `ruff check .` — all checks pass (the standalone ruff binary targets
  `py314`, so it lints the real 3.14 source).
- [x] Backend tests: full offline suite **200 passed, 22 skipped** (20 new
  `test_import_export_offline.py` cases: full/filtered export, round-trip, preview
  classification per policy, merge/replace/skip, invalid envelope/entity/reference,
  invalid-field export case, and execute rollback on persist failure). New
  `tests/integration/test_import_export.py` covers the real-HA round-trip and a rejected
  invalid document.

> **Environment note:** this sandbox's egress policy blocks the Python 3.14
> `python-build-standalone` download (`403`), and the repo source is 3.14-only (PEP 758
> `except A, B:`). I therefore ran the offline `pytest` + `mypy` on Python 3.13 with the
> two unrelated 3.14-only `except` clauses temporarily parenthesized (semantically
> identical), then restored them byte-for-byte (`repository.py` shows no diff). The
> authoritative `ruff check` runs against the real 3.14 syntax and passes; `mypy` reported
> no issues on the new module before restoration. CI runs the full 3.14 gate.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases: rollback, invalid docs, policies).
- [x] Docs updated (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and
  `docs/data_shapes.md` in sync.
- [x] Load-bearing invariants preserved (paths recomputed on import; import goes through
  `load_state`, keeping search indexes and `location_path` consistent; item `version`
  round-trips).

## Screenshots (card / UI changes)

New header **Export** / **Import** buttons and an import dialog with a preview table
(items/locations × add/update/conflict/unchanged), `merge`/`replace`/`skip` radios, and a
structured error panel. (No screenshot tooling available in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_