### PR TITLE
fix(card): say what every remaining disclosure opens

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -281,6 +281,65 @@ describe('hv-card-shell: search and filters', () => {
     expect(sr.querySelector('[data-testid="filter-active-dot"]')).toBeTruthy();
   });
 
+  // aria-expanded on its own says only that something opened; which element it
+  // opened was left to whatever happened to follow the button in reading order.
+  it('names the surface the filter button discloses, at either width', async () => {
+    const id = 'card-filter-surface';
+    for (const mobile of [false, true]) {
+      const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })], mobile });
+      const toggle = () => sr.querySelector('[data-testid="filter-toggle"]') as HTMLButtonElement;
+      // What the surface holds while it is shut. On a phone that surface is the
+      // sheet, which is slotted whether or not it shows, so its own state tells.
+      const showing = () => {
+        const surface = sr.getElementById(id) as (HTMLElement & { open?: boolean }) | null;
+        return mobile ? !!surface?.open : !!surface?.querySelector('hv-filter-panel');
+      };
+
+      // The desktop panel remembers whether it was left open, so this starts
+      // from whatever that remembered and proves the pairing across the flip.
+      for (const step of ['as mounted', 'after the flip']) {
+        const was = { expanded: toggle().getAttribute('aria-expanded'), showing: showing() };
+        const where = `mobile=${mobile}, ${step}`;
+        expect(toggle().getAttribute('aria-controls'), where).toBe(id);
+        // The id has to resolve in both states — a button pointing at nothing
+        // announces as controlling nothing — so the surface outlives the panel.
+        expect(sr.getElementById(id), where).toBeTruthy();
+
+        toggle().click();
+        await settle(el);
+        // Only the contents come and go; the element the button names stays.
+        expect(showing(), `${where}, contents flipped`).toBe(!was.showing);
+        expect(sr.getElementById(id), `${where}, still there`).toBeTruthy();
+        // The phone's button reads the desktop panel's remembered state as well
+        // as the sheet's, so its announcement is not the sheet's alone and the
+        // surface above is what says whether the press landed.
+        if (!mobile) {
+          expect(toggle().getAttribute('aria-expanded'), `${where}, flipped`).toBe(
+            String(was.expanded !== 'true'),
+          );
+        }
+      }
+      el.remove();
+    }
+  });
+
+  it('names the full view the expand button discloses, open or shut', async () => {
+    const id = 'card-full-view-surface';
+    const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
+    const toggle = () => sr.querySelector('[data-testid="expand-toggle"]') as HTMLButtonElement;
+
+    expect(toggle().getAttribute('aria-controls')).toBe(id);
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    expect(sr.getElementById(id), 'shut').toBeTruthy();
+
+    toggle().click();
+    await settle(el);
+
+    expect(toggle().getAttribute('aria-expanded')).toBe('true');
+    expect(toggle().getAttribute('aria-controls')).toBe(id);
+    expect(sr.getElementById(id), 'open').toBe(sr.querySelector('[data-testid="card-full-view"]'));
+  });
+
   it('shows a removable chip per active filter and clears them', async () => {
     const { el, store, sr } = await mountShell({ items: [makeItem({ id: '1', category: 'Tools' })] });
     store.setFilters({ category: 'Tools', checkedOutOnly: true });

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -31,6 +31,22 @@ const SEARCH_DEBOUNCE_MS = 200;
 const FILTER_PANEL_STORAGE_KEY = 'haventory:filter-panel-open:v1';
 
 /**
+ * What the header's expand button discloses, named so `aria-controls` can point
+ * at it. The surface is in the tree whether or not it is open — an
+ * `aria-controls` that resolves to nothing announces the button as controlling
+ * nothing — and `open` decides what it draws.
+ */
+const FULL_VIEW_ID = 'card-full-view-surface';
+
+/**
+ * What the filter button discloses. Which element that is depends on the width:
+ * the panel under the search row on a desktop, the bottom sheet on a phone. Only
+ * one of the two is ever rendered, so both carry the same id and the button can
+ * name it without knowing which it got.
+ */
+const FILTER_SURFACE_ID = 'card-filter-surface';
+
+/**
  * The standard card.
  *
  * A container: it holds the `Store` and drives it directly. Interactions nest
@@ -941,6 +957,7 @@ export class HVCardShell extends LitElement {
           data-testid="expand-toggle"
           aria-label="Open full view"
           aria-expanded=${String(this._fullViewOpen)}
+          aria-controls=${FULL_VIEW_ID}
           title="Open full view"
           @click=${() => {
             this._fullViewOpen = true;
@@ -986,6 +1003,7 @@ export class HVCardShell extends LitElement {
           data-testid="filter-toggle"
           aria-label="Filters"
           aria-expanded=${String(this._filterPanelOpen || this._filterSheetOpen)}
+          aria-controls=${FILTER_SURFACE_ID}
           title="Filters"
           @click=${this._toggleFilterSurface}
         >
@@ -1006,9 +1024,11 @@ export class HVCardShell extends LitElement {
             ></hv-filter-chips>
           </div>`
         : null}
-      ${!mobile && this._filterPanelOpen
-        ? html`<div class="panel-holder">${this._renderFilterPanel(false)}</div>`
-        : null}
+      ${mobile
+        ? null
+        : html`<div class="panel-holder" id=${FILTER_SURFACE_ID} ?hidden=${!this._filterPanelOpen}>
+            ${this._filterPanelOpen ? this._renderFilterPanel(false) : null}
+          </div>`}
       ${this._renderDegradedBanners()} ${this._renderBanners()}
 
       <hv-list
@@ -1057,6 +1077,7 @@ export class HVCardShell extends LitElement {
         : null}
 
       <hv-full-view
+        id=${FULL_VIEW_ID}
         data-testid="card-full-view"
         ?open=${this._fullViewOpen}
         .store=${this.store}
@@ -1073,6 +1094,7 @@ export class HVCardShell extends LitElement {
       ></hv-full-view>
       ${mobile
         ? html`<hv-bottom-sheet
+            id=${FILTER_SURFACE_ID}
             label="Filters"
             ?open=${this._filterSheetOpen}
             data-testid="filter-sheet"

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1020,6 +1020,41 @@ describe('hv-full-view: phone-width children', () => {
     }
   });
 
+  // aria-expanded on its own says only that something opened; which element it
+  // opened was left to whatever happened to follow the button in reading order.
+  it('names the holder the Filters button discloses, open or shut', async () => {
+    const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
+    const toggle = () => q(sr, '[data-testid="full-filters-toggle"]') as HTMLButtonElement;
+    const id = 'full-view-filter-panel';
+
+    expect(toggle().getAttribute('aria-controls')).toBe(id);
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    // The id has to resolve in both states — a button pointing at nothing
+    // announces as controlling nothing — so the holder outlives the panel.
+    const shut = sr.getElementById(id);
+    expect(shut, 'holder shut').toBeTruthy();
+    expect(shut?.querySelector('[data-testid="full-filter-panel"]'), 'no panel while shut').toBe(null);
+
+    toggle().click();
+    await settle(el);
+
+    expect(toggle().getAttribute('aria-expanded')).toBe('true');
+    expect(toggle().getAttribute('aria-controls')).toBe(id);
+    expect(sr.getElementById(id)?.querySelector('[data-testid="full-filter-panel"]')).toBeTruthy();
+  });
+
+  // The holder sets a display of its own, which outranks the browser's rule for
+  // [hidden] — without this it would lay out its padding while empty.
+  it('takes the shut holder out of the layout it would otherwise pad', async () => {
+    const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
+    expect((sr.getElementById('full-view-filter-panel') as HTMLElement).hidden).toBe(true);
+    expect(fullCss()).toMatch(/\.panel-holder\[hidden\] \{[^}]*display: none/);
+
+    (q(sr, '[data-testid="full-filters-toggle"]') as HTMLButtonElement).click();
+    await settle(el);
+    expect((sr.getElementById('full-view-filter-panel') as HTMLElement).hidden).toBe(false);
+  });
+
   it('keeps the desktop panel live-applying, with no commit row', async () => {
     const restore = stubViewport(false);
     try {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -62,6 +62,12 @@ type SidebarSection = 'locations' | 'categories' | 'tags';
 const sectionPanelId = (section: SidebarSection) => `sidebar-section-${section}`;
 
 /**
+ * What the context bar's Filters button discloses, on the same terms: the holder
+ * stays in the tree shut or open, and only the panel inside it comes and goes.
+ */
+const FILTER_PANEL_ID = 'full-view-filter-panel';
+
+/**
  * The expanded workspace.
  *
  * The coloured app bar is the mode signal — the standard card never has one, so
@@ -595,6 +601,13 @@ export class HVFullView extends LitElement {
            hung 5px off the bottom of a landscape screen. */
         box-sizing: border-box;
         max-height: min(80dvh, calc(100% - 116px));
+      }
+      /* The holder outlives the panel inside it so the id the Filters button
+         names always resolves. The display above would otherwise beat the
+         browser's own rule for [hidden] and leave the empty box laying out its
+         padding. */
+      .panel-holder[hidden] {
+        display: none;
       }
       .panel-scroll {
         flex: 1;
@@ -1369,6 +1382,7 @@ export class HVFullView extends LitElement {
           class="filters-button ${this._filtersOpen ? 'on' : ''}"
           data-testid="full-filters-toggle"
           aria-expanded=${String(this._filtersOpen)}
+          aria-controls=${FILTER_PANEL_ID}
           @click=${() => {
             this._filtersOpen = !this._filtersOpen;
             // The phone panel stages its edits, so its button has a number to
@@ -1595,8 +1609,9 @@ export class HVFullView extends LitElement {
           ${this._renderSidebar()}
           <div class="main">
             ${this._renderContextBar()}
-            ${this._filtersOpen
-              ? html`<div class="panel-holder">
+            <div class="panel-holder" id=${FILTER_PANEL_ID} ?hidden=${!this._filtersOpen}>
+              ${this._filtersOpen
+                ? html`
                   <div class="panel-scroll">
                   <hv-filter-panel
                     data-testid="full-filter-panel"
@@ -1620,8 +1635,9 @@ export class HVFullView extends LitElement {
                   ></hv-filter-panel>
                   </div>
                   ${this._narrow ? this._renderPanelFoot() : null}
-                </div>`
-              : null}
+                `
+                : null}
+            </div>
             ${this._editing !== null
               ? html`<div class="editor-holder">
                   <hv-item-editor

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -502,6 +502,29 @@ describe('hv-item-editor: location and tags', () => {
     expect(saves[0].changes?.location_id).toBe('garage');
   });
 
+  // aria-expanded on its own says only that something opened; which element it
+  // opened was left to whatever happened to follow the button in reading order.
+  it('names the holder the location field discloses, open or shut', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const field = () => q(el, '[data-testid="editor-location"]') as HTMLButtonElement;
+    const id = 'editor-location-tree-holder';
+
+    expect(field().getAttribute('aria-controls')).toBe(id);
+    expect(field().getAttribute('aria-expanded')).toBe('false');
+    // The id has to resolve in both states — a button pointing at nothing
+    // announces as controlling nothing — so the holder outlives the tree in it.
+    const shut = el.shadowRoot?.getElementById(id);
+    expect(shut, 'holder shut').toBeTruthy();
+    expect(shut?.querySelector('hv-location-tree'), 'no tree while shut').toBe(null);
+
+    field().click();
+    await el.updateComplete;
+
+    expect(field().getAttribute('aria-expanded')).toBe('true');
+    expect(field().getAttribute('aria-controls')).toBe(id);
+    expect(el.shadowRoot?.getElementById(id)?.querySelector('hv-location-tree')).toBeTruthy();
+  });
+
   // The modal had a dedicated Clear button next to the location field; here the
   // same job belongs to the tree's own clear row, and it has to reach the save
   // payload as a null rather than being quietly dropped.
@@ -567,6 +590,17 @@ describe('hv-item-editor: category picker', () => {
   const options = (el: HVItemEditor) =>
     all(el, '[data-testid="editor-category-option"]').map((o) => o.dataset.value);
 
+  /**
+   * The listbox is the element the combobox names, so it stays put and empties
+   * out instead of leaving — shut means hidden with nothing in it, not gone.
+   */
+  function expectListShut(el: HVItemEditor) {
+    const list = q(el, '[data-testid="editor-category-list"]') as HTMLElement | null;
+    expect(list).toBeTruthy();
+    expect(list?.hidden).toBe(true);
+    expect(list?.children).toHaveLength(0);
+  }
+
   async function focusCategory(el: HVItemEditor) {
     const input = q(el, '[data-testid="editor-category"]') as HTMLInputElement;
     input.focus();
@@ -576,7 +610,7 @@ describe('hv-item-editor: category picker', () => {
 
   it('shows every existing category on focus, before a single keystroke', async () => {
     const el = await mount(null);
-    expect(q(el, '[data-testid="editor-category-list"]')).toBe(null);
+    expectListShut(el);
 
     await focusCategory(el);
     expect(options(el)).toEqual(['Hardware', 'Tools']);
@@ -607,6 +641,28 @@ describe('hv-item-editor: category picker', () => {
     expect(css).not.toMatch(/\.tree-holder[^{]*\{[^}]*position: fixed/);
   });
 
+  // The combobox always named its listbox, but the listbox left the DOM with
+  // the options — so while shut the name pointed at nothing.
+  it('names a listbox that is there whether or not it is showing', async () => {
+    const el = await mount(null);
+    const input = () => q(el, '[data-testid="editor-category"]') as HTMLInputElement;
+    const id = 'editor-category-list';
+
+    expect(input().getAttribute('aria-controls')).toBe(id);
+    expect(input().getAttribute('aria-expanded')).toBe('false');
+    expect(el.shadowRoot?.getElementById(id), 'listbox shut').toBeTruthy();
+    expectListShut(el);
+
+    await focusCategory(el);
+
+    expect(input().getAttribute('aria-expanded')).toBe('true');
+    expect(input().getAttribute('aria-controls')).toBe(id);
+    const open = el.shadowRoot?.getElementById(id);
+    expect(open?.getAttribute('role'), 'the popup itself, not a wrapper').toBe('listbox');
+    expect(open?.hidden).toBe(false);
+    expect(options(el)).toEqual(['Hardware', 'Tools']);
+  });
+
   it('narrows the list while typing', async () => {
     const el = await mount(null);
     await focusCategory(el);
@@ -627,7 +683,7 @@ describe('hv-item-editor: category picker', () => {
     // The same button closes it again.
     (q(el, '[data-testid="editor-category-toggle"]') as HTMLButtonElement).click();
     await el.updateComplete;
-    expect(q(el, '[data-testid="editor-category-list"]')).toBe(null);
+    expectListShut(el);
   });
 
   it('fills the field from a picked option and saves it', async () => {
@@ -639,7 +695,7 @@ describe('hv-item-editor: category picker', () => {
     await el.updateComplete;
 
     expect((q(el, '[data-testid="editor-category"]') as HTMLInputElement).value).toBe('Tools');
-    expect(q(el, '[data-testid="editor-category-list"]')).toBe(null);
+    expectListShut(el);
 
     (q(el, '[data-testid="editor-save"]') as HTMLButtonElement).click();
     expect(saves[0].changes?.category).toBe('Tools');
@@ -665,7 +721,7 @@ describe('hv-item-editor: category picker', () => {
     await el.updateComplete;
     input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     await el.updateComplete;
-    expect(q(el, '[data-testid="editor-category-list"]')).toBe(null);
+    expectListShut(el);
     expect(cancels).toBe(0);
   });
 
@@ -680,7 +736,7 @@ describe('hv-item-editor: category picker', () => {
     const el = await mount(null, { categorySuggestions: [] });
     expect(q(el, '[data-testid="editor-category-toggle"]')).toBe(null);
     await focusCategory(el);
-    expect(q(el, '[data-testid="editor-category-list"]')).toBe(null);
+    expectListShut(el);
   });
 });
 
@@ -822,6 +878,36 @@ describe('hv-item-editor: mobile layout', () => {
     expect(q(el, '[data-testid="editor-description"]')).toBeTruthy();
     expect(q(el, '[data-testid="editor-cf-add"]')).toBeTruthy();
     expect(q(el, '[data-testid="editor-inspection-date"]')).toBeTruthy();
+  });
+
+  // aria-expanded on its own says only that something opened; which element it
+  // opened was left to whatever happened to follow the toggle in reading order.
+  it('names what More fields discloses, open or shut', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }), { mobile: true });
+    const toggle = () => q(el, '[data-testid="editor-more-toggle"]') as HTMLButtonElement;
+    const id = 'editor-more-fields';
+
+    expect(toggle().getAttribute('aria-controls')).toBe(id);
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    // The id has to resolve in both states — a toggle pointing at nothing
+    // announces as controlling nothing — so the holder outlives the fields.
+    const shut = el.shadowRoot?.getElementById(id);
+    expect(shut, 'holder shut').toBeTruthy();
+    expect(shut?.children, 'no fields while shut').toHaveLength(0);
+
+    toggle().click();
+    await el.updateComplete;
+
+    expect(toggle().getAttribute('aria-expanded')).toBe('true');
+    expect(toggle().getAttribute('aria-controls')).toBe(id);
+    const open = el.shadowRoot?.getElementById(id);
+    expect(open?.querySelector('[data-testid="editor-description"]'), 'fields open inside it').toBeTruthy();
+  });
+
+  // The fields are cells of the form's grid; a holder that laid itself out would
+  // take their place in it and swallow the gaps between them.
+  it('keeps the holder out of the grid its fields belong to', () => {
+    expect(editorCss()).toMatch(/\.more-fields \{[^}]*display: contents/);
   });
 
   it('summarises what is inside the disclosure', async () => {

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -44,6 +44,17 @@ const CUSTOM_FIELD_TYPES: { value: CustomFieldType; label: string }[] = [
 ];
 
 /**
+ * What the form's three disclosures open, named so `aria-controls` can point at
+ * them. Each target stays in the tree whether or not it is open — an
+ * `aria-controls` that resolves to nothing announces the control as controlling
+ * nothing — and only the contents come and go, so closing still discards the
+ * state inside. Shadow scoping keeps the ids unique with several editors mounted.
+ */
+const LOCATION_TREE_ID = 'editor-location-tree-holder';
+const CATEGORY_LIST_ID = 'editor-category-list';
+const MORE_FIELDS_ID = 'editor-more-fields';
+
+/**
  * The one edit surface: the inline expander, the full view and the mobile sheet.
  *
  * The row expands in place and the location tree opens *inside* the form, so
@@ -542,6 +553,13 @@ export class HVItemEditor extends LitElement {
         min-height: var(--hv-tap-min, auto);
         padding: 0 8px;
       }
+      /* The fields it holds are cells of the form's grid, and a box around them
+         would take their place in it and collapse the gaps between them. This
+         element exists only to carry the id the More fields toggle names, so it
+         lays nothing out — empty, it takes no room either. */
+      .more-fields {
+        display: contents;
+      }
       .more-toggle {
         display: flex;
         align-items: center;
@@ -780,6 +798,7 @@ export class HVItemEditor extends LitElement {
         class="field-button ${this._model.locationId ? '' : 'empty'}"
         data-testid="editor-location"
         aria-expanded=${String(this._locationOpen)}
+        aria-controls=${LOCATION_TREE_ID}
         @click=${() => {
           this._locationOpen = !this._locationOpen;
         }}
@@ -787,9 +806,9 @@ export class HVItemEditor extends LitElement {
         ${icon('mapMarker', 15)}${renderAreaChip(parts.areaName)}<span class="value">${parts.path}</span
         >${icon('chevronDown', 15)}
       </button>
-      ${this._locationOpen
-        ? html`<div class="tree-holder">
-            <hv-location-tree
+      <div class="tree-holder" id=${LOCATION_TREE_ID} ?hidden=${!this._locationOpen}>
+        ${this._locationOpen
+          ? html`<hv-location-tree
               data-testid="editor-location-tree"
               .nodes=${this.locationTree}
               .areas=${this.areas}
@@ -801,9 +820,9 @@ export class HVItemEditor extends LitElement {
                 this._patch({ locationId: (e.detail as { locationId: string | null }).locationId });
                 this._locationOpen = false;
               }}
-            ></hv-location-tree>
-          </div>`
-        : null}
+            ></hv-location-tree>`
+          : null}
+      </div>
     </div>`;
   }
 
@@ -938,7 +957,7 @@ export class HVItemEditor extends LitElement {
           autocomplete="off"
           aria-autocomplete="list"
           aria-expanded=${String(this._categoryOpen)}
-          aria-controls="editor-category-list"
+          aria-controls=${CATEGORY_LIST_ID}
           aria-activedescendant=${this._categoryOpen && this._categoryIndex >= 0
             ? `editor-category-option-${this._categoryIndex}`
             : ''}
@@ -970,15 +989,16 @@ export class HVItemEditor extends LitElement {
             </button>`
           : null}
       </div>
-      ${this._categoryOpen
-        ? html`<div
-            class="list-holder floating"
-            role="listbox"
-            id="editor-category-list"
-            data-testid="editor-category-list"
-            style=${this._categoryStyle}
-          >
-            ${options.length
+      <div
+        class="list-holder floating"
+        role="listbox"
+        id=${CATEGORY_LIST_ID}
+        data-testid="editor-category-list"
+        ?hidden=${!this._categoryOpen}
+        style=${this._categoryStyle}
+      >
+        ${this._categoryOpen
+          ? html`${options.length
               ? options.map(
                   (c, i) => html`<button
                     class="option ${i === this._categoryIndex ? 'active' : ''} ${
@@ -998,9 +1018,9 @@ export class HVItemEditor extends LitElement {
                 )
               : html`<div class="option-empty" data-testid="editor-category-empty">
                   No existing category matches “${typed}” — saving adds it as a new one.
-                </div>`}
-          </div>`
-        : null}
+                </div>`}`
+          : null}
+      </div>
     </div>`;
   }
 
@@ -1292,6 +1312,7 @@ export class HVItemEditor extends LitElement {
         class="more-toggle"
         data-testid="editor-more-toggle"
         aria-expanded=${String(this._moreOpen)}
+        aria-controls=${MORE_FIELDS_ID}
         @click=${() => {
           this._moreOpen = !this._moreOpen;
         }}
@@ -1299,21 +1320,24 @@ export class HVItemEditor extends LitElement {
         ${icon(this._moreOpen ? 'chevronDown' : 'chevronRight', 19)} More fields
         <span class="summary">${summary || 'description · dates · custom fields'}</span>
       </button>
-      ${this._moreOpen
-        ? html`
-            <div class="cell span3">
-              <label class="hv-label" for="editor-description">Description</label>
-              <textarea
-                id="editor-description"
-                class="hv-input"
-                data-testid="editor-description"
-                .value=${model.description}
-                @input=${(e: Event) => this._patch({ description: (e.target as HTMLTextAreaElement).value })}
-              ></textarea>
-            </div>
-            ${this._renderStateFields()} ${this._renderCustomFields()}
-          `
-        : null}
+      <div class="more-fields" id=${MORE_FIELDS_ID}>
+        ${this._moreOpen
+          ? html`
+              <div class="cell span3">
+                <label class="hv-label" for="editor-description">Description</label>
+                <textarea
+                  id="editor-description"
+                  class="hv-input"
+                  data-testid="editor-description"
+                  .value=${model.description}
+                  @input=${(e: Event) =>
+                    this._patch({ description: (e.target as HTMLTextAreaElement).value })}
+                ></textarea>
+              </div>
+              ${this._renderStateFields()} ${this._renderCustomFields()}
+            `
+          : null}
+      </div>
     `;
   }
 

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -249,6 +249,81 @@ describe('hv-location-tree: filtering and cycle guard', () => {
   });
 });
 
+// aria-expanded on its own says only that something opened; which element it
+// opened was left to whatever happened to follow the row in reading order — and
+// a collapsed node renders no descendants at all, so there was nothing to name.
+describe('hv-location-tree: what a row discloses', () => {
+  const row = (el: HVLocationTree, id: string) =>
+    q(el, `[data-testid="tree-row"][data-id="${id}"]`) as HTMLElement;
+  const twisty = (el: HVLocationTree, id: string) =>
+    q(el, `[data-testid="tree-row"][data-id="${id}"] [data-testid="tree-twisty"]`) as HTMLButtonElement;
+
+  it('names the container its children go in, collapsed or expanded', async () => {
+    const el = await mount();
+    const id = row(el, 'garage').getAttribute('aria-controls') as string;
+    expect(id).toBeTruthy();
+    expect(row(el, 'garage').getAttribute('aria-expanded')).toBe('false');
+
+    // The id has to resolve in both states — a row pointing at nothing announces
+    // as controlling nothing — so the container stays behind, emptied.
+    const shut = el.shadowRoot?.getElementById(id);
+    expect(shut, 'container while collapsed').toBeTruthy();
+    expect(shut?.querySelector('[data-testid="tree-row"]'), 'no children while collapsed').toBe(null);
+
+    twisty(el, 'garage').click();
+    await el.updateComplete;
+
+    expect(row(el, 'garage').getAttribute('aria-expanded')).toBe('true');
+    expect(row(el, 'garage').getAttribute('aria-controls')).toBe(id);
+    const open = el.shadowRoot?.getElementById(id);
+    expect(
+      [...(open?.querySelectorAll('[data-testid="tree-row"]') ?? [])].map((r) => (r as HTMLElement).dataset.id),
+    ).toEqual(['shelf-a', 'shelf-b']);
+  });
+
+  it('gives each node a container of its own that survives a re-render', async () => {
+    const el = await mount();
+    el.revealPathTo('bin-3');
+    await el.updateComplete;
+
+    const named = Object.fromEntries(rows(el).map((r) => [r.dataset.id, r.getAttribute('aria-controls')]));
+    expect(named.garage).toBeTruthy();
+    expect(named['shelf-b']).toBeTruthy();
+    expect(named.garage, 'two nodes, two containers').not.toBe(named['shelf-b']);
+    // A leaf discloses nothing, so it names nothing rather than a dead id.
+    expect(named['shelf-a']).toBe(null);
+    expect(named['bin-3']).toBe(null);
+
+    const before = named.garage;
+    el.showCounts = !el.showCounts;
+    await el.updateComplete;
+    expect(row(el, 'garage').getAttribute('aria-controls'), 'derived from the node id, not the render').toBe(
+      before,
+    );
+  });
+
+  // Location ids are uuids today, so the escaping is what keeps this honest for
+  // ids from anywhere else: distinct keys can never land on one container, and
+  // what comes out has to be usable as a selector.
+  it('keeps two ids apart however the raw ids are punctuated', async () => {
+    const kid = (parent: string) => [node(`${parent}/kid`, 'Kid', parent, [1, 1])];
+    const el = await mount({
+      nodes: [
+        node('a b', 'Spaced', null, [1, 2], kid('a b')),
+        node('a-b', 'Hyphened', null, [1, 2], kid('a-b')),
+      ],
+    });
+
+    const spaced = row(el, 'a b').getAttribute('aria-controls') as string;
+    const hyphened = row(el, 'a-b').getAttribute('aria-controls') as string;
+    expect(spaced).not.toBe(hyphened);
+    for (const id of [spaced, hyphened]) {
+      expect(el.shadowRoot?.getElementById(id), id).toBeTruthy();
+      expect(el.shadowRoot?.querySelector(`#${id}`), `${id} as a selector`).toBeTruthy();
+    }
+  });
+});
+
 describe('hv-location-tree: area grouping', () => {
   const AREAS = [
     { id: 'area-kitchen', name: 'Kitchen' },
@@ -270,6 +345,29 @@ describe('hv-location-tree: area grouping', () => {
     const el = await mountAreas();
     expect(headNames(el)).toEqual(['Area: Garage', 'Area: Kitchen', 'No area']);
     expect(ids(el)).toEqual(['bench', 'fridge', 'attic']);
+  });
+
+  // A band collapses the same way a node does, and its key carries a colon that
+  // could not be written into a selector as it stands.
+  it('names the roots each band discloses, collapsed or expanded', async () => {
+    const el = await mountAreas();
+    const head = () => heads(el)[0];
+    const id = head().getAttribute('aria-controls') as string;
+    expect(id).toBeTruthy();
+    expect(head().getAttribute('aria-expanded')).toBe('true');
+    expect(el.shadowRoot?.getElementById(id)?.querySelector('[data-testid="tree-row"]')).toBeTruthy();
+    expect(el.shadowRoot?.querySelector(`#${id}`), 'usable as a selector').toBeTruthy();
+    // Each band names its own, so collapsing one says nothing about the others.
+    expect(new Set(heads(el).map((h) => h.getAttribute('aria-controls'))).size).toBe(heads(el).length);
+
+    (head().querySelector('[data-testid="tree-area-twisty"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(head().getAttribute('aria-expanded')).toBe('false');
+    expect(head().getAttribute('aria-controls')).toBe(id);
+    const shut = el.shadowRoot?.getElementById(id);
+    expect(shut, 'container while collapsed').toBeTruthy();
+    expect(shut?.querySelector('[data-testid="tree-row"]'), 'no roots while collapsed').toBe(null);
   });
 
   it('marks an area with the chip every surface uses, not as a path segment', async () => {

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import type { TemplateResult } from 'lit';
 import { tokens, base } from '../ui/tokens';
 import { icon } from '../ui/icons';
@@ -12,6 +13,28 @@ import type { AreaRef, LocationTreeNode } from '../store/types';
 
 /** The tail of ungrouped roots, keyed like a group so it collapses like one. */
 const NO_AREA_KEY = 'no-area';
+
+/**
+ * The container a row discloses, named so `aria-controls` can point at it. A
+ * collapsed row renders no descendants at all, so the container stays behind
+ * empty rather than leaving with them — an `aria-controls` that resolves to
+ * nothing announces the row as controlling nothing.
+ *
+ * The id has to survive being written into a selector and has to be the row's
+ * alone. The prefix keeps a uuid that opens with a digit from opening the id,
+ * and every character outside the id alphabet — the colon in an area key,
+ * whatever a later id scheme brings — becomes `_<code point>_`. Escaping `_`
+ * itself is what keeps that mapping one-to-one, so two keys cannot collapse
+ * onto one container.
+ */
+const containerId = (prefix: string, key: string) =>
+  `${prefix}-${key.replace(/[^A-Za-z0-9-]/g, (c) => `_${c.charCodeAt(0).toString(16)}_`)}`;
+
+/** Where a node's children go, derived from the node id so it never moves. */
+const nodeChildrenId = (nodeId: string) => containerId('tree-children', nodeId);
+
+/** Where an area band's roots go, derived from the key the band collapses under. */
+const areaRootsId = (key: string) => containerId('tree-area-roots', key);
 
 /**
  * The backend's nested location tree, rendered as it is served. One component
@@ -365,6 +388,7 @@ export class HVLocationTree extends LitElement {
           role="treeitem"
           aria-selected=${String(selected)}
           aria-expanded=${hasChildren ? String(open) : 'undefined'}
+          aria-controls=${ifDefined(hasChildren ? nodeChildrenId(node.id) : undefined)}
           aria-level=${depth + 1}
           data-testid="tree-row"
           data-id=${node.id}
@@ -461,7 +485,11 @@ export class HVLocationTree extends LitElement {
             : null}
         </div>
         <slot name=${`after-${node.id}`}></slot>
-        ${open ? children.map((c) => this._renderNode(c, depth + 1, isExcluded)) : null}
+        ${hasChildren
+          ? html`<div id=${nodeChildrenId(node.id)} ?hidden=${!open}>
+              ${open ? children.map((c) => this._renderNode(c, depth + 1, isExcluded)) : null}
+            </div>`
+          : null}
       </div>
     `;
   }
@@ -510,6 +538,7 @@ export class HVLocationTree extends LitElement {
       role="treeitem"
       aria-selected=${String(selected)}
       aria-expanded=${String(open)}
+      aria-controls=${areaRootsId(key)}
       aria-level="1"
       data-testid="tree-area-head"
       data-area=${group?.id ?? NO_AREA_KEY}
@@ -548,7 +577,9 @@ export class HVLocationTree extends LitElement {
     const open = filtering || !this._collapsedAreas.has(key);
     return html`<div>
       ${this._renderAreaHeader(group, roots, open, key)}
-      ${open ? visible.map((r) => this._renderNode(r, 1, false)) : null}
+      <div id=${areaRootsId(key)} ?hidden=${!open}>
+        ${open ? visible.map((r) => this._renderNode(r, 1, false)) : null}
+      </div>
     </div>`;
   }
 

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -331,6 +331,38 @@ describe('hv-organize-dialog: locations', () => {
     });
   });
 
+  // aria-expanded on its own says only that something opened; which element it
+  // opened was left to whatever happened to follow the picker in reading order.
+  it('names the holder each location picker discloses, open or shut', async () => {
+    const items = [makeItem({ id: '1', location_id: 'shelf-a' })];
+    const { el, sr } = await mount({ items, locations });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+
+    for (const [action, picker, id] of [
+      ['tree-edit', 'location-parent', 'location-parent-tree-holder'],
+      ['tree-merge', 'merge-target', 'merge-target-tree-holder'],
+    ]) {
+      (tree.shadowRoot?.querySelector(`[data-testid="${action}"][data-id="garage"]`) as HTMLButtonElement).click();
+      await settle(el);
+      const control = () => q(sr, `[data-testid="${picker}"]`) as HTMLButtonElement;
+
+      expect(control().getAttribute('aria-controls'), picker).toBe(id);
+      expect(control().getAttribute('aria-expanded'), picker).toBe('false');
+      // The id has to resolve in both states — a picker pointing at nothing
+      // announces as controlling nothing — so the holder outlives the tree.
+      const shut = sr.getElementById(id);
+      expect(shut, `${picker} shut`).toBeTruthy();
+      expect(shut?.querySelector('hv-location-tree'), `${picker}: no tree while shut`).toBe(null);
+
+      control().click();
+      await settle(el);
+
+      expect(control().getAttribute('aria-expanded'), picker).toBe('true');
+      expect(control().getAttribute('aria-controls'), picker).toBe(id);
+      expect(sr.getElementById(id)?.querySelector('hv-location-tree'), `${picker} open`).toBeTruthy();
+    }
+  });
+
   it('excludes the location itself from its own parent picker, so no cycle is possible', async () => {
     const { el, sr } = await mount({ locations });
     const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -22,6 +22,16 @@ import './hv-location-tree';
 
 export type OrganizeTab = 'locations' | 'categories' | 'tags';
 
+/**
+ * The trees the two location pickers open, named so `aria-controls` can point at
+ * them. Each holder stays in the tree whether or not it is open — an
+ * `aria-controls` that resolves to nothing announces the control as controlling
+ * nothing — and only the tree inside comes and goes, so closing a picker still
+ * discards its scroll and filter.
+ */
+const LOC_PARENT_TREE_ID = 'location-parent-tree-holder';
+const MERGE_TARGET_TREE_ID = 'merge-target-tree-holder';
+
 /** The three batch rewrites, and how each reads once it is over. */
 const PAST_TENSE: Record<string, string> = {
   Merge: 'Merged',
@@ -851,6 +861,7 @@ export class HVOrganizeDialog extends LitElement {
             class="control"
             data-testid="location-parent"
             aria-expanded=${String(this._locParentOpen)}
+            aria-controls=${LOC_PARENT_TREE_ID}
             @click=${() => {
               this._locParentOpen = !this._locParentOpen;
             }}
@@ -858,9 +869,9 @@ export class HVOrganizeDialog extends LitElement {
             ${icon('mapMarker', 15)}<span class="value">${parent?.name ?? 'Top level'}</span>
             ${icon('chevronDown', 15)}
           </button>
-          ${this._locParentOpen
-            ? html`<div class="tree-holder">
-                <hv-location-tree
+          <div class="tree-holder" id=${LOC_PARENT_TREE_ID} ?hidden=${!this._locParentOpen}>
+            ${this._locParentOpen
+              ? html`<hv-location-tree
                   data-testid="location-parent-tree"
                   .nodes=${tree}
                   .areas=${this.st?.areasCache?.areas ?? []}
@@ -871,9 +882,9 @@ export class HVOrganizeDialog extends LitElement {
                     this._locParent = (e.detail as { locationId: string | null }).locationId;
                     this._locParentOpen = false;
                   }}
-                ></hv-location-tree>
-              </div>`
-            : null}
+                ></hv-location-tree>`
+              : null}
+          </div>
         </div>
       </div>
       ${this._locError
@@ -952,6 +963,7 @@ export class HVOrganizeDialog extends LitElement {
           style="flex:1;min-width:180px"
           data-testid="merge-target"
           aria-expanded=${String(this._mergeTargetOpen)}
+          aria-controls=${MERGE_TARGET_TREE_ID}
           @click=${() => {
             this._mergeTargetOpen = !this._mergeTargetOpen;
           }}
@@ -960,9 +972,9 @@ export class HVOrganizeDialog extends LitElement {
           ${icon('chevronDown', 15)}
         </button>
       </div>
-      ${this._mergeTargetOpen
-        ? html`<div class="tree-holder">
-            <hv-location-tree
+      <div class="tree-holder" id=${MERGE_TARGET_TREE_ID} ?hidden=${!this._mergeTargetOpen}>
+        ${this._mergeTargetOpen
+          ? html`<hv-location-tree
               data-testid="merge-target-tree"
               .nodes=${tree}
               .areas=${this.st?.areasCache?.areas ?? []}
@@ -972,9 +984,9 @@ export class HVOrganizeDialog extends LitElement {
                 this._mergeTarget = (e.detail as { locationId: string | null }).locationId;
                 this._mergeTargetOpen = false;
               }}
-            ></hv-location-tree>
-          </div>`
-        : null}
+            ></hv-location-tree>`
+          : null}
+      </div>
       <span class="note" data-testid="merge-effect">
         ${target
           ? `${parts.join(' and ')} move to "${target.name}", then "${source.name}" is deleted.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -151,10 +151,25 @@ header carries `aria-checked="mixed"` for a partial page), and `hv-column-picker
 A control that expands something carries `aria-expanded` **and** `aria-controls`, and the
 element it names stays in the tree whether or not it is open — an `aria-controls` that
 resolves to nothing announces the control as controlling nothing. Only the contents come and
-go, so collapsing still discards the state inside. Both filter surfaces are wired this way:
-`hv-filter-panel`'s location chip points at its tree holder, and `hv-full-view`'s three
-sidebar headings each point at `sidebar-section-<section>`. Ids are shadow-scoped, so the
-desktop panel and the phone sheet can both be mounted without colliding.
+go, so collapsing still discards the state inside. Every disclosure in the card is wired this
+way: `hv-filter-panel`'s location chip, `hv-full-view`'s sidebar headings and Filters button,
+`hv-card-shell`'s expand and filter buttons, `hv-item-editor`'s location, category and "More
+fields" fields, `hv-organize-dialog`'s two location pickers, and `hv-location-tree`'s rows and
+area bands. Ids are shadow-scoped, so the desktop panel and the phone sheet can both be
+mounted without colliding. `hv-overflow-menu` is the one disclosure outside this rule: a menu
+button announces its popup with `aria-haspopup`, so its menu is free to leave the DOM.
+
+Where the target keeps a rendered box of its own it is held in the tree with `hidden`, so an
+empty one neither paints nor takes a grid gap; a holder that sets a `display` of its own
+needs a `[hidden]` rule to go with it, because an author rule outranks the browser's. Where
+the contents belong to a layout the holder must not join — the item editor's "More fields"
+are cells of the form grid — the holder takes `display: contents` instead and stays empty.
+
+Two ids are generated rather than fixed, both in `hv-location-tree`: a row names a container
+derived from its node id, and an area band names one derived from its collapse key. Anything
+outside the id alphabet is escaped as `_<code point>_`, escaping `_` itself, which keeps the
+mapping one-to-one — two nodes cannot collapse onto one container — and keeps the result
+usable as a selector. A row with no children discloses nothing and so names nothing.
 
 ### The area beside a location
 


### PR DESCRIPTION
Follow-up from #174, which set the pattern: a stable id on the disclosure
target, and the target stays in the tree in both states so the id always
resolves while only the contents come and go.

Nine controls announced `aria-expanded` without naming what it expanded,
leaving that to whatever happened to follow the control in reading order. Each
now carries `aria-controls` on the same terms.

| Control | Names |
|---|---|
| `hv-card-shell` expand button | `card-full-view-surface` — the full view, always mounted, `open` decides what it draws |
| `hv-card-shell` filter button | `card-filter-surface` — the desktop holder or the phone sheet; only one is ever rendered, so both take the id |
| `hv-full-view` Filters button | `full-view-filter-panel` |
| `hv-item-editor` location field | `editor-location-tree-holder` |
| `hv-item-editor` category combobox | `editor-category-list` |
| `hv-item-editor` More fields | `editor-more-fields` |
| `hv-organize-dialog` parent picker | `location-parent-tree-holder` |
| `hv-organize-dialog` merge target | `merge-target-tree-holder` |
| `hv-location-tree` rows and area bands | `tree-children-<node>` / `tree-area-roots-<key>` |

The category combobox already named `editor-category-list`, but the listbox
left the DOM with its options, so while shut the name pointed at nothing. The
listbox now stays and empties instead — which is also what the APG combobox
examples do. Five assertions that read "the list is gone" now read "the list is
not showing"; the helper says so once.

`hv-location-tree` is the special case the brief called out. A collapsed row
renders no descendants at all and so had no container to name; one now holds
them, keyed off the node id, and an area band keys off its collapse key.
Anything outside the id alphabet is escaped as `_<code point>_` — escaping `_`
itself, which is what keeps the mapping one-to-one, so two nodes can never
collapse onto one container. A row with no children discloses nothing and names
nothing rather than a dead id.

The pairing sits on the row rather than on the twisty button inside it, because
the row is the `role="treeitem"` that carries `aria-expanded`; a button with
`aria-controls` and no expand state of its own would be the odd half of a pair.

`hv-overflow-menu` was left alone.

### Nothing moves on screen

A holder with a rendered box of its own is held in the tree with `hidden`, so an
empty one neither paints nor takes a grid gap. Two places needed more than that:

- `hv-full-view`'s `.panel-holder` sets `display: flex`, and an author rule
  outranks the browser's rule for `[hidden]` — without an explicit
  `.panel-holder[hidden]` it would lay out its padding while empty. Asserted.
- `hv-item-editor`'s "More fields" are cells of the form's grid. A holder that
  laid itself out would take their place in it and swallow the 12px gaps between
  them, so it takes `display: contents` and stays empty when shut. Asserted.

### Tests

Per component, in #174's shape: `aria-controls` matches the target id, the id
resolves in both states, `aria-expanded` flips. For the tree additionally: two
nodes get distinct containers, a node's id survives a re-render, and two raw ids
that a naive sanitiser would fold together (`a b` / `a-b`) stay apart and stay
usable as selectors.

Both gates green: `pytest` 458 passed / 22 skipped, `ruff`, `mypy` clean;
`eslint`, `tsc --noEmit`, `vitest` 1001 passed, `npm audit`, `npm run build`.

### Follow-ups

Not fixed here — each is a change to what a control announces, which is outside
an `aria-controls` pass:

1. **`hv-card-shell`'s filter button announces wrongly on a phone.**
   `aria-expanded` reads `_filterPanelOpen || _filterSheetOpen`, and
   `_filterPanelOpen` is restored from the remembered *desktop* preference. So
   on a phone, once the panel has ever been opened on a desktop, the button
   announces "expanded" permanently and never flips as the sheet opens and
   shuts. The phone case should read the sheet alone. This is why the new test
   checks the flip at desktop width and the surface's own state on a phone.
2. **`hv-location-tree` writes `aria-expanded="undefined"`** on a row with no
   children (`hasChildren ? String(open) : 'undefined'`, a literal string, not
   an omitted attribute). Not a valid ARIA value; the attribute should be absent.
3. **`hv-card-shell`'s "debounces the search before touching the store" is
   timing-flaky** — it failed once in three full-suite runs at 431ms against a
   200ms debounce, and passes alone. Real-timer sensitivity under load, not
   related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
