### PR TITLE
fix(card): reflect live inventory changes from WS subscriptions

### DIFF
--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -428,6 +428,44 @@ describe('Store', () => {
     expect(listCalls).toBe(2);
   });
 
+  // Regression: live items/stats subscription events must reach the store WITHOUT
+  // any explicit re-fetch. This guards the contract that Home Assistant delivers
+  // the inner event payload (not the {id, type:'event', event} envelope) to the
+  // subscribeMessage callback — a mismatch there silently freezes the live card.
+  it('applies live item events (created/quantity_changed/deleted) to the list without a re-list', async () => {
+    const existing = makeItem({ id: '1', name: 'Existing', quantity: 1 });
+    const hass = makeMockHass({ items: [existing] });
+    const store = new Store(hass);
+    await store.init();
+    expect(store.state.value.items.length).toBe(1);
+
+    // An item created elsewhere appears live.
+    hass.__emit('items', 'created', { item: makeItem({ id: '2', name: 'Fresh', quantity: 3 }) });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(store.state.value.items.map((i) => i.id)).toContain('2');
+
+    // A quantity change on an existing row is reflected live.
+    hass.__emit('items', 'quantity_changed', { item: makeItem({ id: '1', name: 'Existing', quantity: 9 }) });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(store.state.value.items.find((i) => i.id === '1')?.quantity).toBe(9);
+
+    // A delete removes the row live.
+    hass.__emit('items', 'deleted', { item: makeItem({ id: '2', name: 'Fresh' }) });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(store.state.value.items.map((i) => i.id)).not.toContain('2');
+  });
+
+  it('updates statsCounts live from a stats counts event', async () => {
+    const hass = makeMockHass({ items: [] });
+    const store = new Store(hass);
+    await store.init();
+
+    const counts = { items_total: 42, low_stock_count: 3, checked_out_count: 1, locations_total: 7 };
+    hass.__emit('stats', 'counts', { counts });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(store.state.value.statsCounts).toEqual(expect.objectContaining({ items_total: 42, locations_total: 7 }));
+  });
+
   it('caches distinct categories and tags with counts on init', async () => {
     const items = [
       makeItem({ id: '1', category: 'Tools', tags: ['red'] }),

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -240,9 +240,11 @@ export interface HassLike {
   // Home Assistant's callWS returns the `result` part of the message.
   callWS<T>(msg: Record<string, unknown>): Promise<T>;
   // WebSocket connection with subscribeMessage to receive event messages; returns unsubscribe.
+  // Home Assistant delivers the *inner* event payload to the callback (the `event`
+  // field of the `{id, type:'event', event}` wire frame), not the whole envelope.
   connection: {
     subscribeMessage(
-      cb: (msg: { id: number; type: 'event'; event: AnyEventPayload }) => void,
+      cb: (event: AnyEventPayload) => void,
       msg: Record<string, unknown>,
     ): Unsubscribe | Promise<Unsubscribe>;
   };

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -192,10 +192,12 @@ export class WSClient {
     if (opts && 'location_id' in opts) msg.location_id = opts.location_id ?? null;
     if (opts && 'include_subtree' in opts) msg.include_subtree = !!opts.include_subtree;
 
-    const unsubOrPromise = this.hass.connection.subscribeMessage((message) => {
-      // message: { id, type: 'event', event: AnyEventPayload }
-      if (!message || message.type !== 'event') return;
-      cb(message.event as AnyEventPayload);
+    const unsubOrPromise = this.hass.connection.subscribeMessage((event) => {
+      // Home Assistant's `subscribeMessage` delivers the *inner* event payload
+      // (the `event` field of the `{id, type:'event', event}` wire frame) to the
+      // callback — NOT the whole envelope. Guard only against a nullish payload.
+      if (!event) return;
+      cb(event as AnyEventPayload);
     }, msg);
 
     // Home Assistant may return either an unsubscribe function or a Promise<unsubscribe>.

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -9,7 +9,9 @@ import type {
   StatsCounts,
 } from './store/types';
 
-type SubCb = (msg: { id: number; type: 'event'; event: AnyEventPayload }) => void;
+// Mirror real Home Assistant: `subscribeMessage` hands the callback the *inner*
+// event payload, not the `{id, type:'event', event}` envelope.
+type SubCb = (event: AnyEventPayload) => void;
 
 interface MockConfig {
   items?: Item[];
@@ -28,10 +30,6 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
   let conflictOnUpdate = !!initial?.conflictOnUpdate;
   let healthOverride: { healthy?: boolean; issues?: string[]; generation?: number } | null = null;
   const subs: Record<string, SubCb[]> = {};
-
-  function nextId() {
-    return Math.floor(Math.random() * 100000);
-  }
 
   const hass: HassLike & {
     __emit: (topic: AnyEventPayload['topic'], action: string, payload: Record<string, unknown>) => void;
@@ -314,8 +312,9 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
     },
     __emit(topic: AnyEventPayload['topic'], action: string, payload: Record<string, unknown>) {
       const callbacks = subs[topic] || [];
-      const event = { domain: 'haventory', topic, action, ts: new Date().toISOString(), ...payload } as AnyEventPayload as any;
-      callbacks.forEach((cb) => cb({ id: nextId(), type: 'event', event }));
+      // Deliver the inner payload exactly as real Home Assistant does.
+      const event = { domain: 'haventory', topic, action, ts: new Date().toISOString(), ...payload } as AnyEventPayload;
+      callbacks.forEach((cb) => cb(event));
     },
     __setConflict(on: boolean) { conflictOnUpdate = on; },
     __setItems(it: Item[]) { items = [...it]; },


### PR DESCRIPTION
## Problem

Discovered during the WP4 online stress test: with the card **open and idle**, live inventory changes never appeared. Under a sustained backend write-storm the visible list stayed frozen at its initial 50 rows and the header stats count froze (e.g. 586 for 24s) while the repository grew past 1000 items. The card only updated when an explicit user action (search/filter) forced a re-fetch — breaking HAventory's local-push premise.

## Root cause

Home Assistant's `connection.subscribeMessage(cb, msg)` delivers the **inner event payload** to `cb` (the `event` field of the `{id, type:'event', event}` wire frame), **not** the whole envelope. The card's callback gated on `message.type !== 'event'` and returned early for every real event, so `cb` never fired and none of the store handlers (`onItemsEvent` / `onStatsEvent` / `onLocationsEvent`) ran.

The unit-test mock delivered the **full envelope** instead of the inner payload, so the subscription tests passed while the real card was dead — the classic "green tests, broken feature" trap.

## Fix

- `store/ws.ts` — the `subscribeMessage` callback now receives the event payload directly (matching real HA).
- `store/types.ts` — corrected the `HassLike.connection.subscribeMessage` callback signature to `(event: AnyEventPayload) => void`.
- `test.utils.ts` — the mock now delivers the inner payload, faithfully mirroring HA.
- `store/store.test.ts` — added regression tests asserting live **item** (created/quantity_changed/deleted) and **stats** updates flow through without a re-fetch.

Verified the new tests (and the pre-existing subscription tests, now that the mock is faithful) **fail** against the old callback and **pass** with the fix.

## Testing

Frontend gate green: `vitest` (165 passed), `eslint` (0), `tsc --noEmit` (0), `vite build` (OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)