### PR TITLE
fix(config): declare single_config_entry in the manifest

### DIFF
--- a/custom_components/haventory/manifest.json
+++ b/custom_components/haventory/manifest.json
@@ -16,5 +16,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/chrreiter/HAventory/issues",
   "requirements": [],
+  "single_config_entry": true,
   "version": "0.3.0"
 }

--- a/docs/release_testing_plan.md
+++ b/docs/release_testing_plan.md
@@ -123,7 +123,7 @@ client + OS version, date. Put it in the results log.
 | A1 | Fresh install on a clean HA (ENV-B): HACS/manual copy → restart → add integration via config flow → add card via the UI card picker | Integration sets up without error; card appears in the picker; empty state renders with no locations and no console error | ✅ |
 | A2 | Card resource auto-registration (storage-mode Lovelace) | `/haventory_static/haventory-card.js?v=<version>` present exactly once in `.storage/lovelace_resources`; `curl -I` on it returns 200 with **no** `Cache-Control` header; card loads without a manual step | ✅ |
 | A3 | YAML-mode Lovelace (ENV-B, `lovelace: mode: yaml`) | Resource registration is skipped with a clear log line, and the card still loads — the frontend extra-module URL covers YAML mode, so there is no manual step here either | ✅ |
-| A4 | Attempt a second config entry | Rejected as single-instance; no duplicate storage or resource | |
+| A4 | Attempt a second config entry | HAventory is absent from the "Add integration" picker while an entry exists, so the attempt cannot start; a flow initiated outside the picker aborts with "Already configured. Only a single configuration is possible." No duplicate storage or resource | |
 | A5 | First-run with a pre-existing store (upgrade-in-place from a dev instance) | Existing items/locations load; `health` healthy | ✅ |
 
 ### B — Mobile / touch (companion app)

--- a/tests/test_config_flow_offline.py
+++ b/tests/test_config_flow_offline.py
@@ -1,7 +1,7 @@
 """Offline tests for HAventory config flow.
 
 Scenarios:
-- Single-instance guard aborts with reason
+- Single-instance guard aborts with reason, and the manifest declares the same rule
 - async_step_user happy path creates entry
 - The card title is asked for at setup, normalized, and seeded into the options
 - Import path: create entry if no existing (if supported)
@@ -56,6 +56,21 @@ async def test_single_instance_guard_aborts(monkeypatch) -> None:
     result = await flow.async_step_user(user_input=None)
     assert result["type"] == "abort"
     assert result["reason"] == "single_instance_allowed"
+
+
+def test_manifest_declares_single_config_entry() -> None:
+    """The manifest must declare the same single-instance rule the flow enforces.
+
+    `single_config_entry` is what removes HAventory from the "Add integration"
+    picker once an entry exists, so the second attempt never starts. The in-flow
+    guard above still covers the paths that bypass the picker, and the two must
+    agree: dropping the manifest key would silently put the entry back in the
+    picker only to abort on its first step.
+    """
+
+    root = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest.get("single_config_entry") is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #233.

## What

`custom_components/haventory/manifest.json` now declares `"single_config_entry": true`.

The config flow has always refused a second entry in code
([config_flow.py:191-192](custom_components/haventory/config_flow.py#L191-L192),
`async_abort(reason="single_instance_allowed")`), but the manifest never said so.
The key is HA's declarative form of the same rule and moves enforcement earlier: HA
drops HAventory from the **Add integration** picker once an entry exists, so a second
attempt never starts rather than starting and aborting on its first step.

Correctness is unchanged — this only changes *where* the user meets the rule — so it is
a `fix`, not a feature, and keeps the release a patch.

## The in-flow guard stays

It covers the routes that do not go through the picker, and `tests/test_config_flow_offline.py`
asserts it. A manifest key on its own is also a rule with nothing in this repository
asserting it, so a new test pins the two together; it fails if the key is dropped
(verified by removing it and watching the test go red).

## No `config.abort` string is owed

`strings.json` has no `config.abort` block at all. Checked against Home Assistant
2026.6.0 — the declared floor in `hacs.json` — rather than assumed:

- HA raises this abort itself, in `ConfigEntriesFlowManager.async_init`, with
  `translation_domain=HOMEASSISTANT_DOMAIN` on the result
  ([`config_entries.py`](https://github.com/home-assistant/core/blob/2026.6.0/homeassistant/config_entries.py#L1487-L1504)).
- The frontend localizes `component.${translation_domain || handler}.config.abort.${reason}`
  (`step-flow-abort` → `renderAbortDescription`), so that resolves to
  `component.homeassistant.config.abort.single_instance_allowed`, which core ships as
  **"Already configured. Only a single configuration is possible."** — never to
  `component.haventory.*`.
- The in-flow guard's own abort *would* resolve under `component.haventory.*`, but with
  the manifest key in place it is unreachable whenever it could fire: HA's pre-flight
  aborts before the flow object is constructed for every source except `ignore`,
  `reauth` and `reconfigure`, and HAventory implements neither `async_step_reauth` nor
  `async_step_reconfigure` (its only steps are `async_step_user` and the options flow's
  `async_step_init`).

So a local string would be dead weight in every path. The guard remains as
defence-in-depth, not as something a user reads.

## Also

`docs/release_testing_plan.md` A4 said "Rejected as single-instance", which no longer
describes what a tester sees — the entry point is now absent from the picker rather than
present-and-rejecting. Updated so nobody files a bug when they cannot find it.

## Testing

Backend gate green: `pytest -q` 538 passed / 22 skipped, `ruff check`, `ruff format --check`,
`mypy` all clean. hassfest runs in CI and validates the key — its schema carries
`vol.Optional("single_config_entry"): bool` in the shared `INTEGRATION_MANIFEST_SCHEMA`
that `CUSTOM_INTEGRATION_MANIFEST_SCHEMA` extends, so custom integrations may declare it.

Frontend untouched, so the frontend gate was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
