### PR TITLE
fix(hooks): stop the session hook destroying the integration env

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,9 +2,10 @@
 # HAventory SessionStart hook: bootstrap a fresh Claude Code session.
 #
 # Idempotent — safe to re-run when dependencies already exist:
-#   * creates .venv (preferring python3.12, the project target) if missing,
-#     then pip-installs backend dev deps (pip skips already-satisfied ones)
+#   * syncs the backend env from pyproject.toml + uv.lock (`uv sync`), falling
+#     back to venv + requirements-dev.txt only where uv is absent
 #   * runs `npm ci` in cards/haventory-card only when node_modules is absent
+#   * provisions the separate integration env (.venv-integration), best-effort
 #
 # Runs synchronously so tests/lint/build are ready before the agent starts.
 set -euo pipefail
@@ -14,29 +15,54 @@ cd "$PROJECT_DIR"
 
 log() { printf '[session-start] %s\n' "$1" >&2; }
 
-# --- Backend: Python venv + dev dependencies -------------------------------
-if [ ! -d .venv ]; then
+# Every Python path below is the POSIX venv layout (`bin/`), and so is every
+# helper that consumes these environments — scripts/test_integration.sh runs
+# "$INT_VENV/bin/python" directly. Under Git Bash / MSYS / Cygwin on Windows, uv
+# and venv write `Scripts/` instead, so `bin/python` never appears no matter how
+# well the environment was built. Teaching this one script both layouts would
+# produce an environment the rest of the repo still cannot run, so the Python
+# blocks are skipped outright instead. CLAUDE.md is explicit: there is no Windows
+# host support — develop through WSL2, where these paths are the Linux ones.
+#
+# macOS is deliberately not excluded: it is POSIX and `bin/` is correct there.
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  MINGW* | MSYS* | CYGWIN*) POSIX_VENV_HOST=0 ;;
+  *) POSIX_VENV_HOST=1 ;;
+esac
+
+# --- Backend: Python environment + dev dependencies -------------------------
+# `uv sync` is the documented bootstrap (CLAUDE.md) and the only one that
+# reproduces the locked set: requirements-dev.txt carries its own header saying
+# it is a generated pip fallback for environments without uv, not a second source
+# of truth. The fallback searches 3.14 first because requires-python is >=3.14 and
+# the source uses PEP 758 unparenthesized `except A, B:`, which does not parse on
+# 3.13 — an older interpreter yields an environment that cannot import the
+# integration at all, which is worse than no environment.
+if [ "$POSIX_VENV_HOST" -eq 0 ]; then
+  log "Windows shell detected; skipping the Python bootstrap (develop through WSL2, see CLAUDE.md)"
+elif command -v uv >/dev/null 2>&1; then
+  log "syncing backend environment (uv sync)"
+  uv sync
+elif [ -x .venv/bin/pip ]; then
+  log "uv not found; installing backend dev dependencies into the existing .venv"
+  .venv/bin/python -m pip install --quiet --upgrade pip
+  .venv/bin/pip install --quiet -r requirements-dev.txt
+else
   PYTHON_BIN=""
-  for candidate in python3.12 python3 python; do
+  for candidate in python3.14 python3 python; do
     if command -v "$candidate" >/dev/null 2>&1; then
       PYTHON_BIN="$candidate"
       break
     fi
   done
   if [ -z "$PYTHON_BIN" ]; then
-    log "no python interpreter found; skipping backend bootstrap"
+    log "no uv and no python interpreter found; skipping backend bootstrap"
   else
-    log "creating .venv with $PYTHON_BIN"
+    log "uv not found; creating .venv with $PYTHON_BIN"
     "$PYTHON_BIN" -m venv .venv
+    .venv/bin/python -m pip install --quiet --upgrade pip
+    .venv/bin/pip install --quiet -r requirements-dev.txt
   fi
-fi
-
-if [ -x .venv/bin/pip ]; then
-  log "installing backend dev dependencies"
-  .venv/bin/python -m pip install --quiet --upgrade pip
-  .venv/bin/pip install --quiet -r requirements-dev.txt
-else
-  log "no .venv/bin/pip; skipping backend dependency install"
 fi
 
 # --- Frontend: npm dependencies --------------------------------------------
@@ -63,23 +89,25 @@ fi
 # restricted-egress sandboxes that can't fetch Python 3.14). The offline suite is
 # unaffected either way. Run the suite with: scripts/test_integration.sh
 INT_VENV=".venv-integration"
-if command -v uv >/dev/null 2>&1; then
-  if [ ! -x "$INT_VENV/bin/python" ]; then
-    log "provisioning integration test env ($INT_VENV) — best-effort"
-    if uv python install 3.14 >/dev/null 2>&1 \
-       && uv venv --python 3.14 "$INT_VENV" >/dev/null 2>&1 \
-       && uv pip install --python "$INT_VENV/bin/python" \
-            -r requirements-integration.txt >/dev/null 2>&1; then
-      log "integration env ready; run scripts/test_integration.sh"
-    else
-      log "integration env unavailable (needs Python 3.14 + network for HA core); skipping"
-      rm -rf "$INT_VENV" 2>/dev/null || true
-    fi
-  else
-    log "integration env present; skipping"
-  fi
-else
+if [ "$POSIX_VENV_HOST" -eq 0 ]; then
+  log "Windows shell detected; skipping the integration env (scripts/test_integration.sh is POSIX-only)"
+elif ! command -v uv >/dev/null 2>&1; then
   log "uv not found; skipping integration env bootstrap"
