### PR TITLE
fix(e2e): let the live-update smoke discover the view holding the card

### DIFF
--- a/.claude/skills/run-haventory/card_views.test.mjs
+++ b/.claude/skills/run-haventory/card_views.test.mjs
@@ -9,8 +9,13 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 import { cardViewsOf, holdsCard, parsePathOverrides, pickView } from "./card_views.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 // The dev dashboard's real config, as `lovelace/config` returns it.
 const DEV_DASHBOARD = {
@@ -122,3 +127,37 @@ test("parsePathOverrides finds nothing to do when --path is absent", () => {
     error: null,
   });
 });
+
+// --- every harness asks, none assumes -------------------------------------
+//
+// A harness that writes its own dashboard URL is right until the instance is
+// rearranged, and then it fails as "haventory-card never appeared" — which reads
+// like a card that stopped registering, not like a URL that stopped existing.
+// The live-update smoke sat on `/lovelace/default_view` and failed exactly that
+// way. So the rule is the whole point of this module: harnesses ask it.
+//
+// The card's e2e smoke is in the card package rather than beside the others,
+// which is precisely why it drifted unnoticed — it is checked here with them.
+const HARNESSES = [
+  ...readdirSync(here)
+    .filter((f) => f.endsWith(".mjs") && !f.startsWith("card_views"))
+    .map((f) => path.join(here, f)),
+  path.resolve(here, "..", "..", "..", "cards", "haventory-card", "e2e", "live-updates.smoke.mjs"),
+];
+
+// Only `//` comments appear in these files, so dropping those lines leaves the
+// code — a path named in prose is documentation, not a destination.
+const codeOf = (file) =>
+  readFileSync(file, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join("\n");
+
+for (const file of HARNESSES.filter((f) => codeOf(f).includes("page.goto("))) {
+  const name = path.basename(file);
+  test(`${name} takes its URL from card_views, never its own`, () => {
+    const code = codeOf(file);
+    assert.match(code, /import \{[^}]*\bcardPath\b[^}]*\} from ["'][^"']*card_views\.mjs["']/);
+    assert.doesNotMatch(code, /["'`][^"'`]*\/(lovelace|dashboard-)[^"'`]*["'`]/);
+  });
+}

--- a/README.md
+++ b/README.md
@@ -349,9 +349,11 @@ npm i && npx playwright install chromium   # one-time
 npm run test:e2e                            # skips cleanly if RUN_ONLINE is unset
 ```
 
-The card must be deployed on a dashboard at `--path` (default `/lovelace/default_view`),
-e.g. via `scripts/reload_addon.sh`. The test is idempotent — it creates a uniquely-named
-item and deletes it (best-effort cleanup even on failure).
+The card must be on a dashboard (deploy e.g. via `scripts/reload_addon.sh`), but no path is
+assumed: the run walks the instance's dashboards for a view holding a `custom:haventory-card`
+in a normal column — the narrow layout the assertions target — and prints the one it chose.
+`--path <ha-url-path>` forces a different view. The test is idempotent — it creates a
+uniquely-named item and deletes it (best-effort cleanup even on failure).
 
 #### Coverage
 

--- a/cards/haventory-card/e2e/live-updates.smoke.mjs
+++ b/cards/haventory-card/e2e/live-updates.smoke.mjs
@@ -25,17 +25,15 @@
 // (`npx playwright install chromium`).
 //
 // Usage (from cards/haventory-card/):
-//   RUN_ONLINE=1 node e2e/live-updates.smoke.mjs [--path /lovelace/default_view]
+//   RUN_ONLINE=1 node e2e/live-updates.smoke.mjs [--path <ha-url-path>]
 //   RUN_ONLINE=1 npm run test:e2e
+//
+// Which dashboard view holds the card is discovered from the instance rather than
+// assumed — see card_views.mjs. `--path` forces one.
 //
 // Exit codes: 0 = pass or skipped, 1 = a live-update assertion failed, 2 = misconfig.
 
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-
-const here = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(here, '..', '..', '..');
+import { cardPath, haConfig } from '../../../.claude/skills/run-haventory/card_views.mjs';
 
 // --- opt-in gate ---------------------------------------------------------
 if (!process.env.RUN_ONLINE) {
@@ -44,16 +42,7 @@ if (!process.env.RUN_ONLINE) {
 }
 
 // --- config: env wins, repo-root .env fills the gaps ---------------------
-try {
-  for (const line of readFileSync(path.join(repoRoot, '.env'), 'utf8').split(/\r?\n/)) {
-    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
-    if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
-  }
-} catch {
-  /* no .env — rely on real env vars */
-}
-const base = (process.env.HA_BASE_URL ?? 'http://localhost:8123').replace(/\/$/, '');
-const token = process.env.HA_TOKEN;
+const { base, token } = haConfig();
 if (!token) {
   console.error('FAIL(config): missing HA_TOKEN (env or repo-root .env).');
   process.exit(2);
@@ -64,7 +53,6 @@ const flag = (name, dflt) => {
   const i = args.indexOf(name);
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
 };
-const urlPath = flag('--path', '/lovelace/default_view');
 
 // Playwright is an optional peer of this smoke — resolve it lazily so a plain
 // `npm run test:e2e` on a machine without a browser skips cleanly instead of crashing.
@@ -75,6 +63,12 @@ try {
   console.log('SKIP: Playwright is not installed. Run `npm i` then `npx playwright install chromium`.');
   process.exit(0);
 }
+
+// The card picks its layout from its own rendered width, and every assertion below
+// is on `hv-list-row` — the narrow branch. A `type: panel` view hands the card the
+// whole content area and renders the table instead, so this asks for a view that
+// holds the card in a normal column.
+const urlPath = await cardPath('column', { override: flag('--path', null) });
 
 // Unique, greppable names so we never collide with real data and cleanup is targeted.
 // Date.now() is fine here — this is a standalone Node script, not a workflow.


### PR DESCRIPTION
`e2e/live-updates.smoke.mjs` defaulted to `/lovelace/default_view`, which nothing on the dev
instance has had for some time. The failure mode is the one `card_views.mjs` was written to
prevent: a 30 s wait for `haventory-card` that reads like a card which stopped registering,
not like a URL that stopped existing. Every run needed `--path /dashboard-dev/0` to get
anywhere.

The smoke now asks `cardPath('column', …)` — a view holding the card in a normal column,
which is the narrow layout its `hv-list-row` assertions target; a `type: panel` view would
hand the card the whole content area and render the table instead. That is what the five
sibling harnesses in the skill already do, and the run prints the view it chose and why.
`--path` stays, now as an explicit override. The same module owns the `.env` read, so the
smoke's duplicate loader goes with it.

The guard lives in `card_views.test.mjs` and covers **every** harness, not just this one:
each script that calls `page.goto` must take its URL from `card_views`, and none may carry a
dashboard URL of its own. The smoke is checked there with the others precisely because
sitting in the card package, away from them, is how it drifted unnoticed. Confirmed it fails
against the pre-fix file and passes after.

Verified: `node --test` in the skill 19/19; smoke PASS with no `--path` (discovers
`/dashboard-dev/0`, no shape warning) and PASS with `--path` forcing one; `RUN_ONLINE` unset
still skips cleanly at exit 0. Gates green — backend 458 passed / 22 skipped, ruff + mypy
clean; eslint, `tsc --noEmit`, 1004 vitest tests, build clean. The stress regimen is not
re-run: this touches no backend and no card source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
