### PR TITLE
docs(skills): scope the Windows/Git Bash notes to the host they apply to

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -10,12 +10,14 @@ WebSocket API via `.claude/skills/run-haventory/driver.py`; drive/screenshot the
 or the sidebar panel in the real HA frontend via
 `.claude/skills/run-haventory/screenshot.mjs` (Playwright).
 
-All paths below are relative to the repo root. This is a **Windows host**: run the
-`.sh` scripts through Git Bash (they work there), everything else is shell-agnostic.
+All paths below are relative to the repo root and every command is **Linux/bash**, which is
+the only development host the repo supports — on Windows the supported path is WSL2
+(`CONTRIBUTING.md`). Notes tagged **[Windows/Git Bash]** cover driving a Windows host's
+Docker and filesystem through Git Bash instead; nothing else here depends on them.
 
 ## Prerequisites
 
-- Docker Desktop with the dev container **`home-assistant`** running
+- Docker (Docker Desktop on a Windows host) with the dev container **`home-assistant`** running
   (`ghcr.io/home-assistant/home-assistant:stable`, port 8123). Check: `docker ps`.
   It was provisioned once by hand (image run + HA onboarding in the browser); if it's
   ever gone, that one-time onboarding has to be redone in a browser — not scripted.
@@ -53,7 +55,7 @@ cd .claude/skills/run-haventory && npm install --no-audit --no-fund && npx playw
 
 Builds the card **into** `custom_components/haventory/www/` so it rides along with the
 component copy, then copies the integration into the container, restarts HA (~30 s), and
-initialises the config entry via WS. Run from Git Bash:
+initialises the config entry via WS. Run from the repo root:
 
 ```bash
 set -a; . ./.env; set +a
@@ -256,7 +258,7 @@ node screenshot.mjs --path /haventory --element haventory-panel --out panel.png
 defaults to `haventory-card`. The sidebar panel is a **different custom element** —
 `/haventory` renders `<haventory-panel>` and no card at all — so shooting it without
 `--element` only ever times out. Both flags are needed together; the script says which
-roots exist when the wait times out. From Git Bash, prefix the command with
+roots exist when the wait times out. [Windows/Git Bash] prefix the command with
 `MSYS_NO_PATHCONV=1` — `--path /haventory` is exactly the leading-slash value the
 path-conversion gotcha below mangles.
 
@@ -312,9 +314,11 @@ momentum-scroll quirks) still need a real device — see "Real phone on the LAN"
 #### Real phone on the LAN (ground truth)
 
 The container publishes 8123 on the host, so a phone on the same network can hit
-`http://<host-LAN-IP>:8123` directly (`ipconfig` for the IP; Windows Firewall must allow
-inbound 8123 on the private profile). This is the only way to test real fingers, momentum
-scrolling, iOS Safari, and the HA Companion app's webview.
+`http://<host-LAN-IP>:8123` directly — `ip addr` for the IP ([Windows/Git Bash] `ipconfig`),
+and the host firewall has to allow inbound 8123 (on Windows, on the private profile). Docker
+running *inside* WSL2 publishes onto the VM rather than the LAN, so that case additionally
+needs mirrored networking mode or a `netsh interface portproxy` forward. This is the only way
+to test real fingers, momentum scrolling, iOS Safari, and the HA Companion app's webview.
 
 ### Drive the import sheet
 
@@ -339,7 +343,7 @@ This is what the WS-level scripts cannot check: whether the sheet *describes* th
 backend actually applies. `replace` overwrites the ids the document carries and deletes
 nothing, which is only visible by reading the sheet next to the counts it produces.
 
-From Git Bash, pass the document as a native path with forward slashes
+[Windows/Git Bash] pass the document as a native path with forward slashes
 (`"C:/Users/you/backup.json"`) and prefix the command with `MSYS_NO_PATHCONV=1` if you
 override `--path` — see the path-conversion gotcha below.
 
@@ -496,12 +500,12 @@ No HA and no dependency beyond Node:
 cd .claude/skills/run-haventory && node --test
 ```
 
-The in-process HA integration suite (`scripts/test_integration.sh`, real HA core via
-phacc) does **not** run on this Windows host: the script builds a POSIX venv path and HA
-core imports `fcntl`. A throwaway `python:3.14-slim` container is the proven way to run it
-here — one `docker run` with the repo bind-mounted, `pip install -r
+The in-process HA integration suite (`scripts/test_integration.sh`, real HA core via phacc)
+runs directly on Linux/WSL2. It cannot run on a Windows host at all — the script builds a
+POSIX venv path and HA core imports `fcntl` — and a throwaway `python:3.14-slim` container is
+the proven way to get it there: one `docker run` with the repo bind-mounted, `pip install -r
 requirements-integration.txt`, then `pytest -o asyncio_mode=auto tests/integration`. That
