### PR TITLE
feat: settle inspection_date as the next inspection due, with a count, filter and card surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,12 @@ item and deletes it (best-effort cleanup even on failure).
   validation/repository/storage errors so HA surfaces them.
 - Areas via `homeassistant.helpers.area_registry.async_get(hass)`; never auto-create areas.
 - Case-insensitive search; denormalized `location_path` on items; item `version` for optimistic concurrency.
+- Two calendar-derived counts on `haventory/stats`, each with a matching `item/list` filter:
+  `overdue_count` / `overdue_only` for a passed `due_date` (checked-out items only, since
+  that is where a due date can exist), and `inspection_overdue_count` /
+  `inspection_overdue_only` for a passed `inspection_date` — the date the item is next due
+  for inspection, over the whole inventory, since an inspection is independent of any
+  check-out. Both move with the calendar and emit no event when the date rolls over.
 - **WebSocket rate limiting (opt-in, off by default)**: per-connection **and** global
   token buckets for commands (excess requests get a `rate_limited` error) and for
   subscription broadcasts (excess events are dropped, never breaking the command).
@@ -363,18 +369,19 @@ Redesigned in WP4.1. Lit + TypeScript + Vite; tests with Vitest; build outputs t
 - **Standard card** — one Add button and a single ⋮ menu (Select items, Organize, Refresh,
   Diagnostics, Export backup / Export current view, Import); Columns is offered in the full
   view, which is the only surface it changes. Live stat badges — items, low stock, overdue,
-  checked out — are click-to-filter. Rows carry a quantity stepper, a LOW badge, an overdue
-  check-out chip, and hover actions.
+  due for inspection, checked out — are click-to-filter. Rows carry a quantity stepper, a
+  LOW badge, an overdue check-out chip, an "Inspection due" chip, and hover actions.
 - **Filters** — a collapsible panel exposing the whole backend filter object: location
   (from a real tree), area, include-subtree, category chips with counts, tag chips with an
-  any/all toggle, low-stock-only, checked-out, overdue and no-location — each with the
-  count of what it would keep — plus updated / created windows (each row's ≥ flips to ≤ for
+  any/all toggle, low-stock-only, checked-out, overdue, inspection-due and no-location —
+  each with the count of what it would keep — plus updated / created windows (each row's ≥ flips to ≤ for
   "before") and sort across all six sortable fields.
   "Low stock" (a filter) and "Low stock first" (an ordering) are separate, independently
   clearable controls. Active filters appear as removable chips.
 - **Editing** — the row expands in place; there is no dialog chain. Full field parity:
   name, description, quantity, low-stock threshold, category, tags, location (picked from
-  a tree inside the form), checked-out with due date, inspection date, and typed
+  a tree inside the form), checked-out with due date, next inspection (with the same
+  +7 / +31 / +90 / +X quick offsets the check-out popover offers), and typed
   custom fields (text / number / yes-no / date). Saves send the item's expected version so
   a concurrent edit surfaces as a conflict.
 - **Full view** — a fullscreen workspace with a coloured app bar, a **browse sidebar**, and
@@ -391,8 +398,8 @@ Redesigned in WP4.1. Lit + TypeScript + Vite; tests with Vitest; build outputs t
   category exists through the items using it, so that is where making one is explained.
   From the second selected tag on, the Tags heading carries the same any/all control the
   filter panel has, since that is the mode governing what the sidebar just selected. The
-  app bar's stat pills are the card's: low in amber, overdue in red, checked out, each
-  click-to-filter. An empty table names the reason and offers a way out — the same
+  app bar's stat pills are the card's: low in amber, overdue in red, to-inspect in amber,
+  checked out, each click-to-filter. An empty table names the reason and offers a way out — the same
   wording and the same offers as the card's list.
 
   At phone width the sidebar folds away and the surface hands its own breakpoint down to
@@ -410,8 +417,8 @@ Redesigned in WP4.1. Lit + TypeScript + Vite; tests with Vitest; build outputs t
   batch rewrites over every affected item; a location merge re-files that location's items,
   re-parents its children and deletes the husk — all with the same progress and
   partial-failure reporting.
-- **Check-out** invites an optional due date (+1 / +7 / +30 day suggestions) rather than
-  silently checking out with none — the date is what makes overdue highlighting mean
+- **Check-out** invites an optional due date (+7 / +31 / +90 / +X day suggestions) rather
+  than silently checking out with none — the date is what makes overdue highlighting mean
   anything. "No due date" stays a first-class choice.
 - **Mobile** — the card switches layout from its own width. Tapping a row opens one bottom
   sheet holding everything about the item; filters open as a staged sheet whose apply

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -68,6 +68,7 @@ describe('hv-card-shell: header', () => {
     expect(sr.querySelector('[data-testid="badge-low"]')).toBe(null);
     expect(sr.querySelector('[data-testid="badge-out"]')).toBe(null);
     expect(sr.querySelector('[data-testid="badge-overdue"]')).toBe(null);
+    expect(sr.querySelector('[data-testid="badge-inspection"]')).toBe(null);
   });
 
   // A due date that has passed was invisible from the card: the row said
@@ -85,6 +86,29 @@ describe('hv-card-shell: header', () => {
       badge.click();
       await settle(el);
       expect(store.state.value.filters.overdueOnly).toBe(true);
+      el.remove();
+    }
+  });
+
+  // `inspection_date` is when the item is next due for inspection, so a date
+  // behind us is work waiting — and the count is over the whole inventory,
+  // not just what is checked out.
+  it('counts items due for inspection in a badge of their own, on any width', async () => {
+    const items = [
+      makeItem({ id: '1', inspection_date: '2000-01-01' }),
+      makeItem({ id: '2', checked_out: true, inspection_date: '2000-06-01' }),
+      makeItem({ id: '3', inspection_date: '2999-12-31' }),
+    ];
+    for (const mobile of [false, true]) {
+      const { el, store, sr } = await mountShell({ items, mobile });
+      const badge = sr.querySelector('[data-testid="badge-inspection"]') as HTMLButtonElement;
+      expect(badge?.textContent, `mobile=${mobile}`).toContain('2 to inspect');
+
+      badge.click();
+      await settle(el);
+      expect(store.state.value.filters.inspectionDueOnly).toBe(true);
+      // Pressing it filters server-side, so the list narrows to the two.
+      expect(store.state.value.items.map((i) => i.id).sort()).toEqual(['1', '2']);
       el.remove();
     }
   });

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -128,10 +128,11 @@ export class HVCardShell extends LitElement {
         order: 1;
         flex-basis: 100%;
         margin-left: 0;
-        /* Three of these — low, overdue, checked out — with five-digit counts
-           will not always make one line of a 320px phone. Wrapping costs a
-           second 44px band in the worst case; not wrapping pushes the last one
-           off the side of the card, where it cannot be pressed at all. */
+        /* Four of these — low, overdue, to inspect, checked out — with
+           five-digit counts will not make one line of a 320px phone. Wrapping
+           costs a second 44px band in the worst case; not wrapping pushes the
+           last one off the side of the card, where it cannot be pressed at
+           all. */
         flex-wrap: wrap;
         row-gap: 6px;
       }
