### PR TITLE
feat: set the minimum supported Home Assistant version to 2026.3.1

### DIFF
--- a/.devcontainer/develop.sh
+++ b/.devcontainer/develop.sh
@@ -3,7 +3,7 @@
 #
 # Brings up a real Home Assistant (current stable on Python 3.14, provisioned by
 # uv) with the integration symlinked in, so edits are picked up on restart. This
-# runs current stable, not the declared 2026.3.1 floor — the floor is what the
+# runs current stable, not the declared 2026.6.0 floor — the floor is what the
 # phacc suite pins. Requires network access.
 set -euo pipefail
 

--- a/.devcontainer/develop.sh
+++ b/.devcontainer/develop.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Run Home Assistant with HAventory (+ HACS) against the working tree.
 #
-# This is the WP4 E2E hook: it brings up a real Home Assistant (the declared
-# 2026.7 / Python 3.14 runtime, provisioned by uv) with the integration
-# symlinked in, so edits are picked up on restart. Requires network access.
+# Brings up a real Home Assistant (current stable on Python 3.14, provisioned by
+# uv) with the integration symlinked in, so edits are picked up on restart. This
+# runs current stable, not the declared 2026.3.1 floor — the floor is what the
+# phacc suite pins. Requires network access.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
     id: ha_version
     attributes:
       label: Home Assistant version
-      description: Settings → About, e.g. 2026.7.3. Minimum supported is 2026.3.1.
+      description: Settings → About, e.g. 2026.7.3. Minimum supported is 2026.6.0.
       placeholder: "2026.7.3"
     validations:
       required: true
@@ -78,5 +78,5 @@ body:
       options:
         - label: I searched existing issues and this is not a duplicate.
           required: true
-        - label: I am running a supported Home Assistant version (>= 2026.3.1).
+        - label: I am running a supported Home Assistant version (>= 2026.6.0).
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
     id: ha_version
     attributes:
       label: Home Assistant version
-      description: Settings → About, e.g. 2026.7.3. Minimum supported is 2026.7.
+      description: Settings → About, e.g. 2026.7.3. Minimum supported is 2026.3.1.
       placeholder: "2026.7.3"
     validations:
       required: true
@@ -78,5 +78,5 @@ body:
       options:
         - label: I searched existing issues and this is not a duplicate.
           required: true
