### PR TITLE
docs(open-items): reconcile the ledger after the v0.2.0 payload batch

### DIFF
--- a/docs/item46_area_preview_plan.md
+++ b/docs/item46_area_preview_plan.md
@@ -1,8 +1,7 @@
 # Item 46 — effective-area preview in the location editor
 
 Status: **delivered**, in `v0.2.0`. Tracker row: `open-items.md` item 46 (removed; the
-resolution note carries the outcome). Paste-ready prompt:
-[`v1_prompts.md`](v1_prompts.md#item-46).
+resolution note carries the outcome; the prompt is retired from `v1_prompts.md`).
 
 ## The gap
 

--- a/docs/open-items.md
+++ b/docs/open-items.md
@@ -17,7 +17,8 @@ non-blocking).
   pass** against `main` @ `08218f0` (post-#159), refreshed against `d65ff64` once the
   sidebar panel's PR-2 (#160) landed, re-checked against `main` @ `9180d8f` in the
   **#162 collection pass** (2026-08-02), and re-checked again against `main` @ `04ff0b3` in
-  the **close-out pass** of the same day (after #163–#165).
+  the **close-out pass** of the same day (after #163–#165). Reconciled against
+  `main` @ `0583c29` after the **v0.2.0 payload batch** (#167–#172) landed.
 - **Item numbers are stable and append-only** — new items get the next free number
   rather than renumbering the list, so references from PRs and docs keep resolving.
   Read each table's own ordering, not the numbering, for priority. (The one exception —
@@ -249,6 +250,7 @@ non-blocking).
 > the location it holds. A sweep test walks every chip and row in both branches and fails on
 > any that paints itself "on" without saying so, so a chip cannot be added without a state.
 > Its row is removed below.
+
 > Item **23** (a location rename bumped every subtree item's `version`) is resolved, as
 > designed in [`item23_rename_version_plan.md`](item23_rename_version_plan.md).
 > `location_path` is derived data — the backend computes it from the tree and no client can
@@ -263,6 +265,7 @@ non-blocking).
 > `test-haventory` harness's RACE 1 and release-test F5 now assert the new rule instead of
 > the old hazard. Its row is removed below and its prompt out of
 > [`v1_prompts.md`](v1_prompts.md).
+
 > **Item 57** (a HACS upgrade never deletes files inside the integration directory) is
 > resolved. Half of it was a measurement, and it came back clean: the `haventory.zip` assets
 > published for `v0.1.0` and `v0.1.1` carry the same eighteen members, and every one of them
@@ -279,6 +282,7 @@ non-blocking).
 > no-op. The rule that fills the list lives in `CONTRIBUTING.md` — a PR deleting or renaming
 > a file inside `custom_components/haventory/` appends its old path in the same PR. Its rows
 > are removed from both tables below.
+
 > Item **69** (the screenshot harness could not reach the sidebar panel) is delivered.
 > `screenshot.mjs` takes `--element`, which names the root it waits for and scopes
 > `--search`/`--swipe` to; it defaults to `haventory-card`, so every existing invocation is
@@ -292,6 +296,7 @@ non-blocking).
 > 10/10 panel surfaces and 14/14 desktop card surfaces captured. Its row is removed below
 > and its prompt out of [`v1_prompts.md`](v1_prompts.md). This is what item 82's README
 > imagery was waiting on, and the precondition item 70 sequences behind.
+
 > **Item 46 resolved (2026-08-02).** The location editor now states the area select's
 > whole-tree consequence under the select, before Save, and its row is removed above.
 > Building it corrected the item's own premise: picking the default option on a *nested*
@@ -310,6 +315,32 @@ non-blocking).
 > hidden outright when Home Assistant defines no areas, and the name field takes the row.
 > Verified live against the dev container on `R1_Kitchen` (7 locations, area on the root)
 > and `R1_Garage` (8, no area).
