### PR TITLE
fix(skill): ask the instance where the card lives instead of hard-coding it

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -134,37 +134,66 @@ node screenshot.mjs --search sponges --out screenshot-search.png   # type into t
 
 Screenshots land in `.claude/skills/run-haventory/*.png` (gitignored). The script
 prints browser console errors — check them when the card renders blank.
-`--path /dashboard-dev/0` is the default — see "Where the card lives" below.
+With no `--path` it opens the discovered `column` view — see "Where the card lives" below.
 `--search` exercises the real pipeline
 (card → WS → repository index → filtered render), so it doubles as a UI smoke:
 searching `sponges` must reduce the list to the one matching item.
 
 #### Where the card lives
 
-Home Assistant's **default** dashboard on the dev instance is the generated one, which
-holds no HAventory card and redirects `/lovelace/<anything>` to `/home/overview`. Every
-card-driving harness therefore defaults to the separate **`dev`** dashboard
-(`url_path: dashboard-dev`, storage mode), which carries two views:
-
-| view | URL | shape | who uses it |
-|---|---|---|---|
-| 0 (no `path`) | `/dashboard-dev/0` | `sections` grid, card in a normal column | `screenshot.mjs`, `visual_pass.mjs` mobile, `import_policies.mjs`, `rl_banner.mjs` |
-| `wide` | `/dashboard-dev/wide` | `type: panel`, card gets the full window width | `visual_pass.mjs` desktop, `drive_import.mjs` |
-
-Each view holds one `{type: custom:haventory-card}` and nothing else that matters. A view
-without a `path` is addressed by **index**, which is why the first one is `/0`.
-
-The two shapes are not interchangeable: the card picks its layout from **its own**
-rendered width, so in a sections column even a 1440px window gets the narrow branch.
-Check what the instance actually has before assuming a path is wrong:
+**Nothing hard-codes a dashboard.** Every card-driving harness asks the instance where the
+card is, through the shared `card_views.mjs`: it walks `lovelace/dashboards/list`, reads
+each dashboard's `lovelace/config`, and keeps the views that really hold a
+`custom:haventory-card` — at any depth, so a card in a sections grid, a stack or behind a
+conditional all count. Ask it yourself:
 
 ```bash
-uv run python .claude/skills/run-haventory/driver.py send '{"type":"lovelace/dashboards/list"}'
-uv run python .claude/skills/run-haventory/driver.py send '{"type":"lovelace/config","url_path":"dashboard-dev"}'
+cd .claude/skills/run-haventory && node card_views.mjs
 ```
 
+```
+2 view(s) hold custom:haventory-card:
+  column  /dashboard-dev/0         sections  dev › view 0
+  wide    /dashboard-dev/wide      panel     dev › wide
+wide    -> /dashboard-dev/wide
+column  -> /dashboard-dev/0
+```
+
+Two view **shapes** matter, because the card picks its layout from **its own** rendered
+width — 600px, `MOBILE_BREAKPOINT` in `src/ui/responsive.ts` — and not the window's. A
+sections column measures ~500px even in a 1440px window, so it gets the narrow branch:
+
+| shape | what qualifies | who asks for it |
+|---|---|---|
+| `wide` | a `type: panel` view — the card gets the whole content area (~1184px here) | `visual_pass.mjs` desktop, `drive_import.mjs` |
+| `column` | any other view — sections, masonry — the column a card normally sits in | `screenshot.mjs`, `visual_pass.mjs` mobile, `import_policies.mjs`, `rl_banner.mjs` |
+
+A view without a `path` is addressed by **index**, which is why the dev instance's sections
+view is `/dashboard-dev/0`. Each harness prints the view it resolved and why, so a run says
+where it went:
+
+```
+view (desktop): /dashboard-dev/wide  ← dev › wide (panel)
+view (mobile): /dashboard-dev/0  ← dev › view 0 (sections)
+```
+
+Three things discovery does when it cannot give a clean answer, all of them out loud:
+
+- **Nothing found** — no card on any dashboard, HA down, or a non-admin token that cannot
+  list dashboards: falls back to `/dashboard-dev/wide` and `/dashboard-dev/0`, the dev
+  instance's own views, so the harness still fails with its own message about the root it
+  waited for.
+- **Only the wrong shape exists** — say, a card that lives solely in a sections column:
+  that view is used and the line carries a `WARNING`, because a recipe failing on the
+  layout it did not ask for says more than a 404 on a path nothing has.
+- **The shape was wrong anyway** — `visual_pass.mjs`'s two card passes assert the branch
+  the card actually took (`d-layout`, `m-layout`) before running a single recipe. Enough
+  testids are shared between the branches that a wrong-shape run would otherwise pass while
+  photographing the other layout.
+
 The sidebar panel at `/haventory` needs none of this — HA routes it from the integration's
-own registration, so it is the one surface that survives any dashboard edit.
+own registration, so it is the one surface that survives any dashboard edit, and both
+`panel` passes go straight there.
 
 #### The sidebar panel
 
@@ -249,7 +278,8 @@ node drive_import.mjs ~/backup.json --policy replace       # preview with replac
 node drive_import.mjs ~/backup.json --apply --out restore  # WRITES; screenshots the result
 ```
 
-Defaults: `--policy merge`, `--out import`, `--path /dashboard-dev/wide`. The document is pasted
+Defaults: `--policy merge`, `--out import`, and — with no `--path` — the discovered `wide`
+view, so the preview table gets its room. The document is pasted
 verbatim and deliberately **not** validated first, so malformed input can be used to drive the
 card's parse-error and server-rejection paths. `--apply` mutates the instance and import is
 all-or-nothing with no undo — export first.
@@ -307,15 +337,26 @@ node visual_pass.mjs --only mobile --surfaces detail-sheet,filter-sheet
 node visual_pass.mjs --only panel         # sidebar panel, desktop width
 node visual_pass.mjs --only panel-mobile  # sidebar panel, 375x812
 node visual_pass.mjs --list               # surface names
+node visual_pass.mjs --path desktop=/other/wide --path mobile=/other/0
 ```
 
 Four passes — 14 card surfaces at desktop width, 8 at phone width, and the sidebar panel
 at both (10 wide, 8 narrow) — each a recipe of clicks against the card's own
 `data-testid`s. It is a DOM check as much as a screenshot run: a surface counts as
 captured only if its root element exists afterwards, so a renamed testid fails loudly
