### PR TITLE
feat: register HAventory mark as custom icon set for sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Checklist below and [CONTRIBUTING.md](CONTRIBUTING.md).
 HAventory adds itself to the **sidebar** during setup, so there is somewhere to click
 before you have built a dashboard. The entry opens the full view as a page of its own —
 the same workspace the card's ⋮ → full view opens, with the same menu, dialogs and
-editors — and carries whatever name you gave the card.
+editors — and carries the HAventory mark and whatever name you gave the card.
 
 - **Turning it off:** Settings → Devices & services → HAventory → **Configure** →
   *Show HAventory in the sidebar*. The entry appears and disappears as you save the form;

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -3,6 +3,7 @@ import type { HassLike } from './store/types';
 import { Store } from './store/store';
 import { resolveColorScheme } from './ui/theme';
 import { DEFAULT_CARD_TITLE } from './ui/card-title';
+import { registerBrandIcon } from './ui/brand-icon';
 import { defineCardElement } from './register';
 import './components/hv-card-shell';
 // The sidebar panel is a second element out of this one bundle, so importing it
@@ -127,6 +128,10 @@ export class HAventoryCard extends LitElement {
 }
 
 defineCardElement('haventory-card', HAventoryCard);
+
+// From the entry module, because the sidebar entry carries the mark on every
+// page — including the ones no card is on.
+registerBrandIcon();
 
 // Lovelace card picker metadata
 export function getStubConfig() {

--- a/cards/haventory-card/src/ui/brand-icon.test.ts
+++ b/cards/haventory-card/src/ui/brand-icon.test.ts
@@ -1,0 +1,108 @@
+import {
+  HAVENTORY_ICONSET,
+  HAVENTORY_ICON_NAME,
+  HAVENTORY_MARK_PATH,
+  HAVENTORY_MARK_VIEW_BOX,
+  HAVENTORY_PANEL_ICON,
+  registerBrandIcon,
+} from './brand-icon';
+
+afterEach(() => {
+  delete window.customIcons;
+});
+
+// Everything here is a contract with the Home Assistant frontend: the shape it
+// reads icon sets out of, and the winding its single-path renderer needs.
+describe('the HAventory icon set', () => {
+  it('answers a lookup with the mark and its viewBox', async () => {
+    registerBrandIcon();
+
+    const set = window.customIcons?.[HAVENTORY_ICONSET];
+    expect(set).toBeTruthy();
+    await expect(set!.getIcon(HAVENTORY_ICON_NAME)).resolves.toEqual({
+      path: HAVENTORY_MARK_PATH,
+      viewBox: HAVENTORY_MARK_VIEW_BOX,
+    });
+  });
+
+  it('is the icon string the backend registers for the panel', () => {
+    expect(HAVENTORY_PANEL_ICON).toBe(`${HAVENTORY_ICONSET}:${HAVENTORY_ICON_NAME}`);
+  });
+
+  it('lists its glyph for the icon picker', async () => {
+    registerBrandIcon();
+
+    const set = window.customIcons![HAVENTORY_ICONSET];
+    await expect(set.getIconList?.()).resolves.toEqual([{ name: HAVENTORY_ICON_NAME }]);
+  });
+
+  it('resolves an unknown name rather than rejecting', async () => {
+    registerBrandIcon();
+
+    const set = window.customIcons![HAVENTORY_ICONSET];
+    await expect(set.getIcon('nonesuch')).resolves.toHaveProperty('path', HAVENTORY_MARK_PATH);
+  });
+
+  it('adds to the registry the frontend already made, keeping its identity', () => {
+    const existing = {};
+    window.customIcons = existing;
+
+    registerBrandIcon();
+
+    expect(window.customIcons).toBe(existing);
+  });
+
+  it('leaves another integration set alone', () => {
+    const other = { getIcon: () => Promise.resolve({ path: 'M0,0' }) };
+    window.customIcons = { other };
+
+    registerBrandIcon();
+
+    expect(window.customIcons.other).toBe(other);
+    expect(window.customIcons[HAVENTORY_ICONSET]).toBeTruthy();
+  });
+
+  it('creates the registry when the frontend has not', () => {
+    expect(window.customIcons).toBeUndefined();
+
+    registerBrandIcon();
+
+    expect(Object.keys(window.customIcons!)).toEqual([HAVENTORY_ICONSET]);
+  });
+
+  it('registering twice leaves one entry', () => {
+    registerBrandIcon();
+    registerBrandIcon();
+
+    expect(Object.keys(window.customIcons!)).toEqual([HAVENTORY_ICONSET]);
+  });
+});
+
+describe('the mark path', () => {
+  // `ha-svg-icon` sets no fill-rule, so nonzero decides: the crates are holes
+  // only while they run against the house, and the handle slots are solid only
+  // while they run with it. Reverse a group and the mark fills in.
+  const subpaths = HAVENTORY_MARK_PATH.split('Z').slice(0, -1);
+
+  it('is one house, three crates and three handle slots', () => {
+    expect(subpaths).toHaveLength(7);
+    expect(HAVENTORY_MARK_PATH.trimEnd().endsWith('Z')).toBe(true);
+  });
+
+  it('winds the crates against the house that encloses them', () => {
+    const [house, ...rest] = subpaths;
+    const crates = rest.slice(0, 3);
+    const handles = rest.slice(3);
+
+    expect(house).toContain('A22,22 0 0 1');
+    expect(house).not.toContain('A22,22 0 0 0');
+    for (const crate of crates) {
+      expect(crate).toContain('A14,14 0 0 0');
+      expect(crate).not.toContain('A14,14 0 0 1');
+    }
+    for (const handle of handles) {
+      expect(handle).toContain('A9,9 0 0 1');
+      expect(handle).not.toContain('A9,9 0 0 0');
+    }
+  });
+});

--- a/cards/haventory-card/src/ui/brand-icon.ts
+++ b/cards/haventory-card/src/ui/brand-icon.ts
@@ -1,0 +1,94 @@
+/**
+ * The HAventory mark, published to Home Assistant as a custom icon set.
+ *
+ * A `panel_custom` sidebar icon is a *string*, so artwork can only reach the
+ * sidebar through HA's icon registry: `ha-icon` resolves any prefix outside
+ * `mdi:` against `window.customIcons`, and registering here is what makes the
+ * backend's `PANEL_ICON` — `haventory:logo` — resolvable. The sidebar cannot
+ * ask for it before its panel list arrives over the websocket, which is well
+ * after this bundle (loaded on every page as an extra module) has evaluated.
+ */
+
+/** Prefix of the icon string: the integration domain, so nothing else claims it. */
+export const HAVENTORY_ICONSET = 'haventory';
+
+/** The one glyph in the set. */
+export const HAVENTORY_ICON_NAME = 'logo';
+
+/** What the backend registers as the panel's `sidebar_icon`. */
+export const HAVENTORY_PANEL_ICON = `${HAVENTORY_ICONSET}:${HAVENTORY_ICON_NAME}`;
+
+export const HAVENTORY_MARK_VIEW_BOX = '0 0 512 512';
+
+// The house, clockwise.
+const HOUSE =
+  'M242.17,54.89 A22,22 0 0 1 269.83,54.89 L457.83,206.89 A22,22 0 0 1 466,224 ' +
+  'L466,430 A22,22 0 0 1 444,452 L68,452 A22,22 0 0 1 46,430 L46,224 ' +
+  'A22,22 0 0 1 54.17,206.89 Z';
+
+// The three crates, counter-clockwise, which is what cuts them out of the house.
+const CRATES = [
+  'M214,174 A14,14 0 0 0 200,188 V264 A14,14 0 0 0 214,278 H298 ' +
+    'A14,14 0 0 0 312,264 V188 A14,14 0 0 0 298,174 Z',
+  'M148,294 A14,14 0 0 0 134,308 V384 A14,14 0 0 0 148,398 H232 ' +
+    'A14,14 0 0 0 246,384 V308 A14,14 0 0 0 232,294 Z',
+  'M280,294 A14,14 0 0 0 266,308 V384 A14,14 0 0 0 280,398 H364 ' +
+    'A14,14 0 0 0 378,384 V308 A14,14 0 0 0 364,294 Z',
+];
+
+// The three handle slots, clockwise again, which fills them back in inside the
+// crates.
+const HANDLES = [
+  'M237,202 H275 A9,9 0 0 1 275,220 H237 A9,9 0 0 1 237,202 Z',
+  'M171,322 H209 A9,9 0 0 1 209,340 H171 A9,9 0 0 1 171,322 Z',
+  'M303,322 H341 A9,9 0 0 1 341,340 H303 A9,9 0 0 1 303,322 Z',
+];
+
+/**
+ * The mark as a single path.
+ *
+ * `ha-svg-icon` renders one `<path d>` and sets no `fill-rule`, so the default
+ * `nonzero` decides what is solid: a subpath is a hole only when it is wound
+ * against the shape enclosing it. Reversing any of the three groups above turns
+ * the crates back into solid blocks.
+ */
+export const HAVENTORY_MARK_PATH = [HOUSE, ...CRATES, ...HANDLES].join(' ');
+
+interface CustomIcon {
+  path: string;
+  viewBox?: string;
+}
+
+interface CustomIconHelpers {
+  getIcon: (name: string) => Promise<CustomIcon>;
+  getIconList?: () => Promise<{ name: string }[]>;
+}
+
+declare global {
+  interface Window {
+    customIcons?: Record<string, CustomIconHelpers>;
+  }
+}
+
+/**
+ * Publish the mark under the `haventory:` prefix.
+ *
+ * Idempotent, and safe whichever side of the frontend's own boot this runs on.
+ */
+export function registerBrandIcon(): void {
+  if (typeof window === 'undefined') return;
+
+  // Mutate, never replace: the frontend captures this object once, when it
+  // first imports its icon module, and reads every later lookup off that same
+  // reference — a fresh object here would never be consulted.
+  const registry = (window.customIcons ??= {});
+
+  registry[HAVENTORY_ICONSET] = {
+    // Every name in the set answers with the mark. HA calls this without
+    // handling a rejection, so a mistyped icon renders the logo rather than
+    // raising an unhandled rejection inside the frontend.
+    getIcon: () =>
+      Promise.resolve({ path: HAVENTORY_MARK_PATH, viewBox: HAVENTORY_MARK_VIEW_BOX }),
+    getIconList: () => Promise.resolve([{ name: HAVENTORY_ICON_NAME }]),
+  };
+}

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -39,7 +39,12 @@ DEFAULT_SIDEBAR_PANEL_ENABLED: bool = True
 # it is also what a removal has to name.
 PANEL_URL_PATH: str = "haventory"
 PANEL_ELEMENT_NAME: str = "haventory-panel"
-PANEL_ICON: str = "mdi:package-variant-closed"
+# The HAventory mark, which the card bundle publishes as an icon set under the
+# `haventory:` prefix (`cards/haventory-card/src/ui/brand-icon.ts`) — a
+# non-`mdi:` prefix resolves out of the frontend's own icon registry, nowhere
+# else, so the two spellings have to agree. Nothing resolves it without the
+# bundle, and without the bundle there is no panel to put an icon on.
+PANEL_ICON: str = "haventory:logo"
 
 # -----------------------------
 # WebSocket rate limiting (config-entry options)

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -265,6 +265,7 @@ re-render it — so each container subscribes to `store.state.onChange` itself i
 |---|---|
 | `tokens.ts` | Every design token as a `--hv-*` custom property, bound to the HA theme variable first with the mock hex as fallback, plus dark-mode and reduced-motion overrides. `base` adds the pill/icon-button/chip/input primitives. Composed as `static styles = [tokens, base, css\`…\`]`. |
 | `icons.ts` | ~30 MDI glyphs as inline path data, rendered as `<svg fill="currentColor">`. See the deviation note below. |
+| `brand-icon.ts` | The HAventory mark as one path, published to HA's icon registry (`window.customIcons`) under the `haventory:` prefix so the sidebar entry can name it. The backend's `PANEL_ICON` is the matching string. |
 | `responsive.ts` | `ResponsiveController` — a Lit reactive controller that drives mobile mode from the card's own measured width (≤600px). |
 | `relative-time.ts` | "2 h ago" / "Jul 31" formatting, overdue checks, and the `+N days` arithmetic the check-out chips use. |
 | `item-form.ts` | Form model and payload building for the edit surfaces: validation per field, typed custom fields, tag normalization, and the `custom_fields_set` / `custom_fields_unset` diff. |

--- a/docs/sidebar-panel.md
+++ b/docs/sidebar-panel.md
@@ -129,7 +129,7 @@ container). Signatures are identical at both ends.
 - **Register on setup** (after `_register_frontend_module`), when the option is on
   and the bundle exists (missing bundle keeps the graceful DEBUG skip):
   `frontend_url_path="haventory"`, `webcomponent_name="haventory-panel"`,
