### PR TITLE
fix(storage): schedule the debounced persist as an HA tracked task

### DIFF
--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -261,9 +261,10 @@ async def async_persist_repo(hass: HomeAssistant) -> None:
 async def async_request_persist(hass: HomeAssistant) -> None:
     """Request a debounced persistence operation.
 
-    Cancels any pending persist task and schedules a new one after the debounce
-    delay. This coalesces rapid changes into a single persistence operation,
-    reducing disk I/O while maintaining data safety.
+    Cancels any pending persist task and schedules a new one — as a Home
+    Assistant tracked background task — after the debounce delay. This coalesces
+    rapid changes into a single persistence operation, reducing disk I/O while
+    maintaining data safety.
 
     The debounce delay is PERSIST_DEBOUNCE_DELAY (1.0 seconds by default).
     """
@@ -305,7 +306,12 @@ async def async_request_persist(hass: HomeAssistant) -> None:
         },
     )
 
-    bucket["persist_task"] = asyncio.create_task(_delayed_persist())
+    # Schedule through HA rather than asyncio directly: hass tracks the task and
+    # cancels/awaits it during shutdown, so a pending debounce cannot outlive the
+    # event loop.
+    bucket["persist_task"] = hass.async_create_background_task(
+        _delayed_persist(), name=f"{DOMAIN} debounced persist"
+    )
 
 
 async def async_persist_immediate(hass: HomeAssistant) -> None:

--- a/stubs/homeassistant/core.pyi
+++ b/stubs/homeassistant/core.pyi
@@ -4,8 +4,16 @@ Only the surface HAventory touches is typed precisely; everything else falls
 back to Any via __getattr__. See pyproject [tool.mypy] mypy_path.
 """
 
+import asyncio
+from collections.abc import Coroutine
 from typing import Any
 
 class HomeAssistant:
     data: dict[str, Any]
+    def async_create_background_task[R](
+        self,
+        target: Coroutine[Any, Any, R],
+        name: str,
+        eager_start: bool = True,
+    ) -> asyncio.Task[R]: ...
     def __getattr__(self, name: str) -> Any: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,10 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def __init__(self) -> None:
             self.data = {}
 
+        def async_create_background_task(self, target, name, eager_start=True):
+            """Stand in for HA's tracked-task helper; the real one also cancels on shutdown."""
+            return asyncio.create_task(target, name=name)
+
     ha_core.HomeAssistant = HomeAssistant
     sys.modules["homeassistant.core"] = ha_core
 

--- a/tests/test_storage_concurrency_offline.py
+++ b/tests/test_storage_concurrency_offline.py
@@ -27,6 +27,24 @@ from homeassistant.core import HomeAssistant
 RAPID_MUTATION_COUNT = 3
 
 
+class _TrackedTaskHass:
+    """hass double that records the background tasks it is handed.
+
+    Mirrors ``HomeAssistant.async_create_background_task``'s signature so the
+    debounced persist path is driven through the same call it makes against a
+    real core, and keeps every scheduled task addressable for assertions.
+    """
+
+    def __init__(self) -> None:
+        self.data: dict = {}
+        self.background_tasks: list[tuple[str, asyncio.Task]] = []
+
+    def async_create_background_task(self, target, name, eager_start=True):
+        task = asyncio.create_task(target, name=name)
+        self.background_tasks.append((name, task))
+        return task
+
+
 @pytest.mark.asyncio
 async def test_persist_lock_prevents_concurrent_saves():
     """Concurrent persist calls are serialized by lock, preventing race conditions."""
@@ -61,7 +79,7 @@ async def test_persist_lock_prevents_concurrent_saves():
 @pytest.mark.asyncio
 async def test_debounce_coalesces_rapid_changes():
     """Rapid persist requests are coalesced into a single save operation."""
-    hass = MagicMock()
+    hass = _TrackedTaskHass()
     hass.data = {"haventory": {}}
 
     # Create mock store that counts save calls
@@ -93,7 +111,7 @@ async def test_debounce_coalesces_rapid_changes():
 @pytest.mark.asyncio
 async def test_debounce_cancels_pending_task():
     """New persist request cancels previous pending task."""
