### PR TITLE
ci: gate the card's tsc --noEmit typecheck

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Closes #
 <!-- Both gates must be green. Paste the commands you ran / their results. -->
 
 - [ ] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q`, `uv run ruff check .`, `uv run mypy`
-- [ ] Frontend (`cards/haventory-card`): `npx eslint .`, `npx vitest run`, `npm run build`
+- [ ] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`, `npm run build`
 
 ## Checklist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,10 @@ jobs:
         run: npm ci --no-audit --no-fund
       - name: Lint
         run: npx eslint .
+      - name: Types (tsc --noEmit)
+        # The build below cannot catch this: Vite transpiles through esbuild,
+        # which strips types without checking them.
+        run: npm run typecheck
       - name: Test (vitest w/ coverage)
         run: npx vitest run --coverage
       - name: Frontend coverage summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ uv run mypy
 Frontend (in `cards/haventory-card`):
 ```bash
 npx eslint .
+npm run typecheck
 npx vitest run
 npm run build
 ```
@@ -274,8 +275,9 @@ Adopted tooling (latest stable at review time; verified against release pages / 
   `hass.async_create_background_task(...)` (WP0.5 finding; effort S)~~ — done: the persist
   task is HA-tracked.
 - **TypeScript 7**: adopt once typescript-eslint supports it (currently capped `<6.1.0`).
-- **`tsc --noEmit`** is clean as of WP2 follow-ups (`npm run typecheck`); not yet part of the
-  gate — adding it is a WP4/WP5 call.
+- ~~**`tsc --noEmit`** is clean as of WP2 follow-ups (`npm run typecheck`); not yet part of the
+  gate — adding it is a WP4/WP5 call.~~ — done: `npm run typecheck` runs in the `frontend` CI
+  job and in `scripts/lint.sh` / `scripts/ci_local.sh`.
 - **release-please** wiring lands in WP5.
 - ~~**Windows-only test scaffolding**: `tests/conftest.py` uses
   `asyncio.WindowsSelectorEventLoopPolicy` / `set_event_loop_policy`, both deprecated for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ uv run mypy
 
 # Frontend (in cards/haventory-card)
 npx eslint .
+npm run typecheck
 npx vitest run
 npm run build
 ```

--- a/README.md
+++ b/README.md
@@ -157,12 +157,13 @@ uv run mypy
 
 # Frontend (in cards/haventory-card)
 npx eslint .
+npm run typecheck
 npx vitest run
 npm run build
 ```
 
 Or all at once: `scripts/ci_local.sh` (backend lint + types + tests w/ coverage, then
-frontend install + lint + test + build). Lint only: `scripts/lint.sh`. Backend tests
+frontend install + lint + types + test + build). Lint only: `scripts/lint.sh`. Backend tests
 only: `scripts/test.sh`. Frontend tests: `scripts/test_frontend.sh [--coverage|--watch]`.
 
 ### Testing
@@ -452,7 +453,7 @@ so a stale dashboard config never breaks the card.
 
 - GitHub Actions (`ubuntu-latest`): backend (uv, ruff + mypy + pytest w/ coverage, Python
   3.14), a dedicated **integration** job (in-process HA via phacc, Python 3.14),
-  frontend (eslint + vitest + build, Node 22/24 matrix), actionlint,
+  frontend (eslint + tsc + vitest + build, Node 22/24 matrix), actionlint,
   hassfest + HACS validation, CodeQL, OpenSSF Scorecard, and dependency review.
   Third-party actions are SHA-pinned; first-party `actions/*` use `@v7`.
 - PR hygiene: Conventional-Commit PR-title check, path-based auto-labeling

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -295,8 +295,8 @@ Run:
 ```bash
 cd cards/haventory-card
 npx eslint .
-npx vitest run
 npm run typecheck
+npx vitest run
 npm run build
 ```
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run the full local gate: backend lint + types + tests (with coverage), then
-# frontend install + lint + tests + build. Mirrors the CI pipeline.
+# frontend install + lint + types + tests + build. Mirrors the CI pipeline.
 source "$(dirname "$0")/common.sh"
 
 cd "$REPO_ROOT"
@@ -35,8 +35,8 @@ PY
 fi
 
 if command -v npm >/dev/null 2>&1; then
