### PR TITLE
feat: allow filing locations under empty areas in organize dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Backend (repo root):
 ```bash
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q
 uv run ruff check .
+uv run ruff format --check .   # CI fails on formatting alone; `ruff check` does not cover it
 uv run mypy
 ```
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,10 @@ throughout.
   custom fields (text / number / yes-no / date). Saves send the item's expected version so
   a concurrent edit surfaces as a conflict.
 - **Full view** — a fullscreen workspace with a coloured app bar, a **browse sidebar**, and
-  a sortable table. Only columns the backend can sort by get a clickable header. The
+  a sortable table. Only columns the backend can sort by get a clickable header. A browser
+  that has made no choice yet shows every optional column — quantity, category, location,
+  tags, due, next inspection, updated — and the ⋮ → **Columns** picker is where you thin
+  that down; the table scrolls sideways rather than dropping a column you kept. The
   sidebar leads with the location tree carrying the backend's own per-location counts and
   an orphans row, then **Categories** and **Tags** as sections of their own; each heading
   collapses from a chevron and states how many there are — locations counted at every

--- a/README.md
+++ b/README.md
@@ -37,10 +37,17 @@ Checklist below and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Finding HAventory after install
 
-HAventory adds itself to the **sidebar** during setup, so there is somewhere to click
-before you have built a dashboard. The entry opens the full view as a page of its own —
-the same workspace the card's ⋮ → full view opens, with the same menu, dialogs and
-editors — and carries the HAventory mark and whatever name you gave the card.
+Setup asks two things — what the card is called, and whether HAventory gets a **sidebar**
+entry (yes by default, so there is somewhere to click before you have built a dashboard).
+Both are editable afterwards under **Configure**. The entry opens the full view as a page
+of its own — the same workspace the card's ⋮ → full view opens, with the same menu,
+dialogs and editors — and carries the HAventory mark and whatever name you gave the card.
+
+- **Reload the browser page once after installing.** Home Assistant hands an integration's
+  JavaScript to a page when that page loads, so a tab that was already open when HAventory
+  was installed or updated has neither the card nor the artwork behind its sidebar icon
+  yet — the entry shows up without its mark until the next load. One ordinary reload is
+  all it takes; no cache clearing, and nothing to repeat later.
 
 - **Turning it off:** Settings → Devices & services → HAventory → **Configure** →
   *Show HAventory in the sidebar*. The entry appears and disappears as you save the form;

--- a/README.md
+++ b/README.md
@@ -502,7 +502,12 @@ throughout.
   you save it: an area belongs to a whole tree, so the line under the select names the tree
   root it will be stored on and how many locations that reaches — and on a location that
   merely inherits, it names the area it inherits. With no Home Assistant areas defined the
