### PR TITLE
fix(card): stop the import sheet promising Replace deletes

### DIFF
--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -73,7 +73,17 @@ describe('hv-import-sheet: step 1', () => {
     expect(policies.map((p) => p.dataset.policy)).toEqual(['merge', 'replace', 'skip']);
     expect(policies[0].getAttribute('aria-checked')).toBe('true');
     // Each explains what it does, rather than relying on the word alone.
-    expect(policies[1].textContent).toContain('Delete everything not in the file');
+    expect(policies[1].textContent).toContain("Overwrite matching items with the file's version");
+  });
+
+  it('promises no deletion, because no policy deletes', async () => {
+    // `replace` overwrites the ids the file carries and leaves every other item
+    // alone; a user who reads it as a whole-inventory swap would import a small
+    // file expecting a prune and silently keep everything else.
+    const el = await mount();
+    for (const policy of all(el, '[data-testid="import-policy"]')) {
+      expect(policy.textContent?.toLowerCase()).not.toMatch(/delete|remove|wipe|erase/);
+    }
   });
 
   it('cannot preview an empty document', async () => {

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -8,16 +8,20 @@ import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
 import type { ImportBucketCounts, ImportPolicy, ImportPreview, ImportSummary } from '../store/types';
 
+// Every policy decides one thing: what happens to an item the file and the
+// inventory both have. None of them deletes anything — an item absent from the
+// file is always left alone — so each description says so, because "Replace"
+// on its own reads like a whole-inventory swap.
 const POLICIES: { id: ImportPolicy; title: string; description: string }[] = [
   {
     id: 'merge',
     title: 'Merge',
-    description: 'Keep existing items, update the ones present in the file, add the rest',
+    description: 'Update matching items field by field, combining tags; add the rest',
   },
   {
     id: 'replace',
     title: 'Replace',
-    description: 'Delete everything not in the file — the file becomes the whole inventory',
+    description: "Overwrite matching items with the file's version; add the rest",
   },
   { id: 'skip', title: 'Skip', description: "Only add items that don't exist yet" },
 ];


### PR DESCRIPTION
## What

The import sheet described the **Replace** policy as:

> Delete everything not in the file — the file becomes the whole inventory

It does not delete. `_plan_entities` (`custom_components/haventory/import_export.py:568-597`) iterates the ids the *document* carries and never touches anything else; the three policies differ only in what they do to an id that is present in **both** the file and the inventory:

| policy | id in both, and differs |
|---|---|
| `merge` | overlay incoming onto existing (tags unioned, `custom_fields` incoming-wins) |
| `replace` | overwrite wholesale with the incoming entity |
| `skip` | keep the existing entity, report it as `conflict` |

`docs/backend_api_contract.md:238-241` already documents this correctly — only the card copy was wrong.

## Evidence

Imported a deliberately tiny document (3 items / 1 location) with `policy: replace` into the live 1000-item dev instance:

```
document contains 3 items and 1 locations
before import: items=1000 locations=40
after import:  items=1000 locations=40

VERDICT: REPLACE DOES NOT PRUNE — absent entities survive (1000 items remain, card copy says 3)
```

The preview step does save the user from acting blindly — it reported "Nothing in this file would change the inventory" — but someone importing a small file *in order to prune* would read that zero as "already clean" and never learn the other 997 survived.

## Change

Copy only; no behavior change. Each description now says what happens to a matching item, and the deletion language is gone. Merge's wording moves in step so the two remain distinguishable (field-by-field overlay vs. wholesale overwrite) — with only Replace corrected, the two policies would have read identically.

```
Merge    Update matching items field by field, combining tags; add the rest
Replace  Overwrite matching items with the file's version; add the rest
Skip     Only add items that don't exist yet          (unchanged — already accurate)
```

The group is already labelled "If an item already exists", which frames all three correctly.

## Tests

- Updated the existing assertion in `hv-import-sheet.test.ts` to the corrected Replace text.
- Added a regression test asserting no policy description contains delete/remove/wipe/erase, so the promise cannot come back.

Frontend gate: eslint clean, `tsc --noEmit` clean, vitest 774 passed / 42 files. Backend gate: 274 passed / 22 skipped, ruff + mypy clean.

## Follow-up (not in this PR)

The sheet never *positively* states that an import cannot delete. The policy descriptions no longer imply it, but if the reassurance is wanted it belongs as one line under the radiogroup rather than repeated in all three descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
