### PR TITLE
build(card): bump transitive postcss past GHSA-fxqj-rqcc-2cmp and track the lockfile version in release-please

### DIFF
--- a/cards/haventory-card/package-lock.json
+++ b/cards/haventory-card/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haventory-card",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haventory-card",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "^3.1.0"
@@ -2314,7 +2314,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,16 @@
           "jsonpath": "$.version"
         },
         {
+          "type": "json",
+          "path": "cards/haventory-card/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "cards/haventory-card/package-lock.json",
+          "jsonpath": "$.packages[\"\"].version"
+        },
+        {
           "type": "generic",
           "path": "custom_components/haventory/const.py"
         },

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Assert every version string in the repository agrees — and matches the tag.
 
-Six files carry the release version, and release-please rewrites each of them
+Seven files carry the release version, and release-please rewrites each of them
 through a different mechanism: the `python` release type handles
-``pyproject.toml``, two ``extra-files`` JSON entries handle the integration
-manifest and the card's ``package.json``, a generic annotation handles
-``const.py``, a TOML jsonpath handles ``uv.lock``, and the manifest file is
-release-please's own bookkeeping. Any one of them can silently stop being
-rewritten — a moved line drops a generic annotation, a renamed key orphans a
-jsonpath — and the failure mode is a release that ships mismatched versions
-rather than an error.
+``pyproject.toml``, ``extra-files`` JSON entries handle the integration
+manifest, the card's ``package.json`` and its ``package-lock.json``, a generic
+annotation handles ``const.py``, a TOML jsonpath handles ``uv.lock``, and the
+manifest file is release-please's own bookkeeping. Any one of them can silently
+stop being rewritten — a moved line drops a generic annotation, a renamed key
+orphans a jsonpath, and a jsonpath that matches nothing is a no-op rather than
+an error — and the failure mode is a release that ships mismatched versions
+rather than a failure.
 
 Run with no arguments to check the files against each other. Pass ``--tag`` (or
 set ``GITHUB_REF_NAME`` on a tag build) to also require the git tag to name the
@@ -54,6 +55,27 @@ def _uv_lock_version() -> str:
     raise AssertionError("uv.lock: no [[package]] entry named 'haventory'")
 
 
+def _package_lock_version() -> str:
+    """The version the card's lockfile records — in both of the places it does.
+
+    npm writes the root package's version twice: once at the top level and again
+    under the ``""`` key in ``packages``. It takes one ``extra-files`` entry per
+    copy, so rewriting only one is a live failure mode, and the copy left behind
+    does not merely disagree — the next ``npm install`` rewrites it to match
+    ``package.json`` and dirties the working tree, exactly like a stale
+    ``uv.lock``.
+    """
+    path = "cards/haventory-card/package-lock.json"
+    data = json.loads((REPO_ROOT / path).read_text(encoding="utf-8"))
+    root = str(data["version"])
+    nested = str(data["packages"][""]["version"])
+    if root != nested:
+        raise AssertionError(
+            f"{path}: root version {root!r} disagrees with packages[''] version {nested!r}"
+        )
+    return root
+
+
 def _const_version() -> str:
     text = (REPO_ROOT / "custom_components/haventory/const.py").read_text(encoding="utf-8")
     match = re.search(r'^INTEGRATION_VERSION:\s*str\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
@@ -71,6 +93,7 @@ def collect_versions() -> dict[str, str]:
         ".release-please-manifest.json": _json_version(".release-please-manifest.json", key="."),
         "pyproject.toml": _pyproject_version(),
         "cards/haventory-card/package.json": _json_version("cards/haventory-card/package.json"),
+        "cards/haventory-card/package-lock.json": _package_lock_version(),
         "custom_components/haventory/const.py": _const_version(),
         "uv.lock": _uv_lock_version(),
     }

--- a/tests/test_release_version_consistency.py
+++ b/tests/test_release_version_consistency.py
@@ -17,6 +17,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+import check_version_consistency  # noqa: E402
 from check_version_consistency import collect_versions, tag_version  # noqa: E402
 
 # The two sources release-please rewrites outside `extra-files`: the `python`
@@ -34,6 +35,7 @@ def test_every_version_file_agrees() -> None:
         ".release-please-manifest.json",
         "pyproject.toml",
         "cards/haventory-card/package.json",
+        "cards/haventory-card/package-lock.json",
         "custom_components/haventory/const.py",
         "uv.lock",
     }
@@ -53,6 +55,55 @@ def test_release_please_rewrites_every_collected_file() -> None:
     listed = {entry["path"] if isinstance(entry, dict) else entry for entry in extra_files}
 
     assert listed == set(collect_versions()) - NOT_EXTRA_FILES
