### PR TITLE
build(card): switch to `codeSplitting: false` for single-file output

### DIFF
--- a/cards/haventory-card/vite.config.ts
+++ b/cards/haventory-card/vite.config.ts
@@ -25,7 +25,10 @@ export default defineConfig({
     rollupOptions: {
       external: [],  // Bundle everything since HA doesn't provide dependencies
       output: {
-        inlineDynamicImports: true  // Single file output for HACS
+        // The integration serves exactly one bundle at
+        // /haventory_static/haventory-card.js, so the build must emit a single
+        // file — no chunk may be split out.
+        codeSplitting: false
       }
     },
     minify: true,

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -247,6 +247,20 @@ def hav_init(monkeypatch, tmp_path):
 # --------------------------------------------------------------------------- #
 
 
+def test_the_card_build_emits_a_single_file() -> None:
+    """The card build keeps code splitting off, so the bundle has no siblings.
+
+    Everything the loaders name is one file. A split chunk would land in the
+    served directory beside it, and both the directory's ``.gitignore`` entry and
+    the release-zip check — which asserts the bundle is present, not that it is
+    alone — would pass it through into the HACS asset. ``emptyOutDir: false``
+    then keeps every such chunk across later builds.
+    """
+    config = (REPO_ROOT / "cards" / "haventory-card" / "vite.config.ts").read_text(encoding="utf-8")
+
+    assert re.search(r"^\s*codeSplitting: false$", config, re.MULTILINE) is not None
+
+
 @pytest.mark.asyncio
 async def test_serves_the_bundle_directory_without_cache_headers(hav_init, tmp_path):
     """The card directory is served at a fixed path, with revalidation left on.


### PR DESCRIPTION
## Summary

Vite 8 (rolldown) warns on every card build that `inlineDynamicImports` is deprecated in favour of `codeSplitting: false`. Harmless today, build-breaking on the future Vite major that turns it into an error — i.e. in the same PR that bumps Vite. Renamed now, ahead of that.

The constraint the old comment stated survives the rename: the build must emit a **single file**, because the integration serves exactly one bundle at `/haventory_static/haventory-card.js` and HACS copies exactly that tree.

Added a guard test for that constraint (`test_the_card_build_emits_a_single_file`), because nothing else catches its loss: `custom_components/haventory/www/` is git-ignored, and `check_release_zip.py` asserts the bundle is *present*, not that it is *alone* — so a split chunk would ride into the HACS asset unnoticed, and `emptyOutDir: false` would keep every such chunk across later builds. The test fails against the pre-change config and passes after it.

Closes #264

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green, plus a before/after build comparison.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **541 passed, 22 skipped**; `uv run ruff check .` → all checks passed; `uv run ruff format --check .` → 106 files already formatted; `uv run mypy` → no issues in 14 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean, `npx vitest run` → **1094 passed (51 files)**, `npm run build` clean

Build output, before and after (clean `www/` both times):

```
before:  WARN  inlineDynamicImports option is deprecated, please use codeSplitting: false instead.
         ../../custom_components/haventory/www/haventory-card.js  458.88 kB │ gzip: 106.27 kB

after:   (no warning)
         ../../custom_components/haventory/www/haventory-card.js  458.88 kB │ gzip: 106.27 kB
```

One file in the output directory, byte-identical size (458887 bytes) — matching the v0.3.1 baseline the issue records.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — guard test added; verified it fails against the old config.
- [ ] Docs updated where behavior changed — n/a, no behavior change.
- [ ] WebSocket API changes keep `ws.py` and the docs in sync — n/a, no API change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched.

## Screenshots (card / UI changes)

n/a — build configuration only; the emitted bundle is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bz5KV3cpFjB9YdBA6v2z2p)_