### PR TITLE
chore(scripts): use ClientWSTimeout for ws_connect (drop deprecated ClientTimeout)

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -149,8 +149,10 @@ clean-start mode), then `Online smoke test completed successfully.`
   `reload_addon.sh --sleep 30` covers it; with the default `--sleep 8` the final
   WS entry-init step can race a not-yet-up HA (it prints a WS-init error — harmless,
   rerun `uv run python scripts/ws_init_haventory.py`).
-- **aiohttp deprecation**: `ws_connect(timeout=ClientTimeout(...))` is deprecated —
-  use `aiohttp.ClientWSTimeout(ws_receive=...)` in new WS scripts.
+- **aiohttp `ws_connect` timeout**: passing a `ClientTimeout` to `ws_connect` is deprecated —
+  use `aiohttp.ClientWSTimeout(ws_receive=...)` (per-receive budget). All WS scripts now use
+  the new form; to bound the *upgrade handshake* wrap `ws_connect` in
+  `asyncio.wait_for(..., timeout=connect_timeout_s)` (`ClientWSTimeout` does not cover it).
 - **Mutations rejected with error code `conflict`** mean a stale `expected_version` —
   that's optimistic concurrency working, not a bug; re-`get` the item and retry.
 

--- a/scripts/stress_test.py
+++ b/scripts/stress_test.py
@@ -275,8 +275,15 @@ class HAWebSocketClient:
         """Establish WebSocket connection and authenticate."""
         try:
             self._session = aiohttp.ClientSession()
-            timeout = aiohttp.ClientTimeout(total=CONNECT_TIMEOUT_S)
-            self._ws = await self._session.ws_connect(self.ws_url, timeout=timeout)
+            # Bound the upgrade handshake with CONNECT_TIMEOUT_S (asyncio.wait_for); the
+            # per-receive budget is RECV_TIMEOUT_S (ClientWSTimeout.ws_receive). Passing a
+            # ClientTimeout to ws_connect is deprecated in aiohttp.
+            self._ws = await asyncio.wait_for(
+                self._session.ws_connect(
+                    self.ws_url, timeout=aiohttp.ClientWSTimeout(ws_receive=RECV_TIMEOUT_S)
+                ),
+                timeout=CONNECT_TIMEOUT_S,
+            )
 
             # Receive hello
             await asyncio.wait_for(self._ws.receive_json(), timeout=RECV_TIMEOUT_S)

--- a/scripts/ws_probe.py
+++ b/scripts/ws_probe.py
@@ -60,9 +60,14 @@ async def run_probe() -> int:
     ws_url = _ws_url_from_base(base)
 
     async with aiohttp.ClientSession() as session:
-        # Connection timeout for initial websocket upgrade
-        timeout = aiohttp.ClientTimeout(total=connect_timeout_s)
-        async with session.ws_connect(ws_url, timeout=timeout) as ws:
+        # Bound the websocket upgrade with connect_timeout_s (asyncio.wait_for); the
+        # per-receive budget is recv_timeout_s (ClientWSTimeout.ws_receive). Passing a
+        # ClientTimeout to ws_connect is deprecated in aiohttp.
+        ws = await asyncio.wait_for(
+            session.ws_connect(ws_url, timeout=aiohttp.ClientWSTimeout(ws_receive=recv_timeout_s)),
+            timeout=connect_timeout_s,
+        )
+        async with ws:
             try:
                 # Receive hello
                 _hello = await asyncio.wait_for(ws.receive_json(), timeout=recv_timeout_s)

--- a/scripts/ws_subscribe.py
+++ b/scripts/ws_subscribe.py
@@ -101,8 +101,14 @@ async def run_subscriber() -> int:
     ws_url = _ws_url_from_base(base)
 
     async with aiohttp.ClientSession() as session:
-        timeout = aiohttp.ClientTimeout(total=connect_timeout_s)
-        async with session.ws_connect(ws_url, timeout=timeout) as ws:
+        # Bound the websocket upgrade with connect_timeout_s (asyncio.wait_for); the
+        # per-receive budget is recv_timeout_s (ClientWSTimeout.ws_receive). Passing a
+        # ClientTimeout to ws_connect is deprecated in aiohttp.
+        ws = await asyncio.wait_for(
+            session.ws_connect(ws_url, timeout=aiohttp.ClientWSTimeout(ws_receive=recv_timeout_s)),
+            timeout=connect_timeout_s,
+        )
+        async with ws:
             try:
                 _hello = await asyncio.wait_for(ws.receive_json(), timeout=recv_timeout_s)
                 await ws.send_json({"type": "auth", "access_token": token})


### PR DESCRIPTION
## What & why

aiohttp deprecated passing a `ClientTimeout` to `ClientSession.ws_connect(...)`. The newer
WS helpers (`.claude/skills/run-haventory/driver.py`, the `test-haventory` `stress.py`)
already use `ClientWSTimeout`, but three cross-platform scripts still passed the deprecated
form and emitted a `DeprecationWarning` on every connect:

- `scripts/ws_probe.py`
- `scripts/ws_subscribe.py`
- `scripts/stress_test.py` (`HAWebSocketClient.connect()`)

## The subtlety (why not a one-line swap)

`ClientWSTimeout.ws_receive` bounds **each receive**, not the upgrade handshake. A naive
`ClientTimeout(total=connect_timeout_s)` → `ClientWSTimeout(ws_receive=connect_timeout_s)`
swap would:
1. silently drop the connect/handshake bound, and
2. for the long-lived subscriber, tighten every event-wait to the (shorter) connect timeout —
   so an idle subscription waiting for the next event would time out early.

## Change

Migrate faithfully, preserving behavior:
- Keep the **upgrade handshake** bounded by `connect_timeout_s` via `asyncio.wait_for(ws_connect(...), timeout=connect_timeout_s)`.
- Set `ClientWSTimeout(ws_receive=recv_timeout_s)` for the **per-receive** budget — matching the explicit `asyncio.wait_for(..., recv_timeout_s)` that already wraps every receive.
- Refresh the aiohttp gotcha in `run-haventory/SKILL.md` to document both halves.

No product code touched — dev/online tooling only.

## Verification (live, against the dev HA container)

- `ws_probe.py` (`haventory/version`) → result, exit 0, **no** `DeprecationWarning` on stderr.
- `ws_subscribe.py` (`items`, `HAV_MAX_EVENTS=0`) → subscribe ack, exit 0, clean stderr.
- `stress_test.HAWebSocketClient.connect()` → connect + `haventory/version` success, exit 0.
- Container log scan over the window → no traceback / `unknown_error` / `ServerTimeout`.
- `ruff check` + `py_compile` + pre-commit → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
