### PR TITLE
fix(init): read the card's cache-buster version off the loop

### DIFF
--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
+from homeassistant.loader import async_get_integration
 
 try:
     from homeassistant.components.lovelace import LOVELACE_DATA
@@ -204,29 +205,57 @@ async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:
     await _unregister_frontend_module(hass)
 
 
-def _card_resource_url() -> str:
+def _read_manifest_version() -> str:
+    """Parse the version out of the shipped manifest file. Blocks — run it in the executor."""
+    try:
+        manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    except OSError, ValueError:
+        return ""
+    raw = manifest.get("version")
+    return raw if isinstance(raw, str) else ""
+
+
+async def _async_manifest_version(hass: HomeAssistant) -> str:
+    """Version this integration declares, or `""` when it cannot be determined.
+
+    Home Assistant parses `manifest.json` when it loads the integration and keeps
+    the result, so the version is already in memory. Reading the file here instead
+    would be blocking I/O on the event loop, which HA's loop protection reports as
+    a warning with a full stack trace on every startup. The executor read is the
+    fallback for the case where the loader has no manifest to hand us.
+    """
+    try:
+        integration = await async_get_integration(hass, DOMAIN)
+        raw = integration.manifest.get("version")
+    except Exception:
+        LOGGER.debug(
+            "Integration manifest unavailable from the loader; reading the file instead",
+            extra={"domain": DOMAIN, "op": "frontend_register"},
+        )
+    else:
+        if isinstance(raw, str) and raw:
+            return raw
+
+    try:
+        return await hass.async_add_executor_job(_read_manifest_version)
+    except Exception:
+        LOGGER.debug(
+            "Could not read the integration manifest; registering the card unversioned",
+            extra={"domain": DOMAIN, "op": "frontend_register", "path": str(_MANIFEST_PATH)},
+        )
+        return ""
+
+
+async def _async_card_resource_url(hass: HomeAssistant) -> str:
     """`/local` URL for the card bundle, carrying the manifest version as `?v=`.
 
     `/local/` is served with a month-long `max-age`, so without the query a browser
     — or the companion app's webview, which is harder to clear — keeps serving the
     bundle from before an integration update and runs an old card against a new
-    backend. Falls back to the bare path if the manifest cannot be read, since a
-    missing cache-buster must not stop the card from being registered at all.
+    backend. Falls back to the bare path if the version cannot be determined, since
+    a missing cache-buster must not stop the card from being registered at all.
     """
-    version = ""
-    # Blocking read of a file shipped inside the integration, once per setup; not
-    # worth an executor round-trip (and the test Hass stub has no executor).
-    try:
-        manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
-    except OSError, ValueError:
-        LOGGER.debug(
-            "Could not read the integration manifest; registering the card unversioned",
-            extra={"domain": DOMAIN, "op": "frontend_register", "path": str(_MANIFEST_PATH)},
-        )
-    else:
-        raw = manifest.get("version")
-        version = raw if isinstance(raw, str) else ""
-
+    version = await _async_manifest_version(hass)
     if not version:
         return _CARD_URL_PATH
     return f"{_CARD_URL_PATH}?v={quote(version, safe='')}"
