### PR TITLE
fix(storage): name a corrupt schema_version instead of crashing or coercing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,3 +734,8 @@ and ask questions in [Discussions](https://github.com/chrreiter/HAventory/discus
   after restoring a backup taken on a newer version. The entry stops with that error and the
   store is left untouched; re-install the newer version to read it, or replace
   `haventory_store` with a backup taken on the running version.
+- **"stored data has a corrupt schema_version (…); expected an integer"**: `haventory_store`
+  holds something other than a whole number under `schema_version` — a hand edit, a truncated
+  write, or a quoted number such as `"5"`, which is not the same as `5` and is not assumed to
+  mean it. The entry stops with that error and the store is left untouched; fix the value in
+  the file, or replace `haventory_store` with a backup.

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -60,7 +60,7 @@ from .const import (
     PANEL_ICON,
     PANEL_URL_PATH,
 )
-from .exceptions import SchemaDowngradeError, StorageError
+from .exceptions import CorruptSchemaVersionError, SchemaDowngradeError, StorageError
 from .rate_limit import RateLimitConfig, RateLimiter
 from .repository import Repository
 from .storage import (
@@ -69,6 +69,7 @@ from .storage import (
     DomainStore,
     async_persist_immediate,
     cancel_pending_persist,
+    read_schema_version,
     schema_downgrade_message,
 )
 
@@ -143,6 +144,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         # ConfigEntryError, not ConfigEntryNotReady: retrying cannot teach this build
         # a newer schema, and the message reaches the user in the entry's error state.
+        raise ConfigEntryError(str(exc)) from exc
+    except CorruptSchemaVersionError as exc:
+        LOGGER.error(
+            "Refusing to set up against storage whose schema_version is unreadable",
+            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
+            exc_info=True,
+        )
+        # Same reasoning as the downgrade above: no number of retries turns a
+        # corrupt version into a readable one, so the entry stops with the
+        # specific message instead of backing off behind a generic one.
         raise ConfigEntryError(str(exc)) from exc
     except StorageError as exc:
         LOGGER.error(
@@ -853,7 +864,7 @@ def _validate_storage_payload(payload: dict[str, Any], *, schema_version: int) -
     if not isinstance(payload, dict):
         raise StorageError("storage payload is not a dict")
 
-    stored_version = int(payload.get("schema_version", -1))
+    stored_version = read_schema_version(payload, missing=-1)
     if stored_version > int(schema_version):
         raise SchemaDowngradeError(
             schema_downgrade_message(

--- a/custom_components/haventory/exceptions.py
+++ b/custom_components/haventory/exceptions.py
@@ -115,3 +115,12 @@ class SchemaDowngradeError(StorageError):
     forward-only, so retrying or rewriting can only lose data. Callers are
     expected to stop and leave the stored payload untouched.
     """
+
+
+class CorruptSchemaVersionError(StorageError):
+    """Raised when persisted data carries a ``schema_version`` that is not an integer.
+
+    Separate from its parent for the same reason as its sibling above: nothing
+    about a retry turns a ``null`` or a string into a version, so callers stop
+    rather than back off, and the stored payload is left for a human to repair.
+    """

--- a/custom_components/haventory/migrations.py
+++ b/custom_components/haventory/migrations.py
@@ -10,16 +10,28 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Final
 
+from .exceptions import SchemaDowngradeError
+
 
 def migrate(payload: dict[str, Any], *, from_version: int, to_version: int) -> dict[str, Any]:
     """Migrate ``payload`` from ``from_version`` to ``to_version``.
 
     Steps are applied sequentially: vN -> vN+1 -> ... -> vM.
+
+    Raises ``SchemaDowngradeError`` when asked to go backwards.
     """
 
     if from_version > to_version:
-        # We do not support downgrades; return the original as-is
-        return payload
+        # Steps are forward-only, so a downgrade would run none of them and still
+        # leave the loop stamping ``to_version`` on data written by a schema this
+        # build cannot read — relabelling it for whoever saves the result. The
+        # storage layer refuses newer payloads before it ever calls this, and the
+        # refusal it raises is the one users see; this guard is what stops a
+        # second caller from reintroducing the silent relabel.
+        raise SchemaDowngradeError(
+            f"refusing to migrate schema version {from_version} down to {to_version}: "
+            "migrations are forward-only"
+        )
 
     data: dict[str, Any] = deepcopy(payload)
     version = int(from_version)

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, Final, cast
 
@@ -26,7 +27,12 @@ from homeassistant.helpers.storage import Store
 
 from . import migrations
 from .const import DOMAIN
-from .exceptions import NotLoadedError, SchemaDowngradeError, StorageError
+from .exceptions import (
+    CorruptSchemaVersionError,
+    NotLoadedError,
+    SchemaDowngradeError,
+    StorageError,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,6 +44,12 @@ STORAGE_KEY: Final[str] = "haventory_store"
 
 # Debounce delay for persistence operations (seconds)
 PERSIST_DEBOUNCE_DELAY: Final[float] = 1.0
+
+# How much of a corrupt ``schema_version`` the refusal quotes back. The value is
+# whatever the file holds, and the message reaches the config entry's error state
+# in the UI, so a misplaced items dict landing on that key must not paste the
+# whole inventory into it.
+_MAX_REPORTED_VERSION_CHARS: Final[int] = 60
 
 
 def _empty_payload() -> dict[str, Any]:
@@ -62,6 +74,38 @@ def schema_downgrade_message(*, stored_version: int, supported_version: int) -> 
         "Upgrade HAventory to a version that understands this data, or restore a backup "
         "taken with this version. The stored data was left unchanged."
     )
+
+
+def _corrupt_schema_version_message(value: object) -> str:
+    """Build the refusal shown when ``schema_version`` is not an integer."""
+
+    shown = repr(value)
+    if len(shown) > _MAX_REPORTED_VERSION_CHARS:
+        shown = shown[: _MAX_REPORTED_VERSION_CHARS - 1] + "…"
+    return (
+        f"stored data has a corrupt schema_version ({shown}); expected an integer. "
+        "HAventory will not guess which schema this data uses. Repair the stored file "
+        "or restore a backup, then reload HAventory. The stored data was left unchanged."
+    )
+
+
+def read_schema_version(payload: Mapping[str, Any], *, missing: int) -> int:
+    """Read ``schema_version`` out of a stored payload, refusing to guess.
+
+    A hand-edited or truncated store can hold anything under this key, and
+    ``int()`` treats the two failure modes inconsistently: it raises on ``None``
+    or ``"abc"``, and silently invents a version for anything it can parse —
+    ``"4"`` becoming 4, ``True`` becoming 1 — so the data would be read, and
+    rewritten, under a version the file never claimed. Only a genuine ``int`` is
+    a version here; ``missing`` is what an absent key means to the caller.
+    """
+
+    if "schema_version" not in payload:
+        return missing
+    value = payload["schema_version"]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CorruptSchemaVersionError(_corrupt_schema_version_message(value))
+    return value
 
 
 def _get_persist_lock(hass: HomeAssistant) -> asyncio.Lock:
@@ -118,7 +162,7 @@ class DomainStore:
             return _empty_payload()
 
         # Defensive: missing schema_version means treat as version 0
-        from_version = int(raw.get("schema_version", 0)) if isinstance(raw, dict) else 0
+        from_version = read_schema_version(raw, missing=0) if isinstance(raw, dict) else 0
 
         if from_version != self._schema_version:
             migrated = await self.async_migrate_if_needed(raw)
@@ -150,7 +194,9 @@ class DomainStore:
         Returns the migrated (or original) payload.
 
         Raises ``SchemaDowngradeError`` when ``raw`` was written by a newer schema
-        version than this build supports, leaving the stored payload untouched.
+        version than this build supports, and ``CorruptSchemaVersionError`` when
+        it carries no readable version at all. Both leave the stored payload
+        untouched.
         """
 
         if not isinstance(raw, dict):  # Corrupted or unexpected
@@ -167,7 +213,7 @@ class DomainStore:
             )
             raise StorageError("corrupted storage payload: not a dict")
 
-        from_version = int(raw.get("schema_version", 0))
+        from_version = read_schema_version(raw, missing=0)
         to_version = self._schema_version
         if from_version == to_version:
             # Normalize missing keys even when versions match

--- a/tests/test_exceptions_offline.py
+++ b/tests/test_exceptions_offline.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 import pytest
 from custom_components.haventory.exceptions import (
     ConflictError,
+    CorruptSchemaVersionError,
     HaventoryError,
     NotFoundError,
+    SchemaDowngradeError,
     StorageError,
     ValidationError,
+    error_code,
 )
 
 
@@ -50,3 +53,15 @@ async def test_storage_error_message_and_type():
     exc = StorageError(message)
     assert isinstance(exc, HaventoryError)
     assert str(exc) == message
+
+
+@pytest.mark.asyncio
+async def test_schema_refusals_stay_storage_errors():
+    # Both refusals ride the contract's storage_error code rather than widening
+    # the taxonomy the WebSocket clients know.
+    for cls in (SchemaDowngradeError, CorruptSchemaVersionError):
+        message = f"{cls.__name__} message"
+        exc = cls(message)
+        assert isinstance(exc, StorageError)
+        assert str(exc) == message
+        assert error_code(exc) == "storage_error"

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -8,7 +8,10 @@ from copy import deepcopy
 import custom_components.haventory as haven_init
 import pytest
 from custom_components.haventory.const import CONF_CARD_TITLE, DEFAULT_CARD_TITLE
-from custom_components.haventory.exceptions import SchemaDowngradeError
+from custom_components.haventory.exceptions import (
+    CorruptSchemaVersionError,
+    SchemaDowngradeError,
+)
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
 from homeassistant.config_entries import ConfigEntry
@@ -105,6 +108,54 @@ async def test_validate_storage_payload_reports_newer_version_specifically() -> 
         haven_init._validate_storage_payload(payload, schema_version=CURRENT_SCHEMA_VERSION)
 
     assert str(CURRENT_SCHEMA_VERSION + 2) in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_refuses_corrupt_schema_version_and_leaves_store_intact(
+    monkeypatch,
+) -> None:
+    """A non-integer schema_version stops setup with the corruption message."""
+
+    hass = HomeAssistant()
+    entry = ConfigEntry()
+    key = "test_init_corrupt_schema_version"
+    monkeypatch.setattr(haven_init, "STORAGE_KEY", key)
+
+    pre_payload = {
+        "schema_version": None,
+        "items": {"i1": {"id": "i1", "name": "Screws", "quantity": 5}},
+        "locations": {"l1": {"id": "l1", "name": "Garage"}},
+    }
+    raw_store = HAStore(hass, CURRENT_SCHEMA_VERSION, key)
+    await raw_store.async_save(deepcopy(pre_payload))
+
+    # ConfigEntryError, not ConfigEntryNotReady: backing off forever cannot repair
+    # a corrupt file, and the generic "storage load failed" hid what was wrong.
+    with pytest.raises(ConfigEntryError) as excinfo:
+        await haven_init.async_setup_entry(hass, entry)
+
+    message = str(excinfo.value)
+    assert "schema_version" in message
+    assert "None" in message
+
+    assert await raw_store.async_load() == pre_payload
+    assert "repository" not in hass.data[haven_init.DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_validate_storage_payload_rejects_a_numeric_string_version() -> None:
+    """``"5"`` is corruption, not the current version — validation must not coerce it."""
+
+    payload = {
+        "schema_version": str(CURRENT_SCHEMA_VERSION),
+        "items": {},
+        "locations": {},
+    }
+
+    with pytest.raises(CorruptSchemaVersionError) as excinfo:
+        haven_init._validate_storage_payload(payload, schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert repr(str(CURRENT_SCHEMA_VERSION)) in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_migrations_offline.py
+++ b/tests/test_migrations_offline.py
@@ -4,17 +4,19 @@ Scenarios:
 - Older version N → current version: transformed shape and version update
 - No-op when already current; idempotency on repeated runs
 - Empty file / missing keys → safe defaults
+- Backwards migration → refused rather than passed through and relabelled
 - Corrupt payload / loader exception → logged with context and safe fallback
 """
 
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import Any
 
 import pytest
 from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.exceptions import StorageError
+from custom_components.haventory.exceptions import SchemaDowngradeError, StorageError
 from custom_components.haventory.migrations import migrate
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
 from homeassistant.core import HomeAssistant
@@ -87,20 +89,28 @@ async def test_missing_keys_and_empty_payload_safe_defaults() -> None:
 
 
 @pytest.mark.asyncio
-async def test_downgrade_returns_original(caplog: pytest.LogCaptureFixture) -> None:
-    """Downgrade returns original payload; migrate stays quiet."""
+async def test_downgrade_is_refused_rather_than_relabelled() -> None:
+    """A backwards migration raises instead of passing the payload through.
 
-    caplog.set_level(logging.DEBUG)
+    Passing it through is the dangerous half: the caller stamps ``to_version``
+    onto whatever comes back, so data written by a schema this build cannot read
+    would be relabelled as one it can.
+    """
+
     payload = {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+    before = deepcopy(payload)
 
-    # Act: request a downgrade path (from_version > to_version)
-    result = migrate(
-        payload, from_version=CURRENT_SCHEMA_VERSION, to_version=CURRENT_SCHEMA_VERSION - 1
-    )
+    with pytest.raises(SchemaDowngradeError) as excinfo:
+        migrate(payload, from_version=CURRENT_SCHEMA_VERSION, to_version=CURRENT_SCHEMA_VERSION - 1)
 
-    # Assert: original returned unchanged; we don't enforce specific log content
-    assert result is payload or result == payload
-    # No strict log assertion since migrate() intentionally stays quiet for downgrades
+    # Both versions named, so a caller's log says which direction was asked for.
+    message = str(excinfo.value)
+    assert str(CURRENT_SCHEMA_VERSION) in message
+    assert str(CURRENT_SCHEMA_VERSION - 1) in message
+
+    # A refusal touches nothing.
+    assert payload == before
+    assert isinstance(excinfo.value, StorageError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_offline.py
+++ b/tests/test_storage_offline.py
@@ -7,15 +7,21 @@ Scenarios:
 - Migration failure raises StorageError and does not persist changes
 - Corrupted payload (non-dict) raises StorageError
 - A payload written by a newer schema is refused without rewriting the store
+- A payload whose schema_version is not an integer is refused, never coerced
 """
 
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import Any
 
 import pytest
 from custom_components.haventory import migrations
-from custom_components.haventory.exceptions import SchemaDowngradeError, StorageError
+from custom_components.haventory.exceptions import (
+    CorruptSchemaVersionError,
+    SchemaDowngradeError,
+    StorageError,
+)
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
 from homeassistant.core import HomeAssistant
@@ -285,6 +291,110 @@ async def test_newer_schema_version_never_reaches_migrations(monkeypatch) -> Non
 
     with pytest.raises(SchemaDowngradeError):
         await store.async_load()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("label", "stored"),
+    [
+        ("null", None),
+        ("numeric_string", "4"),
+        ("word", "abc"),
+        ("float", 4.0),
+        ("bool", True),
+        ("list", [4]),
+        ("dict", {"v": 4}),
+    ],
+)
+async def test_corrupt_schema_version_is_refused_and_store_untouched(
+    label: str, stored: Any
+) -> None:
+    """A non-integer schema_version is named as corruption, not coerced or crashed on."""
+
+    hass = HomeAssistant()
+    key = f"test_store_corrupt_version_{label}"
+    store = DomainStore(hass, key=key)
+
+    pre_payload = {
+        "schema_version": stored,
+        "items": {"i1": {"id": "i1", "name": "Screws", "quantity": 5}},
+        "locations": {"l1": {"id": "l1", "name": "Garage"}},
+    }
+    raw_store = HAStore(hass, CURRENT_SCHEMA_VERSION, key)
+    await raw_store.async_save(deepcopy(pre_payload))
+
+    with pytest.raises(CorruptSchemaVersionError) as excinfo:
+        await store.async_load()
+
+    # The message quotes the offending value back, so `"4"` is distinguishable
+    # from `4` in the log — that pair is exactly what coercion used to hide.
+    message = str(excinfo.value)
+    assert "schema_version" in message
+    assert repr(stored) in message
+
+    # Still a storage failure, so every existing handler keeps mapping it.
+    assert isinstance(excinfo.value, StorageError)
+
+    # Refusing means refusing to write, too.
+    assert await raw_store.async_load() == pre_payload
+
+
+@pytest.mark.asyncio
+async def test_corrupt_schema_version_message_is_bounded() -> None:
+    """A huge value under the key is truncated, not pasted into the error state."""
+
+    hass = HomeAssistant()
+    key = "test_store_corrupt_version_huge"
+    store = DomainStore(hass, key=key)
+
+    huge = "x" * 5000
+    raw_store = HAStore(hass, CURRENT_SCHEMA_VERSION, key)
+    await raw_store.async_save({"schema_version": huge, "items": {}, "locations": {}})
+
+    with pytest.raises(CorruptSchemaVersionError) as excinfo:
+        await store.async_load()
+
+    message = str(excinfo.value)
+    assert huge not in message
+    assert "…" in message
+    assert len(message) < len(huge)
+
+
+@pytest.mark.asyncio
+async def test_corrupt_schema_version_never_reaches_migrations(monkeypatch) -> None:
+    """The refusal happens before ``migrations.migrate`` is consulted."""
+
+    hass = HomeAssistant()
+    key = "test_store_corrupt_version_skips_migrate"
+    store = DomainStore(hass, key=key)
+
+    raw_store = HAStore(hass, CURRENT_SCHEMA_VERSION, key)
+    await raw_store.async_save({"schema_version": None, "items": {}, "locations": {}})
+
+    def _fail(_payload, *, from_version, to_version):  # type: ignore[no-untyped-def]
+        raise AssertionError("migrations.migrate must not run for a corrupt version")
+
+    monkeypatch.setattr(migrations, "migrate", _fail)
+
+    with pytest.raises(CorruptSchemaVersionError):
+        await store.async_load()
+
+
+@pytest.mark.asyncio
+async def test_absent_schema_version_still_loads_as_version_zero() -> None:
+    """A missing key is not corruption: it means v0 and migrates forward."""
+
+    hass = HomeAssistant()
+    key = "test_store_missing_version"
+    store = DomainStore(hass, key=key)
+
+    raw_store = HAStore(hass, CURRENT_SCHEMA_VERSION, key)
+    await raw_store.async_save({"items": {"i1": {"id": "i1", "name": "Screws"}}, "locations": {}})
+
+    loaded = await store.async_load()
+
+    assert loaded["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert loaded["items"]["i1"]["name"] == "Screws"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`int(raw.get("schema_version", 0))` handled the two corruption shapes inconsistently. A hand-edited `null` or a non-numeric string raised `ValueError`/`TypeError`, which the setup path caught in its `except Exception` catch-all and reported as `ConfigEntryNotReady("storage load failed")` — a message that names neither the file nor the field. Anything `int()` could parse went the other way: `"5"` became 5 and `true` became 1, so the store was read, migrated and rewritten under a version it never claimed. `_validate_storage_payload` in `__init__.py` repeated the same expression.

`read_schema_version` in `storage.py` now reads the field for all three call sites: a real `int` (bool excluded — `True` is not version 1) is the version, an absent key means whatever the caller says it means, and everything else raises `CorruptSchemaVersionError` quoting the offending value back, so `'5'` is distinguishable from `5` in the log. The refusal is truncated at 60 characters of repr, because a misplaced items dict landing on that key would otherwise paste the whole inventory into the config entry's error state.

Setup stops on it with `ConfigEntryError`, not `ConfigEntryNotReady`, for the same reason the newer-schema refusal does: no number of retries repairs a corrupt file, and the specific message reaches the user in the entry's error state instead of a backoff loop behind a generic one. The store is left untouched, and README's troubleshooting section carries the new message beside the downgrade one.

The issue's related trap is closed in the same pass: `migrations.migrate`'s downgrade pass-through returned the payload unchanged, and the caller then stamps `to_version` onto whatever comes back — relabelling data this build cannot read. Storage refuses newer payloads before it ever calls this, so the path is unreachable from production today; raising `SchemaDowngradeError` is what stops a second caller from reintroducing the silent relabel.

Closes #198

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (511 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1058 passed), `npm run build` — all green

New cases: seven corrupt shapes (`null`, `"4"`, `"abc"`, `4.0`, `true`, list, dict) refused at load with the store byte-intact and `migrations.migrate` never consulted; a missing key still loading as v0 and migrating forward; the message bounded against a 5000-character value; setup refusing with `ConfigEntryError` and no repository registered; validation rejecting a numeric string; the migration downgrade guard; and both schema refusals pinned to the contract's `storage_error` code.

Verified against the old expression rather than only against the new one: restoring `int(raw.get(...))` fails six of the new cases, and the three that still pass do so through the second call site in `async_migrate_if_needed` — which is why both sites moved.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md` troubleshooting; the WS contract and data shapes are unchanged — `CorruptSchemaVersionError` subclasses `StorageError`, so the wire taxonomy still says `storage_error`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync. — no WS change in this PR.
- [x] Load-bearing invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`). — untouched; this is the storage load path only.

## Screenshots (card / UI changes)

None — backend only.

---
_Generated by [Claude Code](https://claude.ai/code/session_013tP3L6mgZVXBPkmRi3TdxV)_