### PR TITLE
fix(api): refuse WebSocket commands after config-entry removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ is left pointing at a card that is about to disappear. (If your Lovelace runs in
 any entry is yours, in `configuration.yaml` — delete the `resources:` line by hand. An
 Overview shortcut is yours too, and is removed the same way it was added.)
 
+**The API stops answering at once.** Home Assistant keeps a WebSocket command registered
+until it restarts, so a dashboard still open in another tab can go on talking to HAventory
+after you remove it. It is refused rather than served: every command comes back as an
+error, and nothing more is written to your inventory. Reload that tab and the card is gone.
+
 **Your inventory is deliberately kept.** Items and locations live in the Home Assistant
 store file `<config>/.storage/haventory_store`, which removal does not touch: adding the
 integration again restores everything, which is what you want when you remove it to

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -67,6 +67,7 @@ from .storage import (
     STORAGE_KEY,
     DomainStore,
     async_persist_immediate,
+    cancel_pending_persist,
     schema_downgrade_message,
 )
 
@@ -212,6 +213,31 @@ async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> Non
     )
 
 
+async def _async_flush_pending_writes(hass: HomeAssistant, *, op: str) -> None:
+    """Write out whatever is still unsaved, before the state that holds it goes.
+
+    A pending debounce is cleared either way: with nothing loaded there is
+    nothing to write, and leaving the task scheduled would only fire it against
+    a repository that is on its way out.
+    """
+
+    bucket = hass.data.get(DOMAIN) or {}
+    if bucket.get("store") is None or bucket.get("repository") is None:
+        cancel_pending_persist(hass, op=op)
+        return
+
+    try:
+        await async_persist_immediate(hass)
+    except Exception:  # pragma: no cover - defensive
+        # This is the last chance to write; a failure here silently drops
+        # whatever was still unsaved, which nobody but an operator can recover.
+        LOGGER.error(
+            "Failed to persist during teardown",
+            extra={"domain": DOMAIN, "op": op},
+            exc_info=True,
+        )
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry.
 
@@ -222,17 +248,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     bucket = hass.data.get(DOMAIN) or {}
 
-    # Ensure any pending changes are persisted before unload
-    try:
-        await async_persist_immediate(hass)
-    except Exception:  # pragma: no cover - defensive
-        # Unload is the last chance to write; a failure here silently drops
-        # whatever was still unsaved, which nobody but an operator can recover.
-        LOGGER.error(
-            "Failed to persist during unload",
-            extra={"domain": DOMAIN, "op": "unload"},
-            exc_info=True,
-        )
+    await _async_flush_pending_writes(hass, op="unload")
 
     # Hand back the frontend module URL; setup re-adds it on the next load. The
     # static route stays, along with the flag that records it: aiohttp cannot
@@ -279,6 +295,30 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _drop_entry_runtime(hass: HomeAssistant) -> None:
+    """Leave the domain bucket holding only what outlives the config entry.
+
+    Home Assistant has no API for unregistering a WebSocket command, so ours go
+    on listening after the integration is removed. Emptying the bucket is what
+    makes them refuse: `ws._repo` raises `StorageError` without a repository, so
+    every command answers a `storage_error` envelope instead of letting a
+    dashboard left open read — and write — an inventory nothing owns any more.
+    The same lookup backs the `haventory.*` service handlers.
+
+    `_STATIC_PATH_KEY` is kept: it records an aiohttp route, which cannot be
+    unregistered and so outlives every entry. Dropping the flag would make a
+    re-add in the same run serve `/haventory_static` a second time.
+    """
+
+    bucket = hass.data.get(DOMAIN)
+    if not isinstance(bucket, dict):
+        return
+
+    kept = {key: bucket[key] for key in (_STATIC_PATH_KEY,) if key in bucket}
+    bucket.clear()
+    bucket.update(kept)
+
+
 async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:
     """Clean up after the config entry has been removed from Home Assistant.
 
@@ -287,12 +327,18 @@ async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:
     behind, either points at an asset that disappears with the integration, and
     a dead `module` URL fails to load on every dashboard render.
 
+    It then flushes whatever was still unsaved and drops the loaded runtime, so
+    the API stops answering for an integration that is gone rather than serving
+    on until the next restart.
+
     The HA `Store` file is deliberately kept, so re-adding the integration
     restores the inventory. Purging it is a manual step (README → Installation
     → "Removing HAventory").
     """
 
     await _unregister_frontend_module(hass)