-  field is not shown at all.
+  field is not shown at all. The **Parent location** picker offers the areas alongside the
+  locations, including areas nothing is filed under yet: picking one moves the whole
+  subtree out to the top level *and* into that area, which is how a tree changes rooms.
+  The merge target picker offers locations only — an area heads the tree without being part
+  of it and holds no items itself, so a merge, which has to hand this location's items to
+  something, always names a location.
 - **Check-out** invites an optional due date (+7 / +31 / +90 / +X day suggestions) rather
   than silently checking out with none — the date is what makes overdue highlighting mean
   anything. "No due date" stays a first-class choice.

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -30,8 +30,8 @@ export class HVDataTable extends LitElement {
         flex-direction: column;
         min-height: 0;
         min-width: 0;
-        /* The column template has a hard minimum — 786px for the default set,
-           826px with the selection column — and a grid whose tracks do not fit
+        /* The column template has a hard minimum — 1020px for the default set,
+           1060px with the selection column — and a grid whose tracks do not fit
            overflows its own box rather than shrinking. With overflow visible
            that spilled content was simply clipped by the shell: at 375px the
            rows measured clientWidth 634 against scrollWidth 854, and the Tags,

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -454,6 +454,38 @@ describe('hv-location-tree: area grouping', () => {
     expect(areaId).toBe('area-kitchen');
   });
 
+  // Filing a tree under an area is how it gets there, so an area that holds
+  // nothing yet has to be reachable — otherwise only areas already in use are.
+  it('bands an area holding nothing when the host files locations under areas', async () => {
+    const empty = [{ id: 'area-cellar', name: 'Cellar' }, ...AREAS];
+    const el = await mountAreas({ areas: empty, areaSelectable: true, showEmptyAreas: true });
+    expect(headNames(el)).toEqual(['Area: Cellar', 'Area: Garage', 'Area: Kitchen', 'No area']);
+
+    const cellar = heads(el)[0];
+    // Nothing under it to disclose: no twisty, and no container to point at.
+    expect(cellar.querySelector('[data-testid="tree-area-twisty"]')).toBeNull();
+    expect(cellar.getAttribute('aria-expanded')).toBeNull();
+    expect(cellar.getAttribute('aria-controls')).toBeNull();
+
+    let areaId: string | null = null;
+    el.addEventListener('select-area', (e) => {
+      areaId = (e as CustomEvent).detail.areaId;
+    });
+    (cellar.querySelector('[data-testid="tree-area-select"]') as HTMLButtonElement).click();
+    expect(areaId).toBe('area-cellar');
+  });
+
+  it('drops the empty bands while a filter is on, since none of them can match', async () => {
+    const empty = [{ id: 'area-cellar', name: 'Cellar' }, ...AREAS];
+    const el = await mountAreas({ areas: empty, showEmptyAreas: true, filterText: 'bench' });
+    expect(headNames(el)).toEqual(['Area: Garage']);
+  });
+
+  it('bands only the areas in use when the host is browsing', async () => {
+    const el = await mountAreas({ areas: [{ id: 'area-cellar', name: 'Cellar' }, ...AREAS] });
+    expect(headNames(el)).toEqual(['Area: Garage', 'Area: Kitchen', 'No area']);
+  });
+
   it('never offers the no-area tail as a filter — it is the absence of one', async () => {
     const el = await mountAreas({ areaSelectable: true });
     let fired = 0;

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -254,13 +254,24 @@ export class HVLocationTree extends LitElement {
   @property({ type: Number }) matchingTotalCount: number | null = null;
   @property({ type: Boolean }) showCounts = false;
   /**
-   * Let an area header be picked, filtering the list to that area. Only a
-   * browsing tree sets this: a picker assigns a `location_id`, and an area is
-   * not one.
+   * Let an area header be picked, emitting `select-area` instead of `select`.
+   *
+   * What picking one means belongs to the caller: browsing filters the list to
+   * the area, while the parent picker files the location at the top level of it.
+   * Trees that hand back a `location_id` — the item editor's, the merge target —
+   * leave this off, because an area is not a location and holds no items itself.
    */
   @property({ type: Boolean }) areaSelectable = false;
-  /** The area the list is currently filtered to, for the header's selected state. */
+  /** The area currently chosen, for the header's selected state. */
   @property({ type: String }) selectedAreaId: string | null = null;
+  /**
+   * Band every area Home Assistant knows, not only the ones already holding a
+   * location tree. An area with nothing in it is still somewhere a tree can be
+   * filed, which is the whole point of picking one — so the parent picker sets
+   * this and browsing does not. A filter suspends it: an empty band matches
+   * nothing and would only stand between the user and the rows that do.
+   */
+  @property({ type: Boolean }) showEmptyAreas = false;
   /** Reveal the rename/merge/delete affordances on hover. Only the organize dialog sets this. */
   @property({ type: Boolean }) manage = false;
   /**
@@ -532,6 +543,7 @@ export class HVLocationTree extends LitElement {
     roots: LocationTreeNode[],
     open: boolean,
     key: string,
+    empty: boolean,
   ) {
     const pickable = this.areaSelectable && group !== null;
     const selected =
@@ -544,24 +556,28 @@ export class HVLocationTree extends LitElement {
       class="row area-head ${selected ? 'selected' : ''} ${pickable ? 'selectable' : ''}"
       role="treeitem"
       aria-selected=${String(selected)}
-      aria-expanded=${String(open)}
-      aria-controls=${areaRootsId(key)}
+      aria-expanded=${ifDefined(empty ? undefined : String(open))}
+      aria-controls=${ifDefined(empty ? undefined : areaRootsId(key))}
       aria-level="1"
       data-testid="tree-area-head"
       data-area=${group?.id ?? NO_AREA_KEY}
     >
-      <button
-        class="twisty"
-        data-testid="tree-area-twisty"
-        data-area=${group?.id ?? NO_AREA_KEY}
-        aria-label=${open ? `Collapse ${group?.name ?? 'No area'}` : `Expand ${group?.name ?? 'No area'}`}
-        @click=${(e: Event) => {
-          e.stopPropagation();
-          this._toggleArea(key);
-        }}
-      >
-        ${icon(open ? 'chevronDown' : 'chevronRight', 17)}
-      </button>
+      ${empty
+        ? html`<span class="twisty placeholder">${icon('chevronRight', 17)}</span>`
+        : html`<button
+            class="twisty"
+            data-testid="tree-area-twisty"
+            data-area=${group?.id ?? NO_AREA_KEY}
+            aria-label=${open
+              ? `Collapse ${group?.name ?? 'No area'}`
+              : `Expand ${group?.name ?? 'No area'}`}
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              this._toggleArea(key);
+            }}
+          >
+            ${icon(open ? 'chevronDown' : 'chevronRight', 17)}
+          </button>`}
       ${pickable
         ? html`<button
             class="area-name"
@@ -579,14 +595,19 @@ export class HVLocationTree extends LitElement {
   /** One group's header and, while it is open, the roots filed under it. */
   private _renderAreaSection(group: AreaGroup | null, roots: LocationTreeNode[], filtering: boolean) {
     const visible = roots.filter((r) => this._visible(r));
-    if (!visible.length) return null;
+    // An area holding nothing is still a target where areas are pickable; with
+    // no roots under it there is nothing to disclose, so it heads no container.
+    const empty = visible.length === 0;
+    if (empty && !(this.showEmptyAreas && group !== null && !filtering)) return null;
     const key = group ? `area:${group.id}` : NO_AREA_KEY;
-    const open = filtering || !this._collapsedAreas.has(key);
+    const open = !empty && (filtering || !this._collapsedAreas.has(key));
     return html`<div>
-      ${this._renderAreaHeader(group, roots, open, key)}
-      <div id=${areaRootsId(key)} ?hidden=${!open}>
-        ${open ? visible.map((r) => this._renderNode(r, 1, false)) : null}
-      </div>
+      ${this._renderAreaHeader(group, roots, open, key, empty)}
+      ${empty
+        ? null
+        : html`<div id=${areaRootsId(key)} ?hidden=${!open}>
+            ${open ? visible.map((r) => this._renderNode(r, 1, false)) : null}
+          </div>`}
     </div>`;
   }
 
@@ -602,8 +623,10 @@ export class HVLocationTree extends LitElement {
   }
 
   render() {
-    const { areaGroups, ungrouped } = groupRootsByArea(this.nodes, this.areas);
     const filtering = this.filterText.trim().length > 0;
+    const { areaGroups, ungrouped } = groupRootsByArea(this.nodes, this.areas, {
+      includeEmptyAreas: this.showEmptyAreas && !filtering,
+    });
     // With no area anywhere there is nothing to group by, and a lone "No area"
     // band over the whole tree would name a distinction that does not exist.
     const rendered = areaGroups.length

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -453,6 +453,75 @@ describe('hv-organize-dialog: locations', () => {
     });
   });
 
