### PR TITLE
fix(api): refuse while no config entry is loaded, and let the card recover

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ until it restarts, so a dashboard still open in another tab can go on talking to
 after you remove it. It is refused rather than served: every command comes back as an
 error, and nothing more is written to your inventory. Reload that tab and the card is gone.
 
+The same holds while the integration is **disabled**, and briefly while it **reloads** — an
+entry that owns nothing serves nothing. A card left open is told its live updates stopped
+and re-opens them by itself once setup finishes, so a reload costs it a few seconds of a
+"Live updates paused" banner and no refresh. Disable it for longer and the card stops
+waiting and offers Refresh instead.
+
 **Your inventory is deliberately kept.** Items and locations live in the Home Assistant
 store file `<config>/.storage/haventory_store`, which removal does not touch: adding the
 integration again restores everything, which is what you want when you remove it to

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1399,6 +1399,21 @@ describe('hv-card-shell: degraded states', () => {
     expect(banner(sr, 'degraded-live-updates')).toBe(null);
   });
 
+  it('blames the backend, not a limiter, when HAventory itself went away', async () => {
+    // The two pauses look identical to the subscription machinery and nothing
+    // alike to the person reading the banner: one means events may be dropped,
+    // the other that there is no backend to send them.
+    const { el, store, hass, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
+    hass.__failSubscribe({ code: 'storage_error', message: 'repository not initialized' });
+    hass.__emit('items', 'unavailable', {});
+    for (let i = 0; i < 20; i++) await settle(el);
+
+    expect(store.state.value.degraded.liveUpdates).toBe('paused');
+    const paused = banner(sr, 'degraded-live-updates');
+    expect(paused?.shadowRoot?.textContent).toContain('HAventory is not available');
+    expect(paused?.shadowRoot?.textContent).not.toContain('rate limited');
+  });
+
   it('announces a wholesale reload after an import', async () => {
     const { el, hass, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
     const seen: boolean[] = [];

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -767,13 +767,17 @@ export class HVCardShell extends LitElement {
       // Ranked above the generic rate-limit warning below: that one says events
       // *may* have been dropped, this one says there are no events at all.
       const retrying = degraded.liveUpdates === 'retrying';
+      const cause =
+        degraded.liveUpdatesReason === 'unavailable'
+          ? 'HAventory is not available'
+          : 'rate limited';
       banners.push(html`<hv-banner
         kind="warning"
         glyph="clock"
         heading="Live updates paused"
         message=${retrying
-          ? ' · rate limited. Retrying automatically; this list may be out of date until then.'
-          : ' · rate limited. This list may be out of date until you refresh.'}
+          ? ` · ${cause}. Retrying automatically; this list may be out of date until then.`
+          : ` · ${cause}. This list may be out of date until you refresh.`}
         data-testid="degraded-live-updates"
       >
         ${retrying

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
@@ -28,6 +28,7 @@ const NO_DEGRADATION: DegradedState = {
   nextRetryAt: null,
   reloading: false,
   liveUpdates: 'live',
+  liveUpdatesReason: null,
   nextLiveRetryAt: null,
 };
 

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -537,6 +537,131 @@ describe('Store: rate limiting and degraded state', () => {
   });
 });
 
+describe('Store: the backend going away and coming back', () => {
+  const UNAVAILABLE = { code: 'storage_error', message: 'repository not initialized; run integration setup' };
+
+  /** What a config-entry teardown puts on every open subscription. */
+  function tearDown(hass: ReturnType<typeof makeMockHass>) {
+    hass.__emit('items', 'unavailable', {});
+    hass.__emit('locations', 'unavailable', {});
+    hass.__emit('stats', 'unavailable', {});
+  }
+
+  it('re-opens the subscriptions a reload took away', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+    const store = new Store(hass, fast);
+    await store.init();
+    expect(hass.__subscribeCalls).toHaveLength(3);
+
+    tearDown(hass);
+    await flush(3);
+
+    // One more round, and live updates are back without the user touching
+    // anything — a reload must not cost a manual refresh.
+    expect(hass.__subscribeCalls).toHaveLength(6);
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+    expect(store.state.value.degraded.liveUpdatesReason).toBeNull();
+    expect(store.state.value.connected.items).toBe(true);
+    expect(store.state.value.errorQueue).toEqual([]);
+    hass.__emit('items', 'created', { item: makeItem({ id: '9' }) });
+    expect(store.state.value.items.map((i) => i.id)).toContain('9');
+  });
+
+  it('waits out the window in which the backend is still refusing', async () => {
+    const hass = makeMockHass({ items: [] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    // Setup has not finished, so the first two re-subscribe rounds are refused
+    // exactly the way a command is during a reload.
+    hass.__failSubscribeNext(6, UNAVAILABLE);
+    tearDown(hass);
+    await settleSubscribes();
+    expect(store.state.value.degraded.liveUpdates).toBe('retrying');
+    expect(store.state.value.degraded.liveUpdatesReason).toBe('unavailable');
+    // Not rate limiting — the banner must not blame a limiter that is off.
+    expect(store.state.value.degraded.rateLimited).toBe(false);
+
+    await flush(6);
+
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+    expect(store.state.value.degraded.liveUpdatesReason).toBeNull();
+    // Nothing reached the user: waiting out a reload is not an error.
+    expect(store.state.value.errorQueue).toEqual([]);
+  });
+
+  it('re-reads the inventory once the backend answers again', async () => {
+    // A backend that went away and came back re-read its store, and every event
+    // in between went to a subscription that no longer existed.
+    const hass = makeMockHass({ items: [makeItem({ id: '1', name: 'Before' })] });
+    const store = new Store(hass, fast);
+    await store.init();
+    expect(store.state.value.items.map((i) => i.name)).toEqual(['Before']);
+
+    hass.__setItems([makeItem({ id: '2', name: 'After' })]);
+    tearDown(hass);
+    await flush(4);
+
+    expect(store.state.value.items.map((i) => i.name)).toEqual(['After']);
+  });
+
+  it('gives up once the budget is spent, and says what stopped', async () => {
+    const hass = makeMockHass({ items: [] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    // Disabled or removed rather than reloading: nothing is coming back.
+    hass.__failSubscribe(UNAVAILABLE);
+    tearDown(hass);
+    await flush(20);
+
+    expect(store.state.value.degraded.liveUpdates).toBe('paused');
+    expect(store.state.value.degraded.liveUpdatesReason).toBe('unavailable');
+    expect(store.state.value.degraded.nextLiveRetryAt).toBeNull();
+    expect(store.state.value.connected.items).toBe(false);
+    // Reported once, when retrying is over — not on every attempt.
+    expect(store.state.value.errorQueue.map((e) => e.code)).toEqual(['storage_error']);
+    // The first round from init plus a bounded seven, three topics each.
+    expect(hass.__subscribeCalls).toHaveLength(24);
+
+    // The budget stays spent until something restarts it.
+    await flush(6);
+    expect(hass.__subscribeCalls).toHaveLength(24);
+  });
+
+  it('treats one teardown as one outage, however many topics report it', async () => {
+    const hass = makeMockHass({ items: [] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    // All three topics carry the same signal; three re-subscribe rounds for one
+    // reload would triple the load on a backend that is still starting up.
+    tearDown(hass);
+    await flush(3);
+
+    expect(hass.__subscribeCalls).toHaveLength(6);
+  });
+
+  it('starts a fresh budget for a second teardown', async () => {
+    const hass = makeMockHass({ items: [] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    tearDown(hass);
+    await flush(3);
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+
+    // A dashboard open for days sees more than one reload; the second must not
+    // inherit an exhausted budget from the first.
+    hass.__failSubscribeNext(3, UNAVAILABLE);
+    tearDown(hass);
+    await flush(4);
+
+    expect(store.state.value.degraded.liveUpdates).toBe('live');
+    expect(store.state.value.errorQueue).toEqual([]);
+  });
+});
+
 describe('subscribeRetryDelayMs', () => {
   it('prefers the envelope hint over the backoff, in either unit', () => {
     expect(subscribeRetryDelayMs({ code: 'rate_limited', data: { retry_after_ms: 250 } }, 0, 400)).toBe(250);

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -18,6 +18,7 @@ import type {
   ItemFilter,
   ItemUpdate,
   ListItemsResult,
+  LiveUpdatePause,
   Location,
   LocationTreeNode,
   StatsCounts,
@@ -66,6 +67,17 @@ const RATE_LIMIT_ATTEMPTS = 4;
 const SUBSCRIBE_RETRY_ATTEMPTS = 4;
 
 /**
+ * Re-subscribes allowed while the backend reports itself unavailable.
+ *
+ * Larger than the rate-limited budget because it is spent on a different bet: a
+ * config-entry reload refuses for as long as setup takes, and giving up inside
+ * that window would leave a card that only ever needed to wait stuck asking for
+ * a manual refresh. Still bounded — a disabled or removed integration is not
+ * coming back on its own, and the banner has to stop promising otherwise.
+ */
+const SUBSCRIBE_UNAVAILABLE_ATTEMPTS = 7;
+
+/**
  * Ceiling on a single re-subscribe wait. Also clamps a server-sent retry-after
  * hint, so a wrong or hostile value cannot park live updates indefinitely.
  */
@@ -74,6 +86,9 @@ const SUBSCRIBE_RETRY_MAX_MS = 30_000;
 /** Topics `subscribeTopics` opens as one round: items, stats, locations. */
 const SUBSCRIBE_TOPIC_COUNT = 3;
 
+/** Event action the backend sends every open subscription as its entry tears down. */
+const BACKEND_UNAVAILABLE_ACTION = 'unavailable';
+
 const NO_DEGRADATION: DegradedState = {
   rateLimited: false,
   connectionLost: false,
@@ -81,6 +96,7 @@ const NO_DEGRADATION: DegradedState = {
   nextRetryAt: null,
   reloading: false,
   liveUpdates: 'live',
+  liveUpdatesReason: null,
   nextLiveRetryAt: null,
 };
 
@@ -353,25 +369,49 @@ export class Store {
     this.subscribeRefusal = null;
     const onOpen = () => this.onSubscribeSettled(round, null);
     const onError = (err: unknown) => this.onSubscribeSettled(round, { err });
+    // The backend's teardown signal arrives on whichever topics are open, and
+    // says the same thing on each — handle it once, ahead of the topic handlers,
+    // which only know how to fold an inventory payload into the view.
+    const onEvent = (handle: (evt: AnyEventPayload) => void) => (evt: AnyEventPayload) => {
+      if (evt.action === BACKEND_UNAVAILABLE_ACTION) this.onBackendUnavailable();
+      else handle(evt);
+    };
 
     if (this.itemsUnsub) this.itemsUnsub();
-    this.itemsUnsub = this.ws.subscribe('items', (evt: AnyEventPayload) => this.onItemsEvent(evt), {
+    this.itemsUnsub = this.ws.subscribe('items', onEvent((evt) => this.onItemsEvent(evt)), {
       location_id: this.state.value.filters.locationId ?? undefined,
       include_subtree: true, // Always include sublocations
       onError,
       onOpen,
     });
     if (this.statsUnsub) this.statsUnsub();
-    this.statsUnsub = this.ws.subscribe('stats', (evt: AnyEventPayload) => this.onStatsEvent(evt), {
+    this.statsUnsub = this.ws.subscribe('stats', onEvent((evt) => this.onStatsEvent(evt)), {
       onError,
       onOpen,
     });
     if (this.locationsUnsub) this.locationsUnsub();
     this.locationsUnsub = this.ws.subscribe(
       'locations',
-      (evt: AnyEventPayload) => this.onLocationsEvent(evt),
+      onEvent((evt) => this.onLocationsEvent(evt)),
       { onError, onOpen },
     );
+  }
+
+  /**
+   * The config entry serving these subscriptions is tearing down.
+   *
+   * A reload is the common case and it ends by itself, so the card waits it out
+   * on the same backoff a refused subscribe uses rather than reporting an error
+   * for something that will be over in a moment. The first attempt is scheduled
+   * rather than immediate: the backend is mid-teardown and would certainly
+   * refuse. Disabled and removed look identical from here, and end as the
+   * budget running out.
+   */
+  private onBackendUnavailable() {
+    if (this.state.value.degraded.liveUpdatesReason === 'unavailable') return;
+    this.stateObs.set({ connected: { items: false, stats: false } });
+    this.subscribeAttempt = 0;
+    this.scheduleReopen('unavailable', null);
   }
 
   /** Fold one subscribe outcome into its round, and act once the round is complete. */
@@ -383,9 +423,14 @@ export class Store {
 
     const refused = this.subscribeRefusal;
     if (!refused) {
+      const wasUnavailable = this.state.value.degraded.liveUpdatesReason === 'unavailable';
       this.subscribeAttempt = 0;
       this.stateObs.set({ connected: { items: true, stats: true } });
-      this.setDegraded({ liveUpdates: 'live', nextLiveRetryAt: null });
+      this.setDegraded({ liveUpdates: 'live', liveUpdatesReason: null, nextLiveRetryAt: null });
+      // A backend that went away and came back was reading its store afresh, and
+      // every event in between was addressed to subscriptions that no longer
+      // existed. Nothing on screen is trustworthy until it has been re-read.
+      if (wasUnavailable) void this.reloadAll().catch(() => undefined);
       return;
     }
     this.onSubscribeRefused(refused.err);
@@ -395,30 +440,57 @@ export class Store {
    * A refused subscribe means live updates are gone, silently — no event will
    * ever arrive to hint at it.
    *
-   * `rate_limited` is the expected refusal and the contract's guidance is to
-   * retry later, so the card backs off and says it is retrying instead of
-   * dropping an error on a user who has done nothing wrong. Once the budget is
-   * spent it stops, reports the refusal and leaves the manual refresh as the way
-   * back. Any other refusal is an outage and is reported at once.
+   * Two refusals are worth waiting out. `rate_limited` is the expected one and
+   * the contract's guidance is to retry later; `storage_error` is what a backend
+   * with no config entry answers, which a reload clears on its own. Either way
+   * the card backs off and says it is retrying instead of dropping an error on a
+   * user who has done nothing wrong. Once the budget is spent it stops, reports
+   * the refusal and leaves the manual refresh as the way back. Any other refusal
+   * is an outage and is reported at once.
    */
   private onSubscribeRefused(err: unknown) {
     this.stateObs.set({ connected: { items: false, stats: false } });
 
-    if (errorCode(err) !== 'rate_limited') {
-      this.setDegraded({ connectionLost: true, liveUpdates: 'paused', nextLiveRetryAt: null });
+    const code = errorCode(err);
+    const reason: LiveUpdatePause | null =
+      code === 'rate_limited' ? 'rate_limited' : code === 'storage_error' ? 'unavailable' : null;
+    if (reason === null) {
+      this.setDegraded({
+        connectionLost: true,
+        liveUpdates: 'paused',
+        liveUpdatesReason: null,
+        nextLiveRetryAt: null,
+      });
       this.pushError(err);
       return;
     }
 
-    if (this.subscribeAttempt >= SUBSCRIBE_RETRY_ATTEMPTS) {
-      this.setDegraded({ rateLimited: true, liveUpdates: 'paused', nextLiveRetryAt: null });
+    // Sticky, and set here rather than alongside the pause: it says events may
+    // have been dropped, which stays true for the rest of the session however
+    // the subscriptions end up.
+    if (reason === 'rate_limited') this.setDegraded({ rateLimited: true });
+
+    const budget =
+      reason === 'unavailable' ? SUBSCRIBE_UNAVAILABLE_ATTEMPTS : SUBSCRIBE_RETRY_ATTEMPTS;
+    if (this.subscribeAttempt >= budget) {
+      this.setDegraded({ liveUpdates: 'paused', liveUpdatesReason: reason, nextLiveRetryAt: null });
       this.pushError(err);
       return;
     }
 
+    this.scheduleReopen(reason, err);
+  }
+
+  /** Book the next re-subscribe and say so, so the banner can show the wait. */
+  private scheduleReopen(reason: LiveUpdatePause, err: unknown) {
     const delay = subscribeRetryDelayMs(err, this.subscribeAttempt, this.retryBaseMs);
     this.subscribeAttempt += 1;
-    this.setDegraded({ rateLimited: true, liveUpdates: 'retrying', nextLiveRetryAt: Date.now() + delay });
+    this.setDegraded({
+      liveUpdates: 'retrying',
+      liveUpdatesReason: reason,
+      nextLiveRetryAt: Date.now() + delay,
+    });
+    this.cancelSubscribeRetry();
     this.subscribeRetryHandle = setTimeout(() => {
       this.subscribeRetryHandle = null;
       this.openSubscriptions(false);
@@ -826,6 +898,7 @@ export class Store {
       cur.nextRetryAt === next.nextRetryAt &&
       cur.reloading === next.reloading &&
       cur.liveUpdates === next.liveUpdates &&
+      cur.liveUpdatesReason === next.liveUpdatesReason &&
       cur.nextLiveRetryAt === next.nextLiveRetryAt;
     if (same) return;
     this.stateObs.set({ degraded: next });

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -335,6 +335,14 @@ export interface BaseEventPayload {
   ts: string;
 }
 
+/**
+ * Sent on every open subscription, whatever its topic, when the config entry
+ * serving it tears down — an unload, a disable, a removal, or the first half of
+ * a reload. Carries no payload: it says the subscription has stopped, not that
+ * anything in the inventory changed.
+ */
+export type TeardownAction = 'unavailable';
+
 export interface ItemsEventPayload extends BaseEventPayload {
   topic: 'items';
   // `item` is present for per-item actions; absent for the wholesale `reloaded`
@@ -348,18 +356,19 @@ export interface ItemsEventPayload extends BaseEventPayload {
   | 'checked_out'
   | 'checked_in'
   | 'quantity_changed'
-  | 'reloaded';
+  | 'reloaded'
+  | TeardownAction;
 }
 
 export interface LocationsEventPayload extends BaseEventPayload {
   topic: 'locations';
   location?: Location;
-  action: 'created' | 'renamed' | 'moved' | 'deleted' | 'reloaded';
+  action: 'created' | 'renamed' | 'moved' | 'deleted' | 'reloaded' | TeardownAction;
 }
 
 export interface StatsEventPayload extends BaseEventPayload {
   topic: 'stats';
-  action: 'counts';
+  action: 'counts' | TeardownAction;
   counts: StatsCounts;
 }
 
@@ -433,6 +442,8 @@ export interface DegradedState {
   reloading: boolean;
   /** Whether the topic subscriptions are up, being re-opened, or given up on. */
   liveUpdates: LiveUpdateState;
+  /** Why live updates are not `live`; null while they are. */
+  liveUpdatesReason: LiveUpdatePause | null;
   /** Epoch ms of the next automatic re-subscribe, when one is scheduled. */
   nextLiveRetryAt: number | null;
 }
@@ -445,6 +456,17 @@ export interface DegradedState {
  * brings live updates back.
  */
 export type LiveUpdateState = 'live' | 'retrying' | 'paused';
+
+/**
+ * What stopped live updates — the two cases read the same to the subscription
+ * machinery and completely differently to the person reading the banner.
+ *
+ * `rate_limited`: the limiter refused the subscribe; the backend is there and
+ * the data on screen is current as of the last event.
+ * `unavailable`: no config entry owns the data — HAventory is reloading, or has
+ * been disabled or removed — so every command is being refused too.
+ */
+export type LiveUpdatePause = 'rate_limited' | 'unavailable';
 
 export interface StoreState {
   items: Item[];

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -244,37 +244,15 @@ async def _async_flush_pending_writes(hass: HomeAssistant, *, op: str) -> None:
         )
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry.
+def _cleanup_ws_test_stub_registry(hass: HomeAssistant) -> None:
+    """Take our handlers back out of the offline stub's command registry.
 
-    Clears idempotent registration flags and ephemeral data such as WS
-    subscriptions. If the test websocket stub is present, remove our
-    registered handlers from its registry.
+    Real Home Assistant has no API for this, which is why teardown drops the
+    runtime instead; the stub does, and leaving handlers in its list would carry
+    them into the next test.
     """
 
     bucket = hass.data.get(DOMAIN) or {}
-
-    await _async_flush_pending_writes(hass, op="unload")
-
-    # Hand back the frontend module URL; setup re-adds it on the next load. The
-    # static route stays, along with the flag that records it: aiohttp cannot
-    # unregister a route, and a reload must not try to add it twice.
-    _remove_extra_js_url(hass)
-
-    # A sidebar entry outliving the backend it opens is a link to a page that
-    # cannot load; setup registers it again.
-    _remove_sidebar_panel(hass)
-
-    # Clear registration flags
-    bucket.pop("services_registered", None)
-    bucket.pop("ws_registered", None)
-
-    # Drop ephemeral data
-    bucket.pop("subscriptions", None)
-    bucket.pop("rate_limiter", None)
-    bucket.pop("card_title", None)
-
-    # Test stub cleanup: remove our handlers from __ws_commands__
     try:  # pragma: no cover - exercised in offline tests only
         registry = hass.data.get("__ws_commands__")
         handlers = bucket.get("ws_handlers") or []
@@ -296,7 +274,46 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             exc_info=True,
         )
 
-    bucket.pop("ws_handlers", None)
+
+async def _async_teardown_entry(hass: HomeAssistant, *, op: str) -> None:
+    """Give up everything the config entry owns, in the order that keeps it safe.
+
+    Flush first, while the repository is still reachable; then tell open
+    subscribers, while the subscription registry still lists them; then hand back
+    the frontend registrations, which read the URL the bucket recorded; and only
+    then empty the bucket.
+    """
+
+    await _async_flush_pending_writes(hass, op=op)
+
+    ws_mod.notify_backend_unavailable(hass)
+
+    # Hand back the frontend module URL; setup re-adds it on the next load. The
+    # static route stays, along with the flag that records it: aiohttp cannot
+    # unregister a route, and a reload must not try to add it twice.
+    _remove_extra_js_url(hass)
+
+    # A sidebar entry outliving the backend it opens is a link to a page that
+    # cannot load; setup registers it again.
+    _remove_sidebar_panel(hass)
+
+    _drop_entry_runtime(hass)
+
+
+async def async_unload_entry(hass: HomeAssistant, _entry: ConfigEntry) -> bool:
+    """Unload a config entry.
+
+    An unloaded entry owns nothing, so it serves nothing: the runtime goes the
+    way it does on removal, and the WebSocket commands — which Home Assistant
+    cannot unregister — refuse from here until setup runs again. That covers a
+    disabled entry, which stays in this state, and a reload, which passes through
+    it for as long as setup takes.
+    """
+
+    # Ahead of the teardown, which empties the bucket the handler list lives in.
+    _cleanup_ws_test_stub_registry(hass)
+
+    await _async_teardown_entry(hass, op="unload")
 
     return True
 
@@ -305,15 +322,15 @@ def _drop_entry_runtime(hass: HomeAssistant) -> None:
     """Leave the domain bucket holding only what outlives the config entry.
 
     Home Assistant has no API for unregistering a WebSocket command, so ours go
-    on listening after the integration is removed. Emptying the bucket is what
-    makes them refuse: `ws._repo` raises `StorageError` without a repository, so
-    every command answers a `storage_error` envelope instead of letting a
-    dashboard left open read — and write — an inventory nothing owns any more.
-    The same lookup backs the `haventory.*` service handlers.
+    on listening whether the entry is unloaded, disabled or removed. Emptying the
+    bucket is what makes them refuse: `ws._repo` raises `NotLoadedError` without a
+    repository, so every command answers the contract's `storage_error` envelope
+    instead of letting a dashboard left open read — and write — state the entry
+    no longer owns. The same lookup backs the `haventory.*` service handlers.
 
     `_STATIC_PATH_KEY` is kept: it records an aiohttp route, which cannot be
-    unregistered and so outlives every entry. Dropping the flag would make a
-    re-add in the same run serve `/haventory_static` a second time.
+    unregistered and so outlives every entry. Dropping the flag would make the
+    next setup in the same run serve `/haventory_static` a second time.
     """
 
     bucket = hass.data.get(DOMAIN)
@@ -333,9 +350,10 @@ async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:
     behind, either points at an asset that disappears with the integration, and
     a dead `module` URL fails to load on every dashboard render.
 
-    It then flushes whatever was still unsaved and drops the loaded runtime, so
-    the API stops answering for an integration that is gone rather than serving
-    on until the next restart.
+    It then runs the same teardown an unload does, so the API stops answering for
+    an integration that is gone rather than serving on until the next restart.
+    Home Assistant unloads before it removes, so that teardown has usually
+    already run and finds nothing left to give up.
 
     The HA `Store` file is deliberately kept, so re-adding the integration
     restores the inventory. Purging it is a manual step (README → Installation
@@ -343,8 +361,7 @@ async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:
     """
 
     await _unregister_frontend_module(hass)
-    await _async_flush_pending_writes(hass, op="remove")
-    _drop_entry_runtime(hass)
+    await _async_teardown_entry(hass, op="remove")
 
 
 def _read_manifest_version() -> str:

--- a/custom_components/haventory/exceptions.py
+++ b/custom_components/haventory/exceptions.py
@@ -38,6 +38,17 @@ class StorageError(HaventoryError):
     """Raised when storage operations fail or data is corrupted."""
 
 
+class NotLoadedError(StorageError):
+    """Raised when no config entry owns the data: unloaded, disabled or removed.
+
+    A ``StorageError`` so the wire contract does not move: the client sees the
+    taxonomy's ``storage_error``, which is what "HAventory is unavailable" has
+    always meant. The subclass exists for the log alone — nothing has broken and
+    there is no server-side fault to investigate, so a dashboard that keeps
+    retrying must not fill the Home Assistant log with tracebacks.
+    """
+
+
 # Codes an operator has to act on. Everything else in the contract's taxonomy —
 # validation_error, not_found, conflict, rate_limited — is a rejection the
 # caller can recover from by fixing and resending the request, so it must not
@@ -59,13 +70,28 @@ def error_code(exc: BaseException) -> str:
     return "unknown_error"
 
 
-def log_severity(code: str) -> int:
+def _is_client_recoverable(code: str, exc: BaseException | None) -> bool:
+    """Whether the rejection is the caller's to act on rather than an operator's.
+
+    ``NotLoadedError`` carries the contract's ``storage_error`` code but is not
+    a fault: the entry is unloaded, disabled or removed, which is a state
+    somebody chose. Only the client (stop asking) or the operator (re-enable the
+    entry) can move it, and neither learns anything from a traceback — so it is
+    graded on the exception rather than on the code it maps to.
+    """
+
+    if isinstance(exc, NotLoadedError):
+        return True
+    return code not in OPERATOR_ACTIONABLE_CODES
+
+
+def log_severity(code: str, exc: BaseException | None = None) -> int:
     """Return the log level a boundary rejection carrying ``code`` is logged at."""
 
-    return logging.ERROR if code in OPERATOR_ACTIONABLE_CODES else logging.WARNING
+    return logging.WARNING if _is_client_recoverable(code, exc) else logging.ERROR
 
 
-def log_exc_info(code: str) -> bool | None:
+def log_exc_info(code: str, exc: BaseException | None = None) -> bool | None:
     """Return the ``exc_info`` argument for a boundary log carrying ``code``.
 
     A traceback earns its place only when it says something the message does
@@ -79,7 +105,7 @@ def log_exc_info(code: str) -> bool | None:
     leave a falsy-but-present ``exc_info`` slot behind instead of no slot.
     """
 
-    return True if code in OPERATOR_ACTIONABLE_CODES else None
+    return None if _is_client_recoverable(code, exc) else True
 
 
 class SchemaDowngradeError(StorageError):

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -22,6 +22,7 @@ from .const import DOMAIN
 from .exceptions import (
     ConflictError,
     NotFoundError,
+    NotLoadedError,
     StorageError,
     ValidationError,
     error_code,
@@ -144,7 +145,7 @@ def _get_repo(hass: HomeAssistant) -> Repository:
     bucket = hass.data.get(DOMAIN) or {}
     repo = bucket.get("repository")
     if repo is None:
-        raise StorageError("repository not initialized; run integration setup")
+        raise NotLoadedError("repository not initialized; run integration setup")
     return repo  # type: ignore[return-value]
 
 
@@ -153,10 +154,10 @@ def _log_domain_error(op: str, context: dict[str, Any], exc: Exception) -> None:
     # just raises it before the domain layer gets a chance to.
     code = "validation_error" if isinstance(exc, vol.Invalid) else error_code(exc)
     LOGGER.log(
-        log_severity(code),
+        log_severity(code, exc),
         str(exc),
         extra={"domain": DOMAIN, "op": op, **context},
-        exc_info=log_exc_info(code),
+        exc_info=log_exc_info(code, exc),
     )
 
 

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.storage import Store
 
 from . import migrations
 from .const import DOMAIN
-from .exceptions import SchemaDowngradeError, StorageError
+from .exceptions import NotLoadedError, SchemaDowngradeError, StorageError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -251,9 +251,9 @@ async def async_persist_repo(hass: HomeAssistant) -> None:
         store = bucket.get("store")
         repo = bucket.get("repository")
         if store is None:
-            raise StorageError("storage manager not initialized; run integration setup")
+            raise NotLoadedError("storage manager not initialized; run integration setup")
         if repo is None:
-            raise StorageError("repository not initialized; run integration setup")
+            raise NotLoadedError("repository not initialized; run integration setup")
 
         start_time = time.monotonic()
         generation = getattr(repo, "generation", None)

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -23,6 +23,7 @@ from .const import DEFAULT_CARD_TITLE, DOMAIN, INTEGRATION_VERSION
 from .exceptions import (
     ConflictError,
     NotFoundError,
+    NotLoadedError,
     StorageError,
     ValidationError,
     error_code,
@@ -42,19 +43,19 @@ def _repo(hass: HomeAssistant) -> Repository:
     bucket = hass.data.get(DOMAIN) or {}
     repo = bucket.get("repository")
     if repo is None:
-        raise StorageError("repository not initialized; run integration setup")
+        raise NotLoadedError("repository not initialized; run integration setup")
     return cast("Repository", repo)
 
 
 def _require_loaded(hass: HomeAssistant) -> None:
-    """Refuse the command when no config entry owns the data any more.
+    """Refuse the command when no config entry owns the data.
 
     Home Assistant cannot unregister a WebSocket command, so these keep
-    listening after the integration is removed — and removal empties the domain
-    bucket for exactly this check to find. It sits in the guard rather than in
-    the handlers so the whole surface goes quiet at once: the commands that read
-    no inventory (ping, version, config) would otherwise keep answering for an
-    integration that is gone.
+    listening after the integration is unloaded, disabled or removed — and each
+    of those empties the domain bucket for exactly this check to find. It sits in
+    the guard rather than in the handlers so the whole surface goes quiet at
+    once: the commands that read no inventory (ping, version, config) would
+    otherwise keep answering for a backend that owns nothing.
     """
 
     _repo(hass)
@@ -106,10 +107,10 @@ def _error_envelope(
 def _error_message(_id: int, exc: Exception, *, context: dict[str, Any]) -> dict[str, Any]:
     code = error_code(exc)
     LOGGER.log(
-        log_severity(code),
+        log_severity(code, exc),
         str(exc),
         extra={"domain": DOMAIN, **(context or {})},
-        exc_info=log_exc_info(code),
+        exc_info=log_exc_info(code, exc),
     )
     return _error_envelope(_id, code, str(exc), context or None)
 
@@ -692,6 +693,39 @@ def _broadcast_event(
             "Failed to broadcast WS event",
             extra={"domain": DOMAIN, "op": "broadcast_event", "topic": topic, "action": action},
         )
+
+
+# Action every open subscription receives when the config entry serving it goes
+# away. A subscription is bound to a WebSocket connection, which outlives the
+# entry, so without it nothing on the wire marks the end: no further event ever
+# arrives and a client cannot tell that from an inventory nobody is editing.
+BACKEND_UNAVAILABLE_ACTION = "unavailable"
+
+
+def notify_backend_unavailable(hass: HomeAssistant) -> None:
+    """Tell every open subscription that it has stopped delivering.
+
+    Teardown calls this while the registry is still populated; the subscriptions
+    themselves go with the rest of the runtime immediately after.
+
+    Deliberately not routed through ``_broadcast_event``: this is a lifecycle
+    signal rather than inventory traffic, so it ignores the rate limiter. A
+    connection whose event budget happened to be spent would otherwise be the one
+    client left believing its topics are still live.
+    """
+
+    for conn, subs in list(_subs_bucket(hass).items()):
+        for sub_id, sub in list(subs.items()):
+            _send_event_message(
+                conn,
+                sub_id,
+                {
+                    "domain": DOMAIN,
+                    "topic": sub.get("topic"),
+                    "action": BACKEND_UNAVAILABLE_ACTION,
+                    "ts": _now_ts(),
+                },
+            )
 
 
 def _broadcast_counts(hass: HomeAssistant) -> None:
@@ -1431,14 +1465,14 @@ async def ws_items_bulk(
             # on its own.
             code = error_code(exc)
             LOGGER.log(
-                log_severity(code),
+                log_severity(code, exc),
                 "Bulk operation failed, continuing with remaining ops",
                 extra={
                     "domain": DOMAIN,
                     "op": "items_bulk_op_failed",
                     **ctx,
                 },
-                exc_info=log_exc_info(code),
+                exc_info=log_exc_info(code, exc),
             )
 
             results[op_id] = {

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -26,11 +26,9 @@ Notes:
 - `validation_error`: Invalid input or invariant violation
 - `not_found`: Referenced entity does not exist
 - `conflict`: Version mismatch on optimistic concurrency
-- `storage_error`: Persistence or setup issue, including a command that arrives after the config entry was removed — see "After removal"
+- `storage_error`: Persistence or setup issue, including a command that arrives while no config entry owns the data — see "While no entry is loaded"
 - `rate_limited`: Command rejected by the (opt-in) WebSocket rate limiter — see "Rate limiting"
 - `unknown_error`: Fallback for unexpected exceptions
-
-Handlers map domain exceptions to these codes and log with context; `conflict` and `storage_error` log at error level; others at warning.
 
 Guarantees (every `haventory/*` command is wrapped by the same guard):
 
@@ -40,16 +38,31 @@ Guarantees (every `haventory/*` command is wrapped by the same guard):
 
 Transport-level errors produced by Home Assistant itself (before a handler runs) are outside this taxonomy and can also be observed by clients: `invalid_format` (request failed the command's voluptuous schema) and `unknown_command` (integration not loaded or unknown `type`).
 
-### After removal
+### Logging
 
-Home Assistant has no API for unregistering a WebSocket command, so every `haventory/*` command stays dispatchable until the next restart — including after the config entry has been removed. Removal drops the loaded runtime (repository, store, limiter, subscriptions), and the guard turns that into a refusal:
+Every rejection the API boundary answers is also logged once, with the same structured context the envelope carries. The level says who is expected to act on it, not how unusual it is:
 
-- **Every command** answers `storage_error`, `ping`, `version` and `config` included: they read no inventory, but a half-answering API for a removed integration is worse than none.
-- **Nothing is written.** A mutation is refused before it reaches the repository, so the kept store file stops changing at the moment of removal.
-- **Live subscriptions stop delivering** and are not torn down message-by-message; a client sees its next command refused.
-- **Re-adding the integration restores everything** — the API and the inventory, which removal deliberately leaves on disk (README → "Removing HAventory").
+| Level | `exc_info` | Codes |
+|---|---|---|
+| WARNING | no traceback | `validation_error`, `not_found`, `conflict`, `rate_limited`, and the `storage_error` raised because no config entry is loaded |
+| ERROR | traceback | every other `storage_error`, and `unknown_error` |
 
-Clients cannot tell this apart from any other `storage_error` by code alone; treating it as "HAventory is unavailable, stop retrying and tell the user" is the intended handling either way.
+A traceback earns its place only where it says something the message does not: a genuine `storage_error` wraps a lower-level failure whose cause chain is the only record of what broke, and an `unknown_error` has no vetted message at all.
+
+The one `storage_error` that logs at WARNING is the refusal described under "While no entry is loaded". It answers `storage_error` on the wire, because that is what the contract has always said, but it reports a state somebody chose rather than a fault: nothing broke, there is no cause chain to print, and the fix is either the client stopping or the operator loading the entry again. A dashboard left open retries for as long as its tab does, so logging that at ERROR with a traceback would bury the Home Assistant log in stack traces for a working system. It is graded on the exception raised (`NotLoadedError`) rather than on the code it maps to, so a real storage failure keeps its ERROR and its traceback.
+
+The service handlers (`haventory.*`) follow the identical policy; `voluptuous` schema rejections there are graded as `validation_error`.
+
+### While no entry is loaded
+
+Home Assistant has no API for unregistering a WebSocket command, so every `haventory/*` command stays dispatchable until the next restart — whether the config entry is unloaded, disabled, removed, or halfway through a reload. Each of those drops the loaded runtime (repository, store, limiter, subscriptions), and the guard turns that into a refusal:
+
+- **Every command** answers `storage_error`, `ping`, `version` and `config` included: they read no inventory, but a half-answering API for a backend that owns nothing is worse than none.
+- **Nothing is written.** A mutation is refused before it reaches the repository, so the store file stops changing the moment the entry goes.
+- **Live subscriptions end**, and each is told so — see the `unavailable` action under "Subscriptions and events". A client that is not listening for it simply stops receiving events.
+- **The next setup restores everything** — the API and the inventory, which teardown flushes on the way out and setup reads back. Removal keeps the store file too, so re-adding the integration brings the inventory with it (README → "Removing HAventory").
+
+Clients cannot tell a reload apart from a removal by code alone. Re-opening the subscriptions on a bounded backoff covers both: a reload is answering again within seconds, and a removal runs the budget out and leaves the client to tell the user.
 
 ### Rate limiting
 
@@ -114,6 +127,7 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - Items topic payloads include `{item: <Item>}` and actions: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed`. The `reloaded` action (emitted after `import/execute`) carries **no** `item` and signals a wholesale dataset replacement.
   - Locations topic payloads include `{location: <Location>}` and actions: `created`, `renamed`, `moved`, `deleted`. The `reloaded` action (emitted after `import/execute`) carries **no** `location`.
   - Stats topic payload `action: "counts"` with `{counts: <stats shape>}`.
+  - The `unavailable` action is sent on **every** topic, once per open subscription, when the config entry serving it tears down — an unload, a disable, a removal, or the first half of a reload. It carries no payload beyond the common fields: it says this subscription has stopped, not that anything in the inventory changed. It is the only event delivered regardless of the rate limiter's event budget, because its loss cannot be recovered by re-listing — a client that never receives it has no reason to re-list at all. Every command is refused with `storage_error` from this point (see "While no entry is loaded"), so a client that re-subscribes should expect to be refused for as long as setup takes and back off rather than give up on the first attempt.
   - When `location_id` filter is provided on subscription:
     - Items: if `include_subtree` (default true) match any item whose `location_path.id_path` contains the filter id; otherwise only direct `location_id` matches.
     - Locations: if `include_subtree` match the location itself or descendants; otherwise only the exact location.

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -254,6 +254,7 @@ Common envelope inside HA WS event wrapper:
 - Items: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed` with `{item: <Item>}`; plus `reloaded` (no `item`) after an import replaces the dataset.
 - Locations: `created`, `renamed`, `moved`, `deleted` with `{location: <Location>}`; plus `reloaded` (no `location`) after an import.
 - Stats: `counts` with `{counts: <Counts>}`.
+- Every topic: `unavailable` (common fields only), sent once per open subscription when the config entry serving it tears down. The subscription is over at that point; see the API contract's "While no entry is loaded".
 
 ### Validation notes
 

--- a/tests/integration/test_config_entry.py
+++ b/tests/integration/test_config_entry.py
@@ -2,17 +2,22 @@
 
 Verifies the integration sets up and tears down cleanly through the real
 ``hass.config_entries`` machinery — the path the offline stubs can't exercise.
-Removal especially: the offline stub takes our handlers back out of its fake
+Teardown especially: the offline stub takes our handlers back out of its fake
 command registry on unload, which real Home Assistant has no API for, so only
 here can "the commands are still registered and refuse" be told apart from "the
 commands are gone".
+
+The reload tests are the reason this file talks to a real WebSocket rather than
+calling handlers: unload, setup and the subscription registry all move under one
+connection that outlives them, and that interleaving is exactly what the stubs
+cannot reproduce.
 """
 
 from __future__ import annotations
 
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -23,6 +28,14 @@ async def _setup(hass: HomeAssistant) -> MockConfigEntry:
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     return entry
+
+
+async def _subscribe(client, sub_id: int, topic: str = "items") -> None:
+    """Open one topic subscription and assert the backend accepted it."""
+
+    await client.send_json({"id": sub_id, "type": "haventory/subscribe", "topic": topic})
+    result = await client.receive_json()
+    assert result["success"] is True, result
 
 
 async def test_config_entry_setup_and_unload(hass: HomeAssistant) -> None:
@@ -46,6 +59,131 @@ async def test_config_entry_setup_and_unload(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
     # Ephemeral registration flags are cleared on unload.
     assert hass.data[DOMAIN].get("ws_registered") is None
+
+
+async def test_unloaded_entry_leaves_the_ws_api_refusing(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """An entry that owns nothing serves nothing — the reload window, held open.
+
+    A reload is this state followed by a setup, so what a command meets here is
+    what it meets mid-reload.
+    """
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Screwdriver"})
+    assert (await client.receive_json())["success"] is True
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Still dispatched — Home Assistant has no API to unregister a command — and
+    # answering the contract's storage_error rather than serving dropped state.
+    for msg_id, command in enumerate(("haventory/item/list", "haventory/ping"), start=2):
+        await client.send_json({"id": msg_id, "type": command})
+        refused = await client.receive_json()
+        assert refused["success"] is False, refused
+        assert refused["error"]["code"] == "storage_error", refused
+
+    assert hass.data[DOMAIN].get("repository") is None
+
+    # The second half of a reload puts it all back, inventory included.
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await client.send_json({"id": 4, "type": "haventory/item/list"})
+    listed = await client.receive_json()
+    assert listed["success"] is True, listed
+    assert [item["name"] for item in listed["result"]["items"]] == ["Screwdriver"]
+
+
+async def test_disabled_entry_refuses_like_a_removed_one(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """Disabling is the case with no setup coming to end it."""
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await hass.config_entries.async_set_disabled_by(entry.entry_id, ConfigEntryDisabler.USER)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Ghost"})
+    refused = await client.receive_json()
+    assert refused["success"] is False, refused
+    assert refused["error"]["code"] == "storage_error", refused
+
+
+async def test_reload_tells_an_open_subscriber_and_lets_it_re_subscribe(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """The whole loop a dashboard left open goes through, over one connection.
+
+    The connection outlives the config entry, so the subscription it opened is
+    the one thing a reload breaks without any error reaching the client: no
+    further event would arrive and nothing would say why. The teardown signal is
+    what turns that into something a card can act on.
+    """
+
+    first_sub, second_sub = 10, 12
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+    await _subscribe(client, first_sub)
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    # Delivered on the subscription's own id, so a client with several topics
+    # open knows which one stopped.
+    signal = await client.receive_json()
+    assert signal["type"] == "event", signal
+    assert signal["id"] == first_sub
+    assert signal["event"] == {
+        "domain": DOMAIN,
+        "topic": "items",
+        "action": "unavailable",
+        "ts": signal["event"]["ts"],
+    }
+
+    # The old subscription is gone with the entry that served it...
+    await client.send_json({"id": 11, "type": "haventory/item/create", "name": "Before"})
+    assert (await client.receive_json())["success"] is True
+
+    # ...and re-opening it is all the card has to do to be live again.
+    await _subscribe(client, second_sub)
+    await client.send_json({"id": 13, "type": "haventory/item/create", "name": "After"})
+
+    # The broadcast is written before the command's own result, so take both
+    # frames and sort them out by type rather than by arrival order.
+    frames = [await client.receive_json(), await client.receive_json()]
+    result = next(f for f in frames if f["type"] == "result")
+    event = next(f for f in frames if f["type"] == "event")
+    assert result["success"] is True, result
+    assert event["id"] == second_sub, event
+    assert event["event"]["action"] == "created"
+    assert event["event"]["item"]["name"] == "After"
+
+
+async def test_reload_keeps_the_inventory(hass: HomeAssistant, hass_ws_client) -> None:
+    """Teardown flushes and setup reads it back, so a reload loses nothing."""
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})
+    assert (await client.receive_json())["success"] is True
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await client.send_json({"id": 2, "type": "haventory/item/list"})
+    listed = await client.receive_json()
+    assert listed["success"] is True, listed
+    assert [item["name"] for item in listed["result"]["items"]] == ["Hammer"]
 
 
 async def test_removed_entry_leaves_the_ws_api_refusing(

--- a/tests/test_entry_unload_refusal_offline.py
+++ b/tests/test_entry_unload_refusal_offline.py
@@ -1,0 +1,354 @@
+"""Offline tests: an unloaded config entry refuses exactly like a removed one.
+
+Unload is one lifecycle step ahead of removal and Home Assistant still cannot
+unregister a WebSocket command, so an entry that is merely *disabled* — or
+halfway through a reload — would go on answering from a store and repository it
+no longer owns. Teardown drops that runtime, which turns "still listening" into
+"refuses", and tells every open subscription its topic has stopped so a card
+left open can re-open it once setup runs again.
+
+The offline stub's unload takes our handlers back out of its fake command
+registry, something real Home Assistant has no API for, so these tests capture
+the handler *before* unloading and call it afterwards — which is what a client
+sending on a still-registered command does.
+``tests/integration/test_config_entry.py`` covers the real ordering, over a real
+WebSocket, against a real core.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from custom_components.haventory import (
+    async_setup,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.haventory import services as services_mod
+from custom_components.haventory import storage as storage_mod
+from custom_components.haventory import ws as ws_mod
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.exceptions import NotLoadedError
+from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+class _StubConn:
+    """Connection stub that keeps every message sent to it."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    def send_message(self, msg: dict) -> None:
+        self.messages.append(msg)
+
+
+def _handler(hass: HomeAssistant, type_: str):
+    """The registered handler for one command type, as HA would dispatch to it."""
+
+    for handler in hass.data.get("__ws_commands__", []):
+        schema = getattr(handler, "_ws_schema", None)
+        if callable(handler) and isinstance(schema, dict) and schema.get("type") == type_:
+            return handler
+    raise AssertionError(f"No handler registered for type {type_}")
+
+
+async def _call(handler, hass: HomeAssistant, _id: int, type_: str, conn=None, **payload):
+    """Send one command straight to a handler, bypassing the stub registry."""
+
+    req = {"id": _id, "type": type_}
+    req.update(payload)
+    target = conn if conn is not None else _StubConn()
+    res = await handler(hass, target, req)
+    return res if res is not None else target.messages[-1]
+
+
+async def _send(hass: HomeAssistant, _id: int, type_: str, conn=None, **payload):
+    return await _call(_handler(hass, type_), hass, _id, type_, conn=conn, **payload)
+
+
+async def _setup_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Set the integration up on a store emptied for this test.
+
+    The offline ``Store`` stub keeps one dict per storage key for the whole
+    session, so a test that goes through the real setup path has to start from a
+    known payload rather than whatever an earlier test left behind.
+    """
+
+    await DomainStore(hass, key=STORAGE_KEY).async_save(
+        {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+    )
+    entry = ConfigEntry()
+    await async_setup(hass, {})
+    assert await async_setup_entry(hass, entry) is True
+    return entry
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "payload"),
+    [
+        ("haventory/item/create", {"name": "While unloaded"}),
+        ("haventory/item/list", {}),
+        ("haventory/stats", {}),
+        ("haventory/location/create", {"name": "Shed"}),
+        ("haventory/subscribe", {"topic": "items"}),
+        # Utility commands read no inventory, but the surface has to go quiet as
+        # a whole: half an API answering for an entry that owns nothing is worse
+        # than none.
+        ("haventory/ping", {}),
+        ("haventory/version", {}),
+        ("haventory/config", {}),
+    ],
+)
+async def test_command_refuses_while_unloaded(command: str, payload: dict) -> None:
+    """Every command answers storage_error for as long as no entry is loaded."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    handler = _handler(hass, command)
+    assert (await _call(handler, hass, 1, command, **payload))["success"] is True
+
+    await async_unload_entry(hass, entry)
+
+    res = await _call(handler, hass, 2, command, **payload)
+    assert res["success"] is False, res
+    assert res["error"]["code"] == "storage_error"
+
+
+@pytest.mark.asyncio
+async def test_unload_drops_the_loaded_runtime() -> None:
+    """Nothing an entry loaded survives it — that is what makes handlers refuse."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    bucket = hass.data[DOMAIN]
+    assert bucket["store"] is not None
+    assert bucket["repository"] is not None
+
+    await async_unload_entry(hass, entry)
+
+    for key in ("store", "repository", "rate_limiter", "card_title", "persist_task"):
+        assert hass.data[DOMAIN].get(key) is None, key
+
+
+@pytest.mark.asyncio
+async def test_unload_keeps_the_static_route_flag() -> None:
+    """The one flag that outlives an entry stays: aiohttp cannot drop a route.
+
+    Losing it would make the reload's setup register ``/haventory_static`` a
+    second time.
+    """
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    hass.data[DOMAIN]["static_path_registered"] = True
+
+    await async_unload_entry(hass, entry)
+
+    assert hass.data[DOMAIN].get("static_path_registered") is True
+
+
+@pytest.mark.asyncio
+async def test_unload_flushes_before_dropping(monkeypatch) -> None:
+    """A debounced write pending at unload lands, and then fires no second time."""
+
+    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    store = hass.data[DOMAIN]["store"]
+    saved: list[dict] = []
+
+    async def _record(payload: dict) -> None:
+        saved.append(payload)
+
+    monkeypatch.setattr(store, "async_save", _record)
+
+    hass.data[DOMAIN]["repository"].create_item({"name": "Unsaved"})
+    await storage_mod.async_request_persist(hass)
+    pending = hass.data[DOMAIN]["persist_task"]
+
+    await async_unload_entry(hass, entry)
+
+    assert len(saved) == 1, "unload writes the pending state out"
+    assert [item["name"] for item in saved[0]["items"].values()] == ["Unsaved"]
+
+    await asyncio.sleep(0.2)
+
+    assert pending.cancelled() or pending.done()
+    assert len(saved) == 1, "the cancelled debounce never fired against a dropped store"
+
+
+@pytest.mark.asyncio
+async def test_unloaded_service_refuses() -> None:
+    """The service surface refuses off the same lookup as the WebSocket one."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    await services_mod.service_item_create(hass, {"name": "Before"})
+
+    await async_unload_entry(hass, entry)
+
+    with pytest.raises(NotLoadedError):
+        await services_mod.service_item_create(hass, {"name": "After"})
+
+
+# -----------------------------
+# Telling open subscribers the topics stopped
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_unload_tells_open_subscribers_their_topic_stopped() -> None:
+    """Every open subscription is told, on its own id and its own topic.
+
+    Nothing else on the wire marks the end: the connection outlives the entry, so
+    a client that is not told simply stops receiving events and cannot tell that
+    from an inventory nobody is editing.
+    """
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    conn = _StubConn()
+    for sub_id, topic in ((11, "items"), (12, "locations"), (13, "stats")):
+        assert (await _send(hass, sub_id, "haventory/subscribe", conn=conn, topic=topic))["success"]
+    conn.messages.clear()
+
+    await async_unload_entry(hass, entry)
+
+    assert [(m["id"], m["event"]["topic"], m["event"]["action"]) for m in conn.messages] == [
+        (11, "items", "unavailable"),
+        (12, "locations", "unavailable"),
+        (13, "stats", "unavailable"),
+    ]
+    assert all(m["type"] == "event" for m in conn.messages)
+    assert all(m["event"]["domain"] == DOMAIN for m in conn.messages)
+
+
+@pytest.mark.asyncio
+async def test_unload_drops_live_subscriptions() -> None:
+    """Having been told, the subscription is gone: nothing more is delivered."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    conn = _StubConn()
+    assert (await _send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
+
+    await async_unload_entry(hass, entry)
+    conn.messages.clear()
+
+    ws_mod._broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+
+    assert conn.messages == []
+    assert hass.data[DOMAIN].get("subscriptions") in (None, {})
+
+
+@pytest.mark.asyncio
+async def test_teardown_signal_outranks_the_event_budget() -> None:
+    """A spent event budget must not be what keeps a client believing it is live.
+
+    The limiter exists to throttle inventory chatter; this is the one event whose
+    loss cannot be recovered by re-listing, because the client would never know
+    to.
+    """
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    limiter = RateLimiter(
+        RateLimitConfig(
+            enabled=True,
+            events_per_second=1.0,
+            events_burst=1.0,
+            global_events_per_second=1.0,
+            global_events_burst=1.0,
+        )
+    )
+    hass.data[DOMAIN]["rate_limiter"] = limiter
+    conn = _StubConn()
+    assert (await _send(hass, 5, "haventory/subscribe", conn=conn, topic="items"))["success"]
+
+    # Drain the global budget, then prove an ordinary broadcast is now dropped.
+    assert limiter.allow_event_broadcast() is True
+    conn.messages.clear()
+    ws_mod._broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+    assert conn.messages == []
+
+    await async_unload_entry(hass, entry)
+
+    assert [m["event"]["action"] for m in conn.messages] == ["unavailable"]
+
+
+# -----------------------------
+# Coming back
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_after_unload_serves_again() -> None:
+    """A reload is unload plus setup, and the second half restores the API."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    created = await _send(hass, 1, "haventory/item/create", name="Screwdriver")
+    assert created["success"] is True
+    handler = _handler(hass, "haventory/item/list")
+
+    await async_unload_entry(hass, entry)
+    assert (await _call(handler, hass, 2, "haventory/item/list"))["success"] is False
+
+    assert await async_setup_entry(hass, ConfigEntry()) is True
+
+    listed = await _call(handler, hass, 3, "haventory/item/list")
+    assert listed["success"] is True, listed
+    assert [item["name"] for item in listed["result"]["items"]] == ["Screwdriver"]
+
+
+@pytest.mark.asyncio
+async def test_a_reload_writes_nothing_while_it_is_refusing(monkeypatch) -> None:
+    """A mutation refused mid-reload is refused before it reaches the repository."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    store = hass.data[DOMAIN]["store"]
+    saved: list[dict] = []
+
+    async def _record(payload: dict) -> None:
+        saved.append(payload)
+
+    monkeypatch.setattr(store, "async_save", _record)
+    handler = _handler(hass, "haventory/item/create")
+
+    await async_unload_entry(hass, entry)
+    saved.clear()  # unload's own flush is test_unload_flushes_before_dropping's business
+
+    res = await _call(handler, hass, 1, "haventory/item/create", name="Ghost")
+
+    assert res["success"] is False
+    assert saved == []
+
+    assert await async_setup_entry(hass, ConfigEntry()) is True
+    listed = await _send(hass, 2, "haventory/item/list")
+    assert [item["name"] for item in listed["result"]["items"]] == []
+
+
+@pytest.mark.asyncio
+async def test_refusal_is_mapped_not_an_unhandled_crash(caplog) -> None:
+    """The refusal goes through the guard's error mapping, not its safety net."""
+
+    hass = HomeAssistant()
+    entry = await _setup_entry(hass)
+    handler = _handler(hass, "haventory/item/create")
+    await async_unload_entry(hass, entry)
+
+    caplog.set_level(logging.DEBUG, logger="custom_components.haventory.ws")
+    res = await _call(handler, hass, 1, "haventory/item/create", name="Nope")
+
+    assert res["error"]["code"] == "storage_error"
+    assert res["error"]["data"]["op"] == "item_create"
+    assert res["error"]["message"] != ws_mod.UNEXPECTED_ERROR_MESSAGE
+    assert not [r for r in caplog.records if "Unexpected error in WS handler" in r.message]

--- a/tests/test_ws_logging_offline.py
+++ b/tests/test_ws_logging_offline.py
@@ -5,9 +5,10 @@ One policy governs every error the API boundary logs:
 - ERROR only where an operator has to act — ``storage_error`` and
   ``unknown_error``.
 - WARNING for contract-defined, client-recoverable rejections —
-  ``validation_error``, ``not_found``, ``conflict``, ``rate_limited``.
-- ``exc_info`` only where a traceback says something the message does not,
-  which is the same two operator-actionable codes.
+  ``validation_error``, ``not_found``, ``conflict``, ``rate_limited``, and the
+  ``storage_error`` a teardown leaves behind, which is a state somebody chose
+  rather than a failure.
+- ``exc_info`` only where a traceback says something the message does not.
 
 The conflict and not-found cases are load-bearing: ``release_testing_plan.md``
 exit criterion 4 forbids any traceback from ``custom_components.haventory`` in
@@ -23,7 +24,7 @@ import pytest
 import voluptuous as vol
 from custom_components.haventory import services as services_mod
 from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.exceptions import StorageError
+from custom_components.haventory.exceptions import NotLoadedError, StorageError
 from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
@@ -211,6 +212,116 @@ async def test_unknown_error_logs_error_with_traceback(caplog, monkeypatch) -> N
     assert record.op == "item_create"
     assert record.levelno == logging.ERROR
     assert record.exc_info is not None
+
+
+# -----------------------------
+# The refusal a teardown leaves behind: same envelope, quieter log
+# -----------------------------
+
+
+def _make_unloaded_hass() -> HomeAssistant:
+    """Commands registered with nothing behind them — what a teardown leaves."""
+
+    hass = HomeAssistant()
+    ws_setup(hass)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_not_loaded_refusal_logs_warning_without_traceback(caplog) -> None:
+    """An entry that is unloaded, disabled or removed is a state, not a fault.
+
+    Nothing broke and no cause chain exists to print; the operator's move is to
+    re-enable the entry, and the client's is to stop asking.
+    """
+
+    hass = _make_unloaded_hass()
+    caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
+
+    res = await _send(hass, 1, "haventory/item/create", name="X")
+    assert res["success"] is False and res["error"]["code"] == "storage_error"
+
+    record = _only(caplog)
+    assert record.op == "item_create"
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is None
+
+
+@pytest.mark.asyncio
+async def test_not_loaded_refusal_keeps_the_storage_error_envelope() -> None:
+    """The wire contract does not move with the log level.
+
+    ``NotLoadedError`` is a ``StorageError``, so clients that key on the code go
+    on seeing exactly what they saw before.
+    """
+
+    hass = _make_unloaded_hass()
+    conn = _ConnStub()
+
+    res = await _send(hass, 1, "haventory/item/list", conn=conn)
+
+    assert res["error"]["code"] == "storage_error"
+    assert res["error"]["data"]["op"] == "item_list"
+    assert res["error"]["message"]
+    assert conn.messages[-1] == res
+
+
+@pytest.mark.asyncio
+async def test_a_retrying_client_leaves_no_tracebacks(caplog) -> None:
+    """The flood case: a dashboard that keeps knocking must not fill the log.
+
+    ``release_testing_plan.md`` exit criterion 4 audits the Home Assistant log
+    for tracebacks from this integration, and a card left open across a removal
+    retries for as long as the tab does.
+    """
+
+    hass = _make_unloaded_hass()
+    caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
+
+    retries = 12
+    for i in range(retries):
+        assert (await _send(hass, i, "haventory/stats"))["error"]["code"] == "storage_error"
+
+    records = _records(caplog)
+    assert len(records) == retries
+    assert {r.levelno for r in records} == {logging.WARNING}
+    assert all(r.exc_info is None for r in records)
+
+
+@pytest.mark.asyncio
+async def test_a_real_storage_failure_still_logs_error_with_traceback(caplog, monkeypatch) -> None:
+    """The quieter rule is scoped to the refusal, not to the code it maps to."""
+
+    hass = _make_hass()
+
+    async def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise StorageError("failed to persist repository")
+
+    monkeypatch.setattr(hass.data[DOMAIN]["store"], "async_save", _raise)
+    caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
+
+    res = await _send(hass, 1, "haventory/item/create", name="X")
+    assert res["success"] is False and res["error"]["code"] == "storage_error"
+
+    record = _only(caplog)
+    assert record.levelno == logging.ERROR
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_service_not_loaded_refusal_logs_warning_without_traceback(caplog) -> None:
+    """The service boundary grades the same refusal the same way."""
+
+    hass = _make_unloaded_hass()
+    caplog.set_level(logging.DEBUG, logger=SERVICES_LOGGER)
+
+    with pytest.raises(NotLoadedError):
+        await services_mod.service_item_create(hass, {"name": "X"})
+
+    record = _only(caplog, SERVICES_LOGGER)
+    assert record.op == "item_create"
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is None
 
 
 # -----------------------------


### PR DESCRIPTION
Two follow-ups from #171, both in the refusal path it introduced.

## 1. Unload kept serving

`async_remove_entry` dropped the loaded runtime; `async_unload_entry` did not. So
a **disabled** entry — and every **reload**, for as long as setup takes — went on
answering `haventory/*` from a store and repository the entry no longer owned.
That is item 43's bug one lifecycle step earlier.

### What an open card actually experienced across a reload (investigated first)

Unload already dropped the subscription registry, so before this change a reload
left an open card **silently stale**: its subscriptions stopped delivering, no
error reached it, and nothing would ever say why. The WebSocket connection
outlives the config entry, so the client cannot tell a dead subscription from an
inventory nobody is editing — it kept rendering `connected: true` forever.

That is not a hypothesis. Running the new integration tests against `main`'s
backend on a real Home Assistant core:

- `test_unloaded_entry_leaves_the_ws_api_refusing` — **fails** (served from the
  dropped runtime)
- `test_disabled_entry_refuses_like_a_removed_one` — **fails** (same)
- `test_reload_tells_an_open_subscriber_and_lets_it_re_subscribe` — **hangs**
  until the suite times out, waiting for a signal that never arrives

### The decision

Unload runs the same teardown removal does: an entry that owns nothing serves
nothing. Simply dropping the runtime would have made the staleness worse, so
teardown now also **tells** its subscribers.

- **Backend** — before dropping the registry, every open subscription receives an
  `unavailable` event on its own id and topic. It bypasses the rate limiter: it
  is the one event whose loss cannot be recovered by re-listing, because a client
  that never receives it has no reason to re-list at all.
- **Card** — treats that as the start of an outage and re-opens its subscriptions
  on the bounded backoff it already had for `rate_limited`, extended to cover the
  `storage_error` a reload window answers with. Seven attempts (~50 s) rather
  than four, because the bet is different: giving up inside a reload window would
  strand a card that only ever needed to wait.

I considered keeping the subscription registry alive across an unload so a reload
would never interrupt it. Rejected: a disabled entry would then leave the card
claiming live updates it is not getting, and the card would never re-read data
the backend re-loaded from its store underneath it.

**End state:** a disabled entry refuses like a removed one; a reload costs an open
card a few seconds of a "Live updates paused" banner and no manual refresh, live
updates included. A disable or removal runs the budget out and leaves the Refresh
button, with the banner naming the real cause instead of blaming a limiter that
is off. Recovery re-reads the inventory, since the backend re-read its store and
every event in between went to a subscription that no longer existed.

## 2. Refusal log volume

The taxonomy prescribed ERROR-with-traceback for `storage_error`, so every
refused command wrote a stack trace for a system working exactly as configured —
and a retrying client would flood the log that release exit criterion 4 audits.

**The wire contract does not move.** `NotLoadedError` subclasses `StorageError`,
so `error_code` still maps it to `storage_error` and clients see the identical
envelope. Only the log changes: the boundary now grades severity on the exception
rather than on the code, and logs this one refusal at WARNING with no traceback —
item 32's client-recoverable policy. Every other `storage_error` keeps its ERROR
and its cause chain, which is pinned by a test.

The rule is stated in `docs/backend_api_contract.md`'s new **Logging** section.

## Verification

- Offline: `458 passed` — new `tests/test_entry_unload_refusal_offline.py`
  (refusal, runtime drop, flush-before-drop, the teardown signal per topic, the
  limiter bypass, recovery) and new cases in `tests/test_ws_logging_offline.py`
  pinning WARNING + `exc_info is None`, the unchanged envelope, and 12 repeated
  refusals leaving no tracebacks.
- **Real HA** (`tests/integration/`, phacc, HA 2026.6.0): `31 passed`. The reload
  path is covered over a real WebSocket — teardown signal, dead old subscription,
  re-subscribe, live event — plus the disabled-entry refusal and inventory
  survival. Not stubs.
- Card: `983 passed`, eslint / `tsc --noEmit` / build clean.

## Follow-ups (not fixed here, per the no-new-ledger-rows instruction)

- `docs/backend_api_contract.md` previously claimed "`conflict` and
  `storage_error` log at error level". `conflict` has logged at WARNING since
  item 32; the line was stale. Corrected as part of the new Logging section.
- A command already past the guard when teardown lands can fail its persist with
  `storage_error` mid-flight. Correct behaviour, and pre-existing on the removal
  path, but the window is genuinely there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
