### PR TITLE
docs(skills): refresh stale test counts and frame them as a growth oracle

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -19,7 +19,7 @@ All paths below are relative to the repo root. This is a **Windows host**: run t
   (`ghcr.io/home-assistant/home-assistant:stable`, port 8123). Check: `docker ps`.
   It was provisioned once by hand (image run + HA onboarding in the browser); if it's
   ever gone, that one-time onboarding has to be redone in a browser — not scripted.
-- `uv` (Python 3.14 env) and Node ≥ 22 on PATH.
+- `uv` (Python 3.14 env) and Node 22.13+ (or ≥ 24, per the card's `engines`) on PATH.
 - Repo-root **`.env`** (gitignored) with the credentials both drivers auto-read:
 
   ```
@@ -483,8 +483,10 @@ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q
 (cd cards/haventory-card && npx vitest run)
 ```
 
-Expected at feature freeze: backend 350 passed / 22 skipped in ~11 s; frontend 812 passed
-across 42 files in ~30 s.
+As of v0.3.1: backend 540 passed / 22 skipped; frontend 1094 passed across 51 files. Both
+counts only grow — a *smaller* one than the last release's means collection broke, not that
+tests were removed — so treat them as a floor, and re-pin them when a release moves them.
+The full gate, with the numbers kept next to it, is the sibling `/test-haventory` skill.
 
 The harness has its own unit cover for the parts of `card_views.mjs` that decide where a
 run looks — which views hold the card, which URL addresses them, what `--path` asked for.
@@ -509,8 +511,8 @@ set -a; . ./.env; set +a
 RUN_ONLINE=1 bash scripts/smoke_online.sh
 ```
 
-Expected: `8 passed, 13 skipped` (the skips need `HA_CONTAINER`, i.e. the destructive
-clean-start mode), then `Online smoke test completed successfully.`
+Expected as of v0.3.1: `8 passed, 13 skipped` (the skips need `HA_CONTAINER`, i.e. the
+destructive clean-start mode), then `Online smoke test completed successfully.`
 
 ## Gotchas
 

--- a/.claude/skills/test-haventory/SKILL.md
+++ b/.claude/skills/test-haventory/SKILL.md
@@ -33,13 +33,13 @@ Both halves must be green. Backend, from the repo root:
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --python 3.14 \
   --with pytest --with pytest-asyncio --with voluptuous --with aiohttp \
   python -m pytest -q
-# → 350 passed, 22 skipped
+# → 540 passed, 22 skipped
 
 uv run --no-project --python 3.14 --with ruff==0.15.22 ruff check custom_components tests
 # → All checks passed!
 
 uv run --no-project --python 3.14 --with mypy --with voluptuous mypy
-# → Success: no issues found in 13 source files
+# → Success: no issues found in 14 source files
 ```
 
 Frontend, from `cards/haventory-card`:
@@ -48,9 +48,16 @@ Frontend, from `cards/haventory-card`:
 npm ci            # first run, or if node_modules is partial (missing rolldown binding)
 npm run lint      # eslint  → clean
 npm run typecheck # tsc --noEmit → clean
-npm test          # vitest  → 812 passed across 42 files
+npm test          # vitest  → 1094 passed across 51 files
 npm run build     # vite → ../../custom_components/haventory/www/ (git-ignored)
 ```
+
+Those counts are **as of v0.3.1** and are a collection oracle, not a target: TDD means every
+release adds tests, so a number *larger* than the one printed here is the normal result. A
+number **smaller** than the last release's — fewer tests, fewer vitest files, fewer mypy
+source files — means collection broke and half the suite silently did not run. Re-pin them
+whenever a release moves them; a stale figure read as an exact expectation misdiagnoses a
+healthy run.
 
 Warm the hooks before committing (never `--no-verify`):
 
@@ -157,7 +164,7 @@ set -a; source .env; set +a
 RUN_ONLINE=1 uv run --no-project --python 3.14 \
   --with pytest --with pytest-asyncio --with aiohttp --with voluptuous \
   python -m pytest -q -m online -k "ws_smoke or ws_smoke_advanced"
-# → 8 passed, 13 skipped
+# → 8 passed, 13 skipped (as of v0.3.1; the skips need the destructive/area gates)
 ```
 
 The full online gate (adds destructive + area-registry tests, double-gated by


### PR DESCRIPTION
## Summary

The pinned expectations in `.claude/skills/test-haventory/SKILL.md` and `.claude/skills/run-haventory/SKILL.md` were two releases stale, so a healthy v0.3.1 run reads as a collection failure.

Re-pinned to the values measured on this branch, and reworded so they stop presenting as timeless:

| Location | Was | Now (measured, v0.3.1) |
|---|---|---|
| test-haventory, backend gate | `350 passed, 22 skipped` | `540 passed, 22 skipped` |
| test-haventory, mypy | `13 source files` | `14 source files` |
| test-haventory, vitest | `812 passed across 42 files` | `1094 passed across 51 files` |
| run-haventory, "Test" section | `350 / 22`, `812 across 42` | `540 / 22`, `1094 across 51` |

Both docs now say the counts are **as of v0.3.1** and state what the oracle actually is: the suites only grow, so a *larger* number is the normal result and a *smaller* one means collection broke and half the suite silently did not run — and the figures get re-pinned whenever a release moves them. That keeps the collection oracle the counts were there for while removing the trap of reading a stale figure as an exact expectation.

Swept the rest of both docs for other drifted counts/versions:

- The two online-smoke expectations (`8 passed, 13 skipped`) are still accurate — verified 21 tests collect under that selection — so they were dated, not changed.
- `visual_pass.mjs` surface counts (14 desktop / 8 mobile / 10 panel / 8 panel-mobile, 42 rows) verified against the source and unchanged.
- The Python 3.14 and `ruff==0.15.22` pins match `pyproject.toml`; the `stress.py` subcommand table matches the script.
- Corrected run-haventory's Node floor from `≥ 22` to `22.13+ (or ≥ 24)` to match the card's `engines`, which excludes 22.0–22.12.

Closes #265

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Documentation only — no source changed. The gate was run to *produce* the new numbers, and is green:

- [x] Backend: `540 passed, 22 skipped`; `ruff check` → All checks passed!; `ruff format --check .` → 106 files already formatted; `mypy` → Success: no issues found in 14 source files
- [x] Frontend (`cards/haventory-card`): `vitest run` → 1094 passed across 51 files. eslint/typecheck/build unaffected by a Markdown-only diff.

Also ran `node --test` in `.claude/skills/run-haventory` (19 passed) while verifying the harness surface counts.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — n/a; the change is the documented expectation of the existing suites, and the new values were measured rather than assumed.
- [x] Docs updated where behavior changed — this PR is the doc update.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Essential invariants preserved — n/a, no code change.

## Screenshots (card / UI changes)

n/a — no visible change.

## Follow-ups (not fixed here, out of the issue's "mechanical staleness only" scope)

- Both skill docs open with "This is a **Windows host**", which contradicts CLAUDE.md's "no Windows host support / develop through WSL2". That is a judgment call about what the docs are for, not drift.
- `test-haventory` line 135 carries "(ships with PR #96)" — dev-history narration of the kind CLAUDE.md rules out for comments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiitR5ZeAA3m4ptnSHpzW3)_