### PR TITLE
chore(skills): adopt the verification harnesses into the run-haventory skill

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -220,6 +220,111 @@ From Git Bash, pass the document as a native path with forward slashes
 (`"C:/Users/you/backup.json"`) and prefix the command with `MSYS_NO_PATHCONV=1` if you
 override `--path` — see the path-conversion gotcha below.
 
+## Verification harnesses
+
+Four checks that need a real instance and a real browser, each with its own oracle so a
+run either passes or says why not. All are read-only except `lifecycle_probe.py`.
+
+| harness | what it proves |
+|---|---|
+| `rl_banner.mjs` | the card's rate-limit degraded-banner lifecycle, with the WS frames that caused each state |
+| `visual_pass.mjs` | every card surface still opens, at desktop and mobile widths |
+| `import_policies.mjs` | the import sheet describes the conflict policy the backend actually applied |
+| `log_sweep.py` | the container log obeys the error taxonomy's severity policy |
+| `lifecycle_probe.py` | resource cache-bust rewriting, schema-downgrade refusal, entry removal/re-add |
+
+### Rate-limit banner lifecycle
+
+```bash
+cd .claude/skills/run-haventory
+node rl_banner.mjs                       # both scenarios; leaves rate limiting OFF
+node rl_banner.mjs --scenario exhausted   # just the paused -> Refresh half
+node rl_banner.mjs --observe 30           # watch only; never touches the options flow
+```
+
+Squeezes the real per-connection command budget through the options flow so the card's
+`subscribe` is refused, then reads what it renders. A refusal is retried four times
+(400/800/1600/3200 ms), so there are two outcomes to check and both are: a retry that wins
+must clear the banner with no user action and offer no button, and a budget that outlasts
+the whole window must switch the wording to "until you refresh" and grow a Refresh that
+restores live updates. Prints a WS trace next to the banner timeline — a paused banner with
+no `rate_limited` frame behind it is a card bug, one with a refusal behind it is the card
+doing its job. A scenario whose budget never provoked its state is reported
+**INCONCLUSIVE**, not as a pass.
+
+Rate limiting is reset to OFF on the way out, including after a failure — every other
+harness assumes it is off.
+
+### Visual surface pass
+
+```bash
+cd .claude/skills/run-haventory
+node visual_pass.mjs --out before     # then make the change, redeploy
+node visual_pass.mjs --out after      # and compare the two folders
+node visual_pass.mjs --only mobile --surfaces detail-sheet,filter-sheet
+node visual_pass.mjs --list           # surface names
+```
+
+Fourteen desktop surfaces and eight mobile ones, each a recipe of clicks against the card's
+own `data-testid`s. It is a DOM check as much as a screenshot run: a surface counts as
+captured only if its root element exists afterwards, so a renamed testid fails loudly
+instead of silently photographing the wrong screen. Exit is non-zero if any surface failed
+to open or the browser logged a console error. The narrow layout is a different component
+tree (sheets, not panels), which is why the two lists differ rather than sharing one.
+
+### Import policy cross-check
+
+```bash
+cd .claude/skills/run-haventory
+node import_policies.mjs              # synthesizes a document from live data
+node import_policies.mjs --doc backup.json
+```
+
+Runs all three policies twice — once through `haventory/import/preview` on a direct WS
+connection, once through the card's sheet — and compares the eight bucket counts the sheet
+renders against the ones the server returned, plus the conflict sentence against the policy
+it was computed under. Writes nothing: preview is a server-side dry run and there is no
+`--apply`. With no `--doc` it builds its own document by exporting the live inventory,
+cutting it to a handful of entities and editing some of them, which is the only way to get
+entries in all four buckets without mutating anything.
+
+### Log severity sweep
+
+```bash
+uv run python .claude/skills/run-haventory/log_sweep.py --since 30m
+uv run python .claude/skills/run-haventory/log_sweep.py --all --show 20
+```
+
+Groups the container log into records (so a traceback stays with its header) and sorts them
+three ways: **BLOCKING** — an HAventory traceback, an `unknown_error`, or a
+client-recoverable code logged at ERROR; **EXPECTED** — the contract's WARNING rejections,
+which fuzz layers produce by the hundred; **KNOWN** — type-loose frames HA core rejects
+before `ws_guard` runs (open item 53), surfaced without failing the sweep. Exits 1 on any
+blocking finding. Run it after every online layer: offline stubs stay green while real HA
+throws, which is how the `__slots__` bug was found.
+
+### Lifecycle probe (restarts HA, edits `.storage`)
+
+```bash
+uv run python .claude/skills/run-haventory/lifecycle_probe.py resources --yes
+uv run python .claude/skills/run-haventory/lifecycle_probe.py downgrade --yes
+uv run python .claude/skills/run-haventory/lifecycle_probe.py entry --yes
+uv run python .claude/skills/run-haventory/lifecycle_probe.py all --yes
+```
+
+`resources` sets the Lovelace resource to each shape a restart can find — hand-pinned
+`?v=<hash>`, stale `?v=<old version>`, bare URL — restarts, and asserts one entry survives
+**under the original resource id**; a second entry would load the card module twice and the
+second `customElements.define` would throw. `downgrade` writes a higher `schema_version`
+into the store and asserts the entry lands in `setup_error` (not `setup_retry` — retrying
+cannot teach this build a newer schema) with the payload untouched. `entry` removes the
+config entry, checks the resource went with it and the store did not, then re-adds through
+the config flow and checks exactly one resource comes back.
+
+`downgrade` and `entry` snapshot the store first and restore it on the way out, including
+on failure — but each subcommand restarts the container several times, so point it only at
+the disposable dev instance.
+
 ## Test
 
 Offline suites (no HA needed — full gate incl. lint is in CLAUDE.md):
