### PR TITLE
docs: state that import matches entities by id, never by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,26 @@ item and deletes it (best-effort cleanup even on failure).
   independently of a full-instance snapshot. See
   [`docs/backend_api_contract.md`](docs/backend_api_contract.md) and
   [`docs/data_shapes.md`](docs/data_shapes.md).
+  - **Import matches entities by id, and only by id — never by name.** Every incoming item
+    and location is looked up by its id: an id already in the inventory is the same entity
+    (left `unchanged`, `update`d, or reported as a `conflict` under `skip`), an id that is
+    absent is added. Names are not consulted under any policy, which is deliberate —
+    matching by name would silently fuse two genuinely different "Shelf A"s.
+  - **So restoring a backup onto hand-rebuilt locations or items duplicates them; it does
+    not merge onto them.** Anything you delete and recreate by hand comes back with a fresh
+    id, so the backup's copies count as new entities and you end up with two of each.
+    The duplicates are not inert: each imported item carries the backup's `location_id`, so
+    the items repoint onto the *newly added* duplicate location, and the location you
+    rebuilt keeps its name while its contents move to its twin. Measured against a running
+    instance: a 40-location backup previewed against a 53-location inventory gives
+    `locations add=0 unchanged=40` when the ids are intact, but `add=17 unchanged=23` — 70
+    locations with 17 duplicate name pairs, and 402 items moving from `unchanged` to
+    `update` — when 17 of those locations had been rebuilt by hand first.
+  - **Safe restore paths:** restore into an **empty inventory**, or restore a backup whose
+    ids are still intact (the entities were never deleted and recreated). Either way run
+    `import/preview` first and read the `add` counts: entities you expect the import to
+    match onto must appear under `unchanged`/`update`, and a location you already have
+    showing up under `add` means you are about to duplicate it.
 
 ### Frontend (Lovelace card)
 

