### PR TITLE
fix(card): give every informational chip one shared style

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { counted, plural } from '../ui/plural';
 import { ResponsiveController } from '../ui/responsive';
@@ -59,6 +60,7 @@ export class HVCardShell extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -149,49 +151,13 @@ export class HVCardShell extends LitElement {
         flex-wrap: wrap;
         row-gap: 6px;
       }
-      .badge {
-        border: 1px solid var(--hv-divider);
-        background: none;
-        border-radius: var(--hv-radius-chip);
-        padding: 3px 9px;
-        font: 500 11px var(--hv-font);
-        color: var(--hv-text-secondary);
-        white-space: nowrap;
-      }
       /* These are filter toggles, not decoration, and on their own row there is
-         height to spare — so they take a full tap-height target. */
+         height to spare — so they take a full tap-height target, which is also
+         the one thing that makes them bigger than a chip anywhere else. */
       :host([mobile]) .badge {
-        display: inline-flex;
-        align-items: center;
         min-height: var(--hv-tap-min, auto);
         padding: 0 14px;
         font-size: 12.5px;
-      }
-      .badge.low {
-        color: var(--hv-warn);
-        background: var(--hv-warn-bg);
-        border-color: transparent;
-      }
-      .badge.out {
-        color: var(--hv-primary-darker);
-        background: var(--hv-primary-tint);
-        border-color: transparent;
-      }
-      .badge.overdue {
-        color: var(--hv-error-deep);
-        background: var(--hv-error-bg);
-        border-color: transparent;
-      }
-      /* Amber like low stock rather than red like overdue: red says an item is
-         out and late back, amber says something on the shelf wants doing. */
-      .badge.inspect {
-        color: var(--hv-warn-deep);
-        background: var(--hv-warn-bg);
-        border-color: transparent;
-      }
-      .badge.on {
-        outline: 2px solid var(--hv-primary);
-        outline-offset: 1px;
       }
       .add {
         display: inline-flex;
@@ -701,10 +667,10 @@ export class HVCardShell extends LitElement {
       <div class="badges">
         ${this.mobile
           ? null
-          : html`<span class="badge" data-testid="badge-total">${counted(counts.items_total, 'item')}</span>`}
+          : html`<span class="hv-chip badge quiet" data-testid="badge-total">${counted(counts.items_total, 'item')}</span>`}
         ${counts.low_stock_count > 0
           ? html`<button
-              class="badge low ${f?.lowStockOnly ? 'on' : ''}"
+              class="hv-chip badge toggle warning ${f?.lowStockOnly ? 'on' : ''}"
               data-testid="badge-low"
               aria-pressed=${String(!!f?.lowStockOnly)}
               title="Show only low-stock items"
@@ -715,7 +681,7 @@ export class HVCardShell extends LitElement {
           : null}
         ${(counts.overdue_count ?? 0) > 0
           ? html`<button
-              class="badge overdue ${f?.overdueOnly ? 'on' : ''}"
+              class="hv-chip badge toggle error ${f?.overdueOnly ? 'on' : ''}"
               data-testid="badge-overdue"
               aria-pressed=${String(!!f?.overdueOnly)}
               title="Show only overdue items"
@@ -726,7 +692,7 @@ export class HVCardShell extends LitElement {
           : null}
         ${(counts.inspection_overdue_count ?? 0) > 0
           ? html`<button
-              class="badge inspect ${f?.inspectionDueOnly ? 'on' : ''}"
+              class="hv-chip badge toggle warning ${f?.inspectionDueOnly ? 'on' : ''}"
               data-testid="badge-inspection"
               aria-pressed=${String(!!f?.inspectionDueOnly)}
               title="Show only items due for inspection"
@@ -737,7 +703,7 @@ export class HVCardShell extends LitElement {
           : null}
         ${counts.checked_out_count > 0
           ? html`<button
-              class="badge out ${f?.checkedOutOnly ? 'on' : ''}"
+              class="hv-chip badge toggle state ${f?.checkedOutOnly ? 'on' : ''}"
               data-testid="badge-out"
               aria-pressed=${String(!!f?.checkedOutOnly)}
               title="Show only checked-out items"

--- a/cards/haventory-card/src/components/hv-chip-input.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { normalizeTags } from '../ui/item-form';
 
@@ -16,6 +17,7 @@ export class HVChipInput extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -36,17 +38,14 @@ export class HVChipInput extends LitElement {
       .field:focus-within {
         border-color: var(--hv-primary);
       }
+      /* A value already entered, not a fact about something else: it takes the
+         chip's shape and the state fill so it reads as one of the card's chips,
+         and owns the rest — a remove affordance, and enough height to be a
+         touch target, which no informational chip needs. */
       .chip {
-        display: inline-flex;
-        align-items: center;
         gap: 3px;
         min-height: var(--hv-tap-min, auto);
-        border: none;
-        border-radius: var(--hv-radius-chip);
-        background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
         padding: 3px 9px;
-        font: 400 12px var(--hv-font);
       }
       .chip svg {
         opacity: 0.75;
@@ -136,7 +135,7 @@ export class HVChipInput extends LitElement {
     return html`
       <div class="field" data-testid="chip-field">
         ${this.values.map(
-          (tag) => html`<span class="chip" data-testid="chip" data-value=${tag}>
+          (tag) => html`<span class="hv-chip state chip" data-testid="chip" data-value=${tag}>
             ${tag}
             <button
               class="hv-icon-button chip-remove"

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -136,7 +136,7 @@ describe('hv-data-table: columns', () => {
     ]);
     expect(q(el, '[data-testid="cell-quantity"]')?.classList.contains('low')).toBe(true);
     expect(q(el, '[data-testid="cell-due_date"]')?.classList.contains('overdue')).toBe(true);
-    expect(el.shadowRoot?.textContent).toContain('LOW');
+    expect(el.shadowRoot?.textContent).toContain('Low');
     expect(el.shadowRoot?.textContent).toContain('Checked out');
   });
 });
@@ -416,10 +416,24 @@ describe('hv-data-table: status column', () => {
     ]);
   });
 
-  it('chips the flagged values and leaves ok as plain text', async () => {
+  // Every value in the column is a chip, or half of it would read as a second
+  // column interleaved with the first. Only the flagged ones are amber.
+  it('chips every value and reserves the warning fill for the flagged ones', async () => {
     const el = await mount(mixed, { columns: ['status'] });
     const cells = all(el, '[data-testid="cell-status"]');
-    expect(cells.map((c) => !!c.querySelector('.status-chip'))).toEqual([true, true, false, false]);
+    expect(cells.map((c) => !!c.querySelector('.hv-chip'))).toEqual([true, true, true, true]);
+    expect(cells.map((c) => !!c.querySelector('.hv-chip.warning'))).toEqual([
+      true,
+      true,
+      false,
+      false,
+    ]);
+    expect(cells.map((c) => !!c.querySelector('.hv-chip.quiet'))).toEqual([
+      false,
+      false,
+      true,
+      true,
+    ]);
   });
 
   it('stands the name-cell chip down, so no row says it twice', async () => {

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -2,6 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue, relativeTime } from '../ui/relative-time';
 import { COLUMN_DEFS, normalizeColumns, tableTemplateFor } from '../store/columns';
@@ -25,6 +26,7 @@ export class HVDataTable extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: flex;
@@ -134,35 +136,6 @@ export class HVDataTable extends LitElement {
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      .low-badge {
-        flex: none;
-        font: 700 10.5px var(--hv-font);
-        letter-spacing: 0.4px;
-        color: var(--hv-warn);
-        background: var(--hv-warn-bg);
-        border-radius: 4px;
-        padding: 2px 6px;
-      }
-      .out-chip {
-        flex: none;
-        font: 500 11px var(--hv-font);
-        color: var(--hv-primary-darker);
-        border: 1px solid var(--hv-primary-tint-border);
-        border-radius: var(--hv-radius-chip);
-        padding: 2px 8px;
-      }
-      /* Same amber as the list row's status chip: a flagged state is a chore,
-         not the out-and-late red. */
-      .status-chip {
-        flex: none;
-        font: 500 11px var(--hv-font);
-        color: var(--hv-warn-deep);
-        background: var(--hv-warn-bg);
-        border: 1px solid var(--hv-warn-border);
-        border-radius: var(--hv-radius-chip);
-        padding: 2px 8px;
-        white-space: nowrap;
-      }
       .cell {
         min-width: 0;
         overflow: hidden;
@@ -170,6 +143,7 @@ export class HVDataTable extends LitElement {
         white-space: nowrap;
         color: var(--hv-text-secondary);
       }
+      .cell .hv-chip,
       .cell .hv-area-chip {
         margin-right: 6px;
       }
@@ -198,14 +172,6 @@ export class HVDataTable extends LitElement {
         display: flex;
         gap: 5px;
         overflow: hidden;
-      }
-      .tag {
-        flex: none;
-        font-size: 11px;
-        color: var(--hv-chip-text);
-        background: var(--hv-chip-bg);
-        border-radius: var(--hv-radius-chip);
-        padding: 2px 8px;
       }
       .actions {
         display: flex;
@@ -378,11 +344,14 @@ export class HVDataTable extends LitElement {
       case 'status': {
         // The column names every row's status, "OK" included — that is what
         // makes it a column rather than a second copy of the exception chip.
+        // "OK" is a chip too, quiet rather than amber: a column that draws half
+        // its values as chips and prints the rest as bare text reads as two
+        // columns interleaved.
         const status = itemStatus(item);
         return html`<span class="cell" role="cell" data-testid="cell-status"
-          >${status === 'ok'
-            ? statusLabel(status)
-            : html`<span class="status-chip">${statusLabel(status)}</span>`}</span
+          ><span class="hv-chip ${status === 'ok' ? 'quiet' : 'warning'}"
+            >${statusLabel(status)}</span
+          ></span
         >`;
       }
       case 'category':
@@ -395,7 +364,7 @@ export class HVDataTable extends LitElement {
       }
       case 'tags':
         return html`<span class="tags" role="cell" data-testid="cell-tags">
-          ${item.tags.length ? item.tags.map((t) => html`<span class="tag">${t}</span>`) : html`<span class="cell">—</span>`}
+          ${item.tags.length ? item.tags.map((t) => html`<span class="hv-chip">${t}</span>`) : html`<span class="cell">—</span>`}
         </span>`;
       case 'due_date':
         return html`<span
@@ -496,13 +465,15 @@ export class HVDataTable extends LitElement {
                     : null}
                   <span class="name-cell" role="cell">
                     <span class="name" data-testid="table-name" title=${item.name}>${item.name}</span>
-                    ${isLowStock(item) ? html`<span class="low-badge">LOW</span>` : null}
+                    ${isLowStock(item)
+                      ? html`<span class="hv-chip warning" aria-label="Low stock">Low</span>`
+                      : null}
                     ${!statusColumn && itemStatus(item) !== 'ok'
-                      ? html`<span class="status-chip" data-testid="table-status"
+                      ? html`<span class="hv-chip warning" data-testid="table-status"
                           >${statusLabel(itemStatus(item))}</span
                         >`
                       : null}
-                    ${item.checked_out ? html`<span class="out-chip">Checked out</span>` : null}
+                    ${item.checked_out ? html`<span class="hv-chip state">Checked out</span>` : null}
                   </span>
                   ${columns.map((key) => this._cell(item, key))}
                   <span class="actions" role="cell">

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -143,9 +143,11 @@ export class HVDataTable extends LitElement {
         white-space: nowrap;
         color: var(--hv-text-secondary);
       }
-      .cell .hv-chip,
-      .cell .hv-area-chip {
-        margin-right: 6px;
+      /* The path elides; the chip ahead of it does not. */
+      .cell.path > .hv-chip-line-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .cell.qty {
         color: var(--hv-text);
@@ -358,8 +360,14 @@ export class HVDataTable extends LitElement {
         return html`<span class="cell" role="cell" data-testid="cell-category" title=${item.category ?? ''}>${item.category || '—'}</span>`;
       case 'location': {
         const parts = itemPathParts(item, this.areas);
-        return html`<span class="cell" role="cell" data-testid="cell-location" title=${pathTitle(parts)}
-          >${renderAreaChip(parts.areaName)}${parts.path || '—'}</span
+        return html`<span
+          class="cell path hv-chip-line"
+          role="cell"
+          data-testid="cell-location"
+          title=${pathTitle(parts)}
+          >${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
+            >${parts.path || '—'}</span
+          ></span
         >`;
       }
       case 'tags':

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue, relativeTime } from '../ui/relative-time';
 import { inferType } from '../ui/item-form';
@@ -25,6 +26,7 @@ export class HVDetailSheet extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -99,38 +101,6 @@ export class HVDetailSheet extends LitElement {
         flex-wrap: wrap;
         gap: 6px;
         margin-top: 8px;
-      }
-      .chip {
-        border: none;
-        border-radius: var(--hv-radius-chip);
-        background: var(--hv-chip-bg);
-        color: var(--hv-chip-text);
-        padding: 3px 9px;
-        font: 400 11.5px var(--hv-font);
-      }
-      .chip.state {
-        background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
-      }
-      .chip.overdue {
-        background: var(--hv-error);
-        color: #fff;
-      }
-      .chip.low {
-        background: var(--hv-warn-bg);
-        color: var(--hv-warn);
-        font-weight: 700;
-        letter-spacing: 0.4px;
-      }
-      /* Amber, not the red the overdue chip takes: red on this card means an
-         item is out and late back, while an inspection that has come due is a
-         chore on something still on the shelf — the same kind of signal as low
-         stock. Keeping the two hues apart is what lets both chips sit in this
-         row without reading as one alarm. */
-      .chip.inspect {
-        background: var(--hv-warn-bg);
-        color: var(--hv-warn-deep);
-        font-weight: 500;
       }
       .hero {
         margin: 0 14px 14px;
@@ -364,26 +334,33 @@ export class HVDetailSheet extends LitElement {
       <div class="title">
         <h2 data-testid="sheet-name">${item.name}</h2>
         <div class="chips">
-          ${low ? html`<span class="chip low" data-testid="sheet-low">LOW</span>` : null}
+          ${low
+            ? html`<span class="hv-chip warning" data-testid="sheet-low" aria-label="Low stock"
+                >Low</span
+              >`
+            : null}
           ${itemStatus(item) !== 'ok'
-            ? html`<span class="chip inspect" data-testid="sheet-status"
+            ? html`<span class="hv-chip warning" data-testid="sheet-status"
                 >${statusLabel(itemStatus(item))}</span
               >`
             : null}
           ${item.checked_out
-            ? html`<span class="chip state ${overdue ? 'overdue' : ''}" data-testid="sheet-out">
+            ? html`<span
+                class="hv-chip ${overdue ? 'error' : 'state'}"
+                data-testid="sheet-out"
+              >
                 ${overdue ? 'Overdue' : 'Checked out'}${item.due_date
                   ? ` · due ${formatDate(item.due_date)}`
                   : ''}
               </span>`
             : null}
           ${inspectionDue
-            ? html`<span class="chip inspect" data-testid="sheet-inspection-due">
+            ? html`<span class="hv-chip warning" data-testid="sheet-inspection-due">
                 Inspection due · ${formatDate(item.inspection_date)}
               </span>`
             : null}
-          ${item.category ? html`<span class="chip" data-testid="sheet-category">${item.category}</span>` : null}
-          ${item.tags.map((t) => html`<span class="chip" data-testid="sheet-tag">${t}</span>`)}
+          ${item.category ? html`<span class="hv-chip" data-testid="sheet-category">${item.category}</span>` : null}
+          ${item.tags.map((t) => html`<span class="hv-chip" data-testid="sheet-tag">${t}</span>`)}
         </div>
       </div>
 

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -51,6 +51,10 @@ export class HVDetailSheet extends LitElement {
         font-size: 13.5px;
         color: var(--hv-text-secondary);
         overflow: hidden;
+      }
+      /* The path elides; the chip ahead of it does not. */
+      .bar .crumb > .hv-chip-line-text {
+        overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
       }
@@ -317,8 +321,10 @@ export class HVDetailSheet extends LitElement {
         <button class="tap" data-testid="sheet-close" aria-label="Close" @click=${this._close}>
           ${icon('close', 22)}
         </button>
-        <span class="crumb" data-testid="sheet-path" title=${pathTitle(parts)}
-          >${renderAreaChip(parts.areaName)}${parts.path || 'No location'}</span
+        <span class="crumb hv-chip-line" data-testid="sheet-path" title=${pathTitle(parts)}
+          >${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
+            >${parts.path || 'No location'}</span
+          ></span
         >
         <button
           class="text-action"

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { locationPathParts, pathTitle } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { formatDate } from '../ui/relative-time';
@@ -125,6 +126,7 @@ export class HVFilterChips extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -135,20 +137,10 @@ export class HVFilterChips extends LitElement {
         gap: 6px;
         align-items: center;
       }
+      /* Each of these removes the filter it names, so the trailing × is part of
+         the target and the chip carries a little more room on that side. */
       .chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 4px;
-        border: none;
-        border-radius: var(--hv-radius-chip);
-        padding: 4px 9px 4px 11px;
-        font: 500 12px var(--hv-font);
-        color: var(--hv-primary-darker);
-        background: var(--hv-primary-tint);
-      }
-      .chip.warning {
-        color: var(--hv-warn);
-        background: var(--hv-warn-bg);
+        padding-right: 6px;
       }
       .chip:hover {
         opacity: 0.85;
@@ -180,21 +172,21 @@ export class HVFilterChips extends LitElement {
     return html`
       <div class="row" data-testid="filter-chips">
         ${chips.map(
-          (chip) => html`<button
-            class="chip ${chip.tone === 'warning' ? 'warning' : ''}"
+          (entry) => html`<button
+            class="hv-chip chip ${entry.tone === 'warning' ? 'warning' : 'state'}"
             data-testid="filter-chip"
-            data-key=${chip.key}
-            aria-label=${`Clear filter ${chip.label}`}
+            data-key=${entry.key}
+            aria-label=${`Clear filter ${entry.label}`}
             @click=${() =>
               this.dispatchEvent(
                 new CustomEvent('remove-filter', {
-                  detail: { key: chip.key, patch: clearedValueFor(chip.key) },
+                  detail: { key: entry.key, patch: clearedValueFor(entry.key) },
                   bubbles: true,
                   composed: true,
                 }),
               )}
           >
-            ${chip.label}${icon('close', 15)}
+            ${entry.label}${icon('close', 15)}
           </button>`,
         )}
         <button

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -826,18 +826,19 @@ describe('hv-filter-panel: pressed state', () => {
     }
   });
 
-  // The row's on state has to be the chip's on state, not a second set of
-  // colours that happens to look similar.
-  it('takes its on state from the chip rule, warning variant included', () => {
+  // The row's on state has to be the shared chip's on state, not a second set
+  // of colours that happens to look similar.
+  it('takes its on state from the shared chip rule, warning variant included', () => {
     const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
     const css = (Array.isArray(sheet) ? sheet : [sheet])
       .map((s) => String(s.cssText))
       .join('\n')
       .replace(/\s+/g, ' ');
 
-    expect(css).toMatch(/\.chip\.on \{[^}]*background: var\(--hv-primary-tint\)/);
-    expect(css).toMatch(/\.chip\.on\.warning \{[^}]*background: var\(--hv-warn-bg\)/);
+    expect(css).toMatch(/\.hv-chip\.toggle\.on \{[^}]*background: var\(--hv-primary-tint\)/);
+    expect(css).toMatch(/\.hv-chip\.toggle\.warning\.on \{[^}]*background: var\(--hv-warn-bg\)/);
     // No rule of its own to drift from those, and no checkbox box left to draw.
+    expect(css).not.toMatch(/[^-]\.chip\.on \{/);
     expect(css).not.toMatch(/\.check\.on \{/);
     expect(css).not.toMatch(/\.box[ .{]/);
   });

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { locationPathParts, pathTitle } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
@@ -65,6 +66,7 @@ export class HVFilterPanel extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -99,35 +101,23 @@ export class HVFilterPanel extends LitElement {
         gap: 7px;
         align-items: center;
       }
+      /* These are values in a form, sat beside the panel's own selects and date
+         fields, so they read at the size of those rather than at the size of a
+         chip that annotates a row elsewhere in the card. */
       .chip {
-        display: inline-flex;
-        align-items: center;
         gap: 5px;
-        border: 1px solid var(--hv-divider);
-        background: transparent;
-        color: var(--hv-chip-text);
-        border-radius: var(--hv-radius-chip);
         padding: 5px 12px;
-        font: 400 12.5px var(--hv-font);
+        font-size: 12.5px;
       }
       :host([mobile]) .chip {
         min-height: var(--hv-tap-min, 36px);
         padding: 0 14px;
         font-size: 13.5px;
       }
-      .chip.on {
-        color: var(--hv-primary-darker);
-        background: var(--hv-primary-tint);
-        border-color: var(--hv-primary);
-      }
-      .chip.on.warning {
-        color: var(--hv-warn);
-        background: var(--hv-warn-bg);
-        border-color: var(--hv-amber);
-      }
+      /* Nothing is picked here yet — an outline that has not been drawn in
+         rather than a value that has. */
       .chip.more {
         border-style: dashed;
-        color: var(--hv-text-secondary);
       }
       .chip .tally {
         opacity: 0.65;
@@ -465,7 +455,7 @@ export class HVFilterPanel extends LitElement {
     opts: { warning?: boolean; tally?: number | null; testid?: string } = {},
   ) {
     return html`<button
-      class="chip check ${on ? 'on' : ''} ${opts.warning ? 'warning' : ''}"
+      class="hv-chip toggle chip check ${on ? 'on' : ''} ${opts.warning ? 'warning' : ''}"
       aria-pressed=${String(on)}
       data-testid=${opts.testid ?? 'filter-check'}
       @click=${onToggle}
@@ -490,7 +480,7 @@ export class HVFilterPanel extends LitElement {
         <span class="hv-label">Where</span>
         <div class="chips">
           <button
-            class="chip ${f.locationId ? 'on' : ''}"
+            class="hv-chip toggle chip ${f.locationId ? 'on' : ''}"
             data-testid="filter-location"
             aria-expanded=${String(this._locationOpen)}
             aria-controls=${LOCATION_TREE_ID}
@@ -553,7 +543,7 @@ export class HVFilterPanel extends LitElement {
         <div class="chips">
           ${shown.map(
             (c) => html`<button
-              class="chip ${f.category === c.value ? 'on' : ''}"
+              class="hv-chip toggle chip ${f.category === c.value ? 'on' : ''}"
               data-testid="filter-category"
               data-value=${c.value}
               aria-pressed=${String(f.category === c.value)}
@@ -565,7 +555,7 @@ export class HVFilterPanel extends LitElement {
           )}
           ${hidden > 0
             ? html`<button
-                class="chip more"
+                class="hv-chip toggle chip more"
                 data-testid="filter-category-more"
                 @click=${() => {
                   this._showAllCategories = true;
@@ -614,7 +604,7 @@ export class HVFilterPanel extends LitElement {
         <div class="chips">
           ${all.map(
             (t) => html`<button
-              class="chip ${selected.has(t.value) ? 'on' : ''}"
+              class="hv-chip toggle chip ${selected.has(t.value) ? 'on' : ''}"
               data-testid="filter-tag"
               data-value=${t.value}
               aria-pressed=${String(selected.has(t.value))}
@@ -626,7 +616,7 @@ export class HVFilterPanel extends LitElement {
           )}
           ${extras.map(
             (t) => html`<button
-              class="chip on"
+              class="hv-chip toggle chip on"
               data-testid="filter-tag"
               data-value=${t}
               aria-pressed="true"
@@ -679,7 +669,7 @@ export class HVFilterPanel extends LitElement {
               `
             : html`
                 <button
-                  class="chip ${f.lowStockOnly ? 'on warning' : ''}"
+                  class="hv-chip toggle chip ${f.lowStockOnly ? 'on warning' : ''}"
                   data-testid="filter-low-stock-only"
                   aria-pressed=${String(f.lowStockOnly)}
                   @click=${() => this._patch({ lowStockOnly: !f.lowStockOnly })}
@@ -687,7 +677,7 @@ export class HVFilterPanel extends LitElement {
                   ${f.lowStockOnly ? icon('check', 12) : null}Low stock${tally(c?.low_stock_count)}
                 </button>
                 <button
-                  class="chip ${f.checkedOutOnly ? 'on' : ''}"
+                  class="hv-chip toggle chip ${f.checkedOutOnly ? 'on' : ''}"
                   data-testid="filter-checked-out"
                   aria-pressed=${String(f.checkedOutOnly)}
                   @click=${() => this._patch({ checkedOutOnly: !f.checkedOutOnly })}
@@ -695,7 +685,7 @@ export class HVFilterPanel extends LitElement {
                   ${f.checkedOutOnly ? icon('check', 12) : null}Checked out${tally(c?.checked_out_count)}
                 </button>
                 <button
-                  class="chip ${f.overdueOnly ? 'on warning' : ''}"
+                  class="hv-chip toggle chip ${f.overdueOnly ? 'on error' : ''}"
                   data-testid="filter-overdue"
                   aria-pressed=${String(f.overdueOnly)}
                   @click=${() => this._patch({ overdueOnly: !f.overdueOnly })}
@@ -703,7 +693,7 @@ export class HVFilterPanel extends LitElement {
                   ${f.overdueOnly ? icon('check', 12) : null}Overdue${tally(c?.overdue_count)}
                 </button>
                 <button
-                  class="chip ${f.inspectionDueOnly ? 'on warning' : ''}"
+                  class="hv-chip toggle chip ${f.inspectionDueOnly ? 'on warning' : ''}"
                   data-testid="filter-inspection-due"
                   aria-pressed=${String(f.inspectionDueOnly)}
                   @click=${() => this._patch({ inspectionDueOnly: !f.inspectionDueOnly })}
@@ -711,7 +701,7 @@ export class HVFilterPanel extends LitElement {
                   ${f.inspectionDueOnly ? icon('check', 12) : null}Inspection due${tally(c?.inspection_overdue_count)}
                 </button>
                 <button
-                  class="chip ${f.orphansOnly ? 'on' : ''}"
+                  class="hv-chip toggle chip ${f.orphansOnly ? 'on' : ''}"
                   data-testid="filter-orphans"
                   aria-pressed=${String(f.orphansOnly)}
                   @click=${() => this._patch({ orphansOnly: !f.orphansOnly })}
@@ -746,7 +736,7 @@ export class HVFilterPanel extends LitElement {
             const warning = on && s !== 'ok';
             const tally = tallyFor(s);
             return html`<button
-              class="chip ${on ? 'on' : ''} ${warning ? 'warning' : ''}"
+              class="hv-chip toggle chip ${on ? 'on' : ''} ${warning ? 'warning' : ''}"
               data-testid="filter-status"
               data-value=${s}
               aria-pressed=${String(on)}

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1354,13 +1354,13 @@ describe('hv-full-view: app bar filters', () => {
     expect(q(sr, '[data-testid="full-badge-out"]')?.textContent?.trim()).toBe('2 checked out');
   });
 
-  // Three identically washed pills said nothing apart. The card's hues carry the
-  // meaning; the fills are solid rather than the card's pale tints, because a
-  // tint over this already-coloured bar is unreadable in dark mode.
+  // The card's hues carry the meaning on this bar too, but the fills are solid
+  // rather than the card's pale tints, because a tint over an already-coloured
+  // bar is unreadable in dark mode.
   it('colours low and overdue the way the card does', () => {
     const css = fullCss();
-    expect(css).toMatch(/\.appbar \.pill\.low \{[^}]*background: var\(--hv-amber\)/);
-    expect(css).toMatch(/\.appbar \.pill\.overdue \{[^}]*background: var\(--hv-error\)/);
+    expect(css).toMatch(/\.appbar \.hv-chip\.warning \{[^}]*background: var\(--hv-amber\)/);
+    expect(css).toMatch(/\.appbar \.hv-chip\.error \{[^}]*background: var\(--hv-error\)/);
   });
 
   it('debounces the app bar search', async () => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -554,8 +554,10 @@ export class HVFullView extends LitElement {
         font-weight: 500;
         color: var(--hv-text);
       }
-      .crumb .hv-area-chip {
-        margin-right: 6px;
+      /* The segments and the count wrap as one run of text; only the chip is
+         held out of it, so the row can centre the two against each other. */
+      .crumb > .hv-chip-line-text {
+        flex: 1;
       }
       .filters-button {
         display: inline-flex;
@@ -1440,17 +1442,22 @@ export class HVFullView extends LitElement {
 
     return html`
       <div class="context">
-        <span class="crumb" data-testid="full-breadcrumb">
-          ${filters.orphansOnly
-            ? html`<span class="current">No location</span>`
-            : segments.length
-              ? html`${renderAreaChip(areaName)}${segments.map((seg, i) =>
-                  i === segments.length - 1
-                    ? html`<span class="current">${seg}</span>`
-                    : html`<span>${seg} › </span>`,
-                )}`
-              : html`<span class="current">All items</span>`}
-          ${st?.total !== null && st?.total !== undefined ? html` · ${counted(st.total, 'item')}` : null}
+        <span class="crumb hv-chip-line" data-testid="full-breadcrumb">
+          ${filters.orphansOnly || !segments.length ? null : renderAreaChip(areaName)}
+          <span class="hv-chip-line-text">
+            ${filters.orphansOnly
+              ? html`<span class="current">No location</span>`
+              : segments.length
+                ? segments.map((seg, i) =>
+                    i === segments.length - 1
+                      ? html`<span class="current">${seg}</span>`
+                      : html`<span>${seg} › </span>`,
+                  )
+                : html`<span class="current">All items</span>`}${st?.total !== null &&
+            st?.total !== undefined
+              ? html` · ${counted(st.total, 'item')}`
+              : null}
+          </span>
         </span>
         <span class="spacer"></span>
         ${filterCount > 0

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -2,6 +2,7 @@ import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { counted, plural } from '../ui/plural';
@@ -82,6 +83,7 @@ export class HVFullView extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: contents;
@@ -216,53 +218,35 @@ export class HVFullView extends LitElement {
       .appbar .search input::placeholder {
         color: rgba(255, 255, 255, 0.8);
       }
-      .appbar .pill {
-        flex: none;
-        border: none;
-        border-radius: var(--hv-radius-chip);
+      /*
+       * The bar's filter toggles are the card's chips with the fills
+       * substituted, and they take none of the pressable variant: it reads as an empty
+       * outline until it is applied, and nothing on a primary-coloured bar can.
+       *
+       * The card's tints are pale washes of their hue chosen to sit on a plain
+       * card surface, and in dark mode they are translucent — laid over this
+       * already-blue bar, "low" comes out as faintly warm blue with amber text
+       * on it. Same hues and same meanings, solid fills that do not depend on
+       * what is behind them, and a white ring rather than a primary one,
+       * because primary is what the bar itself is painted.
+       */
+      .appbar .hv-chip {
         background: rgba(255, 255, 255, 0.22);
         color: #fff;
-        padding: 4px 11px;
-        font: 500 11.5px var(--hv-font);
       }
-      .appbar .pill.on {
-        outline: 2px solid #fff;
+      .appbar .hv-chip:hover {
+        background: rgba(255, 255, 255, 0.32);
       }
-      /*
-       * Low and overdue carry the card's meanings here too: amber for a stock
-       * warning, red for a passed due date. Two identical translucent pills
-       * reading "102 low" and "82 out" told you nothing apart.
-       *
-       * They cannot reuse the card's exact fills, though. Those are pale tints
-       * of their hue chosen to sit on a plain card surface, and in dark mode
-       * they are translucent — laid over this already-blue bar, "low" would come
-       * out as faintly warm blue with amber text on it. Same hues, same
-       * meanings, solid fills that do not depend on what is behind them.
-       * Checked out keeps the neutral wash, which is what the card's
-       * primary-tint amounts to on a primary-coloured bar.
-       */
-      .appbar .pill.low {
+      .appbar .hv-chip.on {
+        outline-color: #fff;
+      }
+      .appbar .hv-chip.warning {
         background: var(--hv-amber);
-        color: #3b2600;
+        color: var(--hv-on-amber);
       }
-      .appbar .pill.overdue {
+      .appbar .hv-chip.error {
         background: var(--hv-error);
         color: #fff;
-      }
-      /* Amber like low stock, not red like overdue: red is reserved here for an
-         item that is out and late back, while an inspection that has come due
-         is a chore on something still on the shelf. */
-      .appbar .pill.inspect {
-        background: var(--hv-amber);
-        color: #3b2600;
-      }
-      /* The same amber the status chip carries on rows, in the table and in the
-         detail sheet — one tone for "flagged, but still a chore" wherever a
-         status is marked. The two pills say which flag in words; giving them a
-         hue of their own would be a second status vocabulary on one screen. */
-      .appbar .pill.status {
-        background: var(--hv-amber);
-        color: #3b2600;
       }
       /*
        * Above the phone breakpoint — the complement of NARROW_QUERY, whose own
@@ -1616,7 +1600,7 @@ export class HVFullView extends LitElement {
     const on = (this.st?.filters ?? defaultFilters()).status === status;
     const noun = statusLabel(status).toLowerCase();
     return html`<button
-      class="pill status ${on ? 'on' : ''}"
+      class="hv-chip pill warning ${on ? 'on' : ''}"
       data-testid="full-badge-status"
       data-value=${status}
       aria-pressed=${String(on)}
@@ -1656,7 +1640,7 @@ export class HVFullView extends LitElement {
           <span class="spacer"></span>
           ${counts && counts.low_stock_count > 0
             ? html`<button
-                class="pill low ${filters.lowStockOnly ? 'on' : ''}"
+                class="hv-chip pill warning ${filters.lowStockOnly ? 'on' : ''}"
                 data-testid="full-badge-low"
                 aria-pressed=${String(filters.lowStockOnly)}
                 title="Show only low-stock items"
@@ -1667,7 +1651,7 @@ export class HVFullView extends LitElement {
             : null}
           ${counts && (counts.overdue_count ?? 0) > 0
             ? html`<button
-                class="pill overdue ${filters.overdueOnly ? 'on' : ''}"
+                class="hv-chip pill error ${filters.overdueOnly ? 'on' : ''}"
                 data-testid="full-badge-overdue"
                 aria-pressed=${String(filters.overdueOnly)}
                 title="Show only overdue items"
@@ -1678,7 +1662,7 @@ export class HVFullView extends LitElement {
             : null}
           ${counts && (counts.inspection_overdue_count ?? 0) > 0
             ? html`<button
-                class="pill inspect ${filters.inspectionDueOnly ? 'on' : ''}"
+                class="hv-chip pill warning ${filters.inspectionDueOnly ? 'on' : ''}"
                 data-testid="full-badge-inspection"
                 aria-pressed=${String(filters.inspectionDueOnly)}
                 title="Show only items due for inspection"
@@ -1689,7 +1673,7 @@ export class HVFullView extends LitElement {
             : null}
           ${counts && counts.checked_out_count > 0
             ? html`<button
-                class="pill out ${filters.checkedOutOnly ? 'on' : ''}"
+                class="hv-chip pill ${filters.checkedOutOnly ? 'on' : ''}"
                 data-testid="full-badge-out"
                 aria-pressed=${String(filters.checkedOutOnly)}
                 title="Show only checked-out items"

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { locationPathParts, renderAreaChip } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import {
@@ -71,6 +72,7 @@ export class HVItemEditor extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -100,20 +102,6 @@ export class HVItemEditor extends LitElement {
         font-size: 11.5px;
         color: var(--hv-text-tertiary);
         white-space: nowrap;
-      }
-      .out-chip {
-        flex: none;
-        font: 500 11px var(--hv-font);
-        color: var(--hv-primary-darker);
-        background: var(--hv-surface);
-        border: 1px solid var(--hv-primary-tint-border);
-        border-radius: var(--hv-radius-chip);
-        padding: 2px 8px;
-      }
-      .out-chip.overdue {
-        color: #fff;
-        background: var(--hv-error);
-        border-color: var(--hv-error);
       }
       .grid {
         display: grid;
@@ -580,6 +568,9 @@ export class HVItemEditor extends LitElement {
         font: 400 12px var(--hv-font);
         color: var(--hv-text-secondary);
       }
+      /* Delete is hv-text-button danger from the shared sheet — the same
+         borderless red every other destructive action in the card uses (the
+         detail sheet's own Delete item, the organize dialog's Delete). */
       .actions {
         display: flex;
         align-items: center;
@@ -640,11 +631,6 @@ export class HVItemEditor extends LitElement {
       .save[disabled] {
         opacity: 0.5;
       }
-      /* Delete is hv-text-button danger from the shared sheet — the same
-         borderless red every other destructive action in the card uses (the
-         detail sheet's own Delete item, the organize dialog's Delete). It used
-         to be an outlined 12.5px pill, which made it the one button in the row
-         with a border, its own radius and its own font size. */
       .banner {
         margin: 0 18px;
         padding: 9px 12px;
@@ -1381,7 +1367,7 @@ export class HVItemEditor extends LitElement {
                 ${creating ? 'New item' : `${this.item?.name} — editing`}
               </span>
               ${this.item?.checked_out
-                ? html`<span class="out-chip ${overdue ? 'overdue' : ''}" data-testid="editor-out-chip">
+                ? html`<span class="hv-chip ${overdue ? 'error' : 'state'}" data-testid="editor-out-chip">
                     ${overdue ? 'Overdue' : 'Checked out'}${this.item?.due_date
                       ? ` · due ${formatDate(this.item.due_date)}`
                       : ''}

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -92,13 +92,15 @@ describe('hv-list-row: content', () => {
   it('calls out an overdue check-out in error colour', async () => {
     const el = await mount({ checked_out: true, due_date: '2020-01-01' });
     const chip = q(el, '[data-testid="row-checked-out"]');
-    expect(chip?.classList.contains('overdue')).toBe(true);
+    expect(chip?.classList.contains('error')).toBe(true);
     expect(chip?.textContent).toContain('Overdue');
   });
 
   it('does not call a future due date overdue', async () => {
     const el = await mount({ checked_out: true, due_date: '2099-01-01' });
-    expect(q(el, '[data-testid="row-checked-out"]')?.classList.contains('overdue')).toBe(false);
+    const chip = q(el, '[data-testid="row-checked-out"]');
+    expect(chip?.classList.contains('error')).toBe(false);
+    expect(chip?.classList.contains('state')).toBe(true);
   });
 
   // `inspection_date` says when the item is next due for inspection, so a date

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue } from '../ui/relative-time';
@@ -48,6 +49,7 @@ export class HVListRow extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -134,43 +136,6 @@ export class HVListRow extends LitElement {
         border-radius: 50%;
         background: var(--hv-amber);
       }
-      .low-badge {
-        flex: none;
-        font: 700 10.5px var(--hv-font);
-        letter-spacing: 0.4px;
-        text-transform: uppercase;
-        color: var(--hv-warn);
-        background: var(--hv-warn-bg);
-        border-radius: 4px;
-        padding: 2px 6px;
-      }
-      .out-chip {
-        flex: none;
-        font: 500 11px var(--hv-font);
-        color: var(--hv-primary-darker);
-        border: 1px solid var(--hv-primary-tint-border);
-        border-radius: var(--hv-radius-chip);
-        padding: 2px 8px;
-      }
-      .out-chip.overdue {
-        color: #fff;
-        background: var(--hv-error);
-        border-color: var(--hv-error);
-      }
-      /* Amber, not the out-chip's red: red on this card is reserved for an item
-         that is out and late back, while an inspection that has come due is a
-         chore on something still on the shelf. */
-      .inspect-chip,
-      .status-chip {
-        flex: none;
-        font: 500 11px var(--hv-font);
-        color: var(--hv-warn-deep);
-        background: var(--hv-warn-bg);
-        border: 1px solid var(--hv-warn-border);
-        border-radius: var(--hv-radius-chip);
-        padding: 2px 8px;
-        white-space: nowrap;
-      }
       .hover-actions {
         flex: none;
         display: flex;
@@ -247,14 +212,6 @@ export class HVListRow extends LitElement {
         min-height: var(--hv-tap-min, 40px);
         padding: 0 18px;
         font: 500 13.5px var(--hv-font);
-      }
-      .pending {
-        flex: none;
-        font: 500 11px var(--hv-font);
-        color: var(--hv-warn);
-        background: var(--hv-warn-bg);
-        border-radius: var(--hv-radius-chip);
-        padding: 3px 8px;
       }
       .box {
         flex: none;
@@ -478,20 +435,25 @@ export class HVListRow extends LitElement {
                     : html`${renderAreaChip(parts.areaName)}${secondary || 'No location'}`}
           </span>
         </span>
-        ${this.pending ? html`<span class="pending" data-testid="row-pending">pending</span>` : null}
+        ${this.pending
+          ? html`<span class="hv-chip warning" data-testid="row-pending">Pending</span>`
+          : null}
         ${!this.mobile && low
-          ? html`<span class="low-badge" data-testid="row-low" aria-label="Low stock">LOW</span>`
+          ? html`<span class="hv-chip warning" data-testid="row-low" aria-label="Low stock">Low</span>`
           : null}
         ${!this.mobile && flagged
-          ? html`<span class="status-chip" data-testid="row-status">${statusLabel(status)}</span>`
+          ? html`<span class="hv-chip warning" data-testid="row-status">${statusLabel(status)}</span>`
           : null}
         ${!this.mobile && item.checked_out
-          ? html`<span class="out-chip ${overdue ? 'overdue' : ''}" data-testid="row-checked-out">
+          ? html`<span
+              class="hv-chip ${overdue ? 'error' : 'state'}"
+              data-testid="row-checked-out"
+            >
               ${overdue ? `Overdue · ${formatDate(item.due_date)}` : 'Checked out'}
             </span>`
           : null}
         ${!this.mobile && inspectionDue
-          ? html`<span class="inspect-chip" data-testid="row-inspection-due">
+          ? html`<span class="hv-chip warning" data-testid="row-inspection-due">
               Inspection due
             </span>`
           : null}

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -109,8 +109,16 @@ export class HVListRow extends LitElement {
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      .secondary .hv-area-chip {
-        margin-right: 6px;
+      /* Beats .secondary's own display:block, which is declared later than the
+         shared fragment and would otherwise keep the row inline. */
+      .secondary.hv-chip-line {
+        display: flex;
+      }
+      /* The path elides; the chip ahead of it does not. */
+      .secondary.hv-chip-line > .hv-chip-line-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .secondary.out {
         color: var(--hv-primary-dark);
@@ -411,7 +419,8 @@ export class HVListRow extends LitElement {
         <span class="names">
           <span class="name" data-testid="row-name" title=${item.name}>${item.name}</span>
           <span
-            class="secondary ${this.mobile ? mobileState : ''} ${overdue && this.mobile
+            class="secondary ${this.mobile ? mobileState : 'hv-chip-line'} ${overdue &&
+            this.mobile
               ? 'overdue'
               : ''}"
             data-testid="row-secondary"
@@ -432,7 +441,9 @@ export class HVListRow extends LitElement {
                   ? html`<span data-testid="row-inspection-due">Inspection due</span> · ${formatDate(item.inspection_date)}`
                   : this.mobile
                     ? mobileSecondary || 'No location'
-                    : html`${renderAreaChip(parts.areaName)}${secondary || 'No location'}`}
+                    : html`${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
+                        >${secondary || 'No location'}</span
+                      >`}
           </span>
         </span>
         ${this.pending

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -1,6 +1,6 @@
 import './hv-location-tree';
 import type { HVLocationTree } from './hv-location-tree';
-import { base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import type { LocationTreeNode } from '../store/types';
 
 function node(
@@ -392,16 +392,19 @@ describe('hv-location-tree: area grouping', () => {
   // Both trees that head their roots with a chip are this component — the
   // full view's sidebar and the organize dialog's — so its size is settled
   // here, once, for both.
-  it('sets that chip at row size, leaving the shared chip its smaller one', () => {
+  it('sets both band labels at row size, leaving the shared chip its smaller one', () => {
     const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
     const sheets = Array.isArray(styles) ? styles : [styles];
     const own = String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
-    // Tracks whatever `.row` is set to rather than restating a number beside it.
-    expect(own).toMatch(/\.area-name \.hv-area-chip \{ font-size: inherit/);
+    // Tracks whatever `.row` is set to rather than restating a number beside it,
+    // and both bands are named by one rule so neither can drift from the other.
+    expect(own).toMatch(/\.area-name \.hv-area-chip, \.area-none \{ font-size: inherit/);
     expect(own).toMatch(/\.row \{[^}]*font: 400 [\d.]+px/);
     // The other surfaces put this chip beside a path it qualifies, where it is
     // an annotation and stays smaller than the line carrying it.
-    expect(String(base.cssText)).toMatch(/\.hv-area-chip \{[^}]*font-size: 11px/);
+    expect(String(chip.cssText).replace(/\s+/g, ' ')).toMatch(
+      /\.hv-chip, \.hv-area-chip \{[^}]*font-size: var\(--hv-chip-font-size\)/,
+    );
   });
 
   it('leaves an inventory that assigns no areas exactly as it was', async () => {

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import type { TemplateResult } from 'lit';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import type { IconName } from '../ui/icons';
 import { groupRootsByArea, locationMatches } from '../store/location-tree';
@@ -54,6 +55,7 @@ export class HVLocationTree extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -166,17 +168,13 @@ export class HVLocationTree extends LitElement {
       /* Everywhere else the chip annotates a path it sits beside, so it is set
          smaller than the text it qualifies. Here it *is* the row's label, one
          level of the tree above the locations under it, and reading smaller than
-         them inverted the hierarchy it heads. */
-      .area-name .hv-area-chip {
-        font-size: inherit;
-      }
+         them inverts the hierarchy it heads.
+         The no-area band is that same heading for the locations no area claims,
+         so it takes the same size and shape and says the difference with its
+         fill: an outline where the others carry one. */
+      .area-name .hv-area-chip,
       .area-none {
-        flex: 1;
-        min-width: 0;
-        font-size: 11.5px;
-        letter-spacing: 0.3px;
-        text-transform: uppercase;
-        color: var(--hv-text-tertiary);
+        font-size: inherit;
       }
       .actions {
         flex: none;
@@ -550,7 +548,7 @@ export class HVLocationTree extends LitElement {
       pickable && this.selectedAreaId === group.id && this.selectedId === null && !this.orphansSelected;
     const label = group
       ? renderAreaChip(group.name)
-      : html`<span class="area-none">No area</span>`;
+      : html`<span class="hv-area-chip quiet area-none">No area</span>`;
 
     return html`<div
       class="row area-head ${selected ? 'selected' : ''} ${pickable ? 'selectable' : ''}"

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { chip } from '../ui/chip';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
@@ -72,6 +73,7 @@ export class HVOrganizeDialog extends LitElement {
   static styles = [
     tokens,
     base,
+    chip,
     css`
       :host {
         display: block;
@@ -220,13 +222,6 @@ export class HVOrganizeDialog extends LitElement {
       }
       .value-row:hover {
         background: var(--hv-hover-overlay);
-      }
-      .value-chip {
-        border: 1px solid var(--hv-divider);
-        border-radius: var(--hv-radius-chip);
-        padding: 4px 11px;
-        font-size: 12.5px;
-        color: var(--hv-chip-text);
       }
       .count-link {
         border: none;
@@ -995,7 +990,7 @@ export class HVOrganizeDialog extends LitElement {
 
     return html`<div class="expander" data-testid="location-merge">
       <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap">
-        <span class="value-chip" style="text-decoration: line-through">${source.name}</span>
+        <span class="hv-chip" style="text-decoration: line-through">${source.name}</span>
         ${icon('arrowRight', 18)}
         <button
           class="control"
@@ -1213,7 +1208,7 @@ export class HVOrganizeDialog extends LitElement {
 
     return html`<div class="expander" data-testid="value-editor" data-mode=${editing.mode}>
       <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap">
-        <span class="value-chip" style=${merging ? 'text-decoration: line-through' : ''}>${value}</span>
+        <span class="hv-chip" style=${merging ? 'text-decoration: line-through' : ''}>${value}</span>
         <span style="font-size:12.5px;color:var(--hv-text-secondary)">${counted(count, 'item')}</span>
         ${merging ? icon('arrowRight', 18) : null}
         <label style="display:flex;align-items:center;gap:8px;flex:1;min-width:180px">
@@ -1346,7 +1341,7 @@ export class HVOrganizeDialog extends LitElement {
           ? values.map(
               (v) => html`
                 <div class="value-row" data-testid="value-row" data-value=${v.value}>
-                  <span class="value-chip">${v.value}</span>
+                  <span class="hv-chip">${v.value}</span>
                   ${this._isDraft(v.value)
                     ? html`<span class="draft-note" data-testid="value-draft">
                         new · not saved until an item uses it
@@ -1441,7 +1436,7 @@ export class HVOrganizeDialog extends LitElement {
         <button data-testid="sheet-merge" @click=${() => this._startValueEdit(value, 'merge')}>
           ${icon('callMerge', 20)}Merge into…
           ${suggestion
-            ? html`<span class="value-chip" style="margin-left:auto" data-testid="sheet-merge-suggestion"
+            ? html`<span class="hv-chip" style="margin-left:auto" data-testid="sheet-merge-suggestion"
                 >${suggestion}</span
               >`
             : null}

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { CSSResult } from 'lit';
+import { chip } from './chip';
+import { tokens } from './tokens';
+
+import '../components/hv-card-shell';
+import '../components/hv-chip-input';
+import '../components/hv-data-table';
+import '../components/hv-detail-sheet';
+import '../components/hv-filter-chips';
+import '../components/hv-filter-panel';
+import '../components/hv-full-view';
+import '../components/hv-item-editor';
+import '../components/hv-list-row';
+import '../components/hv-location-tree';
+import '../components/hv-organize-dialog';
+
+/** Every surface that marks something with a chip. */
+const CHIPPED = [
+  'hv-card-shell',
+  'hv-chip-input',
+  'hv-data-table',
+  'hv-detail-sheet',
+  'hv-filter-chips',
+  'hv-filter-panel',
+  'hv-full-view',
+  'hv-item-editor',
+  'hv-list-row',
+  'hv-location-tree',
+  'hv-organize-dialog',
+];
+
+function sheetsOf(tag: string): CSSResult[] {
+  const ctor = customElements.get(tag) as { styles?: CSSResult | CSSResult[] } | undefined;
+  if (!ctor?.styles) throw new Error(`${tag} has no styles`);
+  return Array.isArray(ctor.styles) ? ctor.styles : [ctor.styles];
+}
+
+/** A component's own block — the last fragment, after the shared ones. */
+function ownCss(tag: string): string {
+  const sheets = sheetsOf(tag);
+  return String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+}
+
+describe('ui/chip: the shared fragment', () => {
+  it('reaches every surface that draws a chip', () => {
+    for (const tag of CHIPPED) {
+      expect(sheetsOf(tag), tag).toContain(chip);
+    }
+  });
+
+  it('takes its metrics from tokens, so a theme can move them in one place', () => {
+    const css = String(chip.cssText).replace(/\s+/g, ' ');
+    expect(css).toMatch(/font-size: var\(--hv-chip-font-size\)/);
+    expect(css).toMatch(/padding: var\(--hv-chip-padding\)/);
+    expect(css).toMatch(/border-radius: var\(--hv-radius-chip\)/);
+    expect(String(tokens.cssText)).toMatch(/--hv-chip-font-size: [\d.]+px/);
+    expect(String(tokens.cssText)).toMatch(/--hv-chip-padding: /);
+  });
+
+  it('carries the four fills the card marks things with, and a pressable variant', () => {
+    const css = String(chip.cssText).replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.hv-chip\.state \{[^}]*var\(--hv-primary-tint\)/);
+    expect(css).toMatch(/\.hv-chip\.warning \{[^}]*var\(--hv-warn-bg\)/);
+    expect(css).toMatch(/\.hv-chip\.error \{[^}]*var\(--hv-error-bg\)/);
+    expect(css).toMatch(/\.hv-chip\.quiet, \.hv-area-chip\.quiet \{/);
+    expect(css).toMatch(/\.hv-chip\.toggle \{[^}]*cursor: pointer/);
+  });
+
+  // The whole point of the fragment: one size, not eleven. A component that
+  // sets its own has a reason, and there are exactly two — see below.
+  it('leaves no component restating the chip metrics it already provides', () => {
+    for (const tag of CHIPPED) {
+      const css = ownCss(tag);
+      // Nothing re-rounds a chip or repaints the neutral fill locally.
+      expect(css, tag).not.toMatch(/\.(low-badge|out-chip|status-chip|inspect-chip|value-chip)\b/);
+    }
+  });
+
+  it('is overridden only where a chip must match something beside it', () => {
+    // A form's values read at the size of the form's own fields...
+    expect(ownCss('hv-filter-panel')).toMatch(/\.chip \{[^}]*font-size: 12\.5px/);
+    // ...and a tree's band label at the size of the rows it heads.
+    expect(ownCss('hv-location-tree')).toMatch(
+      /\.area-name \.hv-area-chip, \.area-none \{ font-size: inherit/,
+    );
+    // Every other surface takes the shared size untouched.
+    for (const tag of CHIPPED.filter((t) => t !== 'hv-filter-panel' && t !== 'hv-location-tree')) {
+      expect(ownCss(tag), tag).not.toMatch(/\.(hv-)?chip[^{]*\{[^}]*font-size/);
+    }
+  });
+
+  // An area is marked one way wherever the card marks one, and that mark is not
+  // one of the generic fills — it keeps its own glyph and its own class.
+  it('shares the metrics with the area chip without folding it in', () => {
+    const css = String(chip.cssText).replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.hv-chip, \.hv-area-chip \{/);
+    expect(css).not.toMatch(/\.hv-area-chip\.(state|warning|error)/);
+  });
+});

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -90,6 +90,31 @@ describe('ui/chip: the shared fragment', () => {
     }
   });
 
+  // `vertical-align` centres an inline box on the parent's x-height, which is
+  // the middle of lowercase text and not the middle of the line — so a chip
+  // beside a path sat ~1.4px low. Only a flex row centres the two exactly.
+  it('centres a chip against the text it shares a line with', () => {
+    const css = String(chip.cssText).replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.hv-chip-line \{[^}]*display: flex/);
+    expect(css).toMatch(/\.hv-chip-line \{[^}]*align-items: center/);
+  });
+
+  it('puts every chip that heads a line of text on that row', () => {
+    for (const tag of ['hv-data-table', 'hv-detail-sheet', 'hv-full-view', 'hv-list-row']) {
+      expect(ownCss(tag), tag).toMatch(/\.hv-chip-line-text/);
+    }
+  });
+
+  // text-overflow does nothing on a flex container, so a path left on the row
+  // itself would hard-cut mid-character with no ellipsis to say so.
+  it('moves the elision onto the text when the row becomes a flex box', () => {
+    for (const tag of ['hv-data-table', 'hv-detail-sheet', 'hv-list-row']) {
+      expect(ownCss(tag), tag).toMatch(
+        /\.hv-chip-line-text \{[^}]*text-overflow: ellipsis[^}]*\}/,
+      );
+    }
+  });
+
   // An area is marked one way wherever the card marks one, and that mark is not
   // one of the generic fills — it keeps its own glyph and its own class.
   it('shares the metrics with the area chip without folding it in', () => {

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -129,4 +129,29 @@ export const chip = css`
     opacity: 0.5;
     cursor: default;
   }
+
+  /*
+   * A line a chip shares with the text it qualifies — an area beside its path,
+   * a breadcrumb.
+   *
+   * The row centres the two against each other, which no inline alignment can:
+   * vertical-align: middle puts an inline box on the parent's baseline plus
+   * half its x-height, which is the middle of lowercase text and not the middle
+   * of the line. Beside a path with capitals and digits in it that leaves the
+   * chip sitting low — measured at 1.4px against 13.5px text, and it does not
+   * shrink as the chip does, because the offset is a property of the text.
+   *
+   * The elision has to move onto the text with it: text-overflow has no
+   * effect on a flex container, so a path left on the row itself would hard-cut
+   * mid-character with no ellipsis to say anything had been dropped.
+   */
+  .hv-chip-line {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .hv-chip-line > .hv-chip-line-text {
+    min-width: 0;
+  }
 `;

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -1,0 +1,132 @@
+import { css } from 'lit';
+
+/**
+ * The card's chip vocabulary: the small pill that reports one fact beside the
+ * thing it qualifies — low stock, a status, a tag, an applied filter.
+ *
+ * Every such mark on the card is one of these, at one size, so that a row
+ * carrying several of them reads as a set rather than as four unrelated marks.
+ * Metrics come from `--hv-chip-*` in `tokens`; a surface that must size its
+ * chips to something beside them overrides `font-size` on its own rule and says
+ * why, rather than restating the whole block.
+ *
+ * Three things are deliberately *not* this chip:
+ *
+ * - `.hv-pill` in `tokens` is an action — a button shaped like a pill. A chip
+ *   reports; a pill does something.
+ * - `hv-chip-input`'s tokens are editable input values with a remove
+ *   affordance. They take these metrics and own their own interaction.
+ * - `.hv-area-chip` marks the HA area beside a location path. It shares the
+ *   metrics so it sits level with the chips around it, and keeps its own glyph
+ *   and spelled-out label, because an area is not one of the facts above.
+ *
+ * Usage: `static styles = [tokens, base, chip, css\`...\`]`.
+ */
+export const chip = css`
+  .hv-chip,
+  .hv-area-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+    /* The transparent border is what keeps a bordered chip the same height as a
+       filled one sitting next to it in the same row. */
+    box-sizing: border-box;
+    border: 1px solid transparent;
+    border-radius: var(--hv-radius-chip);
+    padding: var(--hv-chip-padding);
+    background: var(--hv-chip-bg);
+    color: var(--hv-chip-text);
+    font-family: var(--hv-font);
+    font-size: var(--hv-chip-font-size);
+    font-weight: 500;
+    /* Fixed rather than inherited: these ride inside rows whose line-height
+       varies, and a chip that changed height with its host row would break the
+       run of chips beside it. */
+    line-height: 1.4;
+    /* Chips sit inside single-line rows that clip with an ellipsis; a wrap would
+       grow the line box those rows size themselves from. */
+    white-space: nowrap;
+    vertical-align: middle;
+  }
+
+  /*
+   * Pressable. Reads as an empty outline until it carries a hue or is applied,
+   * so a row of them says "these are choices" rather than "these are facts".
+   *
+   * The hue variants below must come after this rule: a pressable chip can
+   * carry one, and both are two-class selectors, so source order is what
+   * decides which fill a pressable warning chip gets.
+   */
+  .hv-chip.toggle {
+    cursor: pointer;
+    background: none;
+    color: var(--hv-text-secondary);
+    border-color: var(--hv-divider);
+  }
+  .hv-chip.toggle:hover {
+    background: var(--hv-hover-overlay);
+  }
+
+  /* What the hue means is fixed card-wide: blue for a state the item is in,
+     amber for a chore on something still on the shelf (low stock, an inspection
+     that has come due), red for an item that is out and late back. Keeping
+     amber and red apart is what lets both sit in one row without reading as a
+     single alarm. */
+  .hv-chip.state {
+    background: var(--hv-primary-tint);
+    color: var(--hv-primary-darker);
+    border-color: transparent;
+  }
+  .hv-chip.warning {
+    background: var(--hv-warn-bg);
+    color: var(--hv-warn-deep);
+    border-color: transparent;
+  }
+  .hv-chip.error {
+    background: var(--hv-error-bg);
+    color: var(--hv-error-deep);
+    border-color: transparent;
+  }
+  /* Present but unremarkable — the "OK" in a status column, the "no area" tail
+     of the location tree. It holds the chip's place in a run of them without
+     claiming the attention a filled one does. */
+  .hv-chip.quiet,
+  .hv-area-chip.quiet {
+    background: none;
+    color: var(--hv-text-tertiary);
+    border-color: var(--hv-divider);
+  }
+
+  /*
+   * Applied. One signal for it card-wide: a ring, which is the only mark
+   * available to a chip whose fill already names its facet.
+   *
+   * A chip with no hue of its own fills as well, or the ring would be drawn
+   * around nothing. The two rules below restate their own hue for the same
+   * reason the ordering note above exists: toggle-and-on is a three-class
+   * selector and would otherwise repaint a hued chip blue.
+   */
+  .hv-chip.on {
+    outline: 2px solid var(--hv-primary);
+    outline-offset: 1px;
+  }
+  .hv-chip.toggle.on {
+    background: var(--hv-primary-tint);
+    color: var(--hv-primary-darker);
+    border-color: transparent;
+  }
+  .hv-chip.toggle.warning.on {
+    background: var(--hv-warn-bg);
+    color: var(--hv-warn-deep);
+  }
+  .hv-chip.toggle.error.on {
+    background: var(--hv-error-bg);
+    color: var(--hv-error-deep);
+  }
+
+  .hv-chip[disabled] {
+    opacity: 0.5;
+    cursor: default;
+  }
+`;

--- a/cards/haventory-card/src/ui/tokens.ts
+++ b/cards/haventory-card/src/ui/tokens.ts
@@ -52,6 +52,10 @@ export const tokens = css`
     --hv-warn-deep: light-dark(#7a4d00, #ffb74d);
     --hv-warn-border: light-dark(#e0c98f, rgba(255, 167, 38, 0.4));
     --hv-amber: #ffa726;
+    /* Ink for text laid directly on --hv-amber. That fill is one fixed hue in
+       both themes, so what reads on it is fixed too — a light-dark() pair here
+       would put white on amber in dark mode, at 1.9:1. */
+    --hv-on-amber: #3b2600;
 
     /* Error */
     --hv-error: var(--error-color, light-dark(#c62828, #ef5350));
@@ -78,6 +82,11 @@ export const tokens = css`
     --hv-radius-dialog: 14px;
     --hv-radius-input: 8px;
     --hv-radius-chip: 999px;
+    /* One size for every chip that reports a fact, so a row carrying several of
+       them reads as a set. A surface whose chips must match something beside
+       them — a field row, an app bar — overrides these on its own rule. */
+    --hv-chip-font-size: 11.5px;
+    --hv-chip-padding: 2px 8px;
     --hv-radius-sheet: 20px;
     /* How wide a bottom sheet is allowed to get before it stops growing with
        the viewport. Roughly HA's own more-info dialog. */
@@ -110,8 +119,9 @@ export const tokens = css`
 
 /**
  * Shared primitives every `hv-*` surface reuses: pill buttons, icon buttons,
- * chips, inputs, section labels and the focus ring. Kept separate from `tokens`
- * so a component can take the variables without the opinionated element styles.
+ * inputs, section labels and the focus ring. Kept separate from `tokens` so a
+ * component can take the variables without the opinionated element styles. The
+ * chip vocabulary lives in `ui/chip.ts`, which not every surface needs.
  *
  * Controls here size themselves from `--hv-tap-min` and `--hv-input-font`, both
  * of which are deliberately *not* declared in `tokens` above: `tokens`
@@ -235,25 +245,6 @@ export const base = css`
   .hv-input:focus {
     border-color: var(--hv-primary);
     outline: none;
-  }
-
-  /* The HA area beside a location path. An area is not a path segment and must
-     never read as one, so every surface that prints a path marks it the same
-     way — hence the shared rule rather than a per-component chip. */
-  .hv-area-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    flex: none;
-    padding: 2px 8px;
-    border-radius: var(--hv-radius-chip);
-    background: var(--hv-chip-bg);
-    color: var(--hv-chip-text);
-    font-size: 11px;
-    /* Sits inside single-line rows that clip with an ellipsis; a wrap would
-       grow the line box those rows size themselves from. */
-    white-space: nowrap;
-    vertical-align: middle;
   }
 
   .hv-sr-only {


### PR DESCRIPTION
Closes #243. Also closes #245 and #246 — both are the same defect in files this
change already opens.

## What was wrong

The card marked things with chips in eleven components and no two agreed. Across
the informational ones alone: **five font sizes** (10.5, 11, 11.5, 12, 12.5px),
**three weights** (400/500/700), **two radii** (4px for `LOW`, 999px for everything
else), a border on some and not others, and *overdue* painted solid red in three
places and soft red in a fourth. There was no shared pill primitive in `src/ui/` —
`base` had `.hv-pill` (an action button) and `.hv-area-chip`, and nothing else.

The screenshot on #243 is the data table, and every mark it circles was a different
size or shape from the one beside it.

## What this does

Adds **`src/ui/chip.ts`** — one composable `css` fragment in the same style as
`tokens.ts` — and replaces the ~40 per-component blocks with it.

- **Base**: one size, one shape, `inline-flex`, a transparent 1px border so a
  bordered chip is the same height as a filled one beside it, and a fixed
  `line-height` so a chip does not change height with the row hosting it.
- **Variants**: `state` (blue — a state the item is in), `warning` (amber — a chore
  on something still on the shelf), `error` (red — out and late back), `quiet`
  (present but unremarkable), and `toggle` for the pressable ones, with `on`.
- The hue vocabulary the card already had in five scattered comments is now stated
  once, where the fills live.

New values went into `tokens.ts` rather than the fragment: `--hv-chip-font-size`,
`--hv-chip-padding`, and `--hv-on-amber` (the ink the app bar lays on its fixed
amber fill, previously `#3b2600` hardcoded four times). `--hv-on-amber` is a single
value, not a `light-dark()` pair, because `--hv-amber` is one fixed hue in both
themes — a pair there would put white on amber at 1.9:1 in dark mode.

### Kept distinct rather than flattened

- **Area chips.** `.hv-area-chip` shares the metrics so it sits level with the chips
  around it, and keeps its own class, home glyph and spelled-out "Area:" label. No
  hue variant applies to it, and a test asserts that.
- **`hv-chip-input`'s chips.** They take the shape and the state fill so they read as
  the card's chips, and own the rest — the remove affordance and the tap-target
  height no informational chip needs.

### Deliberate size overrides, both stated in the CSS

- **Filter panel** — its chips are values in a form and read at the size of the
  selects and date fields beside them (12.5px / 13.5px mobile).
- **Location tree** — its band labels read at the size of the rows they head.

Everything else takes the shared size untouched, and a test fails if a twelfth
component starts setting its own.

## Also fixed, being the same bug

- **The status column** printed `OK` as bare text while its siblings were chips, so
  half the column read as a second column interleaved with the first. Every value is
  now a chip: `OK` quiet, the flagged ones amber.
- **The filter panel marked *overdue* amber** while the card header marked it red.
  Red is the card's documented colour for out-and-late; the panel now agrees.

## #245 — the "No area" band

**Made an equal band, deliberately quieter.**

It takes the same size, shape and position as the area chips heading the other
bands — a sibling, not a different kind of thing — and says the difference with its
fill: an outline where the others carry one, and no home glyph. Equal in structure,
because it does the same structural job; quieter in fill, because there is no area
there and an identical filled chip would read as an area *named* "No area".

Before it was `NO AREA` at 11.5px uppercase tertiary, sitting beside area chips at
row size — the two band labels disagreed on everything.

#203's first bullet (the phone-row area marker) is untouched and stays on the parent.

## #246 — comment archaeology

Stripped the past-tense history from the comments inside the style blocks this
change rewrites, keeping the constraints:

- `hv-item-editor.ts` — "It used to be an outlined 12.5px pill…" is gone; the clause
  about Delete being `hv-text-button danger` survives, moved onto `.actions`, which is
  the rule it is actually about (it had drifted above `.banner`).
- `hv-full-view.ts` — the app-bar pill forensics is rewritten in the present tense
  about the code as it stands: why the bar cannot reuse the card's tints, and why the
  ring is white there.

Bounded to the blocks #243 opens. The rest of #231 stays in #231.

## Testing

Frontend gate green: eslint clean, `tsc --noEmit` clean, **1091 vitest passing**
(51 files), build OK. Backend gate green too (540 passed / 22 skipped, ruff, ruff
format, mypy) — untouched by this, run because the repo asks for both.

New `src/ui/chip.test.ts` asserts the fragment reaches all eleven chipped
components, takes its metrics from tokens, carries the variants, is not restated
locally, and is overridden only in the two places named above. The negative
assertion was mutation-checked — adding a stray `font-size` to one component's chip
rule fails it.

Six existing tests were updated where they pinned the old per-component CSS; each
keeps its original intent, retargeted at the shared rule.

## Visual verification

Not closable from a container, so this was checked against the local Docker HA with
the `run-haventory` skill — same 1002-item inventory for both captures, both themes,
reproducing the framing of the screenshot on #243:

| | dark | light |
|---|---|---|
| before | `i243-before-dark.png` | `i243-before-light.png` |
| after | `i243-after-dark.png` | `i243-after-light.png` |

Plus `i243-after-noarea{,-dark}.png` for #245 and `i243-after-sheet.png` for the
detail sheet's chip row.

`visual_pass.mjs` also ran clean: **42/42 surfaces** captured across desktop, mobile,
panel and panel-mobile, so no surface lost a chip or failed to open.

## Follow-ups (not taken here)

- `--hv-error-border` is unused. It was already unused on `main` before this change,
  so it belongs to #231's dead-code sweep rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