+
+> Item **43** (the WS API kept answering — and writing the kept store — after config-entry
+> removal) is resolved by **#171**, which took the row's decision: handlers refuse once the
+> entry is gone. `async_remove_entry` now flushes anything unsaved, cancels a pending
+> debounced write (`storage.cancel_pending_persist`, shared with the two persist paths) and
+> empties the domain bucket; `ws_guard` requires the loaded runtime first, so every command
+> — `ping`/`version`/`config` included — lands as the contract's `storage_error` envelope,
+> never `unknown_error`, and live subscriptions go with the bucket. The static route's flag
+> is deliberately kept (an aiohttp route cannot be unregistered; dropping the flag would
+> double-serve on re-add), the `Store` file stays on disk, and a re-add restores service —
+> all pinned offline (15 cases) and against real HA. The same PR closed the
+> `async_remove_entry` third of item **51**, whose row is updated. #171 was also the one
+> batch PR that followed the parallel-batch convention and left this file alone.
+
+> **Batch reconcile (2026-08-02, after #167–#172).** All six v0.2.0 payload items — 69, 34,
+> 43, 57, 23, 46 — are delivered and their rows are gone from both tables, along with their
+> prompts in [`v1_prompts.md`](v1_prompts.md). Five of the six PRs edited this file in
+> parallel against the batch convention, and the conflict resolutions that merged them
+> resurrected all six rows while keeping every close-out note — the #164/#165 failure mode,
+> five-fold; this sweep removed them again. The six PRs' follow-ups (the dev instance's
+> stale dashboard paths that block the card passes, unload leaving the runtime serving, the
+> refused-command log volume, the desktop-only panel visual pass, `aria-expanded` without
+> `aria-controls`, and the phone "Show only" rows drawing checkboxes while announcing as
+> toggles) were triaged by the owner as **fix-before-`v0.2.0`** and are being executed
+> directly from session prompts rather than ledger rows — deliberately unnumbered to keep
+> this file lean; the PR bodies of #167–#172 carry their full text.
 
 ---
 
@@ -366,12 +397,6 @@ have a companion plan doc:
 
 | # | Task | Ships in / when | Definition |
 |---|---|---|---|
-| 69 | screenshot harness reaches the panel | `v0.2.0` | prompt |
-| 34 | filter-chip pressed state (a11y) | `v0.2.0` | prompt |
-| 43 | WS refuses after entry removal | `v0.2.0` | prompt |
-| 57 | stale-file sweep for HACS upgrades | `v0.2.0` | prompt |
-| 46 | effective-area preview in the editor | `v0.2.0` | [`item46_area_preview_plan.md`](item46_area_preview_plan.md) |
-| 23 | rename must not bump subtree versions | `v0.2.0` | [`item23_rename_version_plan.md`](item23_rename_version_plan.md) |
 | 79 | execute the validation run (groups A–J, ENV-A/B/C/D) | against `v0.2.0`; fixes → `0.2.x` | prompt (program: [`release_testing_plan.md`](release_testing_plan.md)) |
 | 60 | publish the measured scale ceiling | after 79's F3 | prompt |
 | 82 | README promotion: screenshots + consistency pass | after the `v0.2.0` payload; before 83 | prompt |
@@ -413,18 +438,13 @@ retired when v0.1.0/v0.1.1 cut cleanly):
 
 ## Pre-v1.0
 
