### PR TITLE
docs(open-items): track item/list unknown-filter-key leniency (#24)

### DIFF
--- a/docs/open-items.md
+++ b/docs/open-items.md
@@ -56,6 +56,7 @@ Ordered by impact.
 | 21 | **Undecodable pagination `cursor` returns a full unfiltered page** (`"garbage"`, `""`, base64-junk) instead of `validation_error`. Reject malformed cursors explicitly. | WP4 stress test | Low | S |
 | 22 | **Duplicate bulk `op_id`s collapse silently** — the operations execute but the per-`op_id` results dict keeps only the last, so the client can't tell which of its ops succeeded. Reject duplicate `op_id`s (or document last-wins in the contract). | WP4 stress test | Low | S |
 | 23 | **Location rename bumps every subtree item's `version`** (denormalized `location_path` rewrite), so a client holding a stale `expected_version` for an unrelated field gets a spurious `conflict`. Indexes stay consistent — it's a UX surprise, not corruption. A path-only rewrite need not bump the optimistic-concurrency version. | WP4 stress test | Low | M |
+| 24 | **`item/list` silently ignores unknown filter keys.** The `filter`/`sort` payloads are schema-validated only as `dict` (`ws.py`), and `repository.list_items` reads known keys via `flt.get(...)`, so a typo'd or unsupported key (e.g. `query`/`search` instead of `q`) is dropped and the "filtered" list returns **everything** instead of erroring — a silent-match-all footgun. Same input-hardening family as #20/#21: reject unknown `filter`/`sort` keys with `validation_error`. Confirm the card sends only known keys before tightening (contract change). | run-haventory skill gotcha review | Low | S |
 
 ---
 
@@ -78,3 +79,7 @@ Ordered by impact.
   items 19–23. The two confirmed breakages from the same run — the card not live-updating from
   WS subscriptions, and "Subscription not found" teardown rejections — are addressed separately
   in PRs #93 and #94.
+- A later **gotcha triage of the `run-haventory`/`test-haventory` skills** surfaced item 24
+  (lenient `item/list` filters). The other skill gotchas are environmental (broken `.venv`,
+  partial `node_modules`, Python 3.14 requirement) or expected behavior (optimistic-concurrency
+  `conflict`s, the destructive `HA_CONTAINER` clean-start mode), not tracked here.


### PR DESCRIPTION
## What & why

While triaging the `run-haventory` / `test-haventory` skill **Gotchas** (asked: "check the
gotchas and see if things need to get fixed"), one gotcha turned out to be a real product
input-hardening gap rather than an environmental/expected quirk:

> `item/list` filter key is `q` … **unknown filter keys are silently ignored**, so a typo'd
> filter matches *everything* instead of erroring.

Confirmed against the code: [ws.py](custom_components/haventory/ws.py#L1447-L1452) validates
`filter`/`sort` only as `dict`, and
[repository.list_items](custom_components/haventory/repository.py#L995-L1113) reads known keys
via `flt.get(...)` — any unknown key is never read, so a mistyped/unsupported filter is
dropped and the "filtered" list returns the whole dataset.

## Change

This is a **product API behavior/contract change** (currently lenient), so per CLAUDE.md
("report out-of-scope findings under a Follow-ups note rather than fixing them") I'm
**tracking it**, not changing it here. Adds it as post-v1.0 open-item **#24** (Low / S), in
the same input-hardening family as #20/#21, and notes in "Notes on sources" that the rest of
the skill gotchas are environmental or expected behavior (not tracked).

Docs-only; no code touched.

## The rest of the gotcha triage (for reviewer context)

The other two fixable findings from the same triage ship as **separate PRs by type**:
- **#99** `fix(scripts)`: `stress_test.py` deploy pointed at the retired `reload_addon.ps1`.
- **#100** `chore(scripts)`: deprecated `ws_connect(ClientTimeout)` → `ClientWSTimeout`.

Everything else in the Gotchas sections is environmental (broken `.venv`, partial
`node_modules`, Python 3.14 requirement) or expected behavior (`MSYS_NO_PATHCONV`, the
ratelimit rebuild, optimistic-concurrency `conflict`s, the destructive `HA_CONTAINER` mode) —
left documented, nothing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
