### PR TITLE
test(card): drive the retry-after subscribe test on fake timers

### DIFF
--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -487,25 +487,37 @@ describe('Store: rate limiting and degraded state', () => {
   });
 
   it('waits out the retry-after hint the envelope carries', async () => {
-    const hass = makeMockHass({ items: [] });
-    hass.__failSubscribeNext(3, { ...RATE_LIMITED, data: { op: 'subscribe', retry_after_ms: 40 } });
-    const store = new Store(hass, fast);
+    // `nextLiveRetryAt` is `Date.now() + delay` and the retry itself rides
+    // `setTimeout`, so both have to move on one clock for the wait to be exact
+    // instead of a race against the scheduler. `settleSubscribes()` keeps
+    // working across the switch — it is pure microtasks, which fake timers
+    // leave alone.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    try {
+      const hass = makeMockHass({ items: [] });
+      hass.__failSubscribeNext(3, { ...RATE_LIMITED, data: { op: 'subscribe', retry_after_ms: 40 } });
+      const store = new Store(hass, fast);
 
-    await store.init();
-    await settleSubscribes();
+      await store.init();
+      await settleSubscribes();
 
-    // The hint wins over the store's own (zero, in tests) backoff.
-    const wait = (store.state.value.degraded.nextLiveRetryAt ?? 0) - Date.now();
-    expect(wait).toBeGreaterThan(20);
-    expect(store.state.value.degraded.liveUpdates).toBe('retrying');
+      // The hint wins over the store's own (zero, in tests) backoff.
+      const wait = (store.state.value.degraded.nextLiveRetryAt ?? 0) - Date.now();
+      expect(wait).toBe(40);
+      expect(store.state.value.degraded.liveUpdates).toBe('retrying');
 
-    // Not retried before the hint elapses...
-    await flush(2);
-    expect(hass.__subscribeCalls).toHaveLength(3);
+      // Not retried before the hint elapses...
+      await vi.advanceTimersByTimeAsync(39);
+      expect(hass.__subscribeCalls).toHaveLength(3);
 
-    await new Promise((resolve) => setTimeout(resolve, 60));
-    expect(hass.__subscribeCalls).toHaveLength(6);
-    expect(store.state.value.degraded.liveUpdates).toBe('live');
+      // ...and retried on the very millisecond it does.
+      await vi.advanceTimersByTimeAsync(1);
+      await settleSubscribes();
+      expect(hass.__subscribeCalls).toHaveLength(6);
+      expect(store.state.value.degraded.liveUpdates).toBe('live');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('reports a non-rate-limit subscribe refusal instead of retrying it', async () => {


### PR DESCRIPTION
## Summary

De-flakes `cards/haventory-card/src/store/store.revamp.test.ts` — *"waits out the retry-after hint the envelope carries"* (open-items item 58).

The test ran on real timers: it asserted `hass.__subscribeCalls` had **3** entries while a real 40 ms `retry_after_ms` hint was still outstanding, then re-asserted **6** after a wall-clock `await new Promise((r) => setTimeout(r, 60))`. On a loaded runner the pre-elapse assertion can observe the retry already fired (seen once under memory pressure: expected 3, saw 6). It passed in isolation and in CI, but the race was real.

The fix is **test-only** — the store is untouched. `vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })` puts both halves of the store's scheduling on one clock: `onSubscribeRefused` publishes `nextLiveRetryAt = Date.now() + delay` and arms the retry with `setTimeout(..., delay)` (`src/store/store.ts:391-397`), so mocking `Date` alongside the timers is what makes the wait exact rather than sampled. The assertions become:

| before | after |
|---|---|
| `expect(wait).toBeGreaterThan(20)` | `expect(wait).toBe(40)` |
| `await flush(2)` then expect 3 calls | `await vi.advanceTimersByTimeAsync(39)` then expect 3 calls |
| `setTimeout(…, 60)` then expect 6 calls | `await vi.advanceTimersByTimeAsync(1)` then expect 6 calls |

No product-code seam was needed — the store already uses the global `setTimeout`/`Date`, both of which fake timers own. `settleSubscribes()` is pure microtasks (`await Promise.resolve()` ×3), which fake timers do not intercept, so it still settles the rejected `subscribeMessage` chain unchanged; `flush()` is no longer called from this test. Timers are restored in a `finally`, so a failing assertion cannot leak fake timers into the rest of the file.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue) — test flake, no runtime behavior change
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 335 passed, 22 skipped · `uv run ruff check .` → All checks passed · `uv run mypy` → no issues in 13 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean · `npx vitest run` → 42 files, 812 tests passed · `npm run build` → built (427.68 kB)

**Stability proof.** Vitest 4's CLI has no `--repeats`, so the single test was run in a 50-iteration shell loop *while four busy-loop processes saturated the CPU* (the condition that produced the original miscount): **0 failures / 50 runs**. The whole file also passes standalone (50 tests). The assertions are now scheduler-independent by construction — nothing in the test observes wall-clock time.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — this *is* the test change; it keeps both sides of the boundary (no retry at 39 ms, retry at 40 ms) and now pins the exact hint value.
- [ ] Docs updated — n/a, no behavior change.
- [ ] WebSocket API changes — n/a.
- [x] Load-bearing invariants preserved — untouched (test-only).

## Screenshots (card / UI changes)

n/a — no visible card change.

## Follow-ups (found, not fixed)

- **Item 58 is not in `docs/open-items.md`.** The tracker on `main` tops out at item 55 (`b2b83e0`); there is no row 58 to cross off. Worked from the task spec instead. The reconciling sweep should add/close the row.
- **Sibling timing-sensitive tests were inspected; none share this defect.** In the same describe, the other rate-limited-subscribe tests (`store.revamp.test.ts:419`, `:444`, `:470`) run with `retryBaseMs: 0`, so their retries are zero-delay macrotasks drained by `flush(n)` — the retry timer is always queued before the flush timers, which makes the ordering load-independent rather than wall-clock-dependent. Left as-is.
- **Three wall-clock waits elsewhere in the file are slow, not flaky** — `:728`, `:748` (400 ms each, covering the 250 ms `scheduleTreeRefresh` debounce) and `:803` (5 ms). Each is one-sided ("has happened / is still unchanged by now"), a shape extra scheduling delay can only strengthen. Converting them to fake timers would cut ~800 ms off the suite; worth doing opportunistically, out of scope here. The same pattern appears in `hv-card-shell.test.ts:252`, `:763` and `hv-full-view.test.ts:853` (250 ms each).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANFT31xiEpqey6AzsRNuq3)_