-These ship in **`v0.2.0`** (item 70 alone follows item 79's run — see its sequencing).
-Ordered by impact. Item 4 moved to the release-stage table below, where its remaining
-(post-1.0 submission) half belongs.
+The `v0.2.0` payload is **delivered** — items 69, 34, 43, 57, 23 and 46 all landed
+2026-08-02 as #167–#172 (see the close-out notes above). One row remains, sequenced after
+item 79's run; everything else before 1.0 is the release-stage table below.
 
 | # | Item | Source PR(s) | Impact | Effort |
 |---|------|--------------|--------|--------|
 | 70 | **Strip the scoping-only toolchain before 1.0.** A new contributor currently has to work out for themselves which half of `docs/` and `scripts/` is still live: the repo carries planning and one-off exploration artifacts that were load-bearing while the work was in flight and are dead weight once it ships. **Delivered plan docs** — `docs/sidebar-panel.md` (25 KB, its own status line reads *delivered*; nothing outside this ledger links it) and `docs/card_shipping_plan.md` (20 KB, status *PR-1 and PR-2 implemented*; linked from `CLAUDE.md:57`, from the card-shipping note above and from item 56's row). **Exception:** `docs/release_testing_plan.md` is the validation run itself — executed against `v0.2.0` per the staging above: item 4 is gated on its A1, item 60 on its F3, and closed item 29's last part was deferred into it as D6 — so it goes *after* that run, not before. **Exploration scripts** to triage the same way: `stress_test.py`, `create_test_items.py`, `ws_probe.py`, `ws_subscribe.py`, `ws_init_haventory.py`, and the agent harnesses under `.claude/skills/` (`run-haventory`'s `screenshot.mjs` / `visual_pass.mjs` / `log_sweep.py` / `driver.py` and `test-haventory`'s `stress.py`). Nothing here is a free delete: every script except `common.sh` (sourced by the others) has at least one inbound reference from CI, `CONTRIBUTING.md`, `README.md` or `CLAUDE.md`, and `tests/test_ws_logging_offline.py:12` cites the release plan in a docstring — so each removal takes its references with it, and whatever survives earns one line in `CONTRIBUTING.md` saying what it is for. **Sequence this after item 69**, not before: it repairs the screenshot harness that produces the README and announcement-post imagery, so this removal is what closes the door behind it. Retiring the harness first would only mean rebuilding it the next time a screenshot is needed. | owner 2026-08-01 (contributor onboarding) | Medium (contributor onboarding) | M |
-| 46 | **Area propagation is surprising at the point of use — the effective-area preview from item 37.** Choosing the relabeled default option (#126) on a nested location does more than "stop inheriting": `Repository.update_location` runs `_propagate_area_to_root(key, None)`, clearing the area from the whole tree, and picking an explicit area moves the assignment to the tree root — nothing in the dialog warns about either. Item 37's live-preview idea lands here, with its recorded caution: an honest preview of the non-default options is a whole-tree effect and worth designing deliberately. The mechanics are no longer in the way — item 38's `effectiveAreaIdForLocation` (`ui/area.ts`) is the walk-up-to-root the dialog lacked, over the flat location cache it already holds, so neither a `location/tree` contract change nor new plumbing is needed; what is left is deciding what the dialog should say. Cosmetic while there: with no HA areas the dropdown renders a one-entry select. | item 37 + PR #126 follow-ups | Low–Med | M |
-| 34 | **The desktop filter panel's chips expose no pressed state to assistive tech.** Seven chips in `hv-filter-panel.ts` carry their selected state in an `on` CSS class and nothing else — no `aria-pressed`, no `role` (re-verified 2026-08-01: the file contains zero `aria-pressed`). The *same four* "Show only" facets in that component's mobile branch use `role="checkbox"` + `aria-checked`, and both app bars' stat pills plus the sidebar facet rows use `aria-pressed`, so the desktop panel is the sole surface where a screen reader cannot tell an active filter from an inactive one. Add `aria-pressed` to all seven (or `role="checkbox"`/`aria-checked` to match the mobile branch — pick one and use it for both branches). Promoted to pre-v1.0 (2026-08-02): it is the only surface with this gap, and S. | card UI consistency review 2026-07-26 | Low–Med (accessibility) | S |
-| 43 | **The WS API keeps answering — and writing the kept store — after config-entry removal, until restart.** `async_remove_entry` (#121) removes the Lovelace resource but leaves `hass.data[DOMAIN]["store"]`/`["repository"]` in place, and HA has no way to unregister WS commands, so an open dashboard can keep mutating the inventory after the integration is removed; a restart finishes the teardown. Decide whether handlers should refuse once the entry is gone. Promoted to pre-v1.0 (2026-08-02): removing an integration and finding it still writing is a first-impression bug once strangers are installing it. | PR #121 follow-up | Low–Med | S–M |
-| 57 | **A HACS upgrade never deletes files inside the integration directory.** With `zip_release`, HACS backs up the previous install and then runs `zipfile.extractall` straight over `<config>/custom_components/haventory/` without clearing it first (HACS `repositories/base.py`), so any file a newer release deletes or renames survives every user's upgrade; the dev container shows the same leftover class because `docker cp` also merges rather than replaces. Inert until a release actually removes a module or renames the card bundle — from that release on, either sweep the known stale paths at setup or call the leftover out in the release notes. `scripts/check_release_zip.py` cannot catch this: it validates the asset's layout, not the install directory's history. | PR #148 review | Low (upgrade hygiene) | S |
-| 23 | **Location rename bumps every subtree item's `version`** (denormalized `location_path` rewrite), so a client holding a stale `expected_version` for an unrelated field gets a spurious `conflict`. Indexes stay consistent — it's a UX surprise, not corruption. A path-only rewrite need not bump the optimistic-concurrency version. | WP4 stress test | Low | M |
 
 ### Release-stage tasks (executed in staging order, not by impact)
 
@@ -471,7 +491,7 @@ Ordered by impact.
 | 48 | **Card rate-limit polish left over from #128:** `Store.run()`'s command retries use a fixed exponential backoff (`retryBaseMs * 2 ** attempt`) and ignore the retry-after hint (`subscribeRetryDelayMs` is exported and reusable); the shell's banner chain is exclusive, so the queued-command "Busy — retrying" state is hidden while live updates are paused; and nothing calls `Store.dispose()` — its only caller is still its own test — so a shell torn down mid-backoff relies on GC rather than on the cancellation `dispose()` performs. | PR #128 follow-ups | Low | S–M |
 | 42 | **Storage crashes generically on a corrupt (non-integer) `schema_version`.** `int(raw.get("schema_version", 0))` in `storage.py` raises `ValueError`/`TypeError` on a hand-edited `"schema_version": null` or non-numeric string (a numeric string like `"4"` is silently coerced instead), surfacing as the catch-all `ConfigEntryNotReady("storage load failed")` rather than a specific corruption message — and `_validate_storage_payload` in `__init__.py` repeats the pattern with `int(payload.get("schema_version", -1))`. `import_export.py` already type-checks its version fields; storage could match. Related trap: `migrations.migrate`'s downgrade pass-through is unreachable from production now that storage refuses first (#120) — a second caller would reintroduce the silent relabel. | PR #120 follow-ups | Low | S |
 | 50 | **Two severity calls the #124 logging audit deliberately left open:** the frontend-resource registration failure logs WARNING + traceback although the card never loading is arguably operator-actionable (ERROR — but it is outside the error taxonomy's codes and the integration still functions); and `ws_items_bulk`'s "completed with no successful operations" WARNING summary is redundant with the per-op WARNING lines it follows. | PR #124 follow-ups | Low | S |
-| 51 | **Real-HA integration coverage for the batch's stub-tested paths.** Three changes are asserted against stubs/mocks only, since no batch session could provision `.venv-integration`: `async_remove_entry` against a real `ResourceStorageCollection.async_delete_item` (#121), the tracked-task debounced persist (#123), and the `ConfigEntryError` downgrade refusal (#120). Add cases under `tests/integration/`; until then a local `scripts/test_integration.sh` run covers the gap. #136 sharpened the stakes: the offline `HomeAssistant` stub has no service registry, so `services.setup()` early-returns offline and no offline test can observe real registration semantics — exactly how the never-awaited executor-dispatched service handlers stayed invisible until the item-6 integration test ran (and HA's `_execute_service` executor fallback fails silently, so the same mistake in a future registration would be invisible again outside an integration test). Worth a wider sweep of what else the stubs let through. Still absent as of the 2026-08-01 check: `tests/integration/` has grown to eight modules (config entry, frontend serving, persistence, services, WS items, import/export, areas) and covers none of the three cases. | PR #120/#121/#123 follow-ups, #136 | Low | S–M |
+| 51 | **Real-HA integration coverage for the batch's stub-tested paths.** Three changes are asserted against stubs/mocks only, since no batch session could provision `.venv-integration`: `async_remove_entry` against a real `ResourceStorageCollection.async_delete_item` (#121), the tracked-task debounced persist (#123), and the `ConfigEntryError` downgrade refusal (#120). Add cases under `tests/integration/`; until then a local `scripts/test_integration.sh` run covers the gap. **#171 closed the `async_remove_entry` third**: `test_removal_deletes_the_card_resource_and_module_url` drives the real `ResourceStorageCollection.async_delete_item` and `test_removal_leaves_the_static_route_serving` covers the remove/re-add route case — the debounced-persist and downgrade-refusal thirds remain. #136 sharpened the stakes: the offline `HomeAssistant` stub has no service registry, so `services.setup()` early-returns offline and no offline test can observe real registration semantics — exactly how the never-awaited executor-dispatched service handlers stayed invisible until the item-6 integration test ran (and HA's `_execute_service` executor fallback fails silently, so the same mistake in a future registration would be invisible again outside an integration test). Worth a wider sweep of what else the stubs let through. Still absent as of the 2026-08-01 check: `tests/integration/` has grown to eight modules (config entry, frontend serving, persistence, services, WS items, import/export, areas) and covers none of the three cases. | PR #120/#121/#123 follow-ups, #136 | Low | S–M |
 | 53 | **Type-loose WS frames bypass `ws_guard` and land in HA core's log at ERROR.** A frame that fails the voluptuous schema in `ws.py` is rejected by HA core *before* `ws_guard` runs, and `homeassistant.components.websocket_api.http.connection` logs it at ERROR with the client payload (e.g. `expected int for dictionary value @ data['quantity']. Got 1.5`) — exactly the client mistakes item 32 downgraded to WARNING re-enter the log as ERROR through the front door (4 such lines in the 2026-07-28 session, all from deliberate fuzz). `ws.py` already widens some fields to `object` (`description`, `location_id`, `low_stock_threshold`) and validates them in the model layer; doing the same for `quantity` / `delta` / `operations` / required `name` would route them through `ws_guard` as typed `validation_error` WARNINGs. Deliberate trade-off, flagged rather than decided: schema-level typing is free documentation, so this is a judgment call, not an obvious win. | local verification run 2026-07-28 (F1) | Low–Med (support burden) | S–M |
 | 56 | **The manual `resources.async_load()` in `_async_lovelace_resources` is redundant** at the declared 2026.6.0 floor: `ResourceStorageCollection`'s `async_items` / `async_create_item` / `async_update_item` / `async_delete_item` each ensure the collection is loaded before touching it, so the explicit load-and-flag dance only duplicates that — and writing `resources.loaded = True` reaches into another component's object to do it. A pure cleanup, deliberately left out of the card-shipping PR-1 scope; needs its own test pass because `tests/test_entry_removal_offline.py` asserts the current load-before-delete behaviour. | `docs/card_shipping_plan.md` (PR-1 non-goal) | Low | S |
 | 61 | **Dependabot opens no update PRs for `requirements-integration.txt`.** `.github/dependabot.yml` declares `github-actions`, `npm` and `uv` ecosystems but no `pip` entry. The dependency graph does scan the file (`homeassistant` and `pytest-homeassistant-custom-component` are in the SBOM), so a vulnerability there would alert — what's missing is the automated fix PR. Add a `pip` ecosystem block for `/`; item 29 has since pinned the file to the `2026.6.0` floor, so configure the block to leave the pinned `homeassistant` line alone (an ignore rule, or security-only updates) rather than fight the pin. | PR #135 follow-up | Low | S |

--- a/docs/v1_prompts.md
+++ b/docs/v1_prompts.md
@@ -3,7 +3,9 @@
 The definitive task set for the road to 1.0, one paste-ready prompt per item. The
 staging (which release each item ships in, and in what order) is the **Release staging**
 section of [`open-items.md`](open-items.md) — that section is authoritative; this file
-carries the execution prompts. Complex items have a companion plan doc; their prompts
+carries the execution prompts. The `v0.2.0` payload items (69, 34, 43, 57, 23, 46)
+are delivered (#167–#172) and their prompts are gone from this file — what remains is the
+release-stage tail and the post-1.0 submission. Complex items have a companion plan doc; their prompts
 here point at it. This file supersedes the roadmap artifact's WP8/WP9 prompts, which
 predate the 2026-08-02 staging revision.
 
@@ -18,114 +20,6 @@ Conventions every prompt below assumes (stated once here, per `CLAUDE.md`):
   ever run as a parallel batch instead, do *not* touch the ledger — report follow-ups
   in the PR body and reconcile in one sweep afterwards (the fix-batch pattern).
 - Out-of-scope findings go under a "Follow-ups" note, not into the diff.
-
----
-
-## v0.2.0 payload
-
-### Item 34
-
-**Desktop filter chips: expose pressed state to assistive tech.**
-
-```text
-You are working in the HAventory repo. Read CLAUDE.md first and follow it exactly.
-docs/open-items.md item 34 is the spec. Seven chips in
-cards/haventory-card/src/components/hv-filter-panel.ts carry their selected state in an
-"on" CSS class and nothing else — no aria-pressed, no role. The same component's mobile
-branch uses role="checkbox" + aria-checked for the same four "Show only" facets, and
-both app bars' stat pills and the sidebar facet rows use aria-pressed — the desktop
-panel is the only surface where a screen reader cannot tell an active filter from an
-inactive one.
-
-Pick ONE idiom and use it for both branches of the component (aria-pressed on button
-chips is the natural fit for toggles; if you keep the mobile branch's role="checkbox",
-convert the desktop chips to match — do not leave the two branches on different
-vocabularies). TDD: component specs assert the attribute flips with the filter state on
-every one of the seven chips, and that the mobile branch agrees.
-```
-
-### Item 43
-
-**Refuse WS commands after config-entry removal.**
-
-```text
-You are working in the HAventory repo. Read CLAUDE.md first and follow it exactly.
-docs/open-items.md item 43 is the spec. async_remove_entry (__init__.py:282) removes
-the frontend module but leaves hass.data[DOMAIN]["store"]/["repository"] in place, and
-HA cannot unregister WS commands — so an open dashboard keeps mutating (and persisting)
-the kept store after the integration is removed, until restart.
-
-Decision (made): handlers must refuse once the entry is gone. ws.py's _repo(hass)
-already raises StorageError("repository not initialized...") when the bucket is empty —
-so the fix is to make removal empty it: pop the domain bucket (store, repository, rate
-limiter, any persist debounce — flush/cancel it first, mirroring unload's teardown) in
-async_remove_entry. Every subsequent command then lands as a storage_error envelope
-through the existing ws_guard path; subscriptions: verify what broadcasts do with an
-empty bucket and make teardown drop live subscriptions cleanly. First read
-async_unload_entry and reuse/extract its teardown rather than duplicating it. The HA
-Store *file* stays on disk (deliberate, documented in the removal docstring).
-
-TDD offline: after async_remove_entry, a WS command gets storage_error (not
-unknown_error, no traceback); persistence is not invoked again; re-adding the entry
-restores service. Add the real-HA integration case (tests/integration/) — this is one
-of item 51's stub-only paths, so note in the PR body that it closes the
-async_remove_entry third of item 51.
-```
-
-### Item 57
-
-**Sweep stale files left behind by HACS upgrades.**
-
-```text
-You are working in the HAventory repo. Read CLAUDE.md first and follow it exactly.
-docs/open-items.md item 57 is the spec. HACS zip_release upgrades extract over
-<config>/custom_components/haventory/ without clearing it, so any file a release
-deletes or renames survives every user's upgrade forever.
-
-1. Determine whether any file shipped in v0.1.0/v0.1.1's haventory.zip no longer exists
-   on current main (compare the release assets' file lists against the tree — the
-   release workflow builds the zip, scripts/check_release_zip.py knows the layout).
-2. Implement the sweep: at setup, remove known-stale paths inside the integration
-   directory from an explicit allowlist of retired relative paths (never a wildcard —
-   an operator's own files must survive). Executor-offloaded file I/O, tolerant of
-   absence, logged at DEBUG.
-3. Seed the allowlist with whatever (1) found; leave a clearly-marked list to append to
-   in future releases that delete files.
-
-TDD offline: stale path present → removed on setup; absent → no-op; a path NOT on the
-list survives. Note in the PR body: from now on, any PR deleting a shipped integration
-file must add it to the sweep list (one CONTRIBUTING sentence).
-```
-
-### Item 46
-### Item 23
-
-**Location rename must not bump subtree item versions.** Plan:
-[`item23_rename_version_plan.md`](item23_rename_version_plan.md).
-
-```text
-You are working in the HAventory repo. Read CLAUDE.md first and follow it exactly.
-Read docs/item23_rename_version_plan.md — it is the design; implement it as written
-(path-only rewrites update location_path + search tokens, version and updated_at stay
-untouched; contract docs updated in the three places it names; the test list is the
-TDD spec, including the integration-suite case). Verify the card-correctness assumption
-it flags (what ws.py broadcasts on location/update) before relying on it.
-```
-
-### Item 46 — delivered
-
-**Effective-area preview in the location editor.** Plan:
-[`item46_area_preview_plan.md`](item46_area_preview_plan.md); the outcome is in
-`open-items.md`'s item 46 resolution note. Kept for the record — nothing left to paste.
-
-```text
-You are working in the HAventory repo. Read CLAUDE.md first and follow it exactly.
-Read docs/item46_area_preview_plan.md — it is the design; implement both stages as
-written (areaChangePreview pure function TDD-first, then the dialog render + the
-empty-registry cosmetic fix). Frontend-only; no contract change. Verify the preview
-copy against the live dev container (run-haventory skill) on a nested tree with and
-without areas before committing stage 2.
-```
 
 ---
 


### PR DESCRIPTION
## Summary

The reconcile sweep after #167–#172. All six v0.2.0 payload items (69, 34, 43, 57, 23, 46)
are delivered — but five of the six PRs edited the ledger in parallel against the batch
convention, and the conflict resolutions that merged them **resurrected all six rows** in
both tables while keeping every close-out note: the #164/#165 failure mode, five-fold.

This sweep:

- removes the six rows from the pre-v1.0 and task-definition tables, and the delivered
  prompts from `v1_prompts.md` — including the duplicated item-46 section (an orphan
  `### Item 46` heading directly above `### Item 23`, plus a second "Item 46 — delivered"
  stub) that one resolution produced;
- separates the five surviving close-out notes back into their own blockquote blocks (they
  had merged into one run-on block) and writes the **missing item 43 note** — #171 was the
  one PR that followed the parallel-batch convention and left the ledger alone;
- updates item **51**: #171 closed its `async_remove_entry` third against the real
  `ResourceStorageCollection.async_delete_item` (+ the static-route remove/re-add case);
  the debounced-persist and downgrade-refusal thirds remain;
- records the owner's triage of the batch's six follow-ups: **all fix-before-v0.2.0**,
  executed directly from session prompts rather than ledger rows — deliberately unnumbered
  to keep the file lean; the PR bodies of #167–#172 carry their full text;
- retargets item 46's plan-doc pointer at the resolution note, since its prompt is retired.

State after this PR: the pre-v1.0 table holds only item **70** (sequenced after item 79's
run); everything else before 1.0 is the release-stage table (79, 60, 82, 80, 81, 83, 4).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (435 passed, 22 skipped), `uv run ruff check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (976 passing), `npm run build`

Docs-only; both gates run per convention.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — not applicable, documentation only.
- [x] Docs updated where behavior changed (`docs/open-items.md`, `docs/v1_prompts.md`, `docs/item46_area_preview_plan.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change.
- [x] Load-bearing invariants preserved.

## Screenshots (card / UI changes)

None — documentation only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhZ3AExRhmTAJ6JVG23E6G)_