@@ -314,7 +343,7 @@ async def _rewrite_card_resource(resources: Any, stale: dict[str, Any], url: str
 
 async def _register_frontend_module(hass: HomeAssistant) -> None:
     """Register the built HAventory card asset as a Lovelace resource if present."""
-    url = _card_resource_url()
+    url = await _async_card_resource_url(hass)
 
     # Get filesystem path - handle missing config gracefully for tests
     try:

--- a/stubs/homeassistant/loader.pyi
+++ b/stubs/homeassistant/loader.pyi
@@ -1,0 +1,14 @@
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+class IntegrationNotFound(Exception):
+    domain: str
+
+class Integration:
+    domain: str
+    manifest: dict[str, Any]
+    def __getattr__(self, name: str) -> Any: ...
+
+async def async_get_integration(hass: HomeAssistant, domain: str) -> Integration: ...
+def __getattr__(name: str) -> Any: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ deprecated since Python 3.14 and slated for removal in 3.16.
 """
 
 import asyncio
+import json
 import os
 import platform
 import sys
@@ -92,6 +93,14 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def async_create_background_task(self, target, name, eager_start=True):
             """Stand in for HA's tracked-task helper; the real one also cancels on shutdown."""
             return asyncio.create_task(target, name=name)
+
+        async def async_add_executor_job(self, target, *args):
+            """Stand in for HA's executor offload; the real one uses HA's own thread pool.
+
+            Running the callable on a genuine worker thread keeps the offline suite
+            honest about what does and does not touch the event loop thread.
+            """
+            return await asyncio.get_running_loop().run_in_executor(None, target, *args)
 
     ha_core.HomeAssistant = HomeAssistant
     sys.modules["homeassistant.core"] = ha_core
@@ -316,6 +325,49 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
     ha_helpers_area_registry.async_get = async_get
     sys.modules["homeassistant.helpers.area_registry"] = ha_helpers_area_registry
+
+    # homeassistant.loader
+    ha_loader = types.ModuleType("homeassistant.loader")
+
+    _SHIPPED_MANIFEST = json.loads(
+        (ROOT / "custom_components" / "haventory" / "manifest.json").read_text(encoding="utf-8")
+    )
+
+    class IntegrationNotFound(Exception):  # type: ignore[override]
+        def __init__(self, domain: str) -> None:
+            super().__init__(f"Integration '{domain}' not found.")
+            self.domain = domain
+
+    class Integration:  # type: ignore[override]
+        def __init__(self, domain: str, manifest: dict) -> None:
+            self.domain = domain
+            self.manifest = manifest
+
+    async def async_get_integration(hass: HomeAssistant, domain: str):  # type: ignore[override]
+        """Hand back the manifest HA parsed at load time, doing no file I/O.
+
+        Tests override per-hass through ``hass.data["__integration_manifests__"]``;
+        mapping a domain to None makes the lookup raise, the way it does in real HA
+        for an integration that is not installed.
+        """
+        overrides = getattr(hass, "data", None)
+        if isinstance(overrides, dict) and domain in (
+            overrides.get("__integration_manifests__") or {}
+        ):
+            manifest = overrides["__integration_manifests__"][domain]
+        elif domain == _SHIPPED_MANIFEST.get("domain"):
+            manifest = _SHIPPED_MANIFEST
+        else:
+            manifest = None
+
+        if manifest is None:
+            raise IntegrationNotFound(domain)
+        return Integration(domain, manifest)
+
+    ha_loader.IntegrationNotFound = IntegrationNotFound
+    ha_loader.Integration = Integration
+    ha_loader.async_get_integration = async_get_integration
+    sys.modules["homeassistant.loader"] = ha_loader
 
 
 if _INTEGRATION_MODE:

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
 import os
 import sys
+import threading
 import types
 from pathlib import Path
 from typing import Any
@@ -16,6 +18,10 @@ CARD_PATH = "/local/haventory/haventory-card.js"
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[1] / "custom_components" / "haventory" / "manifest.json"
 )
+
+# Distinguishes "leave the loader stub at its default (the shipped manifest)" from
+# "register None", which makes the lookup raise the way an absent integration does.
+_NO_OVERRIDE = object()
 
 
 def manifest_version() -> str:
@@ -92,6 +98,7 @@ class HassStub:
     def __init__(self, base_path: str) -> None:
         self.data: dict[str, Any] = {}
         self._base_path = base_path
+        self.executor_jobs: list[Any] = []
 
     class _Config:
         def __init__(self, base_path: str) -> None:
@@ -108,16 +115,49 @@ class HassStub:
     def config(self, value):
         self._config = value
 
+    async def async_add_executor_job(self, target, *args):
+        """Mirror HA's executor offload, recording what got handed off.
 
-def make_hass(tmp_path, *, with_asset: bool = True) -> HassStub:
-    """Hass stub whose config dir is `tmp_path`, optionally holding the built card."""
+        A real worker thread, not an inline call: it is what lets a test tell an
+        event-loop file read apart from an offloaded one.
+        """
+        self.executor_jobs.append(target)
+        return await asyncio.get_running_loop().run_in_executor(None, target, *args)
+
+
+def make_hass(tmp_path, *, with_asset: bool = True, manifest: Any = _NO_OVERRIDE) -> HassStub:
+    """Hass stub whose config dir is `tmp_path`, optionally holding the built card.
+
+    `manifest` seeds what the loader hands back for the `haventory` domain: omit it
+    for the shipped manifest, pass a dict to choose the version, pass None to make
+    the lookup fail the way it does for an integration HA has not loaded.
+    """
     if with_asset:
         asset_dir = tmp_path / "www" / "haventory"
         asset_dir.mkdir(parents=True, exist_ok=True)
         (asset_dir / "haventory-card.js").write_text("// test asset")
     hass = HassStub(str(tmp_path))
     hass.config = HassStub._Config(str(tmp_path))
