### PR TITLE
fix: cache-bust the Lovelace card resource URL

### DIFF
--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -6,10 +6,12 @@ the core data structures in hass.data.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -30,6 +32,9 @@ from .repository import Repository
 from .storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore, async_persist_immediate
 
 LOGGER = logging.getLogger(__name__)
+
+_MANIFEST_PATH = Path(__file__).with_name("manifest.json")
+_CARD_URL_PATH = "/local/haventory/haventory-card.js"
 
 
 # This integration is config-entry only; no YAML configuration is accepted.
@@ -166,6 +171,34 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _card_resource_url() -> str:
+    """`/local` URL for the card bundle, carrying the manifest version as `?v=`.
+
+    `/local/` is served with a month-long `max-age`, so without the query a browser
+    — or the companion app's webview, which is harder to clear — keeps serving the
+    bundle from before an integration update and runs an old card against a new
+    backend. Falls back to the bare path if the manifest cannot be read, since a
+    missing cache-buster must not stop the card from being registered at all.
+    """
+    version = ""
+    # Blocking read of a file shipped inside the integration, once per setup; not
+    # worth an executor round-trip (and the test Hass stub has no executor).
+    try:
+        manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    except OSError, ValueError:
+        LOGGER.debug(
+            "Could not read the integration manifest; registering the card unversioned",
+            extra={"domain": DOMAIN, "op": "frontend_register", "path": str(_MANIFEST_PATH)},
+        )
+    else:
+        raw = manifest.get("version")
+        version = raw if isinstance(raw, str) else ""
+
+    if not version:
+        return _CARD_URL_PATH
+    return f"{_CARD_URL_PATH}?v={quote(version, safe='')}"
+
+
 def _points_at_card(resource_url: Any, card_url: str) -> bool:
     """Does an already-registered Lovelace resource serve the HAventory card?
 
@@ -181,9 +214,44 @@ def _points_at_card(resource_url: Any, card_url: str) -> bool:
     return urlsplit(resource_url).path == urlsplit(card_url).path
 
 
+async def _rewrite_card_resource(resources: Any, stale: dict[str, Any], url: str) -> None:
+    """Point an entry left over from an earlier version at the current card URL.
+
+    Rewriting rather than adding: a second entry for the same file loads the card
+    module twice, and the second `customElements.define` throws.
+    """
+    stale_id = stale.get("id")
+    # No update API means YAML mode, where resources are user-managed; no id means
+    # the entry cannot be addressed. Either way, leave it as it stands.
+    if stale_id is None or not hasattr(resources, "async_update_item"):
+        LOGGER.debug(
+            "Cannot rewrite the registered card resource; leaving it as-is",
+            extra={"domain": DOMAIN, "op": "frontend_register", "url": stale.get("url")},
+        )
+        return
+
+    try:
+        await resources.async_update_item(stale_id, {"res_type": "module", "url": url})
+        LOGGER.info(
+            "Updated HAventory card Lovelace resource to the current version",
+            extra={
+                "domain": DOMAIN,
+                "op": "frontend_register",
+                "url": url,
+                "previous_url": stale.get("url"),
+            },
+        )
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.warning(
+            "Failed to update frontend resource",
+            extra={"domain": DOMAIN, "op": "frontend_register", "url": url},
+            exc_info=True,
+        )
+
+
 async def _register_frontend_module(hass: HomeAssistant) -> None:
     """Register the built HAventory card asset as a Lovelace resource if present."""
-    url = "/local/haventory/haventory-card.js"
+    url = _card_resource_url()
 
     # Get filesystem path - handle missing config gracefully for tests
     try:
@@ -228,14 +296,17 @@ async def _register_frontend_module(hass: HomeAssistant) -> None:
 
     # Check if resource already exists
     existing = resources.async_items() or []
-    for item in existing:
-        registered_url = item.get("url")
-        if _points_at_card(registered_url, url):
+    registered = [item for item in existing if _points_at_card(item.get("url"), url)]
+
+    if registered:
+        if any(item.get("url") == url for item in registered):
             LOGGER.debug(
-                "HAventory card resource already registered",
-                extra={"domain": DOMAIN, "op": "frontend_register", "url": registered_url},
+                "HAventory card resource already registered at the current version",
+                extra={"domain": DOMAIN, "op": "frontend_register", "url": url},
             )
-            return
+        else:
+            await _rewrite_card_resource(resources, registered[0], url)
+        return
 
     # Create the resource (only works for storage mode, not YAML mode)
     if not hasattr(resources, "async_create_item"):

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -3,21 +3,46 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 import types
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+CARD_PATH = "/local/haventory/haventory-card.js"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "haventory" / "manifest.json"
+)
+
+
+def manifest_version() -> str:
+    """Version the shipped manifest declares, read independently of the module under test."""
+    return str(json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["version"])
+
+
+def import_haventory(monkeypatch, lovelace_key: str):
+    """Import the integration with ``homeassistant.components.lovelace`` stubbed.
+
+    ``LOVELACE_DATA`` is bound at import time, so the stub has to be in
+    ``sys.modules`` before the import and any cached module has to be dropped.
+    """
+    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=lovelace_key)
+    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
+    sys.modules.pop("custom_components.haventory", None)
+    return importlib.import_module("custom_components.haventory")
+
 
 class MockResourceCollection:
-    """Mock Lovelace resource collection."""
+    """Mock Lovelace resource collection in storage mode (create + update allowed)."""
 
     def __init__(self):
         self.loaded = True
         self._items: list[dict[str, Any]] = []
         self.created: list[dict[str, Any]] = []
+        self.updated: list[tuple[str, dict[str, Any]]] = []
 
     def async_items(self) -> list[dict[str, Any]]:
         return self._items
@@ -27,14 +52,38 @@ class MockResourceCollection:
 
     async def async_create_item(self, data: dict[str, Any]) -> dict[str, Any]:
         self.created.append(data)
-        return {"id": "test_id", **data}
+        item = {"id": f"created_{len(self.created)}", **data}
+        self._items.append(item)
+        return item
+
+    async def async_update_item(self, item_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        for item in self._items:
+            if item.get("id") == item_id:
+                item.update(updates)
+                self.updated.append((item_id, updates))
+                return item
+        raise KeyError(item_id)
+
+
+class MockYamlResourceCollection:
+    """Lovelace resources in YAML mode: readable, with no create/update API."""
+
+    def __init__(self, items: list[dict[str, Any]] | None = None):
+        self.loaded = True
+        self._items: list[dict[str, Any]] = list(items or [])
+
+    def async_items(self) -> list[dict[str, Any]]:
+        return self._items
+
+    async def async_load(self):
+        pass
 
 
 class MockLovelaceData:
     """Mock Lovelace data container."""
 
-    def __init__(self):
-        self.resources = MockResourceCollection()
+    def __init__(self, resources: Any = None):
+        self.resources = MockResourceCollection() if resources is None else resources
 
 
 class HassStub:
@@ -60,163 +109,168 @@ class HassStub:
         self._config = value
 
 
-@pytest.mark.asyncio
-async def test_registers_lovelace_resource_when_present(tmp_path, monkeypatch):
-    """Asset present, resource collection in storage mode => creates resource."""
-    # Mock LOVELACE_DATA constant BEFORE importing the module
-    mock_lovelace_key = "lovelace_data_key"
-    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
-
-    # Clear cached module and reimport to pick up the mocked lovelace
-    if "custom_components.haventory" in sys.modules:
-        del sys.modules["custom_components.haventory"]
-    hav_init = importlib.import_module("custom_components.haventory")
-
-    # Arrange: create fake asset
-    asset_dir = tmp_path / "www" / "haventory"
-    asset_dir.mkdir(parents=True)
-    asset_file = asset_dir / "haventory-card.js"
-    asset_file.write_text("// test asset")
-
+def make_hass(tmp_path, *, with_asset: bool = True) -> HassStub:
+    """Hass stub whose config dir is `tmp_path`, optionally holding the built card."""
+    if with_asset:
+        asset_dir = tmp_path / "www" / "haventory"
+        asset_dir.mkdir(parents=True, exist_ok=True)
+        (asset_dir / "haventory-card.js").write_text("// test asset")
     hass = HassStub(str(tmp_path))
     hass.config = HassStub._Config(str(tmp_path))
+    return hass
 
-    # Set up mock Lovelace data
+
+@pytest.mark.asyncio
+async def test_registers_lovelace_resource_when_present(tmp_path, monkeypatch):
+    """Asset present, resource collection in storage mode => creates versioned resource."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path)
     lovelace_data = MockLovelaceData()
