### PR TITLE
chore(card): drop the unused @lit-labs/virtualizer dependency

### DIFF
--- a/cards/haventory-card/package-lock.json
+++ b/cards/haventory-card/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "haventory-card",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haventory-card",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lit-labs/virtualizer": "^2.1.1",
         "lit": "^3.1.0"
       },
       "devDependencies": {
@@ -409,14 +408,6 @@
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@lit-labs/virtualizer": {
-      "version": "2.1.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "lit": "^3.2.0",
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
@@ -2574,7 +2565,9 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/cards/haventory-card/package.json
+++ b/cards/haventory-card/package.json
@@ -31,7 +31,6 @@
     "test:e2e": "node e2e/live-updates.smoke.mjs"
   },
   "dependencies": {
-    "@lit-labs/virtualizer": "^2.1.1",
     "lit": "^3.1.0"
   },
   "devDependencies": {

--- a/cards/haventory-card/src/test.setup.ts
+++ b/cards/haventory-card/src/test.setup.ts
@@ -1,7 +1,8 @@
 import { afterAll } from 'vitest';
 
-// Minimal polyfills for jsdom environment used in Vitest
-// Virtualizer depends on ResizeObserver
+// Minimal polyfills for jsdom environment used in Vitest.
+// `ui/responsive.ts` observes the card element's own width, so jsdom needs a
+// ResizeObserver it does not ship.
 class RO {
   observe() {}
   unobserve() {}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -476,6 +476,6 @@ track `prefers-color-scheme`.
 ## Known gaps
 
 - Drag-and-drop of items onto sidebar tree nodes (optional in the handoff) is not built.
-- `@lit-labs/virtualizer` is still a dependency but unused; large lists rely on paging.
+- Large lists rely on paging; no row virtualization.
 - The backend cannot sort by category, location or tags, filter by due date, or bulk-create
   items — the UI is shaped around those limits rather than hiding them.


### PR DESCRIPTION
Closes the first bullet of #231 item 3.

`@lit-labs/virtualizer` was declared in the card's `dependencies` at `^2.1.1`
and imported nowhere — no `.ts`, `.js` or `.mjs` file outside `node_modules`
referenced it. The card's large lists page rather than virtualize.

#231 frames this as a choice: adopt it for #191's virtual-scroll bullet, or
drop it. Shipping an unused runtime dependency while that decision waits has
nothing to recommend it, and adding it back is one line if #191 later wants
row virtualization.

## The bundle is unaffected

An unimported dependency was already tree-shaken out, so this is **not** a
bundle-size win. Verified by building before and after:

| | bytes | gzip | SHA-256 |
|---|---|---|---|
| before | 459,351 | 105.28 kB | `d4cbff10…c826b4a` |
| after | 459,351 | 105.28 kB | `d4cbff10…c826b4a` |

Byte-identical. The win is install size and supply-chain surface: one fewer
package in `node_modules` (148 → 147) and one fewer entry in the lockfile.

## Two dangling references, corrected

Removing the dependency would have left two references pointing at something
no longer declared:

- `cards/haventory-card/src/test.setup.ts` attributed its `ResizeObserver`
  polyfill to the virtualizer. The real consumer is `src/ui/responsive.ts`,
  which observes the card element's own width — so the polyfill stays and the
  comment now names what actually needs it.
- `docs/frontend_architecture.md` listed "`@lit-labs/virtualizer` is still a
  dependency but unused" under Known gaps. It now states the gap itself — no
  row virtualization — rather than naming a dependency that is gone.

## Gate

Frontend gate and build, all green in a clean worktree install:

- `npm audit --audit-level=high` — passes (1 moderate, pre-existing and unrelated)
- `npx eslint .` — clean
- `npm run typecheck` — clean
- `npx vitest run` — 1085 passed across 50 files
- `npm run build` — succeeds, output byte-identical as above

Backend untouched; no files removed from `custom_components/haventory/`, so
`RETIRED_PATHS` needs no entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