-instead of silently photographing the wrong screen. Exit is non-zero if any surface failed
-to open or the browser logged a console error. Files are prefixed `d-`, `m-`, `p-` and
-`pm-`.
+instead of silently photographing the wrong screen. The two card passes additionally
+assert the layout branch the card took (`d-layout`, `m-layout`), which is what makes 42
+rows out of 40 surfaces. Exit is non-zero if any of them failed, or the browser logged a
+console error. Files are prefixed `d-`, `m-`, `p-` and `pm-`.
+
+The four passes open **three** URLs — two discovered dashboard views and `/haventory` — so
+`--path` names the pass it applies to (`--path <pass>=<url>`) and may be repeated. A bare
+`--path <url>` is ambiguous across a whole run and is rejected; it is accepted only next to
+`--only`, where there is exactly one pass for it to mean:
+
+```bash
+node visual_pass.mjs --only desktop --path /dashboard-dev/wide
+```
 
 The card's narrow layout is a **different component tree** (sheets, not panels), which is
 why the two card lists differ rather than sharing one. The panel's is not: `hv-full-view`
@@ -394,6 +435,14 @@ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q
 Expected at feature freeze: backend 350 passed / 22 skipped in ~11 s; frontend 812 passed
 across 42 files in ~30 s.
 
+The harness has its own unit cover for the parts of `card_views.mjs` that decide where a
+run looks — which views hold the card, which URL addresses them, what `--path` asked for.
+No HA and no dependency beyond Node:
+
+```bash
+cd .claude/skills/run-haventory && node --test
+```
+
 The in-process HA integration suite (`scripts/test_integration.sh`, real HA core via
 phacc) does **not** run on this Windows host: the script builds a POSIX venv path and HA
 core imports `fcntl`. A throwaway `python:3.14-slim` container is the proven way to run it
@@ -418,11 +467,18 @@ clean-start mode), then `Online smoke test completed successfully.`
   conversion), so a leading-slash flag value never reaches the script intact:
   `node screenshot.mjs --path /dashboard-dev/wide` navigates to
   `http://localhost:8123C:/Program Files/Git/dashboard-dev/wide`, and a `/c/Users/...`
-  document path arrives as `C:\c\Users\...`. Prefix the command with
-  `MSYS_NO_PATHCONV=1`, or pass file paths natively with forward slashes
-  (`"C:/Users/you/backup.json"`). Only values starting with `/` are affected, and the
-  defaults never cross the command line — which is why `--path` looks fine right up
-  until the first time you set it.
+  document path arrives as `C:\c\Users\...`. The per-pass form is rewritten too —
+  `--path desktop=/dashboard-dev/wide` arrives as
+  `desktop=C:/Program Files/Git/dashboard-dev/wide`, since conversion looks at the value
+  after the `=`. Prefix the command with `MSYS_NO_PATHCONV=1`, or pass file paths natively
+  with forward slashes (`"C:/Users/you/backup.json"`). Discovery leaves `--path` rarely
+  needed, which is exactly why it bites the first time you do set one.
+- **An unknown view path is not a 404** — Home Assistant keeps the URL and renders view 0.
+  A harness pointed at a renamed or deleted view therefore finds a perfectly healthy card
+  in the *other* layout, and every recipe whose testids exist in both branches passes on
+  the wrong screen. That silent wrong-shape run is what discovery avoids by asking rather
+  than assuming, and what `visual_pass.mjs`'s `d-layout` / `m-layout` checks catch when a
+  `--path` override points a pass somewhere stale.
 - **A card change you can't see in the browser**: the bundle is served without
   `Cache-Control`, so the browser revalidates and a plain reload is normally enough.
   Check the deployed bytes with the `sha256sum` pair under Deploy before concluding the

