### PR TITLE
ci(frontend): gate dev-scope npm vulnerabilities with npm audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
           cache-dependency-path: cards/haventory-card/package-lock.json
       - name: Install
         run: npm ci --no-audit --no-fund
+      - name: Audit (npm advisories, high+)
+        # The repository's Dependabot auto-triage rule dismisses development-scope
+        # alerts, so the alert dashboard cannot be trusted to surface a vulnerable
+        # dev dependency — this blocking step is where the lockfile is checked.
+        # Kept explicit rather than folded into the install above, whose
+        # `--no-audit` keeps install output free of advisory noise.
+        run: npm audit --audit-level=high
       - name: Lint
         run: npx eslint .
       - name: Types (tsc --noEmit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ uv run mypy
 
 Frontend (in `cards/haventory-card`):
 ```bash
+npm audit --audit-level=high   # dev-scope alerts are auto-dismissed on GitHub; CI is the gate
 npx eslint .
 npm run typecheck
 npx vitest run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ uv run ruff check .
 uv run mypy
 
 # Frontend (in cards/haventory-card)
+npm audit --audit-level=high
 npx eslint .
 npm run typecheck
 npx vitest run

--- a/README.md
+++ b/README.md
@@ -161,14 +161,19 @@ uv run ruff check .
 uv run mypy
 
 # Frontend (in cards/haventory-card)
+npm audit --audit-level=high
 npx eslint .
 npm run typecheck
 npx vitest run
 npm run build
 ```
 
+The audit is the only place a development-scope npm vulnerability becomes visible: the
+repository's Dependabot auto-triage rule dismisses dev-scope alerts, so the alert
+dashboard is not ground truth for the card's lockfile — CI is.
+
 Or all at once: `scripts/ci_local.sh` (backend lint + types + tests w/ coverage, then
-frontend install + lint + types + test + build). Lint only: `scripts/lint.sh`. Backend tests
+frontend install + audit + lint + types + test + build). Lint only: `scripts/lint.sh`. Backend tests
 only: `scripts/test.sh`. Frontend tests: `scripts/test_frontend.sh [--coverage|--watch]`.
 
 ### Testing
@@ -458,7 +463,7 @@ so a stale dashboard config never breaks the card.
 
 - GitHub Actions (`ubuntu-latest`): backend (uv, ruff + mypy + pytest w/ coverage, Python
   3.14), a dedicated **integration** job (in-process HA via phacc, Python 3.14),
-  frontend (eslint + tsc + vitest + build, Node 22/24 matrix), actionlint,
+  frontend (npm audit + eslint + tsc + vitest + build, Node 22/24 matrix), actionlint,
   hassfest + HACS validation, CodeQL, OpenSSF Scorecard, and dependency review.
   Third-party actions are SHA-pinned; first-party `actions/*` use `@v7`.
 - PR hygiene: Conventional-Commit PR-title check, path-based auto-labeling

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run the full local gate: backend lint + types + tests (with coverage), then
-# frontend install + lint + types + tests + build. Mirrors the CI pipeline.
+# frontend install + audit + lint + types + tests + build. Mirrors the CI pipeline.
 source "$(dirname "$0")/common.sh"
 
 cd "$REPO_ROOT"
@@ -35,8 +35,9 @@ PY
 fi
 
 if command -v npm >/dev/null 2>&1; then
-  info 'Frontend: install, lint, types, test, build...'
-  (cd "$CARD_DIR" && npm ci --no-audit --no-fund && npm run lint && npm run typecheck && npm test -- --coverage && npm run build)
+  info 'Frontend: install, audit, lint, types, test, build...'
+  (cd "$CARD_DIR" && npm ci --no-audit --no-fund && npm audit --audit-level=high \
+    && npm run lint && npm run typecheck && npm test -- --coverage && npm run build)
 else
   err 'npm not found; skipping frontend tasks.'
 fi


### PR DESCRIPTION
## Summary

Resolves tracker item 57: make development-scope npm vulnerabilities visible in CI.

The repository's Dependabot auto-triage rule auto-dismisses development-scope alerts, which is why a real high-severity advisory (`brace-expansion`, GHSA-MH99-v99m-4gvg) sat invisible in the card lockfile until the #135 triage. **That auto-dismissal rule stays enabled — this audit gate is the compensating control**, so the lockfile is checked on every PR regardless of what the alert dashboard shows. The Dependabot dashboard is not ground truth for this repo; CI is.

Changes:

- `.github/workflows/ci.yml` — new `Audit (npm advisories, high+)` step in the **existing** `frontend` job, immediately after `Install`, running `npm audit --audit-level=high`. Deliberately a step and not a new job: the `main` ruleset (`.github/rulesets/main.json`) pins its required checks to the ten existing job names, and a new job would not be required-by-default while editing the live ruleset is owner-only. Inside the frontend job the gate is blocking with no settings change. `npm ci --no-audit` is unchanged — install-time audit output is advisory noise; the explicit step is the deterministic, loud gate.
- `scripts/ci_local.sh` — same audit in the frontend block, so local CI parity holds.
- `README.md` (Developer Checklist gate + CI/CD bullet), `CONTRIBUTING.md` gate, `CLAUDE.md` frontend gate — the audit is now listed wherever the frontend gate steps are enumerated, with a short note on why it exists.

No job names change, so the ruleset's required checks stay satisfiable; `tests/test_repo_hardening_offline.py` still passes.

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 335 passed, 22 skipped; `uv run ruff check .` → All checks passed; `uv run mypy` → no issues in 13 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean, `npx vitest run` → 812 passed (42 files), `npm run build` OK.
- [x] The new gate itself: `npm audit --audit-level=high` → `found 0 vulnerabilities`, exit 0 — it lands green.
- [x] `tests/test_repo_hardening_offline.py` → 8 passed (required-check names still derivable from the workflows).
- [x] `.github/workflows/ci.yml` re-parsed; frontend job steps are `Install → Audit → Lint → Types → Test → coverage summary → artifacts → Build`, job list unchanged.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — no new tests: this is a CI step, and the existing repo-hardening test already guards the invariant it could break (job names ⇄ required checks).
- [x] Docs updated where behavior changed (`README.md`, `CONTRIBUTING.md`, `CLAUDE.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Load-bearing invariants preserved — n/a, no runtime code touched.

## Screenshots (card / UI changes)

n/a — no card change.

## Follow-ups (found, not fixed)

- **Item 57 is not in `docs/open-items.md` on `main`** (`b2b83e0`); the tracker table ends at item 55. The spec was taken from the session brief. Per the batch rule this PR does not edit the tracker — the later sweep should add item 57 and mark it resolved.
- `npm audit --audit-level=high` fails only on **high/critical**; moderate dev-scope advisories remain invisible in CI and auto-dismissed on the dashboard. Tightening to `--audit-level=moderate` is a separate call about noise tolerance.
- The audit runs on both matrix legs (`frontend (22)` and `frontend (24)`) and audits the same lockfile twice. Harmless and keeps every leg self-contained, but it is duplicated work if a cheaper single-leg gate is ever wanted.
- Other `npm ci --no-audit` callers (`scripts/setup.sh`, `scripts/build_frontend.sh`, `scripts/test_frontend.sh`, `scripts/reload_addon.sh`) are untouched — they are install/build helpers, not gates.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hP9CryyyYwGBJkt6sUyv1)_