### PR TITLE
fix(scripts): deploy via reload_addon.sh in stress_test.py

### DIFF
--- a/scripts/stress_test.py
+++ b/scripts/stress_test.py
@@ -3,11 +3,11 @@ r"""Backend stress test for HAventory persistence and concurrency fixes.
 This script validates the debounced persistence, concurrent operation handling,
 and bulk operation reliability in a Docker-based Home Assistant backend.
 
-Usage (PowerShell):
-    $env:HA_CONTAINER = 'home-assistant'
-    $env:HA_BASE_URL = 'http://localhost:8123'
-    $env:HA_TOKEN = '<your-long-lived-token>'
-    python .\scripts\stress_test.py
+Usage (Git Bash / Linux):
+    export HA_CONTAINER='home-assistant'
+    export HA_BASE_URL='http://localhost:8123'
+    export HA_TOKEN='<your-long-lived-token>'
+    python scripts/stress_test.py
 
 Options:
     --skip-deploy    Skip deployment step (code already deployed)
@@ -19,6 +19,9 @@ Environment variables:
     HA_CONTAINER: Docker container name (required)
     HA_BASE_URL: Home Assistant base URL (default: http://localhost:8123)
     HA_TOKEN: Long-lived access token (required)
+
+The optional deployment step (omitted with --skip-deploy) shells out to
+``scripts/reload_addon.sh``, so it needs bash on PATH (Git Bash on Windows).
 """
 
 from __future__ import annotations
@@ -369,34 +372,29 @@ async def check_container_running(container_name: str) -> bool:
 
 
 async def deploy_code(container_name: str) -> bool:
-    """Deploy latest code to container using reload_addon.ps1."""
+    """Deploy latest code to the container via scripts/reload_addon.sh."""
     print_status("Deploying latest code to container...", "info")
     try:
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        repo_root = os.path.dirname(script_dir)
-        reload_script = os.path.join(repo_root, "scripts", "reload_addon.ps1")
+        reload_script = os.path.join(script_dir, "reload_addon.sh")
 
-        # ASYNC221: Blocking subprocess is acceptable here (deployment step)
-        # S603/S607: subprocess with trusted input (known script path)
+        # ASYNC221: Blocking subprocess is acceptable here (deployment step).
+        # S603/S607: subprocess with trusted input (known script path).
+        # reload_addon.sh does npm ci + vite build + docker restart, so allow
+        # a generous timeout; needs bash on PATH (Git Bash on Windows).
         result = subprocess.run(  # noqa: ASYNC221, S603
             [  # noqa: S607
-                "powershell",
-                "-NoProfile",
-                "-ExecutionPolicy",
-                "Bypass",
-                "-File",
+                "bash",
                 reload_script,
-                "-ContainerName",
+                "--container",
                 container_name,
-                "-UseDevConfig:$true",
-                "-TailLogs:$false",
-                "-SleepSecondsAfterRestart",
+                "--sleep",
                 "8",
             ],
             check=False,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=300,
         )
         if result.returncode != 0:
             print_status(f"Deployment failed: {result.stderr}", "fail")


### PR DESCRIPTION
## What & why

`scripts/stress_test.py`'s optional deploy step (`deploy_code()`) shelled out to
`powershell … -File scripts/reload_addon.ps1`. WP1 retired the PowerShell tooling and
moved everything to Linux/bash, so **`reload_addon.ps1` no longer exists** — the deploy
path has been dead ever since (running without `--skip-deploy` fails immediately).

## Change

- Invoke the current **`scripts/reload_addon.sh`** via `bash`, mirroring the already-proven
  invocation in `scripts/smoke_online.sh` (`reload_addon.sh --container NAME --sleep 8`).
- Simplify the path derivation — `reload_addon.sh` is a sibling of `stress_test.py`, so
  drop the `repo_root` round-trip.
- Widen the subprocess timeout `120 → 300s` (the `.sh` path does `npm ci` + `vite build` +
  `docker restart`, heavier than the old `.ps1`).
- Refresh the module docstring off the stale `Usage (PowerShell)` / `$env:` example to the
  Git-Bash/Linux form, and note the deploy step needs bash on PATH.

No behavior change to the stress scenarios themselves; only the (previously broken) deploy
helper and its docs.

## Verification

- `ruff check scripts/stress_test.py` → clean; `py_compile` → OK; pre-commit hooks pass.
- No `reload_addon.ps1` / `powershell` / `.ps1` references remain in the file.
- Ran `bash scripts/reload_addon.sh --container __nonexistent__ --sleep 8` to exercise the
  exact argv `deploy_code()` now builds → parses and fails fast with `Container '…' not found`
  (exit 1), confirming the bash wiring. A full end-to-end deploy was not run (it rebuilds the
  card and restarts HA); the invocation matches the proven `smoke_online.sh` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
