### PR TITLE
chore(claude): pin worktree isolation defaults and UV_LINK_MODE

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "UV_LINK_MODE": "copy"
+  },
   "attribution": {
     "sessionUrl": false
   },
@@ -70,5 +73,9 @@
         ]
       }
     ]
+  },
+  "worktree": {
+    "bgIsolation": "worktree",
+    "baseRef": "fresh"
   }
 }


### PR DESCRIPTION
Commits two worktree-related defaults to `.claude/settings.json` so a local override becomes a visible diff rather than a silent divergence.

## What changed

```json
"env": { "UV_LINK_MODE": "copy" },
"worktree": { "bgIsolation": "worktree", "baseRef": "fresh" }
```

- **`worktree.baseRef: "fresh"`** — new worktrees branch from `origin/main`. This is the one that earns its place: concurrent sessions share this clone and switch its HEAD mid-task, so `"head"` would hand a new worktree whatever branch happened to be checked out at the moment it was created.
- **`worktree.bgIsolation: "worktree"`** — background sessions keep Edit/Write blocked in the main checkout until `EnterWorktree` runs.
- **`env.UV_LINK_MODE=copy`** — uv copies instead of hardlinking, which is what a worktree on this setup needs.

## Behavioral impact

None today. Both `worktree` values restate what Claude Code already defaults to; committing them makes a divergence reviewable.

`env` applies to Claude Code sessions only — CI invokes `uv` directly and is unaffected, as is a developer's own shell. Anyone hitting the hardlink problem running `uv` by hand still needs it exported in their profile.

## Scope note

This does **not** make subagents use worktrees. Subagent isolation is a per-call parameter on the Agent tool with no settings-level default; the only standing lever there would be an instruction in `CLAUDE.md`, deliberately left out of this PR.

## Testing

`node`-validated JSON; all pre-existing keys confirmed intact (52 allow rules, empty deny, the SessionStart hook, `attribution.sessionUrl`). Pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)