### PR TITLE
fix(ws): register subscriptions in HA's connection registry for clean teardown

### DIFF
--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -436,6 +436,57 @@ def _cleanup_subscriptions_for_conn(hass: HomeAssistant, conn: object) -> None:
     subs_all.pop(cast("websocket_api.ActiveConnection", conn), None)
 
 
+def _drop_subscription(hass: HomeAssistant, conn: object, sub_id: int) -> None:
+    """Remove a single subscription from the per-connection bucket.
+
+    Registered as the zero-arg teardown callback in HA's ``connection.subscriptions``
+    registry (see ``_register_framework_unsub``). Safe to call repeatedly and after
+    the connection bucket has already been cleaned up.
+    """
+
+    subs_all = _subs_bucket(hass)
+    subs_for_conn = subs_all.get(cast("websocket_api.ActiveConnection", conn))
+    if subs_for_conn is None:
+        return
+    subs_for_conn.pop(sub_id, None)
+    if not subs_for_conn:
+        subs_all.pop(cast("websocket_api.ActiveConnection", conn), None)
+
+
+def _register_framework_unsub(
+    hass: HomeAssistant, conn: websocket_api.ActiveConnection, sub_id: int
+) -> None:
+    """Register the subscription teardown in HA's own subscription registry.
+
+    ``ActiveConnection.subscriptions`` maps a message id to a zero-arg unsubscribe
+    callback, and HA core's generic ``unsubscribe_events`` command pops-and-calls
+    it. The frontend's ``subscribeMessage`` lifecycle tears down via exactly that
+    command, so without an entry here HA core replies ``not_found``
+    ("Subscription not found.") on every teardown — surfacing as an unhandled
+    rejection in the card. Registering the id makes the standard lifecycle work.
+
+    The ``getattr``/``isinstance`` probe mirrors ``_register_close_listener`` so the
+    offline test stubs (which expose no ``subscriptions`` dict) are unaffected.
+    """
+
+    subscriptions = getattr(conn, "subscriptions", None)
+    if isinstance(subscriptions, dict):
+        subscriptions[sub_id] = functools.partial(_drop_subscription, hass, conn, sub_id)
+
+
+def _unregister_framework_unsub(conn: websocket_api.ActiveConnection, sub_id: int) -> None:
+    """Drop the HA-registry entry for a subscription torn down via our own command.
+
+    Keeps ``haventory/unsubscribe`` and HA core's ``unsubscribe_events`` symmetric so
+    a subscription removed through the dedicated command leaves no stale callback in
+    ``connection.subscriptions``.
+    """
+
+    subscriptions = getattr(conn, "subscriptions", None)
+    if isinstance(subscriptions, dict):
+        subscriptions.pop(sub_id, None)
+
+
 def _register_close_listener(hass: HomeAssistant, conn: websocket_api.ActiveConnection) -> None:
     """Attach cleanup to a connection close callback when available.
 
@@ -869,10 +920,14 @@ async def ws_subscribe(
         sub["location_id"] = msg.get("location_id")
     if "include_subtree" in msg:
         sub["include_subtree"] = bool(msg.get("include_subtree"))
+    sub_id = int(msg.get("id", 0))
     subs_all = _subs_bucket(hass)
     subs_for_conn = subs_all.setdefault(conn, {})
-    subs_for_conn[int(msg.get("id", 0))] = sub
+    subs_for_conn[sub_id] = sub
     _register_close_listener(hass, conn)
+    # Let HA core's generic `unsubscribe_events` (the path the frontend uses) tear
+    # this subscription down cleanly, instead of replying "Subscription not found".
+    _register_framework_unsub(hass, conn, sub_id)
     LOGGER.debug(
         "Subscribed",
         extra={
@@ -907,6 +962,8 @@ async def ws_unsubscribe(
         removed = subs_for_conn.pop(sub_id, None) is not None
         if not subs_for_conn:
             subs_all.pop(conn, None)
+    # Keep HA's own subscription registry in sync with this explicit teardown.
+    _unregister_framework_unsub(conn, sub_id)
     LOGGER.debug(
         "Unsubscribed",
         extra={

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -81,6 +81,12 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 - Unsubscribe
   - `haventory/unsubscribe` request: `{id, type, subscription: number}`
   - Result: `null`
+  - A subscription is also registered in Home Assistant's own connection registry
+    under its `id`, so it can equally be torn down via HA core's standard
+    `unsubscribe_events` (`{id, type: "unsubscribe_events", subscription: number}`).
+    This is the path the frontend's `connection.subscribeMessage` lifecycle uses;
+    both routes cancel the subscription and the connection close hook remains the
+    backstop for dropped clients.
 
 - Event payloads (inside `event`):
   - Common: `{domain: "haventory", topic: "items"|"locations"|"stats", action: string, ts: string, ...payload}`

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -36,6 +36,35 @@ class _ConnStub:
             cb()
 
 
+class _HAConnStub(_ConnStub):
+    """Connection stub that mirrors HA's ``ActiveConnection`` subscription registry.
+
+    Real ``ActiveConnection`` exposes a ``subscriptions`` dict (message id -> zero-arg
+    unsub callback) that both the framework's ``unsubscribe_events`` command and the
+    disconnect path drive. The plain ``_ConnStub`` deliberately omits it (exercising the
+    ``on_close`` fallback); this subclass restores it so we can drive the framework
+    teardown path the frontend actually uses.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.subscriptions: dict[Any, Callable[[], None]] = {}
+
+    def core_unsubscribe_events(self, subscription: int) -> bool:
+        """Emulate HA core's ``unsubscribe_events``: pop-and-call, or report missing."""
+        if subscription in self.subscriptions:
+            self.subscriptions.pop(subscription)()
+            return True
+        return False
+
+    def close(self) -> None:
+        # HA calls every registered unsub on disconnect, then any close callbacks.
+        for unsub in list(self.subscriptions.values()):
+            unsub()
+        self.subscriptions.clear()
+        super().close()
+
+
 def _get_handler(
     hass: HomeAssistant, type_: str
 ) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