-    hass.data[mock_lovelace_key] = lovelace_data
+    hass.data["lovelace_data_key"] = lovelace_data
 
-    # Act
     await hav_init._register_frontend_module(hass)
 
-    # Assert: resource was created
     assert len(lovelace_data.resources.created) == 1
     created = lovelace_data.resources.created[0]
-    assert created["url"] == "/local/haventory/haventory-card.js"
+    assert created["url"] == f"{CARD_PATH}?v={manifest_version()}"
     assert created["res_type"] == "module"
+
+
+@pytest.mark.asyncio
+async def test_registered_url_carries_the_manifest_version(tmp_path, monkeypatch):
+    """The `?v=` value comes from the manifest, not from a constant in the code."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"domain": "haventory", "version": "9.9.9"}), encoding="utf-8")
+    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", manifest)
+
+    hass = make_hass(tmp_path)
+    lovelace_data = MockLovelaceData()
+    hass.data["lovelace_data_key"] = lovelace_data
+
+    await hav_init._register_frontend_module(hass)
+
+    assert [c["url"] for c in lovelace_data.resources.created] == [f"{CARD_PATH}?v=9.9.9"]
+
+
+@pytest.mark.asyncio
+async def test_registers_bare_url_when_manifest_version_unavailable(tmp_path, monkeypatch):
+    """An unreadable manifest degrades to the unversioned URL instead of failing setup."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", tmp_path / "no-such-manifest.json")
+
+    hass = make_hass(tmp_path)
+    lovelace_data = MockLovelaceData()
+    hass.data["lovelace_data_key"] = lovelace_data
+
+    await hav_init._register_frontend_module(hass)
+
+    assert [c["url"] for c in lovelace_data.resources.created] == [CARD_PATH]
 
 
 @pytest.mark.asyncio
 async def test_skips_when_asset_missing(tmp_path, monkeypatch):
     """Asset not present => does not create resource."""
