### PR TITLE
fix(card): say what a filter disclosure opens, and paint the sheet's rows as toggles

### DIFF
--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -316,6 +316,30 @@ describe('hv-filter-panel: dates and location', () => {
     expect(el.shadowRoot?.querySelector('hv-location-tree')).toBe(null);
   });
 
+  // aria-expanded on its own says only that something opened; which element it
+  // opened was left to whatever happened to follow the chip in reading order.
+  it('names the holder the location chip discloses, open or shut', async () => {
+    const el = await mount();
+    const chip = () => q(el, '[data-testid="filter-location"]') as HTMLButtonElement;
+    const id = 'filter-location-tree-holder';
+
+    expect(chip().getAttribute('aria-controls')).toBe(id);
+    expect(chip().getAttribute('aria-expanded')).toBe('false');
+    // The id has to resolve in both states — a control pointing at nothing
+    // announces as controlling nothing — so the holder outlives the tree in it.
+    const shut = el.shadowRoot?.getElementById(id);
+    expect(shut, 'holder shut').toBeTruthy();
+    expect(shut?.querySelector('hv-location-tree'), 'no tree while shut').toBe(null);
+
+    chip().click();
+    await el.updateComplete;
+
+    expect(chip().getAttribute('aria-expanded')).toBe('true');
+    expect(chip().getAttribute('aria-controls')).toBe(id);
+    const open = el.shadowRoot?.getElementById(id);
+    expect(open?.querySelector('hv-location-tree'), 'tree open inside the holder').toBeTruthy();
+  });
+
   it('names the picked location on the chip', async () => {
     const el = await mount(
       { locationId: 'shelf-a' },
@@ -493,9 +517,9 @@ describe('hv-filter-panel: native control affordances', () => {
   });
 
   // On a phone the fields took --hv-input-font (16px on this surface) while the
-  // chips beside them are 13.5px and the checkbox rows 14px, so the area select
-  // — the one full-width control in the panel — was the largest text on the
-  // page. Desktop has always matched its chips at 12.5px.
+  // chips beside them are 13.5px, so the area select — the one full-width
+  // control in the panel — was the largest text on the page. Desktop has always
+  // matched its chips at 12.5px.
   it('sizes its fields like the chips beside them, in both layouts', () => {
     const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
     const css = (Array.isArray(sheet) ? sheet : [sheet])
@@ -703,23 +727,84 @@ describe('hv-filter-panel: pressed state', () => {
   });
 
   it('keeps the announced state in step with the paint, chip for chip', async () => {
-    const el = await mount({ category: 'Tools', tags: ['m4'], overdueOnly: true });
-    // A chip paints itself; a checkbox row paints the box inside it.
-    const painted = (b: HTMLElement) => b.classList.contains('on') || !!b.querySelector('.box.on');
-    const toggles = all(el, 'button.chip, button.check').filter(
-      (b) => b.dataset.testid !== 'filter-location' && b.dataset.testid !== 'filter-category-more',
-    );
-
-    expect(toggles.length).toBeGreaterThanOrEqual(STATEFUL_CHIPS.length);
-    for (const toggle of toggles) {
-      expect(toggle.getAttribute('aria-pressed'), toggle.dataset.testid).toBe(
-        String(painted(toggle)),
+    for (const mobile of [false, true]) {
+      const el = await mount(
+        { category: 'Tools', tags: ['m4'], overdueOnly: true, includeSubtree: true },
+        { mobile },
       );
+      // Every toggle in the panel paints itself, rows included: a row is a chip
+      // in another shape, not a checkbox that paints a box inside it.
+      const painted = (b: HTMLElement) => b.classList.contains('on');
+      const toggles = all(el, 'button.chip, button.check').filter(
+        (b) => b.dataset.testid !== 'filter-location' && b.dataset.testid !== 'filter-category-more',
+      );
+
+      expect(toggles.length, `mobile=${mobile}`).toBeGreaterThanOrEqual(STATEFUL_CHIPS.length);
+      for (const toggle of toggles) {
+        expect(toggle.getAttribute('aria-pressed'), `${toggle.dataset.testid}, mobile=${mobile}`).toBe(
+          String(painted(toggle)),
+        );
+      }
+      // Not vacuous: this mount has some on and some off.
+      const states = toggles.map((t) => t.getAttribute('aria-pressed'));
+      expect(states, `mobile=${mobile}`).toContain('true');
+      expect(states, `mobile=${mobile}`).toContain('false');
+      el.remove();
     }
-    // Not vacuous: this mount has some on and some off.
-    const states = toggles.map((t) => t.getAttribute('aria-pressed'));
-    expect(states).toContain('true');
-    expect(states).toContain('false');
+  });
+
+  // The rows announce as toggle buttons but drew a checkbox's box, which left
+  // the sheet as the one surface where the paint and the announcement disagreed.
+  it('paints every row as a chip rather than a checkbox, at both widths', async () => {
+    const ROWS = ['filter-include-subtree', 'filter-low-stock-first', 'filter-low-stock-only'];
+    for (const mobile of [false, true]) {
+      const el = await mount({ lowStockOnly: true, includeSubtree: true, lowStockFirst: true }, { mobile });
+      for (const testid of ROWS) {
+        const row = q(el, `[data-testid="${testid}"]`);
+        // "Low stock" is a chip on a desktop and a row in the sheet; the other
+        // two are rows at both widths.
+        if (!mobile && testid === 'filter-low-stock-only') continue;
+        const where = `${testid}, mobile=${mobile}`;
+        expect(row.classList.contains('chip'), where).toBe(true);
+        expect(row.querySelector('.box'), where).toBe(null);
+        expect(row.querySelector('.mark'), where).toBeTruthy();
+      }
+      el.remove();
+    }
+  });
+
+  // The row's on state has to be the chip's on state, not a second set of
+  // colours that happens to look similar.
+  it('takes its on state from the chip rule, warning variant included', () => {
+    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
+    const css = (Array.isArray(sheet) ? sheet : [sheet])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+
+    expect(css).toMatch(/\.chip\.on \{[^}]*background: var\(--hv-primary-tint\)/);
+    expect(css).toMatch(/\.chip\.on\.warning \{[^}]*background: var\(--hv-warn-bg\)/);
+    // No rule of its own to drift from those, and no checkbox box left to draw.
+    expect(css).not.toMatch(/\.check\.on \{/);
+    expect(css).not.toMatch(/\.box[ .{]/);
+  });
+
+  it('reserves the mark so a row keeps its label in place as it is pressed', async () => {
+    const el = await mount({}, { mobile: true });
+    const row = q(el, '[data-testid="filter-low-stock-only"]');
+    expect(row.getAttribute('aria-pressed')).toBe('false');
+    expect(row.querySelector('.mark'), 'off rows still hold the slot open').toBeTruthy();
+
+    const el2 = await mount({ lowStockOnly: true }, { mobile: true });
+    expect(q(el2, '[data-testid="filter-low-stock-only"]').querySelector('.mark svg')).toBeTruthy();
+
+    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
+    const css = (Array.isArray(sheet) ? sheet : [sheet])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.check \.mark \{[^}]*width: 12px/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.check \.mark \{[^}]*width: 15px/);
   });
 
   it('flips as the filter is applied, not only on mount', async () => {

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -28,6 +28,15 @@ const SORT_FIELDS: { field: SortField; label: string }[] = [
 /** How many category chips to show before collapsing the rest behind "More…". */
 const CATEGORY_CHIP_LIMIT = 4;
 
+/**
+ * The element the location chip discloses, named so `aria-controls` can point at
+ * it. The holder stays in the tree whether or not it is open — an `aria-controls`
+ * that resolves to nothing announces the chip as controlling nothing — and only
+ * its contents come and go. Shadow scoping keeps the id unique even with the
+ * desktop panel and the phone sheet both mounted.
+ */
+const LOCATION_TREE_ID = 'filter-location-tree-holder';
+
 /** The two timestamps a "Changed" row can compare, and the filter keys behind them. */
 type DateField = 'updated' | 'created';
 
@@ -257,48 +266,38 @@ export class HVFilterPanel extends LitElement {
         color: var(--hv-text-on-primary);
         font-weight: 500;
       }
-      .check {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        font-size: 12.5px;
-        color: var(--hv-chip-text);
-        border: none;
-        background: none;
-        padding: 4px 0;
-      }
+      /*
+       * A "Show only" row is a chip in another shape, and carries the chip class
+       * to say so: it holds the same filter the wider panel draws as a chip and
+       * announces the same way, so it takes the chip's outline and on-state
+       * rather than restating those tokens — a row that paints a checkbox while
+       * announcing a toggle describes two widgets. Only what a full-width row
+       * needs on top of a chip lives here.
+       *
+       * Five of these stack under "Show only" in the sheet, and pills each sized
+       * to their own label leave that column with a ragged right edge.
+       */
       :host([mobile]) .check {
-        min-height: var(--hv-tap-min, 44px);
+        box-sizing: border-box;
         width: 100%;
-        font-size: 14px;
+        min-height: var(--hv-tap-min, 44px);
       }
-      .box {
+      /* The mark holds its width while the row is off, so a stacked column keeps
+         one left edge for its labels instead of shifting each row as it is
+         pressed. The two widths are the glyph sizes the row renderer asks for. */
+      .check .mark {
         display: inline-grid;
         place-items: center;
-        width: 15px;
-        height: 15px;
-        border-radius: 4px;
-        border: 1.5px solid var(--hv-text-tertiary);
-        color: #fff;
+        width: 12px;
         flex: none;
       }
-      :host([mobile]) .box {
-        width: 20px;
-        height: 20px;
-        border-radius: 5px;
-      }
-      .box.on {
-        background: var(--hv-primary);
-        border-color: var(--hv-primary);
-      }
-      .box.on.warning {
-        background: var(--hv-amber);
-        border-color: var(--hv-amber);
+      :host([mobile]) .check .mark {
+        width: 15px;
       }
       .tally-right {
         margin-left: auto;
         font-size: 12.5px;
-        color: var(--hv-text-tertiary);
+        opacity: 0.65;
       }
       select {
         font: inherit;
@@ -453,7 +452,9 @@ export class HVFilterPanel extends LitElement {
    * card announces as a pressed toggle button — the app bars' stat pills, the
    * sidebar's facet rows, this panel's chips — and the "Show only" facets render
    * as rows here and as chips on a wider screen, so a single facet would
-   * otherwise change vocabulary with the viewport it is read on.
+   * otherwise change vocabulary with the viewport it is read on. The row is
+   * painted to match: it takes the chip's on state, so what the row draws and
+   * what it announces describe the same widget.
    */
   private _renderCheckbox(
     label: string,
@@ -462,14 +463,12 @@ export class HVFilterPanel extends LitElement {
     opts: { warning?: boolean; tally?: number | null; testid?: string } = {},
   ) {
     return html`<button
-      class="check"
+      class="chip check ${on ? 'on' : ''} ${opts.warning ? 'warning' : ''}"
       aria-pressed=${String(on)}
       data-testid=${opts.testid ?? 'filter-check'}
       @click=${onToggle}
     >
-      <span class="box ${on ? 'on' : ''} ${opts.warning ? 'warning' : ''}">
-        ${on ? icon('check', this.mobile ? 15 : 12) : null}
-      </span>
+      <span class="mark">${on ? icon('check', this.mobile ? 15 : 12) : null}</span>
       <span>${label}</span>
       ${opts.tally !== undefined && opts.tally !== null
         ? html`<span class="tally-right">${opts.tally}</span>`
@@ -492,6 +491,7 @@ export class HVFilterPanel extends LitElement {
             class="chip ${f.locationId ? 'on' : ''}"
             data-testid="filter-location"
             aria-expanded=${String(this._locationOpen)}
+            aria-controls=${LOCATION_TREE_ID}
             @click=${() => {
               this._locationOpen = !this._locationOpen;
             }}
@@ -518,9 +518,9 @@ export class HVFilterPanel extends LitElement {
             { testid: 'filter-include-subtree' },
           )}
         </div>
-        ${this._locationOpen
-          ? html`<div class="tree-holder">
-              <hv-location-tree
+        <div class="tree-holder" id=${LOCATION_TREE_ID} ?hidden=${!this._locationOpen}>
+          ${this._locationOpen
+            ? html`<hv-location-tree
                 data-testid="filter-location-tree"
                 .nodes=${this.locationTree}
                 .areas=${this.areas}
@@ -532,9 +532,9 @@ export class HVFilterPanel extends LitElement {
                   this._patch({ locationId: (e.detail as { locationId: string | null }).locationId });
                   this._locationOpen = false;
                 }}
-              ></hv-location-tree>
-            </div>`
-          : null}
+              ></hv-location-tree>`
+            : null}
+        </div>
       </div>
     `;
   }

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -572,6 +572,33 @@ describe('hv-full-view: sidebar facets', () => {
     ).toBe('true');
   });
 
+  // aria-expanded on its own says only that something opened; which element it
+  // opened was left to whatever happened to follow the heading in reading order.
+  it('names the panel each heading discloses, open or shut', async () => {
+    const { el, sr } = await mount({ items: faceted, locations: [loc('garage', 'Garage')] });
+    const toggle = (section: string) =>
+      q(sr, `[data-testid="sidebar-toggle-${section}"]`) as HTMLButtonElement;
+
+    for (const section of ['locations', 'categories', 'tags']) {
+      const id = `sidebar-section-${section}`;
+      expect(toggle(section).getAttribute('aria-controls'), section).toBe(id);
+      expect(toggle(section).getAttribute('aria-expanded'), `${section} open`).toBe('true');
+      // The id has to resolve in both states — a control pointing at nothing
+      // announces as controlling nothing.
+      expect(sr.getElementById(id), `${section} open`).toBeTruthy();
+
+      toggle(section).click();
+      await settle(el);
+
+      expect(toggle(section).getAttribute('aria-expanded'), `${section} shut`).toBe('false');
+      expect(toggle(section).getAttribute('aria-controls'), `${section} shut`).toBe(id);
+      expect(sr.getElementById(id), `${section} shut`).toBeTruthy();
+
+      toggle(section).click();
+      await settle(el);
+    }
+  });
+
   it('collapses a section from its heading, keeping the heading reachable', async () => {
     const { el, sr } = await mount({ items: faceted, locations: [loc('garage', 'Garage')] });
     const toggle = q(sr, '[data-testid="sidebar-toggle-tags"]') as HTMLButtonElement;

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -54,6 +54,14 @@ export const NARROW_QUERY = '(max-width: 700px)';
 type SidebarSection = 'locations' | 'categories' | 'tags';
 
 /**
+ * The element a section heading discloses, named so `aria-controls` can point at
+ * it. Each panel stays in the tree whether or not its section is open — an
+ * `aria-controls` that resolves to nothing announces the heading as controlling
+ * nothing — and only its contents come and go.
+ */
+const sectionPanelId = (section: SidebarSection) => `sidebar-section-${section}`;
+
+/**
  * The expanded workspace.
  *
  * The coloured app bar is the mode signal — the standard card never has one, so
@@ -1037,6 +1045,7 @@ export class HVFullView extends LitElement {
       class="section-toggle"
       data-testid=${`sidebar-toggle-${section}`}
       aria-expanded=${String(open)}
+      aria-controls=${sectionPanelId(section)}
       @click=${() => {
         this._sections = { ...this._sections, [section]: !open };
       }}
@@ -1119,28 +1128,30 @@ export class HVFullView extends LitElement {
           </button>
         </span>
       </div>
-      ${open
-        ? values.length
-          ? values.map(
-              (v) => html`<button
-                class="value-row ${isOn(v.value) ? 'on' : ''}"
-                data-testid=${`sidebar-${section}-row`}
-                data-value=${v.value}
-                aria-pressed=${String(isOn(v.value))}
-                @click=${() => onPick(v.value)}
-              >
-                ${isOn(v.value) ? icon('check', 15) : null}
-                <!-- These clip with an ellipsis, and a clipped value the user
-                     typed is otherwise unreadable — there is nowhere else in
-                     the sidebar it appears in full. -->
-                <span class="label" title=${v.value}>${v.value}</span>
-                <span class="tally">${v.count}</span>
-              </button>`,
-            )
-          : html`<div class="section-empty" data-testid=${`sidebar-${section}-empty`}>
-              ${section === 'tags' ? 'No tags in use yet' : 'No categories in use yet'}
-            </div>`
-        : null}
+      <div id=${sectionPanelId(section)} ?hidden=${!open}>
+        ${open
+          ? values.length
+            ? values.map(
+                (v) => html`<button
+                  class="value-row ${isOn(v.value) ? 'on' : ''}"
+                  data-testid=${`sidebar-${section}-row`}
+                  data-value=${v.value}
+                  aria-pressed=${String(isOn(v.value))}
+                  @click=${() => onPick(v.value)}
+                >
+                  ${isOn(v.value) ? icon('check', 15) : null}
+                  <!-- These clip with an ellipsis, and a clipped value the user
+                       typed is otherwise unreadable — there is nowhere else in
+                       the sidebar it appears in full. -->
+                  <span class="label" title=${v.value}>${v.value}</span>
+                  <span class="tally">${v.count}</span>
+                </button>`,
+              )
+            : html`<div class="section-empty" data-testid=${`sidebar-${section}-empty`}>
+                ${section === 'tags' ? 'No tags in use yet' : 'No categories in use yet'}
+              </div>`
+          : null}
+      </div>
     `;
   }
 
@@ -1176,7 +1187,9 @@ export class HVFullView extends LitElement {
             </button>
           </span>
         </div>
-        ${this._sections.locations ? this._renderLocationSection() : null}
+        <div id=${sectionPanelId('locations')} ?hidden=${!this._sections.locations}>
+          ${this._sections.locations ? this._renderLocationSection() : null}
+        </div>
         ${this._renderFacetSection(
           'categories',
           'Categories',

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -130,9 +130,14 @@ styling.
 
 A filter that is on announces with `aria-pressed`, everywhere: both app bars' stat pills,
 the sidebar's category and tag rows, and every chip and row in `hv-filter-panel`. The panel
-draws the same "Show only" facets as chips on a desktop and as checkbox-styled rows in the
-phone sheet, so the shared word is what stops one facet from announcing as a checkbox at one
-width and a toggle at another — colour alone says nothing to a screen reader.
+draws the same "Show only" facets as chips on a desktop and as full-width rows in the phone
+sheet, so the shared word is what stops one facet from announcing as a checkbox at one width
+and a toggle at another — colour alone says nothing to a screen reader.
+
+The paint follows the same rule. A row in the sheet carries the `chip` class beside its own,
+so it takes the chip's outline and on-state tokens rather than drawing a checkbox's box; the
+one thing it adds is a fixed-width mark, which holds a stacked column's labels on one left
+edge as rows are pressed. Anything still drawing a box is selecting, not filtering.
 
 The other two vocabularies mark genuinely different widgets, and neither is a filter:
 `role="radio"` for a segmented picker whose options are exclusive (tag match mode in both
@@ -140,6 +145,16 @@ the panel and the sidebar, sort direction, the import sheet's policy) plus `role
 for the item editor's boolean custom field, and `role="checkbox"` for *selecting* rows
 rather than filtering them — `hv-list-row`, `hv-data-table`'s header and row boxes (the
 header carries `aria-checked="mixed"` for a partial page), and `hv-column-picker`.
+
+### What a disclosure opens
+
+A control that expands something carries `aria-expanded` **and** `aria-controls`, and the
+element it names stays in the tree whether or not it is open — an `aria-controls` that
+resolves to nothing announces the control as controlling nothing. Only the contents come and
+go, so collapsing still discards the state inside. Both filter surfaces are wired this way:
+`hv-filter-panel`'s location chip points at its tree holder, and `hv-full-view`'s three
+sidebar headings each point at `sidebar-section-<section>`. Ids are shadow-scoped, so the
+desktop panel and the phone sheet can both be mounted without colliding.
 
 ### The area beside a location
 


### PR DESCRIPTION
Two follow-ups from #167, both in the filter surfaces. No behaviour changed.

## 1. `aria-expanded` without `aria-controls`

A disclosure said that *something* opened; **which** element it opened was left to whatever
happened to follow the control in reading order. Four controls were in that shape:
`hv-filter-panel`'s location chip, and `hv-full-view`'s three sidebar headings.

Each now carries `aria-controls` pointing at a stable id — `filter-location-tree-holder`
and `sidebar-section-<section>` — and **the target stays in the tree in both states**, since
an `aria-controls` that resolves to nothing announces the control as controlling nothing.
Only the contents come and go, so collapsing still discards the state inside (the location
tree's expansion, the sidebar's rows) exactly as before. The collapsed holder is `hidden`,
so it takes no layout. Ids are shadow-scoped, so the desktop panel and the phone sheet can
both be mounted without colliding.

## 2. The sheet's rows announced as toggles and drew a checkbox

`hv-filter-panel`'s "Show only" rows took `aria-pressed` in #167 but kept painting a
checkbox's box — the one place left in the card where the paint and the announcement
described different widgets.

A row now carries the `chip` class beside its own, so it takes the desktop chip's outline
and on-state **tokens directly** (`--hv-primary-tint` / `--hv-primary` /
`--hv-primary-darker`, and `--hv-warn-bg` / `--hv-amber` / `--hv-warn` for the warning
facets) rather than restating them somewhere they could drift. The `.box` rules are gone;
a fixed-width `.mark` replaces them, which holds a stacked column's labels on one left edge
instead of shifting each row as it is pressed. "Include sub-locations" and "Low stock first"
ride the same renderer and change with them, at both widths.

## Live check — dev HA container, 375x812, real card, 1031 seeded items

"Show only", with the warning facet on. Same amber the desktop chip uses; the footer reads
`Show 137 items` against the row's own tally of 137, so the filter still applies:

<img src="https://raw.githubusercontent.com/chrreiter/HAventory/assets/filter-a11y-screens/docs/assets/filter-a11y-sheet-showonly.png" width="330">

"Where" and "Sort" — the two rows that also exist on a desktop — as primary-tinted pills:

<img src="https://raw.githubusercontent.com/chrreiter/HAventory/assets/filter-a11y-screens/docs/assets/filter-a11y-sheet-where.png" width="330"> <img src="https://raw.githubusercontent.com/chrreiter/HAventory/assets/filter-a11y-screens/docs/assets/filter-a11y-sheet-sort.png" width="330">

And the desktop panel at 1440x900, where "Include sub-locations" now sits in the "Where" row
as a pill among the chips it belongs with, and the sidebar's sections render unchanged
through their new wrappers:

<img src="https://raw.githubusercontent.com/chrreiter/HAventory/assets/filter-a11y-screens/docs/assets/filter-a11y-desktop.png" width="900">

(Screenshots are parked on the non-merging branch `assets/filter-a11y-screens` — delete it
once this PR is closed.)

## Tests

- **`hv-filter-panel`** — the chip's `aria-controls` matches the holder's id, the id resolves
  open *and* shut, and the tree is inside the holder only when open.
- **`hv-full-view`** — all three headings, both branches: id matches, id resolves, and
  `aria-expanded` flips.
- **The #167 sweep** (paint matches announcement, chip for chip) now runs at **both** widths
  rather than desktop only, and keys off the row's own class instead of `.box.on`, which no
  longer exists. Two new tests pin the visual: no `.box` survives and every row carries
  `chip`; the on-state and warning tokens come from the `.chip.on` rules; the mark is
  reserved when off.

Gates: backend `435 passed, 22 skipped` + ruff + mypy clean; frontend eslint, `tsc --noEmit`,
`981 passed` across 48 files, and the build.

## Follow-ups (not in this diff)

- **Five more `aria-expanded` controls have no `aria-controls`**, outside the two components
  this PR was scoped to: `hv-card-shell`'s full-view and filter toggles, `hv-item-editor`'s
  location / category / "more fields" disclosures, `hv-organize-dialog`'s two location
  pickers, and `hv-location-tree`'s row twisties. `hv-overflow-menu` is the one that is
  already fine. The tree's twisty is the interesting case — its target is generated per node,
  so it needs an id derived from the node id rather than a constant.
- **`.tally-right` was reading `--hv-text-tertiary`**, a fixed grey, which sat oddly on a
  warn-tinted pill. It now inherits the pill's colour at `opacity: 0.65`, matching how the
  desktop chip treats its own count. Small and in the same rule block, so it is in this diff
  rather than deferred — flagging it because it is the one visual change not asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)