### PR TITLE
fix(skill): point the screenshot harness at the dashboard the card lives on

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -128,16 +128,43 @@ Subscriptions (watch events while mutating): `uv run python scripts/ws_subscribe
 From the skill dir (`cd .claude/skills/run-haventory`):
 
 ```bash
-node screenshot.mjs                                          # default dashboard view
+node screenshot.mjs                                          # the card in a dashboard column
 node screenshot.mjs --search sponges --out screenshot-search.png   # type into the card's search box first
 ```
 
 Screenshots land in `.claude/skills/run-haventory/*.png` (gitignored). The script
 prints browser console errors — check them when the card renders blank.
-`--path /lovelace/default_view` is the default view; that dashboard already contains
-`custom:haventory-card`. `--search` exercises the real pipeline
+`--path /dashboard-dev/0` is the default — see "Where the card lives" below.
+`--search` exercises the real pipeline
 (card → WS → repository index → filtered render), so it doubles as a UI smoke:
 searching `sponges` must reduce the list to the one matching item.
+
+#### Where the card lives
+
+Home Assistant's **default** dashboard on the dev instance is the generated one, which
+holds no HAventory card and redirects `/lovelace/<anything>` to `/home/overview`. Every
+card-driving harness therefore defaults to the separate **`dev`** dashboard
+(`url_path: dashboard-dev`, storage mode), which carries two views:
+
+| view | URL | shape | who uses it |
+|---|---|---|---|
+| 0 (no `path`) | `/dashboard-dev/0` | `sections` grid, card in a normal column | `screenshot.mjs`, `visual_pass.mjs` mobile, `import_policies.mjs`, `rl_banner.mjs` |
+| `wide` | `/dashboard-dev/wide` | `type: panel`, card gets the full window width | `visual_pass.mjs` desktop, `drive_import.mjs` |
+
+Both views hold a bare `{type: custom:haventory-card}`. A view without a `path` is
+addressed by **index**, which is why the first one is `/0`.
+
+The two shapes are not interchangeable: the card picks its layout from **its own**
+rendered width, so in a sections column even a 1440px window gets the narrow branch.
+Check what the instance actually has before assuming a path is wrong:
+
+```bash
+uv run python .claude/skills/run-haventory/driver.py send '{"type":"lovelace/dashboards/list"}'
+uv run python .claude/skills/run-haventory/driver.py send '{"type":"lovelace/config","url_path":"dashboard-dev"}'
+```
+
+The sidebar panel at `/haventory` needs none of this — HA routes it from the integration's
+own registration, so it is the one surface that survives any dashboard edit.
 
 #### The sidebar panel
 
@@ -222,7 +249,7 @@ node drive_import.mjs ~/backup.json --policy replace       # preview with replac
 node drive_import.mjs ~/backup.json --apply --out restore  # WRITES; screenshots the result
 ```
 
-Defaults: `--policy merge`, `--out import`, `--path /lovelace/wide`. The document is pasted
+Defaults: `--policy merge`, `--out import`, `--path /dashboard-dev/wide`. The document is pasted
 verbatim and deliberately **not** validated first, so malformed input can be used to drive the
 card's parse-error and server-rejection paths. `--apply` mutates the instance and import is
 all-or-nothing with no undo — export first.
@@ -277,19 +304,28 @@ cd .claude/skills/run-haventory
 node visual_pass.mjs --out before     # then make the change, redeploy
 node visual_pass.mjs --out after      # and compare the two folders
 node visual_pass.mjs --only mobile --surfaces detail-sheet,filter-sheet
-node visual_pass.mjs --only panel     # just the sidebar panel on /haventory
-node visual_pass.mjs --list           # surface names
+node visual_pass.mjs --only panel         # sidebar panel, desktop width
+node visual_pass.mjs --only panel-mobile  # sidebar panel, 375x812
+node visual_pass.mjs --list               # surface names
 ```
 
-Fourteen desktop surfaces, eight mobile ones and ten on the sidebar panel, each a recipe of
-clicks against the card's own `data-testid`s. It is a DOM check as much as a screenshot
-run: a surface counts as captured only if its root element exists afterwards, so a renamed
-testid fails loudly instead of silently photographing the wrong screen. Exit is non-zero if
-any surface failed to open or the browser logged a console error. The narrow layout is a
-different component tree (sheets, not panels), which is why the two card lists differ rather
-than sharing one; the panel pass runs against `haventory-panel` on `/haventory` and needs no
-`wide` dashboard, since HA gives a panel the whole content area. Files are prefixed `d-`,
-`m-` and `p-`.
+Four passes — 14 card surfaces at desktop width, 8 at phone width, and the sidebar panel
+at both (10 wide, 8 narrow) — each a recipe of clicks against the card's own
+`data-testid`s. It is a DOM check as much as a screenshot run: a surface counts as
+captured only if its root element exists afterwards, so a renamed testid fails loudly
+instead of silently photographing the wrong screen. Exit is non-zero if any surface failed
+to open or the browser logged a console error. Files are prefixed `d-`, `m-`, `p-` and
+`pm-`.
+
+The card's narrow layout is a **different component tree** (sheets, not panels), which is
+why the two card lists differ rather than sharing one. The panel's is not: `hv-full-view`
+keeps one tree and switches on its own `(max-width: 700px)` query, so `panel-mobile` re-runs
+the panel recipes at 375px and adds the three assertions that only hold there — the sidebar
+is gone, the filter panel grows a staged apply/cancel footer instead of applying live, and
+the app bar shows the button that reopens HA's drawer. That last one is driven by HA's
+`narrow` property rather than the media query, so the width has to satisfy both switches.
+
+The panel passes need no `wide` dashboard — HA gives a panel the whole content area.
 
 ### Import policy cross-check
 
@@ -380,8 +416,8 @@ clean-start mode), then `Online smoke test completed successfully.`
 
 - **Git Bash rewrites any argument that looks like an absolute POSIX path** (MSYS path
   conversion), so a leading-slash flag value never reaches the script intact:
-  `node screenshot.mjs --path /lovelace/wide` navigates to
-  `http://localhost:8123C:/Program Files/Git/lovelace/wide`, and a `/c/Users/...`
+  `node screenshot.mjs --path /dashboard-dev/wide` navigates to
+  `http://localhost:8123C:/Program Files/Git/dashboard-dev/wide`, and a `/c/Users/...`
   document path arrives as `C:\c\Users\...`. Prefix the command with
   `MSYS_NO_PATHCONV=1`, or pass file paths natively with forward slashes
   (`"C:/Users/you/backup.json"`). Only values starting with `/` are affected, and the

--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -151,8 +151,8 @@ card-driving harness therefore defaults to the separate **`dev`** dashboard
 | 0 (no `path`) | `/dashboard-dev/0` | `sections` grid, card in a normal column | `screenshot.mjs`, `visual_pass.mjs` mobile, `import_policies.mjs`, `rl_banner.mjs` |
 | `wide` | `/dashboard-dev/wide` | `type: panel`, card gets the full window width | `visual_pass.mjs` desktop, `drive_import.mjs` |
 
-Both views hold a bare `{type: custom:haventory-card}`. A view without a `path` is
-addressed by **index**, which is why the first one is `/0`.
+Each view holds one `{type: custom:haventory-card}` and nothing else that matters. A view
+without a `path` is addressed by **index**, which is why the first one is `/0`.
 
 The two shapes are not interchangeable: the card picks its layout from **its own**
 rendered width, so in a sections column even a 1440px window gets the narrow branch.

--- a/.claude/skills/run-haventory/drive_import.mjs
+++ b/.claude/skills/run-haventory/drive_import.mjs
@@ -9,7 +9,7 @@
 //   node drive_import.mjs <document.json> [--policy merge|replace|skip]
 //                         [--apply] [--out <prefix>] [--path <ha-url-path>]
 //
-// Defaults: --policy merge, --out import, --path /lovelace/wide.
+// Defaults: --policy merge, --out import, --path /dashboard-dev/wide.
 //
 // The document is pasted verbatim and is NOT validated here — driving the
 // card's own parse-error and server-rejection paths is a supported use, so
@@ -76,7 +76,7 @@ if (!["merge", "replace", "skip"].includes(policy)) {
 }
 
 const outPrefix = flag("--out", "import");
-const urlPath = flag("--path", "/lovelace/wide");
+const urlPath = flag("--path", "/dashboard-dev/wide");
 const apply = args.includes("--apply");
 const shot = (suffix) => path.resolve(skillDir, `${outPrefix}-${suffix}.png`);
 

--- a/.claude/skills/run-haventory/import_policies.mjs
+++ b/.claude/skills/run-haventory/import_policies.mjs
@@ -58,7 +58,7 @@ if (!token) {
   process.exit(2);
 }
 
-const urlPath = flag("--path", "/lovelace/default_view");
+const urlPath = flag("--path", "/dashboard-dev/0");
 const outPrefix = flag("--out", "policies");
 const sampleSize = Number(flag("--items", "6"));
 const docPath = flag("--doc", null);

--- a/.claude/skills/run-haventory/rl_banner.mjs
+++ b/.claude/skills/run-haventory/rl_banner.mjs
@@ -14,7 +14,7 @@
 //   node rl_banner.mjs --scenario retrying   # refuse the first round, let a retry win
 //   node rl_banner.mjs --scenario exhausted  # refuse every retry, then Refresh
 //   node rl_banner.mjs --observe 30          # watch only; never touches the options flow
-//   node rl_banner.mjs --path /lovelace/wide --out rl
+//   node rl_banner.mjs --path /dashboard-dev/wide --out rl
 //
 // Scenarios (both drive the options flow over REST, exactly as the integration's
 // own config flow does, and always reset rate limiting to OFF on the way out):
@@ -63,7 +63,7 @@ const flag = (name, dflt) => {
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
 };
 
-const urlPath = flag("--path", "/lovelace/default_view");
+const urlPath = flag("--path", "/dashboard-dev/0");
 const outPrefix = flag("--out", "rl");
 const observeSecs = args.includes("--observe") ? Number(flag("--observe", "30")) : null;
 const scenarioArg = flag("--scenario", null);

--- a/.claude/skills/run-haventory/screenshot.mjs
+++ b/.claude/skills/run-haventory/screenshot.mjs
@@ -12,7 +12,7 @@
 //                       [--search <text>] [--tap <selector>]
 //                       [--swipe <dir>[@<selector>]] [--wait <ms>]
 //
-// Defaults: --out screenshot.png, --path /lovelace/default_view, desktop 1280x900.
+// Defaults: --out screenshot.png, --path /dashboard-dev/0, desktop 1280x900.
 //
 // --element names the root the run waits for and scopes --search/--swipe to. The
 // dashboard card is the default; the sidebar panel at /haventory renders
@@ -78,7 +78,11 @@ const flag = (name, dflt) => {
 const has = (name) => args.includes(name);
 
 const outFile = path.resolve(skillDir, flag("--out", "screenshot.png"));
-const urlPath = flag("--path", "/lovelace/default_view");
+// The default dashboard is HA's generated one and carries no HAventory card, so
+// the card lives on a `dev` dashboard: view 0 is a sections grid, which is the
+// narrow column a card normally sits in. Views without a `path` are addressed by
+// index. See SKILL.md for the dashboard the dev instance is expected to have.
+const urlPath = flag("--path", "/dashboard-dev/0");
 const rootElement = flag("--element", "haventory-card");
 const fullPage = has("--full");
 const haDark = has("--dark");

--- a/.claude/skills/run-haventory/visual_pass.mjs
+++ b/.claude/skills/run-haventory/visual_pass.mjs
@@ -1,5 +1,5 @@
-// Walk HAventory's surfaces — the card at desktop and mobile widths, and the
-// sidebar panel — screenshotting each and reporting whether it actually opened.
+// Walk HAventory's surfaces — the card and the sidebar panel, each at a desktop
+// and a phone width — screenshotting each and reporting whether it actually opened.
 //
 // A single screenshot proves one view renders; this proves the set of them do,
 // which is what a UI change needs before and after. Each surface is a named
@@ -11,9 +11,9 @@
 // exits non-zero if any surface, at any width, failed to open.
 //
 // Usage (from the skill dir, .claude/skills/run-haventory/):
-//   node visual_pass.mjs                       # desktop + mobile + panel into ./visual/
+//   node visual_pass.mjs                       # every pass into ./visual/
 //   node visual_pass.mjs --out before          # ./before/  (then --out after to compare)
-//   node visual_pass.mjs --only desktop        # or --only mobile, --only panel
+//   node visual_pass.mjs --only desktop        # or mobile, panel, panel-mobile
 //   node visual_pass.mjs --surfaces list,search,full-view
 //   node visual_pass.mjs --dark                # HA dark theme + dark OS scheme
 //   node visual_pass.mjs --list                # print the surface names and exit
@@ -41,8 +41,10 @@ const flag = (name, dflt) => {
 // --- surface recipes ------------------------------------------------------
 // `open` is a list of steps run in order against the pass's root element:
 //   ["click", <sel>]  ["hover", <sel>]  ["fill", <sel>, <text>]  ["key", <key>]  ["wait", <ms>]
-// `expect` is the selector that must be visible once the recipe has run.
-// Selectors pierce shadow DOM, so nested components address directly.
+// `expect` is the selector — or list of selectors — that must be visible once the
+// recipe has run; `hidden` is the optional counterpart, for a layout whose point
+// is that something is gone. Selectors pierce shadow DOM, so nested components
+// address directly.
 //
 // Every recipe starts from a freshly loaded page. Chaining them instead would be
 // faster, but a modal left standing puts a scrim over everything that follows
@@ -51,8 +53,8 @@ const flag = (name, dflt) => {
 // the full view rather than assuming the previous surface left it up.
 //
 // Surfaces are named after what a reader would call the screen, and prefixed
-// d-/m-/p- in the file name so the desktop, mobile and panel captures of the
-// same surface sort next to each other.
+// d-/m-/p-/pm- in the file name so the desktop, mobile and the two panel
+// captures of the same surface sort next to each other.
 //
 // The card chooses its layout from ITS OWN width, not the viewport's, so the
 // desktop pass runs on the `wide` dashboard view: in a normal dashboard column
@@ -313,10 +315,75 @@ const PANEL_SURFACES = [
   },
 ];
 
+// The panel on a phone. Unlike the card, whose narrow layout is a different
+// component tree, `hv-full-view` keeps one tree and switches on a media query at
+// 700px — so these are the panel recipes again, at a width where that branch is
+// live, plus the three assertions that only hold there: the sidebar is gone, the
+// filter panel grows a staged apply/cancel footer, and the app bar trades the
+// close button for the button that reopens Home Assistant's own drawer (which a
+// panel must offer itself once HA has collapsed it).
+const PANEL_MOBILE_SURFACES = [
+  {
+    id: "01-page",
+    open: [],
+    expect: [`${PANEL} [data-testid="full-table"]`, `${PANEL} [data-testid="panel-menu"]`],
+    hidden: `${PANEL} [data-testid="full-sidebar"]`,
+  },
+  {
+    id: "02-filters",
+    open: [["click", `${PANEL} [data-testid="full-filters-toggle"]`], ["wait", 500]],
+    // The footer is the narrow branch's own: the wide panel applies each change
+    // as it is made, this one stages them behind Apply.
+    expect: [`${PANEL} [data-testid="full-filter-panel"]`, `${PANEL} [data-testid="full-panel-foot"]`],
+  },
+  {
+    id: "03-search",
+    open: [
+      ["fill", `${PANEL} [data-testid="full-search"]`, "box"],
+      ["wait", 1500],
+    ],
+    expect: `${PANEL} [data-testid="full-table"]`,
+  },
+  {
+    id: "04-add-editor",
+    open: [["click", `${PANEL} [data-testid="full-add-item"]`], ["wait", 600]],
+    expect: `${PANEL} [data-testid="item-editor"]`,
+  },
+  {
+    id: "05-row-editor",
+    open: [
+      ["hover", `${PANEL} [data-testid="table-row"]`],
+      ["click", `${PANEL} [data-testid="table-edit"]`],
+      ["wait", 600],
+    ],
+    expect: `${PANEL} [data-testid="item-editor"]`,
+  },
+  {
+    id: "06-overflow",
+    open: [["click", PANEL_OVERFLOW]],
+    expect: `${PANEL} [data-testid="overflow-menu"]`,
+  },
+  {
+    id: "07-organize",
+    open: [
+      ["click", PANEL_OVERFLOW],
+      ["click", panelMenu("organize")],
+      ["wait", 800],
+    ],
+    expect: `${PANEL} [data-testid="organize-dialog"]`,
+  },
+  {
+    id: "08-columns",
+    open: [["click", `${PANEL} [data-testid="columns-expanded"]`], ["wait", 600]],
+    expect: `${PANEL} [data-testid="column-options"]`,
+  },
+];
+
 if (args.includes("--list")) {
-  console.log("desktop:", DESKTOP_SURFACES.map((s) => s.id).join(", "));
-  console.log("mobile: ", MOBILE_SURFACES.map((s) => s.id).join(", "));
-  console.log("panel:  ", PANEL_SURFACES.map((s) => s.id).join(", "));
+  console.log("desktop:     ", DESKTOP_SURFACES.map((s) => s.id).join(", "));
+  console.log("mobile:      ", MOBILE_SURFACES.map((s) => s.id).join(", "));
+  console.log("panel:       ", PANEL_SURFACES.map((s) => s.id).join(", "));
+  console.log("panel-mobile:", PANEL_MOBILE_SURFACES.map((s) => s.id).join(", "));
   process.exit(0);
 }
 
@@ -345,13 +412,21 @@ const only = flag("--only", null);
 const wanted = flag("--surfaces", null)?.split(",").map((s) => s.trim());
 mkdirSync(outDir, { recursive: true });
 
+// Home Assistant's default dashboard is the generated one and holds no HAventory
+// card, so both card passes run on the `dev` dashboard: its `wide` view is
+// panel-mode (the card gets the window's full width), and view 0 is a sections
+// grid (the narrow column a card normally sits in). Views without a `path` are
+// addressed by index. SKILL.md documents the dashboard the dev instance needs.
+const WIDE_VIEW = "/dashboard-dev/wide";
+const COLUMN_VIEW = "/dashboard-dev/0";
+
 const PASSES = [
   {
     key: "desktop",
     prefix: "d",
     root: CARD,
     surfaces: DESKTOP_SURFACES,
-    urlPath: "/lovelace/wide",
+    urlPath: WIDE_VIEW,
     contextOptions: { viewport: { width: 1440, height: 900 } },
   },
   {
@@ -359,7 +434,7 @@ const PASSES = [
     prefix: "m",
     root: CARD,
     surfaces: MOBILE_SURFACES,
-    urlPath: "/lovelace/default_view",
+    urlPath: COLUMN_VIEW,
     contextOptions: { ...devices["iPhone 15"], deviceScaleFactor: 2 },
   },
   {
@@ -371,6 +446,22 @@ const PASSES = [
     surfaces: PANEL_SURFACES,
     urlPath: "/haventory",
     contextOptions: { viewport: { width: 1440, height: 900 } },
+  },
+  {
+    // 375px is below `hv-full-view`'s own 700px breakpoint AND narrow enough for
+    // Home Assistant to collapse its sidebar, which is what sets the panel's
+    // `narrow` property — the two independent switches this pass exists to cover.
+    key: "panel-mobile",
+    prefix: "pm",
+    root: PANEL,
+    surfaces: PANEL_MOBILE_SURFACES,
+    urlPath: "/haventory",
+    contextOptions: {
+      viewport: { width: 375, height: 812 },
+      hasTouch: true,
+      isMobile: true,
+      deviceScaleFactor: 2,
+    },
   },
 ].filter((p) => !only || p.key === only);
 
@@ -454,7 +545,12 @@ for (const pass of PASSES) {
     try {
       await loadRoot();
       for (const s of surface.open) await step(s);
-      await page.waitForSelector(surface.expect, { timeout: 10000 });
+      for (const sel of [surface.expect].flat()) {
+        await page.waitForSelector(sel, { timeout: 10000 });
+      }
+      // A layout defined by what it drops needs the absence asserted too, or the
+      // recipe passes on the branch it was written to rule out.
+      if (surface.hidden) await page.waitForSelector(surface.hidden, { state: "hidden", timeout: 10000 });
       await page.waitForTimeout(500); // let transitions settle before the capture
       await page.screenshot({ path: file });
       console.log(`  PASS  ${name}`);


### PR DESCRIPTION
Two follow-ups from #170 and #172, both in the `run-haventory` screenshot harness.

## 1. The card-driving harnesses pointed at a dashboard that no longer resolves

Confirmed against the running dev container before changing anything:

```
$ driver.py send '{"type":"lovelace/dashboards/list"}'
  -> map, dashboard-dev            # no `lovelace` entry: the default dashboard is generated
$ driver.py send '{"type":"lovelace/config"}'
  -> {"code": "config_not_found", "message": "No config found."}
$ driver.py send '{"type":"lovelace/config","url_path":"dashboard-dev"}'
  -> view[0] path=None  type=sections  cards=[custom:haventory-card]
     view[1] path='wide' type=panel     cards=[custom:haventory-card]
```

The default dashboard has no stored config, so HA serves its generated one. Confirmed in a
browser what that means for the two old defaults:

```
/lovelace/default_view -> http://localhost:8123/home/overview   haventory-card in DOM: 0   custom element defined: true
/lovelace/wide         -> http://localhost:8123/home/overview   haventory-card in DOM: 0   custom element defined: true
```

Both redirect to the generated overview, which has no HAventory card — while the custom
element is registered perfectly well. The harness then died waiting 30 s for
`haventory-card`, which reads as a card that failed to register rather than a path that
stopped resolving.

The `dev` dashboard already carries exactly the two layouts the harness needs, so the
defaults were repointed onto it:

| harness | was | now |
|---|---|---|
| `screenshot.mjs` | `/lovelace/default_view` | `/dashboard-dev/0` |
| `visual_pass.mjs` desktop | `/lovelace/wide` | `/dashboard-dev/wide` |
| `visual_pass.mjs` mobile | `/lovelace/default_view` | `/dashboard-dev/0` |
| `drive_import.mjs` | `/lovelace/wide` | `/dashboard-dev/wide` |
| `import_policies.mjs` | `/lovelace/default_view` | `/dashboard-dev/0` |
| `rl_banner.mjs` | `/lovelace/default_view` | `/dashboard-dev/0` |

**Beyond the reported scope:** the issue named `screenshot.mjs` and `visual_pass.mjs`, but
`drive_import.mjs`, `import_policies.mjs` and `rl_banner.mjs` carried the same dead default
and were dead for the same reason. Fixing two of five would have left "the harness works out
of the box" false. All three are verified below.

SKILL.md gains a **"Where the card lives"** section: which dashboard, which view is which
shape, why the two are not interchangeable (the card picks its layout from its own rendered
width, so a sections column gets the narrow branch even in a 1440px window), and the two WS
commands that show what an instance actually has.

### Why repoint rather than repair the instance

Repairing means taking over HA's **default** dashboard, converting it from the generated
strategy dashboard to storage mode. That is the more intrusive change: it replaces what the
instance owner sees at `/lovelace` and in the sidebar, and it is only undone by deleting the
stored config. It also does not remove the coupling — the harness would still depend on a
hand-provisioned dashboard, just a different one. The `dev` dashboard is deliberate, already
has both layouts, and is the one the last two sessions actually used.

If you prefer the repair anyway, one WS call does it — after which the old defaults work and
this PR's path changes should be reverted:

```bash
uv run python .claude/skills/run-haventory/driver.py send '{"type":"lovelace/config/save","config":{"views":[
  {"title":"Home","path":"default_view","cards":[{"type":"custom:haventory-card"}]},
  {"title":"wide","path":"wide","type":"panel","cards":[{"type":"custom:haventory-card"}]}]}}'
```

Caveat: saving a config to the default dashboard takes it out of auto-generated mode
permanently — every auto-populated entity card disappears until you
`lovelace/config/delete` it again.

## 2. Phone-width panel pass

`visual_pass.mjs` gains a fourth pass, `panel-mobile` (375x812, touch on, captured as
`pm-*`), so `hv-full-view`'s narrow branch is exercised under the panel host.

The panel's narrow layout is **not** a separate component tree the way the card's is —
`hv-full-view` keeps one tree and switches on its own `(max-width: 700px)` query — so the
pass re-runs the panel recipes at a width that satisfies both that query and HA's own
`narrow` flag (which is what puts `panel-menu` in the app bar), and asserts the three things
that only hold there:

- the sidebar is gone (`full-sidebar` hidden),
- the filter panel stages behind an Apply footer (`full-panel-foot`) instead of applying live,
- the app bar carries the button that reopens HA's drawer (`panel-menu`), since a panel owns
  the whole content area and nothing else on screen can bring the sidebar back.

Verified as real discriminators, not vacuous assertions: at 1440px (`p-02-filters`) the
sidebar is visible and there is no footer; at 375px (`pm-01`, `pm-02`) neither holds.

Two small additions to the recipe format make that possible: `expect` now accepts a list of
selectors that must all be visible, and an optional `hidden` names one that must not be — a
layout defined by what it drops needs the absence asserted too, or the recipe passes on the
very branch it was written to rule out.

## Verification

All live against the dev container, **no `--path` passed to anything**.

`node visual_pass.mjs --only <pass>`:

| pass | surfaces |
|---|---|
| `desktop` | 14/14 |
| `mobile` | 8/8 |
| `panel` | 10/10 |
| `panel-mobile` | 8/8 (new) |

`node visual_pass.mjs` (all four passes in one run): **40/40 surfaces**, exit 0.

The other three repointed harnesses, also on their defaults:

- `node rl_banner.mjs --observe 8` — reaches the card, traces WS frames, exit 0
- `node import_policies.mjs` — `merge PASS · replace PASS · skip PASS`, exit 0
- `node drive_import.mjs <doc>` — pastes, previews, reads back the sheet's counts, exit 0

## Gates

Backend: `435 passed, 22 skipped` · `ruff check` clean · `ruff format --check` clean
(103 files) · `mypy` clean (14 source files).

Frontend: `npm audit` 0 vulnerabilities · `eslint` clean · `tsc --noEmit` clean ·
`vitest` `48 files / 976 tests passed` · `npm run build` 444.33 kB (gzip 100.79 kB).

## Follow-ups

- **The dashboard name is still hard-coded**, so this breaks again the day someone renames
  the `dev` dashboard — the same failure mode, one identifier along. The durable fix is for
  the harness to *discover* the card: walk `lovelace/dashboards/list` → `lovelace/config`,
  find the views containing `custom:haventory-card`, and prefer a `type: panel` view for the
  desktop pass and a column view for the narrow one, falling back to the current constants.
  That is a bigger change than this fix and worth doing on its own.
- `visual_pass.mjs --path` still forces **one** path across every pass, which no longer
  matches a run with four passes on three different URLs. It is only useful for pinning a
  single dashboard layout; a per-pass override would be more honest.

Not added to `docs/open-items.md` per the request — these are pre-v0.2.0 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
