### PR TITLE
docs: truth up the README's rate-limiting and calendar-entity claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,12 @@ What HAventory does *not* do today, stated up front so none of it is a surprise:
   Settings → Devices & services → HAventory → **Configure** turns on per-connection and
   global token buckets: excess commands are rejected with a `rate_limited` error and
   excess subscription broadcasts are dropped. Dropped broadcasts are silent on the wire —
-  events carry no sequence number, so a missing one cannot be detected by its absence.
+  events carry no sequence number, so a missing one cannot be detected by its absence. A
+  limiter tight enough to refuse the card's *subscribe* is not silent, though: the card
+  re-opens the refused round up to four times, waiting out a retry-after hint when the
+  refusal carries one and backing off exponentially when it does not, and once that budget
+  is spent it says **Live updates paused** and offers a Refresh — so a list that has
+  stopped updating never passes for one with nothing to report.
 - **Import identity is the id, never the name.** The `merge` / `replace` / `skip` policies
   all classify an incoming item or location by its id. Restoring a backup onto entities
   you rebuilt by hand — which carry fresh uuids — therefore duplicates them instead of
@@ -581,7 +586,9 @@ and ask questions in [Discussions](https://github.com/chrreiter/HAventory/discus
 ## Conventions
 
 - Domain/package: `haventory` under `custom_components/haventory`; services `haventory.*`;
-  built assets `www/haventory/`; calendar entity `calendar.haventory`.
+  built assets `www/haventory/`; calendar entity `calendar.haventory` — a reserved name for
+  the post-1.0 calendar work ([open item 9](docs/open-items.md)), not an entity that exists
+  today.
 - Logging: avoid reserved `LogRecord` keys in logger extras — use `item_name` /
   `location_name`, not `name`.
 


### PR DESCRIPTION
Fixes **item 41** (pre-v1.0, *Post-batch README truth-ups*) from `docs/open-items.md` — the two halves that the 2026-07-27 batch made actionable. Docs-only; no source or test changes.

## (a) Known limitations → rate limiting: add the card behavior #128 shipped

The entry described backend posture only (buckets, `rate_limited`, dropped broadcasts), which left the reader knowing a refused subscription is possible but not that the card notices. Added, verified against the code rather than the item text:

- re-opens a refused subscribe round **up to four times** — `SUBSCRIBE_RETRY_ATTEMPTS = 4`, [store.ts:66](cards/haventory-card/src/store/store.ts#L66), spent at [store.ts:385](cards/haventory-card/src/store/store.ts#L385);
- **waits out a retry-after hint when the refusal carries one**, exponential backoff otherwise — `subscribeRetryDelayMs` / `retryAfterHintMs`, [store.ts:105-125](cards/haventory-card/src/store/store.ts#L105-L125) (reads `retry_after_ms` or `retry_after` seconds from `data` / `context` / top level, clamped to 30 s);
- then **pauses visibly with a Refresh action** — the "Live updates paused" banner at [hv-card-shell.ts:925-948](cards/haventory-card/src/components/hv-card-shell.ts#L925-L948), whose Refresh button renders only in the non-retrying (`'paused'`) state.

Wording deliberately says "when the refusal carries one" rather than implying the backend sends a hint — it does not today (`retry_after` appears nowhere in `custom_components/`; the card's read is forward-compatible by design, as `docs/frontend_architecture.md:185-197` records).

## (b) Conventions → `calendar.haventory` reconciled with "creates no entities"

Both statements were true and read as contradictory. The Conventions line now marks the name as reserved for the post-1.0 calendar work (open item 9) rather than describing an entity a user could go looking for.

## Verified, not edited — Implementation Status → Phase 2.5

The #129 follow-up flagged the Phase 2.5 claim that the revamp "closes … the card's silent failure when a subscription is rate-limited" ([README.md:514-516](README.md#L514-L516)) as stale against pre-batch `main`. Checked against merged `main`: #128 (`4082f76`) is in, the retry + paused-banner path exists and is covered by tests (`store.revamp.test.ts:406-549`, `hv-card-shell.test.ts:1355-1378`). Accurate as written — left alone per the item.

## Not fixed — deferred by the item's own guard

- **Item 41 (c), the published scale ceiling.** The item gates this on release-test **F3** ("Scale on real hardware … record the size at which it degrades and publish it as a supported ceiling", `docs/release_testing_plan.md:175`), which has not been run — no measured number exists to substitute. The Known limitations bullet keeps item 19's extrapolation (~70 ms/create @250, ~114 @500, ~200 @1000, trending to ~1 s at a few thousand) and is still correctly labelled as a curve, not a measurement. Running F3 is a manual release-readiness exercise well outside this item's S effort, so it stays for whoever runs that pass.

## Follow-ups found, not fixed

- `CLAUDE.md`'s "Naming" convention line carries the same bare `calendar.haventory` as the README did, with the same ambiguity. Item 41 scopes itself to the README, so it is untouched — worth the same one-clause fix in a docs sweep.

## Gates

Backend — `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (327 passed, 22 skipped), `ruff check` (clean), `ruff format --check` (88 files formatted), `mypy` (no issues, 13 files).
Frontend — `npx eslint .` (clean), `npx vitest run` (812 passed, 42 files), `npm run typecheck` (clean), `npm run build` (427.68 kB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