-path also covers hosts whose WSL has no DNS.
+container path also covers a WSL install whose DNS is broken.
 
 Online smoke against the running container (non-destructive as long as
 `HA_CONTAINER` is unset — verify with `echo $HA_CONTAINER` first):
@@ -516,8 +520,8 @@ destructive clean-start mode), then `Online smoke test completed successfully.`
 
 ## Gotchas
 
-- **Git Bash rewrites any argument that looks like an absolute POSIX path** (MSYS path
-  conversion), so a leading-slash flag value never reaches the script intact:
+- [Windows/Git Bash] **Git Bash rewrites any argument that looks like an absolute POSIX
+  path** (MSYS path conversion), so a leading-slash flag value never reaches the script intact:
   `node screenshot.mjs --path /dashboard-dev/wide` navigates to
   `http://localhost:8123C:/Program Files/Git/dashboard-dev/wide`, and a `/c/Users/...`
   document path arrives as `C:\c\Users\...`. The per-pass form is rewritten too —

--- a/.claude/skills/test-haventory/SKILL.md
+++ b/.claude/skills/test-haventory/SKILL.md
@@ -10,20 +10,25 @@ adversarial **stress regimen** `.claude/skills/test-haventory/stress.py` (the pr
 break-it driver), the **live-update browser smoke** `cards/haventory-card/e2e/live-updates.smoke.mjs`,
 and the **online WS pytest smokes** (`-m online`).
 
-All paths are relative to the repo root. This is a **Windows host**: run `.sh`/`.py` through
-Git Bash. Plain `uv run` works against the project `.venv` — the `--no-project` form below is
-still correct and is what to fall back to if the venv is ever unusable again, but it is no
-longer required. Canonical clean-Linux/CI commands live in the README ("The gate").
+All paths are relative to the repo root and every command below is **Linux/bash**, which is
+the only development host the repo supports — CI runs `ubuntu-latest`, and on Windows the
+supported path is WSL2 (`CONTRIBUTING.md`). A handful of notes are tagged
+**[Windows/Git Bash]**: they are workarounds for driving a Windows host's Docker and
+filesystem through Git Bash instead, and nothing else here depends on them. Plain `uv run`
+works against the project `.venv` — the `--no-project` form below is still correct and is
+what to fall back to if the venv is ever unusable, but it is no longer required. Canonical
+clean-Linux/CI commands live in the README ("The gate").
 
 ## Prerequisites
 
 - **uv** (provisions CPython 3.14 automatically — the source uses PEP 758 syntax that does
-  not parse on ≤3.13), **Node 22.13+**, **Docker** (for the online surfaces), **Git Bash**.
+  not parse on ≤3.13), **Node 22.13+**, **Docker** (for the online surfaces). [Windows/Git
+  Bash] **Git Bash** for the `.sh`/`.py` helpers.
 - `pre-commit` on PATH (the git hook needs it): `uv tool install pre-commit`.
 - A `.env` at the repo root with `HA_BASE_URL` + `HA_TOKEN` (a long-lived token; per session,
   never committed). The online surfaces read it directly.
-- For the browser smoke: Chromium for Playwright — `npx playwright install chromium` (cached
-  at `~/AppData/Local/ms-playwright` on this host).
+- For the browser smoke: Chromium for Playwright — `npx playwright install chromium`. It
+  caches under `~/.cache/ms-playwright`; [Windows/Git Bash] `~/AppData/Local/ms-playwright`.
 
 ## The commit gate (offline — run before every commit)
 
@@ -68,13 +73,14 @@ pre-commit run --files <changed paths>
 ## Deploy current code first (required for all online surfaces)
 
 The online surfaces test the **running container**, so deploy the working tree into it first.
-`docker cp` of host paths mangles under Git Bash, so use a tar pipe (verified this session):
+A tar pipe works on every host and sidesteps `docker cp`'s host-path mangling under Git Bash:
 
 ```bash
 # Build first: the bundle lands in custom_components/haventory/www/ and ships
 # with the component in the same tar.
 npm --prefix cards/haventory-card run build >/dev/null
-tar -C custom_components -cf - haventory | MSYS_NO_PATHCONV=1 \
+# [Windows/Git Bash] prefix the docker exec with MSYS_NO_PATHCONV=1 so /config survives.
+tar -C custom_components -cf - haventory | \
   docker exec -i home-assistant sh -lc \
   'cd /config/custom_components && tar -xf - && find haventory -type d -name __pycache__ -prune -exec rm -rf {} +'
 docker restart home-assistant
@@ -95,7 +101,7 @@ gate (`healthy: true`, `issues: []`). Run **one at a time, non-destructive first
 last**. Reads `HA_BASE_URL`/`HA_TOKEN` from `.env`.
 
 ```bash