+  // An area heads the top level rather than sitting anywhere in the tree, so
+  // moving a subtree into one is both halves at once: out to the top level, and
+  // into that area. The picker is where both are said in one gesture.
+  describe('filing a subtree under an area', () => {
+    const tree = [loc('garage', 'Garage', null, 'area-garage'), loc('shelf-a', 'Shelf A', 'garage')];
+
+    async function openParentPicker() {
+      const ctx = await mount({ locations: tree });
+      const calls: { id: string; changes: Record<string, unknown> }[] = [];
+      const real = ctx.store.updateLocation.bind(ctx.store);
+      ctx.store.updateLocation = (id, changes) => {
+        calls.push({ id, changes: changes as Record<string, unknown> });
+        return real(id, changes);
+      };
+
+      const treeEl = q(ctx.sr, '[data-testid="organize-tree"]') as HTMLElement;
+      (
+        treeEl.shadowRoot?.querySelector(
+          '[data-testid="tree-row"][data-id="garage"] [data-testid="tree-twisty"]',
+        ) as HTMLButtonElement
+      ).click();
+      await settle(ctx.el);
+      (
+        treeEl.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="shelf-a"]') as HTMLButtonElement
+      ).click();
+      await settle(ctx.el);
+      (q(ctx.sr, '[data-testid="location-parent"]') as HTMLButtonElement).click();
+      await settle(ctx.el);
+      const picker = q(ctx.sr, '[data-testid="location-parent-tree"]') as HTMLElement;
+      return { ...ctx, calls, picker };
+    }
+
+    it('offers every area, including the one nothing is filed under yet', async () => {
+      const { picker } = await openParentPicker();
+      const offered = [
+        ...(picker.shadowRoot?.querySelectorAll('[data-testid="tree-area-select"]') ?? []),
+      ].map((b) => (b as HTMLElement).dataset.area);
+      expect(offered).toEqual(['area-garage', 'area-kitchen']);
+    });
+
+    it('moves the subtree to the top level of the area picked, in one save', async () => {
+      const { el, sr, picker, calls } = await openParentPicker();
+      (
+        picker.shadowRoot?.querySelector(
+          '[data-testid="tree-area-select"][data-area="area-kitchen"]',
+        ) as HTMLButtonElement
+      ).click();
+      await settle(el);
+
+      // Both halves of the move, on both controls that state them.
+      expect(q(sr, '[data-testid="location-parent"]')?.textContent).toContain('Top level · Kitchen');
+      expect((q(sr, '[data-testid="location-area"]') as HTMLSelectElement).value).toBe('area-kitchen');
+      expect(q(sr, '[data-testid="location-area-preview"]')?.textContent).toContain('Kitchen');
+
+      (q(sr, '[data-testid="location-save"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      expect(calls[0].changes.newParentId).toBeNull();
+      expect(calls[0].changes.areaId).toBe('area-kitchen');
+    });
+
+    it('calls the row that clears the parent what it does in a parent picker', async () => {
+      const { picker } = await openParentPicker();
+      expect(
+        picker.shadowRoot?.querySelector('[data-testid="tree-all"]')?.textContent?.trim(),
+      ).toContain('Top level');
+    });
+  });
+
   it('drops a failed save off the screen when the dialog is reopened', async () => {
     const { el, store, sr } = await mount({ locations });
     store.updateLocation = () => Promise.reject(new Error('Location is busy'));
@@ -560,6 +629,8 @@ describe('hv-organize-dialog: locations', () => {
     (tree.shadowRoot?.querySelector('[data-testid="tree-merge"][data-id="garage"]') as HTMLButtonElement).click();
     await settle(el);
     expect(q(sr, '[data-testid="merge-effect"]')?.textContent).toContain('Pick a location');
+    // The one row in that picker a merge cannot land on, and why.
+    expect(q(sr, '[data-testid="merge-effect"]')?.textContent).toContain('hold no items themselves');
 
     (q(sr, '[data-testid="merge-target"]') as HTMLButtonElement).click();
     await settle(el);

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -16,7 +16,14 @@ import { DialogFocus } from '../ui/dialog-focus';
 import { describeFailure } from './hv-bulk-bar';
 import { makeBulkOp } from '../store/store';
 import type { Store } from '../store/store';
-import type { BulkFailure, DistinctValue, Item, LocationTreeNode, StoreState } from '../store/types';
+import type {
+  AreaRef,
+  BulkFailure,
+  DistinctValue,
+  Item,
+  LocationTreeNode,
+  StoreState,
+} from '../store/types';
 import './hv-confirm';
 import './hv-location-tree';
 
@@ -465,6 +472,13 @@ export class HVOrganizeDialog extends LitElement {
     this._dialogFocus.sync(this.open, () =>
       this.renderRoot.querySelector<HTMLElement>('[data-testid="organize-dialog"]'),
     );
+    // A native select stops following its options' `selected` attributes once it
+    // has been touched, so an area chosen in the parent tree is written to the
+    // live element rather than left to the bindings to express.
+    const areaSelect = this.renderRoot.querySelector<HTMLSelectElement>(
+      '[data-testid="location-area"]',
+    );
+    if (areaSelect) areaSelect.value = this._locArea ?? '';
   }
 
   protected willUpdate(changed: Map<string, unknown>) {
@@ -797,6 +811,19 @@ export class HVOrganizeDialog extends LitElement {
     return html`<span class="note" data-testid="location-area-preview">${line}</span>`;
   }
 
+  /**
+   * What the parent button reads.
+   *
+   * A top-level location names the area it is filed under as well: the picker
+   * sets both, and the button would otherwise look untouched after an area was
+   * chosen in it.
+   */
+  private _parentLabel(parent: LocationTreeNode | null, areas: readonly AreaRef[]): string {
+    if (parent) return parent.name;
+    const areaName = areaNameById(areas, this._locArea);
+    return areaName ? `Top level · ${areaName}` : 'Top level';
+  }
+
   private _renderLocationEditor(nodeId: string | 'new') {
     const tree = this.st?.locationTreeCache ?? [];
     const node = nodeId === 'new' ? null : this._findNode(tree, nodeId);
@@ -866,7 +893,7 @@ export class HVOrganizeDialog extends LitElement {
               this._locParentOpen = !this._locParentOpen;
             }}
           >
-            ${icon('mapMarker', 15)}<span class="value">${parent?.name ?? 'Top level'}</span>
+            ${icon('mapMarker', 15)}<span class="value">${this._parentLabel(parent, areas)}</span>
             ${icon('chevronDown', 15)}
           </button>
           <div class="tree-holder" id=${LOC_PARENT_TREE_ID} ?hidden=${!this._locParentOpen}>
@@ -874,12 +901,24 @@ export class HVOrganizeDialog extends LitElement {
               ? html`<hv-location-tree
                   data-testid="location-parent-tree"
                   .nodes=${tree}
-                  .areas=${this.st?.areasCache?.areas ?? []}
+                  .areas=${areas}
                   .selectedId=${this._locParent}
+                  .selectedAreaId=${this._locParent === null ? this._locArea : null}
                   .excludeSubtreeOf=${node?.id ?? null}
                   showAll
+                  allLabel="Top level"
+                  areaSelectable
+                  showEmptyAreas
                   @select=${(e: CustomEvent) => {
                     this._locParent = (e.detail as { locationId: string | null }).locationId;
+                    this._locParentOpen = false;
+                  }}
+                  @select-area=${(e: CustomEvent) => {
+                    // An area heads the top level rather than sitting in the
+                    // tree, so picking one is both halves of the move: out to
+                    // the top level, and into that area.
+                    this._locParent = null;
+                    this._locArea = (e.detail as { areaId: string }).areaId;
                     this._locParentOpen = false;
                   }}
                 ></hv-location-tree>`
@@ -991,7 +1030,14 @@ export class HVOrganizeDialog extends LitElement {
         ${target
           ? `${parts.join(' and ')} move to "${target.name}", then "${source.name}" is deleted.
              Items in sub-locations stay where they are; their paths just change.`
-          : 'Pick a location to continue.'}
+          : // An area heads the tree without being part of it and holds no items
+            // of its own, so it is the one row here that cannot take a merge.
+            // Editing the location is where a whole subtree moves into an area.
+            `Pick a location to continue.${
+              (this.st?.areasCache?.areas?.length ?? 0) > 0
+                ? ' Areas group location trees and hold no items themselves, so the contents need a location to go to — to move this one into an area instead, edit it and pick the area as its parent.'
+                : ''
+            }`}
       </span>
       <div class="actions">
         <span class="spacer"></span>

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -25,6 +25,11 @@ describe('columns model', () => {
     expect(loadColumnPrefs()).toEqual(DEFAULT_COLUMNS);
   });
 
+  // A fresh browser shows the whole record; thinning it down is the picker's job.
+  it('defaults to every column', () => {
+    expect(DEFAULT_COLUMNS).toEqual(COLUMN_DEFS.map((c) => c.key));
+  });
+
   it('round-trips a saved selection (normalized)', () => {
     saveColumnPrefs(['tags', 'due_date', 'quantity']);
     expect(loadColumnPrefs()).toEqual(['quantity', 'tags', 'due_date']);
@@ -82,8 +87,8 @@ describe('table column widths', () => {
   // Pinned as a number so that adding a column, or widening one, shows up here
   // as a deliberate change rather than as another phone-width overflow.
   it('cannot lay the default table out narrower than a phone', () => {
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(786);
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(826);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1020);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1060);
   });
 
   it('only fits a phone when almost every column is turned off', () => {

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -49,14 +49,14 @@ export const COLUMN_DEFS: readonly ColumnDef[] = [
 
 const COLUMN_ORDER: ColumnKey[] = COLUMN_DEFS.map((c) => c.key);
 
-/** The table opens on Name | Qty | Category | Tags | Due | Updated. */
-export const DEFAULT_COLUMNS: readonly ColumnKey[] = [
-  'quantity',
-  'category',
-  'tags',
-  'due_date',
-  'updated_at',
-];
+/**
+ * A browser that has made no choice yet gets every column.
+ *
+ * Showing the whole record is what makes the optional columns discoverable at
+ * all; the picker is there to thin it down. The table scrolls sideways when the
+ * full set is wider than the viewport, so no column is unreachable.
+ */
+export const DEFAULT_COLUMNS: readonly ColumnKey[] = COLUMN_DEFS.map((c) => c.key);
 
 export const COLUMN_PREFS_STORAGE_KEY = 'haventory:columns:v1';
 

--- a/cards/haventory-card/src/store/location-tree.ts
+++ b/cards/haventory-card/src/store/location-tree.ts
@@ -81,9 +81,16 @@ export interface GroupedRoots {
 export function groupRootsByArea(
   nodes: readonly LocationTreeNode[],
   areas: readonly AreaRef[],
+  opts: { includeEmptyAreas?: boolean } = {},
 ): GroupedRoots {
   const byArea = new Map<string, LocationTreeNode[]>();
   const ungrouped: LocationTreeNode[] = [];
+
+  // A picker that files locations under areas has to offer every area Home
+  // Assistant knows, including the ones holding nothing yet — otherwise an area
+  // can only be reached once something is already in it. Browsing bands only
+  // the areas in use.
+  if (opts.includeEmptyAreas) for (const area of areas) byArea.set(area.id, []);
 
   for (const node of nodes) {
     const areaId = node.area_id ?? null;

--- a/custom_components/haventory/config_flow.py
+++ b/custom_components/haventory/config_flow.py
@@ -82,9 +82,7 @@ def _user_schema() -> vol.Schema:
     return vol.Schema(
         {
             vol.Required(CONF_CARD_TITLE, default=DEFAULT_CARD_TITLE): str,
-            vol.Required(
-                CONF_SIDEBAR_PANEL_ENABLED, default=DEFAULT_SIDEBAR_PANEL_ENABLED
-            ): bool,
+            vol.Required(CONF_SIDEBAR_PANEL_ENABLED, default=DEFAULT_SIDEBAR_PANEL_ENABLED): bool,
         }
     )
 
@@ -197,9 +195,7 @@ class HAventoryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             return self.async_show_form(step_id="user", data_schema=_user_schema())
 
         title = clean_card_title(user_input.get(CONF_CARD_TITLE))
-        sidebar = bool(
-            user_input.get(CONF_SIDEBAR_PANEL_ENABLED, DEFAULT_SIDEBAR_PANEL_ENABLED)
-        )
+        sidebar = bool(user_input.get(CONF_SIDEBAR_PANEL_ENABLED, DEFAULT_SIDEBAR_PANEL_ENABLED))
         return self.async_create_entry(
             title=title,
             data={},

--- a/custom_components/haventory/config_flow.py
+++ b/custom_components/haventory/config_flow.py
@@ -74,8 +74,19 @@ def clean_card_title(value: Any) -> str:
 
 
 def _user_schema() -> vol.Schema:
-    """Build the setup-step schema (the card title is all there is to ask)."""
-    return vol.Schema({vol.Required(CONF_CARD_TITLE, default=DEFAULT_CARD_TITLE): str})
+    """Build the setup-step schema: what the card is called, and where it lives.
+
+    The same two fields the options flow opens with, so setup decides them once
+    rather than leaving the sidebar entry to be discovered under Configure.
+    """
+    return vol.Schema(
+        {
+            vol.Required(CONF_CARD_TITLE, default=DEFAULT_CARD_TITLE): str,
+            vol.Required(
+                CONF_SIDEBAR_PANEL_ENABLED, default=DEFAULT_SIDEBAR_PANEL_ENABLED
+            ): bool,
+        }
+    )
 
 
 def _rate_limit_schema(current: dict[str, Any]) -> vol.Schema:
@@ -175,9 +186,9 @@ class HAventoryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step.
 
-        Single-instance setup: the only thing to ask for is the name the card
-        should carry, which seeds both the entry title and the card-title
-        option the options flow edits later.
+        Single-instance setup: the name the card carries seeds both the entry
+        title and the card-title option, and the sidebar answer is stored as the
+        same option the options flow edits later.
         """
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -186,4 +197,11 @@ class HAventoryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             return self.async_show_form(step_id="user", data_schema=_user_schema())
 
         title = clean_card_title(user_input.get(CONF_CARD_TITLE))
-        return self.async_create_entry(title=title, data={}, options={CONF_CARD_TITLE: title})
+        sidebar = bool(
+            user_input.get(CONF_SIDEBAR_PANEL_ENABLED, DEFAULT_SIDEBAR_PANEL_ENABLED)
+        )
+        return self.async_create_entry(
+            title=title,
+            data={},
+            options={CONF_CARD_TITLE: title, CONF_SIDEBAR_PANEL_ENABLED: sidebar},
+        )

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -3,17 +3,19 @@
     "step": {
       "user": {
         "title": "HAventory",
-        "description": "Set up HAventory integration for inventory management in Home Assistant.",
+        "description": "Set up HAventory for inventory management in Home Assistant. Both answers below, and everything else, can be changed later under Configure.",
         "data": {
-          "card_title": "Card title"
+          "card_title": "Card title",
+          "sidebar_panel_enabled": "Show HAventory in the sidebar"
         },
         "data_description": {
-          "card_title": "Heading shown on the HAventory card. Changeable later under Configure."
+          "card_title": "Heading shown on the HAventory card.",
+          "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. Each user can still hide the entry through the sidebar's own Edit sidebar mode."
         }
       }
     },
     "create_entry": {
-      "default": "Successfully configured HAventory"
+      "default": "Successfully configured HAventory. Reload this browser page once: the card and its sidebar icon are loaded when a page opens, so a page that was already open has neither yet."
     }
   },
   "options": {

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -3,17 +3,19 @@
     "step": {
       "user": {
         "title": "HAventory",
-        "description": "Set up HAventory integration for inventory management in Home Assistant.",
+        "description": "Set up HAventory for inventory management in Home Assistant. Both answers below, and everything else, can be changed later under Configure.",
         "data": {
-          "card_title": "Card title"
+          "card_title": "Card title",
+          "sidebar_panel_enabled": "Show HAventory in the sidebar"
         },
         "data_description": {
-          "card_title": "Heading shown on the HAventory card. Changeable later under Configure."
+          "card_title": "Heading shown on the HAventory card.",
+          "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. Each user can still hide the entry through the sidebar's own Edit sidebar mode."
         }
       }
     },
     "create_entry": {
-      "default": "Successfully configured HAventory"
+      "default": "Successfully configured HAventory. Reload this browser page once: the card and its sidebar icon are loaded when a page opens, so a page that was already open has neither yet."
     }
   },
   "options": {

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -238,11 +238,17 @@ above their members, collapse like any node (a `_collapsedAreas` set, so absence
 open), sum their members' subtree counts, and stay visible while any member survives the
 text filter without matching it themselves.
 
-A header is never a location: it carries no id a picker could assign. Only the full-view
-sidebar sets `areaSelectable`, where pressing a header emits `select-area` and sets
-`filters.areaId` — a filter the item query already accepts, so the row does something real.
-In the editor, bulk-move and organize pickers the headers are inert labels that only
-collapse.
+A header is never a location: it carries no id a picker could assign, so `areaSelectable`
+makes it emit `select-area` rather than `select`, and what that means belongs to the host.
+The full-view sidebar sets `filters.areaId` from it — a filter the item query already
+accepts. The organize dialog's **parent** picker files the location at the top level of the
+area, which is both halves of moving a subtree between areas in one gesture; it also sets
+`showEmptyAreas`, so `groupRootsByArea` bands every area in the registry and not only the
+ones already holding a tree (an area you cannot reach until something is in it is no target
+at all). An empty band heads nothing, so it renders without a twisty and without
+`aria-expanded`/`aria-controls`, and a text filter suspends the empty bands entirely.
+Everywhere a `location_id` is what comes back — the item editor, bulk move, the merge
+target — headers stay inert labels that only collapse: an area holds no items itself.
 
 ### Container vs presentation
 
@@ -363,6 +369,10 @@ updated. Each definition carries a `tableSize` for the full-view table and — o
 backend can actually sort by it — a `sortField`. Category, location and tags have none, so
 their headers are not clickable: a header that looks interactive but does nothing is worse
 than a plain one.
+
+`DEFAULT_COLUMNS` is every key: a browser that has made no choice sees the whole record,
+and the picker is what thins it. The full set is wider than a phone and wider than many
+desktops, which `hv-data-table` answers by scrolling sideways rather than dropping columns.
 
 Preferences persist in `localStorage` under `haventory:columns:v1` as `{ expanded: [...] }`.
 Any other key in that record is ignored, so an older or newer payload never breaks the load.

--- a/docs/sidebar-panel.md
+++ b/docs/sidebar-panel.md
@@ -36,8 +36,8 @@ Overview offers is **a navigation path worth adding as a shortcut** — which me
 
 Register a **HAventory sidebar panel** at `/haventory` that renders the card's
 extended view (`hv-full-view`) as a full page, served from the existing card bundle.
-Expose a **"Show HAventory in the sidebar" toggle in the options flow** (default on)
-that registers/removes the panel live. This yields:
+Expose a **"Show HAventory in the sidebar" toggle** (default on) in the setup step and
+in the options flow, which registers/removes the panel live. This yields:
 
 - HAventory in the sidebar automatically on install — zero-config discoverability,
   for every user of the instance.
@@ -236,7 +236,12 @@ the feature on. Includes the live verification pass.
 - Sidebar title follows the existing **card title option** (falls back "HAventory"),
   so a user who renamed the card to "Pantry" sees "Pantry" in the sidebar.
 - Icon `haventory:logo` — the HAventory mark, registered as a custom icon set by the
-  card bundle; URL path `haventory`; `require_admin=False`.
+  card bundle; URL path `haventory`; `require_admin=False`. The artwork therefore
+  reaches a browser only with the bundle, and the bundle only when a page loads:
+  installing while a tab is open puts the entry in that tab's sidebar without its
+  mark, because `ha-icon` resolves an icon once and does not re-resolve when a set
+  registers later. One ordinary page reload is the whole of it; the setup step's
+  closing message says so.
 - Panel renders the **extended view**, not a page-sized card.
 - The panel offers the **full ⋮ menu** — organize, import and diagnostics included.
   Every surface `hv-full-view` can raise is owned by `host-surfaces.ts` and rendered

--- a/tests/test_config_flow_offline.py
+++ b/tests/test_config_flow_offline.py
@@ -22,6 +22,7 @@ from custom_components.haventory.const import (
     CONF_CARD_TITLE,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
+    DEFAULT_SIDEBAR_PANEL_ENABLED,
 )
 from homeassistant.config_entries import ConfigEntry
 
@@ -69,12 +70,19 @@ async def test_user_step_creates_entry(monkeypatch) -> None:
     assert result["type"] == "create_entry"
     assert result["title"] == DEFAULT_CARD_TITLE
     assert result["data"] == {}
-    assert result["options"] == {CONF_CARD_TITLE: DEFAULT_CARD_TITLE}
+    assert result["options"] == {
+        CONF_CARD_TITLE: DEFAULT_CARD_TITLE,
+        CONF_SIDEBAR_PANEL_ENABLED: DEFAULT_SIDEBAR_PANEL_ENABLED,
+    }
 
 
 @pytest.mark.asyncio
-async def test_user_step_asks_for_the_card_title(monkeypatch) -> None:
-    """Setup opens a form rather than creating an unnamed entry outright."""
+async def test_user_step_asks_for_the_title_and_the_sidebar(monkeypatch) -> None:
+    """Setup opens a form rather than creating an unnamed entry outright.
+
+    Both fields the options flow opens with are asked here, so the sidebar entry
+    is a decision at setup rather than a discovery under Configure.
+    """
 
     flow = HAventoryConfigFlow()
     monkeypatch.setattr(flow, "_async_current_entries", lambda: [], raising=False)
@@ -82,7 +90,11 @@ async def test_user_step_asks_for_the_card_title(monkeypatch) -> None:
     result = await flow.async_step_user(user_input=None)
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert _schema_keys(result["data_schema"]) == {CONF_CARD_TITLE}
+    assert _schema_keys(result["data_schema"]) == {CONF_CARD_TITLE, CONF_SIDEBAR_PANEL_ENABLED}
+    assert (
+        _schema_default(result["data_schema"], CONF_SIDEBAR_PANEL_ENABLED)
+        is DEFAULT_SIDEBAR_PANEL_ENABLED
+    )
 
 
 @pytest.mark.asyncio
@@ -94,7 +106,24 @@ async def test_user_step_uses_the_submitted_title(monkeypatch) -> None:
 
     result = await flow.async_step_user(user_input={CONF_CARD_TITLE: "  Pantry  "})
     assert result["title"] == "Pantry"
-    assert result["options"] == {CONF_CARD_TITLE: "Pantry"}
+    assert result["options"][CONF_CARD_TITLE] == "Pantry"
+
+
+@pytest.mark.asyncio
+async def test_user_step_stores_a_declined_sidebar(monkeypatch) -> None:
+    """Answering "no" at setup has to survive as the stored option.
+
+    Absence reads as on everywhere the panel is applied, so an opt-out only
+    holds if the setup step writes it down.
+    """
+
+    flow = HAventoryConfigFlow()
+    monkeypatch.setattr(flow, "_async_current_entries", lambda: [], raising=False)
+
+    result = await flow.async_step_user(
+        user_input={CONF_CARD_TITLE: "Pantry", CONF_SIDEBAR_PANEL_ENABLED: False}
+    )
+    assert result["options"][CONF_SIDEBAR_PANEL_ENABLED] is False
 
 
 @pytest.mark.asyncio
@@ -105,7 +134,7 @@ async def test_blank_title_falls_back_to_the_default(monkeypatch) -> None:
     monkeypatch.setattr(flow, "_async_current_entries", lambda: [], raising=False)
 
     result = await flow.async_step_user(user_input={CONF_CARD_TITLE: "   "})
-    assert result["options"] == {CONF_CARD_TITLE: DEFAULT_CARD_TITLE}
+    assert result["options"][CONF_CARD_TITLE] == DEFAULT_CARD_TITLE
 
 
 @pytest.mark.asyncio

--- a/tests/test_repository_locations_offline.py
+++ b/tests/test_repository_locations_offline.py
@@ -132,3 +132,32 @@ async def test_location_item_counts_and_no_location_count() -> None:
     # Unknown location id raises NotFoundError
     with pytest.raises(NotFoundError):
         repo.get_location_item_counts("00000000-0000-4000-8000-000000000000")
+
+
+@pytest.mark.asyncio
+async def test_moving_a_subtree_to_the_top_level_files_it_under_a_new_area() -> None:
+    """One update does both halves of "move this subtree into an area".
+
+    The parent change commits before the area propagates, so the area lands on
+    the moved location — a root of its own by then — instead of rewriting the
+    tree it is leaving. The area the old tree carries is untouched, and the
+    items under the moved subtree follow by inheritance.
+    """
+
+    repo = Repository()
+    garage = repo.create_location(name="Garage", area_id="area-garage")
+    shelf = repo.create_location(name="Shelf", parent_id=garage.id)
+    bin_1 = repo.create_location(name="Bin 1", parent_id=shelf.id)
+    repo.create_item(ItemCreate(name="Car", location_id=str(garage.id)))
+    drill = repo.create_item(ItemCreate(name="Drill", location_id=str(bin_1.id)))
+
+    moved = repo.update_location(shelf.id, new_parent_id=None, area_id="area-cellar")
+
+    assert moved.parent_id is None
+    assert moved.area_id == "area-cellar"
+    assert repo.get_location(garage.id).area_id == "area-garage"
+    # Descendants inherit from the root rather than storing an area of their own.
+    assert repo.get_location(bin_1.id).area_id is None
+
+    in_cellar = repo.list_items(flt={"area_id": "area-cellar"})
+    assert [i.id for i in in_cellar["items"]] == [drill.id]


### PR DESCRIPTION
## Summary

Extends the location tree component to support showing and selecting empty areas (those with no locations filed under them yet), enabling the organize dialog's parent picker to file subtrees into any area in the registry. This is essential for the parent picker's use case: moving a location to the top level of an area requires that area to be reachable even if nothing is in it yet.

The changes introduce:
- `showEmptyAreas` property on `hv-location-tree` to band all areas (not just those in use)
- `groupRootsByArea` now accepts an `includeEmptyAreas` option to pre-populate the area map
- Empty area headers render without a twisty, `aria-expanded`, or `aria-controls` (nothing to disclose)
- Empty bands are suspended when a text filter is active (they can't match anything)
- The organize dialog's parent picker now sets `areaSelectable` and `showEmptyAreas`, and listens to `select-area` events to file locations at the top level of the chosen area
- Parent button label now reflects the area when a top-level location is being edited
- Merge target picker clarifies why areas cannot be merge targets (they hold no items themselves)

Also updates the setup flow to ask for the sidebar panel preference at install time (alongside card title), rather than leaving it to the options flow, so both decisions are made once during setup.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` ✓, `uv run ruff check .` ✓, `uv run mypy` ✓
- Frontend: `npx eslint .` ✓, `npm run typecheck` ✓, `npx vitest run` ✓, `npm run build` ✓

New tests added:
- `hv-location-tree.test.ts`: bands empty areas when `showEmptyAreas` is true; drops empty bands during filtering; only bands areas in use when browsing
- `hv-organize-dialog.test.ts`: offers every area in the parent picker; moves subtree to top level of chosen area in one save; clarifies merge target restrictions
- `test_repository_locations_offline.py`: verifies that moving a subtree to the top level and into a new area updates both parent and area in one call

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated (happy path + edge cases)
- [x] Docs updated where behavior changed (`README.md`, `docs/frontend_architecture.md`, `docs/sidebar-panel.md`)
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`)

https://claude.ai/code/session_01KydC2Z4Pej7gr2C15Tqw7w