### PR TITLE
docs(api): correct check_out due_date to optional, matching the implemented schema

### DIFF
--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -125,8 +125,11 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - Result: `<Item>`; emits `items/quantity_changed` and `stats/counts`.
 
 - `haventory/item/check_out`
-  - Payload: `{item_id: string, due_date: YYYY-MM-DD, expected_version?: number}`
+  - Payload: `{item_id: string, due_date?: YYYY-MM-DD|null, expected_version?: number}`
   - Result: `<Item>`; emits `items/checked_out` and `stats/counts`.
+  - `due_date` is optional here: omitting it (or passing `null`) checks the item out with
+    no due date. Note this differs from the `haventory.item_check_out` **service**, whose
+    schema requires `due_date`.
 
 - `haventory/item/check_in`
   - Payload: `{item_id: string, expected_version?: number}`

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -95,6 +95,38 @@ async def test_item_quantity_and_checkout_helpers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_item_check_out_due_date_is_optional() -> None:
+    """Check out without a due date, and with an explicit null one.
+
+    The WS schema declares ``due_date`` optional and nullable (unlike the
+    ``haventory.item_check_out`` service, which requires it), so both forms
+    check the item out and leave ``due_date`` unset.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    item_id = created["result"]["id"]
+
+    # Omitted entirely
+    res = await _send(hass, 2, "haventory/item/check_out", item_id=item_id)
+    assert res["success"] is True
+    assert res["result"]["checked_out"] is True
+    assert res["result"]["due_date"] is None
+
+    await _send(hass, 3, "haventory/item/check_in", item_id=item_id)
+
+    # Explicit null
+    res = await _send(hass, 4, "haventory/item/check_out", item_id=item_id, due_date=None)
+    assert res["success"] is True
+    assert res["result"]["checked_out"] is True
+    assert res["result"]["due_date"] is None
+
+
+@pytest.mark.asyncio
 async def test_item_list_pagination_cursor_passthrough() -> None:
     """List items returns items array and next_cursor passthrough shape."""
 


### PR DESCRIPTION
## Summary

Follow-up to #102 (already merged), reconciling one more doc drift. The implemented schema is treated as master and the doc follows it.

`docs/backend_api_contract.md` listed `due_date` as a required payload field on `haventory/item/check_out`, but the implementation makes it optional:

- `ws.py` declares `vol.Optional("due_date"): vol.Any(str, None)`
- `Repository.check_out` passes `due_date=None` straight through to `update_item`
- the card already checks an item out with `null` (`index.ts` → `store.checkOut(item.id, null)`)

The doc now documents `due_date?: YYYY-MM-DD|null` and notes that this differs from the `haventory.item_check_out` **service**, whose `SCHEMA_ITEM_CHECK_OUT` does require the field — so the asymmetry is intentional and documented rather than looking like a second bug.

Also adds `test_item_check_out_due_date_is_optional`, pinning both accepted forms (field omitted, explicit `null`). The existing check-out test only covered the with-a-date path, which is why the doc could disagree with the schema unnoticed.

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (270 passed, 22 skipped), `uv run ruff check .` (clean), `uv run mypy` (no issues in 13 files)
- [x] Frontend (`cards/haventory-card`): `npx eslint .` (clean), `npx vitest run` (165 passed, 17 files), `npm run build` (built `www/haventory/haventory-card.js`)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case). — *omitted `due_date` and explicit `null`; no production code changed*
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

No card changes (one doc correction and one added test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_