-    hass = MagicMock()
+    hass = _TrackedTaskHass()
     hass.data = {"haventory": {}}
 
     mock_store = AsyncMock(spec=DomainStore)
@@ -125,7 +143,7 @@ async def test_debounce_cancels_pending_task():
 @pytest.mark.asyncio
 async def test_immediate_persist_bypasses_debounce():
     """Immediate persist cancels pending debounced task and saves immediately."""
-    hass = MagicMock()
+    hass = _TrackedTaskHass()
     hass.data = {"haventory": {}}
 
     mock_store = AsyncMock(spec=DomainStore)
@@ -151,6 +169,91 @@ async def test_immediate_persist_bypasses_debounce():
     # Should have saved immediately, not after debounce delay
     elapsed = save_times[0] - start_time
     assert elapsed < PERSIST_DEBOUNCE_DELAY
+
+
+@pytest.mark.asyncio
+async def test_debounce_schedules_ha_tracked_background_task(monkeypatch):
+    """The debounced persist is scheduled through hass, not asyncio directly.
+
+    A task handed to Home Assistant is cancelled and awaited on shutdown; a bare
+    asyncio task is not, so the scheduling call itself is the contract here.
+    """
+    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
+
+    hass = _TrackedTaskHass()
+    saved: list[dict] = []
+
+    async def record_save(data):
+        saved.append(data)
+
+    mock_store = AsyncMock(spec=DomainStore)
+    mock_store.async_save = record_save
+    repo = Repository()
+    repo.create_item(ItemCreate(name="Tracked"))
+    hass.data[DOMAIN] = {"store": mock_store, "repository": repo}
+
+    await async_request_persist(hass)
+
+    assert len(hass.background_tasks) == 1
+    name, task = hass.background_tasks[0]
+    assert DOMAIN in name
+    assert hass.data[DOMAIN]["persist_task"] is task
+
+    await asyncio.sleep(0.2)
+
+    assert task.done()
+    assert len(saved) == 1
+    assert len(saved[0]["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_debounce_coalesces_across_tracked_tasks(monkeypatch):
+    """Every request gets its own tracked task, but only the last one persists."""
+    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
+
+    hass = _TrackedTaskHass()
+    saved: list[dict] = []
+
+    async def record_save(data):
+        saved.append(data)
+
+    mock_store = AsyncMock(spec=DomainStore)
+    mock_store.async_save = record_save
+    hass.data[DOMAIN] = {"store": mock_store, "repository": Repository()}
+
+    for _ in range(RAPID_MUTATION_COUNT):
+        await async_request_persist(hass)
+        await asyncio.sleep(0.01)
+
+    await asyncio.sleep(0.2)
+
+    assert len(hass.background_tasks) == RAPID_MUTATION_COUNT
+    assert all(task.done() for _, task in hass.background_tasks)
+    assert len(saved) == 1
+
+
+@pytest.mark.asyncio
+async def test_debounced_tracked_task_reports_failure_without_raising(monkeypatch, caplog):
+    """A failing debounced persist is logged inside the task, never propagated.
+
+    The tracked task belongs to Home Assistant once scheduled, so a storage
+    failure has to surface as a log record rather than as a task exception.
+    """
+    caplog.set_level(logging.ERROR)
+    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
+
+    hass = _TrackedTaskHass()
+    # No "store" entry: async_persist_repo raises StorageError.
+    hass.data[DOMAIN] = {"repository": Repository()}
+
+    await async_request_persist(hass)
+    _, task = hass.background_tasks[0]
+
+    await asyncio.sleep(0.2)
+
+    assert task.done()
+    assert task.exception() is None
+    assert any("Debounced persist task failed" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -259,7 +362,7 @@ async def test_debounce_request_logs(caplog):
     """Debounced persist requests log appropriately."""
     caplog.set_level(logging.DEBUG)
 
-    hass = MagicMock()
+    hass = _TrackedTaskHass()
     hass.data = {"haventory": {}}
 
     mock_store = AsyncMock(spec=DomainStore)


### PR DESCRIPTION
## Summary

Resolves **item 8 of [`docs/open-items.md`](../blob/main/docs/open-items.md)** — *"`storage.py` debounced persist uses bare `asyncio.create_task` instead of `hass.async_create_background_task(...)` (HA guidance: tracked tasks are cancelled/awaited on shutdown)"*.

`async_request_persist` (`custom_components/haventory/storage.py`) now schedules its debounced `_delayed_persist()` through `hass.async_create_background_task(coro, name="haventory debounced persist")` instead of `asyncio.create_task(...)`. Home Assistant tracks the task and cancels/awaits it during shutdown, so a pending debounce can no longer outlive the event loop.

Nothing else changes — same `PERSIST_DEBOUNCE_DELAY`, same coalescing, same cancel-on-supersede, same task handle stored at `hass.data[DOMAIN]["persist_task"]`. As item 8 notes, the path is production-dead today (WS and service handlers persist immediately), so there is no user-visible behavior change.

Both Home Assistant stub surfaces lacked the helper and gained it:

- `tests/conftest.py` — the offline `HomeAssistant` stub delegates to `asyncio.create_task(target, name=name)`.
- `stubs/homeassistant/core.pyi` — the mypy stub declares `async_create_background_task[R](target: Coroutine[Any, Any, R], name: str, eager_start: bool = True) -> asyncio.Task[R]`, matching HA core's signature (previously it resolved to `Any` via `__getattr__`).

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **281 passed, 22 skipped**; `uv run ruff check .` → **All checks passed!**; `uv run mypy` → **Success: no issues found in 13 source files**
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npx vitest run` → **775 passed (42 files)**; `npm run build` → built `www/haventory/haventory-card.js`

Three new tests in `tests/test_storage_concurrency_offline.py`, driven through a `_TrackedTaskHass` double that mirrors HA's helper signature and records every task it is handed:

- `test_debounce_schedules_ha_tracked_background_task` — the request goes through the tracked-task helper, under a `haventory`-prefixed name; the returned task is the one stored in `hass.data`; the repository state actually reaches the store when the debounce elapses.
- `test_debounce_coalesces_across_tracked_tasks` — three rapid requests create three tracked tasks, all of which complete, but only one save happens.
- `test_debounced_tracked_task_reports_failure_without_raising` (error case) — a persist failure inside the tracked task is logged, not raised into HA's task tracker (`task.exception() is None`).

All three fail against the pre-fix `storage.py` (`IndexError: list index out of range` — no tracked task is ever created) and pass after it. The four pre-existing debounce tests moved off `MagicMock` onto the same double, since a `MagicMock` hass would return a mock instead of running the coroutine.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — n/a: no user-visible behavior change, no README/contract surface touched.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched.

## Follow-ups

- **Two trackers still list this as open** and were deliberately left alone (`docs/open-items.md` was explicitly out of scope for this branch): item 8 in `docs/open-items.md`, and the mirrored `CLAUDE.md` "WP1 follow-ups" bullet *"`storage.py`: switch the debounced persist from bare `asyncio.create_task` to `hass.async_create_background_task(...)`"*, plus the WP0.5 findings entry above it that reads "Flagged for WP1 (not fixed …)". Both need marking done — owner's call on wording.
- **The integration suite was not run** for this change: `.venv-integration` does not exist in this environment and provisioning it needs a full HA install from `requirements-integration.txt`. Nothing under `tests/integration/` exercises `async_request_persist`, and the offline gate covers the changed path, but a real-core run would be the place to confirm HA accepts the call from the persist coroutine's context.
- **`eager_start` semantics differ slightly from the old code**: HA's helper defaults to `eager_start=True`, so `_delayed_persist()` now begins executing synchronously up to its first `await asyncio.sleep(...)` rather than on the next loop tick. Harmless here (the first statement *is* that sleep), but worth knowing if the coroutine ever grows work ahead of the sleep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsTEmuWGYj7dqeeBWyR2Fs)_