### PR TITLE
chore: public-release polish — templates, community files, strings sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,8 +21,8 @@ body:
     id: haventory_version
     attributes:
       label: HAventory version
-      description: The integration version (HACS, or `manifest.json`), e.g. 0.0.1.
-      placeholder: "0.0.1"
+      description: The version HACS lists for HAventory, or the `version` field in `manifest.json`.
+      placeholder: "e.g. 1.2.3"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: 💬 Questions & discussions
     url: https://github.com/chrreiter/HAventory/discussions
-    about: Ask questions, share setups, or float ideas here (enable Discussions in repo settings).
+    about: Ask questions, share setups, or float ideas here.
   - name: 📖 Documentation
     url: https://github.com/chrreiter/HAventory#readme
     about: Installation, developer, and WebSocket API docs.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,10 @@ repos:
         args:
           # "batery" is deliberate: it is the typo'd tag the organize dialog's
           # merge suggestion is tested against. "afterall" is vitest's teardown
-          # hook `afterAll`, which the tracker names.
-          - --ignore-words-list=hass,batery,afterall
+          # hook `afterAll`, which the tracker names. "socio-economic" is the
+          # Contributor Covenant's spelling, and CODE_OF_CONDUCT.md quotes that
+          # document verbatim so it stays checkable against the original.
+          - --ignore-words-list=hass,batery,afterall,socio-economic
         exclude: |
           (?x)^(
             custom_components/haventory/www/|

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,142 @@
+# Contributor Covenant Code of Conduct
+
+> HAventory has a single maintainer, so wherever the text below says "community leaders",
+> read "the maintainer". The standard wording is kept intact rather than reworded, because
+> it is the version people already know and can check against the original.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+For this project, "community spaces" means the issue tracker, pull requests, and
+[Discussions](https://github.com/chrreiter/HAventory/discussions).
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer, [@chrreiter](https://github.com/chrreiter).
+
+There is no separate conduct inbox for this project. If the matter can be public,
+open an [issue](https://github.com/chrreiter/HAventory/issues) or raise it in the
+thread where it happened. If it should not be public, GitHub's
+[report abuse](https://github.com/contact/report-abuse) form reaches GitHub
+Support, who can act on account-level conduct and pass a report on.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 Thanks for your interest in HAventory! This project is a Home Assistant custom
 integration (domain `haventory`) plus a Lit + TypeScript Lovelace card.
 Contributions of all kinds are welcome — bug reports, features, docs, and code.
+Taking part means following the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Ways to contribute
 
@@ -13,6 +14,9 @@ Contributions of all kinds are welcome — bug reports, features, docs, and code
   [Discussions](https://github.com/chrreiter/HAventory/discussions) or the
   [Home Assistant community](https://community.home-assistant.io/).
 - **Send a pull request** (see below).
+
+Found a security problem? Do not open an issue — [SECURITY.md](SECURITY.md) has the
+private reporting route and says what to expect from a one-maintainer project.
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -704,6 +704,8 @@ persistence-across-restart. Exit codes: `0` pass, `1` failures, `2` setup error.
 Contributions are welcome! See **[CONTRIBUTING.md](CONTRIBUTING.md)**. File bugs and feature
 requests through the [issue tracker](https://github.com/chrreiter/HAventory/issues/new/choose),
 and ask questions in [Discussions](https://github.com/chrreiter/HAventory/discussions).
+Taking part means following the [Code of Conduct](CODE_OF_CONDUCT.md). Security problems go
+through [private reporting](SECURITY.md), never a public issue.
 
 ## Conventions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security policy
+
+HAventory is a Home Assistant custom integration maintained by one person in their spare
+time. This policy describes what that actually means rather than promising a response
+window nobody is on call to meet.
+
+## Supported versions
+
+Only the most recent release. Fixes ship as a new release; there are no backports to older
+tags and there is no long-term-support line. The minimum supported Home Assistant version
+is declared in `hacs.json`, and HACS enforces it at install time.
+
+## Reporting a vulnerability
+
+Report privately — **please do not open a public issue** for a security problem.
+
+Use GitHub's private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/chrreiter/HAventory/security/advisories/new).
+It is enabled on this repository, and the report stays visible only to you and the
+maintainer until an advisory is published.
+
+Useful things to include: the HAventory and Home Assistant versions, whether the problem is
+in the integration or the card, what an attacker gains, and the shortest reproduction you
+have. A proof of concept is welcome but not required.
+
+## What to expect
+
+- **Acknowledgement** — best effort, usually within a week. A holiday or a busy stretch can
+  make it longer; there is no SLA behind this and it would be dishonest to write one.
+- **A fix** — timing follows severity and how much of the integration has to move. Anything
+  that lets an unauthenticated caller read or change inventory data is treated as urgent.
+- **Credit** — in the advisory and the changelog, unless you would rather not be named.
+- **Disclosure** — coordinated. Once a fixed release exists, the report is published as a
+  GitHub Security Advisory. If a report goes unanswered for 90 days, publish it; a silent
+  maintainer is not a reason for a problem to stay hidden.
+
+## Scope
+
+**In scope:** the integration in `custom_components/haventory/` and the Lovelace card in
+`cards/haventory-card/`, as shipped in a release.
+
+**Out of scope**, because they are somebody else's to fix — report them upstream, though do
+say so if HAventory's particular use of them is what makes the problem reachable:
+
+- Home Assistant itself, HACS, and third-party dependencies.
+- A Home Assistant instance exposed to the internet without authentication in front of it.
+- The security of the machine Home Assistant runs on.
+
+## What HAventory's design already assumes
+
+Two properties shape what does and does not count as a vulnerability here:
+
+- **HAventory has no authentication of its own.** Every WebSocket command, service call and
+  the sidebar panel rides Home Assistant's session, so a caller is already an authenticated
+  Home Assistant user. HAventory does not distinguish further — there are no per-user
+  permissions and no admin-only commands. "An authenticated Home Assistant user can edit the
+  inventory" is therefore the design, not a finding. An *unauthenticated* caller reaching
+  data or mutating state is very much a finding, as is anything that uses HAventory to step
+  outside Home Assistant's own boundaries.
+- **Everything stays local.** Inventory data is persisted through Home Assistant's `Store`
+  into its `.storage` directory, inheriting that directory's permissions and backup
+  handling. HAventory contacts no external service and sends no telemetry, so there is no
+  server-side component to attack and nothing leaves the instance unless the user exports it.

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -61,5 +61,51 @@
         }
       }
     }
+  },
+  "services": {
+    "item_create": {
+      "name": "Create item",
+      "description": "Create a new inventory item."
+    },
+    "item_update": {
+      "name": "Update item",
+      "description": "Update an existing inventory item."
+    },
+    "item_delete": {
+      "name": "Delete item",
+      "description": "Delete an inventory item."
+    },
+    "item_move": {
+      "name": "Move item",
+      "description": "Move an item to a new location (or root)."
+    },
+    "item_adjust_quantity": {
+      "name": "Adjust quantity",
+      "description": "Add or subtract from item quantity."
+    },
+    "item_set_quantity": {
+      "name": "Set quantity",
+      "description": "Set item quantity exactly."
+    },
+    "item_check_out": {
+      "name": "Check out item",
+      "description": "Mark an item as checked out with due date."
+    },
+    "item_check_in": {
+      "name": "Check in item",
+      "description": "Mark an item as not checked out."
+    },
+    "location_create": {
+      "name": "Create location",
+      "description": "Create a new storage location."
+    },
+    "location_update": {
+      "name": "Update location",
+      "description": "Update an existing storage location."
+    },
+    "location_delete": {
+      "name": "Delete location",
+      "description": "Delete a storage location."
+    }
   }
 }

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -75,6 +75,26 @@
       "name": "Delete item",
       "description": "Delete an inventory item."
     },
+    "item_move": {
+      "name": "Move item",
+      "description": "Move an item to a new location (or root)."
+    },
+    "item_adjust_quantity": {
+      "name": "Adjust quantity",
+      "description": "Add or subtract from item quantity."
+    },
+    "item_set_quantity": {
+      "name": "Set quantity",
+      "description": "Set item quantity exactly."
+    },
+    "item_check_out": {
+      "name": "Check out item",
+      "description": "Mark an item as checked out with due date."
+    },
+    "item_check_in": {
+      "name": "Check in item",
+      "description": "Mark an item as not checked out."
+    },
     "location_create": {
       "name": "Create location",
       "description": "Create a new storage location."

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,6 @@
   "name": "HAventory",
   "render_readme": true,
   "content_in_root": false,
-  "country": ["all"],
   "homeassistant": "2026.6.0",
   "zip_release": true,
   "filename": "haventory.zip",

--- a/tests/test_config_flow_offline.py
+++ b/tests/test_config_flow_offline.py
@@ -226,20 +226,18 @@ def test_translation_strings_carry_no_urls() -> None:
 
 
 def test_translation_flow_sections_match_strings() -> None:
-    """`translations/en.json` must repeat the flow text `strings.json` declares.
+    """`translations/en.json` must repeat every section `strings.json` declares.
 
-    Home Assistant renders the config and options flows from the translation
-    file; `strings.json` is only the source hassfest validates. An edit that
-    lands in one file but not the other ships a screen with the stale text and
-    nothing fails. `en.json` legitimately carries more than `strings.json`
-    (the `services` section), so only the sections both must share are compared.
+    Home Assistant renders the config flow, the options flow and the service
+    catalog from the translation file; `strings.json` is only the source
+    hassfest validates. An edit that lands in one file but not the other ships a
+    screen with the stale text and nothing fails.
     """
 
     root = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
     strings = json.loads((root / "strings.json").read_text(encoding="utf-8"))
     en = json.loads((root / "translations" / "en.json").read_text(encoding="utf-8"))
-    for section in ("config", "options"):
-        assert en.get(section) == strings.get(section), f"{section!r} sections differ"
+    assert en == strings
 
 
 @pytest.mark.asyncio

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -4,14 +4,18 @@ Scenarios:
 - item_create validates and creates an item; logs context on success
 - item_update applies update and logs validation errors without stack trace
 - location_create and update wire through to repository
+- the service catalog agrees across registration, `services.yaml` and `strings.json`
 """
 
 from __future__ import annotations
 
 import inspect
+import json
+from pathlib import Path
 
 import pytest
 import voluptuous as vol
+import yaml
 from custom_components.haventory import services as services_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import ConflictError, NotFoundError, StorageError
@@ -236,3 +240,25 @@ async def test_repository_exceptions_are_logged(monkeypatch, caplog) -> None:
     with pytest.raises(StorageError):
         await services_mod.service_location_create(hass, {"name": "Root"})
     assert any(getattr(r, "op", None) == "location_create" for r in caplog.records)
+
+
+def test_service_catalog_agrees_across_registration_yaml_and_strings() -> None:
+    """Every registered service is described in `services.yaml` and translated.
+
+    Home Assistant renders a service in the UI from three files that nothing
+    joins up: `services.py` registers it, `services.yaml` declares its fields,
+    and `strings.json` supplies the name and description the frontend shows —
+    falling back to the `services.yaml` text only where the translation is
+    missing. A service added to one file and not the others still works over the
+    API, so the gap shows up as a shabby entry in the service picker rather than
+    as a failure.
+    """
+
+    package = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
+    registered = {name for name, _handler, _schema in services_mod.SERVICES}
+    documented = set(yaml.safe_load((package / "services.yaml").read_text(encoding="utf-8")))
+    translated = json.loads((package / "strings.json").read_text(encoding="utf-8"))["services"]
+
+    assert documented == registered, "services.yaml and the SERVICES table disagree"
+    assert set(translated) == registered, "strings.json and the SERVICES table disagree"
+    assert all(entry.keys() == {"name", "description"} for entry in translated.values())


### PR DESCRIPTION
Closes #224.

Five pieces of staleness a stranger meets before they reach any code, plus the two
community-health files the repo was missing.

## What changed

**`.github/ISSUE_TEMPLATE/bug_report.yml`** — the HAventory version field asked for
"e.g. 0.0.1" and placed the same number; the current release is 0.3.0, so it had been stale
across three minors. The issue suggests putting a real current version in. I took the escape
hatch it offers instead and **worded it to avoid a literal**: the description now points at
where the number lives (HACS, or `version` in `manifest.json`) and the placeholder is a
format example, `e.g. 1.2.3`. Nothing to revisit next release.

The two HA-floor claims elsewhere in that file are untouched — `tests/test_min_ha_version.py`
enumerates them as declaration sites and would fail if a wording change broke its patterns.

**`.github/ISSUE_TEMPLATE/config.yml`** — dropped "(enable Discussions in repo settings)".
Confirmed against the API that Discussions is enabled.

**`hacs.json`** — removed `"country": ["all"]`. "all" is not an ISO 3166-1 code, and the
key's absence already means unrestricted. Checked before removing, as the issue asks:
`tests/test_min_ha_version.py` reads only the `homeassistant` key from the file and
`scripts/check_version_consistency.py` never opens it. Nothing else in the repo mentions
`country`.

**Service strings sync** — `translations/en.json` carried a `services` block `strings.json`
lacked. Synced in the direction the issue names: the block now lives in `strings.json` and
`en.json` mirrors it.

One thing worth flagging: that block named **6 of the 11 registered services**. HA falls
back to the `services.yaml` text where a translation is missing, so the five stragglers were
being rendered from a different file. They are now in both JSON files with **exactly the
text `services.yaml` already showed for them**, so no displayed string changes — this stays
a no-behaviour-change patch.

**`SECURITY.md`** — kept honest about a single-maintainer hobby integration: best-effort
acknowledgement (usually within a week), explicitly no SLA, fixes on the current release
only with no backports. Reports route through GitHub private vulnerability reporting, which
is already enabled on this repo, so no email address had to be published.

It also states the two design facts that decide whether something is a finding at all:
HAventory has no authentication of its own (every WS command, service call and the sidebar
panel ride HA's session, and `require_admin=False` — there are no per-user permissions), and
everything stays local in HA's `Store` with no external service to attack.

**`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, verbatim, with a short note that
"community leaders" means the one maintainer. The verbatim text is why codespell gains a
`socio-economic` exception in `.pre-commit-config.yaml`.

⚠️ **One judgment call for you:** the enforcement contact. You have no public email on your
GitHub profile and your commits use the `users.noreply` address, which bounces, so I did not
invent a contact. The section names what actually works today — public issues, and GitHub's
report-abuse form for anything that shouldn't be public — and says plainly that there is no
private conduct inbox. If you'd rather publish an address, that's a one-line edit.

**README / CONTRIBUTING** link both new files.

## Tests

`tests/test_config_flow_offline.py` compared only the sections both JSON files had to share,
on the stated premise that `en.json` legitimately carried more. It no longer does, so it
compares the whole file.

New test in `tests/test_services_offline.py` ties the service catalog together across the
three files that describe a service and which nothing joins up: the `SERVICES` registration
table, `services.yaml`, and `strings.json`. A service added to one and not the others still
works over the API, so today that gap shows up only as a shabby entry in the service picker.

## Gate

Both halves green.

- Backend: `pytest` 538 passed / 22 skipped, `ruff check`, `ruff format --check`, `mypy`
  (14 files, clean).
- Frontend: `eslint`, `typecheck`, `vitest` 1085 passed / 50 files, `build`
  (459.35 kB, unchanged — no card source touched).

## Follow-ups

- `npm audit` reports a **moderate** postcss advisory (GHSA-fxqj-rqcc-2cmp, incomplete fix
  of GHSA-6g55-p6wh-862q). Pre-existing, dev-scope, unrelated to this branch, and below the
  `--audit-level=high` gate, so nothing here fails on it — noting it because the Dependabot
  dashboard auto-dismisses dev-scope alerts and won't show it.
- `services.yaml` still carries `name`/`description` for all 11 services. They are now
  redundant with the translations for every one of them, but they are the fallback HA uses
  when a translation is missing, so I left them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