+
+
+def test_release_please_rewrites_both_copies_in_the_card_lockfile() -> None:
+    """The card lockfile needs one ``extra-files`` entry per copy of the version.
+
+    The wiring check above compares paths, so a single entry for this file looks
+    complete there while leaving the second copy at the previous release. A
+    jsonpath that matches nothing is a silent no-op in release-please, so the
+    entries themselves are the only place this can be asserted.
+    """
+    config = json.loads((REPO_ROOT / "release-please-config.json").read_text(encoding="utf-8"))
+    jsonpaths = {
+        entry["jsonpath"]
+        for entry in config["packages"]["."]["extra-files"]
+        if isinstance(entry, dict) and entry["path"] == "cards/haventory-card/package-lock.json"
+    }
+
+    assert jsonpaths == {"$.version", '$.packages[""].version'}
+
+
+def _write_card_lock(root: Path, top: str, nested: str) -> None:
+    path = root / "cards/haventory-card/package-lock.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"name": "haventory-card", "version": top, "packages": {"": {"version": nested}}}
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_card_lock_version_reads_the_version_both_copies_agree_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_card_lock(tmp_path, "0.4.0", "0.4.0")
+    monkeypatch.setattr(check_version_consistency, "REPO_ROOT", tmp_path)
+
+    assert check_version_consistency._package_lock_version() == "0.4.0"
+
+
+def test_card_lock_version_rejects_a_half_rewritten_lockfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One copy bumped and the other left behind must fail, not pick a winner."""
+    _write_card_lock(tmp_path, "0.4.0", "0.3.1")
+    monkeypatch.setattr(check_version_consistency, "REPO_ROOT", tmp_path)
+
+    with pytest.raises(AssertionError, match="disagrees"):
+        check_version_consistency._package_lock_version()
 
 
 def test_tag_version_strips_the_prefix() -> None:


### PR DESCRIPTION
## Summary

Two commits: the advisory bump #263 asks for, and the release-please wiring that stops the drift the bump exposed.

**1. `build(card): bump transitive postcss past GHSA-fxqj-rqcc-2cmp`**

`npm audit` reported one moderate advisory against **postcss ≤ 8.5.22** — [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp), an incomplete fix of GHSA-6g55-p6wh-862q where an attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset. It reaches us transitively via `haventory-card → vite@8.1.5 → postcss`, so it is dev-scope only: postcss runs at build time and never ships in the bundle. vite's dependency range already accepts the patched release, so this is a **lockfile-only bump to 8.5.25** — no `overrides` entry needed. `npm audit` now reports zero vulnerabilities at every level.

**2. `build: track the card lockfile version in release-please`**

Bumping the lockfile surfaced that its root `version` was a release behind `package.json`. `release-please-config.json` listed `cards/haventory-card/package.json` in `extra-files` but not its lockfile, so every release bumped one and left the other. That is not cosmetic: like a stale `uv.lock`, the next `npm install` rewrites the copy to match `package.json` and dirties the working tree.

npm records the root version **twice** — top level and again under the `""` key in `packages` — so it takes one `extra-files` entry per copy. The consistency check grows a seventh source (`scripts/check_version_consistency.py`, `collect_versions`), and because **a jsonpath that matches nothing is a silent no-op in release-please rather than an error**, the new collector reads both copies and refuses a half-rewritten lockfile instead of picking a winner.

### How the jsonpath was verified

Not by inference — by installing `release-please@16.18.0` (the version `release-please-action@v4.4.1` bundles) and driving its own `GenericJson` updater with the jsonpath strings read straight out of the committed config:

- both copies move to the target version;
- the file's formatting, its `lockfileVersion`, and every dependency entry are untouched (a 4-line diff, exactly the two version fields);
- the trailing newline is preserved;
- a non-matching path silently changes nothing — which is what makes the wiring test load-bearing rather than decorative.

Both new guards were mutation-tested: dropping the `$.packages[""].version` entry fails `test_release_please_rewrites_both_copies_in_the_card_lockfile`, and dropping the file entirely fails that plus the existing `test_release_please_rewrites_every_collected_file`.

Per the issue, #210's policy half — whether the CI gate tightens from `--audit-level=high` to `moderate` — stays with #210.

Closes #263

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green.

- [x] Backend: `544 passed, 22 skipped` (up 3 — the new lockfile guards); `ruff check` — all checks passed; `ruff format --check` — 106 files already formatted; `mypy` — no issues in 14 source files.
- [x] Frontend (`cards/haventory-card`): `eslint` clean; `tsc --noEmit` clean; `vitest run` — 51 files, 1094 tests passed; `npm run build` — bundle emitted (458.88 kB, 106.27 kB gzip).
- [x] `npm audit` and `npm audit --audit-level=high` — found 0 vulnerabilities.
- [x] `scripts/check_version_consistency.py` — `OK: all 7 version files agree on 0.3.1`; with `--tag v0.3.1` — tag and all 7 agree.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — three: the two-entry wiring assertion, plus happy path and the half-rewritten-lockfile error case for the new collector.
- [x] Docs updated where behavior changed — the module docstring in `check_version_consistency.py` (six files → seven, and the new silent-no-op caveat). No user-visible behavior changed, so no `README.md` change.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Essential invariants preserved — untouched; no integration source file is modified.

## Screenshots (card / UI changes)

n/a — no visible change; postcss is build-time only and the card bundle is unaffected.