-    # Mock lovelace BEFORE importing
-    mock_lovelace_key = "lovelace_data_key"
-    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
-
-    if "custom_components.haventory" in sys.modules:
-        del sys.modules["custom_components.haventory"]
-    hav_init = importlib.import_module("custom_components.haventory")
-
-    hass = HassStub(str(tmp_path))
-    hass.config = HassStub._Config(str(tmp_path))
-
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path, with_asset=False)
     lovelace_data = MockLovelaceData()
-    hass.data[mock_lovelace_key] = lovelace_data
+    hass.data["lovelace_data_key"] = lovelace_data
 
-    # Act (no asset file created)
     await hav_init._register_frontend_module(hass)
 
-    # Assert: no resource created
     assert len(lovelace_data.resources.created) == 0
 
 
 @pytest.mark.asyncio
-async def test_skips_when_resource_already_exists(tmp_path, monkeypatch):
-    """Resource already registered => does not create duplicate."""
-    # Mock lovelace BEFORE importing
-    mock_lovelace_key = "lovelace_data_key"
-    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
-
-    if "custom_components.haventory" in sys.modules:
-        del sys.modules["custom_components.haventory"]
-    hav_init = importlib.import_module("custom_components.haventory")
-
-    # Arrange: create fake asset
-    asset_dir = tmp_path / "www" / "haventory"
-    asset_dir.mkdir(parents=True)
-    asset_file = asset_dir / "haventory-card.js"
-    asset_file.write_text("// test asset")
-
-    hass = HassStub(str(tmp_path))
-    hass.config = HassStub._Config(str(tmp_path))
-
-    # Mock Lovelace with existing resource
+async def test_reregistration_at_the_same_version_is_idempotent(tmp_path, monkeypatch):
+    """Entry already at the current `?v=` => nothing is created and nothing is written."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path)
+    current_url = f"{CARD_PATH}?v={manifest_version()}"
     lovelace_data = MockLovelaceData()
     lovelace_data.resources._items = [
-        {"id": "existing", "url": "/local/haventory/haventory-card.js", "type": "module"}
+        {"id": "existing", "url": current_url, "type": "module"},
     ]
-    hass.data[mock_lovelace_key] = lovelace_data
+    hass.data["lovelace_data_key"] = lovelace_data
 
-    # Act
+    await hav_init._register_frontend_module(hass)
     await hav_init._register_frontend_module(hass)
 
-    # Assert: no new resource created
-    assert len(lovelace_data.resources.created) == 0
+    assert lovelace_data.resources.created == []
+    assert lovelace_data.resources.updated == []
+    assert [i["url"] for i in lovelace_data.resources.async_items()] == [current_url]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "registered_url",
     [
-        "/local/haventory/haventory-card.js?v=38b725595b78",
-        "/local/haventory/haventory-card.js?v=1&foo=bar",
-        "/local/haventory/haventory-card.js#frag",
+        # Registered before cache-busting existed.
+        CARD_PATH,
+        f"{CARD_PATH}?v=0.0.1",
+        f"{CARD_PATH}?v=38b725595b78",
+        f"{CARD_PATH}?v=1&foo=bar",
+        f"{CARD_PATH}#frag",
     ],
 )
-async def test_skips_when_resource_registered_with_cache_busting_query(
+async def test_updates_existing_entry_when_the_version_changed(
     tmp_path, monkeypatch, registered_url
 ):
-    """A versioned resource URL is the same resource => no duplicate.
+    """A stale entry for the card is rewritten in place, never duplicated.
 
-    `/local/` is served with a month-long `max-age`, so a `?v=<hash>` query is
-    the only way to make browsers pick up a rebuilt bundle. Registering a second
-    resource for the same file loads the card module twice, and the second
-    `customElements.define` throws.
+    `/local/` is served with a month-long `max-age`, so an entry left at the old
+    `?v=` keeps browsers on the previous bundle. Adding a second entry instead
+    would load the card module twice and the second `customElements.define`
+    throws.
     """
