### PR TITLE
fix(services): await service handlers instead of dropping them on the executor

### DIFF
--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -12,10 +12,11 @@ surfaces them to the caller.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import DOMAIN
 from .exceptions import (
@@ -342,6 +343,44 @@ async def service_location_delete(hass: HomeAssistant, data: dict) -> None:
 # Registration
 # -----------------------------
 
+ServiceHandler = Callable[[HomeAssistant, dict[str, Any]], Coroutine[Any, Any, None]]
+
+# Service name -> (handler, voluptuous schema). Home Assistant validates the call
+# against the schema before invoking the handler; the handler re-validates because
+# it is also called directly (tests, and any in-process caller).
+SERVICES: tuple[tuple[str, ServiceHandler, vol.Schema], ...] = (
+    ("item_create", service_item_create, SCHEMA_ITEM_CREATE),
+    ("item_update", service_item_update, SCHEMA_ITEM_UPDATE),
+    ("item_delete", service_item_delete, SCHEMA_ITEM_DELETE),
+    ("item_move", service_item_move, SCHEMA_ITEM_MOVE),
+    ("item_adjust_quantity", service_item_adjust_quantity, SCHEMA_ITEM_ADJUST_QTY),
+    ("item_set_quantity", service_item_set_quantity, SCHEMA_ITEM_SET_QTY),
+    ("item_check_out", service_item_check_out, SCHEMA_ITEM_CHECK_OUT),
+    ("item_check_in", service_item_check_in, SCHEMA_ITEM_CHECK_IN),
+    ("location_create", service_location_create, SCHEMA_LOCATION_CREATE),
+    ("location_update", service_location_update, SCHEMA_LOCATION_UPDATE),
+    ("location_delete", service_location_delete, SCHEMA_LOCATION_DELETE),
+)
+
+
+def _bind(
+    hass: HomeAssistant, handler: ServiceHandler
+) -> Callable[[ServiceCall], Coroutine[Any, Any, None]]:
+    """Adapt a ``(hass, data)`` handler to the ``ServiceCall`` signature HA invokes.
+
+    The returned callable **must be a coroutine function**. Home Assistant classifies
+    every service handler with ``HassJob``: anything that is neither a coroutine
+    function nor a ``@callback`` is dispatched via ``async_add_executor_job``. A
+    plain ``lambda call: handler(hass, ...)`` therefore runs on a worker thread,
+    where it only *constructs* the coroutine — which HA then returns as the service
+    response and never awaits, so the mutation silently never happens.
+    """
+
+    async def _handle(call: ServiceCall) -> None:
+        await handler(hass, dict(call.data))
+
+    return _handle
+
 
 def setup(hass: HomeAssistant) -> None:
     """Register haventory.* services on Home Assistant."""
@@ -356,71 +395,7 @@ def setup(hass: HomeAssistant) -> None:
         bucket["services_registered"] = True
         return
 
-    # Home Assistant will validate inputs according to these schemas before
-    # invoking the handler. Handlers are exported above for testability.
-    hass.services.async_register(
-        DOMAIN,
-        "item_create",
-        lambda call: service_item_create(hass, dict(call.data)),
-        SCHEMA_ITEM_CREATE,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "item_update",
-        lambda call: service_item_update(hass, dict(call.data)),
-        SCHEMA_ITEM_UPDATE,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "item_delete",
-        lambda call: service_item_delete(hass, dict(call.data)),
-        SCHEMA_ITEM_DELETE,
-    )
-    hass.services.async_register(
-        DOMAIN, "item_move", lambda call: service_item_move(hass, dict(call.data)), SCHEMA_ITEM_MOVE
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "item_adjust_quantity",
-        lambda call: service_item_adjust_quantity(hass, dict(call.data)),
-        SCHEMA_ITEM_ADJUST_QTY,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "item_set_quantity",
-        lambda call: service_item_set_quantity(hass, dict(call.data)),
-        SCHEMA_ITEM_SET_QTY,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "item_check_out",
-        lambda call: service_item_check_out(hass, dict(call.data)),
-        SCHEMA_ITEM_CHECK_OUT,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "item_check_in",
-        lambda call: service_item_check_in(hass, dict(call.data)),
-        SCHEMA_ITEM_CHECK_IN,
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        "location_create",
-        lambda call: service_location_create(hass, dict(call.data)),
-        SCHEMA_LOCATION_CREATE,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "location_update",
-        lambda call: service_location_update(hass, dict(call.data)),
-        SCHEMA_LOCATION_UPDATE,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "location_delete",
-        lambda call: service_location_delete(hass, dict(call.data)),
-        SCHEMA_LOCATION_DELETE,
-    )
+    for name, handler, schema in SERVICES:
+        hass.services.async_register(DOMAIN, name, _bind(hass, handler), schema)
 
     bucket["services_registered"] = True

--- a/stubs/homeassistant/core.pyi
+++ b/stubs/homeassistant/core.pyi
@@ -5,7 +5,7 @@ back to Any via __getattr__. See pyproject [tool.mypy] mypy_path.
 """
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from typing import Any
 
 class HomeAssistant:
@@ -16,4 +16,9 @@ class HomeAssistant:
         name: str,
         eager_start: bool = True,
     ) -> asyncio.Task[R]: ...
+    def __getattr__(self, name: str) -> Any: ...
+
+class ServiceCall:
+    # Read-only in real HA; copy it before mutating.
+    data: Mapping[str, Any]
     def __getattr__(self, name: str) -> Any: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,19 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             """
             return await asyncio.get_running_loop().run_in_executor(None, target, *args)
 
+    class ServiceCall:  # type: ignore[override]
+        """Stand in for HA's service-call payload.
+
+        Offline this is annotation-only — ``services.py`` imports the name and the
+        offline tests invoke handlers directly — so only the read-only ``data``
+        mapping is modelled, not HA's full constructor.
+        """
+
+        def __init__(self, data=None) -> None:
+            self.data = types.MappingProxyType(dict(data or {}))
+
     ha_core.HomeAssistant = HomeAssistant
+    ha_core.ServiceCall = ServiceCall
     sys.modules["homeassistant.core"] = ha_core
 
     # homeassistant.exceptions

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -1,0 +1,165 @@
+"""Integration: ``haventory.*`` services dispatched by the real service registry.
+
+The offline suite awaits the registered handler itself, which passes no matter how
+the handler was registered. Home Assistant does not: it classifies every handler
+with ``HassJob`` and sends anything that is not a coroutine function (or a
+``@callback``) to the executor, where a handler that merely *returns* a coroutine
+is never awaited and the mutation silently never happens. Only a call through
+``hass.services.async_call`` exercises that classification, so these tests drive
+every registered service through it and assert the repository actually changed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import voluptuous as vol
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.exceptions import NotFoundError, ValidationError
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import STORAGE_KEY
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+DUE_DATE = "2030-01-01"
+
+
+async def _setup(hass: HomeAssistant) -> Repository:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return hass.data[DOMAIN]["repository"]
+
+
+async def _call(hass: HomeAssistant, service: str, data: dict) -> None:
+    await hass.services.async_call(DOMAIN, service, data, blocking=True)
+    await hass.async_block_till_done()
+
+
+def _only_location_id(repo: Repository) -> str:
+    locations = repo._debug_get_internal_indexes()["locations_by_id"]
+    assert len(locations) == 1, locations
+    return next(iter(locations))
+
+
+def _only_item_id(repo: Repository) -> str:
+    items = repo._debug_get_internal_indexes()["items_by_id"]
+    assert len(items) == 1, items
+    return next(iter(items))
+
+
+async def test_all_services_are_registered(hass: HomeAssistant) -> None:
+    """Setup registers the full ``haventory.*`` catalog."""
+
+    await _setup(hass)
+
+    assert hass.services.async_services_for_domain(DOMAIN).keys() == {
+        "item_create",
+        "item_update",
+        "item_delete",
+        "item_move",
+        "item_adjust_quantity",
+        "item_set_quantity",
+        "item_check_out",
+        "item_check_in",
+        "location_create",
+        "location_update",
+        "location_delete",
+    }
+
+
+async def test_every_service_dispatches_its_handler(hass: HomeAssistant) -> None:
+    """Calling each service through HA runs the handler and mutates the repository.
+
+    One walk covers the whole catalog: a location is created, renamed and finally
+    deleted around an item that is created, edited, re-quantified, checked out and
+    back in, moved and deleted. Every assertion would fail if HA had dispatched the
+    handler to the executor instead of awaiting it.
+    """
+
+    repo = await _setup(hass)
+
+    await _call(hass, "location_create", {"name": "Garage"})
+    location_id = _only_location_id(repo)
+    assert repo.get_location(location_id).name == "Garage"
+
+    await _call(hass, "location_update", {"location_id": location_id, "name": "Workshop"})
+    assert repo.get_location(location_id).name == "Workshop"
+
+    await _call(
+        hass,
+        "item_create",
+        {"name": "Hammer", "quantity": 1, "location_id": location_id, "tags": ["tools"]},
+    )
+    item_id = _only_item_id(repo)
+    item = repo.get_item(item_id)
+    assert item.name == "Hammer"
+    assert item.tags == ["tools"]
+    assert item.location_path.display_path == "Workshop"
+
+    await _call(hass, "item_update", {"item_id": item_id, "description": "Claw hammer"})
+    assert repo.get_item(item_id).description == "Claw hammer"
+
+    adjusted_quantity = 5
+    await _call(hass, "item_adjust_quantity", {"item_id": item_id, "delta": 4})
+    assert repo.get_item(item_id).quantity == adjusted_quantity
+
+    set_quantity = 2
+    await _call(hass, "item_set_quantity", {"item_id": item_id, "quantity": set_quantity})
+    assert repo.get_item(item_id).quantity == set_quantity
+
+    await _call(hass, "item_check_out", {"item_id": item_id, "due_date": DUE_DATE})
+    checked_out = repo.get_item(item_id)
+    assert checked_out.checked_out is True
+    assert checked_out.due_date == DUE_DATE
+
+    await _call(hass, "item_check_in", {"item_id": item_id})
+    assert repo.get_item(item_id).checked_out is False
+
+    await _call(hass, "item_move", {"item_id": item_id, "new_location_id": None})
+    assert repo.get_item(item_id).location_id is None
+
+    await _call(hass, "item_delete", {"item_id": item_id})
+    assert repo.get_counts()["items_total"] == 0
+
+    await _call(hass, "location_delete", {"location_id": location_id})
+    assert repo.get_counts()["locations_total"] == 0
+
+
+async def test_service_call_persists_through_the_store(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """A service mutation reaches the HA Store, not just the in-memory repository."""
+
+    await _setup(hass)
+
+    await _call(hass, "item_create", {"name": "Flashlight", "quantity": 2})
+
+    persisted = hass_storage[STORAGE_KEY]["data"]
+    assert any(i["name"] == "Flashlight" for i in persisted["items"].values())
+
+
+async def test_service_call_surfaces_domain_errors(hass: HomeAssistant) -> None:
+    """A repository error reaches the caller instead of being swallowed mid-dispatch."""
+
+    await _setup(hass)
+
+    with pytest.raises(NotFoundError):
+        await _call(hass, "item_update", {"item_id": "does-not-exist", "name": "Nope"})
+
+
+async def test_service_call_rejects_a_bad_payload(hass: HomeAssistant) -> None:
+    """HA validates against the registered schema before the handler runs."""
+
+    repo = await _setup(hass)
+
+    # ``item_create`` requires a name; the registered schema rejects the call.
+    with pytest.raises(vol.Invalid):
+        await _call(hass, "item_create", {"quantity": 1})
+
+    # A well-typed but domain-invalid value gets past the schema and is rejected
+    # by the model layer, which the handler re-raises.
+    with pytest.raises(ValidationError):
+        await _call(hass, "item_create", {"name": "   "})
+
+    assert repo.get_counts()["items_total"] == 0

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -8,6 +8,8 @@ Scenarios:
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 import voluptuous as vol
 from custom_components.haventory import services as services_mod
@@ -157,6 +159,16 @@ async def test_service_registration_and_schema_errors(monkeypatch, caplog) -> No
         "location_update",
         "location_delete",
     }.issubset(names)
+
+    # Home Assistant classifies each handler with HassJob and dispatches anything
+    # that is neither a coroutine function nor a @callback to the executor, where
+    # a handler that merely returns a coroutine is never awaited. Registering an
+    # `async def` is what keeps the service from silently doing nothing; the
+    # end-to-end proof lives in tests/integration/test_services.py.
+    not_awaitable = [
+        n for (_d, n, h, _s) in hass.services._registered if not inspect.iscoroutinefunction(h)
+    ]
+    assert not not_awaitable
 
     # Grab a handler and feed invalid payload to trigger vol.Invalid
     caplog.clear()


### PR DESCRIPTION
Fixes **item 6** from the pre-v1.0 table in `docs/open-items.md` — *"Pin the
service-registration pattern with a test."*

## What the test found

The item asked for a guard. Writing it exposed the thing it was meant to guard
against: **every `haventory.*` service was a silent no-op in real Home Assistant.**

`services.py` registered each handler as `lambda call: service_x(hass, dict(call.data))`.
HA classifies every service handler with `HassJob` (`get_hassjob_callable_job_type`): a
lambda is neither a coroutine function nor a `@callback`, so it resolves to
`HassJobType.Executor` and `ServiceRegistry._execute_service` dispatches it via
`async_add_executor_job`. The worker thread runs the lambda, which only *constructs* the
coroutine; HA returns that coroutine object as the service response and never awaits it.
The mutation never happens — the only trace is
`RuntimeWarning: coroutine 'service_item_create' was never awaited`.

Confirmed against real HA `2026.7.3`:

```
lambda-returning-coroutine -> HassJobType.Executor
async def                  -> HassJobType.Coroutinefunction
```

The offline suite could not see this: it `await`s the registered handler itself
(`await handler(_Call({}))`), which works no matter how the handler was registered.
Nothing else called the services — the card and scripts all go through the WebSocket API,
which was and is fine.

## The fix

Registration binds each handler through an `async def` adapter, which HA resolves to
`HassJobType.Coroutinefunction` and awaits. The eleven near-identical `async_register`
blocks collapse into one `SERVICES` table. No schema, handler signature, or
`services.yaml` change — the wire contract is unchanged, the services just now run.

## Tests

- **`tests/integration/test_services.py`** (new, 5 cases) — the guard item 6 asked for.
  Drives all eleven services through `hass.services.async_call(..., blocking=True)` against
  a real HA core (phacc) and asserts the repository actually changed after each: location
  create/rename, item create/update/adjust/set-quantity/check-out/check-in/move/delete,
  location delete. Plus a Store round-trip, a `NotFoundError` propagation case, and a
  schema-rejection (`vol.Invalid`) / domain-rejection (`ValidationError`) case.
- **`tests/test_services_offline.py`** — the fast gate now asserts every registered handler
  is a coroutine function, so a regression is caught without needing the integration env.

Both fail on the previous registration (4 of 5 integration cases fail with the
never-awaited warning; the offline case fails listing all eleven services). Both pass on
this branch.

## Gates

| Gate | Result |
|---|---|
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` | 327 passed, 22 skipped |
| `uv run ruff check .` / `ruff format --check .` | clean / 88 files formatted |
| `uv run mypy` | no issues in 13 source files |
| `npx eslint .` / `npm run typecheck` | clean / clean |
| `npx vitest run` | 812 passed (42 files) |
| `npm run build` | built |
| `pytest -o asyncio_mode=auto tests/integration` (HA 2026.7.3, Python 3.14) | 12 passed |

The integration suite is unrunnable natively on this Windows host (POSIX venv paths, HA
core imports `fcntl`); it was run in a throwaway `python:3.14-slim` container against
`requirements-integration.txt`, per the note in item 55.

## Found but not fixed

1. **`stubs/homeassistant/core.pyi` and `tests/conftest.py` needed a `ServiceCall` stub** to
   keep mypy and the offline suite working once `services.py` imports the real type. Both
   are minimal and annotation-shaped. This is another instance of the known stub-divergence
   hazard: the offline `HomeAssistant` stub has no service registry at all, so
   `services.setup()` takes an early-return path offline and *no* offline test can exercise
   real registration semantics. Worth a wider look at what else the stubs let through —
   related to item 51.
2. **`services.yaml` and the README describe services that never worked.** No doc change is
   needed now that they do, but it means the service surface has had no real-HA coverage
   until this PR — the same class of gap item 51 tracks for the batch's stub-tested paths.
3. **Item 51 could absorb this pattern.** The integration suite is the only place these
   semantics are observable; adding the `async_remove_entry` / debounced-persist /
   downgrade-refusal cases it lists would now run in the same green environment.
4. **`_execute_service`'s executor fallback fails silently** — no HA-side warning fires when
   a handler returns an un-awaited coroutine. Nothing actionable in this repo, but it means
   the same mistake in any future handler registration would again be invisible outside an
   integration test. The two guards added here cover the current catalog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
