### PR TITLE
fix(ws): stop stamping a slotted attribute on ActiveConnection

### DIFF
--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -495,41 +495,38 @@ def _register_close_listener(hass: HomeAssistant, conn: websocket_api.ActiveConn
     there is what prevents disconnected clients from leaking subscription
     state. The ``on_close``/``add_close_callback`` probes support the offline
     test stubs.
+
+    Idempotency is derived from the state itself, not stamped on the connection:
+    real HA's ``ActiveConnection`` is ``__slots__``-based (no ``__dict__``), so a
+    ``conn._haventory_close_registered = True`` marker raises ``AttributeError`` on
+    every subscribe there — a benign-but-noisy exception the offline stubs never
+    surface because they carry a ``__dict__``. Our ``"haventory/cleanup"`` key and
+    the idempotent ``_cleanup_subscriptions_for_conn`` make repeat registration a
+    harmless no-op, so no marker is needed.
     """
-
-    if getattr(conn, "_haventory_close_registered", False):
-        return
-
-    registered = False
 
     subscriptions = getattr(conn, "subscriptions", None)
     if isinstance(subscriptions, dict):
-        # String key cannot collide with HA's integer subscription ids.
-        subscriptions["haventory/cleanup"] = functools.partial(
-            _cleanup_subscriptions_for_conn, hass, conn
-        )
-        registered = True
+        # Real-HA path. String key cannot collide with HA's integer subscription
+        # ids; its presence is also the "already registered" marker.
+        if "haventory/cleanup" not in subscriptions:
+            subscriptions["haventory/cleanup"] = functools.partial(
+                _cleanup_subscriptions_for_conn, hass, conn
+            )
+        return
 
+    # Offline-stub path: connections expose on_close / add_close_callback instead of
+    # a subscriptions dict. `_cleanup_subscriptions_for_conn` is idempotent, so even a
+    # repeat registration here only ever removes the (already-removed) bucket.
     closer = getattr(conn, "on_close", None)
     if not callable(closer):
         closer = getattr(conn, "add_close_callback", None)
     if callable(closer):
         try:
             closer(lambda: _cleanup_subscriptions_for_conn(hass, conn))
-            registered = True
         except Exception:  # pragma: no cover - defensive
             LOGGER.debug(
                 "Failed to register WS close listener",
-                extra={"domain": DOMAIN, "op": "subscribe_close_hook"},
-                exc_info=True,
-            )
-
-    if registered:
-        try:
-            conn._haventory_close_registered = True
-        except Exception:  # pragma: no cover - exotic connection objects
-            LOGGER.debug(
-                "Failed to stamp WS close registration",
                 extra={"domain": DOMAIN, "op": "subscribe_close_hook"},
                 exc_info=True,
             )

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -65,6 +65,46 @@ class _HAConnStub(_ConnStub):
         super().close()
 
 
+class _SlottedHAConn:
+    """Faithful stand-in for HA's ``__slots__``-based ``ActiveConnection``.
+
+    Crucially it has **no** ``__dict__``: setting an arbitrary attribute on the
+    connection (as an old ``_haventory_close_registered`` marker did) raises
+    ``AttributeError`` here exactly as it does on real HA — the ``__dict__``-carrying
+    stubs above silently tolerate it and hide the bug. A custom ``__setattr__``
+    *records* every rejected attempt so a test can prove production code never tries.
+    Mirrors only the surface the subscribe path touches: a ``subscriptions`` registry
+    and ``send_message``, with a disconnect ``close()`` that invokes every unsub.
+    """
+
+    __slots__ = ("messages", "stray_set_attempts", "subscriptions")
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "messages", [])
+        object.__setattr__(self, "subscriptions", {})
+        object.__setattr__(self, "stray_set_attempts", [])
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self.__slots__:
+            object.__setattr__(self, name, value)
+            return
+        # Real HA rejects arbitrary attrs (no __dict__); record the attempt first so
+        # tests can assert production code never stamps a marker on the connection.
+        self.stray_set_attempts.append(name)
+        raise AttributeError(
+            f"'_SlottedHAConn' object has no attribute {name!r} "
+            "and no __dict__ for setting new attributes"
+        )
+
+    def send_message(self, msg: dict[str, Any]) -> None:
+        self.messages.append(msg)
+
+    def close(self) -> None:
+        for unsub in list(self.subscriptions.values()):
+            unsub()
+        self.subscriptions.clear()
+
+
 def _get_handler(
     hass: HomeAssistant, type_: str
 ) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
@@ -343,3 +383,49 @@ async def test_dedicated_unsubscribe_clears_framework_registry() -> None:
     assert res["success"] is True
     assert sub_id not in conn.subscriptions
     assert conn not in _subs_bucket(hass)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_on_slotted_connection_never_stamps_attribute() -> None:
+    """Subscribe must not stamp a marker attribute on a ``__slots__`` connection.
+
+    Regression for the WP4 stress re-run finding: ``_register_close_listener`` used to
+    set ``conn._haventory_close_registered = True`` for "register once" behaviour. Real
+    HA's ``ActiveConnection`` is slotted (no ``__dict__``), so that assignment raised
+    ``AttributeError`` on **every** subscribe (caught, but logged as a traceback under
+    debug logging). The ``__dict__``-carrying stubs never surfaced it. Idempotency now
+    derives from the ``"haventory/cleanup"`` key already present in ``subscriptions``.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    conn = _SlottedHAConn()
+
+    # Two subscribes on the same connection must not raise, must register the per-id
+    # framework teardown for each, and must leave exactly one connection-cleanup entry.
+    sub_a, sub_b = 701, 702
+    r1 = await _send(hass, conn, sub_a, "haventory/subscribe", topic="items")
+    r2 = await _send(hass, conn, sub_b, "haventory/subscribe", topic="stats")
+    assert r1["success"] is True
+    assert r2["success"] is True
+    assert sub_a in conn.subscriptions
+    assert sub_b in conn.subscriptions
+    assert list(conn.subscriptions).count("haventory/cleanup") == 1  # idempotent
+
+    # The core assertion: production code never attempted to stamp a marker attribute
+    # on the slotted connection (the old ``_haventory_close_registered = True``).
+    assert conn.stray_set_attempts == []
+    assert not hasattr(conn, "_haventory_close_registered")
+
+    # Both subscriptions are live in our bucket, and the disconnect path
+    # (subscriptions.values()) tears them all down without drift.
+    assert _subs_bucket(hass).get(conn)
+    conn.close()
+    assert conn not in _subs_bucket(hass)
+
+    # Sanity: the stub really is slotted like real HA (rejects arbitrary attrs).
+    with pytest.raises(AttributeError):
+        conn.some_unexpected_attr = 1  # type: ignore[attr-defined]


### PR DESCRIPTION
## Symptom

Re-running the WP4 stress regimen against the live HA container surfaced **12×** in the logs:

```
AttributeError: 'ActiveConnection' object has no attribute '_haventory_close_registered'
and no __dict__ for setting new attributes
```

## Root cause

[`_register_close_listener`](custom_components/haventory/ws.py) stamped `conn._haventory_close_registered = True` as a "register once" marker. Real HA's `ActiveConnection` is `__slots__`-based (no `__dict__`), so that assignment raises `AttributeError` on **every** subscribe.

It was caught, so behavior was intact — subscriptions deliver, `unsubscribe_events` teardown works, close-cleanup works — but it:
- logged a traceback **per subscribe** under debug logging (invisible at prod `info` level, noisy under debug), and
- left the register-once short-circuit permanently **dead** on real HA (the guard never fired, so the body re-ran every subscribe — idempotent, but pointless).

The offline stubs carry a `__dict__`, so the unit suite never saw it — the **same "stub diverges from real HA" class** as the live-subscription fix (#93).

## Fix

Derive idempotency from state, not a stamped attribute: the `"haventory/cleanup"` key already present in `connection.subscriptions` **is** the "already registered" marker, and `_cleanup_subscriptions_for_conn` is idempotent — so no per-connection flag is needed. The stub (`on_close`) path drops the now-unneeded marker too.

## Test

Adds `_SlottedHAConn` — a faithful `__slots__` stand-in (no `__dict__`) that **records** rejected attribute-set attempts. The new test asserts the subscribe path never tries to stamp a marker, stays idempotent across repeat subscribes (exactly one `haventory/cleanup` entry), and tears down cleanly on disconnect. **Verified it fails if the stamp is reintroduced.**

## Verification

- Backend gate green: **pytest 265 passed** / 22 skipped, ruff clean, mypy clean.
- **Confirmed live:** after redeploying the fix, **zero** `AttributeError` log lines across subscribe-heavy stress layers (subteardown + statsprobe), health still `healthy`/`issues=[]`.

Found by the stress-test re-run; fixed per your go-ahead. One PR per fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)