+    await _async_flush_pending_writes(hass, op="remove")
+    _drop_entry_runtime(hass)
 
 
 def _read_manifest_version() -> str:

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -294,6 +294,26 @@ async def async_persist_repo(hass: HomeAssistant) -> None:
             raise StorageError("failed to persist repository") from exc
 
 
+def cancel_pending_persist(hass: HomeAssistant, *, op: str = "persist_cancel") -> None:
+    """Cancel a scheduled debounced persist, if one is pending.
+
+    Anything about to write itself — or about to take away the repository the
+    write would read — has to clear the pending task first, or it fires against
+    state that has moved on.
+    """
+    bucket = hass.data.setdefault(DOMAIN, {})
+
+    existing_task = bucket.get("persist_task")
+    if existing_task is None or existing_task.done():
+        return
+
+    existing_task.cancel()
+    _LOGGER.debug(
+        "Cancelled pending persist task",
+        extra={"domain": DOMAIN, "op": op},
+    )
+
+
 async def async_request_persist(hass: HomeAssistant) -> None:
     """Request a debounced persistence operation.
 
@@ -306,14 +326,7 @@ async def async_request_persist(hass: HomeAssistant) -> None:
     """
     bucket = hass.data.setdefault(DOMAIN, {})
 
-    # Cancel any pending persist task
-    existing_task = bucket.get("persist_task")
-    if existing_task is not None and not existing_task.done():
-        existing_task.cancel()
-        _LOGGER.debug(
-            "Cancelled pending persist task",
-            extra={"domain": DOMAIN, "op": "persist_debounce_cancel"},
-        )
+    cancel_pending_persist(hass, op="persist_debounce_cancel")
 
     async def _delayed_persist() -> None:
         """Execute persistence after debounce delay."""