-export PYTHONIOENCODING=utf-8   # unicode-safe output on Windows consoles
+export PYTHONIOENCODING=utf-8   # [Windows/Git Bash] only; a Linux terminal is UTF-8 already
 S=".claude/skills/test-haventory/stress.py"
 RUN="uv run --no-project --with aiohttp python $S"
 
@@ -107,7 +113,7 @@ $RUN statsprobe    # stats broadcast: ~1 counts event per mutation
 $RUN ratelimit     # enable a tight per-conn budget, hammer, disable, confirm recovery
 $RUN races         # rename vs. item versions, concurrent rename, adjust serialization
 $RUN bulk 1000     # create 250→500→1000 (latency curve) + delete; ~3½ min on a 2000-item store
-MSYS_NO_PATHCONV=1 HA_CONTAINER=home-assistant $RUN restart   # DESTRUCTIVE, last
+HA_CONTAINER=home-assistant $RUN restart   # DESTRUCTIVE, last
 $RUN cleanup       # sweep any leftover stress_test_ data
 ```
 
@@ -139,13 +145,13 @@ uv run python .claude/skills/run-haventory/log_sweep.py --since 30m
 
 Drives the **real card** in headless Chromium and makes changes over a *separate* WS
 connection, so the card can only learn of them via its subscription (create→rename→delete
-reflected live, zero console errors). Opt-in; from `cards/haventory-card` (ships with PR #96):
+reflected live, zero console errors). Opt-in; from `cards/haventory-card`:
 
 ```bash
-RUN_ONLINE=1 PLAYWRIGHT_BROWSERS_PATH="$HOME/AppData/Local/ms-playwright" \
-  node e2e/live-updates.smoke.mjs
+RUN_ONLINE=1 node e2e/live-updates.smoke.mjs
 # → PASS: card reflects live create / rename / delete over the WS subscription
 # (equivalently: RUN_ONLINE=1 npm run test:e2e)
+# [Windows/Git Bash] prepend PLAYWRIGHT_BROWSERS_PATH="$HOME/AppData/Local/ms-playwright"
 ```
 
 Screenshot the card (e.g. while a `stress.py hammer 30` storm runs, to eyeball it under load)
@@ -174,15 +180,17 @@ not re-verified here.
 
 ## Gotchas
 
-- **`--no-project` is the fallback, not the rule** — plain `uv run` works. If it ever fails with
-  `failed to remove file .venv/lib64: Zugriff verweigert` (OneDrive refusing to delete the
-  symlink), add `--no-project` and the `--with` list to run from an ephemeral env instead.
+- **`--no-project` is the fallback, not the rule** — plain `uv run` works. Add `--no-project`
+  and the `--with` list to run from an ephemeral env whenever the project venv is unusable.
+  [Windows/Git Bash] the way that shows up here is `failed to remove file .venv/lib64:
+  Zugriff verweigert`, OneDrive refusing to delete the symlink.
 - **Offline suite needs Python 3.14** (PEP 758 source) and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`;
   `--with aiohttp` is only so the `*_online.py` / stress modules import at collection time.
