### PR TITLE
fix(card): make the table's select-all checkbox visible before it is used

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -17,15 +17,15 @@ async function mount(items: Partial<Item>[], props: Partial<HVDataTable> = {}) {
 const q = (el: HVDataTable, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
 const all = (el: HVDataTable, sel: string) => [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
 
-describe('hv-data-table: narrow screens', () => {
-  const tableCss = () => {
-    const styles = (customElements.get('hv-data-table') as typeof HVDataTable).styles;
-    return (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
-  };
+const tableCss = () => {
+  const styles = (customElements.get('hv-data-table') as typeof HVDataTable).styles;
+  return (Array.isArray(styles) ? styles : [styles])
+    .map((s) => String(s.cssText))
+    .join('\n')
+    .replace(/\s+/g, ' ');
+};
 
+describe('hv-data-table: narrow screens', () => {
   // The template has a hard ~786px minimum, and a grid whose tracks do not fit
   // overflows its box rather than shrinking. With overflow visible the spill
   // was clipped by the shell: rows measured clientWidth 634 / scrollWidth 854
@@ -66,7 +66,7 @@ describe('hv-data-table: narrow screens', () => {
   });
 
   it('gives the sort headers a tappable height', () => {
-    expect(tableCss()).toMatch(/\.head button \{[^}]*min-height: var\(--hv-tap-min, auto\)/);
+    expect(tableCss()).toMatch(/\.head button\.sort \{[^}]*min-height: var\(--hv-tap-min, auto\)/);
   });
 
   it('keeps rows scrolling vertically inside the body', () => {
@@ -258,6 +258,39 @@ describe('hv-data-table: selection mode', () => {
     (q(el, '[data-testid="table-select-all"]') as HTMLButtonElement).click();
 
     expect(seen).toEqual(['select-all', 'clear']);
+  });
+
+  // jsdom does not run the shadow-DOM cascade, so nothing here can read the
+  // painted border. The two halves that produce it are assertable separately:
+  // the box keeps `.box` in every state, and the sort-header reset that would
+  // otherwise outrank it is keyed to a class the box does not carry.
+  it('keeps the header checkbox on .box through none, some and all', async () => {
+    const el = await mount([{ id: '1' }, { id: '2' }], { selectable: true });
+    const master = () => q(el, '[data-testid="table-select-all"]') as HTMLElement;
+    expect([...master().classList]).toEqual(['box']);
+
+    el.selection = new Set(['1']);
+    await el.updateComplete;
+    expect([...master().classList]).toEqual(['box', 'mixed']);
+
+    el.selection = new Set(['1', '2']);
+    await el.updateComplete;
+    expect([...master().classList]).toEqual(['box', 'on']);
+  });
+
+  it('keeps the sort-header reset off the header checkbox', async () => {
+    const css = tableCss();
+    // Unscoped, this rule matches every button in the header — the select-all
+    // included — and its 0-1-1 beats `.box`, so the unchecked box paints
+    // neither border nor fill and the target is invisible until it is used.
+    expect(css).not.toMatch(/\.head button \{/);
+    expect(css).toMatch(/\.head button\.sort \{[^}]*border: none/);
+    expect(css).toMatch(/\.box \{[^}]*border: 1\.5px solid var\(--hv-text-tertiary\)/);
+    expect(css).toMatch(/\.box\.on, \.box\.mixed \{[^}]*background: var\(--hv-primary-dark\)/);
+
+    const el = await mount([{ id: '1' }], { selectable: true });
+    for (const b of all(el, '[data-testid="table-sort"]')) expect(b.classList.contains('sort')).toBe(true);
+    expect(q(el, '[data-testid="table-select-all"]')?.classList.contains('sort')).toBe(false);
   });
 
   it('hides the row action buttons while selecting', async () => {

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -65,7 +65,13 @@ export class HVDataTable extends LitElement {
         color: var(--hv-text-secondary);
         flex: none;
       }
-      .head button {
+      /* This reset must stay keyed to the sort buttons' own class. Written as
+         .head button it also reaches the select-all box, which is a button in
+         this header too, and at 0-1-1 it outranks .box's own 0-1-0 border and
+         background — leaving the checkbox with nothing drawn at all until a
+         selection exists. The border-color on .box.on cannot bring back a
+         border-style of none, so the outline would never return. */
+      .head button.sort {
         display: inline-flex;
         align-items: center;
         gap: 3px;
@@ -78,7 +84,7 @@ export class HVDataTable extends LitElement {
         text-transform: inherit;
         letter-spacing: inherit;
       }
-      .head button.sorted {
+      .head button.sort.sorted {
         color: var(--hv-primary-dark);
       }
       .body {
@@ -269,7 +275,7 @@ export class HVDataTable extends LitElement {
   private _sortHeader(field: SortField, label: string) {
     const active = this.sort?.field === field;
     return html`<button
-      class=${active ? 'sorted' : ''}
+      class="sort ${active ? 'sorted' : ''}"
       data-testid="table-sort"
       data-field=${field}
       aria-sort=${active ? (this.sort.order === 'asc' ? 'ascending' : 'descending') : 'none'}


### PR DESCRIPTION
## Summary

Fixes `docs/open-items.md` **item 39** — the table's select-all checkbox is invisible until something is already selected. (Tracked in `docs/open-items.md`, not as a GitHub issue, so there is nothing to close.)

The control existed and worked; it just wasn't painted. Inside `hv-data-table`, the sort-header reset `.head button { border: none; background: none; … }` (specificity 0-1-1) matched *every* button in the header — the tri-state select-all `.box` included — and outranked `.box { border: 1.5px solid var(--hv-text-tertiary) }` (0-1-0). So the unchecked header box had neither outline nor fill, while every row below it showed one (row boxes sit outside `.head`). `.box.on` / `.box.mixed` (0-2-0) did win the `background` once rows were selected, but `border-color` alone cannot restore a `border-style: none`, so it only ever reappeared as a filled chip — and only after the user had found the invisible target.

The fix is the one the item prescribes: **scope the reset away from the checkbox**, not raise `.box`'s specificity. Of the two options the item names I took the second — the sort buttons get their own `.sort` class (`.head button.sort`, `.head button.sort.sorted`), so the reset reaches only what it was written for and the next button added to this header doesn't fall into the same trap.

A side effect worth naming: the reset also carried `min-height: var(--hv-tap-min, auto)`, which on mobile (`--hv-tap-min: 44px`) stretched the 16px header box to 44px tall while the row boxes stayed square. The header box now matches the rows exactly; its touch target still comes from the `.box::after` inset, same as every other checkbox in the table.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **278 passed, 22 skipped**; `uv run ruff check .` → **All checks passed**; `uv run mypy` → **no issues in 13 source files**
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npx vitest run` → **777 passed (42 files)**; `npm run build` → ok (416.62 kB)

**Unit tests** (`hv-data-table.test.ts`): the header box is asserted to stay on `.box` across all three states — `['box']` unchecked, `['box','mixed']` partial, `['box','on']` all — and a second test guards the cascade half: no unscoped `.head button {` rule survives, the reset is keyed to `.head button.sort`, `.box` still declares its border, and `.box.on, .box.mixed` still declare the fill. The existing tappable-height assertion was retargeted to `.head button.sort`.

**On the live check.** jsdom does not run the shadow-DOM cascade, so none of the above reads a painted border — and **Docker is not available in this environment** (the CLI is installed at 29.3.1 but there is no daemon: `/var/run/docker.sock` does not exist), so the run-haventory deploy + screenshot could not be run. Instead of relying on reasoning alone I verified the matching half empirically with a throwaway light-DOM test (jsdom *does* cascade light-DOM stylesheets), injecting the component's real CSS text and computing styles for `.box`, `.box.on`, `.box.mixed` and `.sort.sorted`:

| selector in the reset | `.box` (none) | `.box.on` | `.box.mixed` | `.sort.sorted` |
|---|---|---|---|---|
| `.head button` (before) | `min-height: var(--hv-tap-min, auto)` | same | same | `min-height: var(--hv-tap-min, auto)` |
| `.head button.sort` (after) | *not applied* | *not applied* | *not applied* | `min-height: var(--hv-tap-min, auto)` |

The reset's declarations land on the header checkbox before the change and do not after it — the boxes are no longer matched by that rule block at all, which is precisely the defect. (jsdom does not expand the `border` shorthand into longhands, so the border itself is not readable there; that half rests on the specificity reasoning above. `background` is readable and behaves as expected: transparent unchecked, `var(--hv-primary-dark)` when on/mixed.) The scratch test was deleted, not committed. A real-browser confirmation is still worth doing whenever this next runs somewhere with Docker.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (all three header states + the specificity guard).
- [ ] Docs updated where behavior changed — n/a: no behavior or API change, and `docs/open-items.md` was deliberately left untouched per the task's instruction.
- [ ] WebSocket API changes — n/a, frontend CSS/markup only.
- [x] Load-bearing invariants preserved — untouched (no backend change).

## Screenshots (card / UI changes)

Not available — no Docker daemon in this environment, see above.

## Follow-ups (not fixed here)

- **Select-all semantics, deliberately out of scope.** Item 39's secondary question stands unanswered: the header button selects **loaded** rows only (`store.selectAllLoaded`, `store.ts:628`), so against a 1000-item filtered set it selects a page while the selection bar counts 1000. `loadAllThenSelectAll` (`store.ts:633`) already implements the other reading. This PR changes only the checkbox's visibility and touches neither function — picking between the two readings (or offering both, e.g. "select all N" after a partial select-all) is a product decision worth its own change.