--- a/.claude/skills/run-haventory/card_views.mjs
+++ b/.claude/skills/run-haventory/card_views.mjs
@@ -1,0 +1,313 @@
+// Where the HAventory card lives on the instance a harness is pointed at, plus
+// the credentials every harness needs to get there.
+//
+// A hard-coded dashboard path makes "works out of the box" a claim about one
+// instance: rename the dashboard, or install the card somewhere else, and every
+// harness fails identically — a 30 s wait for `haventory-card` that reads like a
+// card which failed to register. So the path is discovered: walk
+// `lovelace/dashboards/list`, read each dashboard's config, and keep the views
+// that really hold a `custom:haventory-card`.
+//
+// Two view shapes matter, because the card picks its layout from ITS OWN
+// rendered width rather than the window's:
+//
+//   wide    a `type: panel` view — the card gets the whole content area, which
+//           is the only place its desktop branch appears.
+//   column  anything else (sections, masonry) — the narrow column a card
+//           normally sits in, where even a 1440px window gets the narrow branch.
+//
+// Discovery is best-effort. An instance that is down, a token without admin
+// rights, or a dashboard set with no HAventory card at all falls back to the
+// constants below and says so, so the harness still fails with its own error
+// message rather than this module's.
+//
+// Run it directly to see what an instance actually offers:
+//   node card_views.mjs
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(skillDir, "..", "..", "..");
+
+/**
+ * The dev dashboard SKILL.md describes. Reached only when discovery finds no
+ * HAventory card at all: a documented path that may be wrong beats no path,
+ * because the harness's own "root never appeared" error names the surface it
+ * was waiting for and this module cannot.
+ */
+export const FALLBACK_PATHS = { wide: "/dashboard-dev/wide", column: "/dashboard-dev/0" };
+
+const CARD_TYPE = "custom:haventory-card";
+const WS_TIMEOUT_MS = 10000;
+
+// --- credentials ----------------------------------------------------------
+
+let cachedConfig = null;
+
+/** HA base URL + long-lived token: real env vars win, the repo-root .env fills the gaps. */
+export function haConfig() {
+  if (cachedConfig) return cachedConfig;
+  try {
+    for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
+      const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
+      if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
+    }
+  } catch {
+    /* no .env — rely on real env vars */
+  }
+  cachedConfig = {
+    base: (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, ""),
+    token: process.env.HA_TOKEN,
+  };
+  return cachedConfig;
+}
+
+// --- reading a dashboard config ------------------------------------------
+
+/**
+ * Whether a `custom:haventory-card` sits anywhere inside this slice of a
+ * Lovelace config.
+ *
+ * Walking every value rather than the known containers is both shorter and
+ * proof against Home Assistant adding another one: a card can hang off a
+ * view's `cards`, a sections view's `sections[].cards`, a stack's `cards`, a
+ * conditional's `card`, and each of those can nest.
+ */
+export function holdsCard(node) {
+  if (Array.isArray(node)) return node.some(holdsCard);
+  if (node === null || typeof node !== "object") return false;
+  if (node.type === CARD_TYPE) return true;
+  return Object.values(node).some(holdsCard);
+}
+
+/**
+ * The views of one dashboard config that hold the card, in view order.
+ *
+ * `urlPath` addresses a view by its `path` when it has one and by index when it
+ * does not, which is Home Assistant's own rule and the reason the dev
+ * dashboard's first view is `/0`. A dashboard whose config is a strategy (the
+ * generated Map dashboard, for one) has no `views` at all and contributes
+ * nothing.
+ */
+export function cardViewsOf(config, dashPath, dashTitle = dashPath) {
+  const views = Array.isArray(config?.views) ? config.views : [];
+  const found = [];
+  views.forEach((view, index) => {
+    if (!holdsCard(view)) return;
+    const viewType = view.type ?? "masonry";
+    found.push({
+      urlPath: `/${dashPath}/${view.path ?? index}`,
+      shape: viewType === "panel" ? "wide" : "column",
+      viewType,
+      label: `${dashTitle} › ${view.title ?? view.path ?? `view ${index}`}`,
+    });
+  });
+  return found;
+}
+
+/**
+ * The view a pass of the given shape should open.
+ *
+ * A view of the wrong shape is still returned when it is all there is — the
+ * caller is told, and a recipe failing on the layout it did not ask for says
+ * far more than a 404 on a path nothing has.
+ */
+export function pickView(found, shape) {
+  const exact = found.find((v) => v.shape === shape);
+  if (exact) return { view: exact, exact: true };
+  return { view: found[0] ?? null, exact: false };
+}
+
+// --- talking to the instance ----------------------------------------------
+
+async function connect(base, token) {
+  const ws = new WebSocket(base.replace(/^http/, "ws") + "/api/websocket");
+  const waiters = new Map();
+  let nextId = 1;
+
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`no auth_ok from ${base} within ${WS_TIMEOUT_MS} ms`)), WS_TIMEOUT_MS);
+    const fail = (message) => {
+      clearTimeout(timer);
+      reject(new Error(message));
+    };
+    ws.addEventListener("error", () => fail(`cannot reach ${base}`), { once: true });
+    ws.addEventListener("message", (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.type === "auth_required") ws.send(JSON.stringify({ type: "auth", access_token: token }));
+      else if (msg.type === "auth_ok") {
+        clearTimeout(timer);
+        resolve();
+      } else if (msg.type === "auth_invalid") fail(`WS auth failed: ${msg.message}`);
+      else if (msg.type === "result") {
+        waiters.get(msg.id)?.(msg);
+        waiters.delete(msg.id);
+      }
+    });
+  });
+
+  return {
+    call(payload) {
+      const id = nextId++;
+      ws.send(JSON.stringify({ id, ...payload }));
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timeout waiting for ${payload.type}`)), WS_TIMEOUT_MS);
+        waiters.set(id, (msg) => {
+          clearTimeout(timer);
+          if (msg.success) resolve(msg.result);
+          else reject(new Error(msg.error?.code ?? "error"));
+        });
+      });
+    },
+    close: () => ws.close(),
+  };
+}
+
+let discovery = null;
+
+/**
+ * Every dashboard view on the instance that holds the card.
+ *
+ * Memoized per process: a harness with several passes asks more than once, and
+ * the answer cannot change inside one run.
+ */
+export function discoverCardViews() {
+  discovery ??= (async () => {
+    const { base, token } = haConfig();
+    const notes = [];
+    if (!token) return { found: [], notes: ["no HA_TOKEN, so no discovery"] };
+
+    let ws;
+    try {
+      ws = await connect(base, token);
+    } catch (err) {
+      return { found: [], notes: [`discovery skipped: ${err.message}`] };
+    }
+    try {
+      // The default dashboard carries no `url_path` and is absent from the
+      // list. On an instance whose default is Home Assistant's generated one
+      // there is no stored config to read, which comes back as
+      // `config_not_found` and is a normal answer, not a failure.
+      const targets = [{ urlPath: null, dashPath: "lovelace", title: "default" }];
+      let list = [];
+      try {
+        list = await ws.call({ type: "lovelace/dashboards/list" });
+      } catch (err) {
+        // Listing dashboards is an admin command; a non-admin token gets this
+        // far and no further, which is worth saying out loud.
+        notes.push(`lovelace/dashboards/list failed (${err.message}) — only the default dashboard was searched`);
+      }
+      for (const d of list) {
+        if (d?.url_path) targets.push({ urlPath: d.url_path, dashPath: d.url_path, title: d.title ?? d.url_path });
+      }
+
+      const found = [];
+      for (const target of targets) {
+        let config;
+        try {
+          config = await ws.call(
+            target.urlPath === null
+              ? { type: "lovelace/config" }
+              : { type: "lovelace/config", url_path: target.urlPath },
+          );
+        } catch {
+          continue; // no stored config: generated or strategy-only
+        }
+        found.push(...cardViewsOf(config, target.dashPath, target.title));
+      }
+      return { found, notes };
+    } finally {
+      ws.close();
+    }
+  })();
+  return discovery;
+}
+
+let notesPrinted = false;
+
+/**
+ * The URL path a harness should open for the given shape, announced on stdout
+ * so a run says which view it chose and why. `label` names the caller's own
+ * notion of the pass when it has one; the shape is the sensible default.
+ */
+export async function cardPath(shape, { override = null, label = shape } = {}) {
+  if (override) {
+    console.log(`view (${label}): ${override}  ← --path override`);
+    return override;
+  }
+  const { found, notes } = await discoverCardViews();
+  if (!notesPrinted) {
+    notesPrinted = true;
+    for (const note of notes) console.log(`  (${note})`);
+  }
+  const { view, exact } = pickView(found, shape);
+  if (!view) {
+    const fallback = FALLBACK_PATHS[shape];
+    console.log(`view (${label}): ${fallback}  ← nothing holds a ${CARD_TYPE}; using the documented default`);
+    return fallback;
+  }
+  const why = exact
+    ? `${view.label} (${view.viewType})`
+    : `${view.label} (${view.viewType}) — WARNING: no ${shape === "wide" ? "type: panel" : "non-panel"} view holds the card, so this runs on the wrong layout`;
+  console.log(`view (${label}): ${view.urlPath}  ← ${why}`);
+  return view.urlPath;
+}
+
+// --- per-pass --path overrides -------------------------------------------
+
+/**
+ * Parse repeatable `--path` arguments for a harness that opens several URLs in
+ * one run.
+ *
+ * `--path <pass>=<url>` targets one pass. A bare `--path <url>` cannot say which
+ * of them it means, so it is accepted only when the run has already been
+ * narrowed to a single pass — otherwise it would quietly force one URL onto
+ * passes that need a different view shape, or a different route entirely.
+ *
+ * Returns `{ overrides, error }`; the caller owns how an error is reported.
+ */
+export function parsePathOverrides(args, passKeys, only) {
+  const overrides = {};
+  const specs = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--path" && args[i + 1] !== undefined) specs.push(args[++i]);
+  }
+  for (const spec of specs) {
+    const m = spec.match(/^([A-Za-z][\w-]*)=(.+)$/);
+    if (!m) {
+      if (!only) {
+        return {
+          overrides,
+          error:
+            `--path ${spec}: which pass? Name it — --path <pass>=<url> (${passKeys.join(", ")}) — ` +
+            "or narrow the run with --only <pass> first.",
+        };
+      }
+      overrides[only] = spec;
+      continue;
+    }
+    if (!passKeys.includes(m[1])) {
+      return { overrides, error: `--path ${spec}: unknown pass "${m[1]}" (expected ${passKeys.join(", ")})` };
+    }
+    overrides[m[1]] = m[2];
+  }
+  return { overrides, error: null };
+}
+
+// --- CLI ------------------------------------------------------------------
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const { found, notes } = await discoverCardViews();
+  for (const note of notes) console.log(`(${note})`);
+  console.log(`${found.length} view(s) hold ${CARD_TYPE}:`);
+  for (const v of found) {
+    console.log(`  ${v.shape.padEnd(7)} ${v.urlPath.padEnd(24)} ${v.viewType.padEnd(9)} ${v.label}`);
+  }
+  for (const shape of ["wide", "column"]) {
+    const { view, exact } = pickView(found, shape);
+    const chosen = view ? view.urlPath : `${FALLBACK_PATHS[shape]} (fallback)`;
+    console.log(`${shape.padEnd(7)} -> ${chosen}${view && !exact ? "  (wrong shape — nothing better exists)" : ""}`);
+  }
+}

--- a/.claude/skills/run-haventory/card_views.test.mjs
+++ b/.claude/skills/run-haventory/card_views.test.mjs
@@ -1,0 +1,124 @@
+// Unit cover for the parts of card_views.mjs that decide where a harness looks.
+//
+// Discovery itself needs a running Home Assistant, but everything it decides
+// afterwards — is there a card in this view, which URL addresses it, which
+// shape does a pass get, what did --path ask for — is pure, and a mistake in
+// any of it silently repoints every harness at the wrong screen.
+//
+// Run: node --test   (from .claude/skills/run-haventory/)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cardViewsOf, holdsCard, parsePathOverrides, pickView } from "./card_views.mjs";
+
+// The dev dashboard's real config, as `lovelace/config` returns it.
+const DEV_DASHBOARD = {
+  views: [
+    {
+      type: "sections",
+      sections: [
+        { type: "grid", cards: [{ type: "heading", heading: "New section" }, { type: "custom:haventory-card" }] },
+      ],
+    },
+    { title: "wide", path: "wide", type: "panel", cards: [{ type: "custom:haventory-card" }] },
+  ],
+};
+
+test("holdsCard finds a card nested inside a sections grid", () => {
+  assert.equal(holdsCard(DEV_DASHBOARD.views[0]), true);
+});
+
+test("holdsCard finds a card inside a stack and behind a conditional", () => {
+  const stacked = { cards: [{ type: "vertical-stack", cards: [{ type: "custom:haventory-card" }] }] };
+  const conditional = { cards: [{ type: "conditional", card: { type: "custom:haventory-card" } }] };
+  assert.equal(holdsCard(stacked), true);
+  assert.equal(holdsCard(conditional), true);
+});
+
+test("holdsCard says no to a view of other cards and to a strategy dashboard", () => {
+  assert.equal(holdsCard({ type: "sections", sections: [{ cards: [{ type: "markdown" }] }] }), false);
+  assert.equal(holdsCard({ strategy: { type: "map" } }), false);
+  assert.equal(holdsCard(null), false);
+});
+
+test("cardViewsOf reads both dev-dashboard views with their shapes", () => {
+  assert.deepEqual(cardViewsOf(DEV_DASHBOARD, "dashboard-dev", "dev"), [
+    { urlPath: "/dashboard-dev/0", shape: "column", viewType: "sections", label: "dev › view 0" },
+    { urlPath: "/dashboard-dev/wide", shape: "wide", viewType: "panel", label: "dev › wide" },
+  ]);
+});
+
+test("cardViewsOf addresses a view by index only when it has no path", () => {
+  const config = {
+    views: [
+      { type: "panel", cards: [{ type: "markdown" }] },
+      { path: "stuff", cards: [{ type: "custom:haventory-card" }] },
+      { cards: [{ type: "custom:haventory-card" }] },
+    ],
+  };
+  // The index is the view's own, not its position among the matches: skipping
+  // the first view must not shift the third one to /1.
+  assert.deepEqual(
+    cardViewsOf(config, "d").map((v) => v.urlPath),
+    ["/d/stuff", "/d/2"],
+  );
+});
+
+test("cardViewsOf treats a view with no type as a column and a strategy config as empty", () => {
+  assert.deepEqual(cardViewsOf({ views: [{ cards: [{ type: "custom:haventory-card" }] }] }, "d")[0], {
+    urlPath: "/d/0",
+    shape: "column",
+    viewType: "masonry",
+    label: "d › view 0",
+  });
+  assert.deepEqual(cardViewsOf({ strategy: { type: "map" } }, "map"), []);
+  assert.deepEqual(cardViewsOf(undefined, "d"), []);
+});
+
+test("pickView prefers the asked-for shape wherever it sits", () => {
+  const found = cardViewsOf(DEV_DASHBOARD, "dashboard-dev", "dev");
+  assert.deepEqual(pickView(found, "wide"), { view: found[1], exact: true });
+  assert.deepEqual(pickView(found, "column"), { view: found[0], exact: true });
+});
+
+test("pickView falls back to the wrong shape rather than to nothing, and says so", () => {
+  const columnOnly = cardViewsOf({ views: [{ cards: [{ type: "custom:haventory-card" }] }] }, "d");
+  assert.deepEqual(pickView(columnOnly, "wide"), { view: columnOnly[0], exact: false });
+  assert.deepEqual(pickView([], "wide"), { view: null, exact: false });
+});
+
+const PASSES = ["desktop", "mobile", "panel", "panel-mobile"];
+
+test("parsePathOverrides targets one pass per --path and takes several", () => {
+  const { overrides, error } = parsePathOverrides(
+    ["--path", "desktop=/a/wide", "--out", "x", "--path", "panel-mobile=/haventory"],
+    PASSES,
+    null,
+  );
+  assert.equal(error, null);
+  assert.deepEqual(overrides, { desktop: "/a/wide", "panel-mobile": "/haventory" });
+});
+
+test("parsePathOverrides rejects a bare --path across a whole run", () => {
+  const { error } = parsePathOverrides(["--path", "/a/wide"], PASSES, null);
+  assert.match(error, /which pass/);
+});
+
+test("parsePathOverrides accepts a bare --path once --only names the pass", () => {
+  const { overrides, error } = parsePathOverrides(["--only", "desktop", "--path", "/a/wide"], PASSES, "desktop");
+  assert.equal(error, null);
+  assert.deepEqual(overrides, { desktop: "/a/wide" });
+});
+
+test("parsePathOverrides rejects a pass name it does not have", () => {
+  const { error } = parsePathOverrides(["--path", "tablet=/a/wide"], PASSES, null);
+  assert.match(error, /unknown pass "tablet"/);
+});
+
+test("parsePathOverrides finds nothing to do when --path is absent", () => {
+  assert.deepEqual(parsePathOverrides(["--only", "mobile", "--dark"], PASSES, "mobile"), {
+    overrides: {},
+    error: null,
+  });
+});

--- a/.claude/skills/run-haventory/drive_import.mjs
+++ b/.claude/skills/run-haventory/drive_import.mjs
@@ -9,7 +9,8 @@
 //   node drive_import.mjs <document.json> [--policy merge|replace|skip]
 //                         [--apply] [--out <prefix>] [--path <ha-url-path>]
 //
-// Defaults: --policy merge, --out import, --path /dashboard-dev/wide.
+// Defaults: --policy merge, --out import, and — without --path — the panel-mode
+// dashboard view discovered to hold the card (card_views.mjs).
 //
 // The document is pasted verbatim and is NOT validated here — driving the
 // card's own parse-error and server-rejection paths is a supported use, so
@@ -26,22 +27,13 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { cardPath, haConfig } from "./card_views.mjs";
+
 const skillDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(skillDir, "..", "..", "..");
 
 const args = process.argv.slice(2);
 
-// --- config: env wins, .env fills the gaps -------------------------------
-try {
-  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
-    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
-    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
-  }
-} catch {
-  /* no .env — rely on real env vars */
-}
-const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
-const token = process.env.HA_TOKEN;
+const { base, token } = haConfig();
 if (!token) {
   console.error("Missing HA_TOKEN (env or repo-root .env)");
   process.exit(2);
@@ -76,7 +68,9 @@ if (!["merge", "replace", "skip"].includes(policy)) {
 }
 
 const outPrefix = flag("--out", "import");
-const urlPath = flag("--path", "/dashboard-dev/wide");
+// The import sheet is a wide surface: with no --path, ask the instance for a
+// panel-mode view so the sheet gets the room its preview table needs.
+const urlPathArg = flag("--path", null);
 const apply = args.includes("--apply");
 const shot = (suffix) => path.resolve(skillDir, `${outPrefix}-${suffix}.png`);
 
@@ -91,6 +85,8 @@ console.log(
   `document: ${docPath} (${(documentJson.length / 1024).toFixed(0)} KiB) · policy=${policy}` +
     (apply ? " · APPLY (this writes)" : " · preview only"),
 );
+
+const urlPath = urlPathArg ?? (await cardPath("wide"));
 
 // --- drive ---------------------------------------------------------------
 const browser = await chromium.launch();

--- a/.claude/skills/run-haventory/import_policies.mjs
+++ b/.claude/skills/run-haventory/import_policies.mjs
@@ -34,8 +34,9 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
+import { cardPath, haConfig } from "./card_views.mjs";
+
 const skillDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(skillDir, "..", "..", "..");
 
 const args = process.argv.slice(2);
 const flag = (name, dflt) => {
@@ -43,22 +44,13 @@ const flag = (name, dflt) => {
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
 };
 
-try {
-  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
-    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
-    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
-  }
-} catch {
-  /* no .env — rely on real env vars */
-}
-const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
-const token = process.env.HA_TOKEN;
+const { base, token } = haConfig();
 if (!token) {
   console.error("Missing HA_TOKEN (env or repo-root .env)");
   process.exit(2);
 }
 
-const urlPath = flag("--path", "/dashboard-dev/0");
+const urlPath = flag("--path", null) ?? (await cardPath("column"));
 const outPrefix = flag("--out", "policies");
 const sampleSize = Number(flag("--items", "6"));
 const docPath = flag("--doc", null);

--- a/.claude/skills/run-haventory/rl_banner.mjs
+++ b/.claude/skills/run-haventory/rl_banner.mjs
@@ -14,7 +14,11 @@
 //   node rl_banner.mjs --scenario retrying   # refuse the first round, let a retry win
 //   node rl_banner.mjs --scenario exhausted  # refuse every retry, then Refresh
 //   node rl_banner.mjs --observe 30          # watch only; never touches the options flow
-//   node rl_banner.mjs --path /dashboard-dev/wide --out rl
+//   node rl_banner.mjs --out rl               # screenshot prefix
+//
+// With no --path it opens whichever dashboard view is discovered to hold the
+// card in a normal column (card_views.mjs); the banner is not width-dependent,
+// so any view that renders the card will do.
 //
 // Scenarios (both drive the options flow over REST, exactly as the integration's
 // own config flow does, and always reset rate limiting to OFF on the way out):
@@ -33,26 +37,16 @@
 // Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
 
 import { chromium } from "playwright";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { cardPath, haConfig } from "./card_views.mjs";
+
 const skillDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(skillDir, "..", "..", "..");
 
 const args = process.argv.slice(2);
 
-// --- config: env wins, .env fills the gaps -------------------------------
-try {
-  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
-    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
-    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
-  }
-} catch {
-  /* no .env — rely on real env vars */
-}
-const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
-const token = process.env.HA_TOKEN;
+const { base, token } = haConfig();
 if (!token) {
   console.error("Missing HA_TOKEN (env or repo-root .env)");
   process.exit(2);
@@ -63,7 +57,7 @@ const flag = (name, dflt) => {
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
 };
 
-const urlPath = flag("--path", "/dashboard-dev/0");
+const urlPath = flag("--path", null) ?? (await cardPath("column"));
 const outPrefix = flag("--out", "rl");
 const observeSecs = args.includes("--observe") ? Number(flag("--observe", "30")) : null;
 const scenarioArg = flag("--scenario", null);

--- a/.claude/skills/run-haventory/screenshot.mjs
+++ b/.claude/skills/run-haventory/screenshot.mjs
@@ -12,7 +12,8 @@
 //                       [--search <text>] [--tap <selector>]
 //                       [--swipe <dir>[@<selector>]] [--wait <ms>]
 //
-// Defaults: --out screenshot.png, --path /dashboard-dev/0, desktop 1280x900.
+// Defaults: --out screenshot.png, desktop 1280x900, and — without --path — the
+// dashboard view discovered to hold the card in a normal column (card_views.mjs).
 //
 // --element names the root the run waits for and scopes --search/--swipe to. The
 // dashboard card is the default; the sidebar panel at /haventory renders
@@ -40,12 +41,12 @@
 // renders blank.
 
 import { chromium, devices } from "playwright";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { cardPath, haConfig } from "./card_views.mjs";
+
 const skillDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(skillDir, "..", "..", "..");
 
 const args = process.argv.slice(2);
 
@@ -54,17 +55,7 @@ if (args.includes("--devices")) {
   process.exit(0);
 }
 
-// --- config: env wins, .env fills the gaps -------------------------------
-try {
-  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
-    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
-    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
-  }
-} catch {
-  /* no .env — rely on real env vars */
-}
-const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
-const token = process.env.HA_TOKEN;
+const { base, token } = haConfig();
 if (!token) {
   console.error("Missing HA_TOKEN (env or repo-root .env)");
   process.exit(2);
@@ -78,11 +69,10 @@ const flag = (name, dflt) => {
 const has = (name) => args.includes(name);
 
 const outFile = path.resolve(skillDir, flag("--out", "screenshot.png"));
-// The default dashboard is HA's generated one and carries no HAventory card, so
-// the card lives on a `dev` dashboard: view 0 is a sections grid, which is the
-// narrow column a card normally sits in. Views without a `path` are addressed by
-// index. See SKILL.md for the dashboard the dev instance is expected to have.
-const urlPath = flag("--path", "/dashboard-dev/0");
+// With no --path, ask the instance which dashboard view holds the card in a
+// normal column — the shape a single screenshot is normally after. The sidebar
+// panel is not a dashboard view and is reached with an explicit --path.
+const urlPath = flag("--path", null) ?? (await cardPath("column"));
 const rootElement = flag("--element", "haventory-card");
 const fullPage = has("--full");
 const haDark = has("--dark");

--- a/.claude/skills/run-haventory/visual_pass.mjs
+++ b/.claude/skills/run-haventory/visual_pass.mjs
@@ -17,6 +17,11 @@
 //   node visual_pass.mjs --surfaces list,search,full-view
 //   node visual_pass.mjs --dark                # HA dark theme + dark OS scheme
 //   node visual_pass.mjs --list                # print the surface names and exit
+//   node visual_pass.mjs --path desktop=/other/wide   # one pass onto another view
+//
+// The four passes open three different URLs, so `--path` names the pass it
+// applies to and may be repeated. A bare `--path <url>` is taken only alongside
+// `--only`, where there is exactly one pass for it to mean.
 //
 // Everything it drives is read-only: it opens panels, sheets and editors but
 // never saves, imports or deletes. The one exception is the search box, which is
@@ -25,12 +30,13 @@
 // Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
 
 import { chromium, devices } from "playwright";
-import { readFileSync, mkdirSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { cardPath, haConfig, parsePathOverrides } from "./card_views.mjs";
+
 const skillDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(skillDir, "..", "..", "..");
 
 const args = process.argv.slice(2);
 const flag = (name, dflt) => {
@@ -57,9 +63,10 @@ const flag = (name, dflt) => {
 // captures of the same surface sort next to each other.
 //
 // The card chooses its layout from ITS OWN width, not the viewport's, so the
-// desktop pass runs on the `wide` dashboard view: in a normal dashboard column
-// even a 1440px window gets the narrow branch, where the filter panel is a modal
-// sheet and the full-view link is absent entirely.
+// desktop pass runs on a panel-mode view: in a normal dashboard column even a
+// 1440px window gets the narrow branch, where the filter panel is a modal sheet
+// and the full-view link is absent entirely. Which view that is, on this
+// instance, is discovered — see card_views.mjs.
 //
 // Each pass names the root element it waits for and scopes its selectors to:
 // the sidebar panel at /haventory is a different custom element and renders no
@@ -387,46 +394,33 @@ if (args.includes("--list")) {
   process.exit(0);
 }
 
-// --- config: env wins, .env fills the gaps -------------------------------
-try {
-  for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
-    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
-    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
-  }
-} catch {
-  /* no .env — rely on real env vars */
-}
-const base = (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, "");
-const token = process.env.HA_TOKEN;
+const { base, token } = haConfig();
 if (!token) {
   console.error("Missing HA_TOKEN (env or repo-root .env)");
   process.exit(2);
 }
 
 const outDir = path.resolve(skillDir, flag("--out", "visual"));
-// Per-pass by default; --path forces one view for both, which is how you check
-// a single dashboard layout rather than the two the card is designed for.
-const urlPathOverride = flag("--path", null);
 const haDark = args.includes("--dark");
 const only = flag("--only", null);
 const wanted = flag("--surfaces", null)?.split(",").map((s) => s.trim());
 mkdirSync(outDir, { recursive: true });
 
-// Home Assistant's default dashboard is the generated one and holds no HAventory
-// card, so both card passes run on the `dev` dashboard: its `wide` view is
-// panel-mode (the card gets the window's full width), and view 0 is a sections
-// grid (the narrow column a card normally sits in). Views without a `path` are
-// addressed by index. SKILL.md documents the dashboard the dev instance needs.
-const WIDE_VIEW = "/dashboard-dev/wide";
-const COLUMN_VIEW = "/dashboard-dev/0";
+// The sidebar panel is Home Assistant's own route into the integration, so it
+// needs no dashboard at all — and it gets the whole content area, which is why
+// both panel passes use it at both widths.
+const PANEL_ROUTE = "/haventory";
 
-const PASSES = [
+// `shape` is what the pass needs of a dashboard view (see card_views.mjs); the
+// panel passes name a route instead, because theirs is not a dashboard.
+const ALL_PASSES = [
   {
     key: "desktop",
     prefix: "d",
     root: CARD,
     surfaces: DESKTOP_SURFACES,
-    urlPath: WIDE_VIEW,
+    shape: "wide",
+    layout: "desktop",
     contextOptions: { viewport: { width: 1440, height: 900 } },
   },
   {
@@ -434,17 +428,16 @@ const PASSES = [
     prefix: "m",
     root: CARD,
     surfaces: MOBILE_SURFACES,
-    urlPath: COLUMN_VIEW,
+    shape: "column",
+    layout: "mobile",
     contextOptions: { ...devices["iPhone 15"], deviceScaleFactor: 2 },
   },
   {
-    // The panel needs no `wide` dashboard: Home Assistant gives it the whole
-    // content area, so a normal window is already the layout it ships with.
     key: "panel",
     prefix: "p",
     root: PANEL,
     surfaces: PANEL_SURFACES,
-    urlPath: "/haventory",
+    route: PANEL_ROUTE,
     contextOptions: { viewport: { width: 1440, height: 900 } },
   },
   {
@@ -455,7 +448,7 @@ const PASSES = [
     prefix: "pm",
     root: PANEL,
     surfaces: PANEL_MOBILE_SURFACES,
-    urlPath: "/haventory",
+    route: PANEL_ROUTE,
     contextOptions: {
       viewport: { width: 375, height: 812 },
       hasTouch: true,
@@ -463,7 +456,32 @@ const PASSES = [
       deviceScaleFactor: 2,
     },
   },
-].filter((p) => !only || p.key === only);
+];
+
+const PASS_KEYS = ALL_PASSES.map((p) => p.key);
+// An unrecognised --only would otherwise select no pass at all and the run would
+// report 0/0 captured and exit 0 — a typo that reads as a clean run.
+if (only && !PASS_KEYS.includes(only)) {
+  console.error(`--only ${only}: unknown pass (expected ${PASS_KEYS.join(", ")})`);
+  process.exit(2);
+}
+
+const { overrides, error } = parsePathOverrides(args, PASS_KEYS, only);
+if (error) {
+  console.error(error);
+  process.exit(2);
+}
+
+const PASSES = ALL_PASSES.filter((p) => !only || p.key === only);
+for (const pass of PASSES) {
+  const override = overrides[pass.key] ?? null;
+  if (pass.route && !override) {
+    pass.urlPath = pass.route;
+    console.log(`view (${pass.key}): ${pass.route}  ← the integration's own panel route`);
+  } else {
+    pass.urlPath = await cardPath(pass.shape, { override, label: pass.key });
+  }
+}
 
 const results = [];
 const browser = await chromium.launch({ args: ["--touch-events=enabled"] });