+    if manifest is not _NO_OVERRIDE:
+        hass.data["__integration_manifests__"] = {"haventory": manifest}
     return hass
+
+
+def track_manifest_reads(monkeypatch) -> list[int]:
+    """Record the thread of every `Path.read_text` call from here on.
+
+    HA's blocking-call protection flags exactly this call when it happens on the
+    event loop thread, and answers it with a stack trace on every startup.
+    """
+    threads: list[int] = []
+    real_read_text = Path.read_text
+
+    def tracking_read_text(self, *args, **kwargs):
+        threads.append(threading.get_ident())
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracking_read_text)
+    return threads
 
 
 @pytest.mark.asyncio
@@ -138,13 +178,9 @@ async def test_registers_lovelace_resource_when_present(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_registered_url_carries_the_manifest_version(tmp_path, monkeypatch):
-    """The `?v=` value comes from the manifest, not from a constant in the code."""
+    """The `?v=` value comes from the loaded manifest, not from a constant in the code."""
     hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    manifest = tmp_path / "manifest.json"
-    manifest.write_text(json.dumps({"domain": "haventory", "version": "9.9.9"}), encoding="utf-8")
-    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", manifest)
-
-    hass = make_hass(tmp_path)
+    hass = make_hass(tmp_path, manifest={"domain": "haventory", "version": "9.9.9"})
     lovelace_data = MockLovelaceData()
     hass.data["lovelace_data_key"] = lovelace_data
 
@@ -154,12 +190,81 @@ async def test_registered_url_carries_the_manifest_version(tmp_path, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_the_loaded_manifest_is_read_without_touching_the_filesystem(tmp_path, monkeypatch):
+    """The version comes out of memory: no file read at all, on the loop or off it.
+
+    Home Assistant already parsed `manifest.json` when it loaded the integration.
+    Reading it again during `async_setup_entry` runs on the event loop thread,
+    where HA's loop protection answers it with a stack-trace warning on every
+    startup, so the registered URL must not depend on a file read.
+    """
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path, manifest={"domain": "haventory", "version": "9.9.9"})
+    lovelace_data = MockLovelaceData()
+    hass.data["lovelace_data_key"] = lovelace_data
+    read_threads = track_manifest_reads(monkeypatch)
+
+    await hav_init._register_frontend_module(hass)
+
+    assert [c["url"] for c in lovelace_data.resources.created] == [f"{CARD_PATH}?v=9.9.9"]
+    assert read_threads == []
+    assert hass.executor_jobs == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        # Domain unknown to the loader, which raises rather than returning.
+        None,
+        # Loaded, but carrying nothing usable as a version.
+        {"domain": "haventory"},
+        {"domain": "haventory", "version": ""},
+        {"domain": "haventory", "version": 9},
+    ],
+)
+async def test_falls_back_to_reading_the_manifest_off_the_loop(tmp_path, monkeypatch, manifest):
+    """No version from the loader => read the file, but in the executor."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    manifest_file = tmp_path / "manifest.json"
+    manifest_file.write_text(
+        json.dumps({"domain": "haventory", "version": "8.8.8"}), encoding="utf-8"
+    )
+    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", manifest_file)
+
+    hass = make_hass(tmp_path, manifest=manifest)
+    lovelace_data = MockLovelaceData()
+    hass.data["lovelace_data_key"] = lovelace_data
+    read_threads = track_manifest_reads(monkeypatch)
+
+    await hav_init._register_frontend_module(hass)
+
+    assert [c["url"] for c in lovelace_data.resources.created] == [f"{CARD_PATH}?v=8.8.8"]
+    assert hass.executor_jobs == [hav_init._read_manifest_version]
+    assert read_threads and threading.get_ident() not in read_threads
+
+
+@pytest.mark.asyncio
 async def test_registers_bare_url_when_manifest_version_unavailable(tmp_path, monkeypatch):
-    """An unreadable manifest degrades to the unversioned URL instead of failing setup."""
+    """Neither source yields a version => unversioned URL, rather than a failed setup."""
     hav_init = import_haventory(monkeypatch, "lovelace_data_key")
     monkeypatch.setattr(hav_init, "_MANIFEST_PATH", tmp_path / "no-such-manifest.json")
 
-    hass = make_hass(tmp_path)
+    hass = make_hass(tmp_path, manifest=None)
+    lovelace_data = MockLovelaceData()
+    hass.data["lovelace_data_key"] = lovelace_data
+
+    await hav_init._register_frontend_module(hass)
+
+    assert [c["url"] for c in lovelace_data.resources.created] == [CARD_PATH]
+
+
+@pytest.mark.asyncio
+async def test_registers_bare_url_when_no_executor_is_available(tmp_path, monkeypatch):
+    """A hass without an executor still registers the card, just without `?v=`."""
+    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
+    hass = make_hass(tmp_path, manifest=None)
+    monkeypatch.delattr(HassStub, "async_add_executor_job")
     lovelace_data = MockLovelaceData()
     hass.data["lovelace_data_key"] = lovelace_data
 
@@ -224,11 +329,7 @@ async def test_updates_existing_entry_when_the_version_changed(
     throws.
     """
     hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    manifest = tmp_path / "manifest.json"