@@ -229,8 +334,15 @@ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q
 (cd cards/haventory-card && npx vitest run)
 ```
 
-Expected (as of WP4): backend ~200 passed / 22 skipped in ~7 s; frontend 163 passed
-across 17 files in ~11 s.
+Expected at feature freeze: backend 350 passed / 22 skipped in ~11 s; frontend 812 passed
+across 42 files in ~30 s.
+
+The in-process HA integration suite (`scripts/test_integration.sh`, real HA core via
+phacc) does **not** run on this Windows host: the script builds a POSIX venv path and HA
+core imports `fcntl`. A throwaway `python:3.14-slim` container is the proven way to run it
+here — one `docker run` with the repo bind-mounted, `pip install -r
+requirements-integration.txt`, then `pytest -o asyncio_mode=auto tests/integration`. That
+path also covers hosts whose WSL has no DNS.
 
 Online smoke against the running container (non-destructive as long as
 `HA_CONTAINER` is unset — verify with `echo $HA_CONTAINER` first):
@@ -257,6 +369,12 @@ clean-start mode), then `Online smoke test completed successfully.`
 - **A card change you can't see in the browser is almost always the 31-day
   `/local/` cache** — run `pin_resource.py` (see Deploy) before concluding the fix
   didn't work. Hard-reload (Ctrl+Shift+R) also works, once.
+- **`.storage/lovelace_resources` on disk lags the running instance by ~15 s.** HA's
+  `Store` debounces its writes, so reading that file right after a restart shows the
+  *previous* resource URL while the in-memory collection already serves the new one.
+  Ask the running instance (`lovelace/resources` over WS, as `pin_resource.py` and
+  `lifecycle_probe.py` do) rather than the file — a stale read here looks exactly like
+  the cache-busting rewrite having failed, and it has not.
 - **HA's service worker reloads the page ~30–90 s into a fresh browser context**,
   destroying Playwright's JS execution context mid-run. It looks exactly like a card
   crash but leaves no console output and no HA log entry. `screenshot.mjs` blocks

--- a/.claude/skills/run-haventory/import_policies.mjs
+++ b/.claude/skills/run-haventory/import_policies.mjs
@@ -1,0 +1,336 @@
+// Check that the card's import sheet describes the conflict policy the backend
+// actually applies — for all three policies, against the same document.
+//
+// `drive_import.mjs` drives one policy and leaves the judgement to the eye. This
+// runs each policy twice: once through `haventory/import/preview` on a direct WS
+// connection (the ground truth) and once through the card's own sheet, then
+// compares the four bucket counts the sheet renders against the ones the server
+// returned, and checks the conflict sentence names the right resolution. A sheet
+// that says "Merge keeps the file's values" over counts computed under `skip`
+// would pass every unit test and still mislead every user.
+//
+// Nothing is ever written: preview is a server-side dry run, and --apply is
+// deliberately not offered here.
+//
+// Usage (from the skill dir, .claude/skills/run-haventory/):
+//   node import_policies.mjs                    # synthesize a document from live data
+//   node import_policies.mjs --doc backup.json  # use a document of your own
+//   node import_policies.mjs --items 8          # how many live items to build on
+//   node import_policies.mjs --out policies     # screenshot prefix
+//
+// The synthesized document is built by exporting the live inventory and cutting
+// it down to a handful of entities, then deriving one of each classification
+// from them: some entries left byte-identical (`unchanged`), some with an edited
+// field (`update` under merge/replace, `conflict` under skip) and one carrying a
+// fresh uuid (`add`). Exercising the policies needs a document that disagrees
+// with the inventory in a controlled way, and deriving it from the real data is
+// the only way to get ids that are genuinely already present.
+//
+// Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
+
+import { chromium } from "playwright";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(skillDir, "..", "..", "..");
+
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+
+try {
+  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
+  }
+} catch {
+  /* no .env — rely on real env vars */
+}
+const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
+const token = process.env.HA_TOKEN;
+if (!token) {
+  console.error("Missing HA_TOKEN (env or repo-root .env)");
+  process.exit(2);
+}
+
+const urlPath = flag("--path", "/lovelace/default_view");
+const outPrefix = flag("--out", "policies");
+const sampleSize = Number(flag("--items", "6"));
+const docPath = flag("--doc", null);
+const shot = (name) => path.resolve(skillDir, `${outPrefix}-${name}.png`);
+
+const POLICIES = ["merge", "replace", "skip"];
+// The sentence the sheet is required to print next to a non-zero conflict count.
+const CONFLICT_WORDING = {
+  merge: /Merge keeps the file's values\./,
+  replace: /Replace overwrites them\./,
+  skip: /Skip leaves them as they are\./,
+};
+
+// --- WS ground truth ------------------------------------------------------
+// Node's global WebSocket is enough for a request/response client; the frontend
+// protocol is one authenticated socket with monotonic ids.
+class HaWs {
+  #ws;
+  #id = 1;
+  #waiters = new Map();
+
+  static async connect() {
+    const self = new HaWs();
+    const wsUrl = base.replace(/^http/, "ws") + "/api/websocket";
+    self.#ws = new WebSocket(wsUrl);
+    await new Promise((resolve, reject) => {
+      self.#ws.addEventListener("error", reject, { once: true });
+      self.#ws.addEventListener("open", resolve, { once: true });
+    });
+    return new Promise((resolve, reject) => {
+      self.#ws.addEventListener("message", (ev) => {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === "auth_required") {
+          self.#ws.send(JSON.stringify({ type: "auth", access_token: token }));
+        } else if (msg.type === "auth_ok") {
+          resolve(self);
+        } else if (msg.type === "auth_invalid") {
+          reject(new Error(`WS auth failed: ${msg.message}`));
+        } else if (msg.type === "result") {
+          self.#waiters.get(msg.id)?.(msg);
+          self.#waiters.delete(msg.id);
+        }
+      });
+    });
+  }
+
+  call(payload) {
+    const id = this.#id++;
+    this.#ws.send(JSON.stringify({ id, ...payload }));
+    return new Promise((resolve, reject) => {
+      this.#waiters.set(id, (msg) => (msg.success ? resolve(msg.result) : reject(new Error(JSON.stringify(msg.error)))));
+      setTimeout(() => reject(new Error(`timeout waiting for ${payload.type}`)), 120000);
+    });
+  }
+
+  close() {
+    this.#ws.close();
+  }
+}
+
+/**
+ * Cut a full export down to `n` items plus every location on their ancestry, so
+ * the subset stays referentially self-consistent — an item whose `location_id`
+ * points at a location the document omits is a different test (invalid input),
+ * not this one.
+ */
+function subsetDocument(full, n) {
+  const items = full.items.slice(0, n);
+  const keep = new Set();
+  for (const item of items) for (const id of item.location_path?.id_path ?? []) keep.add(id);
+  return { ...full, items, locations: full.locations.filter((l) => keep.has(l.id)) };
+}
+
+/**
+ * Derive a document that lands entries in every bucket: the first two items are
+ * left untouched, the next two carry an edited field, and one is a copy with a
+ * fresh uuid. Identity is the id and only the id, so re-idding an entry is what
+ * makes it read as new.
+ */
+function deriveMixed(doc) {
+  const items = doc.items.map((it) => ({ ...it }));
+  const edited = [];
+  for (let i = 2; i < Math.min(4, items.length); i++) {
+    items[i] = { ...items[i], description: `import-policy probe ${randomUUID().slice(0, 8)}` };
+    edited.push(items[i].id);
+  }
+  const added = items.length ? { ...items[0], id: randomUUID(), name: `${items[0].name} (policy probe)` } : null;
+  if (added) items.push(added);
+  return {
+    document: { ...doc, items },
+    expectation: { unchanged: Math.min(2, doc.items.length), edited: edited.length, added: added ? 1 : 0 },
+  };
+}
+
+const ws = await HaWs.connect();
+let documentJson;
+let expectation = null;
+if (docPath) {
+  documentJson = readFileSync(docPath, "utf8");
+  console.log(`document: ${docPath} (${(documentJson.length / 1024).toFixed(0)} KiB)`);
+} else {
+  const full = await ws.call({ type: "haventory/export" });
+  const subset = subsetDocument(full, sampleSize);
+  const mixed = deriveMixed(subset);
+  expectation = mixed.expectation;
+  documentJson = JSON.stringify(mixed.document);
+  console.log(
+    `document: synthesized from live export — ${mixed.document.items.length} items, ` +
+      `${mixed.document.locations.length} locations ` +
+      `(${expectation.unchanged} untouched, ${expectation.edited} edited, ${expectation.added} re-idded)`,
+  );
+}
+
+// Ground truth first: one preview per policy, straight from the server.
+const serverPreview = {};
+for (const policy of POLICIES) {
+  const preview = await ws.call({
+    type: "haventory/import/preview",
+    document: JSON.parse(documentJson),
+    policy,
+  });
+  serverPreview[policy] = preview;
+  if (!preview.valid) {
+    console.error(`server rejected the document under ${policy}: ${JSON.stringify(preview.errors).slice(0, 300)}`);
+    ws.close();
+    process.exit(1);
+  }
+  console.log(`  server ${policy.padEnd(7)} items=${JSON.stringify(preview.counts.items)} locations=${JSON.stringify(preview.counts.locations)}`);
+}
+ws.close();
+
+// --- the card's own sheet -------------------------------------------------
+const browser = await chromium.launch();
+// HA's service worker reloads the page 30-90 s into a fresh context; three
+// previews of a real document sit well inside that window.
+const context = await browser.newContext({ viewport: { width: 1280, height: 900 }, serviceWorkers: "block" });
+const page = await context.newPage();
+const consoleErrors = [];
+page.on("console", (msg) => {
+  if (msg.type() === "error") consoleErrors.push(msg.text());
+});
+page.on("pageerror", (err) => consoleErrors.push(`pageerror: ${err.message}`));
+
+await page.addInitScript(
+  ([hassUrl, accessToken]) => {
+    localStorage.setItem(
+      "hassTokens",
+      JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "unused-long-lived",
+        expires_in: 1800,
+        expires: Date.now() + 365 * 24 * 3600 * 1000,
+        hassUrl,
+        clientId: hassUrl + "/",
+      }),
+    );
+  },
+  [base, token],
+);
+
+await page.goto(base + urlPath, { waitUntil: "domcontentloaded" });
+if (page.url().includes("/auth/authorize")) {
+  console.error("Redirected to the login page — hassTokens injection was rejected. Is HA_TOKEN valid?");
+  await browser.close();
+  process.exit(1);
+}
+await page.waitForSelector("haventory-card", { timeout: 30000 });
+await page.waitForTimeout(2500);
+
+/** Read the four bucket counts the sheet rendered, keyed as the sheet keys them. */
+const renderedCounts = () =>
+  page.locator("hv-import-sheet").first().evaluate((el) => {
+    const out = {};
+    for (const row of el.shadowRoot?.querySelectorAll("[data-testid='import-count']") ?? []) {
+      const spans = row.querySelectorAll("span");
+      out[row.getAttribute("data-key")] = Number(spans[1]?.textContent.replace("+", "").trim() ?? "NaN");
+    }
+    return out;
+  });
+
+const sheetText = async () =>
+  (await page.locator("hv-import-sheet").first().evaluate((el) => el.shadowRoot?.textContent ?? ""))
+    .replace(/\s+/g, " ")
+    .trim();
+
+const results = [];
+for (const policy of POLICIES) {
+  console.log(`\n== card sheet: ${policy} ==`);
+  await page.click('haventory-card [data-testid="card-overflow"] button');
+  await page.click('haventory-card [data-testid="overflow-item"][data-id="import"]');
+  await page.waitForSelector('hv-import-sheet [data-testid="import-text"]', { timeout: 10000 });
+
+  // Set the value and fire `input` rather than fill(): a real backup types for
+  // minutes through the input pipeline and blows past Playwright's timeout.
+  await page.locator('hv-import-sheet [data-testid="import-text"]').evaluate((el, text) => {
+    el.value = text;
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, documentJson);
+
+  if (policy !== "merge") {
+    await page.locator(`hv-import-sheet [data-testid="import-policy"][data-policy="${policy}"]`).first().click();
+  }
+  await page.locator('hv-import-sheet [data-testid="import-preview"]').click();
+  await page.waitForSelector(
+    'hv-import-sheet [data-testid="import-execute"], hv-import-sheet [data-testid="import-nothing-to-do"],' +
+      ' hv-import-sheet [data-testid="import-parse-error"], hv-import-sheet [data-testid="import-errors"]',
+    { timeout: 120000 },
+  );
+  await page.waitForTimeout(400);
+  await page.screenshot({ path: shot(policy) });
+
+  const rendered = await renderedCounts();
+  const text = await sheetText();
+  const server = serverPreview[policy];
+  const expectedRender = {
+    "items-add": server.counts.items.add ?? 0,
+    "items-update": server.counts.items.update ?? 0,
+    "items-conflict": server.counts.items.conflict ?? 0,
+    "items-unchanged": server.counts.items.unchanged ?? 0,
+    "locations-add": server.counts.locations.add ?? 0,
+    "locations-update": server.counts.locations.update ?? 0,
+    "locations-conflict": server.counts.locations.conflict ?? 0,
+    "locations-unchanged": server.counts.locations.unchanged ?? 0,
+  };
+  const mismatches = Object.entries(expectedRender).filter(([k, v]) => rendered[k] !== v);
+
+  // The policy the sheet names must be the one the counts were computed under —
+  // the preview is invalidated when the policy changes precisely so these agree.
+  const namesPolicy = new RegExp(`policy\\s*${policy}`, "i").test(text);
+  const conflicts = (server.counts.items.conflict ?? 0) + (server.counts.locations.conflict ?? 0);
+  const wordingOk = conflicts === 0 ? null : CONFLICT_WORDING[policy].test(text);
+
+  console.log(`  rendered: ${JSON.stringify(rendered)}`);
+  console.log(`  server:   ${JSON.stringify(expectedRender)}`);
+  console.log(`  names the policy: ${namesPolicy} · conflicts: ${conflicts} · wording: ${wordingOk ?? "n/a (no conflicts)"}`);
+
+  results.push({
+    policy,
+    ok: mismatches.length === 0 && namesPolicy && wordingOk !== false,
+    detail:
+      mismatches.length === 0
+        ? namesPolicy
+          ? wordingOk === false
+            ? `conflict sentence does not match ${policy}`
+            : "counts and wording agree with the server"
+          : "sheet does not name the policy it previewed"
+        : `count mismatch: ${mismatches.map(([k, v]) => `${k} sheet=${rendered[k]} server=${v}`).join(", ")}`,
+  });
+
+  await page.locator('hv-import-sheet [data-testid="import-cancel"]').click();
+  await page.waitForTimeout(400);
+}
+
+// A document that produced no conflicts under `skip` never exercised the
+// wording at all — say so rather than reporting a pass the run did not earn.
+const skipConflicts =
+  (serverPreview.skip.counts.items.conflict ?? 0) + (serverPreview.skip.counts.locations.conflict ?? 0);
+if (skipConflicts === 0) {
+  console.log("\nNOTE: this document produced no conflicts, so the conflict wording was not exercised.");
+}
+
+console.log("\n== verdict ==");
+for (const r of results) console.log(`  ${r.policy.padEnd(8)} ${r.ok ? "PASS" : "FAIL"}  ${r.detail}`);
+
+const SW_BLOCK_NOISE = /serviceWorker|reading 'addEventListener'/;
+const realErrors = consoleErrors.filter((e) => !SW_BLOCK_NOISE.test(e));
+if (realErrors.length) {
+  console.log(`\nbrowser console errors (${realErrors.length}):`);
+  for (const e of realErrors.slice(0, 10)) console.log(`  ${e}`);
+}
+
+console.log(`\nscreenshots: ${POLICIES.map((p) => shot(p)).join(", ")}`);
+await browser.close();
+process.exit(results.every((r) => r.ok) && !realErrors.length ? 0 : 1);

--- a/.claude/skills/run-haventory/lifecycle_probe.py
+++ b/.claude/skills/run-haventory/lifecycle_probe.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Probe the integration's container-level lifecycle paths against a real Home Assistant.
+
+Three behaviours only exist once HAventory is installed in a running instance,
+and each one is asserted against stubs in the offline suite:
+
+  resources  The card's Lovelace resource carries the manifest version as a
+             cache-busting `?v=`. Whatever a restart finds — a hand-pinned
+             `?v=<hash>`, a stale `?v=<old version>`, or a bare URL with no query
+             at all — must be **rewritten in place, under the same resource id**.
+             Adding a second entry instead would load the card module twice and
+             the second `customElements.define` throws, so "one resource, id
+             preserved" is the assertion, not "the URL is right".
+  downgrade  Storage written by a newer build must be refused, not migrated:
+             migrations are forward-only, so a downgrade can only lose data. The
+             entry must land in an error state that does **not** retry, and the
+             stored payload must come back byte-identical.
+  entry      Removing the config entry must take the Lovelace resource with it
+             and leave the store alone; re-adding must register the resource
+             exactly once and find the data still there.
+
+Every subcommand restarts the container and edits `/config/.storage`, so this is
+opt-in: pass `--yes`. The dev container is disposable by design; do not point it
+at an instance whose data matters. `downgrade` and `entry` snapshot the store
+first and restore it on the way out, including on failure.
+
+Usage (from the repo root):
+  uv run python .claude/skills/run-haventory/lifecycle_probe.py resources --yes
+  uv run python .claude/skills/run-haventory/lifecycle_probe.py downgrade --yes
+  uv run python .claude/skills/run-haventory/lifecycle_probe.py entry --yes
+  uv run python .claude/skills/run-haventory/lifecycle_probe.py all --yes
+
+Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root `.env`, and
+HA_CONTAINER (default "home-assistant") for the docker exec calls.
+"""
+# Dev/agent harness script. Driving the container means shelling out to `docker`
+# on PATH (S603/S607), and the restart has to block the loop while it runs
+# (ASYNC221). The .env loader is copied from driver.py verbatim (PLW2901).
+# ruff: noqa: S603, S607, ASYNC221, PLW2901
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+STORE_PATH = "/config/.storage/haventory_store"
+RECV_TIMEOUT_S = 30.0
+# HA answers /api/ well before it finishes loading integrations, so readiness is
+# polled on the WS command the integration itself registers.
+READY_TIMEOUT_S = 120.0
+HTTP_OK = 200
+
+
+def load_env() -> None:
+    """Populate os.environ from repo-root .env (existing env vars win)."""
+    env_file = REPO_ROOT / ".env"
+    if not env_file.is_file():
+        return
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+def ws_url(base_url: str) -> str:
+    base_url = base_url.rstrip("/")
+    if base_url.startswith("https://"):
+        return f"wss://{base_url[len('https://') :]}/api/websocket"
+    return f"ws://{base_url.removeprefix('http://')}/api/websocket"
+
+
+def container() -> str:
+    return os.environ.get("HA_CONTAINER", "home-assistant")
+
+
+def sh(script: str, stdin: bytes | None = None) -> str:
+    """Run a shell snippet inside the container and return stdout.
+
+    Payloads go in over stdin, never in the script: the store is around a
+    megabyte and Windows caps a command line far below that, failing with a
+    "filename or extension is too long" OSError before docker is even reached.
+    """
+    # MSYS_NO_PATHCONV keeps Git Bash from rewriting the /config paths below into
+    # Windows paths before docker ever sees them.
+    env = {**os.environ, "MSYS_NO_PATHCONV": "1"}
+    cmd = [
+        "docker",
+        "exec",
+        *(["-i"] if stdin is not None else []),
+        container(),
+        "sh",
+        "-lc",
+        script,
+    ]
+    proc = subprocess.run(cmd, input=stdin, capture_output=True, env=env, check=False)
+    if proc.returncode != 0:
+        err = proc.stderr.decode("utf-8", "replace").strip()
+        out = proc.stdout.decode("utf-8", "replace").strip()
+        raise RuntimeError(f"docker exec failed: {err or out}")
+    return proc.stdout.decode("utf-8", "replace")
+
+
+class Ws:
+    """One authenticated HA WebSocket connection with sequential ids."""
+
+    def __init__(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        self._ws = ws
+        self._id = 0
+
+    async def call(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self._id += 1
+        await self._ws.send_json({"id": self._id, **payload})
+        while True:
+            frame = await asyncio.wait_for(self._ws.receive_json(), timeout=RECV_TIMEOUT_S)
+            if frame.get("id") == self._id and frame.get("type") == "result":
+                return frame
+
+
+async def connect(session: aiohttp.ClientSession) -> Ws:
+    base = os.environ["HA_BASE_URL"]
+    token = os.environ["HA_TOKEN"]
+    ws = await session.ws_connect(
+        ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=RECV_TIMEOUT_S)
+    )
+    await asyncio.wait_for(ws.receive_json(), timeout=RECV_TIMEOUT_S)
+    await ws.send_json({"type": "auth", "access_token": token})
+    auth = await asyncio.wait_for(ws.receive_json(), timeout=RECV_TIMEOUT_S)
+    if auth.get("type") != "auth_ok":
+        raise RuntimeError(f"WS auth failed: {auth}")
+    return Ws(ws)
+
+
+async def restart_and_wait(*, expect_integration: bool = True) -> float:
+    """Restart the container; wait until HA answers, and (optionally) HAventory does."""
+    subprocess.run(["docker", "restart", container()], capture_output=True, check=True)
+    started = time.monotonic()
+    deadline = started + READY_TIMEOUT_S
+    base = os.environ["HA_BASE_URL"]
+    token = os.environ["HA_TOKEN"]
+    while time.monotonic() < deadline:
+        await asyncio.sleep(2)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{base.rstrip('/')}/api/",
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    if resp.status != HTTP_OK:
+                        continue
+                if not expect_integration:
+                    return time.monotonic() - started
+                ws = await connect(session)
+                frame = await ws.call({"type": "haventory/version"})
+                if frame.get("success"):
+                    return time.monotonic() - started
+        except TimeoutError, aiohttp.ClientError, RuntimeError, OSError:
+            continue
+    if expect_integration:
+        raise RuntimeError(f"HAventory did not answer within {READY_TIMEOUT_S:.0f}s of the restart")
+    raise RuntimeError(f"HA did not come back within {READY_TIMEOUT_S:.0f}s of the restart")
+
+
+async def lovelace_resources(session: aiohttp.ClientSession) -> list[dict[str, Any]]:
+    ws = await connect(session)
+    frame = await ws.call({"type": "lovelace/resources"})
+    return [r for r in (frame.get("result") or []) if "haventory" in str(r.get("url", ""))]
+
+
+def store_bytes() -> bytes:
+    return sh(f"cat {STORE_PATH} 2>/dev/null || true").encode("utf-8", "replace")
+
+
+def write_store(payload: bytes) -> None:
+    """Replace the store, byte for byte. base64 so no shell quoting applies."""
+    sh(f"base64 -d > {STORE_PATH}", stdin=base64.b64encode(payload))
+
+
+# --------------------------------------------------------------------------- checks
+
+Result = tuple[str, bool, str]
+
+
+async def check_resources() -> list[Result]:
+    """Every starting shape of the resource URL must converge on one rewritten entry."""
+    results: list[Result] = []
+    async with aiohttp.ClientSession() as session:
+        before = await lovelace_resources(session)
+        if len(before) != 1:
+            return [
+                (
+                    "resources/precondition",
+                    False,
+                    f"expected exactly 1 haventory resource, found {len(before)}",
+                )
+            ]
+        original = before[0]
+        print(f"  starting from id={original['id']} url={original['url']}")
+
+        variants = [
+            ("pinned", "/local/haventory/haventory-card.js?v=deadbeefcafe"),
+            ("stale", "/local/haventory/haventory-card.js?v=0.0.0"),
+            ("bare", "/local/haventory/haventory-card.js"),
+        ]
+        for label, url in variants:
+            ws = await connect(session)
+            await ws.call(
+                {"type": "lovelace/resources/update", "resource_id": original["id"], "url": url}
+            )
+            print(f"\n  [{label}] set to {url}; restarting…")
+            await restart_and_wait()
+            after = await lovelace_resources(session)
+            same_id = len(after) == 1 and after[0]["id"] == original["id"]
+            rewritten = len(after) == 1 and after[0]["url"] != url
+            detail = f"{len(after)} resource(s): {[r['url'] for r in after]}"
+            results.append((f"resources/{label}: one entry, id preserved", same_id, detail))
+            results.append(
+                (f"resources/{label}: rewritten to the manifest version", rewritten, detail)
+            )
+            print(f"    -> {detail}")
+    return results
+
+
+async def check_downgrade() -> list[Result]:
+    """A store from a newer build must stop setup without retrying, and stay untouched."""
+    results: list[Result] = []
+    snapshot = store_bytes()
+    if not snapshot.strip():
+        return [("downgrade/precondition", False, f"no store at {STORE_PATH}")]
+    try:
+        payload = json.loads(snapshot)
+        current = payload["data"]["schema_version"]
+        payload["data"]["schema_version"] = current + 99
+        write_store(json.dumps(payload).encode("utf-8"))
+        print(f"  schema_version {current} -> {current + 99}; restarting…")
+
+        # HA itself comes up; the entry is the thing that must fail.
+        await restart_and_wait(expect_integration=False)
+        await asyncio.sleep(5)
+
+        base = os.environ["HA_BASE_URL"].rstrip("/")
+        token = os.environ["HA_TOKEN"]
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{base}/api/config/config_entries/entry",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                entries = await resp.json()
+            entry = next((e for e in entries if e.get("domain") == "haventory"), None)
+            state = entry.get("state") if entry else None
+            print(f"  config entry state: {state}")
+            # setup_error is the terminal state; setup_retry would mean HA is
+            # going to try again, which is exactly what the refusal rules out.
+            results.append(
+                (
+                    "downgrade/entry in setup_error (no retry)",
+                    state == "setup_error",
+                    f"state={state}",
+                )
+            )
+
+            ws = await connect(session)
+            frame = await ws.call({"type": "haventory/version"})
+            refused = not frame.get("success")
+            results.append(
+                (
+                    "downgrade/WS refuses to answer",
+                    refused,
+                    json.dumps(frame.get("error") or frame)[:160],
+                )
+            )
+
+        after = store_bytes()
+        untouched = json.loads(after)["data"]["schema_version"] == current + 99
+        results.append(("downgrade/store left untouched", untouched, "payload not rewritten"))
+    finally:
+        print("  restoring the store and restarting…")
+        write_store(snapshot)
+        await restart_and_wait()
+        results.append(("downgrade/recovered after restore", True, "integration answers again"))
+    return results
+
+
+async def check_entry() -> list[Result]:
+    """Removing the entry drops the resource and keeps the data; re-adding restores one resource."""
+    results: list[Result] = []
+    snapshot = store_bytes()
+    base = os.environ["HA_BASE_URL"].rstrip("/")
+    token = os.environ["HA_TOKEN"]
+    headers = {"Authorization": f"Bearer {token}"}
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            f"{base}/api/config/config_entries/entry",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            entries = await resp.json()
+        entry = next((e for e in entries if e.get("domain") == "haventory"), None)
+        if entry is None:
+            return [("entry/precondition", False, "no haventory config entry to remove")]
+
+        async with session.delete(
+            f"{base}/api/config/config_entries/entry/{entry['entry_id']}",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            print(f"  removed entry {entry['entry_id']} (HTTP {resp.status})")
+        await asyncio.sleep(3)
+
+        after_remove = await lovelace_resources(session)
+        results.append(
+            (
+                "entry/resource removed with the entry",
+                len(after_remove) == 0,
+                f"{len(after_remove)} left",
+            )
+        )
+        results.append(
+            (
+                "entry/store survives removal",
+                bool(store_bytes().strip()),
+                f"{len(store_bytes())} bytes",
+            )
+        )
+
+        # Re-add through the config flow the UI drives, so the single-instance
+        # guard and the resource registration both run for real.
+        async with session.post(
+            f"{base}/api/config/config_entries/flow",
+            headers=headers,
+            json={"handler": "haventory", "show_advanced_options": False},
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            flow = await resp.json()
+        print(f"  config flow: {flow.get('type')} / {flow.get('title') or flow.get('step_id')}")
+        if flow.get("type") == "form":
+            async with session.post(
+                f"{base}/api/config/config_entries/flow/{flow['flow_id']}",
+                headers=headers,
+                json={},
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                flow = await resp.json()
+        results.append(
+            (
+                "entry/re-added via the config flow",
+                flow.get("type") == "create_entry",
+                str(flow.get("type")),
+            )
+        )
+        await asyncio.sleep(5)
+
+        after_add = await lovelace_resources(session)
+        results.append(
+            (
+                "entry/resource registered exactly once",
+                len(after_add) == 1,
+                f"{[r['url'] for r in after_add]}",
+            )
+        )
+
+        ws = await connect(session)
+        frame = await ws.call({"type": "haventory/health"})
+        counts = (frame.get("result") or {}).get("counts", {})
+        kept = counts.get("items_total", -1) > 0 or not snapshot.strip()
+        results.append(("entry/data still there after re-add", kept, json.dumps(counts)))
+    return results
+
+
+CHECKS = {"resources": check_resources, "downgrade": check_downgrade, "entry": check_entry}
+
+
+async def run(names: list[str]) -> int:
+    results: list[Result] = []
+    for name in names:
+        print(f"\n== {name} ==")
+        try:
+            results.extend(await CHECKS[name]())
+        except Exception as exc:
+            # A harness failure is itself a result: reporting it beside the checks
+            # keeps one broken probe from hiding the verdicts of the others.
+            results.append((f"{name}/harness", False, f"{type(exc).__name__}: {exc}"))
+
+    print("\n== verdict ==")
+    for label, ok, detail in results:
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label:52s} {detail}")
+    failed = sum(1 for _, ok, _ in results if not ok)
+    print(f"\n{len(results) - failed}/{len(results)} checks passed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    load_env()
+    argv = sys.argv[1:]
+    names = [a for a in argv if not a.startswith("-")]
+    if not names or (names[0] != "all" and any(n not in CHECKS for n in names)):
+        print(__doc__, file=sys.stderr)
+        return 2
+    if names[0] == "all":
+        names = list(CHECKS)
+    if "--yes" not in argv:
+        print(
+            f"This restarts container '{container()}' and edits {STORE_PATH}. Re-run with --yes.",
+            file=sys.stderr,
+        )
+        return 2
+    if not os.environ.get("HA_TOKEN"):
+        print("Missing HA_TOKEN (env or repo-root .env)", file=sys.stderr)
+        return 2
+    return asyncio.run(run(names))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/run-haventory/log_sweep.py
+++ b/.claude/skills/run-haventory/log_sweep.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Audit the dev container's Home Assistant log against HAventory's severity policy.
+
+An online run is not clean until the server's own log agrees. Offline tests stub
+Home Assistant, so a path that raises only against the real thing stays green in
+the suite and shows up here — and the taxonomy makes a second, quieter promise
+that no test asserts at all: a rejection the caller can fix and resend
+(``validation_error``, ``not_found``, ``conflict``, ``rate_limited``) is logged
+at WARNING, and only ``storage_error`` / ``unknown_error`` — the codes an
+operator has to act on — reach ERROR with a traceback. A support burden hides in
+the difference.
+
+Three findings are reported separately, because they mean different things:
+
+  BLOCKING    an HAventory traceback, an ERROR carrying a client-recoverable
+              code, or an ``unknown_error`` — an unmapped exception reaching the
+              boundary, which is what the taxonomy exists to prevent.
+  EXPECTED    contract-defined WARNING rejections. Fuzz layers produce these by
+              the hundred; they are the policy working.
+  KNOWN       type-loose frames rejected by HA core's own schema check before
+              ``ws_guard`` runs, logged by ``websocket_api`` at ERROR with the
+              client payload. Tracked as open item 53 — a deliberate trade-off,
+              not a regression, so it is surfaced without failing the sweep.
+
+Usage (from the repo root):
+  uv run python .claude/skills/run-haventory/log_sweep.py                 # last 30m
+  uv run python .claude/skills/run-haventory/log_sweep.py --since 2h
+  uv run python .claude/skills/run-haventory/log_sweep.py --all           # whole log
+  uv run python .claude/skills/run-haventory/log_sweep.py --file run.log  # a saved capture
+  uv run python .claude/skills/run-haventory/log_sweep.py --show 20       # more samples
+
+Exit code is 1 when anything BLOCKING was found, 0 otherwise. Reads
+HA_CONTAINER from the environment (default "home-assistant"); nothing else is
+needed, and it never writes to the container.
+"""
+# Dev/agent harness script. It shells out to `docker logs` by design (S603), and
+# classify() is a chain of guards whose readability is the point (PLR0911).
+# ruff: noqa: S603, PLR0911
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Codes the caller can fix and resend. The taxonomy logs these at WARNING; an
+# ERROR carrying one is the finding.
+RECOVERABLE_CODES = ("validation_error", "not_found", "conflict", "rate_limited")
+# The exceptions those codes are mapped from, as they appear on a traceback's
+# last line. A traceback ending in one of these is a rejection; a traceback
+# ending in anything else is a fault.
+RECOVERABLE_EXCEPTIONS = ("ValidationError", "NotFoundError", "ConflictError")
+# The operator-actionable half of the taxonomy. ERROR *with* a traceback is what
+# the policy prescribes for these, so finding one means the policy held — the
+# schema-downgrade refusal is the case that provokes it on purpose.
+ACTIONABLE_EXCEPTIONS = ("SchemaDowngradeError", "StorageError")
+
+# HA colours its log by level, so every line arrives wrapped in SGR escapes and
+# nothing anchored to the start of a line matches until they are stripped.
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# A log line starts with a timestamp; a traceback's continuation lines do not.
+LINE_START = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
+LEVEL = re.compile(r"\b(DEBUG|INFO|WARNING|ERROR|CRITICAL)\b")
+HAVENTORY = re.compile(r"haventory", re.IGNORECASE)
+# HA core rejects a type-loose frame before ws_guard can map it (open item 53).
+CORE_SCHEMA_REJECT = re.compile(
+    r"websocket_api\.http\.connection.*(expected |invalid |required key|extra keys)", re.IGNORECASE
+)
+# HA prints this for every custom integration at every startup.
+LOADER_NOTICE = re.compile(r"homeassistant\.loader\].*custom integration")
+# The storage layer only ever raises StorageError and its subclasses, so ERROR is
+# the severity the taxonomy prescribes for everything it logs. It reports the
+# refusal before raising, on its own line and without a traceback, so the
+# exception name that exempts the setup half of the same event is not in this
+# half — the module is.
+STORAGE_LOGGER = re.compile(r"custom_components\.haventory\.storage\]")
+
+
+def read_log(args: argparse.Namespace) -> str:
+    if args.file:
+        return Path(args.file).read_text(encoding="utf-8", errors="replace")
+    cmd = ["docker", "logs", args.container]
+    if not args.all:
+        cmd += ["--since", args.since]
+    proc = subprocess.run(cmd, capture_output=True, text=True, errors="replace", check=False)
+    if proc.returncode != 0:
+        print(f"docker logs failed: {proc.stderr.strip()}", file=sys.stderr)
+        raise SystemExit(2)
+    return proc.stdout + proc.stderr
+
+
+def to_records(text: str) -> list[list[str]]:
+    """Group physical lines into records so a traceback stays with its header."""
+    records: list[list[str]] = []
+    for raw in text.splitlines():
+        line = ANSI.sub("", raw)
+        if LINE_START.match(line) or not records:
+            records.append([line])
+        else:
+            records[-1].append(line)
+    return records
+
+
+def classify(record: list[str]) -> tuple[str, str]:
+    """Return (bucket, reason) for one log record.
+
+    Severity is judged against the taxonomy, not against the mere presence of a
+    traceback: a rejection the caller can fix and resend belongs at WARNING, and
+    the same rejection at ERROR is the finding. What decides which one a record
+    is, is the exception a traceback ends on — the header text alone cannot tell
+    a rejected quantity from a broken store.
+    """
+    head = record[0]
+    body = "\n".join(record)
+    level_match = LEVEL.search(head)
+    level = level_match.group(1) if level_match else "?"
+    tail = record[-1] if len(record) > 1 else ""
+    has_traceback = any(line.startswith("Traceback (most recent call last)") for line in record[1:])
+    recoverable = any(name in tail for name in RECOVERABLE_EXCEPTIONS) or any(
+        code in body for code in RECOVERABLE_CODES
+    )
+    mentions_haventory = bool(HAVENTORY.search(body))
+    loud = level in {"ERROR", "CRITICAL"}
+
+    if LOADER_NOTICE.search(head):
+        return "IGNORED", ""  # HA says this about every custom integration
+    if "unknown_error" in body:
+        return "BLOCKING", "unknown_error reached the boundary"
+    if loud and CORE_SCHEMA_REJECT.search(body):
+        return "KNOWN", "HA core schema rejection before ws_guard (item 53)"
+    if loud and (
+        any(name in body for name in ACTIONABLE_EXCEPTIONS) or STORAGE_LOGGER.search(head)
+    ):
+        return "EXPECTED", "operator-actionable storage error at ERROR (policy-correct)"
+    if loud and recoverable:
+        return "BLOCKING", "client-recoverable rejection logged at ERROR"
+    if has_traceback and mentions_haventory and not recoverable:
+        return "BLOCKING", "unhandled traceback in an HAventory path"
+    if loud and mentions_haventory:
+        return "BLOCKING", "HAventory ERROR"
+    if level == "WARNING" and mentions_haventory:
+        # exc_info is reserved for the operator-actionable codes, so a traceback
+        # under a WARNING is the older behaviour rather than the current policy.
+        if has_traceback:
+            return "EXPECTED", "WARNING rejection, but carrying a traceback"
+        return "EXPECTED", "contract-defined WARNING rejection"
+    return "IGNORED", ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--container", default=None, help="container name (default $HA_CONTAINER or home-assistant)"
+    )
+    parser.add_argument("--since", default="30m", help="docker logs --since window (default 30m)")
+    parser.add_argument("--all", action="store_true", help="sweep the whole log, ignoring --since")
+    parser.add_argument(
+        "--file", default=None, help="sweep a saved log capture instead of the container"
+    )
+    parser.add_argument(
+        "--show", type=int, default=5, help="sample lines to print per bucket (default 5)"
+    )
+    args = parser.parse_args()
+
+    if args.container is None:
+        args.container = os.environ.get("HA_CONTAINER", "home-assistant")
+
+    text = read_log(args)
+    records = to_records(text)
+    buckets: dict[str, list[list[str]]] = {"BLOCKING": [], "EXPECTED": [], "KNOWN": []}
+    reasons: Counter[str] = Counter()
+    for record in records:
+        bucket, reason = classify(record)
+        if bucket in buckets:
+            buckets[bucket].append(record)
+            reasons[f"{bucket}: {reason}"] += 1
+
+    scope = "whole log" if args.all or args.file else f"last {args.since}"
+    source = args.file or f"container {args.container}"
+    print(f"== log sweep: {source}, {scope} - {len(records)} records ==\n")
+
+    for bucket in ("BLOCKING", "KNOWN", "EXPECTED"):
+        found = buckets[bucket]
+        print(f"{bucket}: {len(found)}")
+        for record in found[: args.show]:
+            print(f"  {record[0][:200]}")
+            # The last line of a traceback names the exception; that is the part
+            # worth showing next to the header.
+            if any(line.startswith("Traceback") for line in record[1:]):
+                print(f"      ...{record[-1][:160]}")
+        if len(found) > args.show:
+            print(f"  ... and {len(found) - args.show} more")
+        print()
+
+    if reasons:
+        print("breakdown:")
+        for reason, count in reasons.most_common():
+            print(f"  {count:5d}  {reason}")
+
+    verdict = "FAIL" if buckets["BLOCKING"] else "PASS"
+    print(f"\nverdict: {verdict} (blocking={len(buckets['BLOCKING'])})")
+    return 1 if buckets["BLOCKING"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/run-haventory/rl_banner.mjs
+++ b/.claude/skills/run-haventory/rl_banner.mjs
@@ -1,0 +1,458 @@
+// Drive the card's rate-limit degraded-banner lifecycle against a real Home
+// Assistant, with the WebSocket traffic that caused each state recorded next to
+// the banner it produced.
+//
+// The card's response to a refused `subscribe` is invisible from the outside:
+// a `rate_limited` refusal makes it back off and retry (SUBSCRIBE_RETRY_ATTEMPTS
+// = 4, 400/800/1600/3200 ms), and only after the budget is spent does it give up
+// and offer a manual Refresh. Both halves live in a shadow root inside another
+// shadow root, and both are timing-dependent, so the only honest way to check
+// them is to squeeze the real server and watch what the real card renders.
+//
+// Usage (from the skill dir, .claude/skills/run-haventory/):
+//   node rl_banner.mjs                       # both scenarios, then leaves limiting OFF
+//   node rl_banner.mjs --scenario retrying   # refuse the first round, let a retry win
+//   node rl_banner.mjs --scenario exhausted  # refuse every retry, then Refresh
+//   node rl_banner.mjs --observe 30          # watch only; never touches the options flow
+//   node rl_banner.mjs --path /lovelace/wide --out rl
+//
+// Scenarios (both drive the options flow over REST, exactly as the integration's
+// own config flow does, and always reset rate limiting to OFF on the way out):
+//   retrying   per-conn budget that refills fast enough for a retry to win, so
+//              the banner must appear as "Retrying automatically" and then clear
+//              itself with no user action -> degraded.liveUpdates live again.
+//   exhausted  per-conn budget that refills slower than the whole retry window,
+//              so all four attempts are refused: the banner must switch to the
+//              "until you refresh" wording and grow a Refresh button, and
+//              pressing it (after limiting is lifted) must restore live updates.
+//
+// A scenario that never provoked its state is reported as INCONCLUSIVE, not as a
+// pass: the budgets below are tuned against the card's fixed backoff schedule and
+// a slow host can miss the window.
+//
+// Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
+
+import { chromium } from "playwright";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(skillDir, "..", "..", "..");
+
+const args = process.argv.slice(2);
+
+// --- config: env wins, .env fills the gaps -------------------------------
+try {
+  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
+  }
+} catch {
+  /* no .env — rely on real env vars */
+}
+const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
+const token = process.env.HA_TOKEN;
+if (!token) {
+  console.error("Missing HA_TOKEN (env or repo-root .env)");
+  process.exit(2);
+}
+
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+
+const urlPath = flag("--path", "/lovelace/default_view");
+const outPrefix = flag("--out", "rl");
+const observeSecs = args.includes("--observe") ? Number(flag("--observe", "30")) : null;
+const scenarioArg = flag("--scenario", null);
+const shot = (name) => path.resolve(skillDir, `${outPrefix}-${name}.png`);
+
+// --- options-flow control (same REST path the HA UI uses) ----------------
+const rest = async (method, apiPath, body) => {
+  const res = await fetch(base + apiPath, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { _status: res.status, _text: text };
+  }
+};
+
+// The options flow validates the whole form, so every key has to be sent even
+// when only the per-connection command budget is being changed.
+const RL_DEFAULTS = {
+  rate_limit_commands_per_second: 20.0,
+  rate_limit_commands_burst: 60.0,
+  rate_limit_global_commands_per_second: 100.0,
+  rate_limit_global_commands_burst: 200.0,
+  rate_limit_events_per_second: 50.0,
+  rate_limit_events_burst: 200.0,
+  rate_limit_global_events_per_second: 500.0,
+  rate_limit_global_events_burst: 1000.0,
+};
+
+async function setRateLimit(enabled, overrides = {}) {
+  const entries = await rest("GET", "/api/config/config_entries/entry");
+  const entry = Array.isArray(entries) ? entries.find((e) => e.domain === "haventory") : null;
+  if (!entry) throw new Error(`no haventory config entry: ${JSON.stringify(entries).slice(0, 200)}`);
+  const flow = await rest("POST", "/api/config/config_entries/options/flow", {
+    handler: entry.entry_id,
+    show_advanced_options: false,
+  });
+  if (!flow.flow_id) throw new Error(`could not start options flow: ${JSON.stringify(flow).slice(0, 200)}`);
+  const res = await rest("POST", `/api/config/config_entries/options/flow/${flow.flow_id}`, {
+    rate_limit_enabled: enabled,
+    ...RL_DEFAULTS,
+    ...overrides,
+  });
+  // A value the schema rejects comes back as the form again, with `errors` —
+  // rate limiting then silently stays as it was and every later assertion in the
+  // scenario measures nothing. The rates below sit above the flow's minimums
+  // (0.1/s for a rate, 1 token for a burst); this catches it if they ever drift.
+  if (res.type !== "create_entry") {
+    throw new Error(`options flow did not save: type=${res.type} errors=${JSON.stringify(res.errors ?? {})}`);
+  }
+  return res;
+}
+
+// --- banner enumeration ---------------------------------------------------
+// Nested shadow roots all the way down: the card sits inside HA's own dashboard
+// components (so `document.querySelector` never reaches it), hv-card-shell
+// renders <hv-banner> hosts, and each host keeps its heading and message inside
+// its own root. `textContent` on any of those hosts reads the light DOM, which
+// is empty. Every level has to be walked explicitly — this is the only way to
+// see what the banner actually says.
+const BANNER_PROBE = () => {
+  const findCard = (root) => {
+    for (const el of root.querySelectorAll("*")) {
+      if (el.tagName.toLowerCase() === "haventory-card") return el;
+      if (el.shadowRoot) {
+        const hit = findCard(el.shadowRoot);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  };
+  const shell = findCard(document)?.shadowRoot?.querySelector("hv-card-shell");
+  const root = shell?.shadowRoot;
+  if (!root) return { present: false, banners: [] };
+  const banners = [...root.querySelectorAll("[data-testid^='degraded-'], [data-testid='banner-entry']")]
+    .filter((el) => el.tagName.toLowerCase() === "hv-banner")
+    .map((el) => ({
+      testid: el.getAttribute("data-testid"),
+      kind: el.getAttribute("kind"),
+      text: (el.shadowRoot?.textContent ?? "").replace(/\s+/g, " ").trim(),
+      // Action buttons are slotted from the shell's root, not the banner's.
+      actions: [...el.querySelectorAll("[slot='actions']")].map((b) => ({
+        testid: b.getAttribute("data-testid"),
+        label: b.textContent.replace(/\s+/g, " ").trim(),
+      })),
+    }));
+  return { present: true, banners };
+};
+
+// --- main ----------------------------------------------------------------
+const browser = await chromium.launch();
+// HA's service worker reloads the page 30-90 s into a fresh context, which would
+// look exactly like the card recovering on its own. A rate-limit run sits inside
+// that window by construction, so the worker has to stay blocked.
+const context = await browser.newContext({ viewport: { width: 1280, height: 900 }, serviceWorkers: "block" });
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on("console", (msg) => {
+  if (msg.type() === "error") consoleErrors.push(msg.text());
+});
+page.on("pageerror", (err) => consoleErrors.push(`pageerror: ${err.message}`));
+
+// --- WS trace ------------------------------------------------------------
+// Playwright surfaces HA's single frontend WebSocket, which multiplexes every
+// command. Recording both directions is what makes a banner explainable: a
+// "Live updates paused" with no refused subscribe in the trace is a card bug,
+// with one it is the card doing its job.
+const trace = [];
+const t0 = Date.now();
+const at = () => `${((Date.now() - t0) / 1000).toFixed(1)}s`;
+page.on("websocket", (ws) => {
+  const pending = new Map(); // id -> command type, so a result can be named
+  ws.on("framesent", ({ payload }) => {
+    let msg;
+    try {
+      msg = JSON.parse(payload);
+    } catch {
+      return;
+    }
+    if (typeof msg.type !== "string") return;
+    if (msg.type === "auth") return; // carries the token
+    if (msg.id !== undefined) pending.set(msg.id, msg.type);
+    if (/haventory|subscribe|unsubscribe/.test(msg.type)) {
+      trace.push({ t: at(), dir: "->", type: msg.type, id: msg.id, sub: msg.subscription ?? msg.event_type });
+    }
+  });
+  ws.on("framereceived", ({ payload }) => {
+    let msg;
+    try {
+      msg = JSON.parse(payload);
+    } catch {
+      return;
+    }
+    const name = pending.get(msg.id) ?? msg.type;
+    if (msg.type === "result" && msg.success === false) {
+      trace.push({ t: at(), dir: "<-", type: name, id: msg.id, error: msg.error?.code, message: msg.error?.message });
+    } else if (msg.type === "result" && /haventory|subscribe/.test(String(name))) {
+      trace.push({ t: at(), dir: "<-", type: name, id: msg.id, ok: true });
+    }
+  });
+});
+
+await page.addInitScript(
+  ([hassUrl, accessToken]) => {
+    localStorage.setItem(
+      "hassTokens",
+      JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "unused-long-lived",
+        expires_in: 1800,
+        expires: Date.now() + 365 * 24 * 3600 * 1000,
+        hassUrl,
+        clientId: hassUrl + "/",
+      }),
+    );
+  },
+  [base, token],
+);
+
+/** Poll the shadow DOM until `predicate` accepts a probe, recording every distinct state. */
+async function watchBanners(seconds, predicate = null, timeline = []) {
+  const deadline = Date.now() + seconds * 1000;
+  let last = "";
+  while (Date.now() < deadline) {
+    const probe = await page.evaluate(BANNER_PROBE).catch(() => ({ present: false, banners: [] }));
+    const key = JSON.stringify(probe.banners.map((b) => [b.testid, b.actions.map((a) => a.testid)]));
+    if (key !== last) {
+      last = key;
+      timeline.push({ t: at(), banners: probe.banners });
+      for (const b of probe.banners) {
+        const acts = b.actions.length ? `  [${b.actions.map((a) => a.label).join(", ")}]` : "";
+        console.log(`  ${at()}  ${b.testid} (${b.kind}): ${b.text}${acts}`);
+      }
+      if (!probe.banners.length) console.log(`  ${at()}  (no degraded banner)`);
+    }
+    if (predicate && predicate(probe, timeline)) return { hit: true, timeline };
+    await page.waitForTimeout(150);
+  }
+  return { hit: false, timeline };
+}
+
+const seen = (timeline, testid) => timeline.some((s) => s.banners.some((b) => b.testid === testid));
+const seenText = (timeline, testid, re) =>
+  timeline.some((s) => s.banners.some((b) => b.testid === testid && re.test(b.text)));
+
+async function loadCard() {
+  await page.goto(base + urlPath, { waitUntil: "domcontentloaded" });
+  if (page.url().includes("/auth/authorize")) {
+    throw new Error("Redirected to the login page — hassTokens injection was rejected. Is HA_TOKEN valid?");
+  }
+  await page.waitForSelector("haventory-card", { timeout: 30000 });
+}
+
+const results = [];
+
+/**
+ * A budget that refills fast enough for one of the four backoff attempts
+ * (400/800/1600/3200 ms) to find tokens again: the card must say it is retrying
+ * and then recover with no user action, so the banner has to disappear on its
+ * own. `retrying` deliberately renders no action button — offering a Refresh
+ * while a retry is already scheduled would invite a redundant round trip.
+ *
+ * The numbers are tuned against what the card actually sends: about eight
+ * commands on load, then three subscribes. A burst of 8 is spent before the
+ * subscribes, and 8/s puts three tokens back within the second retry.
+ */
+async function scenarioRetrying() {
+  console.log("\n== scenario: refused subscribe -> retrying -> recovered ==");
+  await setRateLimit(true, {
+    rate_limit_commands_per_second: 8.0,
+    rate_limit_commands_burst: 8.0,
+    rate_limit_global_commands_per_second: 1000.0,
+    rate_limit_global_commands_burst: 2000.0,
+  });
+  await page.waitForTimeout(2500); // the limiter is rebuilt on options save
+  // Mark before the load: the refusal this scenario is about happens during it.
+  const traceMark = trace.length;
+  await loadCard();
+
+  const timeline = [];
+  await watchBanners(12, (_p, tl) => seen(tl, "degraded-live-updates"), timeline);
+  await page.screenshot({ path: shot("retrying") });
+  // Recovery is the *live-updates* banner going away, not the card going quiet:
+  // `degraded.rateLimited` is sticky until a refresh, so the lower-ranked
+  // "Rate limited · some live updates may have been dropped" banner is expected
+  // to remain. Treating its presence as a failure would fail a correct card.
+  const recovered = await watchBanners(
+    20,
+    (p, tl) => seen(tl, "degraded-live-updates") && !p.banners.some((b) => b.testid === "degraded-live-updates"),
+    timeline,
+  );
+  await page.screenshot({ path: shot("retrying-final") });
+
+  const appeared = seen(timeline, "degraded-live-updates");
+  const saidRetrying = seenText(timeline, "degraded-live-updates", /Retrying automatically/);
+  const offeredNoButton = timeline
+    .flatMap((s) => s.banners)
+    .filter((b) => b.testid === "degraded-live-updates" && /Retrying automatically/.test(b.text))
+    .every((b) => b.actions.length === 0);
+  const refusals = trace.slice(traceMark).filter((e) => e.error === "rate_limited").length;
+
+  // Spending all four attempts is correct behaviour, just not this scenario's:
+  // the budget was tighter than intended, so there was no recovery to observe.
+  const gaveUp = timeline.some((s) =>
+    s.banners.some(
+      (b) => b.testid === "degraded-live-updates" && b.actions.some((a) => a.testid === "degraded-live-refresh"),
+    ),
+  );
+
+  await setRateLimit(false);
+  results.push({
+    scenario: "retrying",
+    verdict: !appeared
+      ? "INCONCLUSIVE (budget never refused a subscribe)"
+      : !recovered.hit && gaveUp
+        ? "INCONCLUSIVE (budget too tight; card exhausted its retries)"
+        : saidRetrying && offeredNoButton && recovered.hit
+          ? "PASS"
+          : "FAIL",
+    detail:
+      `banner=${appeared} retrying-wording=${saidRetrying} no-action-button=${offeredNoButton} ` +
+      `self-recovered=${recovered.hit} rate_limited-frames=${refusals}`,
+  });
+}
+
+/**
+ * A budget that cannot refill inside the whole retry window, so all four
+ * attempts are refused and the card stops on its own. Then the wording must
+ * change to the "until you refresh" reading and the Refresh action must appear —
+ * that button is the only way back, so its absence would strand the card.
+ *
+ * The burst has to be spent exactly at the subscribes, not before them: the card
+ * loads its data first (stats, health, areas, location tree, location list,
+ * distinct values, version, item list — eight commands) and only opens the three
+ * subscriptions once that has come back. Starve it earlier and the bootstrap
+ * itself is refused, the card queues those commands instead, and the scenario
+ * measures the "Busy — retrying" banner rather than the paused one. So: eight
+ * tokens for the load, none for the subscribes, and 0.1/s — the flow's slowest —
+ * so nothing refills inside the roughly six-second retry window.
+ */
+async function scenarioExhausted() {
+  console.log("\n== scenario: every retry refused -> paused -> Refresh restores ==");
+  await setRateLimit(true, {
+    rate_limit_commands_per_second: 0.1,
+    rate_limit_commands_burst: 8.0,
+    rate_limit_global_commands_per_second: 1000.0,
+    rate_limit_global_commands_burst: 2000.0,
+  });
+  await page.waitForTimeout(2500);
+  await loadCard();
+
+  const timeline = [];
+  // 4 attempts at 400/800/1600/3200 ms plus the round trips: ~10 s to give up.
+  const paused = await watchBanners(
+    30,
+    (p) =>
+      p.banners.some(
+        (b) => b.testid === "degraded-live-updates" && b.actions.some((a) => a.testid === "degraded-live-refresh"),
+      ),
+    timeline,
+  );
+  await page.screenshot({ path: shot("exhausted-paused") });
+
+  const saidRefresh = seenText(timeline, "degraded-live-updates", /until you refresh/);
+  let refreshRestored = false;
+  if (paused.hit) {
+    // Lift the squeeze first: Refresh is the user's way back, and it can only
+    // work once the server is answering again.
+    await setRateLimit(false);
+    await page.waitForTimeout(3000);
+    const shell = page.locator("haventory-card").locator("hv-card-shell");
+    await shell.locator("[data-testid='degraded-live-refresh']").click();
+    // Live updates are restored when the paused banner goes; the error the card
+    // queued when it gave up stays until the user dismisses it, which is the
+    // contract — it is the only record that updates were missed.
+    const cleared = await watchBanners(
+      20,
+      (p) => !p.banners.some((b) => b.testid === "degraded-live-updates"),
+      timeline,
+    );
+    refreshRestored = cleared.hit;
+  }
+  await page.screenshot({ path: shot("exhausted-final") });
+
+  await setRateLimit(false);
+  results.push({
+    scenario: "exhausted",
+    verdict: !paused.hit
+      ? "INCONCLUSIVE (card never exhausted its retries)"
+      : saidRefresh && refreshRestored
+        ? "PASS"
+        : "FAIL",
+    detail: `paused-with-action=${paused.hit} refresh-wording=${saidRefresh} refresh-restored-live=${refreshRestored}`,
+  });
+}
+
+let exitCode = 0;
+try {
+  if (observeSecs !== null) {
+    console.log(`== observe only: ${observeSecs}s, rate limiting untouched ==`);
+    await loadCard();
+    await watchBanners(observeSecs);
+  } else {
+    if (!scenarioArg || scenarioArg === "retrying") await scenarioRetrying();
+    if (!scenarioArg || scenarioArg === "exhausted") await scenarioExhausted();
+  }
+} catch (err) {
+  console.error(`\nharness error: ${err.message}`);
+  exitCode = 1;
+} finally {
+  // Rate limiting is off by default and every other harness assumes that, so it
+  // is reset even when this run threw halfway through a scenario.
+  if (observeSecs === null) {
+    try {
+      await setRateLimit(false);
+    } catch (err) {
+      console.error(`WARN: could not reset rate limiting off: ${err.message}`);
+      exitCode = 1;
+    }
+  }
+}
+
+console.log(`\n== WS trace (${trace.length} frames) ==`);
+for (const e of trace) {
+  const tail = e.error ? `ERROR ${e.error}: ${e.message ?? ""}` : e.ok ? "ok" : (e.sub ?? "");
+  console.log(`  ${e.t.padStart(6)} ${e.dir} ${String(e.type).padEnd(34)} ${tail}`);
+}
+
+if (results.length) {
+  console.log("\n== verdict ==");
+  for (const r of results) console.log(`  ${r.scenario.padEnd(10)} ${r.verdict.padEnd(12)} ${r.detail}`);
+  if (results.some((r) => r.verdict === "FAIL")) exitCode = 1;
+}
+
+// Blocking the service worker makes HA's own bundle touch `navigator.serviceWorker`
+// when it is undefined. Flag it rather than hide it, so a real card error stands out.
+const SW_BLOCK_NOISE = /serviceWorker|reading 'addEventListener'/;
+if (consoleErrors.length) {
+  console.log(`\nbrowser console errors (${consoleErrors.length}):`);
+  for (const e of consoleErrors.slice(0, 10)) {
+    console.log(`  ${e}${SW_BLOCK_NOISE.test(e) ? "   <- expected: HA bundle, service worker blocked" : ""}`);
+  }
+}
+
+await browser.close();
+process.exit(exitCode);

--- a/.claude/skills/run-haventory/visual_pass.mjs
+++ b/.claude/skills/run-haventory/visual_pass.mjs
@@ -1,0 +1,410 @@
+// Walk the card's surfaces at desktop and mobile widths, screenshotting each and
+// reporting whether it actually opened.
+//
+// A single screenshot proves one view renders; this proves the set of them do,
+// which is what a UI change needs before and after. Each surface is a named
+// recipe of clicks against the card's own `data-testid`s, so a rename in the
+// card fails the recipe loudly instead of silently capturing the wrong screen.
+//
+// The pass is also a DOM check, not only a picture: every surface asserts that
+// its root element exists in the shadow DOM after the recipe runs, and the run
+// exits non-zero if any surface, at any width, failed to open.
+//
+// Usage (from the skill dir, .claude/skills/run-haventory/):
+//   node visual_pass.mjs                       # desktop + mobile into ./visual/
+//   node visual_pass.mjs --out before          # ./before/  (then --out after to compare)
+//   node visual_pass.mjs --only desktop        # or --only mobile
+//   node visual_pass.mjs --surfaces list,search,full-view
+//   node visual_pass.mjs --dark                # HA dark theme + dark OS scheme
+//   node visual_pass.mjs --list                # print the surface names and exit
+//
+// Everything it drives is read-only: it opens panels, sheets and editors but
+// never saves, imports or deletes. The one exception is the search box, which is
+// cleared again before the next surface.
+//
+// Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
+
+import { chromium, devices } from "playwright";
+import { readFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(skillDir, "..", "..", "..");
+
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+
+// --- surface recipes ------------------------------------------------------
+// `open` is a list of steps run in order against the card:
+//   ["click", <sel>]  ["hover", <sel>]  ["fill", <sel>, <text>]  ["key", <key>]  ["wait", <ms>]
+// `expect` is the selector that must be visible once the recipe has run.
+// Selectors pierce shadow DOM, so nested components address directly.
+//
+// Every recipe starts from a freshly loaded page. Chaining them instead would be
+// faster, but a modal left standing puts a scrim over everything that follows
+// and one failure then cascades into a dozen — which reads as a broken card
+// rather than a broken recipe. That is why the full-view surfaces each re-open
+// the full view rather than assuming the previous surface left it up.
+//
+// Surfaces are named after what a reader would call the screen, and prefixed
+// d-/m- in the file name so a desktop and a mobile capture of the same surface
+// sort next to each other.
+//
+// The card chooses its layout from ITS OWN width, not the viewport's, so the
+// desktop pass runs on the `wide` dashboard view: in a normal dashboard column
+// even a 1440px window gets the narrow branch, where the filter panel is a modal
+// sheet and the full-view link is absent entirely.
+const CARD = "haventory-card";
+const OVERFLOW = `${CARD} [data-testid="card-overflow"] button`;
+const menu = (id) => `${CARD} [data-testid="overflow-item"][data-id="${id}"]`;
+
+// Opening the full view is a shared prefix, not a surface the later ones inherit.
+const OPEN_FULL = [
+  ["click", `${CARD} [data-testid="expand-toggle"]`],
+  ["wait", 1500],
+];
+
+const DESKTOP_SURFACES = [
+  { id: "01-list", open: [], expect: `${CARD} [data-testid="card-list"]` },
+  {
+    id: "02-filter-panel",
+    open: [["click", `${CARD} [data-testid="filter-toggle"]`]],
+    expect: `${CARD} [data-testid="filter-panel"]`,
+  },
+  {
+    id: "03-search",
+    open: [
+      ["fill", `${CARD} [data-testid="search-input"]`, "box"],
+      ["wait", 1500],
+    ],
+    expect: `${CARD} [data-testid="card-list"]`,
+  },
+  {
+    id: "04-add-editor",
+    open: [["click", `${CARD} [data-testid="add-item"]`]],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "05-row-editor",
+    // The row's edit button lives in `.hover-actions` and is transparent until
+    // the row is hovered, so it has to be revealed before it can be clicked.
+    open: [
+      ["hover", `${CARD} [data-testid="list-row"]`],
+      ["click", `${CARD} [data-testid="list-row"] [data-testid="row-edit"]`],
+    ],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "06-overflow",
+    open: [["click", OVERFLOW]],
+    expect: `${CARD} [data-testid="overflow-menu"]`,
+  },
+  {
+    id: "07-organize",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("organize")],
+      ["wait", 800],
+    ],
+    expect: `${CARD} [data-testid="organize-dialog"]`,
+  },
+  {
+    id: "08-diagnostics",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("diagnostics")],
+      ["wait", 800],
+    ],
+    // The panel host is a zero-size wrapper; its status line is what proves the
+    // panel is actually open.
+    expect: `${CARD} [data-testid="diagnostics-status"]`,
+  },
+  {
+    id: "09-import",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("import")],
+    ],
+    expect: `${CARD} [data-testid="import-text"]`,
+  },
+  {
+    id: "10-selection",
+    // Selection mode is entered from the menu; the per-row checkboxes do not
+    // exist until it is on.
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("select-items")],
+      ["wait", 700],
+    ],
+    expect: `${CARD} [data-testid="selection-bar"], ${CARD} [data-testid="bulk-bar"]`,
+  },
+  {
+    id: "11-full-view",
+    // `expand-toggle` is the app-bar control and exists at every width;
+    // `open-full-view` is a footer link the narrow branch does not render.
+    open: OPEN_FULL,
+    expect: `${CARD} [data-testid="full-view"]`,
+  },
+  {
+    id: "12-full-filters",
+    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="full-filters-toggle"]`], ["wait", 500]],
+    expect: `${CARD} [data-testid="full-filter-panel"]`,
+  },
+  {
+    id: "13-full-editor",
+    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="full-add-item"]`], ["wait", 600]],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "14-full-columns",
+    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="columns-expanded"]`], ["wait", 600]],
+    expect: `${CARD} [data-testid="column-options"]`,
+  },
+];
+
+// The narrow layout is a different component tree, not a reflow: the filter
+// panel becomes a sheet, the row opens a detail sheet, and the editor arrives as
+// a bottom sheet. Recipes that only exist here live in their own list.
+const MOBILE_SURFACES = [
+  { id: "01-list", open: [], expect: `${CARD} [data-testid="card-list"]` },
+  {
+    id: "02-filter-sheet",
+    open: [
+      ["click", `${CARD} [data-testid="filter-toggle"]`],
+      ["wait", 600],
+    ],
+    // `filter-sheet` is the bottom-sheet host and has no box of its own, so the
+    // sheet's own footer button is what proves it came up.
+    expect: `${CARD} [data-testid="sheet-cancel"]`,
+    // A modal sheet is not dismissed by pressing its opener again — leaving it
+    // up would put a scrim over every surface that follows.
+  },
+  {
+    id: "03-detail-sheet",
+    open: [
+      ["click", `${CARD} [data-testid="list-row"] [data-testid="row-name"]`],
+      ["wait", 700],
+    ],
+    expect: `${CARD} [data-testid="sheet-name"]`,
+  },
+  {
+    id: "04-add-sheet",
+    open: [
+      ["click", `${CARD} [data-testid="add-item"]`],
+      ["wait", 700],
+    ],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "05-overflow",
+    open: [["click", OVERFLOW]],
+    expect: `${CARD} [data-testid="overflow-menu"]`,
+  },
+  {
+    id: "06-organize",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("organize")],
+      ["wait", 900],
+    ],
+    expect: `${CARD} [data-testid="organize-dialog"]`,
+  },
+  {
+    id: "07-diagnostics",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("diagnostics")],
+      ["wait", 800],
+    ],
+    expect: `${CARD} [data-testid="diagnostics-status"]`,
+  },
+  {
+    id: "08-full-view",
+    open: [
+      ["click", `${CARD} [data-testid="expand-toggle"]`],
+      ["wait", 1500],
+    ],
+    expect: `${CARD} [data-testid="full-view"]`,
+  },
+];
+
+if (args.includes("--list")) {
+  console.log("desktop:", DESKTOP_SURFACES.map((s) => s.id).join(", "));
+  console.log("mobile: ", MOBILE_SURFACES.map((s) => s.id).join(", "));
+  process.exit(0);
+}
+
+// --- config: env wins, .env fills the gaps -------------------------------
+try {
+  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
+  }
+} catch {
+  /* no .env — rely on real env vars */
+}
+const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
+const token = process.env.HA_TOKEN;
+if (!token) {
+  console.error("Missing HA_TOKEN (env or repo-root .env)");
+  process.exit(2);
+}
+
+const outDir = path.resolve(skillDir, flag("--out", "visual"));
+// Per-pass by default; --path forces one view for both, which is how you check
+// a single dashboard layout rather than the two the card is designed for.
+const urlPathOverride = flag("--path", null);
+const haDark = args.includes("--dark");
+const only = flag("--only", null);
+const wanted = flag("--surfaces", null)?.split(",").map((s) => s.trim());
+mkdirSync(outDir, { recursive: true });
+
+const PASSES = [
+  {
+    key: "desktop",
+    prefix: "d",
+    surfaces: DESKTOP_SURFACES,
+    urlPath: "/lovelace/wide",
+    contextOptions: { viewport: { width: 1440, height: 900 } },
+  },
+  {
+    key: "mobile",
+    prefix: "m",
+    surfaces: MOBILE_SURFACES,
+    urlPath: "/lovelace/default_view",
+    contextOptions: { ...devices["iPhone 15"], deviceScaleFactor: 2 },
+  },
+].filter((p) => !only || p.key === only);
+
+const results = [];
+const browser = await chromium.launch({ args: ["--touch-events=enabled"] });
+
+for (const pass of PASSES) {
+  console.log(`\n== ${pass.key} ==`);
+  // HA's service worker reloads the page 30-90 s into a fresh context, which
+  // would destroy the run mid-surface. A full pass is longer than that window.
+  const context = await browser.newContext({
+    ...pass.contextOptions,
+    serviceWorkers: "block",
+    colorScheme: haDark ? "dark" : "light",
+  });
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(`pageerror: ${err.message}`));
+  // A 404 reaches the console as an untraceable "Failed to load resource".
+  // Recording the URLs is the only way to tell an HA-bundle 404 (it asks for
+  // @babel/runtime helpers that are not shipped) from a missing card asset.
+  const notFound = [];
+  page.on("response", (res) => {
+    if (res.status() === 404) notFound.push(res.url());
+  });
+
+  // The HA frontend trusts hassTokens if `expires` is in the future. HA's own
+  // dark mode is a separate switch from the OS colour scheme, so --dark sets both.
+  await page.addInitScript(
+    ([hassUrl, accessToken, dark]) => {
+      localStorage.setItem(
+        "hassTokens",
+        JSON.stringify({
+          access_token: accessToken,
+          token_type: "Bearer",
+          refresh_token: "unused-long-lived",
+          expires_in: 1800,
+          expires: Date.now() + 365 * 24 * 3600 * 1000,
+          hassUrl,
+          clientId: hassUrl + "/",
+        }),
+      );
+      if (dark) localStorage.setItem("selectedTheme", JSON.stringify({ dark: true }));
+    },
+    [base, token, haDark],
+  );
+
+  const url = base + (urlPathOverride ?? pass.urlPath);
+  const loadCard = async () => {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    if (page.url().includes("/auth/authorize")) {
+      console.error("Redirected to the login page — hassTokens injection was rejected. Is HA_TOKEN valid?");
+      await browser.close();
+      process.exit(1);
+    }
+    await page.waitForSelector(CARD, { timeout: 30000 });
+    await page.waitForTimeout(2500); // let the WS subscription deliver the first page
+  };
+
+  const touch = Boolean(pass.contextOptions.hasTouch);
+  const step = async ([kind, target, value]) => {
+    if (kind === "wait") return page.waitForTimeout(Number(target));
+    if (kind === "key") return page.keyboard.press(target);
+    const el = page.locator(target).first();
+    // A hover target is revealed by the hover itself, so it is attached but not
+    // yet visible — waiting for visibility would deadlock.
+    await el.waitFor({ state: kind === "hover" ? "attached" : "visible", timeout: 10000 });
+    if (kind === "fill") return el.fill(value);
+    if (kind === "hover") return el.hover();
+    if (touch) return el.tap();
+    return el.click();
+  };
+
+  for (const surface of pass.surfaces) {
+    if (wanted && !wanted.some((w) => surface.id.includes(w))) continue;
+    const name = `${pass.prefix}-${surface.id}`;
+    const file = path.join(outDir, `${name}.png`);
+    try {
+      await loadCard();
+      for (const s of surface.open) await step(s);
+      await page.waitForSelector(surface.expect, { timeout: 10000 });
+      await page.waitForTimeout(500); // let transitions settle before the capture
+      await page.screenshot({ path: file });
+      console.log(`  PASS  ${name}`);
+      results.push({ name, ok: true });
+    } catch (err) {
+      // Capture the failure too: a screenshot of the wrong screen is the fastest
+      // way to see why a recipe stopped matching.
+      await page.screenshot({ path: file }).catch(() => {});
+      console.log(`  FAIL  ${name}: ${err.message.split("\n")[0]}`);
+      results.push({ name, ok: false, error: err.message.split("\n")[0] });
+    }
+  }
+
+  // Blocking the service worker makes HA's own bundle touch
+  // `navigator.serviceWorker` when it is undefined; HA also requests
+  // @babel/runtime helpers it does not ship. Neither is the card's doing, and
+  // both are constant, so they are named rather than counted as failures.
+  const SW_BLOCK_NOISE = /serviceWorker|reading 'addEventListener'/;
+  const haBundle404 = notFound.filter((u) => /@babel\/runtime|\/unknown\//.test(u));
+  const cardMissing = notFound.filter((u) => /haventory/.test(u));
+  const resourceNoise = haBundle404.length && /Failed to load resource/;
+  const real = consoleErrors.filter(
+    (e) => !SW_BLOCK_NOISE.test(e) && !(resourceNoise && resourceNoise.test(e)),
+  );
+  if (haBundle404.length) console.log(`  (${haBundle404.length} HA-bundle 404s, e.g. ${haBundle404[0]})`);
+  if (cardMissing.length) {
+    console.log(`  MISSING card assets (${cardMissing.length}):`);
+    for (const u of cardMissing.slice(0, 5)) console.log(`    ${u}`);
+    results.push({ name: `${pass.key} assets`, ok: false, error: `${cardMissing.length} card 404s` });
+  }
+  if (real.length) {
+    console.log(`  browser console errors (${real.length}):`);
+    for (const e of real.slice(0, 10)) console.log(`    ${e}`);
+    results.push({ name: `${pass.key} console`, ok: false, error: `${real.length} console errors` });
+  }
+  await context.close();
+}
+
+await browser.close();
+
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} surfaces captured into ${outDir}`);
+if (failed.length) {
+  console.log("failed:");
+  for (const f of failed) console.log(`  ${f.name}: ${f.error}`);
+}
+process.exit(failed.length ? 1 : 0);

--- a/.claude/skills/test-haventory/SKILL.md
+++ b/.claude/skills/test-haventory/SKILL.md
@@ -11,10 +11,9 @@ break-it driver), the **live-update browser smoke** `cards/haventory-card/e2e/li
 and the **online WS pytest smokes** (`-m online`).
 
 All paths are relative to the repo root. This is a **Windows host**: run `.sh`/`.py` through
