### PR TITLE
fix(card): announce only the filter surface the width uses, and no aria-expanded on leaves

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -310,16 +310,37 @@ describe('hv-card-shell: search and filters', () => {
         // Only the contents come and go; the element the button names stays.
         expect(showing(), `${where}, contents flipped`).toBe(!was.showing);
         expect(sr.getElementById(id), `${where}, still there`).toBeTruthy();
-        // The phone's button reads the desktop panel's remembered state as well
-        // as the sheet's, so its announcement is not the sheet's alone and the
-        // surface above is what says whether the press landed.
-        if (!mobile) {
-          expect(toggle().getAttribute('aria-expanded'), `${where}, flipped`).toBe(
-            String(was.expanded !== 'true'),
-          );
-        }
+        // The button reports the surface its own width uses, so the press
+        // shows in the announcement at either width.
+        expect(toggle().getAttribute('aria-expanded'), `${where}, flipped`).toBe(
+          String(!was.showing),
+        );
       }
       el.remove();
+    }
+  });
+
+  it('keeps the remembered desktop panel out of the phone button announcement', async () => {
+    // A desktop session that left the panel open is remembered across loads;
+    // the phone's button reports its own sheet, which starts shut regardless.
+    window.localStorage.setItem('haventory:filter-panel-open:v1', '1');
+    try {
+      const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })], mobile: true });
+      const toggle = () => sr.querySelector('[data-testid="filter-toggle"]') as HTMLButtonElement;
+
+      expect(toggle().getAttribute('aria-expanded')).toBe('false');
+      expect(toggle().classList.contains('on')).toBe(false);
+
+      toggle().click();
+      await settle(el);
+      expect(toggle().getAttribute('aria-expanded')).toBe('true');
+
+      toggle().click();
+      await settle(el);
+      expect(toggle().getAttribute('aria-expanded')).toBe('false');
+      el.remove();
+    } finally {
+      window.localStorage.removeItem('haventory:filter-panel-open:v1');
     }
   });
 

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -947,6 +947,10 @@ export class HVCardShell extends LitElement {
     const loaded = st?.items.length ?? 0;
     const total = st?.total;
     const mobile = this.mobile;
+    // The filter button reports the surface its own width uses. The desktop
+    // panel's open state is remembered across sessions, so reading it on a
+    // phone would announce a surface this width never shows.
+    const filterSurfaceOpen = mobile ? this._filterSheetOpen : this._filterPanelOpen;
 
     return html`
       <div class="header">
@@ -999,10 +1003,10 @@ export class HVCardShell extends LitElement {
           />
         </label>
         <button
-          class="icon-toggle ${this._filterPanelOpen || this._filterSheetOpen ? 'on' : ''}"
+          class="icon-toggle ${filterSurfaceOpen ? 'on' : ''}"
           data-testid="filter-toggle"
           aria-label="Filters"
-          aria-expanded=${String(this._filterPanelOpen || this._filterSheetOpen)}
+          aria-expanded=${String(filterSurfaceOpen)}
           aria-controls=${FILTER_SURFACE_ID}
           title="Filters"
           @click=${this._toggleFilterSurface}

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -302,6 +302,18 @@ describe('hv-location-tree: what a row discloses', () => {
     );
   });
 
+  it('omits aria-expanded on a leaf row instead of writing a non-value', async () => {
+    const el = await mount();
+    el.revealPathTo('bin-3');
+    await el.updateComplete;
+
+    // ARIA has no "undefined" token: a leaf treeitem carries no aria-expanded
+    // at all, the same way it names no container.
+    expect(row(el, 'shelf-a').hasAttribute('aria-expanded')).toBe(false);
+    expect(row(el, 'bin-3').hasAttribute('aria-expanded')).toBe(false);
+    expect(row(el, 'garage').getAttribute('aria-expanded')).toBe('true');
+  });
+
   // Location ids are uuids today, so the escaping is what keeps this honest for
   // ids from anywhere else: distinct keys can never land on one container, and
   // what comes out has to be usable as a selector.

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -387,7 +387,7 @@ export class HVLocationTree extends LitElement {
             : ''}"
           role="treeitem"
           aria-selected=${String(selected)}
-          aria-expanded=${hasChildren ? String(open) : 'undefined'}
+          aria-expanded=${ifDefined(hasChildren ? String(open) : undefined)}
           aria-controls=${ifDefined(hasChildren ? nodeChildrenId(node.id) : undefined)}
           aria-level=${depth + 1}
           data-testid="tree-row"

--- a/docs/open-items.md
+++ b/docs/open-items.md
@@ -18,7 +18,8 @@ non-blocking).
   sidebar panel's PR-2 (#160) landed, re-checked against `main` @ `9180d8f` in the
   **#162 collection pass** (2026-08-02), and re-checked again against `main` @ `04ff0b3` in
   the **close-out pass** of the same day (after #163–#165). Reconciled against
-  `main` @ `0583c29` after the **v0.2.0 payload batch** (#167–#172) landed.
+  `main` @ `0583c29` after the **v0.2.0 payload batch** (#167–#172) landed, and against
+  `main` @ `28f5ccd` after the pre-release follow-up fixes (#173–#178).
 - **Item numbers are stable and append-only** — new items get the next free number
   rather than renumbering the list, so references from PRs and docs keep resolving.
   Read each table's own ordering, not the numbering, for priority. (The one exception —
@@ -511,6 +512,8 @@ Ordered by impact.
 | 86 | **Item status field (OK / Missing / Needs Repair).** A stored, filterable per-item state beside quantity/checkout — schema change (new item field + migration), `ItemFilter` + card surfaces. | roadmap §06 (folded in 2026-08-02) | Medium (feature) | M |
 | 87 | **Area filter on `haventory/subscribe`.** The subscribe schema takes `location_id` / `include_subtree` / `inspection_overdue_only` only (verified 2026-08-02: `ws.py` `_item_matches_filter` knows nothing of areas), while `item/list` accepts `area_id` — so a card filtered to an area still receives every item event and filters client-side. Additive: `area_id` on the subscribe schema + the matcher resolving through the item's `effective_area_id`, mirrored in both contract docs. | roadmap §06 (folded in 2026-08-02) | Low–Med | S–M |
 | 88 | **Quality backlog from the roadmap:** property-based tests (hypothesis) for the repository's index invariants, Playwright visual regression over the card's surfaces, opt-in telemetry. Three separate efforts filed as one placeholder; split when one is picked up. | roadmap §06 (folded in 2026-08-02) | Low | M–L (each) |
+| 89 | **Two "desktop" visual-pass surfaces are not branch-discriminating.** `d-02-filter-panel` and `d-11-full-view` pass in the card's narrow branch too — `filter-panel` is reused inside the mobile filter sheet, and the full view is a modal at any width — so on their own they cannot catch a desktop pass running on the wrong layout. #178's `d-layout` assertion covers the shape for the whole pass; sharper would be each of the two asserting something the narrow branch lacks (the panel applying live with no Apply footer, the full view's sidebar). | PR #178 follow-up | Low (tooling) | S |
+| 90 | **Harness discovery cannot choose between dashboards.** `card_views.mjs` takes the first matching view in `lovelace/dashboards/list` order when several dashboards hold the card; an instance with the card on more than one has no way to say which it means short of a per-pass `--path`. Fine for the dev instance (one card-bearing dashboard); a `--dashboard <url_path>` filter would close it if that ever changes. | PR #178 follow-up | Low (tooling) | S |
 
 ---
 


### PR DESCRIPTION
## Summary

The two announcement bugs #177 reported as follow-ups, triaged fix-now by the owner, plus the ledger rows for the two follow-ups triaged post-v1.0.

1. **The filter button announced the wrong surface on a phone.** `aria-expanded` (and the button's `on` paint) read `_filterPanelOpen || _filterSheetOpen`, and `_filterPanelOpen` is restored from the remembered *desktop* preference — so on a phone, once the panel had ever been left open on a desktop, the button announced "expanded" permanently and drew its on-state while the sheet was shut. It now reports the surface its own width uses: the sheet on a phone, the panel on a desktop. This also corrects the mirror case (a sheet left open across a width change no longer marks the desktop button).
2. **A childless tree row wrote `aria-expanded="undefined"`** — the literal string, not a valid ARIA value. A leaf `treeitem` now carries no `aria-expanded` at all, the same way it names no container (`ifDefined`, matching the `aria-controls` handling one line below).

Ledger: items **89** (branch-discriminating desktop visual-pass surfaces) and **90** (multi-dashboard discovery selection) filed post-v1.0 from #178's follow-ups, per the owner's triage. The same triage dropped the rest: the flaky debounce test is test-infra only (a fixed 250 ms wait racing a 200 ms real timer under runner load — no real-usage effect), and the panel screenshot path default was judged irrelevant.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` — 458 passed, 22 skipped; `uv run ruff check .` clean; `uv run mypy` clean (14 source files)
- [x] Frontend (`cards/haventory-card`): `npm audit --audit-level=high` 0 vulnerabilities; `npx eslint .` clean; `npm run typecheck` clean; `npx vitest run` — 1003 passed across 48 files; `npm run build` 447.70 kB (gzip 102.03 kB)

New tests: the phone button's flip is now asserted at both widths (the desktop-only carve-out in #177's test is gone); a regression test seeds the remembered desktop preference and proves the phone button still announces shut; leaf rows are pinned to carry no `aria-expanded` while a parent keeps its `true`/`false`.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`) — no behavior contract changed; the ledger (`docs/open-items.md`) carries the triage.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

No visual change in any state a width actually shows: the on-paint only changes in the bug case (phone button lit for a surface that was not open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhZ3AExRhmTAJ6JVG23E6G)_