### PR TITLE
fix(card): open the import sheet from the empty state and stop clipping the overflow menu

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -436,6 +436,27 @@ describe('hv-card-shell: list and footer', () => {
     await settle(el);
     expect(store.state.value.filters.q).toBe('');
   });
+
+  // The offer names the same action as the ⋮ menu's "Import backup…", and the
+  // shell owns that sheet. Handing the id up to the host instead drops it: the
+  // host's switch knows only the surfaces it owns, so the press does nothing.
+  it('opens the import sheet from the untouched-inventory offer', async () => {
+    const { el, sr } = await mountShell({ items: [] });
+    const handedUp: string[] = [];
+    el.addEventListener('menu-action', (e) => handedUp.push((e as CustomEvent).detail.id));
+
+    const list = sr.querySelector('hv-list') as HTMLElement;
+    const offer = list.shadowRoot?.querySelector('[data-id="import"]') as HTMLButtonElement;
+    expect(offer).toBeTruthy();
+
+    offer.click();
+    await settle(el);
+
+    expect((sr.querySelector('[data-testid="card-import"]') as HTMLElement & { open: boolean }).open).toBe(
+      true,
+    );
+    expect(handedUp).toEqual([]);
+  });
 });
 
 describe('hv-card-shell: banners', () => {

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -749,7 +749,21 @@ export class HVCardShell extends LitElement {
     // The full view re-dispatches its own menu selections through here; stop the
     // original so the host card does not also see it directly.
     e.stopPropagation();
-    const { id } = e.detail as { id: string };
+    const { id, tab } = e.detail as { id: string; tab?: OrganizeTab };
+    this._runMenuAction(id, tab);
+  };
+
+  /**
+   * What an action id means, for every surface that can name one.
+   *
+   * The ⋮ menus and the empty state's offers share an id vocabulary, and the
+   * shell owns some of those surfaces (import, organize, diagnostics) while the
+   * host card owns others (the column picker, the export download). Both entry
+   * points route through here so they cannot disagree about which is which — an
+   * id the shell handles must not be handed upward, where the host's switch
+   * would drop it on the floor.
+   */
+  private _runMenuAction(id: string, tab?: OrganizeTab) {
     if (id === 'refresh') {
       void this._refresh();
       return;
@@ -768,7 +782,6 @@ export class HVCardShell extends LitElement {
     if (id === 'organize') {
       // The expanded sidebar's facet headings ask for a specific tab; the card
       // menu asks for none and gets Locations, as it always did.
-      const { tab } = e.detail as { tab?: OrganizeTab };
       this._organizeTab = tab ?? 'locations';
       this._organizeOpen = true;
       return;
@@ -781,7 +794,7 @@ export class HVCardShell extends LitElement {
     }
     // Everything else is owned by the host card, which knows about dialogs.
     this.dispatchEvent(new CustomEvent('menu-action', { detail: { id }, bubbles: true, composed: true }));
-  };
+  }
 
   // ---------- Render helpers ----------
   private _renderBadges() {
@@ -969,7 +982,7 @@ export class HVCardShell extends LitElement {
     if (id === 'clear-filters') this.store?.clearFilters();
     else if (id === 'refresh') void this.store?.refreshAll();
     else if (id === 'add-item') this._startEdit('new');
-    else this.dispatchEvent(new CustomEvent('menu-action', { detail: { id }, bubbles: true, composed: true }));
+    else this._runMenuAction(id);
   };
 
   private _renderFilterPanel(mobile: boolean) {

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -55,6 +55,27 @@ export class HVCardShell extends LitElement {
         border-radius: var(--hv-radius-card);
         overflow: hidden;
       }
+      /* The ⋮ menu is an absolutely positioned dropdown inside this box, so the
+         overflow rule above — which is what keeps the list's rows inside the
+         rounded corners — clips it. A card holding few enough items to be shorter
+         than the open menu cuts it off at the bottom edge, and the entries it
+         loses are the last ones: Export and Import. An empty card is the worst
+         case at 269px against a 381px menu.
+
+         Reserving the height the menu needs is what keeps every entry reachable.
+         Measured from the card's top edge: 56px of header above the trigger, a
+         6px gap, then the menu itself; the remainder covers a second line under
+         "Export current view", which the sub-label takes when the filtered count
+         is long.
+
+         Only above 600px, matching hv-overflow-menu's own breakpoint: below it
+         the menu is a fixed bottom sheet anchored to the viewport, which nothing
+         here clips and which would not justify a 470px card on a phone. */
+      @media (min-width: 601px) {
+        :host {
+          min-height: 470px;
+        }
+      }
       /* Declared once here and inherited into every nested component's shadow
          DOM — the shared .hv-icon-button, the sheets, the row steppers and the
          editor all read it, so none of them needs its own copy of "is the card


### PR DESCRIPTION
## Summary

Two user-reported card bugs from live testing (HA 2026.7.3), both on the
import/export surface, both in `hv-card-shell.ts`.

### 1. The empty state's "Import backup" button did nothing

Not a dead button — a misrouted id. The offer and the ⋮ menu name the same
action but travelled different routes:

- **⋮ menu** → `_onMenuSelect` → opens the sheet ✅
- **Empty state** → `_onEmptyAction`, which handled `clear-filters` / `refresh` /
  `add-item` and re-dispatched *everything else* as a `menu-action` event **from
  the shell itself**. That bubbles past the shell's own listeners up to the host
  card, whose switch (`index.ts:_onShellAction`) knows only `columns`,
  `export-all` and `export-view`. `import` fell off the end. Silence.

Both entry points now route through a single `_runMenuAction`, so an id cannot
mean one thing from the menu and nothing from the empty state.

The full view's empty state was never affected — it dispatches `menu-action`
*at* the shell from outside, where `_onMenuSelect` is listening. Only the card's
own empty state took the bad path.

### 2. With few or no items, the ⋮ menu was clipped

The clipper is `overflow: hidden` on the shell host — the rule that keeps list
rows inside the rounded corners. Measured live before the fix:

| | |
|---|---|
| Card height (empty) | 269px |
| Menu height | 381px |
| **Clipped off the bottom** | **168px** |
| Height needed from the card's top | 437px |

The entries lost are the last ones — Export and Import — which is why this
surfaced together with bug 1.

Fixed with `min-height: 470px`, the slack covering a second line under "Export
current view" when the filtered count is long. Scoped to `@media (min-width:
601px)`, matching `hv-overflow-menu`'s own breakpoint: below it the menu is a
fixed bottom sheet anchored to the viewport, nothing clips it, and a 470px floor
on a phone would be waste.

Worth noting this was never empty-state-specific — **any card short enough clips
the same way**, so a card holding one to five items had the bug too. A
`min-height` floor fixes all of them, not just the reported case.

After the fix the menu bottom sits **35px inside** the card, all entries reachable.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

Both gates green on this branch:

- **Backend**: `ruff` clean · `mypy` clean (13 source files) · `278 passed, 22 skipped`
- **Frontend**: `eslint` clean · `tsc --noEmit` clean · `775 passed (42 files)` · build OK (416.14 kB)

New regression test for bug 1 (`hv-card-shell.test.ts`) asserts the press opens
the sheet **and** that nothing is handed up to the host. Counterfactual checked:
reverting just the routing line fails it (`open` is `false`), restoring it passes.

Bug 2 was verified by measuring the live DOM before and after deploying to the
container, on desktop and mobile — the mobile case confirming the card keeps its
natural height and the menu still renders as a bottom sheet.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added (happy path + the no-leak assertion); counterfactual verified
- [x] Docs updated where behavior changed (n/a — no API or contract change)
- [x] Load-bearing invariants preserved (no store, filter, or path code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)