### PR TITLE
fix(card): say what the location area dropdown's default option does

### DIFF
--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -188,6 +188,49 @@ describe('hv-organize-dialog: locations', () => {
     expect(store.state.value.locationsFlatCache?.some((l) => l.name === 'Attic')).toBe(true);
   });
 
+  // The area dropdown's empty value has to say what it does. The backend keeps a tree's
+  // area on the tree root and resolves it downwards, so a nested location inherits from
+  // the tree rather than from the parent named in the picker below it, and a top-level
+  // location has nothing above it to inherit from at all.
+  describe('area default option', () => {
+    const areaDefault = (sr: ShadowRoot) =>
+      (q(sr, '[data-testid="location-area"]') as HTMLSelectElement).options[0]?.textContent?.trim();
+
+    it('reads as "No area" for a new location, which starts at the top level', async () => {
+      const { el, sr } = await mount({ locations });
+      (q(sr, '[data-testid="organize-new-location"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      expect(areaDefault(sr)).toBe('No area');
+    });
+
+    it('reads as "No area" when editing a location that has no parent', async () => {
+      const { el, sr } = await mount({ locations });
+      const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+      (tree.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="garage"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      expect(areaDefault(sr)).toBe('No area');
+    });
+
+    it('names the location tree, not the immediate parent, once there is a parent', async () => {
+      const { el, sr } = await mount({ locations });
+      const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+      (
+        tree.shadowRoot?.querySelector(
+          '[data-testid="tree-row"][data-id="garage"] [data-testid="tree-twisty"]',
+        ) as HTMLButtonElement
+      ).click();
+      await settle(el);
+      (
+        tree.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="shelf-a"]') as HTMLButtonElement
+      ).click();
+      await settle(el);
+
+      expect(areaDefault(sr)).toBe('Inherit from location tree');
+    });
+  });
+
   it('excludes the location itself from its own parent picker, so no cycle is possible', async () => {
     const { el, sr } = await mount({ locations });
     const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -748,6 +748,11 @@ export class HVOrganizeDialog extends LitElement {
     const node = nodeId === 'new' ? null : this._findNode(tree, nodeId);
     const parent = this._locParent ? this._findNode(tree, this._locParent) : null;
     const areas = this.st?.areasCache?.areas ?? [];
+    // The backend holds a tree's area on its root and resolves it downwards, so a nested
+    // location's effective area comes from the tree rather than from its immediate parent
+    // — naming the parent here would point at the wrong node. A top-level location has
+    // nothing above it to resolve from, so for it the empty value just means no area.
+    const areaDefaultLabel = parent ? 'Inherit from location tree' : 'No area';
 
     return html`<div class="expander" data-testid="location-editor">
       <div class="grid2">
@@ -773,9 +778,7 @@ export class HVOrganizeDialog extends LitElement {
               this._locArea = (e.target as HTMLSelectElement).value || null;
             }}
           >
-            <option value="" ?selected=${!this._locArea}>
-              Inherit${parent ? ` (${parent.name})` : ''}
-            </option>
+            <option value="" ?selected=${!this._locArea}>${areaDefaultLabel}</option>
             ${areas.map(
               (a) => html`<option value=${a.id} ?selected=${this._locArea === a.id}>${a.name}</option>`,
             )}


### PR DESCRIPTION
## Summary

`docs/open-items.md` item 37 — the location editor's Area (HA) dropdown labels its empty
value in a way that doesn't describe the mechanic behind it.

Before, `hv-organize-dialog.ts` rendered it as ``Inherit${parent ? ` (${parent.name})` : ''}``:

- On a **top-level** location it read as the bare word "Inherit", with nothing above it to
  inherit from and no explanation of what picking it means.
- On a **nested** location it named the *immediate parent*, but the effective area is
  resolved by walking to the tree root (`Repository._resolve_effective_area_id_for_location`),
  and `Repository._propagate_area_to_root` keeps the assignment on the root — so the value
  does not necessarily come from the parent the label named.

Now the option is worded from what the mechanic actually does: **"No area"** when the
location has no parent, **"Inherit from location tree"** when it does. Wording only — no
change to area propagation or to any other behavior.

Out of scope, per item 37 and tracked there: the live effective-area preview beneath the
dropdown.

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Three vitest cases added to `hv-organize-dialog.test.ts` under a new `area default option`
block, asserting the rendered text of the select's first option: a new location (top level),
an existing location with no parent, and a nested location. Verified they fail against the
old label (`expected 'Inherit' to be 'No area'`, `expected 'Inherit (Garage)' to be 'Inherit
from location tree'`) and pass after the change. No existing test asserted the old label, so
none needed updating.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (278 passed, 22 skipped),
      `uv run ruff check .` (all checks passed), `uv run mypy` (no issues, 13 source files)
- [x] Frontend (`cards/haventory-card`): `npx eslint .` (clean), `npx vitest run`
      (778 passed, 42 files), `npm run build` (ok). `npm run typecheck` also clean.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`) — n/a, card wording only, no documented contract touched. `docs/open-items.md` deliberately left unedited.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

Not captured — the change is the option's text string, covered exactly by the three unit
assertions above.

## Follow-ups

Found while reading the propagation code, not fixed here:

1. **Selecting the default on a *nested* location does more than "stop inheriting".**
   `Repository.update_location` runs `_propagate_area_to_root(key, None)` for any area change,
   so choosing the empty value on a child clears the area from the **tree root**, i.e. from
   the whole tree — not just from the node being edited. "Inherit from location tree" is the
   wording item 37 settled on and is right about where a *set* value comes from, but it does
   not warn about that clearing effect. This is the same asymmetry item 37 already flags for
   the non-default options ("the whole tree rooted at `<RootName>` starts reporting X"), and
   belongs with the preview work rather than with a label tweak.
2. The dropdown renders the empty option even when `areasCache` is empty (the offline mock's
   case), so an install with no HA areas shows a one-entry select. Harmless, but a disabled
   or hint-bearing control might read better; not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDBpSmvKbDuWuLGyVmrDGe)_