### PR TITLE
fix(tests): stop using deprecated asyncio event loop policy APIs on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,9 @@ Adopted tooling (latest stable at review time; verified against release pages / 
 - **`tsc --noEmit`** is clean as of WP2 follow-ups (`npm run typecheck`); not yet part of the
   gate — adding it is a WP4/WP5 call.
 - **release-please** wiring lands in WP5.
-- **Windows-only test scaffolding**: `tests/conftest.py` uses
+- ~~**Windows-only test scaffolding**: `tests/conftest.py` uses
   `asyncio.WindowsSelectorEventLoopPolicy` / `set_event_loop_policy`, both deprecated for
-  removal in Python 3.16 — replace when convenient (effort S).
+  removal in Python 3.16~~ — fixed: `tests/conftest.py` now implements the
+  `pytest_asyncio_loop_factories` hook (Windows-only) to hand pytest-asyncio a
+  `asyncio.SelectorEventLoop` factory directly, instead of mutating the process-wide event
+  loop policy.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,9 +28,12 @@ the offline suite and gets the stubs. As a result:
   and is never collected by the offline run (``collect_ignore`` below).
 
 It also ensures sockets are enabled when pytest-socket is auto-loaded by IDEs
-(required on Windows where creating the event loop uses ``socket.socket``) and
-enforces a selector-based event loop policy on Windows to avoid
+(required on Windows where creating the event loop uses ``socket.socket``) and,
+on Windows, makes pytest-asyncio hand out a selector-based event loop to avoid
 ProactorEventLoop self-pipe issues when sockets are tampered with by plugins.
+That's done via the ``pytest_asyncio_loop_factories`` hook rather than
+``asyncio.set_event_loop_policy``/``WindowsSelectorEventLoopPolicy`` — both are
+deprecated since Python 3.14 and slated for removal in 3.16.
 """
 
 import asyncio
@@ -332,12 +335,16 @@ else:
     except Exception:
         pass
 
-    # On Windows force SelectorEventLoopPolicy early (pytest-asyncio will reuse it)
+    # On Windows, hand pytest-asyncio a selector-based loop factory instead of
+    # forcing a process-wide event loop policy: asyncio.set_event_loop_policy()
+    # and WindowsSelectorEventLoopPolicy are both deprecated since Python 3.14
+    # (removal slated for 3.16). A single-entry mapping keeps every async test
+    # parametrized exactly as before (one run, id hidden) while going through
+    # pytest-asyncio's supported extension point.
     if platform.system() == "Windows":  # pragma: no cover - environment-specific
-        try:
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        except Exception:
-            pass
+
+        def pytest_asyncio_loop_factories():
+            return {"selector": asyncio.SelectorEventLoop}
 
     _install_offline_ha_stubs()
 


### PR DESCRIPTION
## Summary
- `tests/conftest.py` was calling `asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())` on Windows to force a selector-based event loop for pytest-asyncio, both of which are deprecated since Python 3.14 and slated for removal in 3.16.
- Replaced it with pytest-asyncio 1.4's supported `pytest_asyncio_loop_factories` hook (Windows-only), handing out an `asyncio.SelectorEventLoop` factory directly instead of mutating the process-wide event loop policy. Behavior is unchanged (still selector-based on Windows, still one run per test since it's a single-entry factory mapping) — only the mechanism changed.
- Updated the CLAUDE.md WP1 follow-up note that tracked this as outstanding.

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` — 270 passed, 22 skipped, no warnings
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q -W error::DeprecationWarning` — still green (no deprecation warnings anywhere in the run)
- [x] `uv run ruff check .`
- [x] `uv run mypy` (pre-existing conftest.py stub-related errors unchanged, no new errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)