-  info 'Frontend: install, lint, test, build...'
-  (cd "$CARD_DIR" && npm ci --no-audit --no-fund && npm run lint && npm test -- --coverage && npm run build)
+  info 'Frontend: install, lint, types, test, build...'
+  (cd "$CARD_DIR" && npm ci --no-audit --no-fund && npm run lint && npm run typecheck && npm test -- --coverage && npm run build)
 else
   err 'npm not found; skipping frontend tasks.'
 fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Run all linters: ruff (backend), mypy (backend types), eslint (frontend).
+# Run all linters: ruff (backend), mypy (backend types), eslint (frontend),
+# tsc (frontend types).
 source "$(dirname "$0")/common.sh"
 
 cd "$REPO_ROOT"
@@ -16,6 +17,9 @@ mypy_run
 if command -v npm >/dev/null 2>&1; then
   info 'eslint (frontend)...'
   (cd "$CARD_DIR" && npx eslint .)
+
+  info 'tsc --noEmit (frontend types)...'
+  (cd "$CARD_DIR" && npm run typecheck)
 else
   err 'npm not found; skipping frontend lint.'
 fi


### PR DESCRIPTION
Fixes **item 5** of the pre-v1.0 table in `docs/open-items.md` — *"Add `tsc --noEmit` (typecheck) to the CI gate. It is clean (#89/#91) but still not gated, so card type regressions can slip through."*

## What was wrong

The `frontend` CI job ran install → lint → test → build. None of those catch a type error: `npm run build` is Vite, which transpiles through esbuild and **strips types without checking them**. `npm run typecheck` existed in `package.json` since WP2 and was clean, but nothing ran it, so a card type regression could merge green.

## Change

- `.github/workflows/ci.yml` — new **Types (tsc --noEmit)** step in the `frontend` job, between Lint and Test (mirroring the backend job's Lint → Format → Types → Test order). Runs on both Node matrix legs; ~5 s.
- `scripts/lint.sh` — runs `npm run typecheck` after eslint, so the "all linters" script covers frontend types the way it already covers backend types via mypy.
- `scripts/ci_local.sh` — `npm run typecheck` added to the frontend chain, keeping the script a true mirror of CI.
- Docs truth-up so a contributor's local gate matches CI: the frontend command list in `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `.github/pull_request_template.md`, and `docs/frontend_architecture.md` (which already listed `typecheck`, just in a different position — reordered so all five read identically). Also struck the now-done "not yet part of the gate" WP1 follow-up in `CLAUDE.md` and corrected the README CI/CD summary line to `eslint + tsc + vitest + build`.

No source, no behavior, no contract change.

## Verification

Both gates green on the branch:

- **Backend** — `pytest -q` 327 passed / 22 skipped · `ruff check .` clean · `ruff format --check .` 87 files formatted · `mypy` no issues in 13 files.
- **Frontend** — `npx eslint .` clean · `npm run typecheck` clean · `npx vitest run` 812 passed (42 files) · `npm run build` 427.68 kB.
- **actionlint** on the modified workflow: passed (also via the pre-commit hook on commit).
- `scripts/lint.sh` executed end-to-end — the new `tsc --noEmit (frontend types)` step runs and passes.

Error case, since the point of the change is that the gate must *fail*: a deliberate type error (`export const x: number = "not a number"`) in a file under `src/` makes `npm run typecheck` report `TS2322` and exit **2**, which fails the step. Probe reverted; the tree is clean.

## Follow-ups (found, not fixed)

- **`tsconfig.json` covers `src` only.** `vite.config.ts`, `eslint.config.js`, and the `e2e/*.mjs` Playwright drivers are outside `include`, so the new gate does not type-check them. Widening the include set is a separate change with its own fallout (the e2e drivers are plain `.mjs` and would need `allowJs`/`checkJs` decisions) — out of item 5's scope, which is about gating the existing clean check.
- **The typecheck runs twice**, once per Node matrix leg, for an identical result — `tsc` output does not vary with the Node runtime. Harmless at ~5 s; could be hoisted to a single-leg job if the matrix ever gets expensive.
- **pre-commit has no frontend hooks at all** (no eslint, no vitest, no tsc), so the frontend half of the gate remains CI- and script-only for local commits. Adding npm-backed hooks would be a new pattern for that config, not a tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
