### PR TITLE
docs: document manual card resource for YAML-mode Lovelace

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,36 @@ HAventory isn't in the HACS default store yet. To install from this repository:
 Minimum Home Assistant version: **2026.7**. Developers: see the Developer Checklist below
 and [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### YAML-mode dashboards
+
+Step 5 assumes the default storage mode, where the integration registers the card as a
+Lovelace resource for you. In YAML mode, Home Assistant reads the resource list from
+`configuration.yaml` and no integration can add to it, so HAventory skips registration
+(logging `Lovelace in YAML mode; manual resource configuration required` at debug level).
+Nothing else reports the problem: the card is simply missing from the picker, and any
+dashboard already using it shows *Custom element doesn't exist: haventory-card*.
+
+You are in YAML mode if `configuration.yaml` has a `lovelace:` block with `mode: yaml`.
+In the UI, with **Advanced Mode** enabled on your profile, **Settings → Dashboards → ⋮**
+offers no **Resources** entry and the dashboard has no edit (pencil) button.
+
+Register the card yourself next to that `mode:` key:
+
+```yaml
+lovelace:
+  mode: yaml
+  resources:
+    - url: /local/haventory/haventory-card.js
+      type: module
+```
+
+Restart Home Assistant, then refresh your browser (Ctrl/Cmd+Shift+R).
+
+The mode of the *main* dashboard is what decides this. An extra YAML dashboard declared
+under `lovelace: dashboards:` while the main one stays in storage mode still uses the
+UI-managed resource list, so it needs nothing. In storage mode a `resources:` block in
+`configuration.yaml` is ignored — Home Assistant warns and keeps using the UI list.
+
 ---
 
 ## Developer Checklist


### PR DESCRIPTION
## Summary

Fixes **item 28 in [`docs/open-items.md`](../blob/main/docs/open-items.md)** ("YAML-mode Lovelace is undocumented").

`_register_frontend_module` correctly bails out when Lovelace runs in YAML mode — the resource list comes from `configuration.yaml` and no integration can add to it — but the only signal is a debug log line, so the card simply never loads and nothing tells the user why.

Docs-only. Adds a **YAML-mode dashboards** subsection to the README installation section covering:

- **When it applies** — YAML mode only; the *main* dashboard's mode is what decides it, and an extra YAML dashboard under `lovelace: dashboards:` alongside a storage-mode main dashboard needs nothing.
- **How to tell** — a `lovelace:` block with `mode: yaml` in `configuration.yaml`; in the UI, no **Resources** entry under **Settings → Dashboards → ⋮** (with Advanced Mode on) and no edit pencil.
- **What the failure looks like** — card missing from the picker, *Custom element doesn't exist: haventory-card* on existing dashboards, and the debug-level log line the integration emits.
- **The exact fix** — the `resources:` entry with `url: /local/haventory/haventory-card.js` and `type: module`, plus restart + hard refresh. Also notes that in storage mode such a block is ignored (HA warns and keeps the UI list), so nobody adds it to the wrong config.

No code changes. `docs/open-items.md` intentionally untouched.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates run on the working tree to confirm the change is clean (docs-only, so no test additions):

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **278 passed, 22 skipped**; `uv run ruff check .` → **All checks passed!**; `uv run mypy` → **Success: no issues found in 13 source files**
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npx vitest run` → **775 passed (42 files)**; `npm run build` → built `www/haventory/haventory-card.js` (416.14 kB)

Content verified against `custom_components/haventory/__init__.py` (`url = "/local/haventory/haventory-card.js"`, `res_type: "module"`, and the YAML-mode early return) and against HA's Lovelace resource-collection behavior.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [ ] Tests added/updated (happy path + at least one edge/error case). — n/a, docs-only
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync. — n/a, no API change
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

n/a — no card or UI change.

## Follow-ups (not fixed here)

1. **Item 28 cites the wrong line range.** It points at `__init__.py:224-227`, which is the *resource-load* block (`if hasattr(resources, "loaded") …`). The YAML-mode skip is the `async_create_item` capability check at `__init__.py:240-246`. Worth correcting in `docs/open-items.md` — left alone per instructions not to edit that file.
2. **The YAML-mode skip logs at `debug`.** A user in YAML mode sees nothing at default log levels, which is most of why this gap bites. Raising it to `info` (or `warning` — it is an actionable misconfiguration for anyone who expects the card) would make the integration self-documenting, and would pair well with items 26 and 27, which touch the same registration path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHwUZaXo2GajMoiPyVFJy3)_