### PR TITLE
chore(deps): bump brace-expansion to 5.0.8 to clear GHSA-mh99-v99m-4gvg

### DIFF
--- a/cards/haventory-card/package-lock.json
+++ b/cards/haventory-card/package-lock.json
@@ -1187,14 +1187,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chai": {


### PR DESCRIPTION
Closes **open-items item 2** — _"Triage the 19 Dependabot security alerts on `main`"_ (source PR #76).

## Triage result

The alert count has moved on since the item was written. `main` now carries **30 alerts, none open**: 29 `fixed`, 1 `auto_dismissed`. But the dashboard's "0 open" was hiding a live vulnerability, and that is what this PR fixes.

| State | Count | Verdict |
|---|---|---|
| `fixed` | 29 | Genuinely resolved. All npm, all `development` scope, all closed on 2026-07-23 by the WP1 toolchain modernization (vite 5→8, vitest 3→4, eslint 10, and the transitive bumps those pulled). No action. |
| `auto_dismissed` | 1 | **Alert #37 — real, still present in the lockfile.** Fixed here. |
| `open` | 0 | — |

### The one that mattered: alert #37

`GHSA-mh99-v99m-4gvg` — high severity, `brace-expansion <= 5.0.7`, DoS via unbounded expansion length causing an out-of-memory process crash. Reachable as `eslint@10.7.0 → minimatch@10.2.5 → brace-expansion@5.0.7`.

It was **filed and auto-dismissed within the same second** (`created_at` == `auto_dismissed_at` == `2026-07-28T13:06:51Z`) by the repository's development-scope auto-triage rule, so it never appeared as an open alert. `npm audit` on `main` reported it plainly:

```
brace-expansion  <=5.0.7
Severity: high
1 high severity vulnerability
```

The dependency is dev-only — it reaches the tree through eslint and is never part of the shipped `www/haventory/haventory-card.js` bundle — so the auto-dismissal was not *wrong* about the risk. But the fix is a transitive lockfile bump to `5.0.8` with no direct-dependency change and no behavioral surface, so there is no reason to carry it. Post-fix `npm audit` reports `found 0 vulnerabilities`.

### Diff

Lockfile only — 4 insertions, 2 deletions:

- `brace-expansion` `5.0.7` → `5.0.8` (`resolved`/`integrity` restored; the prior entry carried neither)
- its `engines` field narrows `18 || 20 || >=22` → `20 || >=22`, comfortably inside the repo's `engines: ^22.13 || >=24`

No source, config, or CI change. No test accompanies it because there is no behavior to test — the frontend gate is the regression check, and it runs against the reinstalled tree (`npm ci` from the updated lockfile, `brace-expansion@5.0.8` verified installed).

### Coverage check — is anything unscanned?

GitHub's dependency graph sees 279 packages across all three ecosystems the repo actually uses: **npm 223**, **pypi 39**, **github-actions 16**. The pypi set includes `homeassistant` and `pytest-homeassistant-custom-component`, so `requirements-integration.txt` *is* scanned despite living outside `pyproject.toml`/`uv.lock`. Zero Python and zero Actions alerts have ever been filed. No blind spot in what gets *alerted on*.

## Gates

Both green, run in full before the commit.

| Gate | Result |
|---|---|
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` | 327 passed, 22 skipped |
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 87 files already formatted |
| `uv run mypy` | Success — no issues in 13 source files |
| `npx eslint .` | clean |
| `npm run typecheck` | clean |
| `npx vitest run` | 42 files, 812 tests passed |
| `npm run build` | built — 427.68 kB / 97.37 kB gzip |

## Follow-ups — found, not fixed

1. **The auto-triage rule will swallow the next one too, silently.** This is the structural finding behind #37 and outlives the bump. A dev-scope auto-dismissal rule is a reasonable default for a card project, but combined with nothing else it means a high-severity alert can appear and vanish without ever being visible on the dashboard — which is precisely how a *fresh, unfixed* vulnerability came to be sitting in `main` while item 2 read as stale backlog. Two independent ways to close the gap, either sufficient: add `npm audit --audit-level=high` to the `frontend` CI job, or turn the auto-dismissal rule off in repo settings and triage dev-scope alerts by hand. Deliberately not done here — the first widens the CI gate and the second is GitHub-UI work that belongs with **item 7** (repo hardening). Recommend the CI step: it is the one that fails loudly and locally.

2. **`requirements-integration.txt` gets alerts but no automated fix PRs.** `.github/dependabot.yml` declares three ecosystems — `github-actions`, `npm` (`/cards/haventory-card`), `uv` (`/`) — and no `pip` entry. The dependency graph scans the file (confirmed above: `homeassistant`, `pytest-homeassistant-custom-component` are both in the SBOM), so a vulnerability there *would* raise an alert; what is missing is Dependabot opening the update PR. Adding a `pip` ecosystem block for `/` would close it. Interacts with **item 29**, which wants that file pinned to the eventual minimum-HA floor — worth sequencing after 29 so version-bump PRs don't fight the pin.

3. **Vite build emits a deprecation warning**, pre-existing and unrelated to this change: `inlineDynamicImports option is deprecated, please use codeSplitting: false instead`. Harmless today; will become an error in a future Vite major. One-line fix in the card's Vite config whenever someone is next in there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
