### PR TITLE
chore(claude): stop embedding claude.ai session links in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "attribution": {
+    "sessionUrl": false
+  },
   "permissions": {
     "allow": [
       "Bash(uv sync)",


### PR DESCRIPTION
## Summary

Disables the `sessionUrl` attribution setting in `.claude/settings.json` by adding an `attribution` configuration block with `sessionUrl` set to `false`. This prevents session URLs from being included in Claude-generated content.

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

N/A — configuration file change only.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No functional code changes; no tests required


---
_Generated by [Claude Code](https://claude.ai/code)_