-    manifest.write_text(json.dumps({"domain": "haventory", "version": "9.9.9"}), encoding="utf-8")
-    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", manifest)
-
-    hass = make_hass(tmp_path)
+    hass = make_hass(tmp_path, manifest={"domain": "haventory", "version": "9.9.9"})
     lovelace_data = MockLovelaceData()
     lovelace_data.resources._items = [
         {"id": "existing", "url": registered_url, "type": "module"},


### PR DESCRIPTION
Fixes **item 52** in `docs/open-items.md` (local verification run 2026-07-28, F2).

## The problem

`_card_resource_url()` read `manifest.json` with `Path.read_text()` during
`async_setup_entry` — on the event loop. HA's blocking-call protection answered that
with two `WARNING` lines carrying full stack traces **on every startup**, each ending
`please create a bug report at .../HAventory/issues`. Every install's log funnelled its
users at the issue tracker on every boot, and the traces would be flagged by the release
run's log sweep (they were 12 of the 15 tracebacks in the 2026-07-28 verification session).

## The fix

Take the version from the manifest Home Assistant already parsed when it loaded the
integration — `homeassistant.loader.async_get_integration(hass, DOMAIN).manifest["version"]`.
For an integration that is already set up this is a plain `hass.data` cache hit and touches
no file at all.

The file read survives as a fallback for when the loader has no manifest to hand over
(`_read_manifest_version`), now offloaded via `hass.async_add_executor_job`.

Behavior is preserved exactly: a version that cannot be determined from either source
registers the bare `/local/haventory/haventory-card.js` URL rather than failing setup.

## Tests

`tests/test_frontend_registration.py` monkeypatched `_MANIFEST_PATH` to choose a version;
the equivalent seam is now `make_hass(..., manifest=...)`, which seeds what the loader
hands back (omit for the shipped manifest, `None` to make the lookup raise the way it does
for an integration HA has not loaded). Added:

- `test_the_loaded_manifest_is_read_without_touching_the_filesystem` — the requested
  no-blocking-I/O test. Tracks every `Path.read_text` call (the exact call HA's loop
  protection flags) and asserts none happens, on the loop thread or off it, and that no
  executor job was scheduled either.
- `test_falls_back_to_reading_the_manifest_off_the_loop` — parametrized over loader
  outcomes (domain not found, manifest with no version / an empty one / a non-string one):
  the file read happens, but on a worker thread, never the loop's.
- `test_registers_bare_url_when_no_executor_is_available` — guards the "never fail setup"
  contract for a hass with no executor.

`tests/conftest.py` gains a `homeassistant.loader` stub (cached manifest lookup, per-hass
override via `hass.data["__integration_manifests__"]`, `IntegrationNotFound`) and an
`async_add_executor_job` on the HA stub that runs the callable on a genuine worker thread —
which is what lets a test tell an event-loop read apart from an offloaded one.
`stubs/homeassistant/loader.pyi` types the new import for mypy.

## Verification

Both gates green (backend `pytest` 322 passed / 22 skipped, `ruff check`, `ruff format
--check`, `mypy`; frontend `eslint`, `vitest` 792 passed, `npm run build`).

Live against HA 2026.7 in the dev container — `docker logs | grep -c "Detected blocking call"`:

| | blocking-call warnings | card resource |
|---|---|---|
| before | 12 | `?v=0.0.1` |
| after | **0** | `?v=0.0.1` (`already registered at the current version`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