-Git Bash. The project `.venv` is broken here (OneDrive can't delete its `lib64` symlink), so
-**every Python gate runs through an ephemeral `uv run --no-project` env** — the offline
-`.venv` is never used. Canonical clean-Linux/CI commands live in the README ("The gate");
-the ones below are the verified Windows forms.
+Git Bash. Plain `uv run` works against the project `.venv` — the `--no-project` form below is
+still correct and is what to fall back to if the venv is ever unusable again, but it is no
+longer required. Canonical clean-Linux/CI commands live in the README ("The gate").
 
 ## Prerequisites
 
@@ -34,7 +33,7 @@ Both halves must be green. Backend, from the repo root:
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --python 3.14 \
   --with pytest --with pytest-asyncio --with voluptuous --with aiohttp \
   python -m pytest -q
-# → 265 passed, 22 skipped
+# → 350 passed, 22 skipped
 
 uv run --no-project --python 3.14 --with ruff==0.15.22 ruff check custom_components tests
 # → All checks passed!
@@ -49,7 +48,7 @@ Frontend, from `cards/haventory-card`:
 npm ci            # first run, or if node_modules is partial (missing rolldown binding)
 npm run lint      # eslint  → clean
 npm run typecheck # tsc --noEmit → clean
-npm test          # vitest  → 165 passed
+npm test          # vitest  → 812 passed across 42 files
 npm run build     # vite → ../www/haventory/haventory-card.js (git-ignored)
 ```
 
@@ -100,7 +99,7 @@ $RUN subteardown   # HA-core unsubscribe_events teardown (the card's path)
 $RUN statsprobe    # stats broadcast: ~1 counts event per mutation
 $RUN ratelimit     # enable a tight per-conn budget, hammer, disable, confirm recovery
 $RUN races         # rename→version invalidation, concurrent rename, adjust serialization
-$RUN bulk 1000     # create 250→500→1000 (latency curve) + delete; ~25s
+$RUN bulk 1000     # create 250→500→1000 (latency curve) + delete; ~3½ min on a 2000-item store
 MSYS_NO_PATHCONV=1 HA_CONTAINER=home-assistant $RUN restart   # DESTRUCTIVE, last
 $RUN cleanup       # sweep any leftover stress_test_ data
 ```
@@ -120,11 +119,13 @@ $RUN cleanup       # sweep any leftover stress_test_ data
 | `cleanup` | delete everything prefixed `stress_test_` |
 
 **A run is not clean until you scan the server logs** — offline stubs can stay green while
-real HA throws (that is how the `__slots__` bug #97 was found):
+real HA throws (that is how the `__slots__` bug #97 was found). The sibling skill's sweep
+sorts the log by the taxonomy's severity policy instead of by keyword, so the fuzz layers'
+hundreds of contract-defined WARNINGs do not bury the one line that matters:
 
 ```bash
-docker logs home-assistant --since 30m 2>&1 | grep -iE 'traceback|AttributeError|unknown_error'
-# expected: only ValidationError/NotFoundError/ConflictError tracebacks from the fuzz layers
+uv run python .claude/skills/run-haventory/log_sweep.py --since 30m
+# → BLOCKING: 0 ... verdict: PASS
 ```
 
 ## Run (agent path): live-update browser smoke
@@ -166,8 +167,9 @@ not re-verified here.
 
 ## Gotchas
 
-- **Broken project `.venv`** — plain `uv run <x>` fails with `failed to remove file .venv/lib64:
-  Zugriff verweigert` (OneDrive won't delete the symlink). Always add `--no-project`.
+- **`--no-project` is the fallback, not the rule** — plain `uv run` works. If it ever fails with
+  `failed to remove file .venv/lib64: Zugriff verweigert` (OneDrive refusing to delete the
+  symlink), add `--no-project` and the `--with` list to run from an ephemeral env instead.
 - **Offline suite needs Python 3.14** (PEP 758 source) and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`;
   `--with aiohttp` is only so the `*_online.py` / stress modules import at collection time.
 - **Frontend `node_modules` is often partial** (missing `@rolldown/binding-win32-x64-msvc` →
@@ -188,7 +190,8 @@ not re-verified here.
 
 ## Troubleshooting
 
-- **`failed to remove file .venv/lib64: Zugriff verweigert`** — you dropped `--no-project`. Add it.
+- **`failed to remove file .venv/lib64: Zugriff verweigert`** — the project venv is unusable
+  again; re-run with `--no-project` plus the `--with` list.
 - **`Cannot find module '@rolldown/binding-win32-x64-msvc'`** — `npm ci` in `cards/haventory-card`.
 - **`No module named 'aiohttp'`** during pytest collection — add `--with aiohttp` to the uv run.
 - **`GetFileAttributesEx C:\c:` on `docker cp`** — host-path mangling under Git Bash; use the

--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -31,6 +31,7 @@ Run:  uv run --no-project --with aiohttp python .claude/skills/test-haventory/st
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import statistics
@@ -143,6 +144,35 @@ async def connect() -> WSConn:
 
 
 # ----------------------------------------------------------------------------- helpers
+
+
+@contextlib.asynccontextmanager
+async def keepalive(conn: WSConn, interval: float = 30.0):
+    """Keep an otherwise idle control connection alive across a long workload.
+
+    aiohttp only answers the server's WebSocket pings while a receive() is in
+    flight. Nothing awaits the control connection while the workers run, so HA
+    closes it after ~90s and the post-run health check dies with
+    ClientConnectionResetError("Cannot write to closing transport") — which reads
+    as a backend fault and is not one. Pumping a cheap command keeps a receive()
+    in flight.
+
+    Nothing else may use `conn` for the duration: WSConn is single-task by
+    design, and two callers interleaving on one socket would cross their frames.
+    """
+
+    async def _pump() -> None:
+        while True:
+            await asyncio.sleep(interval)
+            await conn.call("haventory/ping")
+
+    task = asyncio.create_task(_pump())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 async def health(conn: WSConn) -> dict:
@@ -880,9 +910,13 @@ async def cmd_bulk(target: int = 1000, conns: int = 8) -> None:
             ids: list[str] = []
             errs: list[dict] = []
             t0 = time.monotonic()
-            await asyncio.gather(
-                *[_create_worker(pool[i], shards[i], None, lat, ids, errs) for i in range(conns)]
-            )
+            async with keepalive(control):
+                await asyncio.gather(
+                    *[
+                        _create_worker(pool[i], shards[i], None, lat, ids, errs)
+                        for i in range(conns)
+                    ]
+                )
             wall = time.monotonic() - t0
             created_total.extend(ids)
             all_latencies.extend(lat)
@@ -933,7 +967,8 @@ async def cmd_bulk(target: int = 1000, conns: int = 8) -> None:
                     del_err.append({"id": iid, "error": fr.get("error")})
 
         t0 = time.monotonic()
-        await asyncio.gather(*[_del_worker(pool[i], del_shards[i]) for i in range(conns)])
+        async with keepalive(control):
+            await asyncio.gather(*[_del_worker(pool[i], del_shards[i]) for i in range(conns)])
         wall = time.monotonic() - t0
         after2 = await health(control)
         print(f"  deleted={del_ok[0]} errors={len(del_err)} wall={wall:.2f}s")


### PR DESCRIPTION
Closes the tooling half of `docs/open-items.md` item **55**, and fixes item **54** on the way.

## Why

The checks written for the 2026-07-27 batch verification were preserved only in that run's
evidence folder, which no longer exists. Every repeat meant rewriting them from scratch —
so the v0.1.0 preflight could not be a repeatable run. These five harnesses now ship with
the skill, each with its own oracle, so a run either passes or says why it could not judge.

## What

| harness | what it proves |
|---|---|
| `rl_banner.mjs` | the card's rate-limit degraded-banner lifecycle, with the WS frames that caused each state |
| `visual_pass.mjs` | every card surface still opens, at desktop and mobile widths |
| `import_policies.mjs` | the import sheet describes the conflict policy the backend actually applied |
| `log_sweep.py` | the container log obeys the error taxonomy's severity policy |
| `lifecycle_probe.py` | resource cache-bust rewriting, schema-downgrade refusal, entry removal/re-add |

Three design notes worth the review time:

- **`rl_banner.mjs` squeezes the real server.** A refused `subscribe` is retried four times
  (400/800/1600/3200 ms) and only then does the card give up, so there are two states to
  check and the harness checks both: a retry that wins must clear the banner with no user
  action and offer no button; a budget that outlasts the window must switch the wording to
  "until you refresh" and grow a Refresh that restores live updates. The budgets are tuned
  against what the card actually sends — eight bootstrap commands, then three subscribes —
  because starving it earlier provokes the *command* retry banner instead and measures the
  wrong thing. A scenario that never provoked its state reports INCONCLUSIVE, not a pass.
- **`visual_pass.mjs` reloads before every surface.** Chaining is faster, but a modal left
  standing puts a scrim over everything after it and one bad recipe cascades into a dozen —
  which reads as a broken card rather than a broken recipe. It also runs the desktop pass on
  the `wide` dashboard view: the card picks its layout from *its own* width, so in a normal
  dashboard column even a 1440px window gets the narrow branch.
- **`log_sweep.py` judges severity, not keywords.** A `ConflictError` at WARNING is the
  taxonomy working; the same rejection at ERROR is the finding. Sorting on the exception a
  traceback ends on is what separates them, and it keeps the fuzz layers' hundreds of
  contract-defined WARNINGs from burying the one line that matters.

## Item 54 (`stress.py` control connection)

`stress.py`'s control connection sat idle while the workers ran, so HA closed it after ~90 s
and the bulk layer failed its post-run health check with `ClientConnectionResetError:
Cannot write to closing transport` — leaving ~1000 `stress_test_` items behind and looking
exactly like a backend fault. Reproduced here, then fixed with a `keepalive` context manager
that pumps a cheap command across the long gathers. Verified: `bulk 1000` now completes both
the create and the 98 s delete phase with its health oracle passing on both sides.

## Also

- The two gotchas item 55 asks to record: the ~15 s `Store` debounce on
  `.storage/lovelace_resources` (reading the file right after a restart shows the old URL
  while the in-memory collection is already correct), and running the integration suite in a
  throwaway `python:3.14-slim` container when the host cannot provide Python 3.14.
- Truth-ups in both skills: expected backend/frontend counts were 265/165, actually 350/812;
  the "project `.venv` is broken, always use `--no-project`" note no longer holds.

## Verification

Every harness was run against the live dev container (HA 2026.7.3, 2000 items / 53
locations) while building it, and the instance ends at its exact pre-run baseline:

- `visual_pass` 22/22 surfaces, zero card console errors, zero card 404s
- `import_policies` 3/3 policies agree with the server, conflict wording correct under `skip`
- `rl_banner` both scenarios PASS; rate limiting left OFF
- `lifecycle_probe` 15/15 (6 resources + 4 downgrade + 5 entry)
- `log_sweep` PASS, 0 blocking

Both gates green: backend 350 passed / 22 skipped, ruff check + format clean, mypy clean;
frontend eslint clean, tsc clean, vitest 812 passed, build clean.

## Follow-ups (not fixed here)

- `pin_resource.py`'s docstring still describes the pre-#122 exact-string matching — the
  documented half of open item **44**, deliberately left with the behaviour it belongs to.
- The 404s `visual_pass` reports are HA's own bundle asking for `@babel/runtime` helpers it
  does not ship. Attributed and excluded rather than silenced, so a genuine missing card
  asset still fails the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
