### PR TITLE
chore(skill): add a driver for the card's import sheet

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -194,6 +194,31 @@ The container publishes 8123 on the host, so a phone on the same network can hit
 inbound 8123 on the private profile). This is the only way to test real fingers, momentum
 scrolling, iOS Safari, and the HA Companion app's webview.
 
+### Drive the import sheet
+
+`drive_import.mjs` puts a backup document through the card's own Import UI — overflow menu →
+paste → policy → Preview → optionally Import — and screenshots each step. Preview only unless
+`--apply` is passed, because the server-side dry run is the point:
+
+```bash
+cd .claude/skills/run-haventory
+node drive_import.mjs ~/backup.json                        # preview with merge
+node drive_import.mjs ~/backup.json --policy replace       # preview with replace
+node drive_import.mjs ~/backup.json --apply --out restore  # WRITES; screenshots the result
+```
+
+Defaults: `--policy merge`, `--out import`, `--path /lovelace/wide`. The document is pasted
+verbatim and deliberately **not** validated first, so malformed input can be used to drive the
+card's parse-error and server-rejection paths. `--apply` mutates the instance and import is
+all-or-nothing with no undo — export first.
+
+This is what the WS-level scripts cannot check: whether the sheet *describes* the policy the
+backend actually applies. `replace` overwrites the ids the document carries and deletes
+nothing, which is only visible by reading the sheet next to the counts it produces.
+
+On Windows pass the document as a native path with forward slashes
+(`"C:/Users/you/backup.json"`); a `/c/...` MSYS path reaches Node as `C:\c\...`.
+
 ## Test
 
 Offline suites (no HA needed — full gate incl. lint is in CLAUDE.md):
@@ -243,8 +268,15 @@ clean-start mode), then `Online smoke test completed successfully.`
   with the long-lived token as `access_token`, a future `expires`, and
   `clientId === origin + "/"` (what `screenshot.mjs` does). No password needed, no
   login form automation.
-- **Playwright selectors pierce shadow DOM** — `haventory-card` and its inner
-  `input[placeholder="Search"]` are directly selectable despite Lit shadow roots.
+- **Playwright selectors pierce shadow DOM but text extraction does not** —
+  `haventory-card` and its inner `input[placeholder="Search"]` are directly selectable
+  despite Lit shadow roots, yet `locator.innerText()` on a shadow host reads its *light*
+  DOM and comes back empty. To read what a component renders, go through the root:
+  `locator.evaluate((el) => el.shadowRoot.textContent)`.
+- **`fill()` is unusable for a whole-inventory document** — a ~1 MB export types through
+  the input pipeline for minutes and blows past Playwright's 30 s default. Set `value` and
+  dispatch the `input` event the component listens for instead; that is one round trip
+  (~6 s for 981 KiB, versus a 180 s timeout).
 - **`reload_addon.sh` overwrites the container's `configuration.yaml`** with
   `dev/ha_config_for_dev.yaml` (previous one backed up as `.bak` inside the container).
   Fine for the dev container; don't point it at a container whose config you care about.

