### PR TITLE
docs: publish a Known limitations section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,42 @@ and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 
+## Known limitations
+
+What HAventory does *not* do today, stated up front so none of it is a surprise:
+
+- **Scale: a few thousand items.** Every mutation re-serializes the entire inventory and
+  rewrites the store blob, so write latency grows with the total item count. Measured p50
+  per create: ~70 ms at 250 items, ~114 ms at 500, ~200 ms at 1000; on that curve a single
+  create trends toward ~1 s at a few thousand items. Reads don't share the problem (query
+  paths are benchmarked at 10 000 items), correctness is unaffected at any size, and no
+  limit is enforced — writes simply get slower. Treat a few thousand items as the
+  comfortable ceiling.
+- **No automation triggers.** The integration creates no entities and fires no events on
+  the Home Assistant bus. Automations and scripts can *call* the `haventory.*` services,
+  but nothing can trigger *on* an inventory change — there is no state object to watch and
+  no event type to listen for. Change notification is WebSocket subscriptions only, for
+  clients holding an open connection.
+- **No admin gating.** No WebSocket command declares `require_admin`, so any logged-in
+  Home Assistant user — not only administrators — can read and mutate the whole inventory.
+  It is a household-wide tool, not a per-user one.
+- **Rate limiting is opt-in and off by default.** Out of the box nothing bounds how fast a
+  client may issue commands or how many subscription events it is sent. Enabling it under
+  Settings → Devices & services → HAventory → **Configure** turns on per-connection and
+  global token buckets: excess commands are rejected with a `rate_limited` error and
+  excess subscription broadcasts are dropped. Dropped broadcasts are silent on the wire —
+  events carry no sequence number, so a missing one cannot be detected by its absence.
+- **Import identity is the id, never the name.** The `merge` / `replace` / `skip` policies
+  all classify an incoming item or location by its id. Restoring a backup onto entities
+  you rebuilt by hand — which carry fresh uuids — therefore duplicates them instead of
+  merging, and the backup's items follow their stored `location_id` onto the duplicate.
+  Restore into an empty inventory, or onto one whose ids are still intact.
+
+These are tracked, with their measurements and proposed fixes, in
+[`docs/open-items.md`](docs/open-items.md).
+
+---
+
 ## Developer Checklist
 
 Use this checklist when working on HAventory. Keep it up to date if conventions change.


### PR DESCRIPTION
## Summary

Fixes **item 31** in `docs/open-items.md` — *"No published 'Known limitations / not supported' list"*. A 1.0 should say up front what the integration does not do; nothing did.

Adds a `## Known limitations` section to the README, placed directly after **Installation** (before the Developer Checklist) so it reads as user-facing rather than developer trivia. Five entries, each verified against the source on `main` rather than taken from the item text:

| Limitation | Verified against |
|---|---|
| **Scale: a few thousand items** — whole-store re-serialize + rewrite per mutation; p50/create ~70 ms @250 → ~114 ms @500 → ~200 ms @1000, trending toward ~1 s at a few thousand. Reads unaffected (query paths benchmarked at 10 000 items); no limit enforced, correctness unaffected. | Measurements cited from open item 19 (WP4 stress test); read-path figure from `tests/test_repository_benchmarks_offline.py` |
| **No automation triggers** — no entities, no HA bus events; `haventory.*` services can be *called* but nothing can trigger *on* a change. | No entity platform modules and no `PLATFORMS`/`async_forward_entry_setups` in `custom_components/haventory/`; no `hass.bus.async_fire` anywhere in the integration |
| **No admin gating** — any logged-in HA user can mutate the inventory. | No `require_admin` on any command in `ws.py` |
| **Rate limiting is opt-in, off by default** — enabled via the options flow; per-connection + global token buckets, excess commands rejected with `rate_limited`, excess broadcasts dropped. | `DEFAULT_RATE_LIMIT_ENABLED = False` (`const.py:30`), `config_flow.py` options flow, `rate_limit.py` |
| **Import identity is the id, never the name** — restoring onto hand-rebuilt entities duplicates rather than merges. | `_plan_entities` (`import_export.py:581-597`); short form placed here per open item 40's own cross-reference to item 31 |

The rate-limiting entry deliberately describes **backend posture only** — what is true on `main` today — and says nothing about how any client reacts to `rate_limited`, so it stays accurate independent of the card-side work tracked as open item 1.

Docs-only. No code, no behavior change. `docs/open-items.md` intentionally untouched (see Follow-ups).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates run in full on this branch; all six steps green.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **278 passed, 22 skipped**; `uv run ruff check .` → **All checks passed!**; `uv run mypy` → **Success: no issues found in 13 source files**
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean (exit 0); `npx vitest run` → **42 files, 775 tests passed**; `npm run build` → **built in 136ms** (416.14 kB / 95.03 kB gzip)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [ ] Tests added/updated — n/a, docs-only change with no code path to exercise.
- [x] Docs updated where behavior changed (`README.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Load-bearing invariants preserved — n/a, no code touched.

## Screenshots (card / UI changes)

n/a — no card or UI change.

## Follow-ups

Findings from writing this, recorded here rather than in `docs/open-items.md` (left untouched by request):

1. **No measured item-count ceiling exists yet.** Item 31 points at release-test **F3**, but F3 ("load ~2× the real inventory on real hardware and *publish* the size at which it degrades") has not been run — the ✅ in that table's last column marks it a **Blocker**, not a completed run. The section therefore publishes the numbers that *are* measured (item 19's stress-test curve, extrapolated) and frames "a few thousand" as a comfortable ceiling rather than inventing a hard number. Worth revisiting once F3 actually runs.

2. **The README already claims the rate-limit card gap is closed.** Under *Implementation Status → Phase 2.5*, the bullet list ends with "Closes the standing gaps for … and the card's silent failure when a subscription is rate-limited" — which contradicts open item 1, still listed as pre-v1.0. One of the two is stale. Not touched here: it sits in a different README section, and resolving it needs the item-1 decision, not a docs edit.

3. **`## Conventions` lists `calendar.haventory` as a naming convention** while the new section states the integration creates no entities. Both are true today (the name is reserved for the post-1.0 calendar work, open item 9), but a reader hitting them in either order may see a contradiction. A parenthetical on the Conventions line would settle it.

Note on conflicts: other open PRs touch the README in different sections; this one only inserts a new section between *Installation* and *Developer Checklist*, so any merge conflict should be positional and trivial.