### PR TITLE
ci: rewrite uv.lock's version with the other five release files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       # The tag is the one version string release-please writes outside a file,
-      # so it is the one that can disagree with the five it writes inside them.
+      # so it is the one that can disagree with the six it writes inside them.
       # It has to be checked here rather than from a `push: tags:` workflow:
       # the tag is pushed with GITHUB_TOKEN, and GitHub does not start new
       # workflow runs for events that token raises, so such a workflow would

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ and it is sticky: left in place, every later release repeats the same version.
 
 ### The version files
 
-Five files carry the version, each rewritten by a different release-please
+Six files carry the version, each rewritten by a different release-please
 mechanism, so each can fail to update independently:
 
 | File | Mechanism |
@@ -169,11 +169,24 @@ mechanism, so each can fail to update independently:
 | `custom_components/haventory/manifest.json` | `extra-files` json + jsonpath |
 | `cards/haventory-card/package.json` | `extra-files` json + jsonpath |
 | `custom_components/haventory/const.py` (`INTEGRATION_VERSION`) | `extra-files` generic + an `x-release-please-version` line annotation |
+| `uv.lock` | `extra-files` toml + jsonpath |
 | `.release-please-manifest.json` | release-please's own bookkeeping |
 
 `INTEGRATION_VERSION` is the one users see: `haventory/version` returns it and
