### PR TITLE
feat(ws): add per-location item counts and filtered list totals

### DIFF
--- a/cards/haventory-card/src/components/hv-import-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-import-dialog.test.ts
@@ -134,7 +134,7 @@ describe('hv-import-dialog', () => {
       policy: 'merge',
       items: { total: 2, add: 2, update: 0, conflict: 0, unchanged: 0 },
       locations: { total: 1, add: 1, update: 0, conflict: 0, unchanged: 0 },
-      totals: { items_total: 2, low_stock_count: 0, checked_out_count: 0, locations_total: 1 },
+      totals: { items_total: 2, low_stock_count: 0, checked_out_count: 0, locations_total: 1, no_location_count: 0 },
     };
     if (el.updateComplete) await el.updateComplete;
 

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -97,6 +97,8 @@ export interface Sort {
 export interface ListItemsResult {
   items: Item[];
   next_cursor: string | null;
+  /** Count of items matching the filter across all pages, independent of limit/cursor. */
+  total: number;
 }
 
 export interface StatsCounts {
@@ -104,6 +106,8 @@ export interface StatsCounts {
   low_stock_count: number;
   checked_out_count: number;
   locations_total: number;
+  /** Items without a location (location_id == null). */
+  no_location_count: number;
 }
 
 export interface AreasListResult {

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -46,6 +46,7 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
             low_stock_count: items.filter((i) => typeof i.low_stock_threshold === 'number' && i.quantity <= (i.low_stock_threshold as number)).length,
             checked_out_count: items.filter((i) => i.checked_out).length,
             locations_total: locations.length,
+            no_location_count: items.filter((i) => i.location_id == null).length,
           };
           return counts as unknown as T;
         }
@@ -55,6 +56,7 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
             low_stock_count: items.filter((i) => typeof i.low_stock_threshold === 'number' && i.quantity <= (i.low_stock_threshold as number)).length,
             checked_out_count: items.filter((i) => i.checked_out).length,
             locations_total: locations.length,
+            no_location_count: items.filter((i) => i.location_id == null).length,
           };
           return {
             healthy: healthOverride?.healthy ?? true,
@@ -110,6 +112,7 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
               low_stock_count: 0,
               checked_out_count: 0,
               locations_total: locations.length,
+              no_location_count: 0,
             },
           };
           return summary as unknown as T;
