### PR TITLE
refactor: test the Lovelace resource outcome, not the load mechanism

### DIFF
--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -471,7 +471,14 @@ async def _async_lovelace_resources(hass: HomeAssistant, *, op: str) -> Any:
         )
         return None
 
-    if hasattr(resources, "loaded") and not resources.loaded:
+    # The collection's create/update/delete each load storage on demand, but
+    # `async_items` cannot — it is a sync callback over an in-memory dict, so an
+    # unloaded collection reports no resources at all. Both callers read it
+    # first: register would add a second entry for a card already registered,
+    # unregister would leave ours behind. Setting the flag is part of the
+    # contract rather than bookkeeping — `async_load` leaves it False, and the
+    # collection's next write would then load and re-add every item again.
+    if not getattr(resources, "loaded", True):
         await resources.async_load()
         resources.loaded = True
 

--- a/docs/card_shipping_plan.md
+++ b/docs/card_shipping_plan.md
@@ -136,9 +136,14 @@ option, and nothing in the dogfood plan installs via HACS-from-branch (the dev l
 | R15 | Stray release asset named `haventory-card.js` would bind HACS's download counter | `filename` names the zip, which `zip_release` makes the installed asset | hacs.json diff |
 | R16 | HA's frontend installs its own `CustomElementRegistry` during boot; a definition made before the swap stays in the registry HA replaced, where the dashboard never looks — the card renders as "custom element doesn't exist" | `defineCardElement()` re-asserts the definition on the first observed registry change, within a 15 s window | 5 cold loads per engine, before/after, on a real HACS install of the release asset |
 
-Out-of-scope follow-up (record in `docs/open-items.md` when implementing): the manual
-`resources.async_load()` in `_async_lovelace_resources` is redundant at the 2026.6.0
-floor (collection methods self-ensure-loaded) and can be dropped in a later cleanup.
+Out-of-scope follow-up, since resolved and **rejected**: the manual `resources.async_load()`
+in `_async_lovelace_resources` looked redundant at the 2026.6.0 floor, on the reading that
+the collection methods all self-ensure-loaded. They do not. `ResourceStorageCollection`
+overrides `async_create_item` / `async_update_item` / `async_delete_item` with an
+ensure-loaded, but not `async_items` — that one is `ObservableCollection.async_items`, a
+*sync* callback over an in-memory dict, so it cannot await a load and reports nothing until
+something else has loaded the collection. Lovelace's `async_setup` never does, and both of
+our callers read `async_items` before writing. The load stays; see the comment on it.
 
 ## Touchpoint inventory
 

--- a/tests/test_entry_removal_offline.py
+++ b/tests/test_entry_removal_offline.py
@@ -36,24 +36,26 @@ def current_card_url() -> str:
 class MockResourceCollection:
     """Storage-mode Lovelace resource collection.
 
-    Mirrors the real collection in the one respect the caller has to get right:
-    an unloaded collection reports no items at all.
+    Mirrors the real collection where the caller has to get it right: `stored` is
+    the backing store, `async_items` sees only what a load has pulled into
+    memory, and `async_delete_item` pulls it in itself.
     """
 
     def __init__(self, items: list[dict[str, Any]] | None = None, *, loaded: bool = True) -> None:
         self.loaded = loaded
-        self._stored: list[dict[str, Any]] = list(items or [])
+        self.stored: list[dict[str, Any]] = list(items or [])
         self.deleted: list[str] = []
 
     def async_items(self) -> list[dict[str, Any]]:
-        return self._stored if self.loaded else []
+        return self.stored if self.loaded else []
 
     async def async_load(self) -> None:
         self.loaded = True
 
     async def async_delete_item(self, item_id: str) -> None:
+        self.loaded = True
         self.deleted.append(item_id)
-        self._stored = [item for item in self._stored if item.get("id") != item_id]
+        self.stored = [item for item in self.stored if item.get("id") != item_id]
 
 
 class MockYamlResourceCollection:
@@ -61,10 +63,10 @@ class MockYamlResourceCollection:
 
     def __init__(self, items: list[dict[str, Any]] | None = None) -> None:
         self.loaded = True
-        self._stored: list[dict[str, Any]] = list(items or [])
+        self.stored: list[dict[str, Any]] = list(items or [])
 
     def async_items(self) -> list[dict[str, Any]]:
-        return self._stored
+        return self.stored
 
     async def async_load(self) -> None:
         pass
@@ -192,8 +194,13 @@ async def test_remove_entry_in_yaml_mode_does_not_raise(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_remove_entry_loads_resources_before_deleting(monkeypatch) -> None:
-    """An unloaded collection reports no items until it is loaded."""
+async def test_remove_entry_deletes_from_an_unloaded_collection(monkeypatch) -> None:
+    """Our resource goes even when nothing has read the collection yet.
+
+    Nothing loads it at Lovelace setup, so this is the state a removal meets on a
+    Home Assistant that has served no dashboard — and an unloaded collection
+    reports no items, which would silently leave the entry behind.
+    """
 
     hav_init = _import_with_lovelace(monkeypatch)
     resources = MockResourceCollection([{"id": "haventory", "url": CARD_URL}], loaded=False)
@@ -201,8 +208,7 @@ async def test_remove_entry_loads_resources_before_deleting(monkeypatch) -> None
 
     await hav_init.async_remove_entry(hass, ConfigEntry())
 
-    assert resources.loaded is True
-    assert resources.deleted == ["haventory"]
+    assert resources.stored == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -68,28 +68,35 @@ def import_haventory(monkeypatch, lovelace_key: str):
 
 
 class MockResourceCollection:
-    """Mock Lovelace resource collection in storage mode (create/update/delete)."""
+    """Mock Lovelace resource collection in storage mode (create/update/delete).
 
-    def __init__(self, items: list[dict[str, Any]] | None = None):
-        self.loaded = True
+    Mirrors where the real collection loads storage and where it does not:
+    `async_items` reports nothing until something loads it, while each mutation
+    method loads first — so a caller that reads before writing has to say so.
+    """
+
+    def __init__(self, items: list[dict[str, Any]] | None = None, *, loaded: bool = True):
+        self.loaded = loaded
         self._items: list[dict[str, Any]] = list(items or [])
         self.created: list[dict[str, Any]] = []
         self.updated: list[tuple[str, dict[str, Any]]] = []
         self.deleted: list[str] = []
 
     def async_items(self) -> list[dict[str, Any]]:
-        return self._items
+        return self._items if self.loaded else []
 
     async def async_load(self):
         self.loaded = True
 
     async def async_create_item(self, data: dict[str, Any]) -> dict[str, Any]:
+        self.loaded = True
         self.created.append(data)
         item = {"id": f"created_{len(self.created)}", **data}
         self._items.append(item)
         return item
 
     async def async_update_item(self, item_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        self.loaded = True
         for item in self._items:
             if item.get("id") == item_id:
                 item.update(updates)
@@ -98,6 +105,7 @@ class MockResourceCollection:
         raise KeyError(item_id)
 
     async def async_delete_item(self, item_id: str) -> None:
+        self.loaded = True
         self.deleted.append(item_id)
         self._items = [item for item in self._items if item.get("id") != item_id]
 
@@ -553,6 +561,28 @@ async def test_collapses_duplicate_card_resources(monkeypatch, tmp_path):
     assert resources.created == []
     assert resources.deleted == ["legacy"]
     assert [i["url"] for i in resources.async_items()] == [expected]
+
+
+@pytest.mark.asyncio
+async def test_finds_the_existing_entry_in_an_unloaded_collection(hav_init):
+    """Registering against a collection nobody has read yet must not add a second entry.
+
+    Nothing loads the resource collection at Lovelace setup, so this is the state
+    setup meets on a Home Assistant that has served no dashboard. An unloaded
+    collection reports no items, and creating on the strength of that would leave
+    two resources for one module — the second `customElements.define` throws.
+    """
+    hass = make_hass()
+    current_url = f"{CARD_PATH}?v={manifest_version()}"
+    resources = MockResourceCollection(
+        [{"id": "existing", "url": current_url, "type": "module"}], loaded=False
+    )
+    hass.data["lovelace_data_key"] = MockLovelaceData(resources)
+
+    await hav_init._register_frontend_module(hass)
+
+    assert resources.created == []
+    assert [i["url"] for i in resources.async_items()] == [current_url]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #207 — by settling it the other way, plus the cleanup around it that does hold up.

## The premise did not survive checking

#207 asks to drop the manual `resources.async_load()` in `_async_lovelace_resources`, on the
reading that `ResourceStorageCollection`'s `async_items` / `async_create_item` /
`async_update_item` / `async_delete_item` each ensure the collection is loaded first.

Three of those four do. **`async_items` does not.** It is not overridden by
`ResourceStorageCollection` at all — it is `ObservableCollection.async_items`:

```python
@callback
def async_items(self) -> list[_ItemT]:
    """Return list of items in collection."""
    return list(self.data.values())
```

Being a *sync* callback, it structurally cannot await a load, so it reports nothing until
something else has loaded the collection. And nothing does at startup: `lovelace.async_setup`
constructs `ResourceStorageCollection` (`loaded = False`) and never loads it — the load is
lazy, driven by the first mutation or the first `lovelace/resources` list from a browser.

Both of our callers read `async_items()` **before** they write.

## So dropping it is a regression, not a cleanup

On a Home Assistant that has served no dashboard yet — i.e. normal startup ordering:

- **Register**: `async_items()` → `[]` → we conclude nothing of ours is registered →
  `async_create_item` (which self-loads, pulling the existing entry into memory) → a
  **second resource for the same module**. The card is fetched twice and the second
  `customElements.define` throws. That is the exact failure `_points_at_card`'s docstring
  exists to prevent.
- **Unregister / remove entry**: `async_items()` → `[]` → nothing matches → our resource is
  orphaned in the user's config after uninstall.

Demonstrated, not argued: with the block removed, both new tests fail, the register one with
`assert [{'res_type': 'module', 'url': '/haventory_static/haventory-card.js?v=0.3.0'}] == []`.

Verified against the declared **2026.6.0** floor (`raw.githubusercontent.com`, tag `2026.6.0`)
and a live **2026.7.4** container. The sync-callback argument is version-independent.

## What this PR does instead

- **Answers the `hasattr` question in the issue**: that guard *is* redundant, and it goes.
  `ResourceStorageCollection.loaded` is `False` and `ResourceYAMLCollection.loaded` is `True`,
  both class attributes; `tests/conftest.py` has no Lovelace stub at all, and every mock in
  the test files defines `.loaded`. Folded into `getattr(resources, "loaded", True)`, which
  keeps the same tolerance for an unknown collection in one check instead of two.
- **Keeps the `resources.loaded = True` write, and explains it.** It is not bookkeeping:
  `StorageCollection.async_load()` does not set the flag — only HA's private
  `_async_ensure_loaded` does — so skipping it makes the collection's next write load again
  and re-add every item to `self.data`, re-firing `CHANGE_ADDED` for each.
- **Retargets the test the issue named.** `test_remove_entry_loads_resources_before_deleting`
  asserted the mechanism (`resources.loaded is True`); it now asserts the outcome — the
  resource is gone from the backing store — under a name that says so.
- **Adds the register-side case, which had no coverage at all.** Every existing mock was
  constructed `loaded=True`, so the duplicate-resource path was never exercised.
- **Both mocks now mirror the real collection**: blind on read until loaded, self-loading on
  mutation. Either test fails if the ensure-load goes.
- **Corrects the note in `docs/card_shipping_plan.md`** that was #207's stated source, so the
  disproved claim stops circulating.

## Testing

Backend gate, all green:

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q     538 passed, 22 skipped
uv run ruff check .                                   All checks passed!
uv run ruff format --check .                          106 files already formatted
uv run mypy                                           Success: no issues found in 14 source files
```

Frontend untouched.

## Note for the maintainer

`docs/open-items.md` item 56 still carries the original framing. Left alone deliberately —
concurrent branches are editing that file — so it needs retiring separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
