### PR TITLE
fix(search): let short query fragments match mid-word

### DIFF
--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -451,6 +451,24 @@ class Repository:
 
         return matches
 
+    def _text_index_covers_query(self, query: str) -> bool:
+        """Return True when the text index can answer ``query`` without false negatives.
+
+        ``_item_matches_q`` matches a query word anywhere inside an item's text,
+        mid-word included. The index only reaches that far through trigrams, so a
+        word shorter than ``TRIGRAM_MIN_LEN`` is reachable only where it happens to
+        start a name word — "wi" finds "Wine" and never "Kiwi". A query with no
+        indexable word at all (punctuation only) is outside the index entirely.
+
+        For those queries the index is a lossy filter rather than a pre-filter, and
+        callers must let the ``filter_items`` scan answer instead. Tokenizes exactly
+        as ``_search_by_text`` does, so the two always agree on the word boundaries
+        the judgement is made over.
+        """
+
+        words = self._tokenize(query)
+        return bool(words) and all(len(w) >= TRIGRAM_MIN_LEN for w in words)
+
     def _search_by_text(self, query: str) -> set[str]:
         """Return item IDs matching the query using indexes.
 
@@ -1019,9 +1037,12 @@ class Repository:
                 candidate_sets.append(s)
 
         # 0. Text Search Index (q)
+        # A pre-filter, authoritative only over the queries the index covers
+        # (``_text_index_covers_query``). Where it does not, ``q`` contributes no
+        # candidate set and the ``filter_items`` post-filter decides on its own —
+        # an index miss there means "cannot tell", not "no match".
         q = (flt.get("q") or "").strip()
-        if q:
-            # We treat text index as authoritative for text matches
+        if q and self._text_index_covers_query(q):
             has_indexed_filter = True
             text_matches = self._search_by_text(q)
             if not text_matches:

--- a/tests/test_repository_search_offline.py
+++ b/tests/test_repository_search_offline.py
@@ -126,3 +126,99 @@ async def test_text_search_multi_word_and_logic() -> None:
     # "Blue Large" -> i2 has Blue but Small. i1/i3 have Large but Red. Should be 0.
     results = repo.list_items(flt={"q": "Blue Large"})["items"]
     assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_text_search_short_fragment_matches_mid_word() -> None:
+    """A fragment shorter than a trigram still matches mid-word.
+
+    Regression: the text index was authoritative for ``q``, so a two-character
+    fragment that starts no word found no word bucket, no name-prefix bucket and
+    no trigram fallback (which needs three characters) — and the empty index
+    result was reported as "no match" instead of falling through to the scan that
+    implements the documented substring contract.
+    """
+    repo = Repository()
+    i1 = repo.create_item({"name": "Kiwi"})
+    repo.create_item({"name": "Hammer"})
+
+    results = repo.list_items(flt={"q": "wi"})["items"]
+    assert len(results) == 1
+    assert results[0].id == i1.id
+
+    # One character is below the prefix floor as well, so no index reaches it.
+    results = repo.list_items(flt={"q": "w"})["items"]
+    assert len(results) == 1
+    assert results[0].id == i1.id
+
+
+@pytest.mark.asyncio
+async def test_short_fragment_matches_beyond_the_word_starts_it_hits() -> None:
+    """A short fragment returns mid-word matches alongside the word-start ones.
+
+    The name-prefix index is built from two characters up, so "wi" *does* find
+    "Wine" — a non-empty index result that is still missing "Kiwi". Treating a
+    non-empty result as complete would leave the bug alive whenever the inventory
+    happens to hold a word starting with the fragment.
+    """
+    repo = Repository()
+    kiwi = repo.create_item({"name": "Kiwi"})
+    wine = repo.create_item({"name": "Wine"})
+    repo.create_item({"name": "Hammer"})
+
+    results = repo.list_items(flt={"q": "wi"})["items"]
+    assert {x.id for x in results} == {kiwi.id, wine.id}
+
+
+@pytest.mark.asyncio
+async def test_short_fragment_falls_through_while_long_one_stays_indexed() -> None:
+    """Only queries the index cannot cover give up the indexed path.
+
+    ``_get_filtered_candidates`` returning ``None`` means "scan everything";
+    returning a list means the index narrowed the field. The fall-through must be
+    confined to sub-trigram fragments, or the fast path is disabled for every
+    search.
+    """
+    repo = Repository()
+    repo.create_item({"name": "Kiwi"})
+    repo.create_item({"name": "Hammer"})
+
+    assert repo._get_filtered_candidates({"q": "wi"}) is None
+    assert repo._get_filtered_candidates({"q": "w"}) is None
+
+    # Three characters reach the trigram fallback, so the index stays in charge.
+    candidates = repo._get_filtered_candidates({"q": "iwi"})
+    assert candidates is not None
+    assert [c.name for c in candidates] == ["Kiwi"]
+
+    # An indexed query that genuinely matches nothing still short-circuits.
+    assert repo._get_filtered_candidates({"q": "zzz"}) == []
+
+
+@pytest.mark.asyncio
+async def test_short_fragment_still_uses_the_other_indexes() -> None:
+    """Dropping ``q`` from the index pre-filter leaves the sibling indexes intact."""
+    repo = Repository()
+    kiwi = repo.create_item({"name": "Kiwi", "category": "Fruit"})
+    repo.create_item({"name": "Kiwi Box", "category": "Storage"})
+
+    candidates = repo._get_filtered_candidates({"q": "wi", "category": "Fruit"})
+    assert candidates is not None
+    assert [c.id for c in candidates] == [kiwi.id]
+
+    results = repo.list_items(flt={"q": "wi", "category": "Fruit"})["items"]
+    assert [x.id for x in results] == [kiwi.id]
+
+
+@pytest.mark.asyncio
+async def test_punctuation_only_query_falls_through_to_the_scan() -> None:
+    """A query with no indexable word is outside the index, not proof of no match."""
+    repo = Repository()
+    i1 = repo.create_item({"name": "Wow!!!"})
+    repo.create_item({"name": "Hammer"})
+
+    assert repo._get_filtered_candidates({"q": "!!!"}) is None
+
+    results = repo.list_items(flt={"q": "!!!"})["items"]
+    assert len(results) == 1
+    assert results[0].id == i1.id


### PR DESCRIPTION
Closes #220.

## The bug

`_get_filtered_candidates` treated the text index as authoritative for `q` and returned `[]` on an index miss, so the substring semantics documented in `_item_matches_q` never ran as a post-filter — there were no candidates left to post-filter. A query word shorter than `TRIGRAM_MIN_LEN` that starts no word missed on every path: `q="wi"` against "Kiwi" finds no word bucket, no name-prefix bucket, and the trigram fallback needs three characters.

## The fix

Fix option 1 from the issue: treat the index as a pre-filter that is authoritative only where it is complete. `_text_index_covers_query` makes that call, and where it says no, `q` contributes no candidate set and the `filter_items` scan answers instead. The sibling indexes (category, location, tags, …) still narrow the field, so a short fragment combined with another filter stays cheap.

The text-index machinery is left in place — removing it is #230's call and not in this release.

### Coverage is a property of the query, not of the result

Worth a reviewer's attention, because it is broader than the issue's reproducer. `PREFIX_MIN_LEN` is 2, so a two-character fragment *does* hit the name-prefix bucket whenever some item's name starts with it: against an inventory holding both "Wine" and "Kiwi", `q="wi"` returns a **non-empty** index result that is still missing "Kiwi". Falling through only on an empty result would have left that wrong answer standing whenever the data happens to contain a word-start match. Pinned by `test_short_fragment_matches_beyond_the_word_starts_it_hits`.

The same reasoning makes a punctuation-only query (`q="!!!"`, zero indexable words) uncovered, where it previously returned nothing even though `_item_matches_q` says "Wow!!!" matches. That is a behavior change beyond the reported reproducer, but in the same direction — bringing the implementation to the contract the docs already state, so no doc change is needed.

### Why 3+ characters keeps the fast path

Not merely untested but safe: a query word is alnum-only after tokenization, so if it is a substring of an item's joined searchable text it is a substring of a single item token, and all of its trigrams are therefore in that token's trigram set. The fallback cannot produce a false negative there.

## Tests

Five cases in `tests/test_repository_search_offline.py`, each verified to fail against the unfixed `repository.py` and pass with it (the five pre-existing search tests pass either way):

- `"wi"` and `"w"` against "Kiwi" — the two-character and one-character mid-word fragments
- the "Wine" + "Kiwi" partial-index case described above
- `_get_filtered_candidates` returns `None` for `"wi"`/`"w"`, a narrowed list for `"iwi"`, and still `[]` for an indexed no-match (`"zzz"`) — asserting the *path*, so the fast path is not silently disabled for everything
- a short fragment combined with `category` still uses the category index

## Gate

`pytest` 516 passed / 22 skipped, `ruff check`, `ruff format --check`, `mypy` all clean. The frontend gate was not run: the diff is `repository.py` plus one test file, zero frontend files.

## Scope

`repository.py` only. No contract change, no doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