@@ -166,6 +167,13 @@ export class HVCardShell extends LitElement {
       .badge.overdue {
         color: var(--hv-error-deep);
         background: var(--hv-error-bg);
+        border-color: transparent;
+      }
+      /* Amber like low stock rather than red like overdue: red says an item is
+         out and late back, amber says something on the shelf wants doing. */
+      .badge.inspect {
+        color: var(--hv-warn-deep);
+        background: var(--hv-warn-bg);
         border-color: transparent;
       }
       .badge.on {
@@ -829,6 +837,7 @@ export class HVCardShell extends LitElement {
       !this.mobile ||
       counts.low_stock_count > 0 ||
       (counts.overdue_count ?? 0) > 0 ||
+      (counts.inspection_overdue_count ?? 0) > 0 ||
       counts.checked_out_count > 0;
     if (!anyBadge) return null;
     return html`
@@ -856,6 +865,17 @@ export class HVCardShell extends LitElement {
               @click=${() => this._setFilters({ overdueOnly: !f?.overdueOnly })}
             >
               ${counts.overdue_count} overdue
+            </button>`
+          : null}
+        ${(counts.inspection_overdue_count ?? 0) > 0
+          ? html`<button
+              class="badge inspect ${f?.inspectionDueOnly ? 'on' : ''}"
+              data-testid="badge-inspection"
+              aria-pressed=${String(!!f?.inspectionDueOnly)}
+              title="Show only items due for inspection"
+              @click=${() => this._setFilters({ inspectionDueOnly: !f?.inspectionDueOnly })}
+            >
+              ${counts.inspection_overdue_count} to inspect
             </button>`
           : null}
         ${counts.checked_out_count > 0

--- a/cards/haventory-card/src/components/hv-checkout-popover.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.ts
@@ -3,27 +3,18 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
-import { addDays, formatDate } from '../ui/relative-time';
+import {
+  DEFAULT_CUSTOM_DAYS,
+  QUICK_DAY_OFFSETS,
+  addDays,
+  formatDate,
+} from '../ui/relative-time';
 import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
 import type { Item } from '../store/types';
 
-/**
- * A week, a month, a quarter. +31 rather than +30 so "a month" lands a month
- * later, and nothing shorter than a week — a single day is less than most
- * borrowings ever run.
- */
-const OFFSETS: { days: number; label: string }[] = [
-  { days: 7, label: '+7 days' },
-  { days: 31, label: '+31 days' },
-  { days: 90, label: '+90 days' },
-];
-
 /** Offset the popover pre-selects when it opens. */
 const DEFAULT_OFFSET = 7;
-
-/** What the custom field starts at when it is first opened. */
-const DEFAULT_CUSTOM = 14;
 
 /**
  * Check-out with an optional due date.
@@ -229,7 +220,7 @@ export class HVCheckoutPopover extends LitElement {
   @state() private _zBase = 0;
   /** The +X days field is showing, and owns the date instead of a preset. */
   @state() private _customOpen = false;
-  @state() private _customDays = DEFAULT_CUSTOM;
+  @state() private _customDays = DEFAULT_CUSTOM_DAYS;
 
 
   /** Opening a surface must put focus in it, or Escape never reaches it. */
@@ -246,7 +237,7 @@ export class HVCheckoutPopover extends LitElement {
       this._zBase = nextZBase();
       this._due = this.item?.due_date || addDays(DEFAULT_OFFSET);
       this._customOpen = false;
-      this._customDays = DEFAULT_CUSTOM;
+      this._customDays = DEFAULT_CUSTOM_DAYS;
     }
   }
 
@@ -311,7 +302,7 @@ export class HVCheckoutPopover extends LitElement {
         </div>
         <div class="body">
           <div class="offsets">
-            ${OFFSETS.map((offset) => {
+            ${QUICK_DAY_OFFSETS.map((offset) => {
               const value = addDays(offset.days);
               return html`<button
                 class="offset ${!this._customOpen && this._due === value ? 'on' : ''}"

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -172,6 +172,28 @@ describe('hv-data-table: sorting', () => {
   });
 });
 
+describe('hv-data-table: inspection column', () => {
+  // The header used to read "Inspected", past tense, over a date the rest of
+  // the card treats as the next one due.
+  it('heads the column with the date it holds', async () => {
+    const el = await mount([{ id: '1' }], { columns: ['inspection_date'] });
+    expect(q(el, '[data-field="inspection_date"]')?.textContent?.trim()).toBe('Next inspection');
+  });
+
+  it('marks a cell whose inspection has come due, and only that one', async () => {
+    const el = await mount(
+      [
+        { id: '1', inspection_date: '2020-01-01' },
+        { id: '2', inspection_date: '2099-01-01' },
+        { id: '3', inspection_date: null },
+      ],
+      { columns: ['inspection_date'] },
+    );
+    const cells = all(el, '[data-testid="cell-inspection_date"]');
+    expect(cells.map((c) => c.classList.contains('due'))).toEqual([true, false, false]);
+  });
+});
+
 describe('hv-data-table: rows', () => {
   it('emits row actions with the item id', async () => {
     const el = await mount([{ id: 'item-1', quantity: 5 }]);

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -166,6 +166,12 @@ export class HVDataTable extends LitElement {
         color: var(--hv-error);
         font-weight: 500;
       }
+      /* Amber rather than the due column's red: a passed inspection date is a
+         chore on an item still on the shelf, not an item that is late back. */
+      .cell.inspection.due {
+        color: var(--hv-warn);
+        font-weight: 500;
+      }
       .cell.updated {
         font-size: 12.5px;
         color: var(--hv-text-tertiary);
@@ -306,7 +312,11 @@ export class HVDataTable extends LitElement {
           >${formatDate(item.due_date)}</span
         >`;
       case 'inspection_date':
-        return html`<span class="cell" data-testid="cell-inspection_date">${formatDate(item.inspection_date)}</span>`;
+        return html`<span
+          class="cell inspection ${isOverdue(item.inspection_date) ? 'due' : ''}"
+          data-testid="cell-inspection_date"
+          >${formatDate(item.inspection_date)}</span
+        >`;
       case 'updated_at':
         return html`<span class="cell updated" data-testid="cell-updated_at">${relativeTime(item.updated_at)}</span>`;
     }

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -127,6 +127,23 @@ describe('hv-detail-sheet: read view', () => {
     expect(facts.find((f) => f.dataset.key === 'inspection')?.textContent).toContain('Not set');
   });
 
+  // The row used to read "Last inspected" while the editor's field called the
+  // same value an inspection date — two readings of one stored date.
+  it('names the inspection fact for the date it holds', async () => {
+    const el = await mount({ inspection_date: '2099-03-04' });
+    const fact = all(el, '[data-testid="sheet-fact"]').find((f) => f.dataset.key === 'inspection');
+    expect(fact?.textContent).toContain('Next inspection');
+    expect(fact?.textContent).not.toContain('Last inspected');
+    expect(q(el, '[data-testid="sheet-inspection-due"]')).toBe(null);
+  });
+
+  it('chips an inspection that has come due, and marks the fact', async () => {
+    const el = await mount({ inspection_date: '2020-05-06' });
+    expect(q(el, '[data-testid="sheet-inspection-due"]')?.textContent).toContain('Inspection due');
+    const fact = all(el, '[data-testid="sheet-fact"]').find((f) => f.dataset.key === 'inspection');
+    expect(fact?.querySelector('.value')?.classList.contains('late')).toBe(true);
+  });
+
   it('shows the version alongside when it was updated', async () => {
     const el = await mount({ version: 14 });
     expect(q(el, '[data-testid="sheet-updated"]')?.textContent).toContain('v14');

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -120,6 +120,16 @@ export class HVDetailSheet extends LitElement {
         font-weight: 700;
         letter-spacing: 0.4px;
       }
+      /* Amber, not the red the overdue chip takes: red on this card means an
+         item is out and late back, while an inspection that has come due is a
+         chore on something still on the shelf — the same kind of signal as low
+         stock. Keeping the two hues apart is what lets both chips sit in this
+         row without reading as one alarm. */
+      .chip.inspect {
+        background: var(--hv-warn-bg);
+        color: var(--hv-warn-deep);
+        font-weight: 500;
+      }
       .hero {
         margin: 0 14px 14px;
         background: var(--hv-surface-raised);
@@ -204,6 +214,12 @@ export class HVDetailSheet extends LitElement {
       }
       .fact .value.yes {
         color: var(--hv-success);
+      }
+      /* An inspection date that has passed asks for something to be done, so
+         it does not read as a neutral fact. Same amber as the chip above it. */
+      .fact .value.late {
+        color: var(--hv-warn-deep);
+        font-weight: 500;
       }
       .actions {
         display: grid;
@@ -316,6 +332,9 @@ export class HVDetailSheet extends LitElement {
   private _renderRead(item: Item) {
     const low = isLowStock(item);
     const overdue = isOverdue(item.due_date);
+    // `inspection_date` is when the item is next due for inspection, so the
+    // same passed-date test the due date gets answers "needs inspecting".
+    const inspectionDue = isOverdue(item.inspection_date);
     const path = displayPath(item);
     const customEntries = Object.entries(item.custom_fields ?? {});
 
@@ -345,6 +364,11 @@ export class HVDetailSheet extends LitElement {
                 ${overdue ? 'Overdue' : 'Checked out'}${item.due_date
                   ? ` · due ${formatDate(item.due_date)}`
                   : ''}
+              </span>`
+            : null}
+          ${inspectionDue
+            ? html`<span class="chip inspect" data-testid="sheet-inspection-due">
+                Inspection due · ${formatDate(item.inspection_date)}
               </span>`
             : null}
           ${item.category ? html`<span class="chip" data-testid="sheet-category">${item.category}</span>` : null}
@@ -391,8 +415,8 @@ export class HVDetailSheet extends LitElement {
           <span class="value ${item.due_date ? '' : 'unset'}">${item.due_date ? formatDate(item.due_date) : 'Not set'}</span>
         </div>
         <div class="fact" data-testid="sheet-fact" data-key="inspection">
-          <span>Last inspected</span>
-          <span class="value ${item.inspection_date ? '' : 'unset'}"
+          <span>Next inspection</span>
+          <span class="value ${item.inspection_date ? '' : 'unset'} ${inspectionDue ? 'late' : ''}"
             >${item.inspection_date ? formatDate(item.inspection_date) : 'Not set'}</span
           >
         </div>

--- a/cards/haventory-card/src/components/hv-filter-chips.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.test.ts
@@ -91,6 +91,14 @@ describe('chipsFor', () => {
     expect(byKey).toMatchObject({ lowStockOnly: 'warning', overdueOnly: 'warning', checkedOutOnly: 'primary' });
   });
 
+  // Pressing the app-bar pill sets a server-side filter; without a chip the
+  // list would be narrowed with nothing on screen saying so, and no way back
+  // except finding the pill again.
+  it('shows the inspection filter as its own removable chip', () => {
+    const chips = chipsFor({ ...defaultFilters(), inspectionDueOnly: true });
+    expect(chips).toEqual([{ key: 'inspectionDueOnly', label: 'Inspection due', tone: 'warning' }]);
+  });
+
   it('emits one chip per date bound so a range can be half-undone', () => {
     const filters = {
       ...defaultFilters(),
@@ -124,7 +132,7 @@ describe('clearedValueFor', () => {
   });
 
   it('clears the boolean toggles to false', () => {
-    for (const key of ['checkedOutOnly', 'orphansOnly', 'lowStockOnly', 'lowStockFirst', 'overdueOnly'] as const) {
+    for (const key of ['checkedOutOnly', 'orphansOnly', 'lowStockOnly', 'lowStockFirst', 'overdueOnly', 'inspectionDueOnly'] as const) {
       expect(clearedValueFor(key)).toEqual({ [key]: false });
     }
   });

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -16,6 +16,7 @@ export type FilterChipKey =
   | 'lowStockOnly'
   | 'lowStockFirst'
   | 'overdueOnly'
+  | 'inspectionDueOnly'
   | 'category'
   | 'tags'
   | 'updatedAfter'
@@ -67,6 +68,8 @@ export function chipsFor(
   if (filters.lowStockFirst) chips.push({ key: 'lowStockFirst', label: 'Low stock first', tone: 'primary' });
   if (filters.checkedOutOnly) chips.push({ key: 'checkedOutOnly', label: 'Checked out', tone: 'primary' });
   if (filters.overdueOnly) chips.push({ key: 'overdueOnly', label: 'Overdue', tone: 'warning' });
+  if (filters.inspectionDueOnly)
+    chips.push({ key: 'inspectionDueOnly', label: 'Inspection due', tone: 'warning' });
   if (filters.orphansOnly) chips.push({ key: 'orphansOnly', label: 'No location', tone: 'primary' });
   // One chip per bound rather than one per field: each is separately clearable,
   // so a range narrowed too far can be half-undone.

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -564,3 +564,50 @@ describe('hv-filter-panel: overdue', () => {
     expect(seen[0]).toEqual({ overdueOnly: true });
   });
 });
+
+describe('hv-filter-panel: inspection due', () => {
+  // The sort menu is the one place the field is named rather than described,
+  // so it has to carry the same forward-looking wording as the editor.
+  it('names the inspection sort field for the date it holds', async () => {
+    const el = await mount();
+    const labels = [...q(el, '[data-testid="filter-sort-field"]').querySelectorAll('option')].map(
+      (o) => (o as HTMLOptionElement).textContent?.trim(),
+    );
+    expect(labels).toContain('Next inspection');
+    expect(labels).not.toContain('Inspection date');
+  });
+
+  it('offers the filter on both widths, tallied from the backend count', async () => {
+    for (const mobile of [false, true]) {
+      const el = await mount(
+        {},
+        {
+          mobile,
+          counts: {
+            items_total: 9,
+            locations_total: 2,
+            low_stock_count: 4,
+            checked_out_count: 3,
+            overdue_count: 1,
+            inspection_overdue_count: 5,
+            no_location_count: 2,
+          },
+        },
+      );
+      const chip = q(el, '[data-testid="filter-inspection-due"]');
+      expect(chip.textContent, `mobile=${mobile}`).toContain('Inspection due');
+      expect(chip.textContent, `mobile=${mobile}`).toContain('5');
+
+      // The phone branch stages its edits behind the "Show N items" row; the
+      // desktop one applies straight away.
+      const applied: Partial<StoreFilters>[] = [];
+      el.addEventListener('change', (e) => applied.push((e as CustomEvent).detail));
+      el.addEventListener('stage', (e) =>
+        applied.push((e as CustomEvent).detail.filters as StoreFilters),
+      );
+      (chip as HTMLButtonElement).click();
+      expect(applied[0], `mobile=${mobile}`).toMatchObject({ inspectionDueOnly: true });
+      el.remove();
+    }
+  });
+});

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -22,7 +22,7 @@ const SORT_FIELDS: { field: SortField; label: string }[] = [
   { field: 'name', label: 'Name' },
   { field: 'quantity', label: 'Quantity' },
   { field: 'due_date', label: 'Due date' },
-  { field: 'inspection_date', label: 'Inspection date' },
+  { field: 'inspection_date', label: 'Next inspection' },
 ];
 
 /** How many category chips to show before collapsing the rest behind "More…". */
@@ -657,6 +657,7 @@ export class HVFilterPanel extends LitElement {
                 ${this._renderCheckbox('Low stock', f.lowStockOnly, () => this._patch({ lowStockOnly: !f.lowStockOnly }), { warning: true, tally: c?.low_stock_count, testid: 'filter-low-stock-only' })}
                 ${this._renderCheckbox('Checked out', f.checkedOutOnly, () => this._patch({ checkedOutOnly: !f.checkedOutOnly }), { tally: c?.checked_out_count, testid: 'filter-checked-out' })}
                 ${this._renderCheckbox('Overdue', f.overdueOnly, () => this._patch({ overdueOnly: !f.overdueOnly }), { warning: true, tally: c?.overdue_count, testid: 'filter-overdue' })}
+                ${this._renderCheckbox('Inspection due', f.inspectionDueOnly, () => this._patch({ inspectionDueOnly: !f.inspectionDueOnly }), { warning: true, tally: c?.inspection_overdue_count, testid: 'filter-inspection-due' })}
                 ${this._renderCheckbox('No location', f.orphansOnly, () => this._patch({ orphansOnly: !f.orphansOnly }), { tally: c?.no_location_count, testid: 'filter-orphans' })}
               `
             : html`
@@ -680,6 +681,13 @@ export class HVFilterPanel extends LitElement {
                   @click=${() => this._patch({ overdueOnly: !f.overdueOnly })}
                 >
                   ${f.overdueOnly ? icon('check', 12) : null}Overdue${tally(c?.overdue_count)}
+                </button>
+                <button
+                  class="chip ${f.inspectionDueOnly ? 'on warning' : ''}"
+                  data-testid="filter-inspection-due"
+                  @click=${() => this._patch({ inspectionDueOnly: !f.inspectionDueOnly })}
+                >
+                  ${f.inspectionDueOnly ? icon('check', 12) : null}Inspection due${tally(c?.inspection_overdue_count)}
                 </button>
                 <button
                   class="chip ${f.orphansOnly ? 'on' : ''}"

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -804,6 +804,30 @@ describe('hv-full-view: app bar filters', () => {
     expect(q(sr, '[data-testid="full-badge-out"]')).toBeTruthy();
   });
 
+  // An inspection that has come due is independent of any check-out, so the
+  // pill counts shelved items the overdue pill never sees.
+  it('carries the inspection count, and filters the list on it', async () => {
+    const due = [
+      makeItem({ id: '1', inspection_date: '2000-01-01' }),
+      makeItem({ id: '2', inspection_date: '2999-12-31' }),
+    ];
+    const { el, store, sr } = await mount({ items: due });
+    const pill = q(sr, '[data-testid="full-badge-inspection"]') as HTMLButtonElement;
+    expect(pill?.textContent).toContain('1 to inspect');
+    expect(q(sr, '[data-testid="full-badge-overdue"]')).toBe(null);
+
+    pill.click();
+    await settle(el);
+    expect(store.state.value.filters.inspectionDueOnly).toBe(true);
+    expect(q(sr, '[data-testid="full-badge-inspection"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(store.state.value.items.map((i) => i.id)).toEqual(['1']);
+  });
+
+  it('drops the inspection pill when nothing is due', async () => {
+    const { sr } = await mount({ items: [makeItem({ id: '1', inspection_date: '2999-12-31' })] });
+    expect(q(sr, '[data-testid="full-badge-inspection"]')).toBe(null);
+  });
+
   // "82 out" reads as "82 out of stock", which is the opposite of what it counts.
   it('spells out what the checked-out pill counts', async () => {
     const { sr } = await mount({ items: flagged });

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -213,6 +213,13 @@ export class HVFullView extends LitElement {
         background: var(--hv-error);
         color: #fff;
       }
+      /* Amber like low stock, not red like overdue: red is reserved here for an
+         item that is out and late back, while an inspection that has come due
+         is a chore on something still on the shelf. */
+      .appbar .pill.inspect {
+        background: var(--hv-amber);
+        color: #3b2600;
+      }
       .appbar .add {
         flex: none;
         display: inline-flex;
@@ -1413,6 +1420,17 @@ export class HVFullView extends LitElement {
                 @click=${() => this._setFilters({ overdueOnly: !filters.overdueOnly })}
               >
                 ${counts.overdue_count} overdue
+              </button>`
+            : null}
+          ${counts && (counts.inspection_overdue_count ?? 0) > 0
+            ? html`<button
+                class="pill inspect ${filters.inspectionDueOnly ? 'on' : ''}"
+                data-testid="full-badge-inspection"
+                aria-pressed=${String(filters.inspectionDueOnly)}
+                title="Show only items due for inspection"
+                @click=${() => this._setFilters({ inspectionDueOnly: !filters.inspectionDueOnly })}
+              >
+                ${counts.inspection_overdue_count} to inspect
               </button>`
             : null}
           ${counts && counts.checked_out_count > 0

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -260,6 +260,70 @@ describe('hv-item-editor: field parity', () => {
     expect(q(el, '[data-testid="editor-inspection-caption"]')?.getAttribute('for')).toBe('editor-inspection');
   });
 
+  // The field is when the item is next due for inspection, so the caption says
+  // that rather than leaving "Inspection date" to be read either way.
+  it('captions the inspection field for the date it holds', async () => {
+    const el = await mount(makeItem({ id: '1' }));
+    const caption = q(el, '[data-testid="editor-inspection-caption"]')?.textContent?.trim();
+    expect(caption).toBe('Next inspection');
+  });
+
+  // An interval is known in weeks or months; a date three months out is
+  // arithmetic. Same jumps as the check-out popover, since it is one gesture.
+  it('offers the same quick offsets the check-out popover does', async () => {
+    const el = await mount(makeItem({ id: '1', inspection_date: null }));
+    expect(all(el, '[data-testid="editor-inspection-offset"]').map((b) => b.dataset.days)).toEqual([
+      '7',
+      '31',
+      '90',
+    ]);
+
+    const dateInput = () => q(el, '[data-testid="editor-inspection-date"]') as HTMLInputElement;
+    (all(el, '[data-testid="editor-inspection-offset"]')[1] as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(dateInput().value).toBe(addDays(31));
+    expect(all(el, '[data-testid="editor-inspection-offset"]')[1].classList.contains('on')).toBe(true);
+  });
+
+  it('takes an interval of your own behind +X days', async () => {
+    const el = await mount(makeItem({ id: '1', inspection_date: null }));
+    expect(q(el, '[data-testid="editor-inspection-custom"]')).toBe(null);
+
+    (q(el, '[data-testid="editor-inspection-offset-custom"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const dateInput = () => q(el, '[data-testid="editor-inspection-date"]') as HTMLInputElement;
+    expect(dateInput().value).toBe(addDays(14));
+
+    const input = q(el, '[data-testid="editor-inspection-custom"]')?.querySelector(
+      'input',
+    ) as HTMLInputElement;
+    input.value = '180';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    expect(dateInput().value).toBe(addDays(180));
+    // No preset can claim the date while the custom field owns it.
+    expect(
+      all(el, '[data-testid="editor-inspection-offset"]').some((b) => b.classList.contains('on')),
+    ).toBe(false);
+
+    // An emptied box means no date yet rather than the last one it wrote.
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    expect(dateInput().value).toBe('');
+  });
+
+  it('saves the date an offset picked', async () => {
+    const el = await mount(makeItem({ id: 'item-1', inspection_date: null, version: 3 }));
+    const saves = onSave(el);
+
+    (all(el, '[data-testid="editor-inspection-offset"]')[0] as HTMLButtonElement).click();
+    await el.updateComplete;
+    (q(el, '[data-testid="editor-save"]') as HTMLButtonElement).click();
+
+    expect(saves[0].changes?.inspection_date).toBe(addDays(7));
+  });
+
   it('stacks the checkout box on a phone rather than halving a date field', () => {
     const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
     const css = (Array.isArray(styles) ? styles : [styles])

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -3,7 +3,14 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { locationLabel } from '../ui/location-path';
 import { icon } from '../ui/icons';
-import { relativeTime, formatDate, isOverdue } from '../ui/relative-time';
+import {
+  DEFAULT_CUSTOM_DAYS,
+  QUICK_DAY_OFFSETS,
+  addDays,
+  formatDate,
+  isOverdue,
+  relativeTime,
+} from '../ui/relative-time';
 import { saveShortcutLabel } from '../ui/keyboard';
 import { counted } from '../ui/plural';
 import { nextZBase } from '../utils/zindex';
@@ -122,7 +129,7 @@ export class HVItemEditor extends LitElement {
         gap: 4px;
         min-width: 0;
       }
-      /* Checked out and Due date are two halves of one fact; Inspection date is
+      /* Checked out and Due date are two halves of one fact; Next inspection is
          unrelated to both. The boxes below carry that split visually, so the
          three fields are never read as three peer settings of the same kind. */
       .state {
@@ -185,6 +192,58 @@ export class HVItemEditor extends LitElement {
         font-size: 11.5px;
         line-height: 1.4;
         color: var(--hv-text-tertiary);
+      }
+      /* Same chips, same states as the check-out popover's: one gesture, so it
+         must not look like two. */
+      .offsets {
+        display: flex;
+        gap: 7px;
+        flex-wrap: wrap;
+      }
+      .offset {
+        border: 1px solid var(--hv-divider);
+        background: none;
+        color: var(--hv-chip-text);
+        border-radius: var(--hv-radius-chip);
+        padding: 6px 13px;
+        font: 400 12.5px var(--hv-font);
+        cursor: pointer;
+      }
+      :host([mobile]) .offset {
+        min-height: var(--hv-tap-min, auto);
+        padding: 0 15px;
+        font-size: 13.5px;
+      }
+      .offset.on {
+        background: var(--hv-primary-dark);
+        border-color: var(--hv-primary-dark);
+        color: #fff;
+        font-weight: 500;
+      }
+      .custom-days {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border: 1px solid var(--hv-divider);
+        border-radius: var(--hv-radius-input);
+        font-size: 13px;
+        color: var(--hv-text-secondary);
+      }
+      .custom-days input {
+        width: 72px;
+        box-sizing: border-box;
+        border: 1px solid var(--hv-input-border);
+        border-radius: var(--hv-radius-input);
+        background: var(--hv-surface);
+        color: var(--hv-text);
+        padding: 5px 8px;
+        font: 400 13.5px var(--hv-font);
+      }
+      :host([mobile]) .custom-days input {
+        min-height: 44px;
+        width: 88px;
+        font-size: var(--hv-input-font, 14.5px);
       }
       /* A native date input clips its own placeholder much below ~140px, and
          half of a 375px screen minus the box padding is under that. */
@@ -614,6 +673,9 @@ export class HVItemEditor extends LitElement {
   /** The check-out dialog, and the button it hangs from on a wide screen. */
   @state() private _checkoutOpen = false;
   @state() private _checkoutAnchor: DOMRect | null = null;
+  /** The inspection field's "+X days" row is showing, and owns the date. */
+  @state() private _inspectionCustomOpen = false;
+  @state() private _inspectionCustomDays = DEFAULT_CUSTOM_DAYS;
 
   /**
    * The footer promises "Esc discards", but that is a keydown handler on the
@@ -942,10 +1004,11 @@ export class HVItemEditor extends LitElement {
    *
    * A due date is half of the checkout — it only means anything while an item
    * is out, which is why it is disabled otherwise and why `commonFields()`
-   * nulls it on save. An inspection date is an unrelated fact about the item.
-   * Laid out as three equal thirds of a row they read as three settings of the
-   * same kind, so the two boxes below carry the distinction visually, on both
-   * widths.
+   * nulls it on save. The inspection date is unrelated to any of that: it is
+   * when the item is next due for inspection, and it stands whether or not
+   * anyone has borrowed it. Laid out as three equal thirds of a row they read
+   * as three settings of the same kind, so the two boxes below carry the
+   * distinction visually, on both widths.
    *
    * The state itself is a button rather than a switch. A switch says "this is
    * a property of the item, set it either way"; checking something out is an
@@ -1013,7 +1076,7 @@ export class HVItemEditor extends LitElement {
         </div>
         <div class="group">
           <label class="group-caption" for="editor-inspection" data-testid="editor-inspection-caption">
-            ${icon('calendar', 14)} Inspection date
+            ${icon('calendar', 14)} Next inspection
           </label>
           <div class="group-body">
             <input
@@ -1024,6 +1087,7 @@ export class HVItemEditor extends LitElement {
               .value=${model.inspectionDate}
               @input=${(e: Event) => this._patch({ inspectionDate: (e.target as HTMLInputElement).value })}
             />
+            ${this._renderInspectionOffsets(model.inspectionDate)}
           </div>
         </div>
       </div>
@@ -1039,6 +1103,70 @@ export class HVItemEditor extends LitElement {
    * when the form is saved, which is what lets it work while creating an item
    * that has no id to check out yet.
    */
+  /**
+   * The same quick jumps the check-out popover offers, on the one date it does
+   * not own. An inspection interval is the kind of thing you know in weeks or
+   * months rather than as a calendar square, and typing a date three months out
+   * means doing the arithmetic yourself. Pressing an offset writes the date into
+   * the field above, so the two controls are one value with two ways in.
+   *
+   * The custom row only appears once "+X days" is pressed: it is the escape
+   * hatch for an interval the three presets do not cover, not a fourth preset.
+   */
+  private _renderInspectionOffsets(current: string) {
+    return html`
+      <div class="offsets" data-testid="editor-inspection-offsets">
+        ${QUICK_DAY_OFFSETS.map((offset) => {
+          const value = addDays(offset.days);
+          return html`<button
+            class="offset ${!this._inspectionCustomOpen && current === value ? 'on' : ''}"
+            data-testid="editor-inspection-offset"
+            data-days=${offset.days}
+            @click=${() => {
+              this._inspectionCustomOpen = false;
+              this._patch({ inspectionDate: value });
+            }}
+          >
+            ${offset.label}
+          </button>`;
+        })}
+        <button
+          class="offset ${this._inspectionCustomOpen ? 'on' : ''}"
+          data-testid="editor-inspection-offset-custom"
+          @click=${() => {
+            this._inspectionCustomOpen = true;
+            this._patch({ inspectionDate: addDays(this._inspectionCustomDays) });
+          }}
+        >
+          +X days
+        </button>
+      </div>
+      ${this._inspectionCustomOpen
+        ? html`<label class="custom-days" data-testid="editor-inspection-custom">
+            <input
+              type="number"
+              min="1"
+              max="3650"
+              inputmode="numeric"
+              aria-label="Days from today"
+              .value=${String(this._inspectionCustomDays)}
+              @input=${(e: Event) => {
+                const days = Number((e.target as HTMLInputElement).value);
+                this._inspectionCustomDays = days;
+                // An empty or nonsense box means no date yet rather than a
+                // stale one, so the field clears instead of keeping the last.
+                this._patch({
+                  inspectionDate:
+                    Number.isFinite(days) && days >= 1 ? addDays(Math.floor(days)) : '',
+                });
+              }}
+            />
+            <span>days from today</span>
+          </label>`
+        : null}
+    `;
+  }
+
   private _onCheckoutPressed = (e: Event) => {
     if (this._model.checkedOut) {
       this._patch({ checkedOut: false });

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -1,6 +1,7 @@
 import './hv-list-row';
 import { makeItem } from '../test.utils';
 import { displayPath, elidePath, isLowStock } from './hv-list-row';
+import { toIsoDate } from '../ui/relative-time';
 import type { HVListRow } from './hv-list-row';
 import type { Item } from '../store/types';
 
@@ -109,6 +110,56 @@ describe('hv-list-row: content', () => {
   it('does not call a future due date overdue', async () => {
     const el = await mount({ checked_out: true, due_date: '2099-01-01' });
     expect(q(el, '[data-testid="row-checked-out"]')?.classList.contains('overdue')).toBe(false);
+  });
+
+  // `inspection_date` says when the item is next due for inspection, so a date
+  // behind us is a chore waiting — on an item nobody has to have borrowed.
+  it('badges a row whose next inspection has passed', async () => {
+    const el = await mount({ inspection_date: '2020-01-01' });
+    expect(q(el, '[data-testid="row-inspection-due"]')?.textContent?.trim()).toBe('Inspection due');
+    expect(q(el, '[data-testid="row-checked-out"]')).toBe(null);
+  });
+
+  it('leaves a future or unset inspection date unbadged', async () => {
+    for (const mobile of [false, true]) {
+      const future = await mount({ inspection_date: '2099-01-01' }, { mobile });
+      expect(q(future, '[data-testid="row-inspection-due"]'), `mobile=${mobile}`).toBe(null);
+
+      const unset = await mount({ inspection_date: null }, { mobile });
+      expect(q(unset, '[data-testid="row-inspection-due"]'), `mobile=${mobile}`).toBe(null);
+    }
+  });
+
+  // The standard card is in its phone layout at any ordinary dashboard width,
+  // and that branch hangs no chips off the row at all — so the one line it has
+  // says it instead, and the badge is not invisible on the commonest surface.
+  it('says it on the phone row, where there is no room for a chip', async () => {
+    const el = await mount({ inspection_date: '2020-05-06' }, { mobile: true });
+    const secondary = q(el, '[data-testid="row-secondary"]');
+    expect(q(el, '[data-testid="row-inspection-due"]')).toBeTruthy();
+    expect(secondary?.textContent).toContain('Inspection due');
+    expect(secondary?.classList.contains('inspect')).toBe(true);
+  });
+
+  // Someone holding the item outranks a chore on the shelf, so the line keeps
+  // saying who has it.
+  it('yields the phone line to the checkout state', async () => {
+    const el = await mount(
+      { checked_out: true, due_date: '2099-01-01', inspection_date: '2020-05-06' },
+      { mobile: true },
+    );
+    const secondary = q(el, '[data-testid="row-secondary"]');
+    expect(secondary?.textContent).toContain('Checked out');
+    expect(secondary?.textContent).not.toContain('Inspection due');
+  });
+
+  // Today's inspection has not been missed — same strictly-before boundary the
+  // backend count and filter use, so the row and the pill cannot disagree.
+  it('does not badge an inspection due today', async () => {
+    for (const mobile of [false, true]) {
+      const el = await mount({ inspection_date: toIsoDate() }, { mobile });
+      expect(q(el, '[data-testid="row-inspection-due"]'), `mobile=${mobile}`).toBe(null);
+    }
   });
 });
 

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -120,6 +120,12 @@ export class HVListRow extends LitElement {
         color: var(--hv-error);
         font-weight: 500;
       }
+      /* Amber, not that red: red here means an item is out and late back, while
+         an inspection that has come due is a chore on something on the shelf. */
+      .secondary.inspect {
+        color: var(--hv-warn-deep);
+        font-weight: 500;
+      }
       .dot {
         display: inline-block;
         vertical-align: middle;
@@ -151,6 +157,19 @@ export class HVListRow extends LitElement {
         color: #fff;
         background: var(--hv-error);
         border-color: var(--hv-error);
+      }
+      /* Amber, not the out-chip's red: red on this card is reserved for an item
+         that is out and late back, while an inspection that has come due is a
+         chore on something still on the shelf. */
+      .inspect-chip {
+        flex: none;
+        font: 500 11px var(--hv-font);
+        color: var(--hv-warn-deep);
+        background: var(--hv-warn-bg);
+        border: 1px solid var(--hv-warn-border);
+        border-radius: var(--hv-radius-chip);
+        padding: 2px 8px;
+        white-space: nowrap;
       }
       .hover-actions {
         flex: none;
@@ -378,6 +397,9 @@ export class HVListRow extends LitElement {
     if (!item) return null;
     const low = isLowStock(item);
     const overdue = isOverdue(item.due_date);
+    // `inspection_date` is when the item is next due for inspection, so a date
+    // already behind us means it is waiting to be done.
+    const inspectionDue = isOverdue(item.inspection_date);
     // The desktop row has room for the whole path; the phone row does not, and
     // clipping it from the right would take the leaf with it.
     const full = displayPath(item);
@@ -386,6 +408,11 @@ export class HVListRow extends LitElement {
     // The tooltip carries the *unelided* path: on a phone the middle of it is
     // dropped on purpose, and this is where the whole thing can still be read.
     const secondaryFull = [full, item.category].filter(Boolean).join(' · ');
+    // A phone row has one line for all of this and no room for the chips the
+    // wide row hangs on the right, so the line says the most interrupting
+    // thing it has: who has the item, then what the item is waiting for, then
+    // where it lives. The path is a tap away in the detail sheet either way.
+    const mobileState = item.checked_out ? 'out' : inspectionDue ? 'inspect' : '';
 
     return html`
       <div
@@ -419,7 +446,7 @@ export class HVListRow extends LitElement {
         <span class="names">
           <span class="name" data-testid="row-name" title=${item.name}>${item.name}</span>
           <span
-            class="secondary ${item.checked_out && this.mobile ? 'out' : ''} ${overdue && this.mobile
+            class="secondary ${this.mobile ? mobileState : ''} ${overdue && this.mobile
               ? 'overdue'
               : ''}"
             data-testid="row-secondary"
@@ -432,7 +459,9 @@ export class HVListRow extends LitElement {
               ? html`${overdue ? 'Overdue' : 'Checked out'}${item.due_date
                   ? ` · due ${formatDate(item.due_date)}`
                   : ''}`
-              : secondary || 'No location'}
+              : this.mobile && inspectionDue
+                ? html`<span data-testid="row-inspection-due">Inspection due</span> · ${formatDate(item.inspection_date)}`
+                : secondary || 'No location'}
           </span>
         </span>
         ${this.pending ? html`<span class="pending" data-testid="row-pending">pending</span>` : null}
@@ -442,6 +471,11 @@ export class HVListRow extends LitElement {
         ${!this.mobile && item.checked_out
           ? html`<span class="out-chip ${overdue ? 'overdue' : ''}" data-testid="row-checked-out">
               ${overdue ? `Overdue · ${formatDate(item.due_date)}` : 'Checked out'}
+            </span>`
+          : null}
+        ${!this.mobile && inspectionDue
+          ? html`<span class="inspect-chip" data-testid="row-inspection-due">
+              Inspection due
             </span>`
           : null}
         ${this.selectable

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+  COLUMN_DEFS,
   COLUMN_PREFS_STORAGE_KEY,
   DEFAULT_COLUMNS,
   loadColumnPrefs,
@@ -53,6 +54,14 @@ describe('columns model', () => {
   it('falls back when the stored object names no selection at all', () => {
     localStorage.setItem(COLUMN_PREFS_STORAGE_KEY, JSON.stringify({ standard: ['quantity'] }));
     expect(loadColumnPrefs()).toEqual(DEFAULT_COLUMNS);
+  });
+
+  // "Inspected" read as the date of the last inspection; the field holds the
+  // next one due, which is what every other surface now says.
+  it('labels the inspection column for the date it holds', () => {
+    const col = COLUMN_DEFS.find((c) => c.key === 'inspection_date');
+    expect(col?.label).toBe('Next inspection');
+    expect(col?.sortField).toBe('inspection_date');
   });
 });
 

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -38,8 +38,10 @@ export const COLUMN_DEFS: readonly ColumnDef[] = [
   { key: 'due_date', label: 'Due', tableSize: '100px', sortField: 'due_date' },
   {
     key: 'inspection_date',
-    label: 'Inspected',
-    tableSize: '100px',
+    label: 'Next inspection',
+    // Wider than the other date columns because the header is what sets the
+    // floor here, not the "Jul 31" it sits above.
+    tableSize: '124px',
     sortField: 'inspection_date',
   },
   { key: 'updated_at', label: 'Updated', tableSize: '96px', sortField: 'updated_at' },

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -65,6 +65,7 @@ describe('toWireFilter', () => {
       lowStockFirst: true,
       orphansOnly: true,
       overdueOnly: true,
+      inspectionDueOnly: true,
       category: 'Hardware',
       updatedAfter: '2026-07-01T00:00:00Z',
       createdAfter: '2026-01-01T00:00:00Z',
@@ -80,6 +81,7 @@ describe('toWireFilter', () => {
       low_stock_first: true,
       orphaned_only: true,
       overdue_only: true,
+      inspection_overdue_only: true,
       category: 'Hardware',
       updated_after: '2026-07-01T00:00:00Z',
       created_after: '2026-01-01T00:00:00Z',
@@ -93,6 +95,7 @@ describe('toWireFilter', () => {
     expect(wire.updated_before).toBeUndefined();
     expect(wire.created_before).toBeUndefined();
     expect(wire.overdue_only).toBeUndefined();
+    expect(wire.inspection_overdue_only).toBeUndefined();
   });
 
   it('keeps low-stock-only and low-stock-first independent', () => {
@@ -132,6 +135,10 @@ describe('activeFilterCount', () => {
 
   it('counts each date bound and the overdue toggle', () => {
     expect(activeFilterCount({ ...defaultFilters(), overdueOnly: true })).toBe(1);
+    // The two date filters answer different questions, so they narrow twice.
+    expect(
+      activeFilterCount({ ...defaultFilters(), overdueOnly: true, inspectionDueOnly: true }),
+    ).toBe(2);
     // A window is two separate bounds, each separately clearable.
     expect(
       activeFilterCount({

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -145,6 +145,7 @@ export function toWireFilter(filters: StoreFilters): ItemFilter {
     low_stock_first: filters.lowStockFirst || undefined,
     orphaned_only: filters.orphansOnly || undefined,
     overdue_only: filters.overdueOnly || undefined,
+    inspection_overdue_only: filters.inspectionDueOnly || undefined,
     category: filters.category || undefined,
     updated_after: filters.updatedAfter || undefined,
     created_after: filters.createdAfter || undefined,
@@ -170,6 +171,7 @@ export function defaultFilters(): StoreFilters {
     orphansOnly: false,
     lowStockOnly: false,
     overdueOnly: false,
+    inspectionDueOnly: false,
     category: null,
     tags: [],
     tagsMode: 'any',
@@ -192,6 +194,7 @@ export function activeFilterCount(filters: StoreFilters): number {
   if (filters.lowStockOnly) n += 1;
   if (filters.lowStockFirst) n += 1;
   if (filters.overdueOnly) n += 1;
+  if (filters.inspectionDueOnly) n += 1;
   if (filters.category) n += 1;
   if (filters.tags.length) n += 1;
   if (filters.updatedAfter) n += 1;

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -81,6 +81,11 @@ export interface ItemFilter {
   orphaned_only?: boolean;
   /** Only items whose `due_date` is strictly before today (UTC). */
   overdue_only?: boolean;
+  /**
+   * Only items whose `inspection_date` is strictly before today (UTC) — i.e.
+   * the next inspection is already missed. Independent of check-out state.
+   */
+  inspection_overdue_only?: boolean;
   location_id?: string | null;
   area_id?: string;
   include_subtree?: boolean;
@@ -115,6 +120,12 @@ export interface StatsCounts {
    * because older backends do not send it.
    */
   overdue_count?: number;
+  /**
+   * Items past the date they were next due for inspection, across the whole
+   * inventory. Calendar-derived like `overdue_count`, and optional for the
+   * same reason: an older backend does not send it.
+   */
+  inspection_overdue_count?: number;
   locations_total: number;
   /** Items without a location (location_id == null). */
   no_location_count: number;
@@ -375,6 +386,8 @@ export interface StoreFilters {
   lowStockOnly: boolean;
   /** Only items past their due date. */
   overdueOnly: boolean;
+  /** Only items past the date they were next due for inspection. */
+  inspectionDueOnly: boolean;
   category: string | null;
   tags: string[];
   tagsMode: TagMatchMode;

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -94,6 +94,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
             low_stock_count: items.filter((i) => typeof i.low_stock_threshold === 'number' && i.quantity <= (i.low_stock_threshold as number)).length,
             checked_out_count: items.filter((i) => i.checked_out).length,
             overdue_count: items.filter((i) => isMockOverdue(i)).length,
+            inspection_overdue_count: items.filter((i) => isMockInspectionDue(i)).length,
             locations_total: locations.length,
             no_location_count: items.filter((i) => i.location_id == null).length,
           };
@@ -105,6 +106,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
             low_stock_count: items.filter((i) => typeof i.low_stock_threshold === 'number' && i.quantity <= (i.low_stock_threshold as number)).length,
             checked_out_count: items.filter((i) => i.checked_out).length,
             overdue_count: items.filter((i) => isMockOverdue(i)).length,
+            inspection_overdue_count: items.filter((i) => isMockInspectionDue(i)).length,
             locations_total: locations.length,
             no_location_count: items.filter((i) => i.location_id == null).length,
           };
@@ -558,6 +560,11 @@ function isMockOverdue(item: Item): boolean {
   return !!item.due_date && item.due_date < new Date().toISOString().slice(0, 10);
 }
 
+/** Same rule against `inspection_date`, over every item rather than the out ones. */
+function isMockInspectionDue(item: Item): boolean {
+  return !!item.inspection_date && item.inspection_date < new Date().toISOString().slice(0, 10);
+}
+
 /** Faithful-but-small mirror of the backend ItemFilter semantics (AND of all predicates). */
 function applyMockFilter(list: Item[], rawFilter: unknown): Item[] {
   const filter = (rawFilter ?? null) as {
@@ -565,6 +572,7 @@ function applyMockFilter(list: Item[], rawFilter: unknown): Item[] {
     checked_out?: boolean;
     orphaned_only?: boolean;
     overdue_only?: boolean;
+    inspection_overdue_only?: boolean;
     location_id?: string | null;
     include_subtree?: boolean;
     category?: string;
@@ -597,6 +605,7 @@ function applyMockFilter(list: Item[], rawFilter: unknown): Item[] {
     if (typeof filter.checked_out === 'boolean' && it.checked_out !== filter.checked_out) return false;
     if (filter.orphaned_only && it.location_id !== null) return false;
     if (filter.overdue_only && !isMockOverdue(it)) return false;
+    if (filter.inspection_overdue_only && !isMockInspectionDue(it)) return false;
     // Canonical 'Z' timestamps compare lexicographically; both bounds are exclusive.
     if (filter.updated_after && !(it.updated_at > filter.updated_after)) return false;
     if (filter.updated_before && !(it.updated_at < filter.updated_before)) return false;

--- a/cards/haventory-card/src/ui/relative-time.ts
+++ b/cards/haventory-card/src/ui/relative-time.ts
@@ -12,7 +12,7 @@ const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 const YEAR = 365 * DAY;
 
-/** Parse an ISO timestamp, returning null for missing or unparseable input. */
+/** Parse an ISO timestamp, returning null for missing or unparsable input. */
 export function parseTs(iso: string | null | undefined): number | null {
   if (!iso) return null;
   const ms = Date.parse(iso);
@@ -21,7 +21,7 @@ export function parseTs(iso: string | null | undefined): number | null {
 
 /**
  * Format `iso` relative to `now` (defaults to the current time).
- * Returns an em dash for missing or unparseable timestamps so callers can drop
+ * Returns an em dash for missing or unparsable timestamps so callers can drop
  * it straight into a cell.
  */
 export function relativeTime(iso: string | null | undefined, now: number = Date.now()): string {
@@ -69,7 +69,25 @@ export function toIsoDate(ms: number = Date.now()): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
-/** `YYYY-MM-DD` offset by whole days from `from` — powers the +1/+7/+30 chips. */
+/** `YYYY-MM-DD` offset by whole days from `from` — powers the quick-offset chips. */
 export function addDays(days: number, from: number = Date.now()): string {
   return toIsoDate(from + days * DAY);
 }
+
+/**
+ * The quick offsets every forward-dating control offers: a week, a month, a
+ * quarter. +31 rather than +30 so "a month" lands a month later, and nothing
+ * shorter than a week — a single day is less than most borrowings ever run,
+ * and less than any inspection interval worth recording.
+ *
+ * Shared so the check-out popover and the editor's inspection field cannot
+ * drift into offering different jumps for the same gesture.
+ */
+export const QUICK_DAY_OFFSETS: readonly { days: number; label: string }[] = [
+  { days: 7, label: '+7 days' },
+  { days: 31, label: '+31 days' },
+  { days: 90, label: '+90 days' },
+];
+
+/** What a "+X days" field starts at when it is first opened. */
+export const DEFAULT_CUSTOM_DAYS = 14;

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -70,6 +70,8 @@ class Item:
     quantity: int = 1
     checked_out: bool = False
     due_date: str | None = None  # YYYY-MM-DD
+    # When the item is next due for inspection — a forward-looking date, so a
+    # value before today means the inspection is outstanding.
     inspection_date: str | None = None  # YYYY-MM-DD
     location_id: uuid.UUID | None = None
     tags: list[str] = field(default_factory=list)
@@ -132,6 +134,8 @@ class ItemFilter(TypedDict, total=False):
     orphaned_only: bool
     # When true, only items whose due_date has passed (see filter_items)
     overdue_only: bool
+    # When true, only items whose inspection_date has passed (see filter_items)
+    inspection_overdue_only: bool
     location_id: str | None
     area_id: str
     include_subtree: bool
@@ -307,7 +311,12 @@ def validate_due_date_rules(*, checked_out: bool, due_date: str | None) -> str |
 
 
 def validate_inspection_date(inspection_date: str | None) -> str | None:
-    """Validate inspection_date format (YYYY-MM-DD) if provided."""
+    """Validate inspection_date format (YYYY-MM-DD) if provided.
+
+    The date is when the item is next due for inspection; a past date is
+    accepted and means the inspection is overdue.
+    """
+
     if inspection_date is None:
         return None
     return normalize_date_yyyy_mm_dd(inspection_date)
@@ -717,6 +726,19 @@ def item_is_overdue(item: Item, *, today: str = "") -> bool:
     return item.due_date < (today or today_utc_date())
 
 
+def item_inspection_is_overdue(item: Item, *, today: str = "") -> bool:
+    """Return True when the item is past the date it was next due for inspection.
+
+    Independent of the check-out state: an inspection is a fact about the item,
+    not about a borrowing, so this walks any item that carries a date. Same
+    text comparison and same ``today`` convention as ``item_is_overdue``.
+    """
+
+    if not item.inspection_date:
+        return False
+    return item.inspection_date < (today or today_utc_date())
+
+
 def _item_matches_location(item: Item, location_id: str | None, include_subtree: bool) -> bool:
     if location_id is None:
         return True
@@ -744,6 +766,7 @@ def filter_items(items: Iterable[Item], flt: ItemFilter | None = None) -> list[I
     - low_stock_only: quantity <= threshold (0 valid, None disables)
     - orphaned_only: only items without a location (location_id is None)
     - overdue_only: due_date set and strictly before today (UTC)
+    - inspection_overdue_only: inspection_date set and strictly before today (UTC)
     - location_id: equals; include_subtree optionally includes descendants (by prefix of id_path)
     - updated_after/created_after: ISO-8601 UTC with 'Z', strictly greater-than
     - updated_before/created_before: ISO-8601 UTC with 'Z', strictly less-than
@@ -760,6 +783,9 @@ def filter_items(items: Iterable[Item], flt: ItemFilter | None = None) -> list[I
     low_stock_only = bool(flt.get("low_stock_only")) if "low_stock_only" in flt else False
     orphaned_only = bool(flt.get("orphaned_only")) if "orphaned_only" in flt else False
     overdue_only = bool(flt.get("overdue_only")) if "overdue_only" in flt else False
+    inspection_overdue_only = (
+        bool(flt.get("inspection_overdue_only")) if "inspection_overdue_only" in flt else False
+    )
     location_id = flt.get("location_id") if "location_id" in flt else None
     include_subtree = bool(flt.get("include_subtree")) if "include_subtree" in flt else False
     updated_after = flt.get("updated_after") if "updated_after" in flt else None
@@ -776,7 +802,7 @@ def filter_items(items: Iterable[Item], flt: ItemFilter | None = None) -> list[I
     ):
         if bound:
             _parse_iso8601_utc(bound, field_name=name)
-    today = today_utc_date() if overdue_only else ""
+    today = today_utc_date() if (overdue_only or inspection_overdue_only) else ""
 
     predicates_active = (
         bool(q)
@@ -787,6 +813,7 @@ def filter_items(items: Iterable[Item], flt: ItemFilter | None = None) -> list[I
         or low_stock_only
         or orphaned_only
         or overdue_only
+        or inspection_overdue_only
         or location_id is not None
         or updated_after is not None
         or created_after is not None
@@ -807,6 +834,9 @@ def filter_items(items: Iterable[Item], flt: ItemFilter | None = None) -> list[I
         matches_low_stock = (not low_stock_only) or item_is_low_stock(it)
         matches_orphaned = (not orphaned_only) or (it.location_id is None)
         matches_overdue = (not overdue_only) or item_is_overdue(it, today=today)
+        matches_inspection = (not inspection_overdue_only) or item_inspection_is_overdue(
+            it, today=today
+        )
         matches_location = _item_matches_location(it, location_id, include_subtree)
         # Canonical fixed-width 'Z' timestamps compare lexicographically, so no
         # per-item parsing is needed (the filter bound was validated above).
@@ -825,6 +855,7 @@ def filter_items(items: Iterable[Item], flt: ItemFilter | None = None) -> list[I
             and matches_low_stock
             and matches_orphaned
             and matches_overdue
+            and matches_inspection
             and matches_location
             and matches_updated
             and matches_created

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -40,6 +40,7 @@ from .models import (
     filter_items,
     is_canonical_utc_timestamp,
     iso_utc_now,
+    item_inspection_is_overdue,
     item_is_low_stock,
     item_is_overdue,
     monotonic_timestamp_after,
@@ -1142,6 +1143,7 @@ class Repository:
             "low_stock_count": len(self._low_stock_item_ids),
             "checked_out_count": len(self._checked_out_item_ids),
             "overdue_count": self._count_overdue(),
+            "inspection_overdue_count": self._count_inspection_overdue(),
             "locations_total": len(self._locations_by_id),
             "no_location_count": len(self._items_by_id) - items_with_location,
         }
@@ -1160,6 +1162,20 @@ class Repository:
             1
             for iid in self._checked_out_item_ids
             if (it := self._items_by_id.get(iid)) is not None and item_is_overdue(it, today=today)
+        )
+
+    def _count_inspection_overdue(self) -> int:
+        """Count items past the date they were next due for inspection.
+
+        Unindexed for the same reason as ``_count_overdue`` — the answer moves
+        with the calendar, and no mutation invalidates it at midnight. The walk
+        covers the whole inventory rather than a subset: an inspection date is
+        independent of any check-out, so any item can carry one.
+        """
+
+        today = today_utc_date()
+        return sum(
+            1 for it in self._items_by_id.values() if item_inspection_is_overdue(it, today=today)
         )
 
     def count_matching_by_location(self, flt: ItemFilter | None = None) -> dict[str | None, int]:

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -30,7 +30,7 @@ from .exceptions import (
     log_severity,
 )
 from .import_export import POLICIES, Policy
-from .models import Item, ItemUpdate, Location, normalize_tags
+from .models import Item, ItemUpdate, Location, normalize_tags, today_utc_date
 from .rate_limit import RateLimiter
 from .repository import UNSET, InternalIndexes, Repository
 from .storage import CURRENT_SCHEMA_VERSION
@@ -409,6 +409,7 @@ class _Subscription(TypedDict, total=False):
     topic: str
     location_id: str | None
     include_subtree: bool
+    inspection_overdue_only: bool
 
 
 def _subs_bucket(
@@ -556,7 +557,24 @@ def _send_event_message(
         )
 
 
+def _payload_inspection_is_overdue(item: dict[str, Any]) -> bool:
+    """Whether a serialized item is past its next-inspection date.
+
+    The matcher is handed the event payload rather than the stored ``Item``, so
+    it cannot call ``item_inspection_is_overdue`` — but it must agree with it,
+    and with ``inspection_overdue_only`` on ``item/list``. Same comparison:
+    YYYY-MM-DD text, strictly before today in UTC.
+    """
+
+    date = item.get("inspection_date")
+    if not isinstance(date, str) or not date:
+        return False
+    return date < today_utc_date()
+
+
 def _item_matches_filter(item: dict[str, Any], sub: _Subscription) -> bool:
+    if sub.get("inspection_overdue_only") and not _payload_inspection_is_overdue(item):
+        return False
     loc_filter = sub.get("location_id")
     if not loc_filter:
         return True
@@ -899,6 +917,7 @@ async def ws_health(
         vol.Required("topic"): str,
         vol.Optional("location_id"): object,
         vol.Optional("include_subtree"): bool,
+        vol.Optional("inspection_overdue_only"): bool,
     }
 )
 @websocket_api.async_response
@@ -916,6 +935,8 @@ async def ws_subscribe(
         sub["location_id"] = msg.get("location_id")
     if "include_subtree" in msg:
         sub["include_subtree"] = bool(msg.get("include_subtree"))
+    if "inspection_overdue_only" in msg:
+        sub["inspection_overdue_only"] = bool(msg.get("inspection_overdue_only"))
     sub_id = int(msg.get("id", 0))
     subs_all = _subs_bucket(hass)
     subs_for_conn = subs_all.setdefault(conn, {})

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -60,9 +60,10 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - Result: `{integration_version: string, schema_version: number}`
 
 - `haventory/stats`
-  - Result: `{items_total: number, low_stock_count: number, checked_out_count: number, overdue_count: number, locations_total: number, no_location_count: number}`
+  - Result: `{items_total: number, low_stock_count: number, checked_out_count: number, overdue_count: number, inspection_overdue_count: number, locations_total: number, no_location_count: number}`
   - `no_location_count` is the number of items without a location (`location_id == null`, i.e. the `orphaned_only` filter's population).
   - `overdue_count` is the number of items whose `due_date` is strictly before today in UTC (the `overdue_only` filter's population). It is derived from the calendar, not from stored state, so it can change without any mutation — no event is emitted when the date rolls over.
+  - `inspection_overdue_count` is the number of items whose `inspection_date` — the date the item is next due for inspection — is strictly before today in UTC (the `inspection_overdue_only` filter's population). It counts the whole inventory, not just checked-out items, because an inspection is independent of any check-out. Calendar-derived in the same way as `overdue_count`, with the same no-event caveat.
 
 - `haventory/distinct_values`
   - Request: `{id, type: "haventory/distinct_values"}` (no payload; extra fields → `validation_error`)
@@ -76,8 +77,9 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 ### Subscriptions and events
 
 - Subscribe
-  - `haventory/subscribe` request: `{id, type, topic: "items"|"locations"|"stats", location_id?: string|null, include_subtree?: boolean}`
+  - `haventory/subscribe` request: `{id, type, topic: "items"|"locations"|"stats", location_id?: string|null, include_subtree?: boolean, inspection_overdue_only?: boolean}`
   - Result: `null` (result envelope with `result: null`)
+  - `inspection_overdue_only` narrows the `items` topic to items past their `inspection_date`, using the same rule as the `item/list` filter of that name. Like every subscription filter it is applied to the event's item payload as it stands *after* the mutation, so an item that leaves the filtered set (its inspection date rescheduled or cleared) produces no event for that subscription — a client that tracks a filtered set re-lists rather than relying on a departure event.
   - Subsequent events delivered as HA WS events to the same connection using this `id` as the subscription id.
 
 - Unsubscribe

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -36,6 +36,11 @@ Object shape for persisted items and API results:
 }
 ```
 
+`inspection_date` is a **forward-looking** date: when the item is next due for inspection.
+A value strictly before today (UTC) means that inspection is overdue — the population behind
+the `inspection_overdue_only` filter and the `inspection_overdue_count` stat. It is
+independent of `checked_out` and of `due_date`; any item can carry one.
+
 Input shapes:
 - ItemCreate (request payload subset; only `name` required):
   - `name: string`
@@ -115,6 +120,7 @@ counts items at the node or any descendant (so it is always >= the direct count)
   - `low_stock_only?: boolean`
   - `orphaned_only?: boolean` (only items without a location, i.e. `location_id == null`)
   - `overdue_only?: boolean` (only items whose `due_date` is strictly before today, UTC)
+  - `inspection_overdue_only?: boolean` (only items whose `inspection_date` is strictly before today, UTC; independent of check-out state)
   - `location_id?: uuid-v4|null`
   - `area_id?: string`
   - `include_subtree?: boolean`
@@ -143,6 +149,7 @@ Counts object used in `stats` results and events:
   "low_stock_count": 0,
   "checked_out_count": 0,
   "overdue_count": 0,
+  "inspection_overdue_count": 0,
   "locations_total": 0,
   "no_location_count": 0
 }
@@ -151,6 +158,8 @@ Counts object used in `stats` results and events:
 `no_location_count` is the number of items without a location (`location_id == null`).
 `overdue_count` is the number of items whose `due_date` is strictly before today (UTC);
 it moves with the calendar, so the same data can report a different count tomorrow.
+`inspection_overdue_count` is the same question asked of `inspection_date`, over the whole
+inventory rather than only the checked-out items, and moves with the calendar the same way.
 
 ### Distinct values
 

--- a/tests/test_models_filter_sort_offline.py
+++ b/tests/test_models_filter_sort_offline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from custom_components.haventory.exceptions import ValidationError
@@ -278,6 +279,55 @@ async def test_filter_overdue_only() -> None:
 
     # Off (or absent) it is not a predicate at all, so nothing is excluded.
     assert filter_items(every, ItemFilter(overdue_only=False)) == every
+
+
+def _utc_day_offset(days: int) -> str:
+    """A UTC calendar date `days` from today, as YYYY-MM-DD."""
+
+    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_filter_inspection_overdue_only_is_strictly_before_today() -> None:
+    """`inspection_overdue_only` keeps items whose next inspection is already past."""
+
+    yesterday = create_item_from_create(
+        {"name": "Yesterday", "inspection_date": _utc_day_offset(-1)}
+    )
+    today = create_item_from_create({"name": "Today", "inspection_date": _utc_day_offset(0)})
+    tomorrow = create_item_from_create({"name": "Tomorrow", "inspection_date": _utc_day_offset(1)})
+    undated = create_item_from_create({"name": "Undated"})
+    every = [yesterday, today, tomorrow, undated]
+
+    # An inspection due today has not been missed yet — the comparison is strict.
+    kept = filter_items(every, ItemFilter(inspection_overdue_only=True))
+    assert [x.name for x in kept] == ["Yesterday"]
+
+    # Off (or absent) it is not a predicate at all, so nothing is excluded.
+    assert filter_items(every, ItemFilter(inspection_overdue_only=False)) == every
+
+
+@pytest.mark.asyncio
+async def test_filter_inspection_overdue_is_independent_of_checkout() -> None:
+    """An inspection is a fact about the item, so the two date filters are separate."""
+
+    shelved = create_item_from_create({"name": "Shelved", "inspection_date": _utc_day_offset(-1)})
+    borrowed = create_item_from_create(
+        {
+            "name": "Borrowed",
+            "checked_out": True,
+            "due_date": _utc_day_offset(-1),
+            "inspection_date": _utc_day_offset(30),
+        }
+    )
+    every = [shelved, borrowed]
+
+    inspection = filter_items(every, ItemFilter(inspection_overdue_only=True))
+    assert [x.name for x in inspection] == ["Shelved"]
+    assert [x.name for x in filter_items(every, ItemFilter(overdue_only=True))] == ["Borrowed"]
+
+    # Both predicates at once is an AND, and nothing here is late on both counts.
+    assert filter_items(every, ItemFilter(overdue_only=True, inspection_overdue_only=True)) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_repository_items_offline.py
+++ b/tests/test_repository_items_offline.py
@@ -7,6 +7,7 @@ and derived counts (checked_out and low_stock).
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from custom_components.haventory.exceptions import ConflictError, NotFoundError
@@ -156,6 +157,63 @@ async def test_overdue_count_and_filter_track_check_in() -> None:
     repo.check_in(late.id)
     assert repo.get_counts()["overdue_count"] == 0
     assert repo.list_items(flt=ItemFilter(overdue_only=True))["items"] == []
+
+
+def _utc_day_offset(days: int) -> str:
+    """A UTC calendar date `days` from today, as YYYY-MM-DD."""
+
+    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_inspection_overdue_count_walks_the_whole_inventory() -> None:
+    """`inspection_overdue_count` spans every item, not just the checked-out ones."""
+
+    repo = Repository()
+    repo.create_item(ItemCreate(name="Ladder", inspection_date=_utc_day_offset(-1)))
+    repo.create_item(
+        ItemCreate(
+            name="Extinguisher",
+            checked_out=True,
+            due_date=_utc_day_offset(7),
+            inspection_date=_utc_day_offset(-30),
+        )
+    )
+    repo.create_item(ItemCreate(name="Harness", inspection_date=_utc_day_offset(0)))
+    repo.create_item(ItemCreate(name="Rope", inspection_date=_utc_day_offset(365)))
+    repo.create_item(ItemCreate(name="Bucket"))
+
+    counts = repo.get_counts()
+    # Two past dates, one on a shelved item and one on a borrowed one. The
+    # inspection due today is not late yet.
+    INSPECTION_OVERDUE = 2
+    assert counts["inspection_overdue_count"] == INSPECTION_OVERDUE
+    # Nothing is past its *due* date: the two counts answer different questions.
+    assert counts["overdue_count"] == 0
+
+    out = repo.list_items(flt=ItemFilter(inspection_overdue_only=True))
+    assert sorted(x.name for x in out["items"]) == ["Extinguisher", "Ladder"]
+    assert out["total"] == INSPECTION_OVERDUE
+
+
+@pytest.mark.asyncio
+async def test_inspection_overdue_count_follows_the_stored_date() -> None:
+    """Rescheduling or clearing the date moves the item out of the population."""
+
+    repo = Repository()
+    ladder = repo.create_item(ItemCreate(name="Ladder", inspection_date=_utc_day_offset(-1)))
+    assert repo.get_counts()["inspection_overdue_count"] == 1
+
+    inspected = repo.update_item(
+        ladder.id, ItemUpdate(inspection_date=_utc_day_offset(365)), expected_version=ladder.version
+    )
+    assert repo.get_counts()["inspection_overdue_count"] == 0
+
+    repo.update_item(
+        inspected.id, ItemUpdate(inspection_date=None), expected_version=inspected.version
+    )
+    assert repo.get_counts()["inspection_overdue_count"] == 0
+    assert repo.list_items(flt=ItemFilter(inspection_overdue_only=True))["items"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -4,11 +4,13 @@ Scenarios:
 - subscribe/unsubscribe lifecycle and echo policy
 - item events delivered with correct shape; stats counts emitted on mutations
 - location_id + include_subtree filters constrain delivered events
+- inspection_overdue_only narrows item events the way item/list narrows a page
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -322,6 +324,76 @@ async def test_location_filters_subtree_and_direct_only() -> None:
         if m.get("type") == "event" and m.get("event", {}).get("topic") == "items"
     }
     assert ids == {SUB_ID_SUBTREE}
+
+
+def _utc_day_offset(days: int) -> str:
+    """A UTC calendar date `days` from today, as YYYY-MM-DD."""
+
+    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
+    """`inspection_overdue_only` narrows item events the same way `item/list` does."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    conn = _ConnStub()
+
+    SUB_ID_INSPECTION = 401
+    SUB_ID_EVERYTHING = 402
+    await _send(
+        hass,
+        conn,
+        SUB_ID_INSPECTION,
+        "haventory/subscribe",
+        topic="items",
+        inspection_overdue_only=True,
+    )
+    await _send(hass, conn, SUB_ID_EVERYTHING, "haventory/subscribe", topic="items")
+
+    def item_event_ids() -> set[object]:
+        return {
+            m.get("id")
+            for m in conn.messages
+            if m.get("type") == "event" and m.get("event", {}).get("topic") == "items"
+        }
+
+    # A missed inspection reaches both subscriptions.
+    conn.messages.clear()
+    late = await _send(
+        hass,
+        conn,
+        3,
+        "haventory/item/create",
+        name="Ladder",
+        inspection_date=_utc_day_offset(-1),
+    )
+    assert late["success"] is True
+    assert item_event_ids() == {SUB_ID_INSPECTION, SUB_ID_EVERYTHING}
+
+    # Due today is not late yet, so the filtered subscription hears nothing —
+    # the same strictly-before boundary the filter and the count use.
+    conn.messages.clear()
+    due_today = await _send(
+        hass,
+        conn,
+        4,
+        "haventory/item/create",
+        name="Harness",
+        inspection_date=_utc_day_offset(0),
+    )
+    assert due_today["success"] is True
+    assert item_event_ids() == {SUB_ID_EVERYTHING}
+
+    # And an item with no inspection date at all never matches.
+    conn.messages.clear()
+    undated = await _send(hass, conn, 5, "haventory/item/create", name="Bucket")
+    assert undated["success"] is True
+    assert item_event_ids() == {SUB_ID_EVERYTHING}
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_utils_offline.py
+++ b/tests/test_ws_utils_offline.py
@@ -86,6 +86,7 @@ async def test_stats_returns_counts() -> None:
         "low_stock_count",
         "checked_out_count",
         "overdue_count",
+        "inspection_overdue_count",
         "locations_total",
         "no_location_count",
     }


### PR DESCRIPTION
Implements **[`docs/open-items.md`](docs/open-items.md) item 36** — *"`inspection_date` has no agreed meaning, and the card says both"* — in full, on the owner's recorded decision (2026-07-26): **`inspection_date` is a future date**, when the item is next due for inspection, the same shape as the checkout's due date.

Backend first, then the card, then the README. Three commits.

## Backend (contract change)

`inspection_date` was validated for shape and nothing else, so the meaning lived entirely in the card's wording — and nothing could answer "how many inspections are outstanding".

- **`Repository.get_counts()` gains `inspection_overdue_count`.** Mirrors `_count_overdue`: deliberately unindexed, because "overdue" moves with the calendar and no mutation invalidates it at midnight. It walks the **whole inventory** rather than `_checked_out_item_ids`, since an inspection is independent of any check-out.
- **`ItemFilter` gains `inspection_overdue_only`**, beside `overdue_only`, carried through `filter_items`, the repository list path, and the `haventory/subscribe` matcher — so a page, a count and a subscription agree on the population.
- **No storage migration.** Only the meaning is settled; the export column list already carries the field, and rows holding *past* dates entered under the old reading stay valid — they now simply read as overdue.
- `docs/backend_api_contract.md` and `docs/data_shapes.md` updated in the same commit as `ws.py`.

## Card

One forward-looking label, **"Next inspection"**, everywhere the field is enumerated: editor caption (was "Inspection date"), sort menu (same), table header (was **"Inspected"**), detail-sheet fact row (was **"Last inspected"** — past tense, the opposite reading).

- **Badge for a passed date** through `isOverdue`, the same strictly-before comparison the backend makes: a list-row badge, a table-cell mark, a detail-sheet chip.
- **App-bar count pill** on both the card and the full view, wired to `inspection_overdue_count`, applying `inspection_overdue_only` server-side — mirroring the overdue pill, plus a removable filter chip and a "Show only" facet so the filter it sets is visible and clearable everywhere the others are.
- **+7 / +31 / +90 / +X quick offsets** on the inspection field (owner-requested, unblocked by this decision). The offsets moved into `ui/relative-time` so the field and `hv-checkout-popover` cannot drift apart.
- Sorting needed nothing — `sortField: 'inspection_date'` already existed.

**Colour rule, stated once and applied everywhere:** amber, not the overdue red. Red on this card means an item is *out and late back*; an inspection that has come due is a chore on something still on the shelf — and it keeps the two app-bar pills apart, which is the whole point of that bar's colour coding.

## Tests

TDD on both sides — 5 backend tests, 14 frontend.

- **pytest**: the count (whole-inventory, independent of `overdue_count`, following an update that reschedules or clears the date), the filter (boundary: **today is not overdue, yesterday is**; independence from checkout; AND-composition with `overdue_only`), and the subscription matcher (filtered vs unfiltered subscription, same boundary). `test_ws_utils_offline` pins the new stats key.
- **vitest**: labels on all four surfaces, the badge on desktop *and* phone rows (with the boundary), the pill on both app bars including the server-side narrowing, the filter chip, the panel facet on both widths, and the offsets (presets, `+X`, an emptied box, and the saved value).

Both gates green before each commit: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (327 passed), `ruff check`, `mypy`, and in `cards/haventory-card` `eslint`, `vitest` (812 passed), `tsc --noEmit`, `npm run build`.

## Live verification (real HA 2026.7.3, 2000 items / 53 locations)

Because the offline suite stubs HA, the WS changes were also driven against the Docker dev instance:

- `haventory/stats` → `inspection_overdue_count: 119` (vs `overdue_count: 86`, confirming the two count different populations); `item/list` with `inspection_overdue_only` → `total: 119`, so count and filter agree.
- Boundary on the real clock: an item dated **today** did not move the count, one dated **yesterday** raised it by exactly one.
- Subscriptions: a filtered and an unfiltered subscription on one connection — the item dated today reached only the unfiltered one, the one dated yesterday reached both, and rescheduling an item *out* of the filtered set produced no event for it (the caveat now written into the contract).
- Card: the pill reads "119 to inspect", pressing it narrows the list to "Showing 50 of 119 filtered" with an "Inspection due ×" chip; rows read "Inspection due · Jul 9"; the sheet shows the chip and "Next inspection"; the editor shows "NEXT INSPECTION" with the four offset chips.
- Zero HAventory tracebacks or ERROR lines in the container log; every test object deleted, instance back at its exact pre-run baseline.

## Follow-ups (not fixed here)

1. **`overdue_only` is still not a subscription-filter key.** `haventory/subscribe` now accepts `inspection_overdue_only` (item 36 asked for it), but the due-date equivalent has never been a subscription filter — so the two date predicates are asymmetric on that one surface. Adding `overdue_only` there is additive and mechanical, but it is outside this item.
2. **A subscription filter never announces a departure.** An item mutated *out* of a filtered subscription's set produces no event for it — pre-existing behaviour of the `location_id` filter, now shared by the new key, and documented in the contract rather than changed. A client tracking a filtered set re-lists, which is what the card does.
3. **The phone row spends its one line on state.** With an inspection due and the item not checked out, the mobile row shows "Inspection due · <date>" in place of the location path (the same trade the checked-out state already makes). The path stays one tap away in the detail sheet — but if that trade is wrong, the alternative is a second line or a dot, both of which cost more than the badge is worth.
4. **`src/ui/relative-time.test.ts` still spells "unparseable"**, which the repo's codespell hook rejects (it blocked a commit here and was fixed in `relative-time.ts` itself). The test file will trip the hook for whoever touches it next.
5. **The inspection column widened from 100px to 124px** to fit the longer header. The default column set does not include it, so the pinned 786px table minimum is unchanged.

Per instruction, `docs/open-items.md` is deliberately untouched — item 36's row is left for the next reconciliation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