--- a/.claude/skills/run-haventory/drive_import.mjs
+++ b/.claude/skills/run-haventory/drive_import.mjs
@@ -1,0 +1,220 @@
+// Drive the card's "Import backup" sheet end to end against a real Home
+// Assistant, and capture what the user actually sees at each step.
+//
+// Pastes a document into the sheet, picks a conflict policy, presses Preview,
+// screenshots the preview, and — only with --apply — presses Import. Without
+// --apply nothing is written: the server-side dry run is the whole point.
+//
+// Usage (from the skill dir, .claude/skills/run-haventory/):
+//   node drive_import.mjs <document.json> [--policy merge|replace|skip]
+//                         [--apply] [--out <prefix>] [--path <ha-url-path>]
+//
+// Defaults: --policy merge, --out import, --path /lovelace/wide.
+//
+// The document is pasted verbatim and is NOT validated here — driving the
+// card's own parse-error and server-rejection paths is a supported use, so
+// malformed input is passed through on purpose.
+//
+// --apply MUTATES the instance it is pointed at. Import is all-or-nothing and
+// there is no undo; export a backup first.
+//
+// Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
+// Prints browser console errors (the card logs there).
+
+import { chromium } from "playwright";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(skillDir, "..", "..", "..");
+
+const args = process.argv.slice(2);
+
+// --- config: env wins, .env fills the gaps -------------------------------
+try {
+  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
+  }
+} catch {
+  /* no .env — rely on real env vars */
+}
+const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
+const token = process.env.HA_TOKEN;
+if (!token) {
+  console.error("Missing HA_TOKEN (env or repo-root .env)");
+  process.exit(2);
+}
+
+// --- args ----------------------------------------------------------------
+const VALUE_FLAGS = new Set(["--policy", "--out", "--path"]);
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+
+// Collect positionals by skipping each value flag together with its value, so
+// the document path may appear anywhere on the command line.
+const positionals = [];
+for (let i = 0; i < args.length; i++) {
+  if (VALUE_FLAGS.has(args[i])) i++;
+  else if (!args[i].startsWith("--")) positionals.push(args[i]);
+}
+
+const docPath = positionals[0];
+if (!docPath) {
+  console.error("Usage: node drive_import.mjs <document.json> [--policy merge|replace|skip]");
+  console.error("                             [--apply] [--out <prefix>] [--path <ha-url-path>]");
+  process.exit(2);
+}
+
+const policy = flag("--policy", "merge");
+if (!["merge", "replace", "skip"].includes(policy)) {
+  console.error(`--policy must be merge, replace or skip (got "${policy}")`);
+  process.exit(2);
+}
+
+const outPrefix = flag("--out", "import");
+const urlPath = flag("--path", "/lovelace/wide");
+const apply = args.includes("--apply");
+const shot = (suffix) => path.resolve(skillDir, `${outPrefix}-${suffix}.png`);
+
+let documentJson;
+try {
+  documentJson = readFileSync(docPath, "utf8");
+} catch (err) {
+  console.error(`Cannot read document: ${err.message}`);
+  process.exit(2);
+}
+console.log(
+  `document: ${docPath} (${(documentJson.length / 1024).toFixed(0)} KiB) · policy=${policy}` +
+    (apply ? " · APPLY (this writes)" : " · preview only"),
+);
+
+// --- drive ---------------------------------------------------------------
+const browser = await chromium.launch();
+// HA's service worker activates ~30-90s into a fresh context and reloads the
+// page, which kills the JS execution context mid-run. An import run is long
+// enough to sit inside that window, so block it — at the cost of one harmless
+// `navigator.serviceWorker` console error from HA's own bundle.
+const context = await browser.newContext({
+  viewport: { width: 1280, height: 900 },
+  serviceWorkers: "block",
+});
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on("console", (msg) => {
+  if (msg.type() === "error") consoleErrors.push(msg.text());
+});
+page.on("pageerror", (err) => consoleErrors.push(`pageerror: ${err.message}`));
+
+// The HA frontend trusts hassTokens if `expires` is in the future; the
+// long-lived token works as access_token. clientId must be `${origin}/`.
+await page.addInitScript(
+  ([hassUrl, accessToken]) => {
+    localStorage.setItem(
+      "hassTokens",
+      JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "unused-long-lived",
+        expires_in: 1800,
+        expires: Date.now() + 365 * 24 * 3600 * 1000,
+        hassUrl,
+        clientId: hassUrl + "/",
+      }),
+    );
+  },
+  [base, token],
+);
+
+await page.goto(base + urlPath, { waitUntil: "domcontentloaded" });
+
+if (page.url().includes("/auth/authorize")) {
+  console.error("Redirected to the login page — hassTokens injection was rejected. Is HA_TOKEN valid?");
+  await browser.close();
+  process.exit(1);
+}
+
+// Playwright selectors pierce shadow DOM, so the card and the sheet inside it
+// are addressable directly.
+await page.waitForSelector("haventory-card", { timeout: 30000 });
+await page.waitForTimeout(2500); // let the card's WS subscription deliver data
+
+// Selectors pierce shadow DOM but text extraction does not: `innerText` on a
+// shadow host reads its light DOM, which is empty here. Go through shadowRoot.
+const sheetText = async () =>
+  (
+    await page
+      .locator("hv-import-sheet")
+      .first()
+      .evaluate((el) => el.shadowRoot?.textContent ?? "")
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+
+// Import lives behind the card's overflow menu.
+await page.click('haventory-card [data-testid="card-overflow"] button');
+await page.click('haventory-card [data-testid="overflow-item"][data-id="import"]');
+await page.waitForSelector('hv-import-sheet [data-testid="import-text"]', { timeout: 10000 });
+
+// Set the value and fire `input` — the event the sheet actually listens for —
+// rather than using fill(). fill() types through the input pipeline, and a
+// full-inventory export (~1 MB) does not finish inside three minutes that way;
+// passing the string as one evaluate argument is a single round trip.
+console.log("pasting…");
+await page.locator('hv-import-sheet [data-testid="import-text"]').evaluate((el, text) => {
+  el.value = text;
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}, documentJson);
+
+if (policy !== "merge") {
+  await page.locator(`hv-import-sheet [data-testid="import-policy"][data-policy="${policy}"]`).first().click();
+}
+await page.screenshot({ path: shot("step1") });
+
+await page.locator('hv-import-sheet [data-testid="import-preview"]').click();
+// Either step 2, or one of the failure surfaces: a client-side JSON parse
+// error, the server's structured list of invalid paths, or a transport error.
+await page.waitForSelector(
+  'hv-import-sheet [data-testid="import-execute"], hv-import-sheet [data-testid="import-nothing-to-do"],' +
+    ' hv-import-sheet [data-testid="import-parse-error"], hv-import-sheet [data-testid="import-errors"],' +
+    ' hv-import-sheet [data-testid="import-error"]',
+  { timeout: 60000 },
+);
+await page.waitForTimeout(400); // let the counts finish rendering
+await page.screenshot({ path: shot("preview") });
+console.log(`\npreview step reads:\n  ${await sheetText()}`);
+
+if (apply) {
+  const execute = page.locator('hv-import-sheet [data-testid="import-execute"]');
+  if ((await execute.count()) === 0) {
+    console.error("\nNothing to import: the preview offered no Import button.");
+    await browser.close();
+    process.exit(1);
+  }
+  await execute.click();
+  await page.waitForSelector(
+    'hv-import-sheet [data-testid="import-done"], hv-import-sheet [data-testid="import-error"]',
+    { timeout: 120000 },
+  );
+  await page.waitForTimeout(400);
+  await page.screenshot({ path: shot("applied") });
+  console.log(`\nafter Import:\n  ${await sheetText()}`);
+}
+
+console.log(`\nscreenshots: ${shot("step1")}, ${shot("preview")}${apply ? `, ${shot("applied")}` : ""}`);
+// Blocking the service worker makes HA's own bundle touch `navigator.serviceWorker`
+// when it is undefined. Flag it rather than hide it, so a real card error stands out.
+const SW_BLOCK_NOISE = /serviceWorker|reading 'addEventListener'/;
+if (consoleErrors.length) {
+  console.log(`browser console errors (${consoleErrors.length}):`);
+  for (const e of consoleErrors.slice(0, 10)) {
+    console.log(`  ${e}${SW_BLOCK_NOISE.test(e) ? "   <- expected: HA bundle, service worker blocked" : ""}`);
+  }
+} else {
+  console.log("no browser console errors");
+}
+await browser.close();


### PR DESCRIPTION
Lands the Playwright driver that was sitting untracked in the skill directory, alongside `driver.py` and `screenshot.mjs`, plus its SKILL.md section.

## Why keep it

`driver.py` exercises the WS import commands and `screenshot.mjs` drives the card generally, but neither answers the question that decides whether a restore goes right: **does the sheet describe the policy the backend actually applies?** That only shows up when the wording is read next to the counts it produces — which is how the Replace copy defect (#113) surfaced.

## What it does

```bash
cd .claude/skills/run-haventory
node drive_import.mjs ~/backup.json                        # preview with merge
node drive_import.mjs ~/backup.json --policy replace       # preview with replace
node drive_import.mjs ~/backup.json --apply --out restore  # WRITES; screenshots the result
```

Overflow menu → paste → policy → Preview → optionally Import, screenshotting each step. Preview-only unless `--apply`, since the server-side dry run is the point. The document is passed through **unvalidated on purpose**, so the card's own parse-error and server-rejection paths can be driven with malformed input.

Brought up to the conventions the other two scripts already follow: repo-root `.env` loading, service workers blocked, the login-redirect check, output resolved against the skill dir, and validated arguments (previously a positional-argument expression that only worked if the document came first, and an unchecked `--policy`).

## Two constraints found the hard way, now in Gotchas

**Selectors pierce shadow DOM; text extraction does not.** `locator.innerText()` on a shadow host reads its *light* DOM and returns empty — the preview step printed nothing while rendering correctly on screen. Text has to come from `evaluate((el) => el.shadowRoot.textContent)`.

**`fill()` is unusable at inventory scale.** A 981 KiB export typed through the input pipeline blew past a 180 s budget. Setting `value` and dispatching the `input` event the component listens for is one round trip:

```
document: export_r1.json (981 KiB) · policy=replace · preview only
preview step reads:
  … Items Add+0 Update0 Conflict0 Unchanged1000 Locations Add+0 Update0 Conflict0 Unchanged40
    Nothing in this file would change the inventory
real  0m6.593s
```

## Verified

Run against live HA 2026.7.3 holding 1000 items / 40 locations, on `main` with #113–#115 merged: full 981 KiB export previews in 6.6 s; a 3-item document under `replace` reports 3 unchanged and leaves 1000 items in place; the only console error is HA's own bundle reacting to the blocked service worker, which the script now labels as expected rather than leaving it to look like a card fault.

`*.png` is already gitignored in that directory, so screenshots stay out of the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
