### PR TITLE
fix(ws): persist before broadcasting so an event implies a durable write

### DIFF
--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -664,9 +664,9 @@ def _broadcast_event(
     action: str,
     payload: dict[str, Any] | None = None,
 ) -> None:
-    # Broadcasts are best-effort: they run after a mutation has already been
-    # applied (and usually persisted), so a broadcast failure must never turn
-    # the originating command into an error.
+    # Broadcasts are best-effort: they run after a mutation has been applied and
+    # persisted, so a broadcast failure must never turn the originating command
+    # into an error.
     try:
         event: dict[str, Any] = {
             "domain": DOMAIN,
@@ -752,9 +752,21 @@ def _broadcast_counts(hass: HomeAssistant) -> None:
 
 
 async def _persist_repo(hass: HomeAssistant) -> None:
-    # Use immediate persistence to ensure storage errors propagate to clients.
-    # Debounced persistence (async_request_persist) swallows errors in background
-    # tasks, breaking the @ws_guard error mapping contract.
+    """Write the repository to disk, propagating failure to the caller.
+
+    Uses immediate persistence so storage errors reach clients: debounced
+    persistence (``async_request_persist``) swallows errors in background tasks,
+    breaking the ``@ws_guard`` error mapping contract.
+
+    **Every mutation handler awaits this before it broadcasts or replies.** That
+    ordering is the whole guarantee an event carries: a subscriber that receives
+    ``items/created`` knows the write behind it succeeded. Broadcasting first
+    would tell subscribers about a change the originating client is about to be
+    told failed, and which a restart then erases. Bulk import
+    (``ws_import_execute``) additionally rolls the dataset back, because a
+    wholesale swap has more to undo than one entity does.
+    """
+
     await storage_mod.async_persist_repo(hass)
 
 
@@ -1125,8 +1137,8 @@ async def ws_item_create(
     payload = {k: v for k, v in msg.items() if k not in {"id", "type"}}
     item = _repo(hass).create_item(payload)  # type: ignore[arg-type]
     serialized = _serialize_item(hass, item)
-    _broadcast_event(hass, topic="items", action="created", payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action="created", payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1178,8 +1190,8 @@ async def ws_item_update(
     updated = _repo(hass).update_item(item_id, update, expected_version=expected)
     serialized = _serialize_item(hass, updated)
     action = "moved" if "location_id" in update else "updated"
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1201,13 +1213,13 @@ async def ws_item_delete(
     before = repo.get_item(item_id)
     serialized_before = _serialize_item(hass, before)
     repo.delete_item(item_id, expected_version=msg.get("expected_version"))
+    await _persist_repo(hass)
     _broadcast_event(
         hass,
         topic="items",
         action="deleted",
         payload={"item": serialized_before},
     )
-    await _persist_repo(hass)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), None))
 
@@ -1229,8 +1241,8 @@ async def ws_item_adjust_quantity(
         msg["item_id"], msg["delta"], expected_version=msg.get("expected_version")
     )
     serialized = _serialize_item(hass, item)
-    _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1256,8 +1268,8 @@ async def ws_item_set_quantity(
         msg["item_id"], qty, expected_version=msg.get("expected_version")
     )
     serialized = _serialize_item(hass, item)
-    _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1281,8 +1293,8 @@ async def ws_item_check_out(
         expected_version=msg.get("expected_version"),
     )
     serialized = _serialize_item(hass, item)
-    _broadcast_event(hass, topic="items", action="checked_out", payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action="checked_out", payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1301,8 +1313,8 @@ async def ws_item_check_in(
 ) -> None:
     item = _repo(hass).check_in(msg["item_id"], expected_version=msg.get("expected_version"))
     serialized = _serialize_item(hass, item)
-    _broadcast_event(hass, topic="items", action="checked_in", payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action="checked_in", payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1329,8 +1341,8 @@ async def ws_item_add_tags(
             "tags": msg.get("tags"),
         },
     )
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1357,8 +1369,8 @@ async def ws_item_remove_tags(
             "tags": msg.get("tags"),
         },
     )
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1387,8 +1399,8 @@ async def ws_item_update_custom_fields(
             "unset": msg.get("unset"),
         },
     )
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1415,8 +1427,8 @@ async def ws_item_set_low_stock_threshold(
             "low_stock_threshold": msg.get("low_stock_threshold"),
         },
     )
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1443,8 +1455,8 @@ async def ws_item_move(
             "location_id": msg.get("location_id"),
         },
     )
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1535,8 +1547,16 @@ async def ws_items_bulk(
                 },
             }
 