--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -73,7 +73,16 @@ describe('hv-import-sheet: step 1', () => {
     expect(policies.map((p) => p.dataset.policy)).toEqual(['merge', 'replace', 'skip']);
     expect(policies[0].getAttribute('aria-checked')).toBe('true');
     // Each explains what it does, rather than relying on the word alone.
-    expect(policies[1].textContent).toContain("Overwrite matching items with the file's version");
+    expect(policies[1].textContent).toContain("Overwrite items matched by id with the file's version");
+  });
+
+  it('says what an item is matched on, because it is the id and not the name', async () => {
+    // A user who reads "matching" as matching by name will rebuild entities by
+    // hand and expect a restore to merge onto them; it adds duplicates instead.
+    const el = await mount();
+    for (const policy of all(el, '[data-testid="import-policy"]')) {
+      expect(policy.textContent).toMatch(/\bid\b/);
+    }
   });
 
   it('promises no deletion, because no policy deletes', async () => {

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -9,21 +9,29 @@ import { DialogFocus } from '../ui/dialog-focus';
 import type { ImportBucketCounts, ImportPolicy, ImportPreview, ImportSummary } from '../store/types';
 
 // Every policy decides one thing: what happens to an item the file and the
-// inventory both have. None of them deletes anything — an item absent from the
-// file is always left alone — so each description says so, because "Replace"
-// on its own reads like a whole-inventory swap.
+// inventory both have — "both have" meaning the same id, never the same name, so
+// an item rebuilt by hand carries a fresh id and is added alongside the file's
+// copy rather than matched to it. Each description names the id as the match key,
+// because "matching" on its own reads as matching by name. None of the policies
+// deletes anything — an item absent from the file is always left alone — so each
+// description says so too, because "Replace" on its own reads like a
+// whole-inventory swap.
 const POLICIES: { id: ImportPolicy; title: string; description: string }[] = [
   {
     id: 'merge',
     title: 'Merge',
-    description: 'Update matching items field by field, combining tags; add the rest',
+    description: 'Update items matched by id field by field, combining tags; add the rest',
   },
   {
     id: 'replace',
     title: 'Replace',
-    description: "Overwrite matching items with the file's version; add the rest",
+    description: "Overwrite items matched by id with the file's version; add the rest",
   },
-  { id: 'skip', title: 'Skip', description: "Only add items that don't exist yet" },
+  {
+    id: 'skip',
+    title: 'Skip',
+    description: "Only add items whose id isn't in the inventory yet; leave matched items as they are",
+  },
 ];
 
 /**

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -235,6 +235,16 @@ data. See `data_shapes.md` for the full document, preview, and summary shapes.
     the structured problems; **state is not mutated**. If persistence fails after the
     in-memory swap, the repository is rolled back to its pre-import snapshot and the
     error surfaces as `storage_error` — a bad import never leaves partial state.
+  - **Identity is the entity id, and only the id.** An incoming item or location whose id is
+    already present *is* the existing entity and is resolved by the policy below; one whose
+    id is absent is a new entity and is added. Names are never compared, under any policy —
+    matching by name would silently fuse two genuinely different "Shelf A"s. The corollary
+    is that importing a document onto entities that were deleted and recreated by hand (and
+    so carry fresh ids) duplicates them rather than merging: the incoming copies classify as
+    `add`, and every incoming item follows its own `location_id` onto the incoming location,
+    leaving the hand-rebuilt one holding nothing. `import/preview` shows this before the
+    write — entities you expect to already exist appear under `unchanged`/`update`, never
+    under `add`.
   - Conflict policies (for ids already present): `skip` keeps the existing entity;
     `replace` overwrites it with the incoming one; `merge` overlays incoming onto
     existing (scalar fields from incoming; item `tags` unioned; item `custom_fields`


### PR DESCRIPTION
## Summary

Docs-only part of **[`docs/open-items.md` item 40](https://github.com/chrreiter/HAventory/blob/main/docs/open-items.md)** — *"Import matches entities by id and only by id, and nothing tells the user."*

`_plan_entities` (`import_export.py:581-597`) keys every classification on the entity id: absent id → `add`, present id → compare and `unchanged`/`update`/`conflict`. Names are never consulted, under any policy. That is the right design — matching by name would silently fuse two genuinely different "Shelf A"s — but it makes one realistic restore path lose data quietly, and nothing in the product said so.

Three wording surfaces, **no behavior change**:

1. **`README.md`** — the JSON import/export (data safety) bullet now states plainly that matching is by entity id and never by name; that restoring a backup onto hand-rebuilt locations/items **duplicates rather than merges** (fresh uuids classify as `add`, and each imported item follows its document's `location_id` onto the *duplicate*, so the rebuilt location keeps its name and loses its contents to its twin); and that the safe restore paths are an empty inventory or a backup whose ids are intact — with `import/preview` as the check either way. Includes the item's measured numbers (40-location backup vs 53-location inventory: `add=0 unchanged=40` with ids intact, `add=17 unchanged=23` → 70 locations / 17 duplicate name pairs / 402 items moving `unchanged`→`update` when 17 locations were rebuilt by hand).
2. **`docs/backend_api_contract.md`** — the import policy list now defines that **identity is the entity id, and only the id**, ahead of the per-policy semantics, plus the duplicate-on-rebuilt-ids corollary and what `import/preview` shows.
3. **`cards/haventory-card/src/components/hv-import-sheet.ts`** — the three policy descriptions no longer turn on the undefined word "matching"; each names the id as the match key (`Update items matched by id …`, `Overwrite items matched by id …`, `Only add items whose id isn't in the inventory yet …`). The file's leading comment records the constraint the labels are standing in for.

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

Both gates green on this branch:

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **278 passed, 22 skipped**; `uv run ruff check .` → **All checks passed!**; `uv run mypy` → **Success: no issues found in 13 source files**
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npx vitest run` → **776 passed (42 files)**; `npm run build` → built (`haventory-card.js`, 416.20 kB)

Test updates in `hv-import-sheet.test.ts`: the existing assertion on the `replace` description tracks its new wording, plus one new case asserting every policy description names what an item is matched on (`/\bid\b/`), so the wording gap cannot silently reopen.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (existing description assertion updated + a new case covering all three policies).
- [x] Docs updated where behavior changed — this PR *is* the docs change; the behavior is unchanged.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change; the contract edit only documents existing behavior.
- [x] Load-bearing invariants preserved (no code paths touched).

## Screenshots (card / UI changes)

Not captured — the card change is three string literals in the import sheet's policy radiogroup; the rendered text is asserted by unit tests.

## Follow-ups (deliberately not in this PR)

- **`import/preview` name-collision warning** — whether the preview should warn when an incoming entity's name collides with a *different* existing id. Item 40 calls this out as a separate decision (effort M), and the preview is the only surface that could catch the duplicate before the write, since it already has both sides in hand. Not folded in here.
- **Item 31's known-limitations list** is where the short form of this caveat belongs, once that list exists.
- `docs/open-items.md` is intentionally untouched by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JePxMSAdYWbfX2h5GYiBuN)_