@@ -512,7 +530,7 @@ for (const pass of PASSES) {
     [base, token, haDark],
   );
 
-  const url = base + (urlPathOverride ?? pass.urlPath);
+  const url = base + pass.urlPath;
   const loadRoot = async () => {
     await page.goto(url, { waitUntil: "domcontentloaded" });
     if (page.url().includes("/auth/authorize")) {
@@ -537,6 +555,32 @@ for (const pass of PASSES) {
     if (touch) return el.tap();
     return el.click();
   };
+
+  // A view of the wrong shape still renders the card, and enough testids are
+  // shared between the two branches that the recipes below would pass while
+  // photographing the other layout — the failure this pass exists to rule out.
+  // The shell reflects the branch it measured itself into, so ask it once, up
+  // front, and fail the pass instead of the reader's trust.
+  if (pass.layout) {
+    const name = `${pass.prefix}-layout`;
+    try {
+      await loadRoot();
+      const mobile = await page
+        .locator(CARD)
+        .first()
+        .evaluate((el) => el.shadowRoot?.querySelector("hv-card-shell")?.hasAttribute("mobile") ?? null);
+      if (mobile !== (pass.layout === "mobile")) {
+        throw new Error(
+          `card took its ${mobile ? "narrow" : "desktop"} branch on ${pass.urlPath}, but this pass needs the ${pass.layout} one`,
+        );
+      }
+      console.log(`  PASS  ${name} (${pass.layout} branch on ${pass.urlPath})`);
+      results.push({ name, ok: true });
+    } catch (err) {
+      console.log(`  FAIL  ${name}: ${err.message.split("\n")[0]}`);
+      results.push({ name, ok: false, error: err.message.split("\n")[0] });
+    }
+  }
 
   for (const surface of pass.surfaces) {
     if (wanted && !wanted.some((w) => surface.id.includes(w))) continue;


### PR DESCRIPTION
Two follow-ups from #175, both in the `run-haventory` screenshot harness.

## 1. Discover the card instead of hard-coding the dashboard

`/dashboard-dev/{0,wide}` was baked into five scripts by name, so renaming that
dashboard reproduces exactly what #175 fixed. New shared `card_views.mjs` walks
`lovelace/dashboards/list` → `lovelace/config` per dashboard (plus the default one, which
answers `config_not_found` when it is Home Assistant's generated dashboard), and keeps the
views that really hold a `custom:haventory-card` — the walk is depth-first over every value,
so a card in a sections grid, a stack or behind a conditional all count.

It serves two shapes, because the card picks its layout from **its own** measured width
(600px, `MOBILE_BREAKPOINT`): `wide` prefers a `type: panel` view, `column` takes anything
else. All five harnesses ride it — `screenshot.mjs`, `visual_pass.mjs`, `drive_import.mjs`,
`import_policies.mjs`, `rl_banner.mjs` — and each prints the view it resolved and why. The
`.env`/credential block those five each carried a copy of moved into the helper as well.

Degradation is explicit: nothing found (HA down, non-admin token, no card anywhere) falls
back to `/dashboard-dev/wide` + `/dashboard-dev/0` and says so, so the harness still fails
with its own message; only-the-wrong-shape is used with a `WARNING` rather than refused.

**A wrong shape was silently passing.** Home Assistant does not 404 an unknown view path —
it keeps the URL and renders view 0. After renaming the dev views, forcing the desktop pass
onto the stale `/dashboard-dev/wide` gave a healthy card at 500px in its **narrow** branch,
and `d-02-filter-panel` / `d-11-full-view` both passed there, because those testids exist in
both branches. Measured:

```
/dashboard-dev/narrow  url=/dashboard-dev/narrow  width=500   shell[mobile]=true
/dashboard-dev/broad   url=/dashboard-dev/broad   width=1184  shell[mobile]=false
/dashboard-dev/wide    url=/dashboard-dev/wide    width=500   shell[mobile]=true   <- view path gone, HA rendered view 0
```

So `visual_pass.mjs`'s two card passes now assert the branch the card actually took
(`d-layout`, `m-layout`) before running a recipe — 42 rows out of 40 surfaces.

## 2. Per-pass `--path` in `visual_pass.mjs`

A single `--path` forced one URL across four passes that open three URLs. It is now
`--path <pass>=<url>` and repeatable. A **bare** `--path` is kept for exactly one case and
SKILL.md says so: alongside `--only`, where there is one pass for it to mean
(`--only desktop --path /dashboard-dev/wide`). Bare `--path` across a whole run is rejected
rather than silently applied to passes needing a different shape or route. An unrecognised
`--only` is rejected too — it used to select no pass at all and report `0/0 … exit 0`.

## Verification (live, against the dev container)

### Discovery output

```
$ node card_views.mjs
2 view(s) hold custom:haventory-card:
  column  /dashboard-dev/0         sections  dev › view 0
  wide    /dashboard-dev/wide      panel     dev › wide
wide    -> /dashboard-dev/wide
column  -> /dashboard-dev/0
```

Proof it is not keyed to the names: both dev-dashboard views were renamed
(`0` → `path: narrow`, `wide` → `broad`) via `lovelace/config/save`, and discovery followed
without a flag changing. The dashboard was restored byte-for-byte afterwards and re-verified.

```
$ node card_views.mjs                       # with the views renamed
2 view(s) hold custom:haventory-card:
  column  /dashboard-dev/narrow    sections  dev › narrow
  wide    /dashboard-dev/broad     panel     dev › broad
wide    -> /dashboard-dev/broad
column  -> /dashboard-dev/narrow

$ node visual_pass.mjs --only desktop --surfaces 01-list          # discovery
view (desktop): /dashboard-dev/broad  ← dev › broad (panel)
  PASS  d-layout (desktop branch on /dashboard-dev/broad)
  PASS  d-01-list
2/2 surfaces captured

$ node visual_pass.mjs --only desktop --surfaces 01-list --path desktop=/dashboard-dev/wide
view (desktop): /dashboard-dev/wide  ← --path override
  FAIL  d-layout: card took its narrow branch on /dashboard-dev/wide, but this pass needs the desktop one
  PASS  d-01-list
1/2 surfaces captured   (exit 1)
```

### Full run, nothing on the command line — 42/42, exit 0

```
view (desktop): /dashboard-dev/wide  ← dev › wide (panel)
view (mobile): /dashboard-dev/0  ← dev › view 0 (sections)
view (panel): /haventory  ← the integration's own panel route
view (panel-mobile): /haventory  ← the integration's own panel route

== desktop ==      PASS d-layout (desktop branch on /dashboard-dev/wide), d-01-list … d-14-full-columns   (15)
== mobile ==       PASS m-layout (mobile branch on /dashboard-dev/0), m-01-list … m-08-full-view          (9)
== panel ==        PASS p-01-page … p-10-import                                                           (10)
== panel-mobile == PASS pm-01-page … pm-08-columns                                                        (8)

42/42 surfaces captured into …/visual
```

### Per-pass override runs

```
$ node visual_pass.mjs --path desktop=/dashboard-dev/wide --path mobile=/dashboard-dev/0 --only desktop --surfaces 01-list
  PASS  d-layout (desktop branch on /dashboard-dev/wide)
  PASS  d-01-list                                        2/2

$ node visual_pass.mjs --only mobile --path /dashboard-dev/0 --surfaces 01-list     # bare, with --only
  PASS  m-layout (mobile branch on /dashboard-dev/0)
  PASS  m-01-list                                        2/2

$ node visual_pass.mjs --path /dashboard-dev/wide
--path /dashboard-dev/wide: which pass? Name it — --path <pass>=<url> (desktop, mobile, panel, panel-mobile) — or narrow the run with --only <pass> first.      (exit 2)

$ node visual_pass.mjs --path tablet=/dashboard-dev/wide
--path tablet=/dashboard-dev/wide: unknown pass "tablet" (expected desktop, mobile, panel, panel-mobile)  (exit 2)

$ node visual_pass.mjs --only deskto
--only deskto: unknown pass (expected desktop, mobile, panel, panel-mobile)                               (exit 2)
```

### The other four harnesses, all through discovery

```
screenshot.mjs        view (column): /dashboard-dev/0  ← dev › view 0 (sections)      screenshot written
screenshot.mjs        --path /haventory --element haventory-panel                     screenshot written
drive_import.mjs      view (wide): /dashboard-dev/wide  ← dev › wide (panel)          preview 823 KiB, exit 0
import_policies.mjs   view (column): /dashboard-dev/0                                 merge/replace/skip PASS, exit 0
rl_banner.mjs         view (column): /dashboard-dev/0  (--observe, read-only)         exit 0
```

## Gates

| gate | result |
|---|---|
| `pytest -q` | 458 passed, 22 skipped |
| `ruff check .` | All checks passed |
| `mypy` | Success: no issues found in 14 source files |
| `eslint .` | clean |
| `tsc --noEmit` | clean |
| `vitest run` | 988 passed across 48 files |
| `npm run build` | 445.88 kB / 101.40 kB gzip |
| `npm audit --audit-level=high` | 0 vulnerabilities |
| `node --test` (new, in the skill dir) | 13 passed |

The harness's pure logic — which views hold the card, which URL addresses them (index vs.
`path`), which shape a pass gets, what `--path` asked for — is covered by
`card_views.test.mjs` under Node's built-in runner. No new dependency; not wired into CI,
since nothing in `.claude/skills/` is.

## Follow-ups (not in this PR, and not added to `docs/open-items.md` — pre-v0.2.0)

- `d-02-filter-panel` and `d-11-full-view` are named as desktop surfaces but pass in the
  narrow branch too (`filter-panel` is reused inside the mobile filter sheet; the full view
  is a modal at any width). The `d-layout` assertion covers the shape now, but the desktop
  recipe list would be sharper if those two asserted something the narrow branch lacks.
- `screenshot.mjs --element haventory-panel` still needs `--path /haventory` passed
  alongside it; defaulting the path from the element would remove the one remaining place a
  route has to be typed.
- Discovery picks the first matching view in dashboard-list order when several qualify. Fine
  for one card per dashboard; an instance with the card on several dashboards has no way to
  say which it means beyond `--path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
