### PR TITLE
fix: location rename must not bump subtree item versions (item 23)

### DIFF
--- a/.claude/skills/test-haventory/SKILL.md
+++ b/.claude/skills/test-haventory/SKILL.md
@@ -98,7 +98,7 @@ $RUN bulkfuzz      # adversarial haventory/items/bulk
 $RUN subteardown   # HA-core unsubscribe_events teardown (the card's path)
 $RUN statsprobe    # stats broadcast: ~1 counts event per mutation
 $RUN ratelimit     # enable a tight per-conn budget, hammer, disable, confirm recovery
-$RUN races         # rename→version invalidation, concurrent rename, adjust serialization
+$RUN races         # rename vs. item versions, concurrent rename, adjust serialization
 $RUN bulk 1000     # create 250→500→1000 (latency curve) + delete; ~3½ min on a 2000-item store
 MSYS_NO_PATHCONV=1 HA_CONTAINER=home-assistant $RUN restart   # DESTRUCTIVE, last
 $RUN cleanup       # sweep any leftover stress_test_ data
@@ -179,8 +179,7 @@ not re-verified here.
 - **`ratelimit` rebuilds the limiter on save** (buckets refill, counters zero) — it samples
   `dropped_commands` before disabling and always resets rate limiting OFF, even on failure.
 - **Expected non-bugs the layers surface — do NOT file as regressions** (tracked in
-  `docs/open-items.md`): duplicate bulk `op_id` → silent last-wins loss (#22); a location
-  rename invalidates every subtree item's `expected_version` → `conflict` (#23); bulk-create
+  `docs/open-items.md`): duplicate bulk `op_id` → silent last-wins loss (#22); bulk-create
   p50 grows superlinearly (O(N²) persist, #19) — a **WARN**, not a failure.
 - **E2E: assert on the item NAME, not the quantity cell** — the card renders quantity only
   when that column is active, but the name always renders.

--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -994,7 +994,7 @@ async def cmd_races() -> None:
     a = await connect()
     b = await connect()
     try:
-        print("== RACE 1: location rename invalidates subtree item versions ==")
+        print("== RACE 1: location rename leaves subtree item versions valid ==")
         await assert_healthy(control, "races/before")
         loc = (await control.call("haventory/location/create", name=PREFIX + "race_loc"))["result"]
         loc_id = loc["id"]
@@ -1027,19 +1027,29 @@ async def cmd_races() -> None:
         )
         code = upd.get("error", {}).get("code") if not upd.get("success") else "SUCCESS"
         print(
-            f"  item/update with stale expected_version -> {code} "
-            f"({'EXPECTED conflict (documented hazard)' if code == 'conflict' else 'no invalidation'})"
+            f"  item/update with pre-rename expected_version -> {code} "
+            f"({'OK, token survived the rename' if code == 'SUCCESS' else '**INVALIDATED**'})"
         )
 
-        # verify every subtree item's version bumped by exactly 1
-        bumped = 0
+        # The path rewrite is derived data: every subtree item keeps the version
+        # it had before the rename. The one just updated is the exception —
+        # that was a real mutation — and every path must carry the new name.
+        held = 0
+        repathed = 0
         for iid, v0 in item_versions.items():
             cur = (await control.call("haventory/item/get", item_id=iid))["result"]
-            if cur["version"] == v0 + 1:
-                bumped += 1
+            expected = v0 + 1 if iid == first_id and code == "SUCCESS" else v0
+            if cur["version"] == expected:
+                held += 1
+            if "race_loc_renamed" in cur["location_path"]["display_path"]:
+                repathed += 1
         print(
-            f"  subtree items version-bumped by exactly 1: {bumped}/{len(item_versions)} "
-            f"{'OK' if bumped == len(item_versions) else '**PARTIAL**'}"
+            f"  subtree items keeping their version: {held}/{len(item_versions)} "
+            f"{'OK' if held == len(item_versions) else '**BUMPED**'}"
+        )
+        print(
+            f"  subtree items carrying the new path: {repathed}/{len(item_versions)} "
+            f"{'OK' if repathed == len(item_versions) else '**STALE PATH**'}"
         )
         await assert_healthy(control, "races/after-rename")
 

--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -1010,7 +1010,7 @@ async def cmd_races() -> None:
             )["result"]
             item_versions[it["id"]] = it["version"]
         first_id = next(iter(item_versions))