@@ -253,3 +282,64 @@ async def test_location_filters_subtree_and_direct_only() -> None:
         if m.get("type") == "event" and m.get("event", {}).get("topic") == "items"
     }
     assert ids == {SUB_ID_SUBTREE}
+
+
+@pytest.mark.asyncio
+async def test_framework_unsubscribe_events_tears_down_subscription() -> None:
+    """Subscriptions register in HA's own registry so core ``unsubscribe_events``
+    (the teardown path the frontend's ``subscribeMessage`` uses) can cancel them.
+
+    Before the fix nothing was registered under the message id, so core replied
+    ``not_found`` ("Subscription not found.") on every teardown — an unhandled
+    rejection in the card.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    sub_id = 501
+    conn = _HAConnStub()
+    res = await _send(hass, conn, sub_id, "haventory/subscribe", topic="items")
+    assert res["success"] is True
+
+    # The zero-arg teardown is registered under the message id — exactly what core's
+    # ``unsubscribe_events`` looks up (`if subscription in connection.subscriptions`).
+    assert sub_id in conn.subscriptions
+    assert callable(conn.subscriptions[sub_id])
+
+    # Events flow while subscribed.
+    await _send(hass, conn, 1, "haventory/item/create", name="Box")
+    assert len(_extract_events(conn, topic="items")) >= 1
+
+    # Emulate core ``unsubscribe_events``: the id is found -> success (no not_found).
+    assert conn.core_unsubscribe_events(sub_id) is True
+    assert sub_id not in conn.subscriptions
+    assert conn not in _subs_bucket(hass)  # our bucket was cleaned up too
+
+    # No further deliveries after teardown.
+    conn.messages.clear()
+    await _send(hass, conn, 2, "haventory/item/create", name="Tape")
+    assert _extract_events(conn, topic="items") == []
+
+
+@pytest.mark.asyncio
+async def test_dedicated_unsubscribe_clears_framework_registry() -> None:
+    """``haventory/unsubscribe`` also clears the HA-registry entry, keeping the two
+    teardown paths symmetric (no stale callback left in ``connection.subscriptions``)."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    sub_id = 601
+    conn = _HAConnStub()
+    await _send(hass, conn, sub_id, "haventory/subscribe", topic="stats")
+    assert sub_id in conn.subscriptions
+
+    res = await _send(hass, conn, 602, "haventory/unsubscribe", subscription=sub_id)
+    assert res["success"] is True
+    assert sub_id not in conn.subscriptions
+    assert conn not in _subs_bucket(hass)


### PR DESCRIPTION
## Problem

Discovered during the WP4 online stress test: every subscription teardown (each expand/collapse or filter change in the card) produced an **unhandled promise rejection** — `{code:"not_found","message":"Subscription not found."}` (HA core's message). Harmless to data, but it's console noise that masks real errors and left the dedicated `haventory/unsubscribe` command effectively dead from the card's side.

## Root cause

`haventory/subscribe` tracked subscriptions only in the integration's own per-connection bucket (`hass.data[DOMAIN]["subscriptions"]`), never in HA's `ActiveConnection.subscriptions` registry. The frontend tears subscriptions down via the standard `connection.subscribeMessage` lifecycle, which sends HA core's generic `unsubscribe_events` with the subscription id. Core looks that id up in `connection.subscriptions`, finds nothing, and replies `not_found`.

## Fix

- `ws_subscribe` now registers a zero-arg teardown under the message id in `connection.subscriptions`, so HA core's `unsubscribe_events` (the path the card uses) finds and cancels the subscription cleanly.
- `ws_unsubscribe` clears that registry entry too, keeping the dedicated command and the core path symmetric (no stale callback left behind).
- The connection **close hook** remains the backstop for dropped clients.
- Registration is guarded by a `getattr`/`isinstance` probe (mirroring the existing close-listener registration), so the offline test stubs — which expose no `subscriptions` dict — are unaffected.

No change to the API surface, envelopes, or event shapes — only teardown behavior. The API contract is updated to document the dual teardown path.

## Testing

- New `_HAConnStub` mirrors HA's `ActiveConnection.subscriptions` registry; two new tests exercise the core `unsubscribe_events` path and the dedicated `haventory/unsubscribe` command. Both **fail** against the pre-fix code (the id is absent from `connection.subscriptions`) and pass with the fix.
- Backend gate green: `pytest` (264 passed, 22 skipped), `ruff` (clean), `mypy` (clean, ws.py is strict-mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)