### PR TITLE
docs: make CLAUDE.md release-stable and re-verify its claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,53 @@
 
 Guidance for Claude Code when working in the HAventory repository.
 
+This file carries no version numbers — not the project's, not the platform floors', not the
+toolchain pins'. Each of those is declared in exactly one file that CI or a test defends, and
+is named here instead of copied, so this file stays true across releases.
+
 ## What this is
 
 HAventory is a Home Assistant **custom integration** (domain `haventory`) for household
 inventory tracking, plus a Lovelace **card** frontend. Local-push, single-instance, HA
 `Store`-backed persistence — no external services.
 
-Targets: minimum Home Assistant **2026.6.0** ⇒ **Python 3.14 everywhere**
-(`requires-python >=3.14`, ruff `target-version = py314`, mypy `3.14`, CI 3.14; the source
-uses 3.14-only PEP 758 syntax). uv provisions the interpreter automatically. Node
-**22.13+ / 24 LTS** (`engines: ^22.13 || >=24`). Toolchain: **uv** (env + lockfile +
-dependency groups), ruff `0.15`, mypy `2`, ESLint `10`, TypeScript `6`, Vite `8`,
-Vitest `4`. Version 0.0.1, unreleased.
+The released version lives in `custom_components/haventory/manifest.json` and
+`cards/haventory-card/package.json`; release-please cuts it and
+`scripts/check_version_consistency.py` (release workflow) plus
+`tests/test_release_version_consistency.py` (CI) keep the two in agreement. Never hand-edit
+either number.
 
-> See the "WP1 Decisions" section at the end for the full adopted platform + tooling set.
+### Platform floors (load-bearing)
+
+Three floors constrain everything, none of them written down here:
+
+- **Minimum Home Assistant** — declared in `hacs.json`, which is what HACS enforces at
+  install time. Every other spelling of it is a copy, and `tests/test_min_ha_version.py`
+  enumerates the copies and fails when one drifts. Add a new copy to that test or don't
+  write it. `requirements-integration.txt` pins the in-process suite to the floor, so CI
+  runs the integration *at* it rather than at whatever is current.
+- **Python** — `requires-python` in `pyproject.toml`; ruff's `target-version` and mypy's
+  `python_version` follow it, and CI installs it. It cannot go lower than HA's own floor,
+  and the source uses PEP 758 unparenthesized `except A, B:`, which does not parse on
+  older interpreters — so an older HA could not import the integration at all. uv
+  provisions the interpreter automatically on `uv sync`; an environment with restricted
+  egress must preinstall it or allow the python-build-standalone download, otherwise the
+  offline suite cannot run there.
+- **Node** — `engines` in `cards/haventory-card/package.json`; CI runs a matrix across the
+  supported majors.
+
+When raising the HA floor, three constraints stack and the binding one is not always the
+same: the HA APIs the integration touches, the Python floor those releases carry, and
+**security** — a declared floor is a recommendation about what to run, so it must not point
+at a release with a known unpatched advisory. That last one moves with new advisories, so
+"the oldest release with no known advisory" is not a fixed number; re-derive it rather than
+assuming the current floor is still the right one. `dependency-review` fails CI if
+`requirements-integration.txt` is pinned below it.
+
+Toolchain: **uv** (env + lockfile + dependency groups), ruff, mypy, ESLint (no separate
+formatter), TypeScript, Vite, Vitest. Pins live in `pyproject.toml` and
+`cards/haventory-card/package.json`; ruff's pin is duplicated in `.pre-commit-config.yaml`
+and the two must move together.
 
 ## Architecture & key files
 
