### PR TITLE
feat(card): make item status a table column and a sidebar facet

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,13 +479,17 @@ throughout.
   a concurrent edit surfaces as a conflict.
 - **Full view** — a fullscreen workspace with a coloured app bar, a **browse sidebar**, and
   a sortable table. Only columns the backend can sort by get a clickable header. A browser
-  that has made no choice yet shows every optional column — quantity, category, location,
-  tags, due, next inspection, updated — and the ⋮ → **Columns** picker is where you thin
-  that down; the table scrolls sideways rather than dropping a column you kept. The
+  that has made no choice yet shows every optional column — quantity, status, category,
+  location, tags, due, next inspection, updated — and the ⋮ → **Columns** picker is where
+  you thin that down; the table scrolls sideways rather than dropping a column you kept.
+  The Status column names every row, OK included, and the name's amber status chip stands
+  down while it is shown so no row says the same word twice. The
   sidebar leads with the location tree carrying the backend's own per-location counts and
-  an orphans row, then **Categories** and **Tags** as sections of their own; each heading
-  collapses from a chevron and states how many there are — locations counted at every
-  depth — and Locations stays at the top. Category picks one value and
+  an orphans row, then **Status**, **Categories** and **Tags** as sections of their own;
+  each heading collapses from a chevron and states how many there are — locations counted
+  at every depth, Status excepted since it always holds the same three rows — and
+  Locations stays at the top. Status prices OK as whatever the two flagged counts leave
+  over. Category and status each pick one value and
   tags accumulate, matching how the backend treats them. With a filter on, each location
   row reads "4 / 37" — matches over total — so you can see where the matches are rather
   than a total that never moves. The counts ignore the *location* filter, since the sidebar

--- a/README.md
+++ b/README.md
@@ -499,7 +499,10 @@ throughout.
   From the second selected tag on, the Tags heading carries the same any/all control the
   filter panel has, since that is the mode governing what the sidebar just selected. The
   app bar's stat pills are the card's: low in amber, overdue in red, to-inspect in amber,
-  checked out, each click-to-filter. An empty table names the reason and offers a way out — the same
+  checked out, each click-to-filter. Beside them, **Missing** and **Needs repair** price the
+  two flagged statuses in the status chip's own amber; each appears only while something
+  carries that flag, and the two are mutually exclusive because the filter takes one status.
+  An empty table names the reason and offers a way out — the same
   wording and the same offers as the card's list.
 
   At phone width the sidebar folds away and the surface hands its own breakpoint down to

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -284,6 +284,49 @@ describe('hv-data-table: rows', () => {
   });
 });
 