-        stale_v = item_versions[first_id]
+        held_v = item_versions[first_id]
 
         # rename the location on conn A
         ren = await a.call(
@@ -1018,11 +1018,11 @@ async def cmd_races() -> None:
         )
         print(f"  rename success={ren.get('success')}")
 
-        # conn B updates an item with the now-stale expected_version
+        # conn B updates an item with the version it read before the rename
         upd = await b.call(
             "haventory/item/update",
             item_id=first_id,
-            expected_version=stale_v,
+            expected_version=held_v,
             description="post-rename",
         )
         code = upd.get("error", {}).get("code") if not upd.get("success") else "SUCCESS"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,9 @@ repos:
       - id: codespell
         args:
           # "batery" is deliberate: it is the typo'd tag the organize dialog's
-          # merge suggestion is tested against.
-          - --ignore-words-list=hass,batery
+          # merge suggestion is tested against. "afterall" is vitest's teardown
+          # hook, named in prose in docs/open-items.md.
+          - --ignore-words-list=hass,batery,afterall
         exclude: |
           (?x)^(
             custom_components/haventory/www/|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ Vitest `4`. Version 0.0.1, unreleased.
   `/haventory`, remove-then-register, driven by the `sidebar_panel_enabled` option).
 - `models.py` — `Item` / `Location` dataclasses, validation, serializers. Items carry a
   denormalized `location_path` (rebuilt on location changes) and a `version` int (starts at 1,
-  bumped on each mutation) for **optimistic concurrency**.
+  bumped on each *item* mutation — derived `location_path` rewrites excluded) for
+  **optimistic concurrency**.
 - `repository.py` — in-memory indexed repository (the source of truth at runtime). Owns the
   search indexes; **search is case-insensitive** (casefold + NFKD accent-stripping) — see
   `_normalize_for_search`. Maintains a generation counter for optimistic locking / debugging.

--- a/README.md
+++ b/README.md
@@ -365,7 +365,10 @@ item and deletes it (best-effort cleanup even on failure).
 - Services via `hass.services.async_register` with `voluptuous` schemas; handlers re-raise
   validation/repository/storage errors so HA surfaces them.
 - Areas via `homeassistant.helpers.area_registry.async_get(hass)`; never auto-create areas.