@@ -212,15 +215,16 @@ export function makeMockHass(initial?: MockConfig): HassLike & {
           const cursor = (msg.cursor as string | undefined) || undefined;
           // Mirror the backend: filter, then sort, then paginate.
           const listed = applyMockSort(applyMockFilter(items, msg.filter), msg.sort);
+          const total = listed.length;
           const page1 = listed.slice(0, limit);
           if (!cursor) {
             const next_cursor = listed.length > limit ? 'cursor-2' : null;
-            return { items: page1, next_cursor } as unknown as T;
+            return { items: page1, next_cursor, total } as unknown as T;
           }
           if (cursor === 'cursor-2') {
-            return { items: listed.slice(limit, limit * 2), next_cursor: null } as unknown as T;
+            return { items: listed.slice(limit, limit * 2), next_cursor: null, total } as unknown as T;
           }
-          return { items: [], next_cursor: null } as unknown as T;
+          return { items: [], next_cursor: null, total } as unknown as T;
         }
         case 'haventory/item/get': {
           const itemId = String((msg as any).item_id);

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -72,6 +72,7 @@ class _TextTokens(NamedTuple):
 class PageResult(TypedDict):
     items: list[Item]
     next_cursor: str | None
+    total: int
 
 
 class InternalIndexes(TypedDict):
@@ -1117,23 +1118,44 @@ class Repository:
         if sort is None:
             sort = Sort(field="updated_at", order="desc")
 
+        # The full filtered+sorted list is materialized before slicing, so the
+        # total number of matches is already known regardless of pagination.
+        total = len(sorted_items)
+
         if limit is None or limit <= 0:
             # No pagination requested
-            return {"items": sorted_items, "next_cursor": None}
+            return {"items": sorted_items, "next_cursor": None, "total": total}
 
         page, next_cursor = self._paginate(sorted_items, sort, limit, cursor)
-        return {"items": page, "next_cursor": next_cursor}
+        return {"items": page, "next_cursor": next_cursor, "total": total}
 
     # -----------------------------
     # Public API — Counts
     # -----------------------------
 
     def get_counts(self) -> dict[str, int]:
+        items_with_location = sum(len(ids) for ids in self._items_by_location_id.values())
         return {
             "items_total": len(self._items_by_id),
             "low_stock_count": len(self._low_stock_item_ids),
             "checked_out_count": len(self._checked_out_item_ids),
             "locations_total": len(self._locations_by_id),
+            "no_location_count": len(self._items_by_id) - items_with_location,
+        }
+
+    def get_location_item_counts(self, location_id: str | uuid.UUID) -> dict[str, int]:
+        """Return item counts for a location.
+
+        ``direct`` counts items whose ``location_id`` is exactly this location;
+        ``subtree`` counts items in this location or any descendant (so
+        ``subtree >= direct``).
+        """
+        key = str(location_id)
+        if key not in self._locations_by_id:
+            raise NotFoundError("location not found")
+        return {
+            "direct": len(self._items_by_location_id.get(key, set())),
+            "subtree": len(self._items_in_subtree.get(key, set())),
         }
 
     def get_distinct_field_values(self) -> dict[str, object]:

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -1465,6 +1465,7 @@ async def ws_item_list(
     result = {
         "items": [_serialize_item(hass, it) for it in page["items"]],
         "next_cursor": page.get("next_cursor"),
+        "total": page["total"],
     }
     conn.send_message(websocket_api.result_message(msg.get("id", 0), result))
 
@@ -1605,6 +1606,7 @@ async def ws_location_tree(
 
     def build_node(loc_id: str) -> dict[str, Any]:
         loc = locs_by_id[loc_id]
+        counts = repo.get_location_item_counts(loc_id)
         return {
             "id": str(loc.id),
             "name": loc.name,
@@ -1616,6 +1618,8 @@ async def ws_location_tree(
                 "display_path": loc.path.display_path,
                 "sort_key": loc.path.sort_key,
             },
+            "direct_item_count": counts["direct"],
+            "subtree_item_count": counts["subtree"],
             "children": [build_node(cid) for cid in sorted(children_by_parent.get(loc_id, set()))],
         }
 

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -60,7 +60,8 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - Result: `{integration_version: string, schema_version: number}`
 
 - `haventory/stats`
-  - Result: `{items_total: number, low_stock_count: number, checked_out_count: number, locations_total: number}`
+  - Result: `{items_total: number, low_stock_count: number, checked_out_count: number, locations_total: number, no_location_count: number}`
+  - `no_location_count` is the number of items without a location (`location_id == null`, i.e. the `orphaned_only` filter's population).
 
 - `haventory/distinct_values`
   - Request: `{id, type: "haventory/distinct_values"}` (no payload; extra fields → `validation_error`)
@@ -158,7 +159,8 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 
 - `haventory/item/list`
   - Payload: `{filter?: <ItemFilter>, sort?: <Sort>, limit?: number, cursor?: string}`
-  - Result: `{items: <Item[]>, next_cursor: string|null}`
+  - Result: `{items: <Item[]>, next_cursor: string|null, total: number}`
+  - `total` is the number of items matching the filter across **all** pages (not the page size), recomputed per request — so "Showing N of `total`" is renderable on every page.
 
 ### Locations
 
@@ -184,7 +186,8 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 
 - `haventory/location/tree`
   - Payload: `{}`
-  - Result: Array of tree nodes: `{id, name, parent_id, path: <LocationPath>, children: <Node[]>}`
+  - Result: Array of tree nodes: `{id, name, parent_id, path: <LocationPath>, direct_item_count, subtree_item_count, children: <Node[]>}`
+  - `direct_item_count` counts items whose `location_id` is exactly that node; `subtree_item_count` counts items in the node or any descendant (`subtree_item_count >= direct_item_count`). Counts change on item create/delete/move — clients showing them should refresh the tree on item events (or on `stats/counts`), not only on location events.
 
 - `haventory/areas/list`
   - Payload: `{}`

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -90,11 +90,15 @@ Location tree node (returned by `location/tree`):
   "parent_id": "uuid-v4|null",
   "area_id": "string|null",
   "path": <LocationPath>,
+  "direct_item_count": 0,
+  "subtree_item_count": 0,
   "children": [ <tree node>, ... ]
 }
 ```
 
 Note: `children` is a recursive array of tree nodes with the same structure.
+`direct_item_count` counts items located exactly at the node; `subtree_item_count`
+counts items at the node or any descendant (so it is always >= the direct count).
 
 ### Filters and sorting
 
@@ -119,15 +123,18 @@ Note: `children` is a recursive array of tree nodes with the same structure.
 
 ### Pagination
 
-- `item/list` returns `{items: <Item[]>, next_cursor: string|null}`.
+- `item/list` returns `{items: <Item[]>, next_cursor: string|null, total: number}`.
+- `total` is the count of items matching the filter across all pages, independent of `limit`/`cursor`.
 - `cursor` is an opaque base64url-encoded JSON with last tuple and sort metadata; pass it back unchanged.
 
 ### Stats
 
 Counts object used in `stats` results and events:
 ```json
-{ "items_total": 0, "low_stock_count": 0, "checked_out_count": 0, "locations_total": 0 }
+{ "items_total": 0, "low_stock_count": 0, "checked_out_count": 0, "locations_total": 0, "no_location_count": 0 }
 ```
+
+`no_location_count` is the number of items without a location (`location_id == null`).
 
 ### Distinct values
 
@@ -202,7 +209,7 @@ Result of `distinct_values`, used by category/tag autocomplete, the browser view
   "policy": "merge",
   "items":     { "total": 2, "add": 2, "update": 0, "conflict": 0, "unchanged": 0 },
   "locations": { "total": 1, "add": 1, "update": 0, "conflict": 0, "unchanged": 0 },
-  "totals": { "items_total": 2, "low_stock_count": 0, "checked_out_count": 0, "locations_total": 1 }
+  "totals": { "items_total": 2, "low_stock_count": 0, "checked_out_count": 0, "locations_total": 1, "no_location_count": 0 }
 }
 ```
 

--- a/tests/test_repository_items_offline.py
+++ b/tests/test_repository_items_offline.py
@@ -391,3 +391,37 @@ async def test_inspection_date_persists_across_create_update_get() -> None:
     new_repo = Repository.from_state(state)
     reloaded = new_repo.get_item(item.id)
     assert reloaded.inspection_date is None
+
+
+@pytest.mark.asyncio
+async def test_list_items_total_counts_all_matches() -> None:
+    """`total` reflects all filtered matches, independent of pagination."""
+
+    repo = Repository()
+    seeded = 5
+    tools = 2
+    for i in range(seeded):
+        repo.create_item(ItemCreate(name=f"Widget {i}", category="tools" if i < tools else "misc"))
+
+    # Unpaginated: total equals the number of items returned
+    out = repo.list_items()
+    assert out["total"] == seeded
+    assert len(out["items"]) == seeded
+
+    # Paginated: every page reports the full total, not the page size
+    page_limit = 2
+    page1 = repo.list_items(limit=page_limit)
+    assert page1["total"] == seeded
+    assert len(page1["items"]) == page_limit
+    page2 = repo.list_items(limit=page_limit, cursor=page1["next_cursor"])
+    assert page2["total"] == seeded
+
+    # Filtered: total counts only matches
+    filtered = repo.list_items(flt=ItemFilter(category="tools"), limit=1)
+    assert filtered["total"] == tools
+    assert len(filtered["items"]) == 1
+
+    # No matches: empty page, zero total
+    none = repo.list_items(flt=ItemFilter(q="zzz-not-there"))
+    assert none["total"] == 0
+    assert none["items"] == []

--- a/tests/test_repository_locations_offline.py
+++ b/tests/test_repository_locations_offline.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 from custom_components.haventory.exceptions import NotFoundError, ValidationError
+from custom_components.haventory.models import ItemCreate, ItemUpdate
 from custom_components.haventory.repository import Repository
 
 
@@ -102,3 +103,32 @@ async def test_update_location_is_atomic_when_path_rebuild_fails(monkeypatch) ->
     assert repo.get_location(b.id).parent_id == old_b.parent_id
     assert {k: set(v) for k, v in repo._children_ids_by_parent_id.items()} == old_children
     assert {lid: loc.path.display_path for lid, loc in repo._locations_by_id.items()} == old_paths
+
+
+@pytest.mark.asyncio
+async def test_location_item_counts_and_no_location_count() -> None:
+    """Per-location direct/subtree counts and the orphan count track item moves."""
+
+    repo = Repository()
+    garage = repo.create_location(name="Garage")
+    shelf = repo.create_location(name="Shelf", parent_id=garage.id)
+
+    repo.create_item(ItemCreate(name="Car", location_id=str(garage.id)))
+    wrench = repo.create_item(ItemCreate(name="Wrench", location_id=str(shelf.id)))
+    repo.create_item(ItemCreate(name="Orphan"))
+
+    # Subtree count includes the location's own items plus descendants
+    assert repo.get_location_item_counts(garage.id) == {"direct": 1, "subtree": 2}
+    assert repo.get_location_item_counts(shelf.id) == {"direct": 1, "subtree": 1}
+    assert repo.get_counts()["no_location_count"] == 1
+
+    # Clearing an item's location updates both the tree counts and the orphan count
+    repo.update_item(wrench.id, ItemUpdate(location_id=None))
+    assert repo.get_location_item_counts(garage.id) == {"direct": 1, "subtree": 1}
+    assert repo.get_location_item_counts(shelf.id) == {"direct": 0, "subtree": 0}
+    expected_orphans = 2
+    assert repo.get_counts()["no_location_count"] == expected_orphans
+
+    # Unknown location id raises NotFoundError
+    with pytest.raises(NotFoundError):
+        repo.get_location_item_counts("00000000-0000-4000-8000-000000000000")

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -231,3 +231,38 @@ async def test_inspection_date_in_create_update_get() -> None:
     res = await _send(hass, 4, "haventory/item/update", item_id=item_id, inspection_date=None)
     assert res["success"] is True
     assert res["result"]["inspection_date"] is None
+
+
+@pytest.mark.asyncio
+async def test_item_list_reports_filtered_total() -> None:
+    """item/list includes `total`: all matches for the filter, on every page."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    await _send(hass, 1, "haventory/item/create", name="Hammer", category="tools")
+    await _send(hass, 2, "haventory/item/create", name="Wrench", category="tools")
+    await _send(hass, 3, "haventory/item/create", name="Glue", category="misc")
+
+    seeded = 3
+    res = await _send(hass, 4, "haventory/item/list", limit=1)
+    assert res["success"] is True
+    assert res["result"]["total"] == seeded
+    assert len(res["result"]["items"]) == 1
+
+    # A later page still reports the full total
+    res_page2 = await _send(
+        hass, 5, "haventory/item/list", limit=1, cursor=res["result"]["next_cursor"]
+    )
+    assert res_page2["result"]["total"] == seeded
+
+    tools = 2
+    filtered = await _send(hass, 6, "haventory/item/list", filter={"category": "tools"}, limit=1)
+    assert filtered["result"]["total"] == tools
+    assert len(filtered["result"]["items"]) == 1
+
+    empty = await _send(hass, 7, "haventory/item/list", filter={"q": "zzz-not-there"})
+    assert empty["result"]["total"] == 0
+    assert empty["result"]["items"] == []

--- a/tests/test_ws_locations_offline.py
+++ b/tests/test_ws_locations_offline.py
@@ -209,3 +209,42 @@ async def test_location_move_subtree_persists(monkeypatch) -> None:
     after = calls["count"]
     # Expect at least one persist triggered by move_subtree
     assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_location_tree_includes_item_counts() -> None:
+    """Tree nodes carry direct and subtree item counts."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    root = await _send(hass, 1, "haventory/location/create", name="Garage")
+    root_id = root["result"]["id"]
+    child = await _send(hass, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
+    child_id = child["result"]["id"]
+
+    await _send(hass, 3, "haventory/item/create", name="Car", location_id=root_id)
+    await _send(hass, 4, "haventory/item/create", name="Wrench", location_id=child_id)
+    await _send(hass, 5, "haventory/item/create", name="Orphan")
+
+    res = await _send(hass, 6, "haventory/location/tree")
+    assert res["success"] is True
+    node = res["result"][0]
+    subtree_total = 2
+    assert node["direct_item_count"] == 1
+    assert node["subtree_item_count"] == subtree_total
+    child_node = node["children"][0]
+    assert child_node["direct_item_count"] == 1
+    assert child_node["subtree_item_count"] == 1
+
+    # Moving the wrench out of the tree drops both counts
+    items = hass.data[DOMAIN]["repository"].list_items(flt={"q": "wrench"})["items"]
+    hass.data[DOMAIN]["repository"].update_item(items[0].id, {"location_id": None})
+    res2 = await _send(hass, 8, "haventory/location/tree")
+    node2 = res2["result"][0]
+    assert node2["direct_item_count"] == 1
+    assert node2["subtree_item_count"] == 1
+    assert node2["children"][0]["direct_item_count"] == 0
+    assert node2["children"][0]["subtree_item_count"] == 0

--- a/tests/test_ws_utils_offline.py
+++ b/tests/test_ws_utils_offline.py
@@ -86,6 +86,7 @@ async def test_stats_returns_counts() -> None:
         "low_stock_count",
         "checked_out_count",
         "locations_total",
+        "no_location_count",
     }
 
 


### PR DESCRIPTION
Duplicate of #104 — both PRs were opened from the same branch (`claude/backup-features-analysis-tu37jy`) at the same moment. Track the change in #104.

- location/tree nodes now carry direct_item_count and subtree_item_count,
  backed by the existing items_by_location_id / items_in_subtree indexes
  (new Repository.get_location_item_counts helper, O(1) per node)
- item/list results now include total: the number of items matching the
  filter across all pages
- stats counts gain no_location_count (items without a location)
- contract + data-shape docs updated; card types and test harness mocks
  extended to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
_Generated by [Claude Code](https://claude.ai/code)_