-every export document is stamped with it. `scripts/check_version_consistency.py`
-compares all five (and, on a tag build, the tag) — run it locally any time:
+every export document is stamped with it.
+
+`uv.lock` is the odd one: nothing reads its version, but uv writes `pyproject`'s
+version into the project's own `[[package]]` entry, so a lockfile left at the
+previous release is rewritten by the next `uv` command and dirties the tree for
+whoever runs it. Its jsonpath —
+`$.package[?(@.name.value=='haventory')].version` — needs the `.value` hop
+because release-please's TOML updater parses string values into
+`{start, end, value}` spans in order to rewrite them in place; a path without it
+matches nothing, and release-please treats no match as a warning rather than an
+error. That is the failure this check exists to make loud.
+
+`scripts/check_version_consistency.py` compares all six (and, on a tag build,
+the tag) — run it locally any time:
 
 ```bash
 uv run python scripts/check_version_consistency.py

--- a/docs/card_shipping_plan.md
+++ b/docs/card_shipping_plan.md
@@ -39,6 +39,11 @@ Package the bundle via HACS `zip_release`: CI builds the card and attaches
   static route exists there, whatever ships.
   Registering the **same URL string** twice is safe — the browser module map dedupes;
   two *different* URLs for the same element throw `customElements.define` errors.
+  Dedupe cuts both ways, though, and the identical URL is what makes the second cut:
+  the module evaluates **once**, for whichever loader fetches it first, so the later
+  loader never re-runs it. The extra-JS loader usually wins that race, which puts the
+  card's `customElements.define` at an unpredictable point in frontend boot rather
+  than reliably after it — see R16 for the failure that follows and its fix.
 
 ### Precedent (verified against source, 2026-07-30)
 
@@ -114,6 +119,7 @@ option, and nothing in the dogfood plan installs via HACS-from-branch (the dev l
 | # | Risk | Mitigation | Verified how |
 |---|---|---|---|
 | R1 | Two loaders → double module eval → `customElements.define` throws | Byte-identical URL from a single builder; browser module map dedupes | offline test asserts both loaders get the same string |
+| R1b | Dedupe also means **only one** loader ever evaluates the module — whichever fetches first — so the card is defined at an unpredictable point in frontend boot | `defineCardElement()` records the registry it defined into and re-asserts the definition when the current registry is no longer that one (see R16) | 5 unit tests + 5 cold loads per engine on a real HACS install |
 | R2 | Existing installs keep a stale `/local/...` resource → duplicate define | Migration rewrites the legacy resource in place | offline test with a pre-seeded legacy resource |
 | R3 | Entry reload re-registers the static path → `RuntimeError` (file paths, order-dependent) | Register the directory, once, behind a `hass.data[DOMAIN]` flag that survives unload | offline test: set up → unload → set up again |
 | R4 | `add_extra_js_url` requires frontend's UrlManager; minimal harnesses (offline stubs, phacc) may lack it | Manifest `dependencies` order real setups; code degrades to DEBUG log when the import/state is missing, mirroring the existing lovelace guards | offline test + run the phacc suite — **which found a harder failure than the graceful one**: a hard `dependencies` entry means HA refuses to set up HAventory *at all* when `frontend` cannot set up, and phacc installs no `home-assistant-frontend` wheel (a real HA installs component requirements at startup; the harness does not), so every integration test failed with `ModuleNotFoundError: hass_frontend`. Fixed by pinning the wheel in `requirements-integration.txt`, guarded against drift by `tests/integration/test_frontend.py` |
@@ -128,6 +134,7 @@ option, and nothing in the dogfood plan installs via HACS-from-branch (the dev l
 | R13 | Wrong zip nesting (extractall does no prefix stripping) | Zip from **inside** `custom_components/haventory`; workflow asserts `manifest.json` and `www/haventory-card.js` at zip root | workflow step |
 | R14 | Old dev installs keep an orphan `www/haventory/` | README keeps a one-line legacy cleanup note; new installs write nothing to `www/` | docs |
 | R15 | Stray release asset named `haventory-card.js` would bind HACS's download counter | `filename` names the zip, which `zip_release` makes the installed asset | hacs.json diff |
+| R16 | HA's frontend installs its own `CustomElementRegistry` during boot; a definition made before the swap stays in the registry HA replaced, where the dashboard never looks — the card renders as "custom element doesn't exist" | `defineCardElement()` re-asserts the definition on the first observed registry change, within a 15 s window | 5 cold loads per engine, before/after, on a real HACS install of the release asset |
 
 Out-of-scope follow-up (record in `docs/open-items.md` when implementing): the manual
 `resources.async_load()` in `_async_lovelace_resources` is redundant at the 2026.6.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,11 @@
         {
           "type": "generic",
           "path": "custom_components/haventory/const.py"
+        },
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='haventory')].version"
         }
       ]
     }

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """Assert every version string in the repository agrees — and matches the tag.
 
-Five files carry the release version, and release-please rewrites each of them
+Six files carry the release version, and release-please rewrites each of them
 through a different mechanism: the `python` release type handles
 ``pyproject.toml``, two ``extra-files`` JSON entries handle the integration
 manifest and the card's ``package.json``, a generic annotation handles
-``const.py``, and the manifest file is release-please's own bookkeeping. Any one
-of them can silently stop being rewritten — a moved line drops a generic
-annotation, a renamed key orphans a jsonpath — and the failure mode is a release
-that ships mismatched versions rather than an error.
+``const.py``, a TOML jsonpath handles ``uv.lock``, and the manifest file is
+release-please's own bookkeeping. Any one of them can silently stop being
+rewritten — a moved line drops a generic annotation, a renamed key orphans a
+jsonpath — and the failure mode is a release that ships mismatched versions
+rather than an error.
 
 Run with no arguments to check the files against each other. Pass ``--tag`` (or
 set ``GITHUB_REF_NAME`` on a tag build) to also require the git tag to name the
@@ -38,6 +39,21 @@ def _pyproject_version() -> str:
         return str(tomllib.load(handle)["project"]["version"])
 
 
+def _uv_lock_version() -> str:
+    """The version recorded for the project's own entry in the lockfile.
+
+    uv writes ``pyproject``'s version into this entry, so a lockfile left behind
+    at the previous release does not merely disagree — the next ``uv`` command
+    rewrites it and dirties the working tree.
+    """
+    with (REPO_ROOT / "uv.lock").open("rb") as handle:
+        packages = tomllib.load(handle)["package"]
+    for package in packages:
+        if package["name"] == "haventory":
+            return str(package["version"])
+    raise AssertionError("uv.lock: no [[package]] entry named 'haventory'")
+
+
 def _const_version() -> str:
     text = (REPO_ROOT / "custom_components/haventory/const.py").read_text(encoding="utf-8")
     match = re.search(r'^INTEGRATION_VERSION:\s*str\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
@@ -56,6 +72,7 @@ def collect_versions() -> dict[str, str]:
         "pyproject.toml": _pyproject_version(),
         "cards/haventory-card/package.json": _json_version("cards/haventory-card/package.json"),
         "custom_components/haventory/const.py": _const_version(),
+        "uv.lock": _uv_lock_version(),
     }
 
 

--- a/tests/test_release_version_consistency.py
+++ b/tests/test_release_version_consistency.py
@@ -8,6 +8,7 @@ fix. The tag half of the same check runs on the tag build; see
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -17,6 +18,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from check_version_consistency import collect_versions, tag_version  # noqa: E402
+
+# The two sources release-please rewrites outside `extra-files`: the `python`
+# release type owns pyproject, and the manifest file is its own bookkeeping.
+NOT_EXTRA_FILES = {"pyproject.toml", ".release-please-manifest.json"}
 
 
 def test_every_version_file_agrees() -> None:
@@ -30,8 +35,24 @@ def test_every_version_file_agrees() -> None:
         "pyproject.toml",
         "cards/haventory-card/package.json",
         "custom_components/haventory/const.py",
+        "uv.lock",
     }
     assert len(set(versions.values())) == 1, f"version mismatch: {versions}"
+
+
+def test_release_please_rewrites_every_collected_file() -> None:
+    """Every file this check compares must be one release-please actually writes.
+
+    Checking agreement only catches a file release-please forgot once the two
+    have already diverged. This catches the wiring itself: a version file added
+    to the check but never listed in ``extra-files`` would sit at the old
+    version until the first release proved it.
+    """
+    config = json.loads((REPO_ROOT / "release-please-config.json").read_text(encoding="utf-8"))
+    extra_files = config["packages"]["."]["extra-files"]
+    listed = {entry["path"] if isinstance(entry, dict) else entry for entry in extra_files}
+
+    assert listed == set(collect_versions()) - NOT_EXTRA_FILES
 
 
 def test_tag_version_strips_the_prefix() -> None:


### PR DESCRIPTION
uv writes pyproject's version into the project's own `[[package]]` entry in
uv.lock, but uv.lock was not among release-please's `extra-files`, so the
lockfile stayed at the previous release. It did not merely disagree: the next
`uv` command rewrote it, so the first developer to run anything after a release
found a dirty tree. v0.1.0 shipped that way and was corrected by hand.

The `toml` updater's jsonpath needs a `.value` hop
(`$.package[?(@.name.value=='haventory')].version`) because release-please
parses TOML string values into `{start, end, value}` spans in order to rewrite
them in place. Verified against the real config and lockfile through
release-please 16.18's own updater: exactly one line changes.

A path that matches nothing is a warning, not an error, so the wiring needs a
guard rather than trust. `collect_versions` gains uv.lock as a sixth source, and
a new test asserts `extra-files` covers every collected file bar the two
release-please rewrites by other means — which catches a version file added to
the check but never wired up, before a release proves it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>