### PR TITLE
fix: match the card's Lovelace resource by path, not by exact URL

### DIFF
--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
+from urllib.parse import urlsplit
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -165,6 +166,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _points_at_card(resource_url: Any, card_url: str) -> bool:
+    """Does an already-registered Lovelace resource serve the HAventory card?
+
+    Compare paths, not whole URLs: a resource may carry a cache-busting query
+    (`?v=<hash>`), and `/local/` is served with a month-long `max-age`, so that
+    query is the only way to make a browser pick up a rebuilt bundle. Matching
+    the full string would treat a versioned entry as somebody else's resource
+    and register a second one for the same file — the card module then loads
+    twice and the second `customElements.define` throws.
+    """
+    if not isinstance(resource_url, str):
+        return False
+    return urlsplit(resource_url).path == urlsplit(card_url).path
+
+
 async def _register_frontend_module(hass: HomeAssistant) -> None:
     """Register the built HAventory card asset as a Lovelace resource if present."""
     url = "/local/haventory/haventory-card.js"
@@ -213,10 +229,11 @@ async def _register_frontend_module(hass: HomeAssistant) -> None:
     # Check if resource already exists
     existing = resources.async_items() or []
     for item in existing:
-        if item.get("url") == url:
+        registered_url = item.get("url")
+        if _points_at_card(registered_url, url):
             LOGGER.debug(
                 "HAventory card resource already registered",
-                extra={"domain": DOMAIN, "op": "frontend_register", "url": url},
+                extra={"domain": DOMAIN, "op": "frontend_register", "url": registered_url},
             )
             return
 

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -157,6 +157,84 @@ async def test_skips_when_resource_already_exists(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "registered_url",
+    [
+        "/local/haventory/haventory-card.js?v=38b725595b78",
+        "/local/haventory/haventory-card.js?v=1&foo=bar",
+        "/local/haventory/haventory-card.js#frag",
+    ],
+)
+async def test_skips_when_resource_registered_with_cache_busting_query(
+    tmp_path, monkeypatch, registered_url
+):
+    """A versioned resource URL is the same resource => no duplicate.
+
+    `/local/` is served with a month-long `max-age`, so a `?v=<hash>` query is
+    the only way to make browsers pick up a rebuilt bundle. Registering a second
+    resource for the same file loads the card module twice, and the second
+    `customElements.define` throws.
+    """
+    mock_lovelace_key = "lovelace_data_key"
+    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
+    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
+
+    if "custom_components.haventory" in sys.modules:
+        del sys.modules["custom_components.haventory"]
+    hav_init = importlib.import_module("custom_components.haventory")
+
+    asset_dir = tmp_path / "www" / "haventory"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "haventory-card.js").write_text("// test asset")
+
+    hass = HassStub(str(tmp_path))
+    hass.config = HassStub._Config(str(tmp_path))
+
+    lovelace_data = MockLovelaceData()
+    lovelace_data.resources._items = [{"id": "existing", "url": registered_url, "type": "module"}]
+    hass.data[mock_lovelace_key] = lovelace_data
+
+    await hav_init._register_frontend_module(hass)
+
+    assert lovelace_data.resources.created == []
+
+
+@pytest.mark.asyncio
+async def test_registers_alongside_unrelated_resources(tmp_path, monkeypatch):
+    """Another integration's card, and a malformed entry, must not block us."""
+    mock_lovelace_key = "lovelace_data_key"
+    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
+    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
+
+    if "custom_components.haventory" in sys.modules:
+        del sys.modules["custom_components.haventory"]
+    hav_init = importlib.import_module("custom_components.haventory")
+
+    asset_dir = tmp_path / "www" / "haventory"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "haventory-card.js").write_text("// test asset")
+
+    hass = HassStub(str(tmp_path))
+    hass.config = HassStub._Config(str(tmp_path))
+
+    lovelace_data = MockLovelaceData()
+    lovelace_data.resources._items = [
+        {"id": "other", "url": "/local/other-card.js", "type": "module"},
+        # Same basename, different integration.
+        {"id": "lookalike", "url": "/hacsfiles/elsewhere/haventory-card.js", "type": "module"},
+        {"id": "malformed", "type": "module"},
+        {"id": "wrong_type", "url": None, "type": "module"},
+    ]
+    hass.data[mock_lovelace_key] = lovelace_data
+
+    await hav_init._register_frontend_module(hass)
+
+    assert [c["url"] for c in lovelace_data.resources.created] == [
+        "/local/haventory/haventory-card.js"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_skips_when_lovelace_not_initialized(tmp_path, monkeypatch):
     """Lovelace not initialized => skips gracefully."""
     # Mock lovelace BEFORE importing


### PR DESCRIPTION
## The bug

`_register_frontend_module` (`custom_components/haventory/__init__.py`) skipped registration only when a registered resource URL matched `/local/haventory/haventory-card.js` **exactly**:

```python
for item in existing:
    if item.get("url") == url:
        return
```

Any query string makes that miss. The integration then registers a *second* resource for the same file, the browser loads the card module twice, and the second `customElements.define('haventory-card', …)` throws an uncaught `CustomElementRegistry` error.

## Why the query string is not hypothetical

HA serves `/local/` with `Cache-Control: public, max-age=2678400` — 31 days, no revalidation — so `?v=<hash>` is the only way to make a browser pick up a rebuilt bundle. Two consequences:

1. The dev workflow already registers exactly that (`.claude/skills/run-haventory/pin_resource.py`), so every restart of a dev instance re-added a bare duplicate that had to be collapsed by hand.
2. **Open item 26** proposes appending `?v=<manifest version>` in production for the same reason. That fix cannot land while this check treats a versioned entry as somebody else's resource — it would make the integration duplicate its own resource on every upgrade, which is precisely the failure item 26 exists to prevent.

Exit criterion 5 of the release testing plan ("no uncaught frontend console error") is what this trips.

## The fix

Compare the URL **path**, ignoring query and fragment, and ignore entries whose `url` is absent or not a string. No change to what gets registered on a clean install.

## Verification

Unit — three new parametrized cases (`?v=<hash>`, multi-param query, fragment) plus a guard that an unrelated `/local/other-card.js`, a same-basename `/hacsfiles/elsewhere/haventory-card.js`, and malformed entries do **not** suppress registration. The three cache-busting cases fail on `main`:

```
FAILED test_skips_when_resource_registered_with_cache_busting_query[...?v=38b725595b78]
FAILED test_skips_when_resource_registered_with_cache_busting_query[...?v=1&foo=bar]
FAILED test_skips_when_resource_registered_with_cache_busting_query[...#frag]
3 failed, 6 passed
```

Live — the mock resource collection in this test file is ours, not HA's, so the branch was also deployed to a real HA 2026.7.3 (Docker) holding a versioned resource and restarted:

```
before:  1 resource   /local/haventory/haventory-card.js?v=38b725595b78
after:   1 resource   /local/haventory/haventory-card.js?v=38b725595b78
log:     DEBUG [custom_components.haventory] HAventory card resource already registered
```

The dedupe branch is genuinely taken against HA's real `ResourceStorageCollection`. Card renders, no browser console errors, no tracebacks in the HA log, and the 1000-item test inventory is untouched.

Gates: backend 278 passed / 22 skipped, ruff + mypy clean; frontend eslint clean, vitest 773 passed.

## Not in this PR

Collapsing duplicates that a previous version already created — this stops new ones. Adding the `?v=` cache-busting URL itself is open item 26; this unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