+describe('hv-data-table: status column', () => {
+  const mixed = [
+    { id: '1', status: 'missing' as const },
+    { id: '2', status: 'needs_repair' as const },
+    { id: '3', status: 'ok' as const },
+    { id: '4' },
+  ];
+
+  // The name-cell chip only ever marks the exceptions. A column that did the
+  // same would leave most rows blank under a header promising a value.
+  it('names every row, ok included, and reads an absent status as ok', async () => {
+    const el = await mount(mixed, { columns: ['status'] });
+    expect(all(el, '[data-testid="cell-status"]').map((c) => c.textContent?.trim())).toEqual([
+      'Missing',
+      'Needs repair',
+      'OK',
+      'OK',
+    ]);
+  });
+
+  it('chips the flagged values and leaves ok as plain text', async () => {
+    const el = await mount(mixed, { columns: ['status'] });
+    const cells = all(el, '[data-testid="cell-status"]');
+    expect(cells.map((c) => !!c.querySelector('.status-chip'))).toEqual([true, true, false, false]);
+  });
+
+  it('stands the name-cell chip down, so no row says it twice', async () => {
+    const el = await mount([{ id: '1', status: 'missing' }], { columns: ['status'] });
+    expect(q(el, '[data-testid="table-status"]')).toBe(null);
+    expect(q(el, '[data-testid="cell-status"]')?.textContent?.trim()).toBe('Missing');
+  });
+
+  it('keeps the name-cell chip when the column is turned off', async () => {
+    const el = await mount([{ id: '1', status: 'missing' }], { columns: ['quantity'] });
+    expect(q(el, '[data-testid="table-status"]')?.textContent?.trim()).toBe('Missing');
+  });
+
+  it('gives the header no sort button — the API cannot order by status', async () => {
+    const el = await mount([{ id: '1' }], { columns: ['status'] });
+    expect(all(el, '[data-testid="table-sort"]').map((b) => b.dataset.field)).not.toContain('status');
+  });
+});
+
 describe('hv-data-table: selection mode', () => {
   it('adds checkboxes and turns row clicks into selection', async () => {
     const el = await mount([{ id: '1' }, { id: '2' }], { selectable: true });

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -317,6 +317,16 @@ export class HVDataTable extends LitElement {
         return html`<span class="cell qty ${isLowStock(item) ? 'low' : ''}" data-testid="cell-quantity"
           >${item.quantity}</span
         >`;
+      case 'status': {
+        // The column names every row's status, "OK" included — that is what
+        // makes it a column rather than a second copy of the exception chip.
+        const status = itemStatus(item);
+        return html`<span class="cell" data-testid="cell-status"
+          >${status === 'ok'
+            ? statusLabel(status)
+            : html`<span class="status-chip">${statusLabel(status)}</span>`}</span
+        >`;
+      }
       case 'category':
         return html`<span class="cell" data-testid="cell-category" title=${item.category ?? ''}>${item.category || '—'}</span>`;
       case 'location': {
@@ -348,6 +358,10 @@ export class HVDataTable extends LitElement {
 
   render() {
     const columns = this._columns;
+    // The name cell's chip is the flagged-status signal for a table that has no
+    // Status column. With the column shown it would put the same word twice on
+    // one row, so the column takes over and the chip stands down.
+    const statusColumn = columns.includes('status');
     const template = tableTemplateFor(columns, { selectable: this.selectable });
     const loadedIds = this.items.map((i) => i.id);
     const selectedCount = loadedIds.filter((id) => this.selection.has(id)).length;
@@ -422,7 +436,7 @@ export class HVDataTable extends LitElement {
                   <span class="name-cell">
                     <span class="name" data-testid="table-name" title=${item.name}>${item.name}</span>
                     ${isLowStock(item) ? html`<span class="low-badge">LOW</span>` : null}
-                    ${itemStatus(item) !== 'ok'
+                    ${!statusColumn && itemStatus(item) !== 'ok'
                       ? html`<span class="status-chip" data-testid="table-status"
                           >${statusLabel(itemStatus(item))}</span
                         >`

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,4 +1,5 @@
 import './hv-full-view';
+import { NARROW_QUERY } from './hv-full-view';
 import { makeMockHass, makeItem } from '../test.utils';
 import { Store } from '../store/store';
 import type { HVFullView } from './hv-full-view';
@@ -81,9 +82,10 @@ describe('hv-full-view: phone-width app bar', () => {
     expect(narrow()).toMatch(/\.appbar \{[^}]*flex-wrap: wrap/);
   });
 
-  it('lets the search field shrink at any width', () => {
+  it('lets the search field shrink to nothing at phone widths', () => {
     // `flex: 1` alone leaves min-width at auto, so the field refuses to
-    // compress below its content and shoves its siblings off the bar.
+    // compress below its content and shoves its siblings off the bar. The
+    // desktop block puts a floor back under it — see the wide-bar describe.
     expect(fullCss()).toMatch(/\.appbar \.search \{[^}]*min-width: 0/);
   });
 
@@ -206,6 +208,43 @@ describe('hv-full-view: phone-width app bar', () => {
 
     const loadAll = q(sr, '[data-testid="selection-load-all"]');
     expect(loadAll?.classList.contains('load-all')).toBe(true);
+  });
+});
+
+// The search is the only item on the bar that can shrink — every pill, the
+// title and both trailing buttons are flex:none — so each pill added comes out
+// of it. With all six showing it collapsed to "Search all 1(" in a 1024px
+// content area, which is what this block exists to stop.
+describe('hv-full-view: wide app bar', () => {
+  const wide = () => {
+    const css = fullCss();
+    const start = css.indexOf('@media (min-width: 701px)');
+    expect(start, 'no wide-viewport block').toBeGreaterThan(-1);
+    // Stop at the phone block so a rule from it can never satisfy these.
+    const end = css.indexOf('@media (max-width: 700px)', start);
+    return end > start ? css.slice(start, end) : css.slice(start);
+  };
+
+  // The complement of NARROW_QUERY: the two blocks must not both apply, and
+  // must not leave a width where neither does.
+  it('picks up exactly where the phone block leaves off', () => {
+    expect(NARROW_QUERY).toBe('(max-width: 700px)');
+    expect(fullCss()).toContain('@media (min-width: 701px)');
+  });
+
+  it('puts a floor under the search rather than letting the pills eat it', () => {
+    expect(wide()).toMatch(/\.appbar \.search \{[^}]*min-width: 260px/);
+  });
+
+  it('lets the bar take a second line once the pills stop fitting', () => {
+    expect(wide()).toMatch(/\.appbar \{[^}]*flex-wrap: wrap/);
+  });
+
+  // A spacer can only push on the line it is on, so once the bar wraps it holds
+  // the first line open while the actions land left-aligned under the title.
+  it('carries the right-alignment on the actions, not on a spacer', () => {
+    expect(wide()).toMatch(/\.appbar \.spacer \{[^}]*display: none/);
+    expect(wide()).toMatch(/\.appbar \.add \{[^}]*margin-left: auto/);
   });
 });
 
@@ -1179,6 +1218,60 @@ describe('hv-full-view: app bar filters', () => {
     await settle(el);
     expect(store.state.value.filters.overdueOnly).toBe(true);
     expect(q(sr, '[data-testid="full-badge-overdue"]')?.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  // The bar priced every derived exception — low, overdue, due for inspection,
+  // checked out — and none of the stored one, so the two flags a person sets by
+  // hand were the only ones with no way back to them from here.
+  it('carries the two flagged statuses, and filters on them', async () => {
+    const statuses = [
+      makeItem({ id: '1', status: 'missing' }),
+      makeItem({ id: '2', status: 'needs_repair' }),
+      makeItem({ id: '3', status: 'needs_repair' }),
+      makeItem({ id: '4' }),
+    ];
+    const pill = (sr: ShadowRoot, value: string) =>
+      sr.querySelector(`[data-testid="full-badge-status"][data-value="${value}"]`) as HTMLButtonElement;
+    const { el, store, sr } = await mount({ items: statuses });
+
+    expect(pill(sr, 'missing').textContent?.replace(/\s+/g, ' ').trim()).toBe('1 missing');
+    expect(pill(sr, 'needs_repair').textContent?.replace(/\s+/g, ' ').trim()).toBe('2 needs repair');
+
+    pill(sr, 'missing').click();
+    await settle(el);
+    expect(store.state.value.filters.status).toBe('missing');
+    expect(pill(sr, 'missing').getAttribute('aria-pressed')).toBe('true');
+
+    pill(sr, 'missing').click();
+    await settle(el);
+    expect(store.state.value.filters.status).toBe(null);
+  });
+
+  // Single-select, so the two pills are mutually exclusive — pressing one while
+  // the other is on replaces it rather than asking for items that are both.
+  it('replaces the active status pill rather than adding to it', async () => {
+    const statuses = [makeItem({ id: '1', status: 'missing' }), makeItem({ id: '2', status: 'needs_repair' })];
+    const pill = (sr: ShadowRoot, value: string) =>
+      sr.querySelector(`[data-testid="full-badge-status"][data-value="${value}"]`) as HTMLButtonElement;
+    const { el, store, sr } = await mount({ items: statuses });
+
+    pill(sr, 'missing').click();
+    await settle(el);
+    pill(sr, 'needs_repair').click();
+    await settle(el);
+
+    expect(store.state.value.filters.status).toBe('needs_repair');
+    expect(pill(sr, 'missing').getAttribute('aria-pressed')).toBe('false');
+    expect(pill(sr, 'needs_repair').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  // "OK" is not an exception, and on a healthy inventory a status pill at all
+  // would be the loudest thing on a bar with nothing to report.
+  it('drops each status pill when nothing carries that flag', async () => {
+    const { sr } = await mount({ items: [makeItem({ id: '1', status: 'missing' })] });
+    expect(q(sr, '[data-testid="full-badge-status"][data-value="missing"]')).toBeTruthy();
+    expect(q(sr, '[data-testid="full-badge-status"][data-value="needs_repair"]')).toBe(null);
+    expect(q(sr, '[data-testid="full-badge-status"][data-value="ok"]')).toBe(null);
   });
 
   it('drops the overdue pill when nothing is overdue', async () => {

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -506,6 +506,7 @@ describe('hv-full-view: sidebar facets', () => {
     const heads = [...sr.querySelectorAll('.sidebar-head .section-toggle')] as HTMLElement[];
     expect(heads.map((h) => h.dataset.testid)).toEqual([
       'sidebar-toggle-locations',
+      'sidebar-toggle-status',
       'sidebar-toggle-categories',
       'sidebar-toggle-tags',
     ]);
@@ -579,7 +580,7 @@ describe('hv-full-view: sidebar facets', () => {
     const toggle = (section: string) =>
       q(sr, `[data-testid="sidebar-toggle-${section}"]`) as HTMLButtonElement;
 
-    for (const section of ['locations', 'categories', 'tags']) {
+    for (const section of ['locations', 'status', 'categories', 'tags']) {
       const id = `sidebar-section-${section}`;
       expect(toggle(section).getAttribute('aria-controls'), section).toBe(id);
       expect(toggle(section).getAttribute('aria-expanded'), `${section} open`).toBe('true');
@@ -676,6 +677,78 @@ describe('hv-full-view: sidebar facets', () => {
     );
     // Captions take no full stop; prose notes do.
     expect(q(sr, '[data-testid="sidebar-tags-empty"]')?.textContent?.trim()).toBe('No tags in use yet');
+  });
+});
+
+describe('hv-full-view: sidebar status', () => {
+  const flagged = [
+    makeItem({ id: '1', status: 'missing' }),
+    makeItem({ id: '2', status: 'needs_repair' }),
+    makeItem({ id: '3', status: 'needs_repair' }),
+    makeItem({ id: '4' }),
+  ];
+  const rows = (sr: ShadowRoot) =>
+    [...sr.querySelectorAll('[data-testid="sidebar-status-row"]')] as HTMLElement[];
+  const tallies = (sr: ShadowRoot) =>
+    rows(sr).map((r) => r.querySelector('.tally')?.textContent?.trim() ?? null);
+
+  // The counts payload prices only the two flagged states; OK is the rest of
+  // the inventory, which is the one number here that has to be derived.
+  it('lists the three statuses with their counts', async () => {
+    const { sr } = await mount({ items: flagged });
+    expect(rows(sr).map((r) => r.dataset.value)).toEqual(['ok', 'missing', 'needs_repair']);
+    expect(tallies(sr)).toEqual(['1', '1', '2']);
+  });
+
+  it('filters to one status and clears it on a second press', async () => {
+    const { el, store, sr } = await mount({ items: flagged });
+    const missing = () => rows(sr).find((r) => r.dataset.value === 'missing');
+
+    missing()?.click();
+    await settle(el);
+    expect(store.state.value.filters.status).toBe('missing');
+    expect(missing()?.classList).toContain('on');
+
+    missing()?.click();
+    await settle(el);
+    expect(store.state.value.filters.status).toBe(null);
+  });
+
+  // Single-select, because the backend filter takes exactly one status — so a
+  // second pick replaces the first rather than adding to it, as category does.
+  it('replaces the selection rather than accumulating it', async () => {
+    const { el, store, sr } = await mount({ items: flagged });
+
+    rows(sr).find((r) => r.dataset.value === 'missing')?.click();
+    await settle(el);
+    rows(sr).find((r) => r.dataset.value === 'needs_repair')?.click();
+    await settle(el);
+
+    expect(store.state.value.filters.status).toBe('needs_repair');
+    expect(rows(sr).filter((r) => r.classList.contains('on')).map((r) => r.dataset.value)).toEqual([
+      'needs_repair',
+    ]);
+  });
+
+  // An older backend sends neither count. Then no row claims a number, rather
+  // than every row claiming one derived from the halves that did arrive.
+  it('drops every tally when the backend prices no statuses', async () => {
+    const { el, store, sr } = await mount({ items: flagged });
+    const counts = store.state.value.statsCounts as unknown as Record<string, unknown>;
+    delete counts.missing_count;
+    delete counts.needs_repair_count;
+    el.requestUpdate();
+    await settle(el);
+
+    expect(tallies(sr)).toEqual([null, null, null]);
+  });
+
+  // Categories and tags tally how many rows they hold; this section always
+  // holds three, so the same number in that slot would be noise.
+  it('heads the section without a tally', async () => {
+    const { sr } = await mount({ items: flagged });
+    expect(q(sr, '[data-testid="sidebar-status-tally"]')).toBe(null);
+    expect(q(sr, '[data-testid="sidebar-toggle-status"]')?.textContent).toContain('Status');
   });
 });
 

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -13,6 +13,8 @@ import { emptyKindFor, renderEmptyState } from '../ui/empty-state';
 import { areaNameById, effectiveAreaIdForLocation } from '../ui/area';
 import { renderAreaChip } from '../ui/location-path';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
+import { ITEM_STATUSES, statusLabel } from '../ui/status';
+import type { ItemStatus } from '../store/types';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
 import type { ColumnKey } from '../store/columns';
@@ -51,7 +53,7 @@ const SEARCH_DEBOUNCE_MS = 200;
 export const NARROW_QUERY = '(max-width: 700px)';
 
 /** The sidebar's collapsible sections, in the order they appear. */
-type SidebarSection = 'locations' | 'categories' | 'tags';
+type SidebarSection = 'locations' | 'status' | 'categories' | 'tags';
 
 /**
  * The element a section heading discloses, named so `aria-controls` can point at
@@ -736,6 +738,7 @@ export class HVFullView extends LitElement {
    */
   @state() private _sections: Record<SidebarSection, boolean> = {
     locations: true,
+    status: true,
     categories: true,
     tags: true,
   };
@@ -1095,6 +1098,58 @@ export class HVFullView extends LitElement {
   }
 
   /**
+   * The stored item status as a sidebar facet.
+   *
+   * Single-select, because the backend filter takes exactly one status, and
+   * pressing the active row clears it — the same contract category has. Unlike
+   * the other two facets the rows are a closed set the backend defines rather
+   * than values discovered from the inventory, so there is nothing to create
+   * and no empty state to fall back to.
+   */
+  private _renderStatusSection() {
+    const st = this.st;
+    const filters = st?.filters ?? defaultFilters();
+    const counts = st?.statsCounts;
+    // Only the two flagged states are priced by the counts payload; OK is
+    // whatever is left of the inventory. An older backend sends neither, and
+    // then no row claims a number rather than every row claiming a wrong one.
+    const missing = counts?.missing_count;
+    const needsRepair = counts?.needs_repair_count;
+    const tallyFor = (s: ItemStatus): number | null => {
+      if (missing === undefined || needsRepair === undefined) return null;
+      if (s === 'missing') return missing;
+      if (s === 'needs_repair') return needsRepair;
+      return Math.max(0, counts!.items_total - missing - needsRepair);
+    };
+    return html`
+      <div class="sidebar-head">
+        ${this._renderSectionToggle('status', 'Status')}
+        <!-- The other sections tally how many rows they hold; this one always
+             holds three, so the number would say the same thing forever. -->
+      </div>
+      <div id=${sectionPanelId('status')} ?hidden=${!this._sections.status}>
+        ${this._sections.status
+          ? ITEM_STATUSES.map((s) => {
+              const on = filters.status === s;
+              const tally = tallyFor(s);
+              return html`<button
+                class="value-row ${on ? 'on' : ''}"
+                data-testid="sidebar-status-row"
+                data-value=${s}
+                aria-pressed=${String(on)}
+                @click=${() => this._setFilters({ status: on ? null : s })}
+              >
+                ${on ? icon('check', 15) : null}
+                <span class="label">${statusLabel(s)}</span>
+                ${tally === null ? null : html`<span class="tally">${tally}</span>`}
+              </button>`;
+            })
+          : null}
+      </div>
+    `;
+  }
+
+  /**
    * Categories and tags as sidebar rows.
    *
    * Category is single-select and tags are multi-select, because that is what
@@ -1203,6 +1258,7 @@ export class HVFullView extends LitElement {
         <div id=${sectionPanelId('locations')} ?hidden=${!this._sections.locations}>
           ${this._sections.locations ? this._renderLocationSection() : null}
         </div>
+        ${this._renderStatusSection()}
         ${this._renderFacetSection(
           'categories',
           'Categories',

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -255,6 +255,44 @@ export class HVFullView extends LitElement {
         background: var(--hv-amber);
         color: #3b2600;
       }
+      /* The same amber the status chip carries on rows, in the table and in the
+         detail sheet — one tone for "flagged, but still a chore" wherever a
+         status is marked. The two pills say which flag in words; giving them a
+         hue of their own would be a second status vocabulary on one screen. */
+      .appbar .pill.status {
+        background: var(--hv-amber);
+        color: #3b2600;
+      }
+      /*
+       * Above the phone breakpoint — the complement of NARROW_QUERY, whose own
+       * block below owns everything at or under it.
+       *
+       * The search is the only item on this bar that can shrink: every pill,
+       * the title and both trailing buttons are flex:none. So each pill added
+       * comes out of the search box, and with all six showing it collapsed to
+       * "Search all 1(" in a 1024px content area. A floor stops that, and the
+       * bar takes a second line instead — which is what the phone layout
+       * already does with these same pills.
+       */
+      @media (min-width: 701px) {
+        .appbar {
+          flex-wrap: wrap;
+        }
+        .appbar .search {
+          min-width: 260px;
+        }
+        /* The spacer can only push on the line it sits on, so once the bar
+           wraps it holds the first line open while the actions it was meant to
+           push land left-aligned under the title. Carrying the margin on the
+           actions themselves keeps them at the right edge of whichever line
+           they end up on, and reads the same as today when nothing wraps. */
+        .appbar .spacer {
+          display: none;
+        }
+        .appbar .add {
+          margin-left: auto;
+        }
+      }
       .appbar .add {
         flex: none;
         display: inline-flex;
@@ -1555,6 +1593,33 @@ export class HVFullView extends LitElement {
     </button>`;
   }
 
+  /**
+   * One flagged status as an app-bar toggle, beside the derived counts.
+   *
+   * Only `missing` and `needs_repair` get one: they are the exceptions worth
+   * interrupting for, and an "OK" pill would price the other 99% of a healthy
+   * inventory. Single-select like every other status surface, so pressing one
+   * while the other is on replaces it rather than asking for items that are
+   * somehow both.
+   */
+  private _renderStatusPill(status: 'missing' | 'needs_repair', count: number | undefined) {
+    // Absent rather than zero: the same rule the overdue and inspection pills
+    // follow, so the bar only ever carries counts worth acting on.
+    if (!count) return null;
+    const on = (this.st?.filters ?? defaultFilters()).status === status;
+    const noun = statusLabel(status).toLowerCase();
+    return html`<button
+      class="pill status ${on ? 'on' : ''}"
+      data-testid="full-badge-status"
+      data-value=${status}
+      aria-pressed=${String(on)}
+      title=${`Show only items marked ${noun}`}
+      @click=${() => this._setFilters({ status: on ? null : status })}
+    >
+      ${count} ${noun}
+    </button>`;
+  }
+
   private _renderAppBar() {
     const st = this.st;
     const filters = st?.filters ?? defaultFilters();
@@ -1626,6 +1691,8 @@ export class HVFullView extends LitElement {
                 ${counts.checked_out_count} checked out
               </button>`
             : null}
+          ${this._renderStatusPill('missing', counts?.missing_count)}
+          ${this._renderStatusPill('needs_repair', counts?.needs_repair_count)}
           <button
             class="add"
             data-testid="full-add-item"

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -61,6 +61,21 @@ describe('columns model', () => {
     expect(loadColumnPrefs()).toEqual(DEFAULT_COLUMNS);
   });
 
+  // The API cannot order by status, so the header must stay inert rather than
+  // look clickable — the same reason category, location and tags have none.
+  it('offers the status column without a sort field', () => {
+    const col = COLUMN_DEFS.find((c) => c.key === 'status');
+    expect(col?.label).toBe('Status');
+    expect(col?.sortField).toBeUndefined();
+    expect(normalizeColumns(['status'])).toEqual(['status']);
+  });
+
+  // Status sits beside Qty: both describe the item itself, ahead of where it is
+  // filed and when it is due.
+  it('orders status second, right after quantity', () => {
+    expect(COLUMN_DEFS.map((c) => c.key).slice(0, 3)).toEqual(['quantity', 'status', 'category']);
+  });
+
   // "Inspected" read as the date of the last inspection; the field holds the
   // next one due, which is what every other surface now says.
   it('labels the inspection column for the date it holds', () => {
@@ -87,8 +102,8 @@ describe('table column widths', () => {
   // Pinned as a number so that adding a column, or widening one, shows up here
   // as a deliberate change rather than as another phone-width overflow.
   it('cannot lay the default table out narrower than a phone', () => {
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1020);
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1060);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1132);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1172);
   });
 
   it('only fits a phone when almost every column is turned off', () => {

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -9,6 +9,7 @@
 
 export type ColumnKey =
   | 'quantity'
+  | 'status'
   | 'category'
   | 'location'
   | 'tags'
@@ -22,9 +23,10 @@ export interface ColumnDef {
   /** grid-template-columns sizing for the full-view table. */
   tableSize: string;
   /**
-   * The backend sort field this column maps to, when it has one. Category,
-   * location and tags are deliberately absent: the API cannot sort by them, and
-   * a header that looks clickable but does nothing is worse than a plain one.
+   * The backend sort field this column maps to, when it has one. Status,
+   * category, location and tags are deliberately absent: the API cannot sort by
+   * them, and a header that looks clickable but does nothing is worse than a
+   * plain one.
    */
   sortField?: 'quantity' | 'due_date' | 'inspection_date' | 'updated_at';
 }
@@ -32,6 +34,9 @@ export interface ColumnDef {
 /** Canonical column order. Selections are normalized to this order. */
 export const COLUMN_DEFS: readonly ColumnDef[] = [
   { key: 'quantity', label: 'Qty', tableSize: '70px', sortField: 'quantity' },
+  // Wide enough for the "Needs repair" chip on one line: a status that wrapped
+  // or clipped would be unreadable in exactly the rows that matter most.
+  { key: 'status', label: 'Status', tableSize: '112px' },
   { key: 'category', label: 'Category', tableSize: 'minmax(110px, 1fr)' },
   { key: 'location', label: 'Location', tableSize: 'minmax(110px, 1fr)' },
   { key: 'tags', label: 'Tags', tableSize: 'minmax(120px, 1.4fr)' },


### PR DESCRIPTION
Closes #239.

The status field that shipped with #238 was readable on rows and selectable in the
filter panel, but the full view could neither put it in a column nor browse by it.
This adds the missing surfaces. Frontend only — no backend, schema or WS contract
change.

## Column

`status` joins the optional columns, between Qty and Category, and so appears in the
⋮ → **Columns** picker automatically. It carries **no sort field**: the API cannot
order by status, and a header that looks clickable but does nothing is worse than a
plain one — the same reason category, location and tags have none.

The column names **every** row, `OK` included. A column that marked only the
exceptions would leave most rows blank under a header promising a value, so instead
the name-cell's amber chip stands down while the column is shown and no row says the
same word twice. Turn the column off and the chip comes back.

A browser with a stored column selection from before this change keeps it — the
unknown key is simply absent — so the chip is what those users keep seeing until
they add the column.

## Sidebar (extended view)

A **Status** section under Locations, beside Categories and Tags. Single-select the
way category is, because the backend filter takes exactly one status; pressing the
active row clears it.

Only the two flagged states are priced by the counts payload, so `OK` is derived as
whatever they leave over. A backend sending neither count leaves every row unpriced
rather than every row claiming a number derived from the half that arrived. The
section head carries no tally: unlike the other two facets it always holds the same
three rows.

## App bar pills

The bar counted every *derived* exception — low stock, overdue, due for inspection,
checked out — and none of the *stored* one, so the two flags a person sets by hand
were the only ones with no quick way back to them. **Missing** and **Needs repair**
now sit beside the rest, each shown only while something carries that flag, in the
status chip's own amber rather than a hue of their own. They are mutually exclusive,
since the filter takes one status. No pill for OK — it would price the other 99% of a
healthy inventory.

### The bar had to be taught to wrap

Six pills do not fit beside the search box. The search is the only item on that bar
that can shrink — every pill, the title and both trailing buttons are `flex: none` —
so it absorbed each pill added and collapsed to `Search all 1(` in a 1024px content
area. Above the phone breakpoint it now has a `min-width` floor and the bar wraps
instead.

The right-alignment moved off the spacer onto the actions themselves: a spacer only
pushes on the line it sits on, so once the bar wrapped it held the first line open
while Add item landed left-aligned under the title. The phone block is untouched —
its own wrap and pill ordering already handled six pills, verified below.

## Filter dialog

Already shipped with #238 (`_renderStatusGroup` in `hv-filter-panel`) and is
unchanged here — verified against the running instance rather than assumed.

## Verification

Both gates green, driven against a real HA instance (1000 items; 3 flagged Missing,
4 Needs repair):

- backend `pytest -q` 498 passed / 22 skipped, `ruff check`, `ruff format --check`, `mypy` clean
- frontend `vitest` **1058 passed / 50 files**, `eslint`, `tsc --noEmit`, `npm run build` clean
- `visual_pass.mjs` — panel **10/10** and panel-mobile **8/8** surfaces, no console errors

Screenshots from the deployed bundle on the sidebar panel at `/haventory` confirm
every surface:

1. **Extended view** — a `STATUS` column (`Missing` / `Needs repair` chips, plain `OK`)
   and a sidebar `STATUS` section reading OK 993 / Missing 3 / Needs repair 4.
2. **App bar** — `3 missing` and `4 needs repair` beside the existing four pills, with
   the search box back at full width and the actions right-aligned on the wrapped line.
3. **Phone width** — the pills flow into the existing two pill rows; layout unchanged.
4. **Filter panel** — the `STATUS` chip row from #238 with its live tallies.
5. **Column picker** — `Status` listed second and checked.
6. **Sidebar filter applied** — pressing **Missing** raises a `Status: Missing` chip,
   narrows the table to exactly the 3 flagged items, and flips the location tree to
   matches-over-total (`2 / 169`, `1 / 136`, …).

New cover: the Status column's cell for all three values and an absent one, the chip
suppression both ways, the header staying unsortable; the sidebar section's ordering,
counts, single-select replace-not-accumulate, clear-on-second-press and no-counts
fallback; both pills' labels, counts, toggle, mutual exclusion and absence at zero;
and the wide-bar block's floor, wrap and alignment asserted on the stylesheet, next to
a check that it is the exact complement of `NARROW_QUERY`.

`columns.test.ts`'s pinned minimum table width moves 1020 → 1132 (1060 → 1172
selectable), which is exactly the deliberate-change signal that test exists to raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