-        - label: I am running a supported Home Assistant version (>= 2026.7).
+        - label: I am running a supported Home Assistant version (>= 2026.3.1).
           required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The declared HA 2026.3.1 runtime. The source is 3.14-only (PEP 758
+        # The declared HA 2026.6.0 runtime. The source is 3.14-only (PEP 758
         # `except A, B:` syntax emitted by the 2026 ruff formatter).
         python-version: [ '3.14' ]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The declared HA 2026.7 runtime. The source is 3.14-only (PEP 758
+        # The declared HA 2026.3.1 runtime. The source is 3.14-only (PEP 758
         # `except A, B:` syntax emitted by the 2026 ruff formatter).
         python-version: [ '3.14' ]
     env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ HAventory is a Home Assistant **custom integration** (domain `haventory`) for ho
 inventory tracking, plus a Lovelace **card** frontend. Local-push, single-instance, HA
 `Store`-backed persistence — no external services.
 
-Targets: minimum Home Assistant **2026.3.1** ⇒ **Python 3.14 everywhere**
+Targets: minimum Home Assistant **2026.6.0** ⇒ **Python 3.14 everywhere**
 (`requires-python >=3.14`, ruff `target-version = py314`, mypy `3.14`, CI 3.14; the source
 uses 3.14-only PEP 758 syntax). uv provisions the interpreter automatically. Node
 **22.13+ / 24 LTS** (`engines: ^22.13 || >=24`). Toolchain: **uv** (env + lockfile +
@@ -165,18 +165,27 @@ blog.
 
 ### Minimum supported HA + Python (SET at feature freeze, 2026-07-29)
 
-- **Minimum supported HA:** **`2026.3.1`**. Derived from the touch points, not from "a recent
-  stable release": every HA symbol the integration uses (`websocket_api` registration +
-  decorators, `helpers.storage.Store`, the config-entry lifecycle, `ConfigFlowResult`,
-  `ConfigEntryError`, `helpers.area_registry.async_get`, `loader.async_get_integration`,
-  `hass.async_create_background_task`, `LOVELACE_DATA` + `ResourceStorageCollection`'s
-  `async_items` / `async_create_item` / `async_update_item` / `async_delete_item`) is present
-  and unchanged in 2026.3.1, verified against that release's wheel. The floor is set by the
-  **Python coupling**, not by any API: 2026.3 is the first series requiring Python 3.14, and
-  the source uses PEP 758 syntax that does not parse on 3.13. `2026.3.1` rather than
-  `2026.3.0` because no phacc build pins 2026.3.0, so 2026.3.1 is the lowest version CI can
-  run against.
+- **Minimum supported HA:** **`2026.6.0`**. Three constraints stack, each stricter than the
+  last:
+  1. **APIs** — every HA symbol the integration uses (`websocket_api` registration +
+     decorators, `helpers.storage.Store`, the config-entry lifecycle, `ConfigFlowResult`,
+     `ConfigEntryError`, `helpers.area_registry.async_get`, `loader.async_get_integration`,
+     `hass.async_create_background_task`, `LOVELACE_DATA` + `ResourceStorageCollection`'s
+     `async_items` / `async_create_item` / `async_update_item` / `async_delete_item`) is
+     present and unchanged as far back as **2026.3.1**, verified against both that release's
+     wheel and 2026.6.0's (the 2026.6 dashboard overhaul left the resource collection API
+     untouched). So the APIs alone would allow 2026.3.
+  2. **Python** — 2026.3 is the first series requiring Python 3.14, and the source uses PEP
+     758 syntax that does not parse on 3.13. Nothing below 2026.3 is possible at all.
+  3. **Security** — every release below 2026.6.0 is affected by GHSA-x84v-g949-293w (high,
+     CVE-2026-54317, fixed in 2026.6.0). A declared floor is a recommendation about what to
+     run, so it does not point at a version with a known unpatched advisory. This is the
+     binding constraint, and `dependency-review` enforces it: pinning
+     `requirements-integration.txt` any lower fails CI.
 - **Python:** **`3.14`** (forced by HA ≥ 2026.3). Non-negotiable given the min-HA choice.
+
+Re-check constraint 3 when raising the floor next: it moves with new advisories, so the
+"oldest release with no known advisory" is not a fixed number.
 
 The floor is defended by CI: `requirements-integration.txt` pins HA to it, so the in-process
 phacc suite runs at the floor, and `tests/test_min_ha_version.py` fails if any declaration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ HAventory is a Home Assistant **custom integration** (domain `haventory`) for ho
 inventory tracking, plus a Lovelace **card** frontend. Local-push, single-instance, HA
 `Store`-backed persistence — no external services.
 
-Targets (as of WP1): minimum Home Assistant **2026.7** ⇒ **Python 3.14 everywhere**
+Targets: minimum Home Assistant **2026.3.1** ⇒ **Python 3.14 everywhere**
 (`requires-python >=3.14`, ruff `target-version = py314`, mypy `3.14`, CI 3.14; the source
 uses 3.14-only PEP 758 syntax). uv provisions the interpreter automatically. Node
 **22.13+ / 24 LTS** (`engines: ^22.13 || >=24`). Toolchain: **uv** (env + lockfile +
@@ -163,14 +163,24 @@ blog.
   (2026-03-04). Every HA release from 2026.3 onward requires Python 3.14. This is not
   optional: declaring a min HA of 2026.3+ forces Python 3.14 on the toolchain.
 
-### Decisions to adopt at release (min HA + Python)
+### Minimum supported HA + Python (SET at feature freeze, 2026-07-29)
 
-- **Minimum supported HA:** **`2026.7`** (current stable at review time; policy = "a recent
-  stable release"). Re-confirm against whatever is current stable on the actual release date.
+- **Minimum supported HA:** **`2026.3.1`**. Derived from the touch points, not from "a recent
+  stable release": every HA symbol the integration uses (`websocket_api` registration +
+  decorators, `helpers.storage.Store`, the config-entry lifecycle, `ConfigFlowResult`,
+  `ConfigEntryError`, `helpers.area_registry.async_get`, `loader.async_get_integration`,
+  `hass.async_create_background_task`, `LOVELACE_DATA` + `ResourceStorageCollection`'s
+  `async_items` / `async_create_item` / `async_update_item` / `async_delete_item`) is present
+  and unchanged in 2026.3.1, verified against that release's wheel. The floor is set by the
+  **Python coupling**, not by any API: 2026.3 is the first series requiring Python 3.14, and
+  the source uses PEP 758 syntax that does not parse on 3.13. `2026.3.1` rather than
+  `2026.3.0` because no phacc build pins 2026.3.0, so 2026.3.1 is the lowest version CI can
+  run against.
 - **Python:** **`3.14`** (forced by HA ≥ 2026.3). Non-negotiable given the min-HA choice.
 
-> Status: RECOMMENDED, pending owner confirmation of the exact min-HA number. The Python
-> floor is determined by the min-HA choice and is not a free variable.
+The floor is defended by CI: `requirements-integration.txt` pins HA to it, so the in-process
+phacc suite runs at the floor, and `tests/test_min_ha_version.py` fails if any declaration
+site drifts from `hacs.json`. Current stable is covered by the dogfood run instead.
 
 ### Toolchain targets for WP1 (record now, change lands in WP1 — not WP0.5)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Contributions of all kinds are welcome — bug reports, features, docs, and code
 ## Development setup
 
 Prerequisites: [uv](https://docs.astral.sh/uv/), Node 22.13+ (or 24 LTS), git.
-Targets are **Home Assistant 2026.7+** ⇒ **Python 3.14** and **Node 22.13+/24**.
+Targets are **Home Assistant 2026.3.1+** ⇒ **Python 3.14** and **Node 22.13+/24**.
 
 ```bash
 # One-shot bootstrap: uv env + card deps + pre-commit hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Contributions of all kinds are welcome — bug reports, features, docs, and code
 ## Development setup
 
 Prerequisites: [uv](https://docs.astral.sh/uv/), Node 22.13+ (or 24 LTS), git.
-Targets are **Home Assistant 2026.3.1+** ⇒ **Python 3.14** and **Node 22.13+/24**.
+Targets are **Home Assistant 2026.6.0+** ⇒ **Python 3.14** and **Node 22.13+/24**.
 
 ```bash
 # One-shot bootstrap: uv env + card deps + pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Home Assistant custom integration (domain `haventory`) for household inventory t
 plus a Lit + TypeScript Lovelace card. Local-push, single-instance, HA `Store`-backed
 persistence — no external services.
 
-**Targets:** Linux dev + `ubuntu-latest` CI. Minimum Home Assistant **2026.7** ⇒ Python
+**Targets:** Linux dev + `ubuntu-latest` CI. Minimum Home Assistant **2026.3.1** ⇒ Python
 **3.14** everywhere (uv provisions the interpreter automatically; the source uses 3.14-only
 PEP 758 syntax). Node **22.13+ / 24 LTS** for the card.
 
@@ -26,7 +26,8 @@ HAventory isn't in the HACS default store yet. To install from this repository:
 4. Add it via **Settings → Devices & Services → Add Integration → HAventory**.
 5. Refresh your browser (Ctrl/Cmd+Shift+R) so the Lovelace card appears in the picker.
 
-Minimum Home Assistant version: **2026.7**. Developers: see the Developer Checklist below
+Minimum Home Assistant version: **2026.3.1** — the first release series requiring Python
+3.14, which the source needs. Developers: see the Developer Checklist below
 and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### YAML-mode dashboards

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Home Assistant custom integration (domain `haventory`) for household inventory t
 plus a Lit + TypeScript Lovelace card. Local-push, single-instance, HA `Store`-backed
 persistence — no external services.
 
-**Targets:** Linux dev + `ubuntu-latest` CI. Minimum Home Assistant **2026.3.1** ⇒ Python
+**Targets:** Linux dev + `ubuntu-latest` CI. Minimum Home Assistant **2026.6.0** ⇒ Python
 **3.14** everywhere (uv provisions the interpreter automatically; the source uses 3.14-only
 PEP 758 syntax). Node **22.13+ / 24 LTS** for the card.
 
@@ -26,9 +26,9 @@ HAventory isn't in the HACS default store yet. To install from this repository:
 4. Add it via **Settings → Devices & Services → Add Integration → HAventory**.
 5. Refresh your browser (Ctrl/Cmd+Shift+R) so the Lovelace card appears in the picker.
 
-Minimum Home Assistant version: **2026.3.1** — the first release series requiring Python
-3.14, which the source needs. Developers: see the Developer Checklist below
-and [CONTRIBUTING.md](CONTRIBUTING.md).
+Minimum Home Assistant version: **2026.6.0** — the oldest release that both runs the
+integration and carries no known security advisory. Developers: see the Developer
+Checklist below and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### YAML-mode dashboards
 

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -249,12 +249,21 @@ describe('hv-list-row: mobile affordances', () => {
     expect(q(el, '[data-testid="row-low"]')).toBe(null);
   });
 
+  // Pinned clock: the due date has to stay in the future *and* in the current
+  // year for the label to read "due Jul 28" — a literal date drifts into
+  // "Overdue" and into the with-year format as the real calendar moves.
   it('replaces the stepper with Check in for a checked-out row', async () => {
-    const el = await mount({ checked_out: true, due_date: '2026-07-28' }, { mobile: true });
-    expect(q(el, '[data-testid="row-stepper"]')).toBe(null);
-    const btn = q(el, '[data-testid="row-check-in"]');
-    expect(btn?.textContent).toContain('Check in');
-    expect(el.shadowRoot?.textContent).toContain('Checked out · due Jul 28');
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 20));
+    try {
+      const el = await mount({ checked_out: true, due_date: '2026-07-28' }, { mobile: true });
+      expect(q(el, '[data-testid="row-stepper"]')).toBe(null);
+      const btn = q(el, '[data-testid="row-check-in"]');
+      expect(btn?.textContent).toContain('Check in');
+      expect(el.shadowRoot?.textContent).toContain('Checked out · due Jul 28');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // A passed date used to render exactly like an upcoming one — same wording,

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -266,6 +266,6 @@ Note: a successful import emits `items/reloaded` and `locations/reloaded` (no `i
 
 ### Compatibility
 
-- Target HA: ≥ 2026.7; Python 3.14 (WP1 floors — see CLAUDE.md). The offline suite validates
+- Target HA: ≥ 2026.3.1; Python 3.14 (see CLAUDE.md). The offline suite validates
   the envelope against the stubs in `tests/conftest.py`; the phacc integration suite
   (`tests/integration/`) validates it against a real in-process HA core.

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -266,6 +266,6 @@ Note: a successful import emits `items/reloaded` and `locations/reloaded` (no `i
 
 ### Compatibility
 
-- Target HA: ≥ 2026.3.1; Python 3.14 (see CLAUDE.md). The offline suite validates
+- Target HA: ≥ 2026.6.0; Python 3.14 (see CLAUDE.md). The offline suite validates
   the envelope against the stubs in `tests/conftest.py`; the phacc integration suite
   (`tests/integration/`) validates it against a real in-process HA core.

--- a/docs/release_testing_plan.md
+++ b/docs/release_testing_plan.md
@@ -12,7 +12,7 @@ Out of scope: feature work, and anything tracked as **post-v1.0** in
 alongside this plan) also live in `open-items.md` — this file is tests only.
 
 **Sequencing.** The run belongs after feature freeze. D6's prerequisite is met: the minimum
-supported HA version is **2026.3.1** (open item 29, derived at feature freeze from the HA
+supported HA version is **2026.6.0** (open item 29, derived at feature freeze from the HA
 APIs the integration actually touches — see CLAUDE.md), so D6 runs against that number.
 
 ---
@@ -39,7 +39,7 @@ A release is "ready" when **all** of the following hold:
 |-----|------|----------|
 | **ENV-A** | Personal production HA instance, real data, real hardware | Everything except destructive scenarios (D8, E2–E4) |
 | **ENV-B** | Throwaway HA in Docker (`scripts/reload_addon.sh`, `run-haventory` skill) | Destructive + adversarial scenarios; YAML-mode Lovelace |
-| **ENV-C** | Docker HA pinned to the **declared minimum supported version**, `2026.3.1` (`hacs.json` `homeassistant`) | D6 — validates the floor |
+| **ENV-C** | Docker HA pinned to the **declared minimum supported version**, `2026.6.0` (`hacs.json` `homeassistant`) | D6 — validates the floor |
 | **ENV-D** | Docker HA restored from an **ENV-A production backup** | E2–E4 restore scenarios, without risking ENV-A |
 
 Clients to cover: desktop Chrome, one of Firefox/Safari desktop, **iOS companion app**,
@@ -149,7 +149,7 @@ Run `haventory/health` after **each** of these, and snapshot the store around D7
 | D3 | Config-entry reload (no HA restart) | Reload succeeds; subscriptions re-established; no duplicate WS handler registration | ✅ |
 | D4 | HA minor update (current stable → next stable) with HAventory installed | Setup succeeds; no deprecation warnings from `custom_components.haventory` | ✅ |
 | D5 | HA **next beta** | Same; any breakage is filed before it reaches stable | |
-| D6 | Minimum supported HA `2026.3.1` (ENV-C). The phacc suite already runs the integration in-process at this version in CI; D6 is the live counterpart — a real container, the card, and the browser | Integration sets up and the full CRUD path works on the declared floor; if it does not, the floor is wrong and must be raised before release | ✅ |
+| D6 | Minimum supported HA `2026.6.0` (ENV-C). The phacc suite already runs the integration in-process at this version in CI; D6 is the live counterpart — a real container, the card, and the browser | Integration sets up and the full CRUD path works on the declared floor; if it does not, the floor is wrong and must be raised before release | ✅ |
 | D7 | Integration update N → N+1 **with real data**, including a schema migration | Migration runs once, is idempotent on a second restart, data intact, `health` healthy | ✅ |
 | D8 | Integration **rollback** N+1 → N (ENV-B only) | Newer-schema data is **refused loudly**: setup fails with `ConfigEntryError` naming both versions and the store file is left byte-identical — never migrated down, never silently relabeled (decided; item 25 fixed by #120) | ✅ |
 | D9 | Card update with a warm browser cache: update the integration, then reload normally (no hard refresh), on desktop **and** in the companion app | New card version actually loads; check `haventory/version` vs. the card build. The resource is now registered as `…haventory-card.js?v=<manifest version>` and a stale entry is rewritten in place (item 26, fixed by #122) | ✅ |

--- a/docs/release_testing_plan.md
+++ b/docs/release_testing_plan.md
@@ -11,11 +11,9 @@ Out of scope: feature work, and anything tracked as **post-v1.0** in
 [`open-items.md`](open-items.md). Pre-v1.0 *tasks* (fixes/docs/release chores identified
 alongside this plan) also live in `open-items.md` — this file is tests only.
 
-**Sequencing.** The run belongs after v1.0 feature freeze. One scenario has a hard
-prerequisite: **D6 cannot run until the minimum supported HA version is actually decided**
-(open item 29) — the `2026.7.0` currently in `hacs.json` is a stale leftover from an earlier
-work package, not a verified floor, and the real number can only be derived once the final
-feature set fixes which HA APIs are used.
+**Sequencing.** The run belongs after feature freeze. D6's prerequisite is met: the minimum
+supported HA version is **2026.3.1** (open item 29, derived at feature freeze from the HA
+APIs the integration actually touches — see CLAUDE.md), so D6 runs against that number.
 
 ---
 
@@ -41,7 +39,7 @@ A release is "ready" when **all** of the following hold:
 |-----|------|----------|
 | **ENV-A** | Personal production HA instance, real data, real hardware | Everything except destructive scenarios (D8, E2–E4) |
 | **ENV-B** | Throwaway HA in Docker (`scripts/reload_addon.sh`, `run-haventory` skill) | Destructive + adversarial scenarios; YAML-mode Lovelace |
-| **ENV-C** | Docker HA pinned to the **minimum supported version — once that number is actually set** (open item 29). The `2026.7.0` currently in `hacs.json` is a stale leftover, not a verified floor; the real minimum is decided after v1.0 is feature-complete | D6 — validates the floor |
+| **ENV-C** | Docker HA pinned to the **declared minimum supported version**, `2026.3.1` (`hacs.json` `homeassistant`) | D6 — validates the floor |
 | **ENV-D** | Docker HA restored from an **ENV-A production backup** | E2–E4 restore scenarios, without risking ENV-A |
 
 Clients to cover: desktop Chrome, one of Firefox/Safari desktop, **iOS companion app**,
@@ -151,7 +149,7 @@ Run `haventory/health` after **each** of these, and snapshot the store around D7
 | D3 | Config-entry reload (no HA restart) | Reload succeeds; subscriptions re-established; no duplicate WS handler registration | ✅ |
 | D4 | HA minor update (current stable → next stable) with HAventory installed | Setup succeeds; no deprecation warnings from `custom_components.haventory` | ✅ |
 | D5 | HA **next beta** | Same; any breakage is filed before it reaches stable | |
-| D6 | Minimum supported HA (ENV-C). **Blocked on open item 29** — the floor has not been set yet, and `hacs.json`'s `2026.7.0` is stale. Run this against whatever number the post-feature-freeze decision lands on | Integration sets up and the full CRUD path works on the declared floor; if it does not, the floor is wrong and must be raised before release | ✅ |
+| D6 | Minimum supported HA `2026.3.1` (ENV-C). The phacc suite already runs the integration in-process at this version in CI; D6 is the live counterpart — a real container, the card, and the browser | Integration sets up and the full CRUD path works on the declared floor; if it does not, the floor is wrong and must be raised before release | ✅ |
 | D7 | Integration update N → N+1 **with real data**, including a schema migration | Migration runs once, is idempotent on a second restart, data intact, `health` healthy | ✅ |
 | D8 | Integration **rollback** N+1 → N (ENV-B only) | Newer-schema data is **refused loudly**: setup fails with `ConfigEntryError` naming both versions and the store file is left byte-identical — never migrated down, never silently relabeled (decided; item 25 fixed by #120) | ✅ |
 | D9 | Card update with a warm browser cache: update the integration, then reload normally (no hard refresh), on desktop **and** in the companion app | New card version actually loads; check `haventory/version` vs. the card build. The resource is now registered as `…haventory-card.js?v=<manifest version>` and a stale entry is rewritten in place (item 26, fixed by #122) | ✅ |

--- a/hacs.json
+++ b/hacs.json
@@ -3,6 +3,6 @@
   "render_readme": true,
   "content_in_root": false,
   "country": ["all"],
-  "homeassistant": "2026.7.0",
+  "homeassistant": "2026.3.1",
   "filename": "haventory-card.js"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,6 +3,6 @@
   "render_readme": true,
   "content_in_root": false,
   "country": ["all"],
-  "homeassistant": "2026.3.1",
+  "homeassistant": "2026.6.0",
   "filename": "haventory-card.js"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Home Assistant custom integration for household inventory trackin
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "chrreiter" }]
-# Matches the declared HA runtime (min HA 2026.3.1 => Python 3.14). uv provisions
+# Matches the declared HA runtime (min HA 2026.6.0 => Python 3.14). uv provisions
 # 3.14 automatically (`uv sync` / `uv python install 3.14`); dev environments
 # must allow the interpreter download or preinstall 3.14.
 requires-python = ">=3.14"
@@ -76,7 +76,7 @@ quote-style = "preserve"
 "scripts/**" = ["ASYNC240", "ASYNC250"]
 
 [tool.mypy]
-# python_version matches requires-python / ruff target (HA 2026.3.1 => 3.14).
+# python_version matches requires-python / ruff target (HA 2026.6.0 => 3.14).
 python_version = "3.14"
 files = ["custom_components/haventory"]
 namespace_packages = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Home Assistant custom integration for household inventory trackin
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "chrreiter" }]
-# Matches the declared HA runtime (min HA 2026.7 => Python 3.14). uv provisions
+# Matches the declared HA runtime (min HA 2026.3.1 => Python 3.14). uv provisions
 # 3.14 automatically (`uv sync` / `uv python install 3.14`); dev environments
 # must allow the interpreter download or preinstall 3.14.
 requires-python = ">=3.14"
@@ -76,7 +76,7 @@ quote-style = "preserve"
 "scripts/**" = ["ASYNC240", "ASYNC250"]
 
 [tool.mypy]
-# python_version matches requires-python / ruff target (HA 2026.7 => 3.14).
+# python_version matches requires-python / ruff target (HA 2026.3.1 => 3.14).
 python_version = "3.14"
 files = ["custom_components/haventory"]
 namespace_packages = true

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -18,9 +18,15 @@
 #         .venv-integration/bin/python -m pytest -o asyncio_mode=auto tests/integration
 #     or simply: scripts/test_integration.sh
 #
-# Version policy: pin the Home Assistant core to the WP0.5 minimum-supported
-# stable (2026.7.3). Because each phacc release pins one exact HA version, this HA
-# pin uniquely selects the matching phacc build — no separate phacc version guess
-# is needed. Bump both together (raise the HA pin) when the minimum-HA target moves.
-homeassistant==2026.7.3
+# Version policy: pin the Home Assistant core to the DECLARED MINIMUM supported
+# version (hacs.json `homeassistant`), so this suite defends the floor rather than
+# re-testing whatever is current. Because each phacc release pins one exact HA
+# version, this HA pin uniquely selects the matching phacc build — no separate
+# phacc version guess is needed. Raise both together (by raising the HA pin) only
+# when the declared minimum moves; `tests/test_min_ha_version.py` fails if the two
+# drift apart.
+#
+# 2026.3.1, not 2026.3.0: no phacc build pins 2026.3.0, so 2026.3.1 is the lowest
+# floor this suite can actually run against.
+homeassistant==2026.3.1
 pytest-homeassistant-custom-component

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -26,7 +26,8 @@
 # when the declared minimum moves; `tests/test_min_ha_version.py` fails if the two
 # drift apart.
 #
-# 2026.3.1, not 2026.3.0: no phacc build pins 2026.3.0, so 2026.3.1 is the lowest
-# floor this suite can actually run against.
-homeassistant==2026.3.1
+# 2026.6.0 rather than 2026.3.x, which the API touch points would also allow:
+# every release below 2026.6.0 is affected by GHSA-x84v-g949-293w (high, fixed in
+# 2026.6.0), and the dependency-review check fails the pin outright.
+homeassistant==2026.6.0
 pytest-homeassistant-custom-component

--- a/tests/test_min_ha_version.py
+++ b/tests/test_min_ha_version.py
@@ -1,0 +1,74 @@
+"""The declared minimum supported Home Assistant version must agree everywhere.
+
+``hacs.json`` carries the number HACS enforces at install time, so it is the
+source of truth here; every other spelling of it is a copy that silently goes
+stale. The copies are enumerated explicitly rather than discovered — a grep for
+version-shaped tokens also matches example versions (the bug-report placeholder)
+and unrelated pins.
+
+``requirements-integration.txt`` is the one that makes the claim testable: the
+in-process HA suite runs against exactly that pin, so pinning it to the floor is
+what turns "minimum supported" from an assertion into something CI defends.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Three components, so a trailing sentence period cannot be swallowed into the
+# match and a two-component claim ("2026.3") fails rather than passing loosely.
+VERSION = r"\d+\.\d+\.\d+"
+
+# (path, pattern, expected number of occurrences). Every capture group must
+# equal the hacs.json floor.
+DECLARATION_SITES: tuple[tuple[str, str, int], ...] = (
+    ("requirements-integration.txt", rf"^homeassistant==({VERSION})$", 1),
+    ("README.md", rf"Minimum Home Assistant (?:version: )?\*\*({VERSION})\*\*", 2),
+    ("CONTRIBUTING.md", rf"\*\*Home Assistant ({VERSION})\+\*\*", 1),
+    (".github/ISSUE_TEMPLATE/bug_report.yml", rf"Minimum supported is ({VERSION})\.", 1),
+    (
+        ".github/ISSUE_TEMPLATE/bug_report.yml",
+        rf"supported Home Assistant version \(>= ({VERSION})\)",
+        1,
+    ),
+    ("pyproject.toml", rf"HA ({VERSION}) =>", 2),
+    (".github/workflows/ci.yml", rf"declared HA ({VERSION}) runtime", 1),
+)
+
+
+def declared_floor() -> str:
+    """The minimum supported HA version as HACS reads it."""
+    return json.loads((REPO_ROOT / "hacs.json").read_text(encoding="utf-8"))["homeassistant"]
+
+
+def test_floor_is_on_the_python_314_side_of_the_split() -> None:
+    """A floor below 2026.3 would be unusable, not merely optimistic.
+
+    HA raised its Python floor to 3.14 in 2026.3. The integration's source uses
+    PEP 758 unparenthesized ``except A, B:``, which does not parse on 3.13, so
+    an older HA could not import it at all.
+    """
+    year, month, _ = (int(part) for part in declared_floor().split("."))
+    assert (year, month) >= (2026, 3)
+
+
+@pytest.mark.parametrize(("relative_path", "pattern", "occurrences"), DECLARATION_SITES)
+def test_declaration_sites_match_hacs_json(
+    relative_path: str, pattern: str, occurrences: int
+) -> None:
+    """Every copy of the floor agrees with ``hacs.json``."""
+    text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    found = re.findall(pattern, text, flags=re.MULTILINE)
+
+    assert len(found) == occurrences, (
+        f"{relative_path}: expected {occurrences} match(es) for {pattern!r}, found {len(found)}"
+    )
+    assert set(found) == {declared_floor()}, (
+        f"{relative_path} declares {sorted(set(found))}, hacs.json declares {declared_floor()!r}"
+    )


### PR DESCRIPTION
## Summary

Open item **29**. `hacs.json` claimed `2026.7.0` — a leftover that predated the current feature set and was never derived from anything. This sets the floor from what the integration actually touches, applies it everywhere the number is repeated, and pins the integration-test HA to it so CI defends it.

### Recommended floor: **2026.3.1**

**Every HA symbol the integration uses is present and unchanged in 2026.3.1**, verified by extracting that release's wheel and checking each site rather than from memory:

| Touch point | Verified in 2026.3.1 |
|---|---|
| `websocket_api.async_register_command`, `@websocket_command`, `@async_response`, `error_message`/`result_message`, `ActiveConnection` | ✅ |
| `helpers.storage.Store(hass, version, key)` + `async_load`/`async_save`/`async_delay_save`/`async_remove` | ✅ |
| Config-entry lifecycle, `ConfigFlowResult`, `OptionsFlow.config_entry` property, `_async_current_entries`, `single_config_entry` manifest key | ✅ |
| `exceptions.ConfigEntryError` / `ConfigEntryNotReady` | ✅ |
| `helpers.area_registry.async_get` | ✅ |
| `loader.async_get_integration` | ✅ |
| `hass.async_create_background_task`, `hass.async_add_executor_job` | ✅ |
| `lovelace.LOVELACE_DATA` + `LovelaceData.resources`; `ResourceStorageCollection.async_items` / `async_create_item` / `async_update_item` / `async_delete_item` / `loaded` / `async_load` | ✅ |

**So no API sets the floor — the Python coupling does.** HA 2026.3.0 (2026-03-04) is the first release requiring Python `>=3.14.2`; every release before it allows 3.13, and the source uses PEP 758 unparenthesized `except A, B:`, which does not parse on 3.13. Anything below 2026.3 is a toolchain change, not a version-string edit.

**Why `2026.3.1` and not `2026.3.0`:** each `pytest-homeassistant-custom-component` release pins one exact HA version, and the phacc series skips 2026.3.0 (`0.13.316` → `2026.2.3`, `0.13.317` → `2026.3.1`). 2026.3.1 is therefore the lowest floor CI can actually run against — and a floor CI cannot run is a claim, not a guarantee.

This widens the supported range from one minor series to five (2026.3 → 2026.7 and onward).

### Applied

- `hacs.json` → `"homeassistant": "2026.3.1"`
- `README.md` (2×), `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/bug_report.yml` (2×), explanatory comments in `pyproject.toml` (2×) and `.github/workflows/ci.yml`
- `requirements-integration.txt`: `homeassistant==2026.7.3` → `==2026.3.1`, so the in-process phacc suite runs the integration **at the declared floor**. The version-policy comment now says "pin to the declared minimum" instead of "pin to current stable".
- Consistency fixes in the same breath: `CLAUDE.md` (the WP0.5 "Decisions to adopt at release" block becomes the settled decision, with the derivation), `docs/backend_api_contract.md`, `.devcontainer/develop.sh`, and the three `docs/release_testing_plan.md` places that described D6 as blocked on this item.

### Test

`tests/test_min_ha_version.py` — `hacs.json` is the source of truth; every other declaration site is checked against it, and a floor below 2026.3 fails outright (the Python-3.14 coupling encoded as an assertion rather than a comment). Edge case covered: a site that stops matching its pattern fails on the occurrence count, so deleting or rewording a declaration is caught as loudly as changing its number.

### Live validation

Not in this PR by design — release-test **D6** validates a real instance at the floor during the WP8 dogfood run.

### Note: an unrelated red test on `main`

`main` was already failing its frontend gate before this branch. `hv-list-row.test.ts` asserted `"Checked out · due Jul 28"` against a hardcoded `due_date: '2026-07-28'`; that date passed on 2026-07-29 and the row correctly re-rendered as `"Overdue · due Jul 28"`. Fixed in its own commit (`test(card): pin the clock…`) by pinning the system clock, since the label needs the due date to be both in the future and in the current year — no literal can stay both. Flagged rather than folded silently: it is not part of item 29.

## Type of change

- [x] New feature (non-breaking change that adds functionality) — widens the supported HA range
- [x] Documentation / tooling / CI
- [x] Bug fix (non-breaking change that fixes an issue) — the date-expired card test

## How was this tested?

Both gates green on the final tree:

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **343 passed, 22 skipped** (351 with the 8 new cases); `uv run ruff check .` → clean; `uv run ruff format --check .` → 90 files formatted; `uv run mypy` → no issues in 13 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npm run typecheck` → clean; `npx vitest run` → **812 passed (42 files)**; `npm run build` → 427.68 kB

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added/updated (happy path + at least one edge/error case)
- [x] Docs updated where behavior changed
- [x] WebSocket API unchanged — no contract drift
- [x] Load-bearing invariants untouched

## Follow-ups

- **CI no longer exercises current-stable HA in-process.** Pinning `requirements-integration.txt` to the floor is what item 29 asks for, and it trades away the "does the newest HA still work" signal. The dogfood/D-series runs cover current stable live, so the split is deliberate — but if that signal is wanted in CI, the integration job would need a matrix over floor + latest rather than a single pinned requirements file.
- `requirements-integration.txt` is not in any Dependabot ecosystem (the `uv` ecosystem reads `pyproject.toml` + `uv.lock`), so the floor pin will not drift on its own. That is the desired behavior here, but it also means a deliberate floor bump is a manual edit.
- `.github/ISSUE_TEMPLATE/bug_report.yml`'s `placeholder: "2026.7.3"` is left as-is: it illustrates the *format* a reporter should type, not the minimum.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLS2t1ca6MKXQj2dgRncrw)_