@@ -357,16 +370,7 @@ async def async_persist_immediate(hass: HomeAssistant) -> None:
     synchronously. Use this for critical paths like shutdown where we need
     to ensure data is written to disk before the process exits.
     """
-    bucket = hass.data.setdefault(DOMAIN, {})
-
-    # Cancel any pending debounced task
-    existing_task = bucket.get("persist_task")
-    if existing_task is not None and not existing_task.done():
-        existing_task.cancel()
-        _LOGGER.debug(
-            "Cancelled pending persist task for immediate persist",
-            extra={"domain": DOMAIN, "op": "persist_immediate_cancel"},
-        )
+    cancel_pending_persist(hass, op="persist_immediate_cancel")
 
     _LOGGER.debug(
         "Immediate persist requested",

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -46,6 +46,20 @@ def _repo(hass: HomeAssistant) -> Repository:
     return cast("Repository", repo)
 
 
+def _require_loaded(hass: HomeAssistant) -> None:
+    """Refuse the command when no config entry owns the data any more.
+
+    Home Assistant cannot unregister a WebSocket command, so these keep
+    listening after the integration is removed — and removal empties the domain
+    bucket for exactly this check to find. It sits in the guard rather than in
+    the handlers so the whole surface goes quiet at once: the commands that read
+    no inventory (ping, version, config) would otherwise keep answering for an
+    integration that is gone.
+    """
+
+    _repo(hass)
+
+
 def _rate_limiter(hass: HomeAssistant) -> RateLimiter | None:
     """Return the configured rate limiter, or None when limiting is off."""
     bucket = hass.data.get(DOMAIN) or {}
@@ -171,6 +185,7 @@ def ws_guard(
                 _send_error(conn, err)
                 return err
             try:
+                _require_loaded(hass)
                 return await func(hass, conn, msg)
             except (ValidationError, NotFoundError, ConflictError, StorageError) as exc:
                 ctx = _context_from_msg(op, msg, context_fields)

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -26,7 +26,7 @@ Notes:
 - `validation_error`: Invalid input or invariant violation
 - `not_found`: Referenced entity does not exist
 - `conflict`: Version mismatch on optimistic concurrency
-- `storage_error`: Persistence or setup issue
+- `storage_error`: Persistence or setup issue, including a command that arrives after the config entry was removed — see "After removal"
 - `rate_limited`: Command rejected by the (opt-in) WebSocket rate limiter — see "Rate limiting"
 - `unknown_error`: Fallback for unexpected exceptions
 
@@ -39,6 +39,17 @@ Guarantees (every `haventory/*` command is wrapped by the same guard):
 - In `haventory/items/bulk`, a failing operation (including an unexpectedly malformed **payload**) fails only its own per-op result; the remaining operations still run and successful ones persist. Note the batch **envelope** is validated first: a structurally malformed operation *entry* (non-object entry, missing/invalid `op_id`, non-string `kind`, non-object `payload`) cannot be reported per-op and rejects the whole command with `validation_error`.
 
 Transport-level errors produced by Home Assistant itself (before a handler runs) are outside this taxonomy and can also be observed by clients: `invalid_format` (request failed the command's voluptuous schema) and `unknown_command` (integration not loaded or unknown `type`).
+
+### After removal
+
+Home Assistant has no API for unregistering a WebSocket command, so every `haventory/*` command stays dispatchable until the next restart — including after the config entry has been removed. Removal drops the loaded runtime (repository, store, limiter, subscriptions), and the guard turns that into a refusal:
+
+- **Every command** answers `storage_error`, `ping`, `version` and `config` included: they read no inventory, but a half-answering API for a removed integration is worse than none.
+- **Nothing is written.** A mutation is refused before it reaches the repository, so the kept store file stops changing at the moment of removal.
+- **Live subscriptions stop delivering** and are not torn down message-by-message; a client sees its next command refused.
+- **Re-adding the integration restores everything** — the API and the inventory, which removal deliberately leaves on disk (README → "Removing HAventory").
+
+Clients cannot tell this apart from any other `storage_error` by code alone; treating it as "HAventory is unavailable, stop retrying and tell the user" is the intended handling either way.
 
 ### Rate limiting
 

--- a/tests/integration/test_config_entry.py
+++ b/tests/integration/test_config_entry.py
@@ -2,6 +2,10 @@
 
 Verifies the integration sets up and tears down cleanly through the real
 ``hass.config_entries`` machinery — the path the offline stubs can't exercise.
+Removal especially: the offline stub takes our handlers back out of its fake
+command registry on unload, which real Home Assistant has no API for, so only
+here can "the commands are still registered and refuse" be told apart from "the
+commands are gone".
 """
 
 from __future__ import annotations
@@ -11,6 +15,14 @@ from custom_components.haventory.repository import Repository
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
 
 
 async def test_config_entry_setup_and_unload(hass: HomeAssistant) -> None:
@@ -34,3 +46,52 @@ async def test_config_entry_setup_and_unload(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
     # Ephemeral registration flags are cleared on unload.
     assert hass.data[DOMAIN].get("ws_registered") is None
+
+
+async def test_removed_entry_leaves_the_ws_api_refusing(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """A dashboard left open cannot go on reading or writing a removed inventory."""
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Screwdriver"})
+    assert (await client.receive_json())["success"] is True
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Still dispatched — Home Assistant has no API to unregister a command — and
+    # answering the contract's storage_error rather than serving dropped state.
+    await client.send_json({"id": 2, "type": "haventory/item/list"})
+    listed = await client.receive_json()
+    assert listed["success"] is False, listed
+    assert listed["error"]["code"] == "storage_error", listed
+
+    await client.send_json({"id": 3, "type": "haventory/item/create", "name": "Ghost"})
+    created = await client.receive_json()
+    assert created["success"] is False, created
+    assert created["error"]["code"] == "storage_error", created
+
+    assert hass.data[DOMAIN].get("repository") is None
+
+
+async def test_re_adding_a_removed_entry_restores_the_inventory(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """Removal keeps the store file, so adding the integration again brings it back."""
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Screwdriver"})
+    assert (await client.receive_json())["success"] is True
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+    await _setup(hass)
+
+    await client.send_json({"id": 2, "type": "haventory/item/list"})
+    listed = await client.receive_json()
+    assert listed["success"] is True, listed
+    assert [item["name"] for item in listed["result"]["items"]] == ["Screwdriver"]

--- a/tests/integration/test_frontend.py
+++ b/tests/integration/test_frontend.py
@@ -132,6 +132,44 @@ async def test_unload_hands_back_the_module_url(hass: HomeAssistant) -> None:
 
 
 @needs_bundle
+async def test_removal_deletes_the_card_resource_and_module_url(hass: HomeAssistant) -> None:
+    """Removal takes both loaders back through the real resource collection.
+
+    The offline suite asserts this against a mock collection; only the real
+    `ResourceStorageCollection.async_delete_item` proves the id we hand it is
+    the one it stores.
+    """
+    entry = await _setup(hass)
+    resources = hass.data["lovelace"].resources
+    assert [r for r in resources.async_items() if r["url"].startswith(CARD_PATH)]
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert [r for r in resources.async_items() if r["url"].startswith(CARD_PATH)] == []
+    assert set(hass.data[frontend.DATA_EXTRA_MODULE_URL].urls) == set()
+
+
+@needs_bundle
+async def test_removal_leaves_the_static_route_serving(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """aiohttp cannot drop a route, so a re-add must not register a second one.
+
+    The flag recording the route is the one piece of domain state removal keeps;
+    losing it turns the next setup into the duplicate registration that leaves
+    the entry in a retry loop.
+    """
+    entry = await _setup(hass)
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+    await _setup(hass)
+
+    assert (await (await hass_client_no_auth()).get(CARD_PATH)).status == HTTP_OK
+
+
+@needs_bundle
 async def test_the_sidebar_panel_lands_in_the_real_panel_registry(hass: HomeAssistant) -> None:
     """`panel_custom` puts a real `Panel` in `hass.data`, built the way HA builds them.
 

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import pytest
 import voluptuous as vol
 from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.exceptions import NotFoundError, ValidationError
+from custom_components.haventory.exceptions import NotFoundError, StorageError, ValidationError
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import STORAGE_KEY
 from homeassistant.core import HomeAssistant
@@ -146,6 +146,29 @@ async def test_service_call_surfaces_domain_errors(hass: HomeAssistant) -> None:
 
     with pytest.raises(NotFoundError):
         await _call(hass, "item_update", {"item_id": "does-not-exist", "name": "Nope"})
+
+
+async def test_service_call_after_removal_refuses(hass: HomeAssistant, hass_storage) -> None:
+    """Services outlive the entry the same way commands do, and refuse the same way.
+
+    ``hass.services.async_remove`` is never called, so the catalog stays; what
+    changes is that the handlers no longer have a repository to reach.
+    """
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await _call(hass, "item_create", {"name": "Torch"})
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert "item_create" in hass.services.async_services_for_domain(DOMAIN)
+    with pytest.raises(StorageError):
+        await _call(hass, "item_create", {"name": "Ghost"})
+
+    assert [i["name"] for i in hass_storage[STORAGE_KEY]["data"]["items"].values()] == ["Torch"]
 
 
 async def test_service_call_rejects_a_bad_payload(hass: HomeAssistant) -> None:

--- a/tests/test_entry_removal_refusal_offline.py
+++ b/tests/test_entry_removal_refusal_offline.py
@@ -1,0 +1,250 @@
+"""Offline tests: once the config entry is removed, the API refuses.
+
+Home Assistant cannot unregister a WebSocket command, so the ``haventory/*``
+commands keep listening after the integration is gone. Removal drops the loaded
+runtime — store, repository, limiter, subscriptions, any pending write — which
+is what turns "still listening" into "refuses", instead of a dashboard left open
+going on reading and writing an inventory nothing owns any more.
+
+These tests call ``async_remove_entry`` without ``async_unload_entry`` first.
+Real Home Assistant unloads before it removes, but the offline stub's unload
+takes our handlers back out of the fake command registry — something real HA has
+no API for — so going through it would leave nothing to send and hide the very
+behaviour under test. ``tests/integration/test_config_entry.py`` covers the real
+ordering against a real core.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from custom_components.haventory import (
+    async_remove_entry,
+    async_setup,
+    async_setup_entry,
+)
+from custom_components.haventory import storage as storage_mod
+from custom_components.haventory import ws as ws_mod
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+WS_LOGGER = "custom_components.haventory.ws"
+
+
+class _StubConn:
+    """Connection stub that keeps every message sent to it."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    def send_message(self, msg: dict) -> None:
+        self.messages.append(msg)
+
+
+async def _send(hass: HomeAssistant, _id: int, type_: str, conn=None, **payload):
+    """Dispatch one WS command through the stub registry, as a client would."""
+
+    for handler in hass.data.get("__ws_commands__", []):
+        schema = getattr(handler, "_ws_schema", None)
+        if not callable(handler) or not isinstance(schema, dict):
+            continue
+        if schema.get("type") != type_:
+            continue
+        req = {"id": _id, "type": type_}
+        req.update(payload)
+        target = conn if conn is not None else _StubConn()
+        res = await handler(hass, target, req)
+        return res if res is not None else target.messages[-1]
+    raise AssertionError(f"No handler responded for type {type_}")
+
+
+async def _setup_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Set the integration up on a store emptied for this test.
+
+    The offline ``Store`` stub keeps one dict per storage key for the whole
+    session, so a test that goes through the real setup path has to start from a
+    known payload rather than whatever an earlier test left behind.
+    """
+
+    await DomainStore(hass, key=STORAGE_KEY).async_save(
+        {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+    )
+    entry = ConfigEntry()
+    await async_setup(hass, {})
+    assert await async_setup_entry(hass, entry) is True
+    return entry
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "payload"),
+    [
+        ("haventory/item/create", {"name": "After removal"}),
+        ("haventory/item/list", {}),
+        ("haventory/stats", {}),
+        ("haventory/location/create", {"name": "Shed"}),
+        ("haventory/subscribe", {"topic": "items"}),
+        # Utility commands read no inventory, but the surface has to go quiet as
+        # a whole: half an API answering a removed integration is worse than none.
+        ("haventory/ping", {}),
+        ("haventory/version", {}),
+        ("haventory/config", {}),
+    ],
+)
+async def test_command_refuses_after_removal(command: str, payload: dict) -> None:
+    """Every command answers storage_error once the entry is gone."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    assert (await _send(hass, 1, command, **payload))["success"] is True
+
+    await async_remove_entry(hass, entry)
+
+    res = await _send(hass, 2, command, **payload)
+    assert res["success"] is False, res
+    assert res["error"]["code"] == "storage_error"
+
+
+@pytest.mark.asyncio
+async def test_refusal_is_mapped_not_an_unhandled_crash(caplog) -> None:
+    """The refusal goes through the guard's error mapping, not its safety net."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    await async_remove_entry(hass, entry)
+
+    caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
+    res = await _send(hass, 1, "haventory/item/create", name="Nope")
+
+    assert res["error"]["code"] == "storage_error"
+    assert res["error"]["data"]["op"] == "item_create"
+    assert res["error"]["message"] != ws_mod.UNEXPECTED_ERROR_MESSAGE
+    assert not [r for r in caplog.records if "Unexpected error in WS handler" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_removal_stops_persistence(monkeypatch) -> None:
+    """A refused mutation writes nothing: the store is nobody's to touch."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    store = hass.data[DOMAIN]["store"]
+    saved: list[dict] = []
+
+    async def _record(payload: dict) -> None:
+        saved.append(payload)
+
+    monkeypatch.setattr(store, "async_save", _record)
+
+    await async_remove_entry(hass, entry)
+    saved.clear()  # removal's own flush is test_removal_flushes_before_dropping's business
+
+    res = await _send(hass, 1, "haventory/item/create", name="Ghost")
+
+    assert res["success"] is False
+    assert saved == []
+
+
+@pytest.mark.asyncio
+async def test_removal_flushes_before_dropping(monkeypatch) -> None:
+    """A debounced write pending at removal lands, and then fires no second time."""
+
+    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    store = hass.data[DOMAIN]["store"]
+    saved: list[dict] = []
+
+    async def _record(payload: dict) -> None:
+        saved.append(payload)
+
+    monkeypatch.setattr(store, "async_save", _record)
+
+    hass.data[DOMAIN]["repository"].create_item({"name": "Unsaved"})
+    await storage_mod.async_request_persist(hass)
+    pending = hass.data[DOMAIN]["persist_task"]
+
+    await async_remove_entry(hass, entry)
+
+    assert len(saved) == 1, "removal writes the pending state out"
+    assert [item["name"] for item in saved[0]["items"].values()] == ["Unsaved"]
+
+    await asyncio.sleep(0.2)
+
+    assert pending.cancelled() or pending.done()
+    assert len(saved) == 1, "the cancelled debounce never fired against a dropped store"
+
+
+@pytest.mark.asyncio
+async def test_removal_drops_the_loaded_runtime() -> None:
+    """Nothing an entry loaded survives it — that is what makes handlers refuse."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    bucket = hass.data[DOMAIN]
+    assert bucket["store"] is not None
+    assert bucket["repository"] is not None
+
+    await async_remove_entry(hass, entry)
+
+    for key in ("store", "repository", "rate_limiter", "card_title", "persist_task"):
+        assert hass.data[DOMAIN].get(key) is None, key
+
+
+@pytest.mark.asyncio
+async def test_removal_keeps_the_static_route_flag() -> None:
+    """The one flag that outlives an entry stays: aiohttp cannot drop a route.
+
+    Losing it would make a re-add in the same run register ``/haventory_static``
+    a second time.
+    """
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    hass.data[DOMAIN]["static_path_registered"] = True
+
+    await async_remove_entry(hass, entry)
+
+    assert hass.data[DOMAIN].get("static_path_registered") is True
+
+
+@pytest.mark.asyncio
+async def test_removal_drops_live_subscriptions() -> None:
+    """A subscriber left over from before removal receives nothing more."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    conn = _StubConn()
+    assert (await _send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
+
+    await async_remove_entry(hass, entry)
+    conn.messages.clear()
+
+    ws_mod._broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+
+    assert conn.messages == []
+    assert hass.data[DOMAIN].get("subscriptions") in (None, {})
+
+
+@pytest.mark.asyncio
+async def test_re_adding_the_entry_restores_service() -> None:
+    """Removal keeps the store file, so a re-add brings the inventory back."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    created = await _send(hass, 1, "haventory/item/create", name="Screwdriver")
+    assert created["success"] is True
+
+    await async_remove_entry(hass, entry)
+    assert (await _send(hass, 2, "haventory/item/list"))["success"] is False
+
+    assert await async_setup_entry(hass, ConfigEntry()) is True
+
+    listed = await _send(hass, 3, "haventory/item/list")
+    assert listed["success"] is True, listed
+    assert [item["name"] for item in listed["result"]["items"]] == ["Screwdriver"]


### PR DESCRIPTION
Closes item **43** in [`docs/open-items.md`](docs/open-items.md); prompt from [`docs/v1_prompts.md`](docs/v1_prompts.md).

## The bug

`async_remove_entry` took back the frontend registrations but left `hass.data[DOMAIN]["store"]`/`["repository"]` in place, and Home Assistant has no API for unregistering a WebSocket command. A dashboard left open in another tab therefore kept reading — and writing — the kept inventory after the integration was removed, until the next restart. Proven against real HA in `tests/integration/test_config_entry.py::test_removed_entry_leaves_the_ws_api_refusing`, which fails on `main` (the create succeeds after removal) and passes here.

## The fix

Decision taken in the item: handlers refuse once the entry is gone.

- **`async_remove_entry`** flushes anything still unsaved, cancels a pending debounced write, and then empties the domain bucket (`_drop_entry_runtime`). The flush/cancel half is extracted from `async_unload_entry` (`_async_flush_pending_writes`) rather than duplicated, and the cancel itself moved into `storage.cancel_pending_persist`, which the two existing persist paths now share.
- **`ws_guard`** gained `_require_loaded`, which is `_repo(hass)` — already raising `StorageError` on an empty bucket. Every command then lands as the contract's `storage_error` envelope through the existing mapping, logged once at ERROR, never as `unknown_error`. It sits in the guard rather than in the handlers so `ping`, `version` and `config` go quiet with the rest: they read no inventory, but a half-answering API for a removed integration is worse than none.
- **Subscriptions** go with the bucket, so a broadcast after removal reaches nobody (and nothing broadcasts anyway — mutations are refused first).
- **`static_path_registered` is deliberately kept.** It records an aiohttp route, which cannot be unregistered; dropping the flag would make a re-add serve `/haventory_static` a second time. `test_removal_leaves_the_static_route_serving` pins that.
- **The `Store` file is kept**, unchanged from before: re-adding the integration restores both the inventory and the API.
- `haventory.*` **services** ride the same lookup and refuse identically — asserted in the integration suite, since the offline stub has no service registry.

## Tests

- `tests/test_entry_removal_refusal_offline.py` (new, 15 cases): every command refuses; the refusal is mapped, not the guard's safety net; nothing is persisted afterwards; a pending debounce is flushed once and never fires again; the runtime is dropped and the route flag is not; live subscriptions receive nothing; a re-add restores service. All 14 non-trivial cases fail without the fix.
- `tests/integration/` (real HA 2026.6.0 via phacc): the refusal over a real WebSocket connection, the re-add restoring the inventory, the service-call refusal, plus the two Lovelace-side cases below.
- Full offline suite 418 passed / 22 skipped, ruff + ruff-format + mypy clean, frontend gate green (eslint, tsc, 951 vitest, build, `npm audit`) — the last unchanged by this PR, which touches no frontend source.
- The integration suite cannot run on the author's Windows host (HA core imports `fcntl`); it was run in a throwaway `python:3.14-slim` container against the mounted worktree: **26 passed**.

## Also closes a third of item 51

Item 51 records `async_remove_entry` as asserted against mocks only. `test_removal_deletes_the_card_resource_and_module_url` now drives the real `ResourceStorageCollection.async_delete_item`, and `test_removal_leaves_the_static_route_serving` covers the remove/re-add route case. Both pass on `main` too — they are coverage of behaviour that was already correct, which is exactly what item 51 asked for. Its other two thirds (the tracked-task debounced persist, the `ConfigEntryError` downgrade refusal) are untouched.

## Ledger

Not updated: this ran as part of a parallel batch (five sibling branches for items 23, 34, 46, 57, 69 were live in the same checkout), and `v1_prompts.md`'s conventions say a batch reconciles `docs/open-items.md` in one sweep afterwards rather than six PRs conflicting on the same file — the failure mode #164/#165 already hit.

## Follow-ups (not fixed here)

- **Unload keeps serving.** `async_unload_entry` still leaves the store and repository in the bucket, so a *disabled* or mid-reload entry answers commands from state the entry no longer owns — the same class of bug as this one, one lifecycle step earlier. Not changed here because it is outside item 43's decision and would make a card see transient errors during every reload; worth deciding deliberately.
- **Log volume.** A refused command logs at ERROR with a traceback, because that is what the taxonomy prescribes for `storage_error`. A client that retries hard after a removal would be noisy. Nothing observed; noting it since release exit criterion 4 counts tracebacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
