### PR TITLE
fix(card): survive Home Assistant's custom element registry swap

### DIFF
--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -4,6 +4,7 @@ import { Store } from './store/store';
 import type { ColumnKey } from './store/columns';
 import { loadColumnPrefs, saveColumnPrefs } from './store/columns';
 import { resolveColorScheme } from './ui/theme';
+import { defineCardElement } from './register';
 import './components/hv-column-picker';
 import './components/hv-card-shell';
 
@@ -181,7 +182,7 @@ export class HAventoryCard extends LitElement {
   }
 }
 
-customElements.define('haventory-card', HAventoryCard);
+defineCardElement('haventory-card', HAventoryCard);
 
 // Lovelace card picker metadata
 export function getStubConfig() {

--- a/cards/haventory-card/src/register.test.ts
+++ b/cards/haventory-card/src/register.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { defineCardElement } from './register';
+
+// Home Assistant replaces window.customElements during boot; these cover the
+// definition landing in whichever registry the dashboard ends up reading.
+
+const realRegistry = window.customElements;
+
+function useRegistry(get: () => CustomElementConstructor | undefined = () => undefined) {
+  const define = vi.fn();
+  Object.defineProperty(window, 'customElements', {
+    value: { define, get: vi.fn(get) } as unknown as CustomElementRegistry,
+    configurable: true,
+    writable: true,
+  });
+  return define;
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'customElements', {
+    value: realRegistry,
+    configurable: true,
+    writable: true,
+  });
+  vi.useRealTimers();
+});
+
+class Dummy extends HTMLElement {}
+
+describe('defineCardElement', () => {
+  it('defines the element in the registry that is current at call time', () => {
+    const define = useRegistry();
+
+    defineCardElement('hv-test-card', Dummy);
+
+    expect(define).toHaveBeenCalledWith('hv-test-card', Dummy);
+  });
+
+  it('re-defines into a registry the frontend swaps in afterwards', () => {
+    vi.useFakeTimers();
+    useRegistry();
+    defineCardElement('hv-test-card', Dummy);
+
+    const afterSwap = useRegistry();
+    vi.advanceTimersByTime(300);
+
+    expect(afterSwap).toHaveBeenCalledWith('hv-test-card', Dummy);
+  });
+
+  it('re-defines once and then stops re-checking', () => {
+    vi.useFakeTimers();
+    useRegistry();
+    defineCardElement('hv-test-card', Dummy);
+
+    const afterSwap = useRegistry();
+    vi.advanceTimersByTime(300);
+    vi.advanceTimersByTime(10_000);
+
+    expect(afterSwap).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a definition the new registry already has alone', () => {
+    vi.useFakeTimers();
+    useRegistry();
+    defineCardElement('hv-test-card', Dummy);
+
+    const afterSwap = useRegistry(() => Dummy);
+    vi.advanceTimersByTime(300);
+
+    expect(afterSwap).not.toHaveBeenCalled();
+  });
+
+  it('gives up re-checking once the window has elapsed', () => {
+    vi.useFakeTimers();
+    useRegistry();
+    defineCardElement('hv-test-card', Dummy);
+
+    vi.advanceTimersByTime(20_000);
+    const afterLateSwap = useRegistry();
+    vi.advanceTimersByTime(1_000);
+
+    expect(afterLateSwap).not.toHaveBeenCalled();
+  });
+});

--- a/cards/haventory-card/src/register.ts
+++ b/cards/haventory-card/src/register.ts
@@ -1,0 +1,39 @@
+/**
+ * Custom element registration that survives Home Assistant's registry swap.
+ *
+ * The frontend installs its own CustomElementRegistry while it boots. A
+ * definition made before that swap stays behind in the registry it replaced,
+ * where the dashboard never looks, and the card renders as a "custom element
+ * doesn't exist" error instead. Which side of the swap a module lands on is
+ * decided by how quickly the browser fetches it — as an extra module URL the
+ * card can evaluate either side, and engines disagree about which — so the
+ * definition is re-asserted whenever the current registry is no longer the one
+ * it was made in.
+ */
+
+const RECHECK_INTERVAL_MS = 250;
+const RECHECK_WINDOW_MS = 15_000;
+
+export function defineCardElement(tag: string, ctor: CustomElementConstructor): void {
+  let registeredIn: CustomElementRegistry | undefined;
+
+  const register = (): boolean => {
+    const registry = customElements;
+    if (registry === registeredIn) return false;
+    if (!registry.get(tag)) registry.define(tag, ctor);
+    registeredIn = registry;
+    return true;
+  };
+
+  register();
+
+  if (typeof window === 'undefined') return;
+
+  // The swap happens once, during boot, so the first change observed is also
+  // the last: re-assert there and stop. The window bounds the wait on a cold
+  // start, where the frontend takes seconds to come up.
+  const until = Date.now() + RECHECK_WINDOW_MS;
+  const timer = window.setInterval(() => {
+    if (register() || Date.now() >= until) window.clearInterval(timer);
+  }, RECHECK_INTERVAL_MS);
+}

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "haventory"
-version = "0.0.1"
+version = "0.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Problem

A HACS install of v0.1.0 renders the card as **"custom element doesn't exist"** (or an endless spinner) in Firefox, every time.

Home Assistant's frontend installs its own `CustomElementRegistry` while it boots. Since PR #147 the card is loaded as an extra module URL from the index page, so it can evaluate on either side of that swap — and a definition made *before* it stays behind in the registry HA replaced, where the dashboard never looks.

Which side the module lands on is a race decided purely by fetch timing, so this is not a Firefox bug. Measured against the released v0.1.0 bundle on a real HACS install:

| Engine | Cold-load failures | Ordering |
|---|---|---|
| Firefox 151 | **5/5** | define 490 ms → swap 539 ms — always loses |
| Chromium 149 | **2/5** | swap 99 ms → define 103 ms — wins by 4 ms, when it wins |
| WebKit 26.5 | 0/5 | — |

The 4 ms margin is why this shipped green. `window.load` is no help: it fires at 1479 ms in Firefox (after the swap) but at 54 ms in Chromium (before the module even runs).

The identical-URL requirement from the shipping plan's R1 makes it worse rather than better: the browser module map dedupes, so the Lovelace resource loader — which runs *after* the frontend is up and would register correctly — never re-evaluates the module.

## Fix

`defineCardElement()` records which registry it defined into and re-asserts the definition when the current registry is no longer that one. The swap happens once during boot, so the first observed change is also the last: re-define there and clear the timer. A 15 s window bounds the wait on a cold start.

Extracted into its own module because testing it inline required re-importing `index.ts`, which re-runs every `@customElement` decorator and throws `NotSupportedError` on the second pass.

## Verification

Deployed to the dev instance (fresh HA 2026.7.4, integration installed through HACS from the v0.1.0 release asset) and re-run:

| Engine | Before | After |
|---|---|---|
| Firefox 151 | 5/5 fail | **0/5** |
| Chromium 149 | 2/5 fail | **0/5** |
| WebKit 26.5 | 0/5 fail | **0/5** |

Card rendering confirmed by screenshot in all three engines.

Gates: frontend eslint + `tsc --noEmit` clean, **817 tests / 43 files**; backend ruff + ruff-format + mypy clean, **377 passed / 22 skipped**. 5 new unit tests cover define-into-current, re-define-after-swap, re-define-once-then-stop, skip-when-already-present, and give-up-after-the-window.

The second commit syncs `uv.lock`, which still recorded `0.0.1` because it is not among release-please's `extra-files` — unrelated to the fix, but it re-dirties the tree on every `uv run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