+    # Only a batch that changed something writes or announces anything. An
+    # all-failed batch deliberately logs no summary of its own: each op already
+    # logged its op_id and reason above, which is what an operator acts on, and a
+    # line repeating "none of them worked" only doubles the log on the worst path.
     if successful_ops:
-        # Log summary of bulk operation
+        # Persist immediately so storage errors surface through @ws_guard, and
+        # before anything else so neither the summary nor an event describes a
+        # batch that never reached disk. The whole batch shares this one write.
+        await _persist_repo(hass)
+
         LOGGER.info(
             "Bulk operation completed",
             extra={
@@ -1550,22 +1570,10 @@ async def ws_items_bulk(
             },
         )
 
-        # Broadcast all successful operations
         for _op_id, serialized, action in successful_ops:
             _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
 
-        # Persist immediately so storage errors surface through @ws_guard.
-        await _persist_repo(hass)
         _broadcast_counts(hass)
-    else:
-        LOGGER.warning(
-            "Bulk operation completed with no successful operations",
-            extra={
-                "domain": DOMAIN,
-                "op": "items_bulk",
-                "total_ops": len(operations),
-            },
-        )
 
     conn.send_message(websocket_api.result_message(msg.get("id", 0), {"results": results}))
 
@@ -1626,8 +1634,8 @@ async def ws_location_create(
         name=msg["name"], parent_id=msg.get("parent_id"), area_id=area_id
     )
     serialized = _serialize_location(loc)
-    _broadcast_event(hass, topic="locations", action="created", payload={"location": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="locations", action="created", payload={"location": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1668,6 +1676,7 @@ async def ws_location_update(
         msg["location_id"], name=msg.get("name"), new_parent_id=new_parent, area_id=area_id
     )
     serialized = _serialize_location(loc)
+    await _persist_repo(hass)
     # If parent changed emit moved; if name changed emit renamed
     # (move takes precedence when both)
     if "new_parent_id" in msg:
@@ -1676,7 +1685,6 @@ async def ws_location_update(
         _broadcast_event(
             hass, topic="locations", action="renamed", payload={"location": serialized}
         )
-    await _persist_repo(hass)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1694,13 +1702,13 @@ async def ws_location_delete(
     before = repo.get_location(loc_id)
     serialized_before = _serialize_location(before)
     repo.delete_location(loc_id)
+    await _persist_repo(hass)
     _broadcast_event(
         hass,
         topic="locations",
         action="deleted",
         payload={"location": serialized_before},
     )
-    await _persist_repo(hass)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), None))
 
@@ -1789,8 +1797,8 @@ async def ws_location_move_subtree(
     new_parent = msg.get("new_parent_id") if "new_parent_id" in msg else UNSET
     loc = _repo(hass).update_location(msg["location_id"], new_parent_id=new_parent)
     serialized = _serialize_location(loc)
-    _broadcast_event(hass, topic="locations", action="moved", payload={"location": serialized})
     await _persist_repo(hass)
+    _broadcast_event(hass, topic="locations", action="moved", payload={"location": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -133,6 +133,11 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
     - Items: if `include_subtree` (default true) match any item whose `location_path.id_path` contains the filter id; otherwise only direct `location_id` matches.
     - Locations: if `include_subtree` match the location itself or descendants; otherwise only the exact location.
 
+- **An event implies a durable write.** Every mutation command persists the change *before* it broadcasts and before it replies, so any event on any topic says the write behind it reached storage. When the write fails the caller receives `storage_error` and **no event is emitted at all** — subscribers are told nothing rather than told about a change that is not on disk. A client may therefore treat a received event as committed and never has to reconcile it against a `storage_error` another client saw for the same change.
+  - The guarantee is about the wire, not about the running repository: a failed write leaves the mutation applied in memory (`import/execute` is the exception — it rolls the dataset back, because a wholesale swap has more to undo than one entity does). Nothing announces that divergence, and it ends at the next restart, which reads back whatever last reached disk.
+  - `items/bulk` shares one write across the whole batch, so a failed write costs the batch its `results` map: the command answers `storage_error` and none of its operations broadcast.
+  - The rate limiter can still drop an event that was persisted — see "Rate limiting". The implication runs one way only: an event means a durable write, but a durable write does not guarantee an event.
+
 ### Items
 
 - `haventory/item/create`
@@ -194,6 +199,7 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - Payload: `{operations: Array<{op_id: string|number, kind: string, payload: object}>}`
   - Supported `kind` values: `item_update`, `item_delete`, `item_move`, `item_adjust_quantity`, `item_set_quantity`, `item_check_out`, `item_check_in`, `item_add_tags`, `item_remove_tags`, `item_update_custom_fields`, `item_set_low_stock_threshold`.
   - Result: `{results: { [op_id: string]: {success: true, result: <Item>} | {success: false, error: {code, message, context}} }}`; if any success, a single `stats/counts` event is emitted.
+  - A failed op fails only itself; the batch continues and reports it under its `op_id`. A failed *write*, by contrast, fails the whole command with `storage_error` and returns no `results` map at all — the batch is one write.
 
 - `haventory/item/list`
   - Payload: `{filter?: <ItemFilter>, sort?: <Sort>, limit?: number, cursor?: string}`

--- a/tests/test_ws_logging_offline.py
+++ b/tests/test_ws_logging_offline.py
@@ -387,6 +387,67 @@ async def test_bulk_unexpected_error_logs_error_with_traceback(caplog, monkeypat
     assert failures[0].exc_info is not None
 
 
+@pytest.mark.asyncio
+async def test_all_failed_bulk_logs_only_its_per_op_lines(caplog) -> None:
+    """A batch where nothing succeeded adds no summary of its own.
+
+    The per-op lines already carry the ``op_id`` and reason an operator acts on;
+    a batch-level "none of them worked" repeats that on the one path where the
+    log is already at its longest.
+    """
+
+    hass = _make_hass()
+    caplog.clear()
+    caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
+
+    res = await _send(
+        hass,
+        1,
+        "haventory/items/bulk",
+        operations=[
+            {"op_id": "a", "kind": "item_update", "payload": {"item_id": "missing-1"}},
+            {"op_id": "b", "kind": "item_delete", "payload": {"item_id": "missing-2"}},
+        ],
+    )
+    results = res["result"]["results"]
+    assert {k: v["success"] for k, v in results.items()} == {"a": False, "b": False}
+
+    records = _records(caplog)
+    assert [r.op for r in records] == ["items_bulk_op_failed"] * 2
+    assert {r.op_id for r in records} == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_partly_successful_bulk_still_logs_its_summary(caplog) -> None:
+    """The summary survives where it still says something: a batch that changed state."""
+
+    hass = _make_hass()
+    created = await _send(hass, 1, "haventory/item/create", name="Widget")
+    item_id = created["result"]["id"]
+
+    caplog.clear()
+    caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
+
+    await _send(
+        hass,
+        2,
+        "haventory/items/bulk",
+        operations=[
+            {
+                "op_id": "a",
+                "kind": "item_adjust_quantity",
+                "payload": {"item_id": item_id, "delta": 1},
+            },
+            {"op_id": "b", "kind": "item_delete", "payload": {"item_id": "missing"}},
+        ],
+    )
+
+    summaries = [r for r in _records(caplog) if r.op == "items_bulk"]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.INFO
+    assert (summaries[0].successful, summaries[0].failed) == (1, 1)
+
+
 # -----------------------------
 # The service boundary follows the same policy
 # -----------------------------

--- a/tests/test_ws_storage_error_offline.py
+++ b/tests/test_ws_storage_error_offline.py
@@ -1,23 +1,27 @@
-"""Offline tests: storage save failure maps to storage_error at WS boundary.
+"""Offline tests: a save failure maps to storage_error and lets no event escape.
 
-Scenarios:
-- Simulate that persisting the repository raises StorageError
-- Invoke a WS command that persists (e.g., item/create)
-- Expect WS error with code 'storage_error' and an ERROR-level log
+Every mutation handler persists before it broadcasts, so a broadcast is a promise
+that the write behind it succeeded. These tests hold both halves of that:
 
-Edge case documentation:
-- When persist fails, mutation is already applied in memory
-- Broadcasts are sent before persist, so subscribers see the change
-- On restart, changes are lost (not persisted to disk)
-- This is a known limitation; rollback would add complexity for a rare edge case
+- a failing persist returns ``storage_error`` to the caller and delivers nothing
+  to subscribers, across every mutation shape the API exposes;
+- a *succeeding* persist delivers the event only once the store write resolved,
+  not merely at some point after the mutation was applied.
+
+The mutation does remain applied in memory when the write fails — the handlers do
+not roll back (``import/execute`` does, because a wholesale dataset swap has more
+to undo than one entity does). That divergence is documented at the bottom of this
+file: it survives only until restart, and no client is told about it.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Callable
+from typing import Any
 
 import pytest
-from custom_components.haventory import ws as ws_module
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import StorageError
 from custom_components.haventory.repository import Repository
@@ -26,7 +30,20 @@ from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
 
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
+class _ConnStub:
+    """Collects everything the backend sends, so tests can read the wire."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def send_message(self, msg: dict[str, Any]) -> None:
+        self.messages.append(msg)
+
+    def on_close(self, callback: Callable[[], None]) -> None:
+        pass
+
+
+async def _send(hass: HomeAssistant, _id: int, type_: str, conn: object = None, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
         schema = getattr(h, "_ws_schema", None)
@@ -36,26 +53,37 @@ async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)
-        return await h(hass, None, req)
+        return await h(hass, conn, req)
     raise AssertionError("No handler responded for type " + type_)
+
+
+def _events(conn: _ConnStub) -> list[dict[str, Any]]:
+    return [m["event"] for m in conn.messages if m.get("type") == "event"]
+
+
+def _make_hass() -> tuple[HomeAssistant, Repository, DomainStore]:
+    hass = HomeAssistant()
+    repo = Repository()
+    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    store = DomainStore(hass)
+    hass.data[DOMAIN]["store"] = store
+    ws_setup(hass)
+    return hass, repo, store
+
+
+def _fail_next_save(monkeypatch: pytest.MonkeyPatch, store: DomainStore) -> None:
+    async def _raise(*_args, **_kwargs):
+        raise StorageError("disk full")
+
+    monkeypatch.setattr(store, "async_save", _raise)
 
 
 @pytest.mark.asyncio
 async def test_ws_maps_storage_error_and_logs(caplog, monkeypatch) -> None:
     """WS should return storage_error when persist fails and log at ERROR level."""
 
-    hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
-    ws_setup(hass)
-
-    # Force persist to raise StorageError via async_save on underlying store
-    async def _raise(*_args, **_kwargs):  # type: ignore[no-untyped-def]
-        raise StorageError("failed to persist repository")
-
-    # Monkeypatch DomainStore.async_save through the instance stored in hass
-    store = hass.data[DOMAIN]["store"]
-    monkeypatch.setattr(store, "async_save", _raise)
+    hass, _repo, store = _make_hass()
+    _fail_next_save(monkeypatch, store)
 
     caplog.set_level(logging.ERROR, logger="custom_components.haventory.ws")
 
@@ -70,185 +98,277 @@ async def test_ws_maps_storage_error_and_logs(caplog, monkeypatch) -> None:
 
 
 # -----------------------------------------------------------------------------
-# Edge case tests: document behavior when persist fails after mutation
+# A failing persist lets nothing onto the wire — every mutation shape
+# -----------------------------------------------------------------------------
+
+
+# One entry per distinct mutation shape in ws.py: everything that persists.
+# (command, payload builder over the seeded ids)
+MUTATIONS: list[tuple[str, str, Callable[[str, str], dict[str, Any]]]] = [
+    ("item_create", "haventory/item/create", lambda _i, _l: {"name": "Fresh"}),
+    ("item_update", "haventory/item/update", lambda i, _l: {"item_id": i, "quantity": 5}),
+    ("item_delete", "haventory/item/delete", lambda i, _l: {"item_id": i}),
+    (
+        "item_adjust_quantity",
+        "haventory/item/adjust_quantity",
+        lambda i, _l: {"item_id": i, "delta": 1},
+    ),
+    (
+        "item_set_quantity",
+        "haventory/item/set_quantity",
+        lambda i, _l: {"item_id": i, "quantity": 7},
+    ),
+    ("item_check_out", "haventory/item/check_out", lambda i, _l: {"item_id": i}),
+    ("item_check_in", "haventory/item/check_in", lambda i, _l: {"item_id": i}),
+    ("item_add_tags", "haventory/item/add_tags", lambda i, _l: {"item_id": i, "tags": ["new"]}),
+    (
+        "item_remove_tags",
+        "haventory/item/remove_tags",
+        lambda i, _l: {"item_id": i, "tags": ["seed"]},
+    ),
+    (
+        "item_update_custom_fields",
+        "haventory/item/update_custom_fields",
+        lambda i, _l: {"item_id": i, "set": {"k": "v"}},
+    ),
+    (
+        "item_set_low_stock_threshold",
+        "haventory/item/set_low_stock_threshold",
+        lambda i, _l: {"item_id": i, "low_stock_threshold": 2},
+    ),
+    ("item_move", "haventory/item/move", lambda i, loc: {"item_id": i, "location_id": loc}),
+    (
+        "items_bulk",
+        "haventory/items/bulk",
+        lambda i, _l: {
+            "operations": [
+                {
+                    "op_id": "a",
+                    "kind": "item_adjust_quantity",
+                    "payload": {"item_id": i, "delta": 1},
+                }
+            ]
+        },
+    ),
+    ("location_create", "haventory/location/create", lambda _i, _l: {"name": "Shed"}),
+    (
+        "location_rename",
+        "haventory/location/update",
+        lambda _i, loc: {"location_id": loc, "name": "Renamed"},
+    ),
+    (
+        "location_reparent",
+        "haventory/location/update",
+        lambda _i, loc: {"location_id": loc, "new_parent_id": None},
+    ),
+    ("location_delete", "haventory/location/delete", lambda _i, loc: {"location_id": loc}),
+    (
+        "location_move_subtree",
+        "haventory/location/move_subtree",
+        lambda _i, loc: {"location_id": loc, "new_parent_id": None},
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("shape", "command", "build"), MUTATIONS, ids=[m[0] for m in MUTATIONS])
+async def test_failed_persist_delivers_no_event(
+    shape: str,
+    command: str,
+    build: Callable[[str, str], dict[str, Any]],
+    monkeypatch,
+    caplog,
+) -> None:
+    """No mutation shape may broadcast a change whose write failed.
+
+    The caller still learns the truth (``storage_error``); the subscribers learn
+    nothing at all, which is the correct thing to tell them about a change that
+    did not reach disk.
+    """
+
+    hass, repo, store = _make_hass()
+
+    # Seed a target for the mutations that need one. The location is a child so
+    # the reparent/move shapes have somewhere to move *from*.
+    parent = repo.create_location(name="House")
+    child = repo.create_location(name="Garage", parent_id=str(parent.id))
+    item = repo.create_item({"name": "Seeded", "quantity": 3, "tags": ["seed"]})
+
+    conn = _ConnStub()
+    for sub_id, topic in ((901, "items"), (902, "locations"), (903, "stats")):
+        res = await _send(hass, sub_id, "haventory/subscribe", conn=conn, topic=topic)
+        assert res["success"] is True
+    conn.messages.clear()
+
+    _fail_next_save(monkeypatch, store)
+    caplog.set_level(logging.ERROR)
+
+    res = await _send(hass, 1, command, conn=conn, **build(str(item.id), str(child.id)))
+
+    assert res["success"] is False, f"{shape} should have failed"
+    assert res["error"]["code"] == "storage_error"
+    assert _events(conn) == [], f"{shape} leaked an event for a write that failed"
+
+
+@pytest.mark.asyncio
+async def test_failed_persist_in_bulk_discards_the_whole_batch(monkeypatch, caplog) -> None:
+    """A bulk whose write fails reports storage_error, not per-op successes.
+
+    Every op in the batch shares one write, so a caller that received per-op
+    ``success: true`` alongside a failed save could not tell which half to trust.
+    """
+
+    hass, repo, store = _make_hass()
+    first = repo.create_item({"name": "One", "quantity": 1})
+    second = repo.create_item({"name": "Two", "quantity": 1})
+
+    conn = _ConnStub()
+    await _send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
+    conn.messages.clear()
+
+    _fail_next_save(monkeypatch, store)
+    caplog.set_level(logging.ERROR)
+
+    res = await _send(
+        hass,
+        1,
+        "haventory/items/bulk",
+        conn=conn,
+        operations=[
+            {
+                "op_id": "a",
+                "kind": "item_adjust_quantity",
+                "payload": {"item_id": str(first.id), "delta": 1},
+            },
+            {
+                "op_id": "b",
+                "kind": "item_set_quantity",
+                "payload": {"item_id": str(second.id), "quantity": 9},
+            },
+        ],
+    )
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "storage_error"
+    assert _events(conn) == []
+
+
+# -----------------------------------------------------------------------------
+# A succeeding persist broadcasts only once the write has resolved
 # -----------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_storage_error_leaves_item_in_memory_but_not_persisted(caplog, monkeypatch) -> None:
-    """When persist fails, item exists in memory but won't survive restart.
+async def test_event_reaches_subscriber_only_after_the_write_resolves(monkeypatch) -> None:
+    """Assert the ordering directly, not just the absence of a broadcast.
 
-    This documents expected edge-case behavior: the mutation succeeds in memory,
-    but the client receives storage_error. On HA restart, the item is lost.
+    A store write that is *in flight* — entered but not yet resolved — must not
+    have produced an event yet. Without this, a handler that broadcast before
+    awaiting would still pass every failure test above whenever the write happens
+    to succeed.
     """
-    hass = HomeAssistant()
-    repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
-    ws_setup(hass)
 
-    # Force persist to fail
-    persist_called = []
+    hass, _repo, store = _make_hass()
 
-    async def _fail_persist(*_args, **_kwargs):
-        persist_called.append(True)
-        raise StorageError("disk full")
+    conn = _ConnStub()
+    await _send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
+    conn.messages.clear()
 
-    monkeypatch.setattr(store, "async_save", _fail_persist)
+    write_entered = asyncio.Event()
+    finish_write = asyncio.Event()
+    events_seen_during_write: list[dict[str, Any]] = []
 
+    async def _slow_save(*_args, **_kwargs):
+        events_seen_during_write.extend(_events(conn))
+        write_entered.set()
+        await finish_write.wait()
+
+    monkeypatch.setattr(store, "async_save", _slow_save)
+
+    task = asyncio.create_task(_send(hass, 1, "haventory/item/create", conn=conn, name="Anvil"))
+    await asyncio.wait_for(write_entered.wait(), timeout=5)
+
+    # The write is open. Nothing may have reached the subscriber yet.
+    assert events_seen_during_write == []
+    assert _events(conn) == []
+
+    finish_write.set()
+    res = await asyncio.wait_for(task, timeout=5)
+
+    assert res["success"] is True
+    actions = [ev.get("action") for ev in _events(conn)]
+    assert actions == ["created"], "the created event must arrive once, after the write"
+
+
+# -----------------------------------------------------------------------------
+# What a failed persist still leaves behind: in-memory divergence, told to nobody
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_create_stays_in_memory_until_restart(monkeypatch, caplog) -> None:
+    """The handlers do not roll back: the item lives in memory but not on disk.
+
+    Nothing on the wire claims otherwise — the caller was told ``storage_error``
+    and no subscriber was told anything — so the divergence is invisible to
+    clients and ends at the next restart.
+    """
+
+    hass, repo, store = _make_hass()
+    _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    # Create item - mutation succeeds but persist fails
     res = await _send(hass, 1, "haventory/item/create", name="Fragile Item")
 
-    # Client receives error
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
-    assert persist_called, "Persist should have been attempted"
 
-    # But item exists in memory (edge case: mutation already applied)
-    result = repo.list_items()
-    items = result["items"]
+    items = repo.list_items()["items"]
     assert len(items) == 1
     assert items[0].name == "Fragile Item"
 
-    # Simulate restart: load fresh repo from what would be on disk (empty)
+    # Restart reads what reached disk, which is nothing.
     fresh_repo = Repository.from_state({"items": {}, "locations": {}})
-    fresh_result = fresh_repo.list_items()
-    assert len(fresh_result["items"]) == 0, "Item lost on restart as expected"
+    assert fresh_repo.list_items()["items"] == []
 
 
 @pytest.mark.asyncio
-async def test_storage_error_broadcast_already_sent(caplog, monkeypatch) -> None:
-    """When persist fails, broadcast has already been sent to subscribers.
+async def test_failed_delete_stays_removed_in_memory_until_restart(monkeypatch, caplog) -> None:
+    """The inverse divergence: the item is gone from memory and still on disk."""
 
-    This documents that subscribers receive the 'created' event even though
-    the client gets storage_error. This is a known limitation - rolling back
-    would add complexity for a rare edge case.
-    """
-    hass = HomeAssistant()
-    repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
-    ws_setup(hass)
-
-    # Track broadcasts
-    broadcast_events: list[dict] = []
-
-    def tracking_broadcast(hass, topic, action, payload):
-        broadcast_events.append({"topic": topic, "action": action, "payload": payload})
-        # Don't actually broadcast in tests (no real subscriptions)
-
-    monkeypatch.setattr(ws_module, "_broadcast_event", tracking_broadcast)
-
-    # Force persist to fail
-    async def _fail_persist(*_args, **_kwargs):
-        raise StorageError("permission denied")
-
-    monkeypatch.setattr(store, "async_save", _fail_persist)
-
-    caplog.set_level(logging.ERROR)
-
-    # Create item
-    res = await _send(hass, 1, "haventory/item/create", name="Broadcast Test")
-
-    # Client receives error
-    assert res["success"] is False
-    assert res["error"]["code"] == "storage_error"
-
-    # But broadcast was already sent (before persist attempted)
-    assert len(broadcast_events) == 1
-    assert broadcast_events[0]["topic"] == "items"
-    assert broadcast_events[0]["action"] == "created"
-    assert broadcast_events[0]["payload"]["item"]["name"] == "Broadcast Test"
-
-
-@pytest.mark.asyncio
-async def test_storage_error_on_delete_item_removed_from_memory(caplog, monkeypatch) -> None:
-    """When persist fails on delete, item is already removed from memory.
-
-    For delete operations, if persist fails, the item was already removed
-    from memory. On restart it would reappear (since delete wasn't persisted).
-    """
-    hass = HomeAssistant()
-    repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
-    ws_setup(hass)
-
-    # Create an item first (with working persistence - mock it to succeed)
+    hass, repo, store = _make_hass()
     item = repo.create_item({"name": "To Delete"})
-    item_id = item.id
 
-    # Now make persist fail
-    async def _fail_persist(*_args, **_kwargs):
-        raise StorageError("io error")
-
-    monkeypatch.setattr(store, "async_save", _fail_persist)
-
+    _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    # Delete item - mutation succeeds but persist fails
-    res = await _send(hass, 1, "haventory/item/delete", item_id=str(item_id))
+    res = await _send(hass, 1, "haventory/item/delete", item_id=str(item.id))
 
-    # Client receives error
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
-
-    # Item is deleted from memory (mutation already applied)
-    result = repo.list_items()
-    items = result["items"]
-    assert len(items) == 0, "Item was deleted from memory"
-
-    # On restart, the item would reappear (since delete wasn't persisted)
-    # This is the inverse edge case - data appears "restored" unexpectedly
+    assert repo.list_items()["items"] == []
 
 
 @pytest.mark.asyncio
-async def test_storage_error_on_update_change_in_memory_only(caplog, monkeypatch) -> None:
-    """When persist fails on update, change exists in memory but not on disk.
+async def test_failed_update_keeps_the_new_value_in_memory(monkeypatch, caplog) -> None:
+    """A partial update is applied in memory even when the write fails."""
 
-    Documents that partial updates are applied in-memory even when persist fails.
-    """
-    hass = HomeAssistant()
-    repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
-    ws_setup(hass)
-
-    # Create item with initial quantity
+    hass, repo, store = _make_hass()
     INITIAL_QTY = 10
+    NEW_QTY = 25
     item = repo.create_item({"name": "Quantity Test", "quantity": INITIAL_QTY})
-    item_id = item.id
 
-    # Now make persist fail
-    async def _fail_persist(*_args, **_kwargs):
-        raise StorageError("readonly filesystem")
-
-    monkeypatch.setattr(store, "async_save", _fail_persist)
-
+    _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    # Update quantity
-    NEW_QTY = 25
     res = await _send(
         hass,
         1,
         "haventory/item/update",
-        item_id=str(item_id),
+        item_id=str(item.id),
         quantity=NEW_QTY,
     )
 
-    # Client receives error
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
-
-    # But change is in memory
-    updated = repo.get_item(item_id)
-    assert updated.quantity == NEW_QTY, "Update applied in memory despite persist failure"
-
-    # On restart, would revert to INITIAL_QTY (the last persisted value)
+    assert repo.get_item(item.id).quantity == NEW_QTY


### PR DESCRIPTION
Closes #221. Closes #247.

## The problem

Every single-item WS mutation handler broadcast its event and replied *before* it persisted — 20 `_broadcast_event(...)` → `await _persist_repo(hass)` pairs across items and locations. When the write failed:

- the caller got `storage_error` ("my create failed"),
- subscribers had already been told `created` (their UI showed the item),
- the repository kept it in memory until restart,
- a retry duplicated it.

Meanwhile `ws_import_execute` snapshotted and rolled back on persist failure, so the codebase held two policies at once.

## The fix

Persist-then-broadcast, applied uniformly at all 20 sites (12 item handlers, the bulk loop, 5 location broadcasts, and the 2 import ones that were already correct). An event on any topic now means the write behind it reached storage; a failed write reaches only the caller.

`ws_import_execute` keeps its rollback untouched — a wholesale dataset swap has more to undo than one entity does, and it already persisted first.

**No handler changes persistence path.** `_persist_repo` was and remains `storage.async_persist_repo`, the immediate write; the debounced path is not involved anywhere in `ws.py`, so moving the `await` earlier does not move a handler onto it.

**Ordering is safe across the new suspension point.** `async_persist_repo` acquires its lock as its first statement, and handlers mutate the repository synchronously before awaiting it, so `asyncio.Lock` FIFO preserves mutation order. Verified against real HA (below), not just argued.

## Also: #247

Dropped the `"Bulk operation completed with no successful operations"` summary WARNING. It repeated, on the worst-case path where the log is already longest, what the per-op WARNING lines immediately above it had already said with the `op_id` and reason an operator acts on. The per-op lines are untouched.

**#206's other half — the frontend-resource registration severity (`__init__.py` `LOGGER.warning` sites) — is deliberately not touched here** and stays with the parent issue.

One adjacent change: the surviving INFO summary moved *below* the write, so it can no longer claim a batch completed that then failed to save.

## Docs

`docs/backend_api_contract.md` states the guarantee explicitly under "Subscriptions and events", since clients may now rely on it — including its two honest limits: a failed write still leaves the mutation applied in memory (nothing announces it; it ends at the next restart), and the implication runs one way only (an event means a durable write; a durable write does not guarantee an event, because the rate limiter can still drop one).

## Tests

- **A failing-persist case per mutation shape** — 18 commands, parametrized — asserting nothing reaches a subscriber *and* the caller still receives `storage_error`. Subscribers are real subscriptions on a live conn stub, so this covers the `stats/counts` event too, not just the entity event.
- **A bulk case** covering the shared write: a failed write costs the batch its `results` map.
- **A direct ordering assertion** — holds a store write open and proves the subscriber sees the event only *after* it resolves, not merely that no broadcast escaped on failure. Without it, a handler that broadcast before awaiting would still pass every failure test whenever the write happens to succeed.
- **Two #247 logging tests**: an all-failed batch logs only its per-op lines; a partly-successful batch still logs its summary.

All 20 new assertions fail against the previous ordering and pass against the new one (verified by stashing `ws.py` and re-running).

Gates: backend 532 passed / 22 skipped, ruff + ruff format + mypy clean; frontend eslint + tsc clean, 1058 vitest tests, build OK.

## Verified against real HA

Deployed to the local Docker HA (1000-item store) and ran the stress regimen — `baseline`, `fuzz`, `bulkfuzz`, `statsprobe`, `subteardown`, `ratelimit`, `races`, `restart`, `cleanup`. All layers PASS, log sweep `BLOCKING: 0`.

The two that matter most for this change:

- **`races`** — 50 concurrent `+1` adjusts still serialize to exactly 50; a location rename still leaves subtree item versions valid.
- **`restart`** — mid-load `docker restart` with an on-disk-vs-API cross-check: 1200/1200 before, 1260/1260 after, no index drift, all known seed items survived.
- **`statsprobe`** — 20 mutations still produce exactly 20 `stats/counts` events, so the reorder drops nothing.

Plus a targeted probe for the one risk this change introduces that no existing layer covers — whether the new suspension point can reorder events for concurrent mutations of the *same* item. 40 concurrent `adjust_quantity` calls delivered 40 events with strictly increasing `version` and `quantity`, final quantity 40: no reordering, no lost update.

## Follow-ups (not in this PR)

- A failed write still leaves the mutation applied in memory for single mutations — the chosen policy's accepted residual, now documented in the contract and covered by tests rather than left implicit. Rolling back single mutations too would be a separate call.
- `docs/open-items.md` row 50 still describes both #206 severity calls; the second half is now done. Left alone here because that file is being edited concurrently by other v0.3.1 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
