### PR TITLE
fix(card): retry a rate-limited subscribe and show that live updates are paused

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1325,6 +1325,49 @@ describe('hv-card-shell: degraded states', () => {
     );
   });
 
+  it('says live updates are paused while a refused subscribe is being retried', async () => {
+    const { el, store, hass, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
+    // One round refused, so the store is mid-backoff when the card renders.
+    hass.__failSubscribeNext(3, { code: 'rate_limited', message: 'rate limit exceeded; retry later' });
+    store.subscribeTopics();
+    await el.updateComplete;
+    await Promise.resolve();
+    await Promise.resolve();
+    await el.updateComplete;
+
+    const paused = banner(sr, 'degraded-live-updates');
+    expect(paused).toBeTruthy();
+    expect(paused?.shadowRoot?.textContent).toContain('Live updates paused');
+    expect(paused?.shadowRoot?.textContent).toContain('Retrying automatically');
+    // Non-blocking: the list is still there and there is nothing to dismiss.
+    expect(sr.querySelector('[data-testid="card-list"], [data-testid="card-table"]')).toBeTruthy();
+
+    // The retry succeeds, so the indicator goes away on its own.
+    await settle(el);
+    await settle(el);
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+    expect(banner(sr, 'degraded-live-updates')).toBe(null);
+  });
+
+  it('offers a refresh once the automatic retries are spent', async () => {
+    const { el, store, hass, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
+    hass.__failSubscribe({ code: 'rate_limited', message: 'rate limit exceeded; retry later' });
+    store.subscribeTopics();
+    for (let i = 0; i < 12; i++) await settle(el);
+
+    expect(store.state.value.degraded.liveUpdates).toBe('paused');
+    const paused = banner(sr, 'degraded-live-updates');
+    expect(paused?.shadowRoot?.textContent).toContain('may be out of date until you refresh');
+
+    hass.__failSubscribe(null);
+    (banner(sr, 'degraded-live-refresh') as HTMLButtonElement).click();
+    await settle(el);
+    await settle(el);
+
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+    expect(banner(sr, 'degraded-live-updates')).toBe(null);
+  });
+
   it('announces a wholesale reload after an import', async () => {
     const { el, hass, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
     const seen: boolean[] = [];

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -902,6 +902,30 @@ export class HVCardShell extends LitElement {
           Reconnect
         </button>
       </hv-banner>`);
+    } else if (degraded.liveUpdates !== 'live') {
+      // Ranked above the generic rate-limit warning below: that one says events
+      // *may* have been dropped, this one says there are no events at all.
+      const retrying = degraded.liveUpdates === 'retrying';
+      banners.push(html`<hv-banner
+        kind="warning"
+        glyph="clock"
+        heading="Live updates paused"
+        message=${retrying
+          ? ' · rate limited. Retrying automatically; this list may be out of date until then.'
+          : ' · rate limited. This list may be out of date until you refresh.'}
+        data-testid="degraded-live-updates"
+      >
+        ${retrying
+          ? null
+          : html`<button
+              slot="actions"
+              class="hv-pill outline"
+              data-testid="degraded-live-refresh"
+              @click=${() => void this._refresh()}
+            >
+              Refresh
+            </button>`}
+      </hv-banner>`);
     } else if (degraded.retrying > 0) {
       banners.push(html`<hv-banner
         kind="warning"

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
@@ -1,6 +1,6 @@
 import './hv-diagnostics-panel';
 import type { HVDiagnosticsPanel } from './hv-diagnostics-panel';
-import type { HealthResult, StatsCounts } from '../store/types';
+import type { DegradedState, HealthResult, StatsCounts } from '../store/types';
 
 const counts: StatsCounts = {
   items_total: 250,
@@ -21,12 +21,14 @@ function health(patch: Partial<HealthResult> = {}): HealthResult {
   };
 }
 
-const NO_DEGRADATION = {
+const NO_DEGRADATION: DegradedState = {
   rateLimited: false,
   connectionLost: false,
   retrying: 0,
   nextRetryAt: null,
   reloading: false,
+  liveUpdates: 'live',
+  nextLiveRetryAt: null,
 };
 
 async function mount(props: Partial<HVDiagnosticsPanel> = {}) {

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -5,6 +5,7 @@ import {
   activeFilterCount,
   defaultFilters,
   makeBulkOp,
+  subscribeRetryDelayMs,
   toWireFilter,
 } from './store';
 import type { Location } from './types';
@@ -27,6 +28,23 @@ function loc(id: string, name: string, parentId: string | null = null): Location
 
 /** Stores under test never wait on real backoff. */
 const fast = { retryBaseMs: 0 };
+
+const RATE_LIMITED = { code: 'rate_limited', message: 'rate limit exceeded; retry later' };
+
+/** Let queued microtasks and any zero-delay timers run. */
+async function flush(rounds = 1): Promise<void> {
+  for (let i = 0; i < rounds; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Drain the microtasks a rejected `subscribeMessage` promise takes to reach the
+ * store, without letting a scheduled re-subscribe fire.
+ */
+async function settleSubscribes(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('toWireFilter', () => {
   it('sends include_subtree explicitly', () => {
@@ -382,12 +400,146 @@ describe('Store: rate limiting and degraded state', () => {
     const store = new Store(hass, fast);
 
     await store.init();
-    await Promise.resolve();
-    await Promise.resolve();
+    await settleSubscribes();
 
     // Live updates are gone; the card must stop claiming it is connected.
     expect(store.state.value.degraded.rateLimited).toBe(true);
     expect(store.state.value.connected.items).toBe(false);
+    // ...and it says so as a state the UI can render, not just a log line.
+    expect(store.state.value.degraded.liveUpdates).toBe('retrying');
+  });
+
+  it('retries a rate-limited subscribe and goes live again', async () => {
+    const hass = makeMockHass({ items: [] });
+    // One whole round refused — three topics — then the limiter lets us back in.
+    hass.__failSubscribeNext(3, RATE_LIMITED);
+    const store = new Store(hass, fast);
+
+    await store.init();
+    await settleSubscribes();
+    expect(store.state.value.degraded.liveUpdates).toBe('retrying');
+    expect(store.state.value.degraded.nextLiveRetryAt).not.toBeNull();
+
+    await flush(3);
+
+    // The indicator is cleared by the retry succeeding, not by the user acting.
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+    expect(store.state.value.degraded.nextLiveRetryAt).toBeNull();
+    expect(store.state.value.connected.items).toBe(true);
+    expect(store.state.value.errorQueue).toEqual([]);
+    // Two rounds of three, so the retry really did re-open every topic...
+    expect(hass.__subscribeCalls).toHaveLength(6);
+    // ...and events flow again, which is the whole point of retrying.
+    hass.__emit('items', 'created', { item: makeItem({ id: '9' }) });
+    expect(store.state.value.items.map((i) => i.id)).toContain('9');
+  });
+
+  it('gives up after a bounded number of retries and surfaces the pause', async () => {
+    const hass = makeMockHass({ items: [] });
+    hass.__failSubscribe(RATE_LIMITED);
+    const store = new Store(hass, fast);
+
+    await store.init();
+    await flush(12);
+
+    expect(store.state.value.degraded.liveUpdates).toBe('paused');
+    expect(store.state.value.degraded.rateLimited).toBe(true);
+    // Nothing further is scheduled: only the user can restart this.
+    expect(store.state.value.degraded.nextLiveRetryAt).toBeNull();
+    expect(store.state.value.connected.items).toBe(false);
+    // The refusal reaches the user exactly once — when retrying is over, not on
+    // every attempt.
+    expect(store.state.value.errorQueue.map((e) => e.code)).toEqual(['rate_limited']);
+    // The first round plus four retries, three topics each. The cap is the point:
+    // a card that kept knocking would be indistinguishable from the load that
+    // tripped the limiter.
+    expect(hass.__subscribeCalls).toHaveLength(15);
+
+    // The budget stays spent until something restarts it.
+    await flush(6);
+    expect(hass.__subscribeCalls).toHaveLength(15);
+  });
+
+  it('clears the paused indicator when a manual refresh gets back in', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+    hass.__failSubscribe(RATE_LIMITED);
+    const store = new Store(hass, fast);
+    await store.init();
+    await flush(12);
+    expect(store.state.value.degraded.liveUpdates).toBe('paused');
+
+    hass.__failSubscribe(null);
+    await store.refreshAll();
+    await flush();
+
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+    expect(store.state.value.degraded.rateLimited).toBe(false);
+    expect(store.state.value.connected.items).toBe(true);
+    hass.__emit('items', 'created', { item: makeItem({ id: '2' }) });
+    expect(store.state.value.items.map((i) => i.id)).toContain('2');
+  });
+
+  it('waits out the retry-after hint the envelope carries', async () => {
+    const hass = makeMockHass({ items: [] });
+    hass.__failSubscribeNext(3, { ...RATE_LIMITED, data: { op: 'subscribe', retry_after_ms: 40 } });
+    const store = new Store(hass, fast);
+
+    await store.init();
+    await settleSubscribes();
+
+    // The hint wins over the store's own (zero, in tests) backoff.
+    const wait = (store.state.value.degraded.nextLiveRetryAt ?? 0) - Date.now();
+    expect(wait).toBeGreaterThan(20);
+    expect(store.state.value.degraded.liveUpdates).toBe('retrying');
+
+    // Not retried before the hint elapses...
+    await flush(2);
+    expect(hass.__subscribeCalls).toHaveLength(3);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(hass.__subscribeCalls).toHaveLength(6);
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+  });
+
+  it('reports a non-rate-limit subscribe refusal instead of retrying it', async () => {
+    // Only `rate_limited` says "try again later"; anything else is an outage the
+    // user needs to see, and quietly re-knocking would hide it.
+    const hass = makeMockHass({ items: [] });
+    hass.__failSubscribe({ code: 'unknown_error', message: 'unexpected error; see Home Assistant logs' });
+    const store = new Store(hass, fast);
+
+    await store.init();
+    await flush(3);
+
+    expect(store.state.value.degraded.connectionLost).toBe(true);
+    expect(store.state.value.degraded.liveUpdates).toBe('paused');
+    expect(store.state.value.errorQueue.map((e) => e.code)).toEqual(['unknown_error']);
+    expect(hass.__subscribeCalls).toHaveLength(3);
+  });
+});
+
+describe('subscribeRetryDelayMs', () => {
+  it('prefers the envelope hint over the backoff, in either unit', () => {
+    expect(subscribeRetryDelayMs({ code: 'rate_limited', data: { retry_after_ms: 250 } }, 0, 400)).toBe(250);
+    // Seconds, the HTTP Retry-After convention.
+    expect(subscribeRetryDelayMs({ code: 'rate_limited', data: { retry_after: 2 } }, 0, 400)).toBe(2000);
+    // The card's own error entries name the bag `context`.
+    expect(subscribeRetryDelayMs({ code: 'rate_limited', context: { retry_after_ms: 30 } }, 3, 400)).toBe(30);
+  });
+
+  it('backs off exponentially when the envelope carries no hint', () => {
+    const delays = [0, 1, 2, 3].map((attempt) => subscribeRetryDelayMs({ code: 'rate_limited' }, attempt, 400));
+    expect(delays).toEqual([400, 800, 1600, 3200]);
+  });
+
+  it('clamps a hint that would park live updates for hours', () => {
+    expect(subscribeRetryDelayMs({ data: { retry_after: 86_400 } }, 0, 400)).toBe(30_000);
+  });
+
+  it('ignores a hint that is not a usable number', () => {
+    expect(subscribeRetryDelayMs({ data: { retry_after_ms: 'soon' } }, 0, 400)).toBe(400);
+    expect(subscribeRetryDelayMs({ data: { retry_after: -5 } }, 0, 400)).toBe(400);
+    expect(subscribeRetryDelayMs({ data: { retry_after: Number.NaN } }, 1, 400)).toBe(800);
   });
 
   it('declares the connection lost after consecutive transport failures', async () => {

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -58,16 +58,70 @@ const CONNECTION_LOST_THRESHOLD = 2;
 /** Attempts (including the first) for a command rejected with `rate_limited`. */
 const RATE_LIMIT_ATTEMPTS = 4;
 
+/**
+ * Automatic re-subscribes after a `rate_limited` refusal, before the card gives
+ * up and waits for the user. Bounded because a limiter tight enough to refuse
+ * every attempt will not be talked round by a card that keeps knocking.
+ */
+const SUBSCRIBE_RETRY_ATTEMPTS = 4;
+
+/**
+ * Ceiling on a single re-subscribe wait. Also clamps a server-sent retry-after
+ * hint, so a wrong or hostile value cannot park live updates indefinitely.
+ */
+const SUBSCRIBE_RETRY_MAX_MS = 30_000;
+
+/** Topics `subscribeTopics` opens as one round: items, stats, locations. */
+const SUBSCRIBE_TOPIC_COUNT = 3;
+
 const NO_DEGRADATION: DegradedState = {
   rateLimited: false,
   connectionLost: false,
   retrying: 0,
   nextRetryAt: null,
   reloading: false,
+  liveUpdates: 'live',
+  nextLiveRetryAt: null,
 };
 
 function errorCode(err: unknown): string {
   return String((err as { code?: unknown } | undefined)?.code ?? 'unknown_error');
+}
+
+function nonNegativeNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+/**
+ * A retry-after hint in milliseconds, or null when the envelope carries none.
+ *
+ * The error taxonomy defines no retry-after field, so this is read defensively:
+ * from `data` (where the contract puts structured context), from `context` (the
+ * name the card's own error entries use) and from the top level, accepting
+ * either milliseconds or the HTTP convention of seconds. A backend that starts
+ * sending one is honoured without a contract change; until then the caller
+ * falls back to its own backoff.
+ */
+function retryAfterHintMs(err: unknown): number | null {
+  const envelope = err as { data?: unknown; context?: unknown } | undefined;
+  for (const source of [envelope, envelope?.data, envelope?.context]) {
+    if (!source || typeof source !== 'object') continue;
+    const bag = source as Record<string, unknown>;
+    const ms = nonNegativeNumber(bag.retry_after_ms);
+    if (ms !== null) return ms;
+    const seconds = nonNegativeNumber(bag.retry_after);
+    if (seconds !== null) return seconds * 1000;
+  }
+  return null;
+}
+
+/**
+ * How long to wait before re-opening a refused subscription: the server's hint
+ * when it sends one, otherwise exponential backoff off the card's base delay.
+ */
+export function subscribeRetryDelayMs(err: unknown, attempt: number, baseMs: number): number {
+  const delay = retryAfterHintMs(err) ?? baseMs * 2 ** attempt;
+  return Math.min(delay, SUBSCRIBE_RETRY_MAX_MS);
 }
 
 /**
@@ -187,6 +241,15 @@ export class Store {
   private retryBaseMs: number;
   private consecutiveTransportFailures = 0;
   private treeRefreshHandle: ReturnType<typeof setTimeout> | null = null;
+  /** Identifies the newest subscribe round, so a superseded one stops reporting. */
+  private subscribeRound = 0;
+  /** Subscribes in the current round that have not resolved or been refused yet. */
+  private subscribePending = 0;
+  /** First refusal seen in the current round, if any. */
+  private subscribeRefusal: { err: unknown } | null = null;
+  /** Automatic re-subscribes already spent on the current outage. */
+  private subscribeAttempt = 0;
+  private subscribeRetryHandle: ReturnType<typeof setTimeout> | null = null;
   /** Last untouched `distinct_values` result, so drafts can be re-merged. */
   private serverDistinct: DistinctValues | null = null;
   /** Values named in the organize dialog that no item carries yet. */
@@ -238,39 +301,103 @@ export class Store {
     this.subscribeTopics();
   }
 
+  /** (Re)open the topic subscriptions, starting the retry budget over. */
   subscribeTopics() {
-    const onError = (err: unknown) => this.onSubscribeError(err);
+    this.openSubscriptions(true);
+  }
+
+  /**
+   * Open the three topic subscriptions as one round.
+   *
+   * The round, not the individual topic, is the unit of health: the rate limiter
+   * bills each subscribe separately, so it can let `items` through and refuse
+   * `stats` a moment later. Live updates only count as restored once every
+   * subscribe in the newest round has been accepted.
+   */
+  private openSubscriptions(resetRetryBudget: boolean) {
+    this.cancelSubscribeRetry();
+    if (resetRetryBudget) this.subscribeAttempt = 0;
+    const round = ++this.subscribeRound;
+    this.subscribePending = SUBSCRIBE_TOPIC_COUNT;
+    this.subscribeRefusal = null;
+    const onOpen = () => this.onSubscribeSettled(round, null);
+    const onError = (err: unknown) => this.onSubscribeSettled(round, { err });
+
     if (this.itemsUnsub) this.itemsUnsub();
     this.itemsUnsub = this.ws.subscribe('items', (evt: AnyEventPayload) => this.onItemsEvent(evt), {
       location_id: this.state.value.filters.locationId ?? undefined,
       include_subtree: true, // Always include sublocations
       onError,
+      onOpen,
     });
     if (this.statsUnsub) this.statsUnsub();
-    this.statsUnsub = this.ws.subscribe('stats', (evt: AnyEventPayload) => this.onStatsEvent(evt), { onError });
+    this.statsUnsub = this.ws.subscribe('stats', (evt: AnyEventPayload) => this.onStatsEvent(evt), {
+      onError,
+      onOpen,
+    });
     if (this.locationsUnsub) this.locationsUnsub();
     this.locationsUnsub = this.ws.subscribe(
       'locations',
       (evt: AnyEventPayload) => this.onLocationsEvent(evt),
-      { onError },
+      { onError, onOpen },
     );
+  }
 
-    this.stateObs.set({ connected: { items: true, stats: true } });
+  /** Fold one subscribe outcome into its round, and act once the round is complete. */
+  private onSubscribeSettled(round: number, refusal: { err: unknown } | null) {
+    if (round !== this.subscribeRound) return; // a newer round has taken over
+    if (refusal && !this.subscribeRefusal) this.subscribeRefusal = refusal;
+    if (this.subscribePending > 0) this.subscribePending -= 1;
+    if (this.subscribePending > 0) return;
+
+    const refused = this.subscribeRefusal;
+    if (!refused) {
+      this.subscribeAttempt = 0;
+      this.stateObs.set({ connected: { items: true, stats: true } });
+      this.setDegraded({ liveUpdates: 'live', nextLiveRetryAt: null });
+      return;
+    }
+    this.onSubscribeRefused(refused.err);
   }
 
   /**
-   * A rejected subscribe means live updates are gone. Rate limiting is the
-   * expected cause; either way the card must stop implying it is live and offer
-   * a manual refresh.
+   * A refused subscribe means live updates are gone, silently — no event will
+   * ever arrive to hint at it.
+   *
+   * `rate_limited` is the expected refusal and the contract's guidance is to
+   * retry later, so the card backs off and says it is retrying instead of
+   * dropping an error on a user who has done nothing wrong. Once the budget is
+   * spent it stops, reports the refusal and leaves the manual refresh as the way
+   * back. Any other refusal is an outage and is reported at once.
    */
-  private onSubscribeError(err: unknown) {
-    const code = errorCode(err);
-    this.setDegraded({
-      rateLimited: code === 'rate_limited' ? true : this.state.value.degraded.rateLimited,
-      connectionLost: code === 'rate_limited' ? this.state.value.degraded.connectionLost : true,
-    });
+  private onSubscribeRefused(err: unknown) {
     this.stateObs.set({ connected: { items: false, stats: false } });
-    this.pushError(err);
+
+    if (errorCode(err) !== 'rate_limited') {
+      this.setDegraded({ connectionLost: true, liveUpdates: 'paused', nextLiveRetryAt: null });
+      this.pushError(err);
+      return;
+    }
+
+    if (this.subscribeAttempt >= SUBSCRIBE_RETRY_ATTEMPTS) {
+      this.setDegraded({ rateLimited: true, liveUpdates: 'paused', nextLiveRetryAt: null });
+      this.pushError(err);
+      return;
+    }
+
+    const delay = subscribeRetryDelayMs(err, this.subscribeAttempt, this.retryBaseMs);
+    this.subscribeAttempt += 1;
+    this.setDegraded({ rateLimited: true, liveUpdates: 'retrying', nextLiveRetryAt: Date.now() + delay });
+    this.subscribeRetryHandle = setTimeout(() => {
+      this.subscribeRetryHandle = null;
+      this.openSubscriptions(false);
+    }, delay);
+  }
+
+  private cancelSubscribeRetry() {
+    if (this.subscribeRetryHandle === null) return;
+    clearTimeout(this.subscribeRetryHandle);
+    this.subscribeRetryHandle = null;
   }
 
   /** Tear down the three subscriptions and any pending tree refresh. */
@@ -279,6 +406,9 @@ export class Store {
     this.statsUnsub?.();
     this.locationsUnsub?.();
     this.itemsUnsub = this.statsUnsub = this.locationsUnsub = null;
+    // Nothing is listening after this, so a queued re-subscribe must not fire.
+    this.subscribeRound += 1;
+    this.cancelSubscribeRetry();
     if (this.treeRefreshHandle !== null) {
       clearTimeout(this.treeRefreshHandle);
       this.treeRefreshHandle = null;
@@ -644,7 +774,9 @@ export class Store {
       cur.connectionLost === next.connectionLost &&
       cur.retrying === next.retrying &&
       cur.nextRetryAt === next.nextRetryAt &&
-      cur.reloading === next.reloading;
+      cur.reloading === next.reloading &&
+      cur.liveUpdates === next.liveUpdates &&
+      cur.nextLiveRetryAt === next.nextLiveRetryAt;
     if (same) return;
     this.stateObs.set({ degraded: next });
   }

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -406,7 +406,20 @@ export interface DegradedState {
   nextRetryAt: number | null;
   /** True while reloading after an import replaced the dataset. */
   reloading: boolean;
+  /** Whether the topic subscriptions are up, being re-opened, or given up on. */
+  liveUpdates: LiveUpdateState;
+  /** Epoch ms of the next automatic re-subscribe, when one is scheduled. */
+  nextLiveRetryAt: number | null;
 }
+
+/**
+ * State of the three topic subscriptions.
+ *
+ * `retrying` means a refused subscribe is being re-attempted on a bounded
+ * backoff; `paused` means the budget is spent, so only an explicit refresh
+ * brings live updates back.
+ */
+export type LiveUpdateState = 'live' | 'retrying' | 'paused';
 
 export interface StoreState {
   items: Item[];

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -254,6 +254,12 @@ export class WSClient {
        * `rate_limited`, which otherwise kills live updates silently.
        */
       onError?: (err: unknown) => void;
+      /**
+       * Called once the backend has accepted the subscribe. The only positive
+       * signal there is: a caller retrying a refused subscribe needs to know
+       * when the topic is live again, and no event may ever arrive to prove it.
+       */
+      onOpen?: () => void;
     }
   ): Unsubscribe {
     const id = nextSubscriptionId++;
@@ -275,25 +281,31 @@ export class WSClient {
 
     // Home Assistant may return either an unsubscribe function or a Promise<unsubscribe>.
     if (typeof unsubOrPromise === 'function') {
+      opts?.onOpen?.();
       return unsubOrPromise as unknown as Unsubscribe;
     }
 
     // Handle Promise<Unsubscribe> with early-cancel support.
     let resolvedUnsub: Unsubscribe | null = null;
     let cancelRequested = false;
-    Promise.resolve(unsubOrPromise)
-      .then((fn) => {
+    // The rejection handler is `then`'s second argument rather than a trailing
+    // `catch`, so a throw from `onOpen` cannot be misread as a refused subscribe.
+    Promise.resolve(unsubOrPromise).then(
+      (fn) => {
         resolvedUnsub = fn as Unsubscribe;
         if (cancelRequested && resolvedUnsub) {
           try { resolvedUnsub(); } catch { /* ignore */ }
+          return;
         }
-      })
-      .catch((err: unknown) => {
+        opts?.onOpen?.();
+      },
+      (err: unknown) => {
         // A rejected subscribe means no live updates at all. Report it so the
-        // card can go degraded and offer a manual refresh instead of quietly
-        // showing stale data.
+        // card can retry, go degraded and offer a manual refresh instead of
+        // quietly showing stale data.
         opts?.onError?.(err);
-      });
+      },
+    );
 
     return () => {
       if (resolvedUnsub) {

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -38,8 +38,12 @@ export interface MockHass extends HassLike {
   __failNext(n: number, err?: unknown): void;
   /** Make every subsequent `haventory/subscribe` reject with `err`. */
   __failSubscribe(err: unknown | null): void;
+  /** Reject the next `n` `haventory/subscribe` calls with `err`, then behave normally. */
+  __failSubscribeNext(n: number, err: unknown): void;
   /** Every callWS `type` seen so far, in order. */
   __calls: string[];
+  /** Every subscribed topic seen so far, in order — refused attempts included. */
+  __subscribeCalls: string[];
 }
 
 export function makeMockHass(initial?: MockConfig): MockHass {
@@ -51,8 +55,10 @@ export function makeMockHass(initial?: MockConfig): MockHass {
   let failRemaining = 0;
   let failError: unknown = new Error('connection lost');
   let subscribeError: unknown | null = null;
+  let subscribeFailRemaining = 0;
   const subs: Record<string, SubCb[]> = {};
   const calls: string[] = [];
+  const subscribeCalls: string[] = [];
 
   const findItem = (msg: Record<string, unknown>): Item => {
     const itemId = String((msg as any).item_id);
@@ -69,6 +75,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
 
   const hass: MockHass = {
     __calls: calls,
+    __subscribeCalls: subscribeCalls,
     async callWS<T>(msg: Record<string, unknown>): Promise<T> {
       const type = String(msg.type || '');
       calls.push(type);
@@ -501,12 +508,14 @@ export function makeMockHass(initial?: MockConfig): MockHass {
     },
     connection: {
       subscribeMessage(cb: SubCb, msg: Record<string, unknown>) {
-        if (subscribeError !== null) {
+        const topic = String((msg as any).topic || '');
+        subscribeCalls.push(topic);
+        if (subscribeFailRemaining > 0) {
           // Real HA rejects the subscribe promise; the client must not treat the
           // topic as live.
+          subscribeFailRemaining -= 1;
           return Promise.reject(subscribeError);
         }
-        const topic = String((msg as any).topic || '');
         subs[topic] ||= [];
         subs[topic].push(cb);
         return () => {
@@ -531,7 +540,14 @@ export function makeMockHass(initial?: MockConfig): MockHass {
       failRemaining = n;
       if (err !== undefined) failError = err;
     },
-    __failSubscribe(err: unknown | null) { subscribeError = err; },
+    __failSubscribe(err: unknown | null) {
+      subscribeError = err;
+      subscribeFailRemaining = err === null ? 0 : Number.POSITIVE_INFINITY;
+    },
+    __failSubscribeNext(n: number, err: unknown) {
+      subscribeError = err;
+      subscribeFailRemaining = n;
+    },
   };
 
   return hass;

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -168,7 +168,7 @@ applies optimistic writes with rollback.
 | `listAllMatching(filter)` / `loadAllPages()` | Omitting `limit` returns every match; used by "Load all N to select" and by tag/category rewrites. |
 | `setFilters(patch)` | Clears the selection (a row that is no longer listed cannot stay selected) and only rebuilds subscriptions when the *location* scope changes. |
 | `bulkExecute(ops, opts)` | Chunks `haventory/items/bulk` (25 ops per call), reports progress, and returns `{succeeded, failed, cancelled}`. |
-| `refreshAll()` | Clears the degraded flags, reloads every cache, and re-subscribes. The contract's prescribed recovery. |
+| `refreshAll()` | Clears the degraded flags, reloads every cache, and re-subscribes with a fresh retry budget. The contract's prescribed recovery. |
 | `exportDocument(scope)` | `'view'` forwards the active filter. |
 | selection API | `toggleSelected`, `setSelected`, `clearSelection`, `selectAllLoaded`, `loadAllThenSelectAll`. |
 
@@ -180,8 +180,21 @@ filter defaults it to `false` server-side while subscriptions default it to `tru
 **Rate limiting and degraded state.** Every WS call goes through `run()`, which retries a
 `rate_limited` rejection with backoff before surfacing it, and classifies failures: a code
 from the backend's taxonomy means the socket is fine, anything else counts toward
-`degraded.connectionLost`. A *rejected subscribe* — which otherwise kills live updates
-silently — marks the card degraded and drops `connected`.
+`degraded.connectionLost`.
+
+A *rejected subscribe* kills live updates outright — no event will ever arrive to hint at
+it — so it is handled separately. The three topics are opened as one **round**, because the
+limiter bills each subscribe separately and can admit `items` while refusing `stats`; live
+updates only count as restored once every subscribe in the newest round is accepted, which
+`WSClient.subscribe`'s `onOpen` reports. A round refused with `rate_limited` is re-opened
+automatically up to four times, waiting the envelope's retry-after hint when it carries one
+(`retry_after_ms`, or `retry_after` in seconds, read from `data`, `context` or the top level
+and clamped to 30 s) and otherwise backing off exponentially. `degraded.liveUpdates` tracks
+this as `'live' | 'retrying' | 'paused'`, with `degraded.nextLiveRetryAt` for the scheduled
+attempt; the shell renders it as a non-blocking banner that clears itself when a retry gets
+back in. Once the budget is spent the state goes `'paused'`, the refusal reaches the error
+queue once, and the banner's Refresh (i.e. `refreshAll()`) is the way back. Any other
+refusal is an outage: reported immediately, never retried.
 
 **Why the card offers a manual Refresh.** Subscription events carry no sequence number or
 generation, and the rate limiter can drop them silently, so a client cannot detect a gap.
@@ -191,7 +204,8 @@ a hidden one.
 ### `WSClient`
 
 A typed wrapper over `hass.callWS` for each `haventory/*` command, plus `subscribe()`, which
-takes an `onError` callback so a refused subscribe is observable.
+takes `onError` and `onOpen` callbacks so both a refused and an accepted subscribe are
+observable.
 
 It is a deliberate 1:1 mirror of the command catalogue in `backend_api_contract.md`: it
 wraps 32 of the backend's 34 commands, omitting only `haventory/cleanup` and


### PR DESCRIPTION
## Summary

Fixes **item 1** in [`docs/open-items.md`](https://github.com/chrreiter/HAventory/blob/main/docs/open-items.md) — *"Card doesn't handle `rate_limited` on `subscribe`"*: with opt-in rate limiting enabled and tripped, a refused `haventory/subscribe` killed live updates **silently**. The store marked itself degraded, pushed one error into the queue and never tried again, so the card sat there showing a list that had quietly stopped updating.

The card now does both halves of what the item asks for — it retries, and it says so.

**Retry, bounded.** The three topics (`items`, `stats`, `locations`) are opened as one **round**. The round, not the individual topic, is the unit of health: the limiter bills each subscribe separately, so it can admit `items` and refuse `stats` a moment later, and "live" is only true once every subscribe in the newest round has been accepted. That needed a positive signal, so `WSClient.subscribe` gained an `onOpen` callback alongside `onError` — no event may ever arrive to prove a topic is live. A round refused with `rate_limited` is re-opened automatically up to **four** times before the card gives up; a limiter tight enough to refuse every attempt will not be talked round by a card that keeps knocking.

**Retry-after hint, respected.** The delay is the envelope's hint when it carries one, otherwise exponential backoff off the store's base delay (400 ms → 3.2 s). The error taxonomy in `docs/backend_api_contract.md` defines no retry-after field, so the hint is read defensively — `retry_after_ms`, or `retry_after` in seconds (the HTTP convention) — from `data`, from `context`, or from the top level, and clamped to 30 s so a wrong or hostile value cannot park live updates. A backend that starts sending one is honoured with no contract change; today it simply never fires.

**Degraded state, surfaced.** `DegradedState` gained `liveUpdates: 'live' | 'retrying' | 'paused'` and `nextLiveRetryAt`. `hv-card-shell` renders it as a non-blocking banner ("Live updates paused · rate limited. Retrying automatically…") that **clears itself** when a retry gets back in — the list stays fully usable throughout. Once the budget is spent the state goes `paused`, the refusal reaches the error queue exactly once (not once per attempt), and the banner grows a Refresh button wired to the recovery the contract already prescribes (`refreshAll()`, which re-lists everything and re-subscribes with a fresh budget).

Any refusal that is **not** `rate_limited` is unchanged: an outage, reported immediately, never retried.

Frontend-only. No backend, no `ws.py`, no contract change.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates run and green on this branch:

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **278 passed, 22 skipped**; `uv run ruff check .` → *All checks passed!*; `uv run mypy` → *Success: no issues found in 13 source files*
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npx vitest run` → **786 passed (42 files)**; `npm run build` → built. `npm run typecheck` (`tsc --noEmit`) also kept clean.

New tests, written first (TDD):

| Test | Pins |
|---|---|
| `retries a rate-limited subscribe and goes live again` | One refused round, then success: state returns to `live`, `nextLiveRetryAt` clears, no error reaches the user, both rounds re-opened all three topics, and an emitted event lands in the store — proof the subscription is really back |
| `gives up after a bounded number of retries and surfaces the pause` | Budget exhaustion: `paused`, no further attempt scheduled, exactly **15** subscribes (1 round + 4 retries × 3 topics) and no more after further ticks, refusal queued exactly once |
| `clears the paused indicator when a manual refresh gets back in` | `refreshAll()` from `paused` restores `live` and live event delivery |
| `waits out the retry-after hint the envelope carries` | A 40 ms hint beats the (zero, in tests) base backoff — no retry before it elapses, retry after |
| `reports a non-rate-limit subscribe refusal instead of retrying it` | `unknown_error` is not retried and is reported at once |
| `subscribeRetryDelayMs` unit block | Hint in ms/seconds from `data`/`context`, exponential fallback, 30 s clamp, and non-numeric/negative/NaN hints ignored |
| `hv-card-shell`: two banner tests | Retrying copy shows while the list stays rendered and disappears on its own; exhausted copy offers Refresh, which restores live and removes the banner |

Test harness: `makeMockHass` gained `__failSubscribeNext(n, err)` (refuse the next *n* subscribes, then behave) and `__subscribeCalls` (topics attempted, in order) so retry counts are assertable rather than inferred.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + several edge/error cases).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md` (the store's "Rate limiting and degraded state" section and the `WSClient` note). `README.md` deliberately untouched: its known-limitations area is owned by another PR. `docs/open-items.md` deliberately untouched too — follow-ups are below instead.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched.

## Screenshots (card / UI changes)

Not captured: the new banner only appears when the opt-in limiter refuses a `subscribe`, which needs a live HA instance with rate limiting configured tight enough to trip. The two `hv-card-shell` tests assert the rendered copy and the button in both states instead.

## Follow-ups (out of scope here)

- **Command retries ignore the same hint.** `Store.run()` retries a `rate_limited` *command* on a fixed exponential backoff and does not consult the envelope. `subscribeRetryDelayMs` is exported and reusable; folding it in would touch tests that pin the current arithmetic, so it was left alone to keep this fix to one thing.
- **`degraded.retrying` is hidden while live updates are paused.** The shell's banner chain is exclusive and the new state is ranked above the "Busy — retrying" and generic "Rate limited" banners, on the grounds that "there are no events at all" outranks "events *may* have been dropped". If a queued-command count should stay visible in that state, the chain needs to become additive.
- **Nothing calls `Store.dispose()`.** It now also cancels a pending re-subscribe and bumps the round so a late settle is ignored, but the pre-existing note stands: the card never invokes it, so a shell torn down mid-backoff relies on GC rather than on this path.
- **Item 31's known-limitations list** should record the posture this lands on: subscribes are retried four times with backoff and then pause visibly until the user refreshes.