@@ -32,35 +65,59 @@ Vitest `4`. Version 0.0.1, unreleased.
   search indexes; **search is case-insensitive** (casefold + NFKD accent-stripping) — see
   `_normalize_for_search`. Maintains a generation counter for optimistic locking / debugging.
 - `storage.py` — HA `Store` persistence with schema versioning (`CURRENT_SCHEMA_VERSION`,
-  `STORAGE_KEY = "haventory_store"`), plus `asyncio.Lock`-serialized writes.
+  `STORAGE_KEY = "haventory_store"`), plus `asyncio.Lock`-serialized writes. A store written
+  by a newer schema is refused, not relabelled — there is no downgrade path except a JSON
+  export taken while the newer version still ran.
 - `migrations.py` — forward-only, **idempotent** schema migrations (`migrate_N_to_N+1`).
 - `ws.py` — WebSocket-first CRUD API (`websocket_api` decorators) and subscriptions
   (items / locations / stats). This is the primary API surface. Every command is wrapped
-  by `ws_guard` (error taxonomy incl. `unknown_error` catch-all and the opt-in
-  `rate_limited` check); error envelopes are built by `_error_envelope`, NOT
+  by `ws_guard` (error taxonomy incl. `unknown_error` catch-all, the opt-in `rate_limited`
+  check, and the loaded-runtime requirement that makes commands refuse once the config
+  entry is gone); error envelopes are built by `_error_envelope`, NOT
   `websocket_api.error_message` (HA's helper has no `data` param).
-- `rate_limit.py` — WP4 opt-in token-bucket rate limiting (per-connection + global, for
+- `rate_limit.py` — opt-in token-bucket rate limiting (per-connection + global, for
   commands and broadcasts). Off by default; configured via the options flow
   (`config_flow.py`); limiter instance lives in `hass.data[DOMAIN]["rate_limiter"]`.
+- `import_export.py` — JSON import/export with `merge` / `replace` / `skip` policies and a
+  read-only preview. **Import identity is the id, never the name.**
+- `stale_files.py` — `RETIRED_PATHS`, the explicit list of files earlier releases shipped
+  inside the integration package and this one does not, swept on setup because a HACS
+  upgrade never deletes. Executor-offloaded, files only, and refuses any entry resolving
+  outside the package directory. Guard tests reject an entry this release still ships and
+  any non-relative path.
 - `services.py` / `services.yaml` — HA services (`haventory.*`) with voluptuous schemas; handlers
-  re-raise validation/repository/storage errors so HA surfaces them.
+  re-raise validation/repository/storage errors so HA surfaces them. Registration binds
+  `async def` adapters: a lambda handler is classified as an executor job, runs on a worker
+  thread, and its coroutine is never awaited — a silent no-op that offline tests cannot see.
 - `areas.py` — HA area registry integration (read-only; never auto-creates areas).
-- `config_flow.py` — single-instance config flow. `const.py`, `exceptions.py`, `manifest.json`,
-  `strings.json`, `translations/`.
+- `config_flow.py` — single-instance config flow; asks for card title and the sidebar-panel
+  preference at setup, and the options flow carries those plus the rate-limit section.
+  `const.py`, `exceptions.py`, `manifest.json`, `strings.json`, `translations/`.
 
 ### Frontend — `cards/haventory-card/`
-Lit 3 + TypeScript + Vite Lovelace card. Source in `src/` (`haventory-card` container,
+Lit + TypeScript + Vite Lovelace card. Source in `src/` (`haventory-card` container,
 `hv-*` components, `store/` for WS client + state). Builds to
 `custom_components/haventory/www/haventory-card.js` (git-ignored; produced in CI and by
 `npm run build`) — inside the integration package, which is the only tree HACS copies. The
 integration serves that directory at `/haventory_static/` and loads the card through both
-a Lovelace resource and `frontend.add_extra_js_url`, on one identical URL. See
-`docs/card_shipping_plan.md`.
+a Lovelace resource and `frontend.add_extra_js_url`, on one identical URL.
+
+The same bundle registers the custom icon set that the backend's `PANEL_ICON` names, so the
+sidebar entry only draws its mark once the bundle has loaded;
+`tests/test_frontend_registration.py` pins that constant and the bundle's exported
+identifier to the same string, across the language boundary neither side can check alone.
 
 ### Docs — `docs/` (link here, don't duplicate)
 - `backend_api_contract.md` — WebSocket envelope, error taxonomy, command catalog, events.
 - `data_shapes.md` — canonical Item/Location/filter/sort/event shapes.
 - `frontend_architecture.md` — card component architecture.
+- `rate_limiting.md` — what the rate-limit options mean and when enabling them is worth it.
+- `release_testing_plan.md` — the manual pre-1.0 validation program (environments,
+  scenarios, exit criteria).
+- `open-items.md` — the pre-v1.0 tracker (see "Where work is tracked" below).
+
+The remaining `docs/*_plan.md` files are per-task design documents, live only until the task
+they describe ships; they are retired as a batch before 1.0.
 
 ## Running tests / lint / build (Linux)
 
@@ -72,6 +129,10 @@ uv run ruff format --check .   # CI fails on formatting alone; `ruff check` does
 uv run mypy
 ```
 
+mypy holds the core modules (`models`, `repository`, `storage`, `ws`) to per-module strict
+mode against local HA stubs in `stubs/` (`mypy_path = custom_components:stubs`); the rest of
+the integration sits at the non-strict baseline.
+
 Frontend (in `cards/haventory-card`):
 ```bash
 npm audit --audit-level=high   # dev-scope alerts are auto-dismissed on GitHub; CI is the gate
@@ -81,18 +142,22 @@ npx vitest run
 npm run build
 ```
 
-In-process HA integration tests (WP1.5 — second, separate mode, opt-in): run the
-integration against a **real** Home Assistant core via
-`pytest-homeassistant-custom-component` (phacc). Needs Python 3.14 + a full HA install
-(from `requirements-integration.txt`; kept out of `pyproject`/`uv.lock`/the offline
-`.venv` so the fast suite stays lean), plugin autoload **on**, pytest-asyncio auto mode:
+In-process HA integration tests (a second, separate mode, opt-in): run the integration
+against a **real** Home Assistant core via `pytest-homeassistant-custom-component` (phacc).
+Needs a full HA install (from `requirements-integration.txt`; kept out of
+`pyproject`/`uv.lock`/the offline `.venv` so the fast suite stays lean), plugin autoload
+**on**, pytest-asyncio auto mode:
 ```bash
-scripts/test_integration.sh               # provisions .venv-integration (Py 3.14 + phacc)
+scripts/test_integration.sh               # provisions .venv-integration
 # manual: .venv-integration/bin/python -m pytest -o asyncio_mode=auto tests/integration
 ```
 The offline suite stays byte-identical: `tests/conftest.py` stubs HA only when the real
 package is absent, and the offline run never collects `tests/integration/`. Do **not**
 set `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` for the integration mode.
+
+The offline `HomeAssistant` stub has no service registry, so `services.setup()` early-returns
+and no offline test can observe real registration semantics. Anything about how HA *dispatches*
+a handler has to be asserted in the integration mode or it is not asserted at all.
 
 Bootstrap a fresh session (also run by the SessionStart hook):
 ```bash
@@ -121,12 +186,18 @@ Offline tests stub HA via `tests/conftest.py`.
 - **WebSocket API contract lives in `docs/`** — keep `ws.py`, `docs/backend_api_contract.md`,
   and `docs/data_shapes.md` in sync when the API changes.
 - **Case-insensitive search** and **denormalized `location_path`** on items are load-bearing
-  invariants — preserve them.
+  invariants — preserve them. `location_path` is derived: the backend computes it from the
+  tree, no client can write it, and rewriting it must not touch an item's `version` or
+  `updated_at` (a location rename is not an item edit).
 - **Optimistic concurrency** via the item `version` field — mutations expect/return it.
 - **Conventional Commits**; small, focused commits. Update `README.md` when behavior changes.
 - **Persistence**: WS and service handlers save immediately (errors propagate as
   `storage_error`); shutdown/unload flushes immediately; debounced saves are for internal/batch
-  work only.
+  work only, and are scheduled through `hass.async_create_background_task` so a pending write
+  is cancelled and awaited on shutdown.
+- **Deleting or renaming a file inside `custom_components/haventory/`** means appending its
+  old path to `RETIRED_PATHS` in the same PR — a HACS upgrade leaves it behind otherwise.
+  The rule is stated in `CONTRIBUTING.md`.
 - **Logging**: avoid reserved `LogRecord` keys in `extra=` — use `item_name` / `location_name`,
   not `name`.
 - **Comments explain constraints, not history.** A comment earns its place by encoding
@@ -145,7 +216,8 @@ Offline tests stub HA via `tests/conftest.py`.
   - A comment that is wrong is worse than none. When a comment names a symbol, a type, a
     caller or a stored shape, that name must still be correct.
   - `TODO`/`FIXME` markers do not belong in committed code — the repo has zero and keeps it
-    that way. Record follow-ups in `docs/open-items.md` instead.
+    that way. Follow-ups go to the tracker ("Where work is tracked" below), never into a
+    marker the next reader has to rediscover.
   - Component-level JSDoc says what the component is responsible for and what it talks to.
     Non-obvious CSS gets a why-comment; obvious CSS gets none.
   - Applies to TypeScript and Python alike. Enforced by review, not by a lint rule — the
@@ -153,162 +225,32 @@ Offline tests stub HA via `tests/conftest.py`.
     ignored.
 - Naming: domain/package `haventory`, services `haventory.*`, built assets
   `custom_components/haventory/www/` served at `/haventory_static/`, calendar entity
-  `calendar.haventory`.
+  `calendar.haventory` — a name reserved for the post-1.0 calendar work, not an entity that
+  exists today.
 - Report out-of-scope findings under a "Follow-ups" note rather than fixing them.
 
 See the README "Developer Checklist" for the full backend/frontend/CI checklist.
 
----
+## Scope decisions that stay true
 
-## HA / Python compatibility baseline (WP0.5, established 2026-07-22)
+- **HAventory keeps all of its pillars.** Core HA has shipped no first-party
+  inventory/pantry/stock feature; the overlap is confined to primitives (counters, to-do due
+  dates, labels/categories, local calendar) and there is no native nested location tree —
+  HA is hard-capped at floor → area, which is the differentiator. Do not migrate a pillar
+  onto a core primitive on the theory that it duplicates one.
+- **Areas are HA's, not ours.** The integration reads the area registry and never creates
+  areas. An item's area is inherited from its location tree's root, exposed as
+  `effective_area_id`, and shown with one chip vocabulary wherever the card marks an area.
+- **Reminders/calendar, when built, ride HA-native primitives** — a `CalendarEntity` plus
+  automations, not a bespoke scheduler. Post-1.0, tracked as an issue; do not start it.
 
-Established empirically (real HA installed in a throwaway venv + integration smoke-tested)
-and by inspecting `home-assistant/core` at the `2026.7.3` tag. Sources: PyPI
-`homeassistant` per-version `requires_python`; HA release blog 2026.1–2026.7; HA developer
-blog.
+## Where work is tracked
 
-- **Current stable HA:** `2026.7.3` (2026.7 series, released 2026-07-01).
-- **HA Python floor:** **Python `>=3.14.2`**, bumped from 3.13 → **3.14 in HA 2026.3**
-  (2026-03-04). Every HA release from 2026.3 onward requires Python 3.14. This is not
-  optional: declaring a min HA of 2026.3+ forces Python 3.14 on the toolchain.
+**GitHub issues** are the tracker: bugs, feature requests, and every deferred follow-up,
+filed with the templates in `.github/ISSUE_TEMPLATE/`. `docs/open-items.md` is the one
+exception — the pre-v1.0 release tracker, carrying the remaining release stages and the
+staging table that says which release each lands in. It is authoritative for staging, and it
+is deleted when 1.0 is cut.
 
-### Minimum supported HA + Python (SET at feature freeze, 2026-07-29)
-
-- **Minimum supported HA:** **`2026.6.0`**. Three constraints stack, each stricter than the
-  last:
-  1. **APIs** — every HA symbol the integration uses (`websocket_api` registration +
-     decorators, `helpers.storage.Store`, the config-entry lifecycle, `ConfigFlowResult`,
-     `ConfigEntryError`, `helpers.area_registry.async_get`, `loader.async_get_integration`,
-     `hass.async_create_background_task`, `LOVELACE_DATA` + `ResourceStorageCollection`'s
-     `async_items` / `async_create_item` / `async_update_item` / `async_delete_item`) is
-     present and unchanged as far back as **2026.3.1**, verified against both that release's
-     wheel and 2026.6.0's (the 2026.6 dashboard overhaul left the resource collection API
-     untouched). So the APIs alone would allow 2026.3.
-  2. **Python** — 2026.3 is the first series requiring Python 3.14, and the source uses PEP
-     758 syntax that does not parse on 3.13. Nothing below 2026.3 is possible at all.
-  3. **Security** — every release below 2026.6.0 is affected by GHSA-x84v-g949-293w (high,
-     CVE-2026-54317, fixed in 2026.6.0). A declared floor is a recommendation about what to
-     run, so it does not point at a version with a known unpatched advisory. This is the
-     binding constraint, and `dependency-review` enforces it: pinning
-     `requirements-integration.txt` any lower fails CI.
-- **Python:** **`3.14`** (forced by HA ≥ 2026.3). Non-negotiable given the min-HA choice.
-
-Re-check constraint 3 when raising the floor next: it moves with new advisories, so the
-"oldest release with no known advisory" is not a fixed number.
-
-The floor is defended by CI: `requirements-integration.txt` pins HA to it, so the in-process
-phacc suite runs at the floor, and `tests/test_min_ha_version.py` fails if any declaration
-site drifts from `hacs.json`. Current stable is covered by the dogfood run instead.
-
-### Toolchain targets for WP1 (record now, change lands in WP1 — not WP0.5)
-
-The min-HA/Python decision above implies these toolchain edits (do them in WP1):
-
-- CI `.github/workflows/ci.yml` → `actions/setup-python` `python-version: '3.12'` → `'3.14'`.
-- `pyproject.toml` `[tool.ruff]` `target-version = "py312"` → `"py314"`.
-- mypy (when configured) `python_version = "3.14"`.
-- Note: the offline test suite stubs HA and does not import real `homeassistant`, so the
-  suite itself does not require Python 3.14 to run — but the declared support target does.
-
----
-
-## HA compatibility review — findings (WP0.5)
-
-Full report is in the WP0.5 session; the durable conclusions:
-
-- **No breaking incompatibility** with current stable (2026.7.3) in any touch point.
-  Verified compatible: `websocket_api` command registration + `@websocket_command` /
-  `@async_response` decorators; `helpers.storage.Store(hass, version, key)`; config-entry
-  lifecycle (`async_setup_entry` / `async_unload_entry`); `helpers.area_registry.async_get`;
-  Lovelace resource auto-registration (`LOVELACE_DATA` + resource collection API unchanged
-  despite the 2026.1 & 2026.6 dashboard overhauls); `manifest.json` keys (no newly-required
-  key). Empirical smoke against real HA 2026.2.3 (last 3.13-compatible release): import +
-  `async_setup_entry` + WS command + `async_unload_entry` all pass, 0 deprecation warnings.
-- **Not affected** by the two 2026.6 config-entry deprecations: HAventory registers no
-  config-entry update listener and uses no advanced-mode config flow.
-- **Fixed (mechanical):** `config_flow.py` now annotates the flow step with
-  `ConfigFlowResult` (HA's recommended type since 2024.4) instead of importing `FlowResult`.
-- ~~**Flagged for WP1 (not fixed — needs a small guarded change):** `storage.py` uses bare
-  `asyncio.create_task(...)` for the debounced persist.~~ — fixed: the debounced persist is
-  scheduled via `hass.async_create_background_task(coro, name=...)`, so a pending debounce
-  is cancelled/awaited on shutdown.
-- **Optional nice-to-haves (not required):** add `"single_config_entry": true` to
-  `manifest.json` (matches the flow's single-instance guard); frontend card could opt into
-  the 2026.6 picker via `getEntitySuggestion`. Neither affects current functionality.
-
----
-
-## Redundancy review vs. core HA (WP0.5, Part B)
-
-Core HA has shipped **no** first-party inventory/pantry/stock feature as of 2026.7. Overlap
-is partial and confined to primitives (counters, to-do due dates, labels/categories, local
-calendar) plus the one strong overlap: **HA Areas** (which HAventory already integrates
-with). HA has **no** nested/multi-level location tree (hard-capped at floor → area).
-
-### Per-item decisions (DECIDED by owner, 2026-07-22)
-
-| # | Pillar | Nearest HA-native (since) | Overlap | Decision |
-|---|---|---|---|---|
-| 1 | Quantity + low-stock threshold | `counter` / `input_number` helpers | weak (no threshold logic) | **Keep as-is** |
-| 2 | Categories + tags | Labels + Categories registries (2024.4) | partial (target HA entities, not item objects) | **Keep as-is** |
-| 3 | Custom fields | none | none | **Keep as-is** |
-| 4 | Check-out + due dates | `todo` due dates (2024.1) | none (primitive only; no borrow/return) | **Keep as-is** |
-| 5 | Inspection dates | `todo` / `calendar` primitive | none | **Keep as-is** |
-| 6 | Multi-level location tree | Floors → Areas (2024.4) = one level only | none (major gap; a differentiator) | **Keep as-is** |
-| 7 | Areas integration | Area registry (0.87), Floors (2024.4) | strong | **Keep as-is** (already rides native Areas) |
-| 8 | JSON import/export (planned) | none | none | **Keep / build as planned** |
-| 9 | Reminders / calendar (post-1.0) | Local Calendar (2022.12) + `todo` + automations | partial | **Rework onto HA-native**: implement the roadmap's `CalendarEntity` (`calendar.haventory`) + HA automations rather than a bespoke reminder scheduler. Effort M, post-1.0. |
-
-Net: HAventory keeps all pillars; only the post-1.0 reminders/calendar work is to be built on
-HA-native primitives (`CalendarEntity` + automations) rather than a custom scheduler. Do NOT
-start that rework here — it is post-1.0 and out of WP0.5 scope; this table just fixes the
-direction. Everything else stays as implemented (no core-HA equivalent to migrate onto).
-
----
-
-## WP1 Decisions — toolchain modernization + Linux-first (2026-07-22)
-
-Adopted tooling (latest stable at review time; verified against release pages / npm registry):
-
-| Area | Choice | Notes |
-|---|---|---|
-| Python env/deps | **uv** (`uv.lock` + `[dependency-groups]`, `[tool.uv] package=false`) | replaces pip + hand `.venv`; `requirements-dev.txt` is now a generated uv export |
-| Lint/format | **ruff 0.15.22** | pin unified across `pyproject.toml` + pre-commit |
-| Type checker | **mypy 2.x**; strict on the core four | WP4: per-module strict for `models`/`repository`/`storage`/`ws` against local HA stubs in `stubs/` (`mypy_path = custom_components:stubs`); the rest stays non-strict (WP5 ratchet) |
-| Frontend pkg mgr | **npm** (kept) | pnpm not worth it for one small package |
-| Frontend lint | **ESLint 10** + `@typescript-eslint 8`; no separate formatter | Biome not adopted (weaker Lit/TS type-aware coverage) |
-| TypeScript | **6.0.3** (hold 7.x) | typescript-eslint 8.65 caps at `<6.1.0`; TS 7 would break type-aware lint. Follow-up: bump to 7 when typescript-eslint supports it |
-| Vite / Vitest | **8 / 4** (+ coverage-v8 4) | upgraded together (vitest 4 needs vite ≥6) |
-| Node | `engines ^22.13 || >=24`; CI 22 + 24 | Node 20 EOL 2026-04-30 |
-| CI | ubuntu-latest, uv (`setup-uv` w/ cache), Python 3.12+3.14 matrix, concurrency+cancel, actionlint, `actions/*@v7`, SHA-pinned hassfest/hacs/setup-uv | moved off windows-latest |
-| Dependabot | grouped updates; **uv** ecosystem for Python | kept over Renovate |
-| Release automation | **release-please** | recommended now, implement in WP5 |
-
-### Platform floors (important, load-bearing)
-
-- **Python 3.14 everywhere** (floor raised 2026-07-22, completing the WP0.5 target):
-  `requires-python = ">=3.14"`, ruff `target-version = "py314"`, mypy
-  `python_version = "3.14"`, CI runs 3.14 only. The source uses PEP 758 unparenthesized
-  `except A, B:` (emitted by ruff's 2026 formatter at py314), so it does **not parse on
-  ≤ 3.13** — there is no 3.12/3.13 support anymore.
-- Dev environments must be able to provide CPython 3.14: uv downloads it automatically on
-  `uv sync`. Environments with restricted egress (e.g. a remote sandbox that blocks
-  python-build-standalone downloads) must preinstall 3.14 or allow the download — otherwise
-  the offline suite cannot run there.
-
-### WP1 follow-ups (out of scope / environment-blocked)
-
-- ~~**Type-harden** `ws.py` + `repository.py` and drop the mypy per-module override~~ —
-  done in WP4 (per-module strict on the core four + `stubs/`).
-- ~~**`storage.py`**: switch the debounced persist from bare `asyncio.create_task` to
-  `hass.async_create_background_task(...)` (WP0.5 finding; effort S)~~ — done: the persist
-  task is HA-tracked.
-- **TypeScript 7**: adopt once typescript-eslint supports it (currently capped `<6.1.0`).
-- ~~**`tsc --noEmit`** is clean as of WP2 follow-ups (`npm run typecheck`); not yet part of the
-  gate — adding it is a WP4/WP5 call.~~ — done: `npm run typecheck` runs in the `frontend` CI
-  job and in `scripts/lint.sh` / `scripts/ci_local.sh`.
-- **release-please** wiring lands in WP5.
-- ~~**Windows-only test scaffolding**: `tests/conftest.py` uses
-  `asyncio.WindowsSelectorEventLoopPolicy` / `set_event_loop_policy`, both deprecated for
-  removal in Python 3.16~~ — gone: Windows host support was dropped, so `tests/conftest.py`
-  carries no platform branch at all (the selector-loop factory it had used went with it).
+**Feature-frozen until 1.0**: a new finding either blocks the release — and goes to
+`docs/open-items.md` — or it is an issue. Nothing else lands in between.


### PR DESCRIPTION
## Summary

The staleness sweep, plus the rule that prevents the next one: **CLAUDE.md now carries no version numbers at all**, so it stays true across releases.

Closes #213

**Why numbers left the file.** `tests/test_min_ha_version.py` already reasons about this for the HA floor — it enumerates the declaration sites explicitly because "every other spelling of it is a copy that silently goes stale". CLAUDE.md held such a copy (`2026.6.0`) and was *not* among the enumerated sites, so nothing would have caught it drifting. Each version fact now names the file that declares it and the check that defends it:

| Was written here | Now points at |
|---|---|
| `Version 0.0.1, unreleased` | `manifest.json` / `package.json`, cut by release-please, agreement guarded by `check_version_consistency.py` + `tests/test_release_version_consistency.py` |
| Minimum HA `2026.6.0` | `hacs.json`, with `tests/test_min_ha_version.py` enumerating the copies |
| Python `3.14` (×5 spellings) | `requires-python`, which ruff/mypy/CI follow |
| Node `22.13+ / 24 LTS` | `engines` in `package.json` |
| ruff `0.15`, mypy `2`, ESLint `10`, TypeScript `6`, Vite `8`, Vitest `4` | `pyproject.toml` / `package.json` (+ the note that ruff's pin is duplicated in `.pre-commit-config.yaml` and the two must move together) |

The only dotted numbers left are `1.0` milestone references — stable across every 0.x release, and the feature-freeze policy is unstatable without them.

**Four dated sections removed** (~180 lines): the HA/Python compatibility baseline, the compatibility findings, the redundancy review, and the WP1 toolchain decisions. These were session reports — strikethrough entries (`~~flagged for WP1~~ — fixed`), work-package numbering, one-time analysis, and instructions to do things already done ("record now, change lands in WP1", "release-please wiring lands in WP5"). That is precisely the development history this file's own comment convention forbids everywhere else, and it was where nearly every version number lived. Their durable conclusions are folded into the live guidance instead: how to raise the HA floor and why the binding constraint (security advisories) moves rather than sitting still; that the pillars stay as they are because core HA has no equivalent; that reminders ride HA-native primitives when built.

**Re-verification against the tree** (issue #213 asked for a pass over the rest) turned up drift beyond the two known items:

- The architecture list was missing `import_export.py` and `stale_files.py` entirely.
- The toolchain table claimed a "Python 3.12+3.14 matrix"; CI runs `['3.14']` only.
- The Naming line still left `calendar.haventory` ambiguous — the README fixed that in #137, the fix never reached here.
- The card build-path claims flagged in the original ledger row were already correct; no change needed.

**Constraints added that an agent can silently break**, each verified in source: the `RETIRED_PATHS` rule when deleting a file inside the package (a HACS upgrade never deletes); `async def` service registration (a lambda handler is classified as an executor job and its coroutine is never awaited — a silent no-op); the offline `HomeAssistant` stub having no service registry, so dispatch semantics are only assertable in the integration mode; the icon-set identifier pinned across the language boundary by `tests/test_frontend_registration.py`; the derived-`location_path` rule that a rename must not touch `version`/`updated_at`; and storage refusing a newer schema rather than relabelling it.

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` — 461 passed, 22 skipped; `uv run ruff check .` clean; `uv run ruff format --check .` — 104 files already formatted; `uv run mypy` clean (14 source files)
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean; `npm run typecheck` clean; `npx vitest run` — 1021 passed across 49 files; `npm run build` clean

Docs-only diff, so the gates are a regression check rather than a test of the change. Every file, symbol, test and constant newly named in the file was confirmed to exist before it was written; the one claim that did not survive checking was corrected in place (the icon-parity test is offline in `tests/test_frontend_registration.py`, not an integration test as #183's body described).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] Tests added/updated — not applicable; no code changed, and CLAUDE.md is enforced by review rather than by a lint rule.
- [x] Docs updated where behavior changed — this is the docs change; no behavior changed.
- [x] WebSocket API changes keep `ws.py` and the contract docs in sync — no API change.
- [x] Load-bearing invariants preserved — none touched; the `location_path` and `version` invariants are now stated more precisely than before.

## Note for whoever merges second

`claude/item-tracker-migration-ldg4cg` (the open-items → issues migration, not yet a PR) also edits CLAUDE.md — the `TODO`/`FIXME` bullet. This branch resolves that overlap by *not* restating the tracking destination there: the bullet points at a new "Where work is tracked" section, which is the single place the policy is stated. A conflict on that hunk resolves to this branch's wording.

That section describes GitHub issues as the tracker with `docs/open-items.md` as the pre-v1.0 exception. Issues #187–#214 exist, so that is true today; the `.github/ISSUE_TEMPLATE/task.yml` they were filed with arrives with the migration branch, which is why this file names the template directory rather than the file.

## Follow-ups (not in this PR)

- `pyproject.toml:92` carries `# WP4: the core modules are held to ... ratcheting them is a WP5 call` — the same work-package narration this sweep removed from CLAUDE.md, in a file CLAUDE.md points at.
- Two suggestions dropped from the removed sections were never tracked anywhere and are now untracked entirely: adding `"single_config_entry": true` to `manifest.json` (it matches the flow's existing single-instance guard), and the card opting into HA's entity picker via `getEntitySuggestion`. Both were recorded as "optional, not required"; say the word and I'll file them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxZ15dPaS8eJ3kJZFbycZd)_