### PR TITLE
fix(card): size the area chip like the tree rows it heads

### DIFF
--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -1,5 +1,6 @@
 import './hv-location-tree';
 import type { HVLocationTree } from './hv-location-tree';
+import { base } from '../ui/tokens';
 import type { LocationTreeNode } from '../store/types';
 
 function node(
@@ -386,6 +387,21 @@ describe('hv-location-tree: area grouping', () => {
     const el = await mountAreas();
     expect(heads(el)[0].querySelector('.hv-area-chip')).toBeTruthy();
     expect(heads(el)[0].querySelector('[data-icon="home"]')).toBeTruthy();
+  });
+
+  // Both trees that head their roots with a chip are this component — the
+  // full view's sidebar and the organize dialog's — so its size is settled
+  // here, once, for both.
+  it('sets that chip at row size, leaving the shared chip its smaller one', () => {
+    const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
+    const sheets = Array.isArray(styles) ? styles : [styles];
+    const own = String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+    // Tracks whatever `.row` is set to rather than restating a number beside it.
+    expect(own).toMatch(/\.area-name \.hv-area-chip \{ font-size: inherit/);
+    expect(own).toMatch(/\.row \{[^}]*font: 400 [\d.]+px/);
+    // The other surfaces put this chip beside a path it qualifies, where it is
+    // an annotation and stays smaller than the line carrying it.
+    expect(String(base.cssText)).toMatch(/\.hv-area-chip \{[^}]*font-size: 11px/);
   });
 
   it('leaves an inventory that assigns no areas exactly as it was', async () => {

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -163,6 +163,13 @@ export class HVLocationTree extends LitElement {
         color: inherit;
         text-align: left;
       }
+      /* Everywhere else the chip annotates a path it sits beside, so it is set
+         smaller than the text it qualifies. Here it *is* the row's label, one
+         level of the tree above the locations under it, and reading smaller than
+         them inverted the hierarchy it heads. */
+      .area-name .hv-area-chip {
+        font-size: inherit;
+      }
       .area-none {
         flex: 1;
         min-width: 0;


### PR DESCRIPTION
An area band heads a level of the location tree, but it borrowed the shared `.hv-area-chip`
rule — 11px, sized for annotating a path it sits *beside* on some other surface. Heading a
level in smaller type than the locations underneath inverted the hierarchy it heads. The
full view's sidebar and the organize dialog show the same tree, so both had it.

The chip now takes the row's own size (`font-size: inherit` under `.area-name`), tracking
`.row` rather than restating a number that could drift from it. Scoped to this component:
the data table, list rows, breadcrumbs, detail sheet and item editor still get the smaller
annotation chip they want, which the test asserts alongside the fix.

Verified against the running dev HA in both surfaces (sidebar + organize dialog), plus the
full regimen: backend 458 passed / 22 skipped, ruff + mypy clean; eslint, `tsc --noEmit`,
1004 vitest tests and the build clean; stress layers `fuzz`/`bulkfuzz`/`subteardown`/
`statsprobe`/`ratelimit`/`races`/`bulk 1000`/`restart`/`cleanup` all oracle-PASS with a
log sweep verdict of PASS (blocking=0); live-update browser smoke PASS; online WS smokes
8 passed / 13 skipped.

Follow-up (not touched here): the "No area" band label is still 11.5px uppercase, so the two
band labels in that tree no longer match each other. That is a separate call about how the
no-area tail should read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