-    mock_lovelace_key = "lovelace_data_key"
-    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"domain": "haventory", "version": "9.9.9"}), encoding="utf-8")
+    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", manifest)
 
-    if "custom_components.haventory" in sys.modules:
-        del sys.modules["custom_components.haventory"]
-    hav_init = importlib.import_module("custom_components.haventory")
-
-    asset_dir = tmp_path / "www" / "haventory"
-    asset_dir.mkdir(parents=True)
-    (asset_dir / "haventory-card.js").write_text("// test asset")
-
-    hass = HassStub(str(tmp_path))
-    hass.config = HassStub._Config(str(tmp_path))
-
+    hass = make_hass(tmp_path)
     lovelace_data = MockLovelaceData()
-    lovelace_data.resources._items = [{"id": "existing", "url": registered_url, "type": "module"}]
-    hass.data[mock_lovelace_key] = lovelace_data
+    lovelace_data.resources._items = [
+        {"id": "existing", "url": registered_url, "type": "module"},
+    ]
+    hass.data["lovelace_data_key"] = lovelace_data
+
+    await hav_init._register_frontend_module(hass)
+
+    expected = f"{CARD_PATH}?v=9.9.9"
+    assert lovelace_data.resources.created == []
+    assert lovelace_data.resources.updated == [
+        ("existing", {"res_type": "module", "url": expected})
+    ]
+    assert [i["url"] for i in lovelace_data.resources.async_items()] == [expected]
+
+    # A second pass at the same version must not write again.
+    await hav_init._register_frontend_module(hass)
+    assert len(lovelace_data.resources.updated) == 1
+    assert lovelace_data.resources.created == []
+
+
+@pytest.mark.asyncio
+async def test_leaves_a_stale_entry_alone_when_it_has_no_id(tmp_path, monkeypatch):
+    """An entry with no id cannot be addressed for update => leave it, add nothing."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path)
+    lovelace_data = MockLovelaceData()
+    lovelace_data.resources._items = [{"url": f"{CARD_PATH}?v=0.0.0", "type": "module"}]
+    hass.data["lovelace_data_key"] = lovelace_data
 
     await hav_init._register_frontend_module(hass)
 
     assert lovelace_data.resources.created == []
+    assert lovelace_data.resources.updated == []
+    assert [i["url"] for i in lovelace_data.resources.async_items()] == [f"{CARD_PATH}?v=0.0.0"]
 
 
 @pytest.mark.asyncio
 async def test_registers_alongside_unrelated_resources(tmp_path, monkeypatch):
     """Another integration's card, and a malformed entry, must not block us."""
-    mock_lovelace_key = "lovelace_data_key"
-    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
-
-    if "custom_components.haventory" in sys.modules:
-        del sys.modules["custom_components.haventory"]
-    hav_init = importlib.import_module("custom_components.haventory")
-
-    asset_dir = tmp_path / "www" / "haventory"
-    asset_dir.mkdir(parents=True)
-    (asset_dir / "haventory-card.js").write_text("// test asset")
-
-    hass = HassStub(str(tmp_path))
-    hass.config = HassStub._Config(str(tmp_path))
-
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path)
     lovelace_data = MockLovelaceData()
     lovelace_data.resources._items = [
         {"id": "other", "url": "/local/other-card.js", "type": "module"},
@@ -225,72 +279,46 @@ async def test_registers_alongside_unrelated_resources(tmp_path, monkeypatch):
         {"id": "malformed", "type": "module"},
         {"id": "wrong_type", "url": None, "type": "module"},
     ]
