### PR TITLE
feat(ci): enable release automation and check the version agrees everywhere

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,17 +1,13 @@
 name: release-please
 
-# DORMANT until WP5 / Phase 3 (see CONTRIBUTING.md → Releases).
-#
-# This workflow is config-ready but does NOT run automatically: it has only a
-# manual `workflow_dispatch` trigger. To turn on automated release PRs, add the
-# `push` trigger to `main` (uncomment below). Running it (manually or on push)
-# opens a release PR that bumps versions across manifest.json / pyproject.toml /
-# card package.json and publishes a GitHub Release with notes generated from
-# Conventional Commit history.
+# Keeps a release PR open and up to date as conventional commits land on main;
+# merging it tags the release and publishes a GitHub Release with generated
+# notes. See CONTRIBUTING.md → Releases for the flow and for what each version
+# bump means here.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
-  # push:
-  #   branches: [main]
 
 permissions:
   contents: read
@@ -24,6 +20,26 @@ jobs:
       pull-requests: write
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071  # v4.4.1
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The tag is the one version string release-please writes outside a file,
+      # so it is the one that can disagree with the five it writes inside them.
+      # It has to be checked here rather than from a `push: tags:` workflow:
+      # the tag is pushed with GITHUB_TOKEN, and GitHub does not start new
+      # workflow runs for events that token raises, so such a workflow would
+      # never fire. The file-to-file half of the check runs on the release PR
+      # itself, in the backend job (tests/test_release_version_consistency.py).
+      - name: Check out the published tag
+        if: steps.release.outputs.release_created == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
+
+      - name: Tag matches the declared version
+        if: steps.release.outputs.release_created == 'true'
+        run: python3 scripts/check_version_consistency.py --tag "$TAG"
+        env:
+          TAG: ${{ steps.release.outputs.tag_name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,65 @@ plus `actionlint`, `hassfest`, HACS validation, CodeQL, and dependency review.
 
 ## Releases
 
-Release automation (release-please) is **config-ready but deferred to WP5** —
-see `.github/workflows/release-please.yml`. When enabled, merging Conventional
-Commits to `main` opens a release PR that bumps the version across
-`manifest.json`, `pyproject.toml`, and the card's `package.json`, and publishes
-a GitHub Release with generated notes.
+Releases are automated with
+[release-please](https://github.com/googleapis/release-please)
+(`.github/workflows/release-please.yml`, `release-please-config.json`). Nobody
+edits a version by hand.
+
+### The flow
+
+1. Conventional Commits land on `main`.
+2. release-please opens — and then keeps updating — a **release PR** titled
+   `chore(main): release <version>`. It bumps every version file, writes
+   `CHANGELOG.md` from the commit history, and updates
+   `.release-please-manifest.json`.
+3. Review that PR like any other. CI runs on it, which is where a version file
+   that release-please *failed* to rewrite gets caught
+   (`tests/test_release_version_consistency.py`).
+4. Merging it tags the release and publishes a GitHub Release with the generated
+   notes. The same workflow run then checks that the tag names the version the
+   repository declares. (That check lives in the release workflow rather than in
+   a `push: tags:` one because the tag is pushed with `GITHUB_TOKEN`, and GitHub
+   does not start new workflow runs for events that token raises.)
+
+### What each commit type does to the version
+
+Pre-1.0, `bump-minor-pre-major` keeps breaking changes from reaching 1.0.0 by
+accident:
+
+| Commit | Effect while `0.x` | Effect once `1.x` |
+|---|---|---|
+| `fix:` | patch (`0.1.0` → `0.1.1`) | patch |
+| `feat:` | **minor** (`0.1.0` → `0.2.0`) | minor |
+| `feat!:` / `BREAKING CHANGE:` | **minor** (capped below 1.0.0) | major |
+| `chore:`, `docs:`, `test:`, `ci:`, `refactor:` | no release on their own | same |
+
+`bump-patch-for-minor-pre-major` is deliberately **not** set: with it, a `feat`
+would only bump the patch pre-1.0, and the first cut off `0.0.1` would be
+`0.0.2` rather than `0.1.0`.
+
+To release a specific version instead of the computed one, put a
+`Release-As: 1.2.3` footer in a commit on `main`. Do **not** use the config's
+`release-as` key — release-please deprecates it in favour of the commit footer,
+and it is sticky: left in place, every later release repeats the same version.
+
+### The version files
+
+Five files carry the version, each rewritten by a different release-please
+mechanism, so each can fail to update independently:
+
+| File | Mechanism |
+|---|---|
+| `pyproject.toml` | `release-type: python` |
+| `custom_components/haventory/manifest.json` | `extra-files` json + jsonpath |
+| `cards/haventory-card/package.json` | `extra-files` json + jsonpath |
+| `custom_components/haventory/const.py` (`INTEGRATION_VERSION`) | `extra-files` generic + an `x-release-please-version` line annotation |
+| `.release-please-manifest.json` | release-please's own bookkeeping |
+
+`INTEGRATION_VERSION` is the one users see: `haventory/version` returns it and
+every export document is stamped with it. `scripts/check_version_consistency.py`
+compares all five (and, on a tag build, the tag) — run it locally any time:
+
+```bash
+uv run python scripts/check_version_consistency.py
+```

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -7,8 +7,11 @@ option keys/defaults for WebSocket rate limiting.
 # Integration domain used across all modules and entity unique IDs
 DOMAIN: str = "haventory"
 
-# Public integration version (kept in sync with manifest.json)
-INTEGRATION_VERSION: str = "0.0.1"
+# Public integration version, surfaced by `haventory/version` and stamped into
+# export documents. release-please rewrites the literal below on the annotation;
+# tests/test_release_version_consistency.py fails if it ever disagrees with
+# manifest.json.
+INTEGRATION_VERSION: str = "0.0.1"  # x-release-please-version
 
 # -----------------------------
 # WebSocket rate limiting (config-entry options)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "packages": {
     ".": {
@@ -18,6 +17,10 @@
           "type": "json",
           "path": "cards/haventory-card/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "custom_components/haventory/const.py"
         }
       ]
     }

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Assert every version string in the repository agrees — and matches the tag.
+
+Five files carry the release version, and release-please rewrites each of them
+through a different mechanism: the `python` release type handles
+``pyproject.toml``, two ``extra-files`` JSON entries handle the integration
+manifest and the card's ``package.json``, a generic annotation handles
+``const.py``, and the manifest file is release-please's own bookkeeping. Any one
+of them can silently stop being rewritten — a moved line drops a generic
+annotation, a renamed key orphans a jsonpath — and the failure mode is a release
+that ships mismatched versions rather than an error.
+
+Run with no arguments to check the files against each other. Pass ``--tag`` (or
+set ``GITHUB_REF_NAME`` on a tag build) to also require the git tag to name the
+same version, which is what closes the loop between the tag and what the
+integration reports at runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _json_version(relative_path: str, key: str = "version") -> str:
+    return json.loads((REPO_ROOT / relative_path).read_text(encoding="utf-8"))[key]
+
+
+def _pyproject_version() -> str:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        return str(tomllib.load(handle)["project"]["version"])
+
+
+def _const_version() -> str:
+    text = (REPO_ROOT / "custom_components/haventory/const.py").read_text(encoding="utf-8")
+    match = re.search(r'^INTEGRATION_VERSION:\s*str\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    if match is None:
+        raise AssertionError("const.py: INTEGRATION_VERSION assignment not found")
+    return match.group(1)
+
+
+def collect_versions() -> dict[str, str]:
+    """The declared version of every file that carries one, by source name."""
+    return {
+        "custom_components/haventory/manifest.json": _json_version(
+            "custom_components/haventory/manifest.json"
+        ),
+        ".release-please-manifest.json": _json_version(".release-please-manifest.json", key="."),
+        "pyproject.toml": _pyproject_version(),
+        "cards/haventory-card/package.json": _json_version("cards/haventory-card/package.json"),
+        "custom_components/haventory/const.py": _const_version(),
+    }
+
+
+def tag_version(tag: str) -> str:
+    """The version a release tag names, e.g. ``v0.1.0`` -> ``0.1.0``."""
+    if not re.fullmatch(r"v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?", tag):
+        raise AssertionError(f"tag {tag!r} is not a release tag of the form vMAJOR.MINOR.PATCH")
+    return tag[1:]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tag",
+        default=None,
+        help="Release tag to check against (defaults to GITHUB_REF_NAME on a tag build).",
+    )
+    args = parser.parse_args()
+
+    versions = collect_versions()
+    distinct = set(versions.values())
+    if len(distinct) != 1:
+        print("Version mismatch across the repository:", file=sys.stderr)
+        for source, version in sorted(versions.items()):
+            print(f"  {version:>12}  {source}", file=sys.stderr)
+        return 1
+
+    declared = distinct.pop()
+
+    tag = args.tag
+    if tag is None and os.environ.get("GITHUB_REF_TYPE") == "tag":
+        tag = os.environ.get("GITHUB_REF_NAME")
+
+    if tag is not None:
+        expected = tag_version(tag)
+        if expected != declared:
+            print(
+                f"Tag {tag!r} names version {expected!r}, but the repository declares "
+                f"{declared!r} in all {len(versions)} version files.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"OK: tag {tag} and all {len(versions)} version files agree on {declared}")
+        return 0
+
+    print(f"OK: all {len(versions)} version files agree on {declared}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_version_consistency.py
+++ b/tests/test_release_version_consistency.py
@@ -1,0 +1,46 @@
+"""The release version must be identical in every file that carries it.
+
+This runs in the ordinary gate, so it fires on the release PR itself — the one
+place where a version that release-please failed to rewrite is still cheap to
+fix. The tag half of the same check runs on the tag build; see
+``scripts/check_version_consistency.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_version_consistency import collect_versions, tag_version  # noqa: E402
+
+
+def test_every_version_file_agrees() -> None:
+    versions = collect_versions()
+
+    # Named explicitly: a source that stops being collected would otherwise make
+    # the agreement assertion pass by covering less.
+    assert set(versions) == {
+        "custom_components/haventory/manifest.json",
+        ".release-please-manifest.json",
+        "pyproject.toml",
+        "cards/haventory-card/package.json",
+        "custom_components/haventory/const.py",
+    }
+    assert len(set(versions.values())) == 1, f"version mismatch: {versions}"
+
+
+def test_tag_version_strips_the_prefix() -> None:
+    assert tag_version("v0.1.0") == "0.1.0"
+    assert tag_version("v1.0.0-rc.1") == "1.0.0-rc.1"
+
+
+@pytest.mark.parametrize("tag", ["0.1.0", "v0.1", "release-0.1.0", "v0.1.0.1", ""])
+def test_tag_version_rejects_non_release_tags(tag: str) -> None:
+    """A tag that is not a release tag must fail loudly rather than parse."""
+    with pytest.raises(AssertionError):
+        tag_version(tag)


### PR DESCRIPTION
## Summary

Open items **3** (enable release automation) and **30** (version numbers still `0.0.1`, keep them in sync with the tag).

Rebased onto `main` after #141 merged — this PR is now a single commit touching 6 files, independent and ready to merge on its own.

### Item 3 — release-please goes live

The push trigger is uncommented and the "DORMANT until WP5" preamble is gone. Merging Conventional Commits to `main` now opens and maintains a release PR; merging that PR tags and publishes.

### The first cut is v0.1.0 — by the bump rules, not an override

I checked the mechanism against the current release-please docs rather than from memory, and the config was set to produce the wrong number:

- `bump-minor-pre-major: true` — while below 1.0.0, a breaking change bumps the **minor**, so the first cut cannot accidentally be `1.0.0`. Keep.
- `bump-patch-for-minor-pre-major: true` — while below 1.0.0, a `feat` bumps only the **patch**. With this set, the first cut off `0.0.1` would have been **`0.0.2`**. **Removed.**

With just `bump-minor-pre-major`, the natural bump off `0.0.1` is a minor → **`0.1.0`**. That is deterministic here: history carries 6 `feat:` commits and 0 breaking changes, and even a breaking change would land on `0.1.0` because the minor cap applies. It also gives the right *ongoing* behaviour for the staging plan — `fix:` keeps you on `0.1.x` through the dogfood, and the next `feat:` takes you to `0.2.0` for the schema exercise.

Two things I deliberately did **not** use, both verified against the docs:

- The config's **`release-as` key is deprecated** — the schema reads *"[DEPRECATED] Override the next version of this package. Consider using a `Release-As` commit instead."* It is also sticky: *"once the release PR is merged you should either remove this or update it to a higher version. Otherwise subsequent `manifest-pr` runs will continue to use this version."*
- **`initial-version`** does not apply — `.release-please-manifest.json` is already bootstrapped to `0.0.1`, so release-please does not treat this as a never-released package.

The `Release-As:` commit footer is documented in CONTRIBUTING as the escape hatch if a specific version is ever needed.

### Item 30 — the version-agreement check

**Found a real gap while wiring this up.** Five files carry the version, each rewritten by a *different* release-please mechanism — and one of them was not wired up at all:

| File | Mechanism | Before |
|---|---|---|
| `pyproject.toml` | `release-type: python` | ✅ |
| `custom_components/haventory/manifest.json` | `extra-files` json + jsonpath | ✅ |
| `cards/haventory-card/package.json` | `extra-files` json + jsonpath | ✅ |
| `custom_components/haventory/const.py` → `INTEGRATION_VERSION` | *(nothing)* | ❌ **would have stayed `0.0.1`** |
| `.release-please-manifest.json` | release-please bookkeeping | ✅ |

`INTEGRATION_VERSION` is the user-visible one: `haventory/version` returns it and every export document is stamped with it. A v0.1.0 release would have shipped a manifest saying `0.1.0` and a running integration reporting `0.0.1`. Fixed with a generic `x-release-please-version` line annotation.

The check itself:

- `scripts/check_version_consistency.py` — compares all five; with `--tag` (or `GITHUB_REF_TYPE=tag`) also requires the tag to name the same version. Runs on stock `python3` (3.11+), no uv needed.
- `tests/test_release_version_consistency.py` — runs in the **ordinary gate**, so it fires on the release PR itself, which is where a missed rewrite is still cheap to fix. It asserts the *set* of collected sources too, so a source that silently stops being checked fails rather than passing by covering less.
- The tag half runs **inside the release workflow**, gated on `release_created`. This was a correction to my own first attempt: I initially added a `push: tags:` job to `ci.yml`, which would never have fired — release-please pushes the tag with `GITHUB_TOKEN`, and GitHub does not start new workflow runs for events that token raises. A required check that never reports is exactly the failure item 30 is trying to prevent, so it moved.

### CONTRIBUTING → Releases

Rewritten from "deferred to WP5" into the actual flow: the four steps, a table of what each commit type does to the version pre- and post-1.0, why `bump-patch-for-minor-pre-major` is deliberately absent, the `Release-As:` escape hatch, and the five version files with the mechanism that rewrites each.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI

## How was this tested?

Re-run in full after the rebase onto `main`:

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **350 passed, 22 skipped**; `uv run ruff check .` → clean; `uv run ruff format --check .` → 92 files; `uv run mypy` → no issues
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npx vitest run` → **812 passed (42 files)**; `npm run typecheck` → clean; `npm run build` → 427.68 kB
- [x] `scripts/check_version_consistency.py` exercised both ways: agreement passes at `0.0.1`; `--tag v0.1.0` correctly fails against the declared `0.0.1` with exit 1
- [x] Both workflow files re-parsed after editing (triggers and job/step lists verified)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added/updated (happy path + edge cases: non-release tag shapes, missing source)
- [x] Docs updated where behavior changed (`CONTRIBUTING.md`)
- [x] WebSocket API unchanged
- [x] Load-bearing invariants untouched

---

## ⚠️ Release blocker, deliberately deferred to its own PR

**A HACS install of a v0.1.0 release would ship no card at all, silently.** You asked for this to be split out rather than folded in here, so it is recorded rather than fixed — **v0.1.0 must not be cut until it is.**

The chain:

1. The integration registers the Lovelace resource at `/local/haventory/haventory-card.js` — that is, `haventory/haventory-card.js` under the HA config directory's `www/` folder (`__init__.py:44`, `:350`).
2. Vite builds the bundle into `cards/www/haventory/`, which is **git-ignored** (`.gitignore:242`) — so it is in no commit, and in no tag's source tarball.
3. HACS with `category: integration` installs only the `custom_components/haventory/` directory into the config's `custom_components/`. It never writes into the config's `www/`.
4. `_register_frontend_module` finds no file and returns at **DEBUG**. The README's install step 5 ("refresh so the card appears in the picker") would simply never happen, with nothing in the log at default levels to say why.

The README's uninstall section already describes the end state as if this worked — *"HACS removes `custom_components/haventory/` but not the built asset"* (README:79) — but nothing ever puts the asset there.

Related: `hacs.json`'s `"filename": "haventory-card.js"` is a leftover plugin-category key. For an integration it is inert without `zip_release: true`, so it currently does nothing.

Both fix routes are available at the declared 2026.6.0 floor (`StaticPathConfig` and `async_register_static_paths` verified present in that release's wheel). The two shapes considered:

- **Package + copy into the config's `www/` at setup** — CI builds and ships `haventory.zip` (`zip_release: true` + `filename`), HACS extracts it into `custom_components/haventory/`, and the integration copies the bundle across when missing or changed. Smallest diff: the `/local/` URL, the `?v=` cache-busting rewrite, the YAML-mode docs, the uninstall docs, the `run-haventory` skill and the deploy scripts all keep working exactly as live-verified on 2026-07-28.
- **Package + serve from the integration directory** — same packaging, but a registered static path instead of a copy. Cleaner, and nothing is written into the user's config; but the resource URL changes, taking the README YAML-mode snippet, the uninstall section, the deploy scripts and the frontend-registration tests with it, and the cache-busting/resource-rewrite path would need re-verifying live.

## Follow-ups

- **`bump-patch-for-minor-pre-major` is gone for good, not just for the first cut.** That is intentional and matches the 0.1.0 → 0.1.x → 0.2.0 staging, but it means any `feat:` merged during the dogfood moves the minor rather than the patch. If you want to stay on `0.1.x` while shipping features, land them as `fix:`/`chore:` or re-add the flag.
- **The tag check is a backstop, not a gate** — it runs after the release is published, because that is the only place it can run under the `GITHUB_TOKEN` rule. The real gate is the file-agreement test on the release PR.
- **CHANGELOG.md does not exist yet**; release-please creates it with the first release. Nothing to do, noted so its sudden appearance in the release PR is not a surprise.
- The `release-please` job now runs on every push to `main`. It is a no-op when there is nothing to release, but it is no longer a manually-triggered workflow, so a bad config surfaces as a red run on `main` rather than silence.
- **Heads-up on merge order:** merging this puts the `release-please` workflow on `main` with its push trigger live, so it will open a `chore(main): release 0.1.0` PR on the next push to `main`. That release PR is yours to merge — and per the blocker above, not before the card-packaging fix lands.