### PR TITLE
fix(card): bring the full view's table up to the card's accessibility bar

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -284,6 +284,118 @@ describe('hv-data-table: rows', () => {
   });
 });
 
+describe('hv-data-table: keyboard', () => {
+  const captured = (el: HVDataTable, names: string[]) => {
+    const seen: string[] = [];
+    for (const name of names) {
+      el.addEventListener(name, (e) => seen.push(`${name}:${(e as CustomEvent).detail.itemId}`));
+    }
+    return seen;
+  };
+  const press = (el: HTMLElement, key: string) =>
+    el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+
+  // The rows were tabbable and had a click handler and nothing else, so on the
+  // one surface that lists every item, no item could be reached without a mouse.
+  it('keeps the same shortcuts the card list row has', async () => {
+    const el = await mount([{ id: 'item-1' }]);
+    const seen = captured(el, ['open-item', 'request-delete', 'increment', 'decrement']);
+    const row = q(el, '[data-testid="table-row"]') as HTMLElement;
+
+    for (const key of ['Enter', 'Delete', '+', '-']) press(row, key);
+
+    expect(seen).toEqual([
+      'open-item:item-1',
+      'request-delete:item-1',
+      'increment:item-1',
+      'decrement:item-1',
+    ]);
+  });
+
+  it('takes the numpad and shifted spellings of the same two keys', async () => {
+    const el = await mount([{ id: 'item-1' }]);
+    const seen = captured(el, ['increment', 'decrement']);
+    const row = q(el, '[data-testid="table-row"]') as HTMLElement;
+
+    // `=` is what an unshifted `+` reports on a US layout; `Add`/`Subtract` are
+    // the numpad's.
+    for (const key of ['=', 'Add', 'Subtract']) press(row, key);
+
+    expect(seen).toEqual(['increment:item-1', 'increment:item-1', 'decrement:item-1']);
+  });
+
+  it('claims the keys it acts on, so the surface below does not answer too', async () => {
+    const el = await mount([{ id: 'item-1' }]);
+    const row = q(el, '[data-testid="table-row"]') as HTMLElement;
+    expect(press(row, 'Enter')).toBe(false);
+    // Anything else is still the browser's — Tab has to keep leaving the row.
+    expect(press(row, 'Tab')).toBe(true);
+  });
+
+  it('follows the row click into selection mode rather than opening the item', async () => {
+    const el = await mount([{ id: 'item-1' }], { selectable: true });
+    const seen = captured(el, ['open-item', 'toggle-select']);
+    press(q(el, '[data-testid="table-row"]') as HTMLElement, 'Enter');
+    expect(seen).toEqual(['toggle-select:item-1']);
+  });
+
+  it('leaves a key pressed on a control inside the row to that control', async () => {
+    // Enter on Edit already opens the editor; the row acting on the same press
+    // would open it a second time, and Delete on any of the three buttons would
+    // ask to delete the item.
+    const el = await mount([{ id: 'item-1' }]);
+    const seen = captured(el, ['open-item', 'request-delete', 'increment', 'decrement']);
+    const edit = q(el, '[data-testid="table-edit"]') as HTMLElement;
+
+    for (const key of ['Enter', 'Delete', '+', '-']) press(edit, key);
+
+    expect(seen).toEqual([]);
+  });
+});
+
+describe('hv-data-table: table semantics', () => {
+  // `row`, `columnheader` and `cell` are only meaningful under a table role.
+  // Without one the structure is dropped and the rows read as a run of text.
+  it('carries the table role the rows and cells hang off', async () => {
+    const el = await mount([{ id: '1' }]);
+    expect(el.getAttribute('role')).toBe('table');
+  });
+
+  it('marks every value in a row as a cell', async () => {
+    const el = await mount([{ id: '1', tags: ['m4'] }]);
+    const row = q(el, '[data-testid="table-row"]') as HTMLElement;
+    const cells = [...row.querySelectorAll('[role="cell"]')];
+    // Name, the five mounted columns, and the action group.
+    expect(cells).toHaveLength(7);
+    expect(cells[0].querySelector('[data-testid="table-name"]')).toBeTruthy();
+    expect(cells.map((c) => c.getAttribute('data-testid'))).toContain('cell-quantity');
+  });
+
+  it('gives each row a cell for every column header', async () => {
+    const el = await mount([{ id: '1' }], { columns: ['quantity', 'location', 'status'] });
+    const headers = all(el, '[role="columnheader"]').length;
+    const cells = (q(el, '[data-testid="table-row"]') as HTMLElement).querySelectorAll('[role="cell"]');
+    expect(cells).toHaveLength(headers);
+  });
+
+  it('spans the empty message across a row, the way a table has to', async () => {
+    // A row group whose only child is a loose message owns something a table
+    // cannot contain, and the whole structure is dropped rather than repaired.
+    const el = await mount([]);
+    const empty = q(el, '[data-testid="table-empty"]') as HTMLElement;
+    expect(empty.getAttribute('role')).toBe('cell');
+    expect(empty.parentElement?.getAttribute('role')).toBe('row');
+    expect(empty.closest('[role="rowgroup"]')).toBeTruthy();
+  });
+
+  it('leaves the announcing to whatever fills the slot', async () => {
+    // The shared empty state is a live region already; a second one wrapped
+    // around it says everything twice.
+    const el = await mount([]);
+    expect(q(el, '[data-testid="table-empty"]')?.getAttribute('role')).not.toBe('status');
+  });
+});
+
 describe('hv-data-table: status column', () => {
   const mixed = [
     { id: '1', status: 'missing' as const },

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -277,6 +277,21 @@ export class HVDataTable extends LitElement {
   @property({ attribute: false }) areas: AreaRef[] = [];
   @property({ attribute: false }) selection: Set<string> = new Set();
 
+  /**
+   * `row`, `columnheader` and `cell` are only meaningful under a table, grid or
+   * treegrid; with no such ancestor the whole structure is thrown away and a
+   * screen reader reads the rows as a run of text. The host is the only element
+   * that can carry it — the header and the row group are siblings at the top of
+   * this shadow root, with nothing above them.
+   *
+   * `table` rather than `grid`: a grid promises cell-by-cell arrow-key
+   * navigation, and this surface moves a row at a time.
+   */
+  connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.hasAttribute('role')) this.setAttribute('role', 'table');
+  }
+
   private get _columns(): ColumnKey[] {
     return normalizeColumns(this.columns);
   }
@@ -311,48 +326,93 @@ export class HVDataTable extends LitElement {
     </button>`;
   }
 
+  /**
+   * The rows carry `tabindex="0"`, so the keyboard can reach them; without this
+   * there is nothing to do once they are reached, and every item on this
+   * surface is behind a mouse.
+   *
+   * Same keys and same meanings as the card's list row, so the two surfaces do
+   * not teach two vocabularies for the same four actions. Enter follows this
+   * table's own row click: in selection mode a click selects rather than opens,
+   * and the keyboard has to land on whatever the pointer lands on.
+   *
+   * A key pressed on a control inside the row belongs to that control. Without
+   * the guard Enter on Edit would open the editor and then fire the row's own
+   * open on top of it, and Delete anywhere in the action group would ask to
+   * delete the item.
+   */
+  private _onRowKeydown(e: KeyboardEvent, item: Item) {
+    if (e.target !== e.currentTarget) return;
+    switch (e.key) {
+      case 'Enter':
+        e.preventDefault();
+        this._emit(this.selectable ? 'toggle-select' : 'open-item', { itemId: item.id });
+        break;
+      case 'Delete':
+        e.preventDefault();
+        this._emit('request-delete', { itemId: item.id });
+        break;
+      case '+':
+      case '=':
+      case 'Add':
+        e.preventDefault();
+        this._emit('increment', { itemId: item.id });
+        break;
+      case '-':
+      case 'Subtract':
+        e.preventDefault();
+        this._emit('decrement', { itemId: item.id });
+        break;
+    }
+  }
+
   private _cell(item: Item, key: ColumnKey) {
     switch (key) {
       case 'quantity':
-        return html`<span class="cell qty ${isLowStock(item) ? 'low' : ''}" data-testid="cell-quantity"
+        return html`<span
+          class="cell qty ${isLowStock(item) ? 'low' : ''}"
+          role="cell"
+          data-testid="cell-quantity"
           >${item.quantity}</span
         >`;
       case 'status': {
         // The column names every row's status, "OK" included — that is what
         // makes it a column rather than a second copy of the exception chip.
         const status = itemStatus(item);
-        return html`<span class="cell" data-testid="cell-status"
+        return html`<span class="cell" role="cell" data-testid="cell-status"
           >${status === 'ok'
             ? statusLabel(status)
             : html`<span class="status-chip">${statusLabel(status)}</span>`}</span
         >`;
       }
       case 'category':
-        return html`<span class="cell" data-testid="cell-category" title=${item.category ?? ''}>${item.category || '—'}</span>`;
+        return html`<span class="cell" role="cell" data-testid="cell-category" title=${item.category ?? ''}>${item.category || '—'}</span>`;
       case 'location': {
         const parts = itemPathParts(item, this.areas);
-        return html`<span class="cell" data-testid="cell-location" title=${pathTitle(parts)}
+        return html`<span class="cell" role="cell" data-testid="cell-location" title=${pathTitle(parts)}
           >${renderAreaChip(parts.areaName)}${parts.path || '—'}</span
         >`;
       }
       case 'tags':
-        return html`<span class="tags" data-testid="cell-tags">
+        return html`<span class="tags" role="cell" data-testid="cell-tags">
           ${item.tags.length ? item.tags.map((t) => html`<span class="tag">${t}</span>`) : html`<span class="cell">—</span>`}
         </span>`;
       case 'due_date':
         return html`<span
           class="cell due ${isOverdue(item.due_date) ? 'overdue' : ''}"
+          role="cell"
           data-testid="cell-due_date"
           >${formatDate(item.due_date)}</span
         >`;
       case 'inspection_date':
         return html`<span
           class="cell inspection ${isOverdue(item.inspection_date) ? 'due' : ''}"
+          role="cell"
           data-testid="cell-inspection_date"
           >${formatDate(item.inspection_date)}</span
         >`;
       case 'updated_at':
-        return html`<span class="cell updated" data-testid="cell-updated_at">${relativeTime(item.updated_at)}</span>`;
+        return html`<span class="cell updated" role="cell" data-testid="cell-updated_at">${relativeTime(item.updated_at)}</span>`;
     }
   }
 
@@ -415,6 +475,7 @@ export class HVDataTable extends LitElement {
                   data-testid="table-row"
                   data-item-id=${item.id}
                   style="grid-template-columns: ${template}"
+                  @keydown=${(e: KeyboardEvent) => this._onRowKeydown(e, item)}
                   @click=${() =>
                     this._emit(this.selectable ? 'toggle-select' : 'open-item', { itemId: item.id })}
                 >
@@ -433,7 +494,7 @@ export class HVDataTable extends LitElement {
                         ${this.selection.has(item.id) ? icon('check', 13) : null}
                       </button>`
                     : null}
-                  <span class="name-cell">
+                  <span class="name-cell" role="cell">
                     <span class="name" data-testid="table-name" title=${item.name}>${item.name}</span>
                     ${isLowStock(item) ? html`<span class="low-badge">LOW</span>` : null}
                     ${!statusColumn && itemStatus(item) !== 'ok'
@@ -444,7 +505,7 @@ export class HVDataTable extends LitElement {
                     ${item.checked_out ? html`<span class="out-chip">Checked out</span>` : null}
                   </span>
                   ${columns.map((key) => this._cell(item, key))}
-                  <span class="actions">
+                  <span class="actions" role="cell">
                     <button
                       data-testid="table-decrement"
                       aria-label="Decrease quantity"
@@ -481,8 +542,17 @@ export class HVDataTable extends LitElement {
                 </div>
               `,
             )
-          : html`<div class="empty" role="status" data-testid="table-empty">
-              <slot name="empty">No items yet</slot>
+          : html`<div role="row">
+              <!-- The message is a cell in a row, the way an empty HTML table
+                   spans one across its width: a row group whose only child is a
+                   loose message owns something a table cannot contain, and the
+                   structure is dropped rather than repaired. The announcement
+                   belongs to whatever fills the slot — the shared empty state
+                   is a live region already, and a second one wrapped around it
+                   says everything twice. -->
+              <div class="empty" role="cell" data-testid="table-empty">
+                <slot name="empty">No items yet</slot>
+              </div>
             </div>`}
       </div>
     `;

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,6 +1,7 @@
 import './hv-full-view';
 import { NARROW_QUERY } from './hv-full-view';
 import { makeMockHass, makeItem } from '../test.utils';
+import { deepActiveElement } from '../ui/dialog-focus';
 import { Store } from '../store/store';
 import type { HVFullView } from './hv-full-view';
 import type { Item, Location } from '../store/types';
@@ -371,6 +372,29 @@ describe('hv-full-view: embedded', () => {
     expect(q(sr, '.backdrop')).toBeTruthy();
     expect(sr.querySelectorAll('.sentinel')).toHaveLength(2);
     expect(q(sr, '[data-testid="expand-toggle"]')).toBeTruthy();
+  });
+
+  // The trap's two ends came from a query rooted in this shadow root, which
+  // stops at every `hv-*` boundary below it. The rows, the sidebar tree and the
+  // editor were all past one, so "last focusable" landed in the middle of the
+  // surface and Tab walked out through everything behind it.
+  it('bounces off the end of the trap into a child component, not out of it', async () => {
+    const { el, sr } = await mount({ items: [makeItem({ id: '1' }), makeItem({ id: '2' })] });
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    const rows = [...(table.shadowRoot?.querySelectorAll('[data-testid="table-row"]') ?? [])];
+    const lastEdit = rows[rows.length - 1].querySelector('[data-testid="table-edit"]');
+
+    // Shift+Tab off the front lands on the leading sentinel, which sends focus
+    // to the last thing inside the trap.
+    (sr.querySelector('.sentinel') as HTMLElement).focus();
+    await el.updateComplete;
+
+    expect(deepActiveElement()).toBe(lastEdit);
+  });
+
+  it('opens on the first control of the surface, not on something nested in it', async () => {
+    const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+    expect(deepActiveElement()).toBe(q(sr, '[data-testid="expand-toggle"]'));
   });
 });
 
@@ -924,6 +948,26 @@ describe('hv-full-view: empty table', () => {
     const empty = q(sr, '[data-testid="empty-state"]') as HTMLElement;
     expect(empty.dataset.kind).toBe('no-items');
     expect(empty.textContent).toContain('No items yet');
+  });
+
+  it('waits for the fetch instead of blaming the filters for the gap', async () => {
+    // Changing a filter clears the rows and asks for the next page, so between
+    // the two the table has nothing to show and no answer yet. It used to fill
+    // that gap with "No items match these filters" and a Clear all button,
+    // against a filter nothing had been counted for.
+    const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Wood Glue' })] });
+    store.setFilters({ q: 'wood' });
+    await el.updateComplete;
+
+    const empty = q(sr, '[data-testid="empty-state"]') as HTMLElement;
+    expect(empty.dataset.kind).toBe('loading');
+    expect(empty.textContent).toContain('Loading items');
+    expect(q(sr, '[data-testid="empty-action"]')).toBe(null);
+
+    await settle(el);
+    await settle(el);
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    expect(table.shadowRoot?.querySelector('[data-testid="table-row"]')).toBeTruthy();
   });
 });
 

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -10,6 +10,7 @@ import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters } from '../store/store';
 import { countLocations } from '../store/location-tree';
 import { emptyKindFor, renderEmptyState } from '../ui/empty-state';
+import { deepFocusables } from '../ui/dialog-focus';
 import { areaNameById, effectiveAreaIdForLocation } from '../ui/area';
 import { renderAreaChip } from '../ui/location-path';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
@@ -898,12 +899,18 @@ export class HVFullView extends LitElement {
   };
 
   // ---------- Focus trap ----------
+  /**
+   * The trap's two sentinels bounce focus to the first and last of these, so the
+   * walk has to reach every control the shell renders — including the ones the
+   * sidebar tree, the filter panel, the editor and the table draw inside their
+   * own shadow roots, which a query rooted here cannot see.
+   *
+   * The sentinels themselves are focusable and would otherwise be their own
+   * first and last, which is a trap that only ever bounces between them.
+   */
   private _focusables(): HTMLElement[] {
-    const root = this.shadowRoot?.querySelector('.shell');
-    if (!root) return [];
-    const sel = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-    return [...root.querySelectorAll<HTMLElement>(sel)].filter(
-      (el) => !el.hasAttribute('disabled') && !el.classList.contains('sentinel'),
+    return deepFocusables(this.shadowRoot?.querySelector('.shell')).filter(
+      (el) => !el.classList.contains('sentinel'),
     );
   }
 

--- a/cards/haventory-card/src/ui/dialog-focus.test.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.test.ts
@@ -178,6 +178,26 @@ describe('deepFocusables', () => {
     expect(ids(root)).toEqual(['a', 'tabbable']);
   });
 
+  it('leaves out what the browser is not drawing', () => {
+    // The table's row actions sit in the layout at `visibility: hidden` until
+    // their row is hovered or focused, and `.focus()` on one is a silent no-op
+    // — a trap ending there leaves focus on its sentinel and never wraps.
+    // jsdom lays nothing out and implements no `checkVisibility`, so the two
+    // states have to be stood in for.
+    const root = build(`<button id="drawn"></button><button id="painted-over"></button>`);
+    const hidden = root.querySelector('#painted-over') as HTMLElement & { checkVisibility: () => boolean };
+    hidden.checkVisibility = () => false;
+    expect(ids(root)).toEqual(['drawn']);
+  });
+
+  it('takes everything when the browser cannot be asked', () => {
+    // Without a layout there is no answer to give, and treating every control
+    // as drawn is what a plain `querySelectorAll` would have said anyway.
+    const root = build(`<button id="a"></button>`);
+    expect('checkVisibility' in (root.querySelector('#a') as HTMLElement)).toBe(false);
+    expect(ids(root)).toEqual(['a']);
+  });
+
   it('survives a surface that has not rendered yet', () => {
     expect(deepFocusables(null)).toEqual([]);
     expect(deepFocusables(undefined)).toEqual([]);

--- a/cards/haventory-card/src/ui/dialog-focus.test.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.test.ts
@@ -1,4 +1,4 @@
-import { DialogFocus, deepActiveElement } from './dialog-focus';
+import { DialogFocus, deepActiveElement, deepFocusables } from './dialog-focus';
 
 function panel(): HTMLElement {
   const el = document.createElement('div');
@@ -92,5 +92,94 @@ describe('DialogFocus', () => {
     const f = new DialogFocus();
     f.sync(false, () => panel());
     expect(document.activeElement).toBe(btn);
+  });
+});
+
+describe('deepFocusables', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  /** `<button id>` per label; `host:<id>` opens a shadow root for what follows. */
+  function build(spec: string): HTMLElement {
+    const root = document.createElement('div');
+    root.innerHTML = spec;
+    document.body.appendChild(root);
+    for (const host of [...root.querySelectorAll('[data-shadow]')]) {
+      const shadow = host.attachShadow({ mode: 'open' });
+      shadow.innerHTML = host.getAttribute('data-shadow') ?? '';
+    }
+    return root;
+  }
+
+  const ids = (root: HTMLElement) => deepFocusables(root).map((el) => el.id);
+
+  it('finds the controls a flat query stops at the shadow boundary of', () => {
+    const root = build(`<button id="a"></button><div data-shadow="<button id='b'></button>"></div>`);
+    expect(root.querySelectorAll('button')).toHaveLength(1);
+    expect(ids(root)).toEqual(['a', 'b']);
+  });
+
+  it('keeps tab order, so first and last are the ends of the trap', () => {
+    const root = build(`
+      <button id="a"></button>
+      <div data-shadow="<button id='b'></button><button id='c'></button>"></div>
+      <button id="d"></button>
+    `);
+    expect(ids(root)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('nests through as many roots as it takes', () => {
+    // The sidebar tree draws its rows inside a component that the full view
+    // draws inside another one; one level of descent is not enough.
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    let node: HTMLElement = root;
+    for (let depth = 0; depth < 3; depth++) {
+      const host = document.createElement('div');
+      node.appendChild(host);
+      node = document.createElement('div');
+      host.attachShadow({ mode: 'open' }).appendChild(node);
+    }
+    node.appendChild(Object.assign(document.createElement('button'), { id: 'deep' }));
+    expect(ids(root)).toEqual(['deep']);
+  });
+
+  it('takes a host element and the content slotted into it', () => {
+    // The full view's table renders its rows itself and takes its empty state
+    // as light DOM, so a walk that stopped at either would miss half the trap.
+    const root = build(`<div data-shadow="<button id='own'></button><slot></slot>">
+      <button id="slotted"></button>
+    </div>`);
+    expect(ids(root)).toEqual(['own', 'slotted']);
+  });
+
+  it('leaves out light DOM that no slot is showing', () => {
+    // The expanded view hands its whole empty state to the table as light DOM,
+    // and the table only slots it in when it has no rows. Written but not
+    // rendered is not focusable, and a trap that ended on a Clear all button
+    // parked beside 50 rows would be pointing at nothing on screen.
+    const root = build(`<div data-shadow="<button id='own'></button>">
+      <button id="unslotted"></button>
+    </div>`);
+    expect(ids(root)).toEqual(['own']);
+  });
+
+  it('leaves out what the tab key would skip', () => {
+    const root = build(`
+      <button id="a"></button>
+      <button id="off" disabled></button>
+      <button id="untabbable" tabindex="-1"></button>
+      <span id="spanner"></span>
+      <div hidden><button id="collapsed"></button></div>
+      <div aria-hidden="true"><button id="masked"></button></div>
+      <span id="tabbable" tabindex="0"></span>
+    `);
+    expect(ids(root)).toEqual(['a', 'tabbable']);
+  });
+
+  it('survives a surface that has not rendered yet', () => {
+    expect(deepFocusables(null)).toEqual([]);
+    expect(deepFocusables(undefined)).toEqual([]);
   });
 });

--- a/cards/haventory-card/src/ui/dialog-focus.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.ts
@@ -21,6 +21,54 @@ export function deepActiveElement(): HTMLElement | null {
   return el;
 }
 
+const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Every focusable control under `root`, in tab order, descending into the shadow
+ * root of any custom element on the way.
+ *
+ * `querySelectorAll` stops at the first shadow boundary, so on a surface
+ * assembled from `hv-*` components it finds only the controls that surface
+ * renders itself. A focus trap built on that list picks a first and a last that
+ * sit somewhere in the middle of what can actually be reached, and Tab walks
+ * straight out of the trap through everything the query could not see.
+ *
+ * The walk follows the flattened tree, which is the one the tab order is taken
+ * from: a host element renders its shadow root in its place, and its light
+ * children appear only where a `<slot>` pulls them in. Walking the light
+ * children directly instead would collect content that is written but not
+ * rendered — the card passes the expanded view's whole empty state to the table
+ * as light DOM, and its buttons exist next to every row it is not showing.
+ */
+export function deepFocusables(root: ParentNode | null | undefined): HTMLElement[] {
+  const found: HTMLElement[] = [];
+
+  function take(el: HTMLElement) {
+    // A hidden subtree is not in the tab order, and `hidden` is how this card
+    // keeps a collapsed panel's controls out of it.
+    if (el.hasAttribute('hidden') || el.getAttribute('aria-hidden') === 'true') return;
+    if (el.matches(FOCUSABLE) && !el.hasAttribute('disabled') && el.getAttribute('tabindex') !== '-1') {
+      found.push(el);
+    }
+    visit(el.shadowRoot ?? el);
+  }
+
+  function visit(node: ParentNode) {
+    for (const el of Array.from(node.children) as HTMLElement[]) {
+      if (el.localName === 'slot') {
+        for (const assigned of (el as HTMLSlotElement).assignedElements({ flatten: true })) {
+          take(assigned as HTMLElement);
+        }
+      } else {
+        take(el);
+      }
+    }
+  }
+
+  if (root) visit(root);
+  return found;
+}
+
 export class DialogFocus {
   /** Where focus came from; also marks "we are currently open". */
   private _returnTo: HTMLElement | null = null;

--- a/cards/haventory-card/src/ui/dialog-focus.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.ts
@@ -24,6 +24,24 @@ export function deepActiveElement(): HTMLElement | null {
 const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 /**
+ * Whether the browser is drawing this element, and would therefore let it take
+ * focus.
+ *
+ * `visibility: hidden` is how this card holds a control in the layout without
+ * offering it — the table's row actions are hidden until their row is hovered
+ * or focused. `.focus()` on one of those is a silent no-op, so a trap that
+ * ended on it would leave focus on its sentinel and never wrap.
+ *
+ * `checkVisibility` is the browser's own answer and needs a layout to give it.
+ * jsdom performs none and does not implement the method; treating everything
+ * as drawn there is exactly what a plain `querySelectorAll` would have said.
+ */
+function isRendered(el: HTMLElement): boolean {
+  if (typeof el.checkVisibility !== 'function') return true;
+  return el.checkVisibility({ checkVisibilityCSS: true, visibilityProperty: true } as CheckVisibilityOptions);
+}
+
+/**
  * Every focusable control under `root`, in tab order, descending into the shadow
  * root of any custom element on the way.
  *
@@ -47,6 +65,7 @@ export function deepFocusables(root: ParentNode | null | undefined): HTMLElement
     // A hidden subtree is not in the tab order, and `hidden` is how this card
     // keeps a collapsed panel's controls out of it.
     if (el.hasAttribute('hidden') || el.getAttribute('aria-hidden') === 'true') return;
+    if (!isRendered(el)) return;
     if (el.matches(FOCUSABLE) && !el.hasAttribute('disabled') && el.getAttribute('tabindex') !== '-1') {
       found.push(el);
     }

--- a/cards/haventory-card/src/ui/empty-state.test.ts
+++ b/cards/haventory-card/src/ui/empty-state.test.ts
@@ -1,15 +1,34 @@
-import { emptyStateCopy } from './empty-state';
+import { emptyKindFor, emptyStateCopy } from './empty-state';
+import { defaultFilters } from '../store/store';
 import type { EmptyKind } from './empty-state';
+import type { StoreFilters } from '../store/types';
 
-const KINDS: EmptyKind[] = ['no-items', 'no-matches', 'empty-location', 'connection-lost'];
+/** The kinds that say the list has settled with nothing in it. */
+const ANSWERS: EmptyKind[] = ['no-items', 'no-matches', 'empty-location', 'connection-lost'];
+const KINDS: EmptyKind[] = ['loading', ...ANSWERS];
+
+function state(patch: { connectionLost?: boolean; loading?: boolean; filters?: Partial<StoreFilters> }) {
+  return {
+    degraded: { connectionLost: patch.connectionLost ?? false },
+    loading: patch.loading ?? false,
+    filters: { ...defaultFilters(), ...patch.filters },
+  };
+}
 
 describe('emptyStateCopy', () => {
   it('always offers a way out', () => {
     // The expanded view's table used to answer "No items match these filters."
     // with nothing to press, on the one surface where over-filtering is easiest.
-    for (const kind of KINDS) {
+    for (const kind of ANSWERS) {
       expect(emptyStateCopy(kind).offers.length, kind).toBeGreaterThan(0);
     }
+  });
+
+  it('offers nothing while the rows are still coming', () => {
+    // Every offer answers a question this one has not asked yet: clearing the
+    // filters would undo a fetch that has not reported, and "add your first
+    // item" claims a count nobody has.
+    expect(emptyStateCopy('loading').offers).toEqual([]);
   });
 
   it('keeps headlines as fragments and detail lines as sentences', () => {
@@ -31,5 +50,34 @@ describe('emptyStateCopy', () => {
 
   it('offers a restore beside the first item on an untouched inventory', () => {
     expect(emptyStateCopy('no-items').offers.map((o) => o.id)).toEqual(['add-item', 'import']);
+  });
+});
+
+describe('emptyKindFor', () => {
+  it('names the filter-derived reasons once the list has settled', () => {
+    expect(emptyKindFor(state({}))).toBe('no-items');
+    expect(emptyKindFor(state({ filters: { q: 'glue' } }))).toBe('no-matches');
+    expect(emptyKindFor(state({ filters: { locationId: 'loc-1' } }))).toBe('empty-location');
+  });
+
+  it('says the rows are on their way rather than blaming the filters', () => {
+    // Changing a filter empties the list and refills it when the answer
+    // arrives. Naming the filters during that gap accuses one of matching
+    // nothing before anything has been counted.
+    expect(emptyKindFor(state({ loading: true, filters: { q: 'glue' } }))).toBe('loading');
+    expect(emptyKindFor(state({ loading: true, filters: { locationId: 'loc-1' } }))).toBe('loading');
+    expect(emptyKindFor(state({ loading: true }))).toBe('loading');
+  });
+
+  it('still leads with the outage, which no fetch is going to survive', () => {
+    expect(emptyKindFor(state({ connectionLost: true, loading: true }))).toBe('connection-lost');
+    expect(emptyKindFor(state({ connectionLost: true, loading: true, filters: { q: 'glue' } }))).toBe(
+      'connection-lost',
+    );
+  });
+
+  it('reads a store that has not answered at all as no items', () => {
+    expect(emptyKindFor(null)).toBe('no-items');
+    expect(emptyKindFor(undefined)).toBe('no-items');
   });
 });

--- a/cards/haventory-card/src/ui/empty-state.ts
+++ b/cards/haventory-card/src/ui/empty-state.ts
@@ -4,7 +4,7 @@ import { activeFilterCount, defaultFilters } from '../store/store';
 import type { StoreFilters } from '../store/types';
 
 /**
- * The four ways a list of items can be empty, and what to say about each.
+ * The ways a list of items can have no rows, and what to say about each.
  *
  * The card's list said it properly — a headline, a line of explanation and
  * something to press ("No items match these filters" + Clear all). The expanded
@@ -21,7 +21,7 @@ import type { StoreFilters } from '../store/types';
  * stop; a detail line or a prose note is written as sentences and punctuated as
  * such.
  */
-export type EmptyKind = 'no-items' | 'no-matches' | 'empty-location' | 'connection-lost';
+export type EmptyKind = 'loading' | 'no-items' | 'no-matches' | 'empty-location' | 'connection-lost';
 
 /** An action offered from an empty list; the first is drawn as primary. */
 export interface EmptyOffer {
@@ -30,12 +30,19 @@ export interface EmptyOffer {
 }
 
 /**
- * Which of the four situations an empty list is in.
+ * Which situation a list with no rows is in.
  *
- * An outage outranks every filter-derived reason: clearing a filter would not
- * bring the rows back. A lone location filter is "nothing filed here" rather
- * than "nothing matched", because the location is the thing the user chose and
- * the offer differs.
+ * An outage outranks everything else: clearing a filter would not bring the
+ * rows back, and a request that cannot be sent is not in flight.
+ *
+ * An in-flight fetch outranks both filter-derived reasons, because changing a
+ * filter empties the list on purpose and refills it when the answer arrives —
+ * naming the filters as the reason during that gap accuses a filter of
+ * matching nothing before anything has been counted.
+ *
+ * A lone location filter is "nothing filed here" rather than "nothing
+ * matched", because the location is the thing the user chose and the offer
+ * differs.
  *
  * Lives here rather than on the components so the card's list and the expanded
  * view's table cannot answer the same situation two different ways.
@@ -43,8 +50,10 @@ export interface EmptyOffer {
 export function emptyKindFor(state: {
   degraded: { connectionLost: boolean };
   filters: StoreFilters;
+  loading: boolean;
 } | null | undefined): EmptyKind {
   if (state?.degraded.connectionLost) return 'connection-lost';
+  if (state?.loading) return 'loading';
   const filters = state?.filters ?? defaultFilters();
   if (filters.locationId && activeFilterCount(filters) === 1) return 'empty-location';
   if (activeFilterCount(filters) > 0) return 'no-matches';
@@ -59,6 +68,11 @@ export interface EmptyStateCopy {
 
 export function emptyStateCopy(kind: EmptyKind, locationName?: string | null): EmptyStateCopy {
   switch (kind) {
+    // The one kind with nothing to offer: the rows are on their way, and every
+    // action the other kinds offer would be an answer to a question that has
+    // not been asked yet.
+    case 'loading':
+      return { headline: 'Loading items', offers: [] };
     case 'connection-lost':
       return {
         headline: "Can't reach Home Assistant",
@@ -103,17 +117,19 @@ export function renderEmptyState(
   return html`<div class="empty" role="status" data-testid="empty-state" data-kind=${kind}>
     <span class="headline">${copy.headline}</span>
     ${copy.detail ? html`<span>${copy.detail}</span>` : null}
-    <div class="offers">
-      ${copy.offers.map(
-        (offer, i) => html`<button
-          class=${i === 0 ? 'hv-pill' : 'hv-pill outline'}
-          data-testid="empty-action"
-          data-id=${offer.id}
-          @click=${() => opts.onAction(offer.id)}
-        >
-          ${offer.label}
-        </button>`,
-      )}
-    </div>
+    ${copy.offers.length
+      ? html`<div class="offers">
+          ${copy.offers.map(
+            (offer, i) => html`<button
+              class=${i === 0 ? 'hv-pill' : 'hv-pill outline'}
+              data-testid="empty-action"
+              data-id=${offer.id}
+              @click=${() => opts.onAction(offer.id)}
+            >
+              ${offer.label}
+            </button>`,
+          )}
+        </div>`
+      : null}
   </div>`;
 }


### PR DESCRIPTION
Closes #223.

The expanded view's table is the surface that lists every item, and it was the one place below the accessibility bar the rest of the card holds. Four fixes, none of them touching `static styles` — #243 rewrites the pill CSS in these same two files next.

## Keyboard access to a row

Rows were `tabindex="0"` with a click handler and nothing else, so a keyboard could reach a row and then do nothing with it. They now answer the same four keys `hv-list-row` does — Enter, Delete, `+`, `-`, numpad and shifted spellings included — with two decisions worth stating:

- **Enter follows this table's own row click**, so in selection mode it selects rather than opens. `hv-list-row`'s Enter opens unconditionally, but this table's click already branches on `selectable`, and the keyboard has to land where the pointer lands.
- **A key pressed on a control inside the row stays that control's.** Without the guard, Enter on Edit would open the editor and then fire the row's own open on top of it, and Delete anywhere in the action group would ask to delete the item.

## Table semantics

`row`, `columnheader` and `cell` are only meaningful under a table, grid or treegrid, and there was no ancestor carrying one — so the whole structure was dropped and the rows read as a run of text. The host now carries `role="table"`; not `grid`, which would promise cell-by-cell arrow-key navigation this surface does not have. The values in a row are marked as cells.

The empty message moves into a row and a cell of its own, the way an empty HTML table spans one across its width: a row group whose only child is a loose message owns something a table cannot contain, and the structure is dropped rather than repaired. It also stops being a live region, because the shared empty state already is one and the two nested said everything twice.

## Focus trap

The trap's two ends came from a query rooted in the full view's own shadow root, which stops at every `hv-*` boundary below it. The rows, the sidebar tree and the editor are all past one, so "last focusable" landed in the middle of the surface and Tab walked out through everything behind it.

`deepFocusables` walks the flattened tree instead — the one the tab order is taken from — following slots rather than light children, so content that is written but not rendered stays out. The card hands the expanded view's whole empty state to the table as light DOM, and its buttons sit there beside every row the table is not showing.

**What the browser found and jsdom could not:** walking into the child shadow roots reaches the table's row action buttons, which sit in the layout at `visibility: hidden` until their row is hovered or focused. `.focus()` on one of those is a silent no-op, so Shift+Tab off the front of the trap left focus parked on the sentinel — a regression on the flat query, whose last hit was always something drawn. The walk now asks `checkVisibility` before taking an element; jsdom lays nothing out and implements no such method, and treating everything as drawn there is what a plain `querySelectorAll` would have said anyway. Second commit, with its own test.

## The gap between a filter change and its answer

`emptyKindFor` had no loading arm, so that gap was filled with "No items match these filters" and a Clear all button, against a filter nothing had been counted for. Loading now outranks both filter-derived kinds and offers nothing — every offer answers a question that has not been asked yet. The outage still outranks loading, since a request that cannot be sent is not in flight. The decision stayed in `ui/empty-state.ts`, which exists so the card's list and the expanded view's table cannot answer the same situation two different ways.

## Verification

Backend gate green (537 passed, ruff/format/mypy clean). Frontend gate green: eslint, tsc, 1085 tests, build.

Against a local Docker Home Assistant, because the focus-trap fix needs a real browser:

- Chromium's own accessibility tree reports **1 table, 101 rows, 450 cells, 10 column headers** where it previously built none.
- Shift+Tab off the front of the trap wraps to the last table row — inside `hv-data-table`'s shadow root — and Tab from there reveals that row's actions and reaches its decrement button.
- `+` / `-` / Enter / Delete drive a real row against the real handlers; Delete asks before deleting.
- A filter change is observed passing through `no-items → loading → no-matches`.
- `visual_pass.mjs` captured 42/42 surfaces; `log_sweep.py` reports 0 blocking findings.

## Follow-ups, not fixed here

- `hv-list-row`'s Enter emits `open-item` even in selection mode, where its own click toggles selection.
- On both surfaces `+` on a checked-out row increments through the keyboard although the button is disabled. The guard belongs in the hosts' `_onRowEvent`, not duplicated in two row components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