-- **Frontend `node_modules` is often partial** (missing `@rolldown/binding-win32-x64-msvc` →
-  vitest/vite crash on start). `npm ci` in `cards/haventory-card` fixes it.
-- **`stress.py restart` needs `MSYS_NO_PATHCONV=1`** (or Git Bash rewrites the `/config/...`
-  docker path) **and `HA_CONTAINER`**. It leaves the container restarted (disposable).
+- **Frontend `node_modules` is often partial** (missing the platform's `@rolldown/binding-*`
+  → vitest/vite crash on start). `npm ci` in `cards/haventory-card` fixes it.
+- **`stress.py restart` needs `HA_CONTAINER`**, and leaves the container restarted
+  (disposable). [Windows/Git Bash] it also needs `MSYS_NO_PATHCONV=1`, or Git Bash rewrites
+  the `/config/...` docker path.
 - **`ratelimit` rebuilds the limiter on save** (buckets refill, counters zero) — it samples
   `dropped_commands` before disabling and always resets rate limiting OFF, even on failure.
 - **Expected non-bugs the layers surface — do NOT file as regressions** (tracked as
@@ -196,12 +204,12 @@ not re-verified here.
 
 ## Troubleshooting
 
-- **`failed to remove file .venv/lib64: Zugriff verweigert`** — the project venv is unusable
-  again; re-run with `--no-project` plus the `--with` list.
-- **`Cannot find module '@rolldown/binding-win32-x64-msvc'`** — `npm ci` in `cards/haventory-card`.
+- **`Cannot find module '@rolldown/binding-…'`** — `npm ci` in `cards/haventory-card`.
 - **`No module named 'aiohttp'`** during pytest collection — add `--with aiohttp` to the uv run.
-- **`GetFileAttributesEx C:\c:` on `docker cp`** — host-path mangling under Git Bash; use the
-  tar-pipe deploy above instead.
+- [Windows/Git Bash] **`failed to remove file .venv/lib64: Zugriff verweigert`** — the project
+  venv is unusable; re-run with `--no-project` plus the `--with` list.
+- [Windows/Git Bash] **`GetFileAttributesEx C:\c:` on `docker cp`** — host-path mangling; use
+  the tar-pipe deploy above instead.
 - **`stress.py` baseline errors / `unknown command`** — check `.env` has `HA_BASE_URL`/`HA_TOKEN`
   and the container is up; run `baseline` first to confirm the integration imported.
 - **E2E redirected to `/auth/authorize`** — `HA_TOKEN` is missing/expired.


### PR DESCRIPTION
## Summary

The two follow-ups noted on #272, done.

**1. The "Windows host" framing contradicted the repo's own policy.** Both skill docs opened with "This is a **Windows host**", while `CONTRIBUTING.md` says the toolchain is "**Linux/bash only** … nothing here is tested on a Windows host. On Windows, develop inside WSL2", `CLAUDE.md` says "no Windows host support", and CI runs `ubuntu-latest`. A reader on the supported host was told the commands were something else.

The Git Bash guidance is hard-won and worth keeping, so it is scoped rather than deleted. Each doc now states the Linux/bash baseline up front, and the genuinely host-specific notes carry a **[Windows/Git Bash]** tag:

- MSYS path conversion (`MSYS_NO_PATHCONV=1` on `stress.py restart`, `--path /haventory`, `docker exec`, document paths), and the `GetFileAttributesEx C:\c:` troubleshooting entry
- the OneDrive `.venv/lib64: Zugriff verweigert` failure that makes `--no-project` necessary
- `PYTHONIOENCODING=utf-8`, and `ipconfig` / the private-profile firewall rule
- the Playwright browser cache — Linux default `~/.cache/ms-playwright` now given alongside `~/AppData/Local/ms-playwright`, and the smoke command no longer hardcodes the Windows path
- Docker Desktop, now "Docker (Docker Desktop on a Windows host)"

Three claims corrected while scoping them:

- `@rolldown/binding-win32-x64-msvc` → `@rolldown/binding-*`: the partial-`node_modules` failure is platform-generic, and the win32 string sends a Linux reader looking for the wrong module name.
- The in-process HA integration suite is described as running **directly** on Linux/WSL2. It previously read as if the throwaway `python:3.14-slim` container were the only way to run it anywhere, when that is the Windows-host workaround.
- The LAN-testing note gains the WSL2 case: Docker inside WSL2 publishes onto the VM, so LAN access needs mirrored networking or a `netsh interface portproxy` forward — otherwise the "phone on the same network" recipe silently doesn't work on the supported host.

**2. Dropped two history references.** "(ships with PR #96)" from the browser-smoke section and "(verified this session)" from the deploy note — the dev-history narration `CLAUDE.md` rules out, dating the doc for no reader benefit.

Independent of #272 (which is already merged); this branch is cut from current `main`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Markdown only, in `.claude/skills/` — no source, no scripts, nothing CI builds or imports. Verified the frontmatter and code fences in both files are still balanced after the edits, and cross-checked every claim I changed against the file that owns it: `CONTRIBUTING.md` / `CLAUDE.md` / `README.md` for the host policy, `cards/haventory-card/package.json` `engines` for Node, `.github/workflows/ci.yml` for `ubuntu-latest`.

- [x] Backend: unaffected (verified green on the same tree in #272)
- [x] Frontend (`cards/haventory-card`): unaffected (verified green on the same tree in #272)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — n/a; no code, and the docs' factual claims were checked against the files that own them.
- [x] Docs updated where behavior changed — this PR is the doc update.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no API change.
- [x] Essential invariants preserved — n/a, no code change.

## Screenshots (card / UI changes)

n/a — no visible change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiitR5ZeAA3m4ptnSHpzW3)_