+elif [ -x "$INT_VENV/bin/python" ]; then
+  log "integration env present; skipping"
+else
+  log "provisioning integration test env ($INT_VENV) — best-effort"
+  if uv python install 3.14 >/dev/null 2>&1 \
+     && uv venv --python 3.14 "$INT_VENV" >/dev/null 2>&1 \
+     && uv pip install --python "$INT_VENV/bin/python" \
+          -r requirements-integration.txt >/dev/null 2>&1; then
+    log "integration env ready; run scripts/test_integration.sh"
+  else
+    # Only reachable when this run just tried to build the env, so this removes a
+    # half-provisioned directory rather than a working one somebody else made.
+    log "integration env unavailable (needs Python 3.14 + network for HA core); skipping"
+    rm -rf "$INT_VENV" 2>/dev/null || true
+  fi
 fi
 
 log "bootstrap complete"

--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,8 @@ haventory.zip
 # Node — the card has its own .gitignore, but tooling run from the repo root
 # (npx, vitest) can drop a node_modules/ here too.
 node_modules/
+
+# Claude Code scratch checkouts. The rest of .claude/ is tracked on purpose —
+# settings, hooks and skills are part of the repo — but worktrees are per-session
+# working copies that would otherwise show as untracked in every session.
+.claude/worktrees/


### PR DESCRIPTION
## Summary

The SessionStart hook deletes `.venv-integration` on every session start on a Git Bash host, and silently installs no backend dependencies there. Two more defects surfaced while reading the file.

Closes #289

**1. Windows venv layout → the destructive loop.** Every Python path in the hook is the POSIX `bin/` layout, and so is every consumer — `scripts/test_integration.sh` runs `"$INT_VENV/bin/python"` directly (lines 29, 35, 41). Under Git Bash / MSYS / Cygwin, uv and `venv` write `Scripts/`, so `bin/python` never appears however well the env was built. Each session: the guard reads "not provisioned", provisioning fails on the same wrong path, and the `else` branch `rm -rf`s the directory it just created — along with any working one already there.

**Adding Windows paths here would produce an env the rest of the repo still cannot run**, so the Python blocks are skipped outright on those shells with a message pointing at WSL2. Detection is `uname -s` matching `MINGW*`/`MSYS*`/`CYGWIN*`, deliberately **not** "is this Linux" — macOS is POSIX, `bin/` is correct there, and a macOS contributor shouldn't be blocked.

**2. Wrong interpreter.** The fallback searched `python3.12` first and its comment called that "the project target". `requires-python` is `>=3.14`, and the source uses PEP 758 unparenthesized `except A, B:`, which doesn't parse on 3.13. This repo's own container has `/usr/bin/python3.12`, so that branch built an env unable to import the integration at all.

**3. Wrong mechanism.** `CLAUDE.md:167-171` documents the bootstrap as `uv sync` from `pyproject.toml` + `uv.lock`. The hook did `venv` + `pip install -r requirements-dev.txt` — a file whose own header calls it "a pip-compatible fallback for environments without uv" — while already requiring uv for the integration env below.

Also: the `rm -rf` now sits under a branch only reachable when this run created the directory, so it cleans up a half-provisioned env rather than somebody's working one.

Second commit gitignores `.claude/worktrees/` (one line; the rest of `.claude/` stays tracked on purpose).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

The hook runs outside both suites, so neither gate exercises it. What I did run:

- `bash -n` — syntax clean. (`shellcheck` isn't installed in this container.)
- **Simulated Git Bash host** — faked `uname -s` as `MINGW64_NT-10.0-22631`, seeded a `Scripts/`-only `.venv-integration`, ran the hook. Result: both Python blocks skip with their messages, npm still runs, exit 0, and **the env is still there afterwards**.
- **Branch mapping** — `MINGW*`/`MSYS*`/`CYGWIN*` → skip; `Linux`/`Darwin`/`unknown` → run.
- **Old behaviour** — with a `Scripts/`-only env, `[ ! -x "$INT_VENV/bin/python" ]` evaluates TRUE, and the only exit from the failed `&&` chain is `rm -rf "$INT_VENV"`.

- [ ] Backend: not run — no backend file changed
- [ ] Frontend: not run — no card file changed

### Needs local verification

The decisive divergence can't be reproduced here: **uv on Linux writes `bin/` no matter what `uname` claims**, so faking the shell identity proves the guard, not the layout. On your Windows host, please confirm:

1. A pre-existing `.venv-integration` **survives** a session start, and the log carries the two skip lines.
2. Under WSL2 (the supported path) the hook still provisions normally — `uv sync` runs and the integration env builds.
3. The `uv sync` switch behaves on a cold cache. If it's slow enough to be annoying at session start, say so — it's currently strict, and I can make it best-effort like the integration block.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added/updated — the hook has no test harness; behaviour was verified by simulation, described above
- [x] Docs updated where behavior changed — the hook's header comment now matches what it does; `CLAUDE.md`'s `uv sync` description becomes true rather than aspirational
- [x] WebSocket API unchanged
- [x] Essential invariants untouched
- [x] No file inside `custom_components/haventory/` deleted or renamed, so `RETIRED_PATHS` is untouched

## Screenshots (card / UI changes)

None — tooling only.

## Not in this PR

The redundant permission rules in `.claude/settings.json` are left alone: #288 touches that file, and this would conflict. `.claude/settings.local.json` is untracked, so its stale-token entries are local-only and can't be fixed from a PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9XCW3zvxCub77DDWdu9TL)_