### PR TITLE
fix(test-harness): close the WS session on every connect() failure path

### DIFF
--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -133,13 +133,21 @@ async def connect() -> WSConn:
     base = os.environ["HA_BASE_URL"]
     token = os.environ["HA_TOKEN"]
     session = aiohttp.ClientSession()
-    ws = await session.ws_connect(ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=20))
-    await asyncio.wait_for(ws.receive_json(), timeout=20)  # hello
-    await ws.send_json({"type": "auth", "access_token": token})
-    auth = await asyncio.wait_for(ws.receive_json(), timeout=20)
-    if auth.get("type") != "auth_ok":
+    # The session is this function's to own until a WSConn takes it: every failure
+    # path has to close it. Callers legitimately retry connect() against an HA that
+    # is down (the restart layer's ready-poll) and swallow the failure, so an
+    # abandoned session there surfaces as an "Unclosed client session" warning — and
+    # the log sweep is an oracle whose value is that a clean run is silent.
+    try:
+        ws = await session.ws_connect(ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=20))
+        await asyncio.wait_for(ws.receive_json(), timeout=20)  # hello
+        await ws.send_json({"type": "auth", "access_token": token})
+        auth = await asyncio.wait_for(ws.receive_json(), timeout=20)
+        if auth.get("type") != "auth_ok":
+            raise RuntimeError(f"auth failed: {auth}")
+    except BaseException:
         await session.close()
-        raise RuntimeError(f"auth failed: {auth}")
+        raise
     return WSConn(session, ws)
 
 
@@ -1306,18 +1314,24 @@ async def cmd_restart() -> None:
         print("\n  waiting for HA to come back ...")
         control = None
         ready = False
-        for i in range(30):
+        for _ in range(30):
             await asyncio.sleep(3)
             try:
                 c = await connect()
-                h = await health(c)
-                if h.get("healthy") is not None:
-                    control = c
-                    ready = True
-                    break
-                await c.close()
             except Exception:  # noqa: BLE001
-                pass
+                continue
+            # Past this point the connection is ours: it is either adopted as the new
+            # control connection or closed here, including when health() fails on a
+            # half-booted HA.
+            try:
+                ready = (await health(c)).get("healthy") is not None
+            except Exception:  # noqa: BLE001
+                ready = False
+            if ready:
+                control = c
+                break
+            with contextlib.suppress(Exception):
+                await c.close()
         if not ready:
             print("  **FAIL: HA did not become ready within timeout**")
             return


### PR DESCRIPTION
## Summary

`connect()` in `.claude/skills/test-haventory/stress.py` created an `aiohttp.ClientSession` and closed it only in the auth-failure branch. A raise from `ws_connect` or either `receive_json` abandoned it. The restart layer's ready-poll calls `connect()` every 3 s while HA is down and swallows the failure, so the ~9–12 s reboot produced three `Unclosed client session` warnings per run — noise in a log sweep whose whole value is that a clean run is silent.

Two changes:

- `connect()` now owns the session across every exit path: everything after `ClientSession()` runs under `try` / `except BaseException` that closes and re-raises. `BaseException` rather than `Exception` so a worker cancelled mid-connect (the storm tasks during `restart`) is covered too. The auth-failure branch just raises now; the handler does the closing.
- The ready-poll splits connect from health: a failed `connect()` continues to the next attempt, and a connection that came up is either adopted as the new control connection or closed here — including when `health()` fails against a half-booted HA, which was a second leak on the same loop.

No behaviour change to any test layer; the poll's swallow-and-retry is correct as written now.

Closes #266

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Docker is unavailable in this environment, so the live restart layer could not be re-run. Instead the leak was reproduced and the fix verified against **real aiohttp** on the exact failure the ready-poll hits: `HA_BASE_URL` pointed at a refused port, driven through the poll's retry-and-swallow shape, then forced GC with a loop exception handler watching for aiohttp's warning.

```
pre-fix  connect(): 3 unclosed-session warnings ['Unclosed client session', ...]
post-fix connect(): 0 unclosed-session warnings []
post-fix cancelled mid-connect: 0 unclosed-session warnings
RESULT: PASS
```

Three warnings before, matching the count observed in the v0.3.1 full-suite run; zero after. The reproduction script lives outside the repo — the offline suite covers `custom_components/haventory`, and pointing it at an exploratory harness that is deliberately outside the lint gate would couple the product gate to skill files. The live confirmation the issue asks for (a `restart` run with zero `Unclosed client session` lines) still wants a machine with Docker.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (540 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1094 passed), `npm run build` — all green

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case) — verified as described above rather than as a committed test, for the reason given.
- [x] Docs updated where behavior changed — none; harness-internal fix with no user-facing behaviour.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched.

## Screenshots (card / UI changes)

None — no card or UI change.

## Follow-ups

Not fixed here, and lower-stakes because they only fire on an already-failing run: `cmd_ratelimit` (`hammer`, `hammer2`) and `cmd_restart`'s worker pool are closed in the try body, so an assertion failure before those lines leaks those connections too. Happy to file an issue if you want them tightened.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9mtmChcCWaY8AJpNzSZ2S)_