-- Case-insensitive search; denormalized `location_path` on items; item `version` for optimistic concurrency.
+- Case-insensitive search; denormalized `location_path` on items; item `version` for optimistic
+  concurrency. `version` counts *item* mutations only — renaming or moving a location rewrites
+  the derived `location_path` across its whole subtree without bumping `version` or restamping
+  `updated_at`, so an expected version taken before the rename is still accepted after it.
 - Two calendar-derived counts on `haventory/stats`, each with a matching `item/list` filter:
   `overdue_count` / `overdue_only` for a passed `due_date` (checked-out items only, since
   that is where a due date can exist), and `inspection_overdue_count` /

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -43,7 +43,6 @@ from .models import (
     item_inspection_is_overdue,
     item_is_low_stock,
     item_is_overdue,
-    monotonic_timestamp_after,
     new_uuid4,
     normalize_search_text,
     normalize_tags,
@@ -802,23 +801,25 @@ class Repository:
         """Refresh ``location_path`` for items under any of the given locations.
 
         Fast path for subtree renames/moves. All items in one location share
-        that location's (already recomputed) ``path``, and only three things
-        change per item: the denormalized ``location_path``, the version /
-        ``updated_at`` bump, and the path-derived text tokens. Everything else
-        is either untouched (location/category/tag/checkout/low-stock buckets,
-        name sort keys) or rebuilt wholesale by the caller via
+        that location's (already recomputed) ``path``, and only two things
+        change per item: the denormalized ``location_path`` and the
+        path-derived text tokens. Everything else is either untouched
+        (location/category/tag/checkout/low-stock buckets, name sort keys) or
+        rebuilt wholesale by the caller via
         ``_rebuild_location_hierarchy_indexes`` (subtree index). The effective
         area is re-resolved once per location and items are re-bucketed only
         when it actually changed.
+
+        ``version`` and ``updated_at`` deliberately stay put. ``location_path``
+        is derived from the location tree — no client can write it — so its
+        rewrite is not an item mutation: bumping ``version`` here would
+        invalidate every optimistic-concurrency token in the subtree, and
+        re-stamping ``updated_at`` would shuffle the "recently updated" sort
+        with rows nobody touched.
         """
 
         if not affected_location_ids:
             return
-
-        # One clock read for the whole batch; per-item monotonicity is still
-        # guaranteed because each item only needs to exceed its own previous
-        # updated_at.
-        now_ts = iso_utc_now()
 
         for loc_id in affected_location_ids:
             item_ids = self._items_by_location_id.get(loc_id)
@@ -846,8 +847,6 @@ class Repository:
                 # dataclasses.replace on this hot path.
                 updated = copy.copy(old_item)
                 updated.location_path = new_path
-                updated.updated_at = monotonic_timestamp_after(old_item.updated_at, now_ts=now_ts)
-                updated.version = old_item.version + 1
                 self._items_by_id[item_id] = updated
 
                 tokens = self._item_text_tokens.get(item_id)
@@ -1407,7 +1406,7 @@ class Repository:
         # Update affected items (now that live maps are consistent)
         affected = {key}
         affected.update(self._collect_descendant_ids(key))
-        # Only rebuild item location_path (and bump versions) when the path can change:
+        # Only rebuild item location_path when the path can actually change:
         # - name change affects display paths
         # - parent change affects ancestry
         if parent_changed or name_changed:

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -264,6 +264,11 @@ Note: a successful import emits `items/reloaded` and `locations/reloaded` (no `i
 ### Versioning and concurrency
 
 - Items include `version: number`. Mutating commands accept `expected_version?: number` and raise `conflict` on mismatch.
+- `version` counts *item* mutations only. `location/update` (and `location/move_subtree`)
+  rewrites the derived `location_path` of every item in the subtree without bumping their
+  `version` or `updated_at`, so an `expected_version` taken before a rename is still
+  accepted after it. Clients learn about the new paths from the `locations` event, not from
+  per-item events — none are emitted for the rewrite.
 - Locations are not versioned in Phase 1.
 
 ### Timestamps

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -36,6 +36,12 @@ Object shape for persisted items and API results:
 }
 ```
 
+`location_path` is **derived**: the backend computes it from the location tree and no client
+can write it. Renaming or moving a location therefore rewrites it on every item in that
+subtree **without bumping `version` or restamping `updated_at`** — a derived-data refresh is
+not an item mutation, so tokens held for optimistic concurrency survive the rename, and the
+"recently updated" sort is not shuffled by rows nobody touched.
+
 `inspection_date` is a **forward-looking** date: when the item is next due for inspection.
 A value strictly before today (UTC) means that inspection is overdue — the population behind
 the `inspection_overdue_only` filter and the `inspection_overdue_count` stat. It is

--- a/docs/item23_rename_version_plan.md
+++ b/docs/item23_rename_version_plan.md
@@ -1,7 +1,8 @@
 # Item 23 — location rename must not bump subtree item versions
 
-Status: **planned** (pre-v1.0, ships in v0.2.0). Tracker row: `open-items.md` item 23.
-Paste-ready prompt: [`v1_prompts.md`](v1_prompts.md#item-23).
+Status: **delivered** — implemented as written; item 23 is closed in
+[`open-items.md`](open-items.md). This document is the implementation contract it was
+built to.
 
 ## The defect
 
@@ -28,12 +29,12 @@ not an item mutation, so:
 
 ## Why the card stays correct
 
-The card does not learn about renamed paths through item versions. A `location/update`
-broadcasts a `locations` event; the store refetches the tree and flat list on it, and the
-item list's paths come back fresh on the next list/refetch. Verify during implementation
-that subscription payloads for *items* are not the delivery channel for path changes
-(check what `ws.py` broadcasts on `location/update`) — if any surface turns out to rely
-on an item event per rewritten item, that surface's refresh path is in scope.
+The card does not learn about renamed paths through item versions — confirmed on both
+sides. `ws_location_update` (and `ws_location_move_subtree`) broadcasts only on the
+`locations` topic, `renamed` / `moved`, never a per-item event for the rewrite; the
+store's `onLocationsEvent` answers either action with a flat-list + tree refetch *and* a
+full `listItems(true)`, so rows carry the new path from that reload, not from a version
+change.
 
 ## Contract touch points
 

--- a/docs/open-items.md
+++ b/docs/open-items.md
@@ -235,6 +235,20 @@ non-blocking).
 > - **The last two PRs' own follow-ups recorded** as items **77** and **78**. Both are
 >   post-v1.0: neither has been observed failing, and both are S if one ever does.
 
+> Item **23** (a location rename bumped every subtree item's `version`) is resolved, as
+> designed in [`item23_rename_version_plan.md`](item23_rename_version_plan.md).
+> `location_path` is derived data — the backend computes it from the tree and no client can
+> write it — so `_update_items_location_paths_for_locations` now rewrites the path and its
+> search tokens and nothing else: `version` and `updated_at` both stay put, and an
+> `expected_version` a client took before a rename is still accepted after it. `updated_at`
+> was left alone deliberately, so a rename cannot shuffle the "recently updated" sort with
+> rows nobody touched. The card was never the delivery channel for this: `location/update`
+> broadcasts on the `locations` topic only, and the store answers `renamed` / `moved` with a
+> tree + flat refetch and a full item reload. Contract stated in `data_shapes.md` and
+> `backend_api_contract.md`, invariant sharpened in `CLAUDE.md`; the stress harness's RACE 1
+> and release-test F5 now assert the new rule instead of the old hazard. Its row is removed
+> below and its prompt out of [`v1_prompts.md`](v1_prompts.md).
+
 ---
 
 ## Release staging
@@ -294,7 +308,6 @@ have a companion plan doc:
 | 34 | filter-chip pressed state (a11y) | `v0.2.0` | prompt |
 | 43 | WS refuses after entry removal | `v0.2.0` | prompt |
 | 57 | stale-file sweep for HACS upgrades | `v0.2.0` | prompt |
-| 23 | rename must not bump subtree versions | `v0.2.0` | [`item23_rename_version_plan.md`](item23_rename_version_plan.md) |
 | 46 | effective-area preview in the editor | `v0.2.0` | [`item46_area_preview_plan.md`](item46_area_preview_plan.md) |
 | 79 | execute the validation run (groups A–J, ENV-A/B/C/D) | against `v0.2.0`; fixes → `0.2.x` | prompt (program: [`release_testing_plan.md`](release_testing_plan.md)) |
 | 60 | publish the measured scale ceiling | after 79's F3 | prompt |
@@ -348,7 +361,6 @@ Ordered by impact. Item 4 moved to the release-stage table below, where its rema
 | 34 | **The desktop filter panel's chips expose no pressed state to assistive tech.** Seven chips in `hv-filter-panel.ts` carry their selected state in an `on` CSS class and nothing else — no `aria-pressed`, no `role` (re-verified 2026-08-01: the file contains zero `aria-pressed`). The *same four* "Show only" facets in that component's mobile branch use `role="checkbox"` + `aria-checked`, and both app bars' stat pills plus the sidebar facet rows use `aria-pressed`, so the desktop panel is the sole surface where a screen reader cannot tell an active filter from an inactive one. Add `aria-pressed` to all seven (or `role="checkbox"`/`aria-checked` to match the mobile branch — pick one and use it for both branches). Promoted to pre-v1.0 (2026-08-02): it is the only surface with this gap, and S. | card UI consistency review 2026-07-26 | Low–Med (accessibility) | S |
 | 46 | **Area propagation is surprising at the point of use — the effective-area preview from item 37.** Choosing the relabeled default option (#126) on a nested location does more than "stop inheriting": `Repository.update_location` runs `_propagate_area_to_root(key, None)`, clearing the area from the whole tree, and picking an explicit area moves the assignment to the tree root — nothing in the dialog warns about either. Item 37's live-preview idea lands here, with its recorded caution: an honest preview of the non-default options is a whole-tree effect and worth designing deliberately. The mechanics are no longer in the way — item 38's `effectiveAreaIdForLocation` (`ui/area.ts`) is the walk-up-to-root the dialog lacked, over the flat location cache it already holds, so neither a `location/tree` contract change nor new plumbing is needed; what is left is deciding what the dialog should say. Cosmetic while there: with no HA areas the dropdown renders a one-entry select. | item 37 + PR #126 follow-ups | Low–Med | M |
 | 43 | **The WS API keeps answering — and writing the kept store — after config-entry removal, until restart.** `async_remove_entry` (#121) removes the Lovelace resource but leaves `hass.data[DOMAIN]["store"]`/`["repository"]` in place, and HA has no way to unregister WS commands, so an open dashboard can keep mutating the inventory after the integration is removed; a restart finishes the teardown. Decide whether handlers should refuse once the entry is gone. Promoted to pre-v1.0 (2026-08-02): removing an integration and finding it still writing is a first-impression bug once strangers are installing it. | PR #121 follow-up | Low–Med | S–M |
-| 23 | **Location rename bumps every subtree item's `version`** (denormalized `location_path` rewrite), so a client holding a stale `expected_version` for an unrelated field gets a spurious `conflict`. Indexes stay consistent — it's a UX surprise, not corruption. A path-only rewrite need not bump the optimistic-concurrency version. | WP4 stress test | Low | M |
 | 57 | **A HACS upgrade never deletes files inside the integration directory.** With `zip_release`, HACS backs up the previous install and then runs `zipfile.extractall` straight over `<config>/custom_components/haventory/` without clearing it first (HACS `repositories/base.py`), so any file a newer release deletes or renames survives every user's upgrade; the dev container shows the same leftover class because `docker cp` also merges rather than replaces. Inert until a release actually removes a module or renames the card bundle — from that release on, either sweep the known stale paths at setup or call the leftover out in the release notes. `scripts/check_release_zip.py` cannot catch this: it validates the asset's layout, not the install directory's history. | PR #148 review | Low (upgrade hygiene) | S |
 
 ### Release-stage tasks (executed in staging order, not by impact)

--- a/docs/open-items.md
+++ b/docs/open-items.md
@@ -245,9 +245,10 @@ non-blocking).
 > rows nobody touched. The card was never the delivery channel for this: `location/update`
 > broadcasts on the `locations` topic only, and the store answers `renamed` / `moved` with a
 > tree + flat refetch and a full item reload. Contract stated in `data_shapes.md` and
-> `backend_api_contract.md`, invariant sharpened in `CLAUDE.md`; the stress harness's RACE 1
-> and release-test F5 now assert the new rule instead of the old hazard. Its row is removed
-> below and its prompt out of [`v1_prompts.md`](v1_prompts.md).
+> `backend_api_contract.md`, invariant sharpened in `CLAUDE.md` and `README.md`; the
+> `test-haventory` harness's RACE 1 and release-test F5 now assert the new rule instead of
+> the old hazard. Its row is removed below and its prompt out of
+> [`v1_prompts.md`](v1_prompts.md).
 
 ---
 

--- a/docs/release_testing_plan.md
+++ b/docs/release_testing_plan.md
@@ -184,7 +184,7 @@ Run `haventory/health` after **each** of these, and snapshot the store around D7
 | F2 | `health` after each of D1–D9 and E2–E4 | `healthy: true`, empty `issues` | ✅ |
 | F3 | Scale on **real** hardware: load ~2× the real inventory and measure create/update/list latency | Latency is acceptable at the target size; record the size at which it degrades and publish it as a supported ceiling. Known: whole-dataset rewrite per mutation, ~200 ms/create @1000 items (open item 19) | ✅ |
 | F4 | Store file size across the run | Growth is proportional to content — no unbounded growth from repeated edits | |
-| F5 | Rename a location near the root of a deep tree | All descendant items' `location_path` rewritten; `health` healthy. Note the known version-bump side effect (open item 23) | |
+| F5 | Rename a location near the root of a deep tree | All descendant items' `location_path` rewritten; their `version` and `updated_at` unchanged (item 23); `health` healthy | |
 
 ### G — Multi-client & permissions
 

--- a/docs/v1_prompts.md
+++ b/docs/v1_prompts.md
@@ -117,20 +117,6 @@ list survives. Note in the PR body: from now on, any PR deleting a shipped integ
 file must add it to the sweep list (one CONTRIBUTING sentence).
 ```
 
-### Item 23
-
-**Location rename must not bump subtree item versions.** Plan:
-[`item23_rename_version_plan.md`](item23_rename_version_plan.md).
-
-```text
-You are working in the HAventory repo. Read CLAUDE.md first and follow it exactly.
-Read docs/item23_rename_version_plan.md — it is the design; implement it as written
-(path-only rewrites update location_path + search tokens, version and updated_at stay
-untouched; contract docs updated in the three places it names; the test list is the
-TDD spec, including the integration-suite case). Verify the card-correctness assumption
-it flags (what ws.py broadcasts on location/update) before relying on it.
-```
-
 ### Item 46
 
 **Effective-area preview in the location editor.** Plan:

--- a/tests/integration/test_ws_items.py
+++ b/tests/integration/test_ws_items.py
@@ -63,6 +63,69 @@ async def test_ws_item_create_get_list(hass: HomeAssistant, hass_ws_client) -> N
     assert "Screwdriver" in names
 
 
+async def test_ws_rename_keeps_item_versions_valid(hass: HomeAssistant, hass_ws_client) -> None:
+    """A location rename must not spend the client's optimistic-concurrency token.
+
+    The rename rewrites the item's derived ``location_path``; a client holding
+    the pre-rename ``version`` for an unrelated field must still be able to
+    update. Exercised against real HA because a stub could get the concurrency
+    check wrong without anything failing.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/location/create", "name": "Garage"})
+    created_loc = await client.receive_json()
+    assert created_loc["success"] is True, created_loc
+    location_id = created_loc["result"]["id"]
+
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "haventory/item/create",
+            "name": "Hammer",
+            "quantity": 1,
+            "location_id": location_id,
+        }
+    )
+    created = await client.receive_json()
+    assert created["success"] is True, created
+    item_id = created["result"]["id"]
+    held_version = created["result"]["version"]
+
+    await client.send_json(
+        {
+            "id": 3,
+            "type": "haventory/location/update",
+            "location_id": location_id,
+            "name": "Workshop",
+        }
+    )
+    renamed = await client.receive_json()
+    assert renamed["success"] is True, renamed
+
+    await client.send_json({"id": 4, "type": "haventory/item/get", "item_id": item_id})
+    fetched = await client.receive_json()
+    assert fetched["success"] is True, fetched
+    assert fetched["result"]["location_path"]["display_path"] == "Workshop"
+    assert fetched["result"]["version"] == held_version
+
+    await client.send_json(
+        {
+            "id": 5,
+            "type": "haventory/item/update",
+            "item_id": item_id,
+            "expected_version": held_version,
+            "name": "Sledgehammer",
+        }
+    )
+    updated = await client.receive_json()
+    assert updated["success"] is True, updated
+    assert updated["result"]["name"] == "Sledgehammer"
+    assert updated["result"]["version"] == held_version + 1
+
+
 async def test_ws_item_get_unknown_returns_error(hass: HomeAssistant, hass_ws_client) -> None:
     """Fetching a missing item surfaces a structured error, not a crash."""
 

--- a/tests/test_repository_move_reindex_offline.py
+++ b/tests/test_repository_move_reindex_offline.py
@@ -1,18 +1,19 @@
-"""Offline tests for the WP4 fast-path item reindexing on subtree moves.
+"""Offline tests for the fast-path item reindexing on subtree moves.
 
 The subtree move/rename path updates items via path-token deltas instead of a
 full unindex/index cycle. These tests pin the invariants that must survive:
 
 - text search agrees with the denormalized path after moves/renames
 - the text indexes stay byte-identical to a from-scratch rebuild
-- item versions bump and updated_at stays strictly monotonic
+- rewriting the derived ``location_path`` leaves ``version`` and ``updated_at``
+  alone, so optimistic-concurrency tokens held by clients stay valid
 - effective-area buckets follow the subtree to its new ancestry
 """
 
 from __future__ import annotations
 
 import pytest
-from custom_components.haventory.models import ItemCreate, ItemFilter
+from custom_components.haventory.models import ItemCreate, ItemFilter, ItemUpdate
 from custom_components.haventory.repository import Repository
 
 
@@ -79,7 +80,22 @@ async def test_text_indexes_match_fresh_rebuild_after_moves() -> None:
 
 
 @pytest.mark.asyncio
-async def test_move_bumps_versions_and_updated_at() -> None:
+async def test_rename_rewrites_paths_without_touching_versions() -> None:
+    repo, t = _build_tree()
+    before = {str(i.id): (i.version, i.updated_at) for i in t["items"]}
+
+    repo.update_location(t["shelf"].id, name="Rack Beta")
+
+    for item_id, (old_version, old_updated) in before.items():
+        item = repo.get_item(item_id)
+        assert "Rack Beta" in item.location_path.display_path
+        assert "Shelf Alpha" not in item.location_path.display_path
+        assert item.version == old_version
+        assert item.updated_at == old_updated
+
+
+@pytest.mark.asyncio
+async def test_move_rewrites_paths_without_touching_versions() -> None:
     repo, t = _build_tree()
     before = {str(i.id): (i.version, i.updated_at) for i in t["items"]}
 
@@ -87,9 +103,46 @@ async def test_move_bumps_versions_and_updated_at() -> None:
 
     for item_id, (old_version, old_updated) in before.items():
         item = repo.get_item(item_id)
-        assert item.version == old_version + 1
-        assert item.updated_at > old_updated
         assert item.location_path.display_path.startswith("Attic")
+        assert item.version == old_version
+        assert item.updated_at == old_updated
+
+
+@pytest.mark.asyncio
+async def test_stale_token_survives_a_rename() -> None:
+    """The scenario item 23 is about: a rename must not spend a client's token."""
+    repo, t = _build_tree()
+    item = t["items"][0]
+    held_version = repo.get_item(item.id).version
+
+    repo.update_location(t["shelf"].id, name="Rack Beta")
+
+    updated = repo.update_item(
+        item.id, ItemUpdate(name="Sledgehammer"), expected_version=held_version
+    )
+    assert updated.name == "Sledgehammer"
+    assert updated.version == held_version + 1
+    # The real mutation still bumps from where the rename left it — the path
+    # rewrite did not desynchronize the counter.
+    assert repo.get_item(item.id).version == held_version + 1
+
+
+@pytest.mark.asyncio
+async def test_area_change_leaves_items_untouched() -> None:
+    """``effective_area_id`` is resolved at serialization, never stored."""
+    repo = Repository()
+    garage = repo.create_location(name="Garage")
+    shelf = repo.create_location(name="Shelf", parent_id=garage.id)
+    item = repo.create_item(ItemCreate(name="Hammer", quantity=1, location_id=str(shelf.id)))
+
+    repo.update_location(shelf.id, area_id="area-garage")
+
+    after = repo.get_item(item.id)
+    assert after.version == item.version
+    assert after.updated_at == item.updated_at
+    assert after.location_path == item.location_path
+    res = repo.list_items(flt=ItemFilter(area_id="area-garage"))
+    assert [i.name for i in res["items"]] == ["Hammer"]
 
 
 @pytest.mark.asyncio
@@ -109,4 +162,4 @@ async def test_effective_area_rebuckets_on_subtree_move() -> None:
     assert res["items"] == []
     res = repo.list_items(flt=ItemFilter(area_id="area-attic"))
     assert [i.name for i in res["items"]] == ["Hammer"]
-    assert repo.get_item(item.id).version == item.version + 1
+    assert repo.get_item(item.id).version == item.version


### PR DESCRIPTION
Closes item **23**, implemented as designed in [`docs/item23_rename_version_plan.md`](docs/item23_rename_version_plan.md).

## The defect

Renaming or re-parenting a location rewrites the denormalized `location_path` of every item in its subtree, and `Repository._update_items_location_paths_for_locations` bumped each item's `version` and `updated_at` while doing it. A client holding an `expected_version` for an *unrelated* field then got a spurious `conflict` — rename a room with 500 items and 500 optimistic-concurrency tokens die at once.

## The change

`location_path` is derived data: the backend computes it from the location tree and no client can write it, so its refresh is not an item mutation. The rewrite now touches the path and its search tokens and nothing else — `version` and `updated_at` both stay put. `updated_at` was left alone deliberately: a rename re-stamping 500 items would shuffle the "recently updated" sort with rows the user never touched. Everything else about `update_location` is unchanged (generation counter, hierarchy indexes, area propagation and re-bucketing).

**No frontend change is needed**, and the plan's card-correctness assumption was verified on both sides before relying on it: `ws_location_update` / `ws_location_move_subtree` broadcast on the `locations` topic only (`renamed` / `moved`), never a per-item event for the rewrite; the store's `onLocationsEvent` answers either action with a flat-list + tree refetch *and* a full `listItems(true)`, so rows get the new path from that reload. The card only ever reads `item.version` off its own copy and sends it back, which this makes strictly more reliable — an open editor's expected version now survives someone renaming a location.

## Tests (TDD — written first, watched fail, then implemented)

Offline, in `tests/test_repository_move_reindex_offline.py`:

1. Rename → every subtree item's `display_path` changes, `version` and `updated_at` identical.
2. Stale-token scenario → read item at version N, rename its location, `update_item(expected_version=N)` **succeeds**.
3. Re-parent (subtree move) → same invariants as (1).
4. The real mutation in (2) still bumps N → N+1 — the rewrite didn't desynchronize the counter.
5. Area change on a tree → items untouched entirely (`effective_area_id` is resolved at serialization, not stored).

The two existing tests that pinned the old behaviour are inverted; `test_effective_area_rebuckets_on_subtree_move` keeps its re-bucketing assertions and now expects an unchanged version.

One integration-suite case (`tests/integration/test_ws_items.py::test_ws_rename_keeps_item_versions_valid`) mirrors (2) end-to-end over a real HA WebSocket connection, since this is exactly the concurrency behaviour a stub could get wrong silently.

## Contract + docs

- `docs/data_shapes.md` — `location_path` is derived; its rewrite bumps neither field.
- `docs/backend_api_contract.md` — same rule where `version` / `expected_version` are defined, plus the note that the `locations` event is the delivery channel.
- `CLAUDE.md` / `README.md` — the invariant sharpened to "bumped on each *item* mutation".
- `docs/release_testing_plan.md` F5 and the `test-haventory` harness's RACE 1 now assert the new rule instead of the old hazard (RACE 1 also checks every subtree item picked up the new path).
- `docs/open-items.md` — row removed, close-out note added; the prompt is out of `docs/v1_prompts.md`.

## Verification

- Backend gate: `pytest -q` 406 passed / 22 skipped, `ruff check .` clean, `mypy` clean.
- Frontend gate: eslint clean, `tsc --noEmit` clean, vitest 951 passed (48 files), build OK.
- Integration suite (phacc, real in-process HA 2026.6.0, run in a throwaway `python:3.14-slim` container): **22 passed**, including the new case.

## Note on one unrelated line

`.pre-commit-config.yaml` gains `afterall` to codespell's ignore list. The hook only scans changed files, and item 77's text on `main` names vitest's `afterAll` hook in prose — so it fires on the first PR to touch `docs/open-items.md`, which is this one.

## Follow-ups

None. Nothing in the plan was left undone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)