### PR TITLE
fix(skill): submit the options form the way the flow shapes it

### DIFF
--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -574,10 +574,26 @@ async def set_rate_limit(
     flow_id = flow.get("flow_id")
     if not flow_id:
         raise RuntimeError(f"could not start options flow: {flow}")
-    user_input: dict[str, Any] = {"rate_limit_enabled": enabled, **RL_DEFAULTS, **overrides}
+
+    # The form groups the rate-limit knobs into a section, so they must be submitted nested
+    # under that section's name rather than flat, and every top-level key is required — a
+    # partial submit is rejected with "required key not provided". HA seeds each field's
+    # `default` from the entry's current options, so echoing the returned schema back
+    # preserves the settings this layer is not trying to change.
+    user_input: dict[str, Any] = {}
+    for field in flow.get("data_schema", []):
+        if field.get("type") == "expandable":
+            section = {f["name"]: f.get("default") for f in field.get("schema", [])}
+            section.update({"rate_limit_enabled": enabled, **RL_DEFAULTS, **overrides})
+            user_input[field["name"]] = section
+        else:
+            user_input[field["name"]] = field.get("default")
+
     res = await _http(
         session, "POST", f"/api/config/config_entries/options/flow/{flow_id}", user_input
     )
+    if res.get("errors"):
+        raise RuntimeError(f"options flow rejected the submit: {res['errors']}")
     return res
 
 
@@ -620,6 +636,9 @@ async def cmd_ratelimit() -> None:
         print(f"  options-flow result type={res.get('type')}")
         ok = await wait_rl_state(True, 30)
         print(f"  rate_limit enabled now: {ok} {'PASS' if ok else '**FAIL**'}")
+        # Everything below asserts on enforcement, which is vacuously satisfied when the
+        # limiter never came up — so stop here rather than report a green run.
+        assert ok, "rate limiting did not turn on; enforcement checks below would be vacuous"
 
         h_pre = await health(control)
         dropped_pre = h_pre["rate_limit"]["dropped_commands"]


### PR DESCRIPTION
## What

The stress regimen's `ratelimit` layer was silently vacuous. It drove the options flow with a **flat** payload, but the form groups the rate-limit knobs inside a `rate_limit` section and marks every top-level key required, so HA rejected the whole submit:

```
{"errors":{"base":["extra keys not allowed @ data['rate_limit_enabled']", ...],
           "rate_limit":"required key not provided"}}
```

Rate limiting therefore never turned on. Because the layer only *printed* a `**FAIL**` line and carried on, every enforcement assertion below it passed trivially against a disabled limiter and the run still exited 0 — the layer reported green while testing nothing.

## How

- Echo the schema HA returns back at it: nest the section's fields under the section name and carry each top-level field's `default`. HA seeds those defaults from the entry's current options, so `card_title` / `sidebar_panel_enabled` survive a submit this layer isn't trying to change.
- Raise when the flow comes back with `errors` instead of returning a result the caller reads `type` off.
- Assert the limiter actually came up, so a failed enable stops the layer rather than producing a vacuous pass. The existing `finally` still resets rate limiting **off** on that path.

## Verification

Before the fix, against the live dev instance:

```
options-flow result type=None
rate_limit enabled now: False **FAIL**
hammer 41 commands: succeeded=41 rate_limited=0
```

After:

```
options-flow result type=create_entry
rate_limit enabled now: True PASS
hammer 41 commands: succeeded=5 rate_limited=36
sample rate_limited envelope: {"code": "rate_limited", "message": "rate limit exceeded; retry later", "data": {"op": "ping"}}
rate-limited create left no item: PASS
dropped_commands 0 -> 36 (delta 36) PASS
post-disable hammer 40 pings: rate_limited=0 PASS (full recovery)
```

Found while running the full five-surface regimen. Everything else was green: backend 458 passed / ruff / mypy, frontend 988 tests + build, phacc in-process HA suite 31 passed, online WS gate 22 passed with `HAV_ONLINE_DESTRUCTIVE=1` and `HA_ALLOW_AREA_MUTATIONS=1`, all stress layers incl. `restart`, live-update browser smoke, and a log sweep at `BLOCKING: 0`.

## Follow-up (not in this PR)

`cards/haventory-card/e2e/live-updates.smoke.mjs` still defaults to `/lovelace/default_view`, which holds no card — it dies on a 30 s `locator('haventory-card')` timeout that reads exactly like a card crash. The skill harnesses were repointed via `discoverCardViews()` in #175; this one wasn't. `--path /dashboard-dev/0` makes it pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