-  `sidebar_title=<card title option>`, `sidebar_icon="mdi:package-variant-closed"`,
+  `sidebar_title=<card title option>`, `sidebar_icon="haventory:logo"`,
   `module_url=<card URL>`, `embed_iframe=False`, `trust_external=False`,
   `require_admin=False`, `config={"title": <card title option>}` (the panel element
   reads `panel.config.title` for its heading, mirroring `haventory/config` for the
@@ -235,7 +235,8 @@ the feature on. Includes the live verification pass.
 - Toggle **default on** — discoverability is the feature; opt-out is respected.
 - Sidebar title follows the existing **card title option** (falls back "HAventory"),
   so a user who renamed the card to "Pantry" sees "Pantry" in the sidebar.
-- Icon `mdi:package-variant-closed`; URL path `haventory`; `require_admin=False`.
+- Icon `haventory:logo` — the HAventory mark, registered as a custom icon set by the
+  card bundle; URL path `haventory`; `require_admin=False`.
 - Panel renders the **extended view**, not a page-sized card.
 - The panel offers the **full ⋮ menu** — organize, import and diagnostics included.
   Every surface `hv-full-view` can raise is owned by `host-surfaces.ts` and rendered
@@ -320,8 +321,7 @@ the feature on. Includes the live verification pass.
 > Scope:
 > 1. `const.py`: `CONF_SIDEBAR_PANEL_ENABLED = "sidebar_panel_enabled"`,
 >    `DEFAULT_SIDEBAR_PANEL_ENABLED = True`, `PANEL_URL_PATH = "haventory"`,
->    `PANEL_ELEMENT_NAME = "haventory-panel"`, `PANEL_ICON =
->    "mdi:package-variant-closed"`.
+>    `PANEL_ELEMENT_NAME = "haventory-panel"`, `PANEL_ICON = "haventory:logo"`.
 > 2. `__init__.py`: a `_async_apply_sidebar_panel(hass, entry)` helper that computes
 >    desired state (option on + bundle present) and converges to it:
 >    remove any existing `haventory` panel (`frontend.async_remove_panel`,

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -19,6 +19,7 @@ import asyncio
 import importlib
 import json
 import logging
+import re
 import sys
 import threading
 import types
@@ -41,9 +42,8 @@ STATIC_URL_PATH = "/haventory_static"
 CARD_PATH = f"{STATIC_URL_PATH}/haventory-card.js"
 # Where installs from before the bundle moved into the package loaded it from.
 LEGACY_CARD_PATH = "/local/haventory/haventory-card.js"
-MANIFEST_PATH = (
-    Path(__file__).resolve().parents[1] / "custom_components" / "haventory" / "manifest.json"
-)
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "custom_components" / "haventory" / "manifest.json"
 
 # Distinguishes "leave the loader stub at its default (the shipped manifest)" from
 # "register None", which makes the lookup raise the way an absent integration does.
@@ -672,6 +672,25 @@ async def test_frontend_without_a_url_manager_degrades_gracefully(hav_init):
 # --------------------------------------------------------------------------- #
 # The sidebar panel
 # --------------------------------------------------------------------------- #
+
+
+def test_the_sidebar_icon_is_the_one_the_card_bundle_publishes() -> None:
+    """``PANEL_ICON`` names an icon set that only the card bundle registers.
+
+    A non-``mdi:`` prefix is resolved against the frontend's icon registry, so
+    the sidebar shows the mark only while the two spellings agree — and a
+    disagreement is silent, costing the entry its icon and nothing else.
+    """
+    source = (REPO_ROOT / "cards" / "haventory-card" / "src" / "ui" / "brand-icon.ts").read_text(
+        encoding="utf-8"
+    )
+
+    def declared(name: str) -> str:
+        match = re.search(rf"^export const {name} = '([^']+)';$", source, re.MULTILINE)
+        assert match is not None, f"{name} is no longer declared in brand-icon.ts"
+        return match.group(1)
+
+    assert PANEL_ICON == f"{declared('HAVENTORY_ICONSET')}:{declared('HAVENTORY_ICON_NAME')}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Replaces the generic `mdi:package-variant-closed` sidebar icon with the HAventory mark (`haventory:logo`), a custom icon set registered by the card bundle. This gives the sidebar panel a branded identity while ensuring the icon is only visible when the bundle is loaded.

The mark is a single-path SVG using the `nonzero` fill rule to create a visual composition: a house outline with three crates cut out (counter-clockwise winding) and three handle slots filled back in (clockwise winding). The icon set is registered idempotently from the card bundle's entry module, so it's available on every page before the sidebar panel list arrives.

Closes the gap between the backend's `PANEL_ICON` constant and the frontend's icon registration — both now reference the same `haventory:logo` identifier.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q`, `uv run ruff check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`, `npm run build`

Added comprehensive unit tests (`brand-icon.test.ts`) covering:
- Icon set lookup and viewBox resolution
- Icon picker listing
- Graceful fallback for unknown icon names
- Registry mutation (preserving existing entries, idempotent registration)
- SVG path winding validation (house clockwise, crates counter-clockwise, handles clockwise)

Added integration test (`test_frontend_registration.py::test_the_sidebar_icon_is_the_one_the_card_bundle_publishes`) verifying that `PANEL_ICON` in the backend matches the icon set and name declared in the card bundle.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated (happy path + edge cases: unknown names, registry mutation, winding validation)
- [x] Docs updated (`docs/sidebar-panel.md`, `README.md`, `docs/frontend_architecture.md`)
- [x] Backend constant (`PANEL_ICON`) and frontend export (`HAVENTORY_PANEL_ICON`) kept in sync via integration test

https://claude.ai/code/session_01T9wXnmxvyZtewWgTTVahp6