-    hass.data[mock_lovelace_key] = lovelace_data
+    hass.data["lovelace_data_key"] = lovelace_data
 
     await hav_init._register_frontend_module(hass)
 
     assert [c["url"] for c in lovelace_data.resources.created] == [
-        "/local/haventory/haventory-card.js"
+        f"{CARD_PATH}?v={manifest_version()}"
     ]
+    assert lovelace_data.resources.updated == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("registered_url", [None, CARD_PATH, f"{CARD_PATH}?v=0.0.0"])
+async def test_yaml_mode_never_touches_resources(tmp_path, monkeypatch, registered_url):
+    """YAML mode has no writable collection: skip, whatever is (or is not) registered."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path)
+    items = [] if registered_url is None else [{"id": "yaml", "url": registered_url}]
+    resources = MockYamlResourceCollection(items)
+    hass.data["lovelace_data_key"] = MockLovelaceData(resources)
+
+    await hav_init._register_frontend_module(hass)
+
+    assert resources.async_items() == items
 
 
 @pytest.mark.asyncio
 async def test_skips_when_lovelace_not_initialized(tmp_path, monkeypatch):
     """Lovelace not initialized => skips gracefully."""
-    # Mock lovelace BEFORE importing
-    mock_lovelace_key = "lovelace_data_key"
-    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path)
 
-    if "custom_components.haventory" in sys.modules:
-        del sys.modules["custom_components.haventory"]
-    hav_init = importlib.import_module("custom_components.haventory")
-
-    # Arrange: create fake asset
-    asset_dir = tmp_path / "www" / "haventory"
-    asset_dir.mkdir(parents=True)
-    asset_file = asset_dir / "haventory-card.js"
-    asset_file.write_text("// test asset")
-
-    hass = HassStub(str(tmp_path))
-    hass.config = HassStub._Config(str(tmp_path))
-
-    # hass.data[mock_lovelace_key] is NOT set - simulates Lovelace not initialized
-
-    # Act - should not raise
+    # hass.data["lovelace_data_key"] is NOT set - simulates Lovelace not initialized
     await hav_init._register_frontend_module(hass)
-
-    # Assert: no error, function completed gracefully
-    assert True
 
 
 @pytest.mark.asyncio
 async def test_skips_when_resources_is_none(tmp_path, monkeypatch):
     """lovelace_data.resources is None => skips gracefully without AttributeError."""
-    # Mock lovelace BEFORE importing
-    mock_lovelace_key = "lovelace_data_key"
-    lovelace_module = types.SimpleNamespace(LOVELACE_DATA=mock_lovelace_key)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path)
+    hass.data["lovelace_data_key"] = types.SimpleNamespace(resources=None)
 
-    if "custom_components.haventory" in sys.modules:
-        del sys.modules["custom_components.haventory"]
-    hav_init = importlib.import_module("custom_components.haventory")
-
-    # Arrange: create fake asset
-    asset_dir = tmp_path / "www" / "haventory"
-    asset_dir.mkdir(parents=True)
-    asset_file = asset_dir / "haventory-card.js"
-    asset_file.write_text("// test asset")
-
-    hass = HassStub(str(tmp_path))
-    hass.config = HassStub._Config(str(tmp_path))
-
-    # Mock Lovelace data with resources=None
-    lovelace_data = types.SimpleNamespace(resources=None)
-    hass.data[mock_lovelace_key] = lovelace_data
-
-    # Act - should not raise AttributeError
     await hav_init._register_frontend_module(hass)
-
-    # Assert: no error, function completed gracefully
-    assert True


### PR DESCRIPTION
## Summary

Fixes **[`docs/open-items.md` item 26](https://github.com/chrreiter/HAventory/blob/main/docs/open-items.md)** — "Lovelace card resource URL has no cache-busting version".

`_register_frontend_module` registered a bare `/local/haventory/haventory-card.js`. `/local/` is served with a month-long `max-age` and no revalidation, so after an integration update a browser — or the companion app's webview, which is harder to clear — keeps serving the previous bundle and runs an old card against a new backend.

The resource is now registered as `/local/haventory/haventory-card.js?v=<version>`:

- **Version source is the integration's own `manifest.json`**, read at setup from `Path(__file__).with_name("manifest.json")` — not restated as a constant in code, so it cannot drift from the shipped manifest (relevant to item 30, which has to keep `manifest.json` and `INTEGRATION_VERSION` in step). The value is percent-encoded into the query. If the manifest is unreadable the card is still registered, just unversioned — a missing cache-buster must not block registration.
- **A stale entry is rewritten in place, never duplicated.** `_points_at_card` already matched on path, so an entry carrying an old `?v=` was recognised as ours and left alone; it is now updated via `async_update_item` to the current URL. A second entry for the same file would load the card module twice and the second `customElements.define` throws. An entry registered before this change (bare URL) upgrades the same way.
- **Re-registration at the same version writes nothing** — the exact-URL match short-circuits before any collection write.
- **YAML mode is unchanged: still skipped.** The YAML resource collection exposes neither `async_create_item` nor `async_update_item`, and both paths check before writing, so user-managed resources are never touched. The same guard covers an entry with no addressable `id`.

`_register_frontend_module` hit ruff's `PLR0911` once the stale-entry branch was added, so the update path lives in a small `_rewrite_card_resource` helper.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

TDD: the new assertions were confirmed red against the unchanged `__init__.py` (9 failed, 8 passed) before the fix landed, green after. `tests/test_frontend_registration.py` grew from 9 to 17 cases and now covers:

- fresh registration → created URL is `…haventory-card.js?v=<manifest version>`, with the expected version read straight from `manifest.json` by the test rather than hardcoded;
- the `?v=` value tracks the manifest — `_MANIFEST_PATH` is pointed at a temp manifest declaring `9.9.9` and the registered URL follows;
- unreadable manifest → falls back to the bare URL;
- **version change** (parametrized over a bare URL, `?v=0.0.1`, `?v=<hash>`, `?v=1&foo=bar`, `#frag`) → the existing entry is updated in place, nothing created, exactly one entry left pointing at the card, and a second pass at the new version writes nothing;
- **idempotent re-registration** at the current version → no create, no update, called twice;
- **YAML mode** (collection with no create/update API), parametrized over no entry / bare entry / stale entry → the collection is left byte-identical;
- a stale entry with no `id` is left alone rather than crashing setup;
- registration alongside unrelated and malformed resource entries.

The file's repeated 5-line "stub lovelace, drop the cached module, reimport" incantation is now an `import_haventory` helper, and hass-stub/asset setup a `make_hass` helper — that is most of the diff line count in the test file.

Both gates green on Linux / Python 3.14:

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **286 passed, 22 skipped**; `uv run ruff check .` → clean (plus `ruff format --check` clean); `uv run mypy` → no issues in 13 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npx vitest run` → **775 passed** (42 files); `npm run build` → ok

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — n/a: no user-facing behavior or API surface documented in `README.md` / `docs/` changes. `docs/open-items.md` deliberately left untouched.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no WS change.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched.

## Screenshots (card / UI changes)

n/a — no card change; the bundle is byte-identical, only the URL it is registered under changes.

## Follow-ups

Out of scope here, reported rather than fixed:

1. **`.claude/skills/run-haventory/pin_resource.py` now gets overwritten on restart.** That dev helper pins the resource to `?v=<sha256 of the built bundle>` so each local rebuild is a new URL — necessary during development, where the manifest version stays `0.0.1` while the bundle changes on every build. With this change the integration recognises that pinned entry as a stale `?v=` and rewrites it to `?v=0.0.1` at the next setup, so `pin_resource.py` has to be re-run after every HA restart, not just after every build. The skill's docs should say so; a content hash would be the better cache-buster for the dev loop either way.
2. **The same file's docstring is stale**: it says the integration "re-adds the un-versioned URL on each HA restart (its 'already registered?' test is an exact string match)". That has not been true since `_points_at_card` started comparing paths, and it is doubly untrue now.
3. **Item 27 (`async_remove_entry`) interacts with this.** Removing the integration still leaves the resource behind — now a versioned one. Whatever cleanup item 27 lands on should match on path, exactly as `_points_at_card` does, or it will miss entries carrying a `?v=` from any other version.

---
_Generated by [Claude Code](https://claude.ai/code/session_019EFicigZ4TE7WocYJmSmPA)_