### PR TITLE
test: validate WS command schemas in the offline stub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,9 @@ plus `actionlint`, `hassfest`, HACS validation, CodeQL, and dependency review.
 
 - **Test-driven**: every feature/fix ships with tests — happy path plus at least
   one edge/error case. Default to offline tests (HA is stubbed in
-  `tests/conftest.py`); async tests use `@pytest.mark.asyncio`.
+  `tests/conftest.py`); async tests use `@pytest.mark.asyncio`. The WebSocket
+  stub applies each command's schema before dispatch, so an offline test sends
+  frames a real client could send and gets `invalid_format` for the rest.
 - **Conventional Commits** for commit messages *and PR titles* (a CI check
   enforces the PR title). Examples: `feat: add low-stock filter`,
   `fix: preserve location_path on move`, `docs: …`, `chore: …`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,11 @@ the offline suite and gets the stubs. As a result:
 * the phacc suite never sees the stubs (real HA is present and autoload is on),
   and is never collected by the offline run (``collect_ignore`` below).
 
+The WebSocket stub validates: it applies each command's schema to a frame
+before dispatch, as an ``ActiveConnection`` does, so an offline test cannot hand
+a handler a payload no client could send. Write offline WS tests against frames
+a real client would produce, and expect ``invalid_format`` for the rest.
+
 It also re-enables sockets when pytest-socket is auto-loaded by an IDE, which
 otherwise blocks the loopback the event loop sets itself up on.
 """
@@ -38,6 +43,9 @@ import os
 import sys
 import types
 from pathlib import Path
+
+import voluptuous as vol
+from voluptuous.humanize import humanize_error
 
 # Ensure project root is on sys.path for module imports (both modes).
 ROOT = Path(__file__).resolve().parents[1]
@@ -240,6 +248,9 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
     ha_helpers_cv.empty_config_schema = empty_config_schema
     ha_helpers_cv.platform_only_config_schema = platform_only_config_schema
     ha_helpers_cv.config_entry_only_config_schema = config_entry_only_config_schema
+    # Verbatim from HA's config_validation; the WebSocket base command schema
+    # below validates every frame's `id` with it.
+    ha_helpers_cv.positive_int = vol.All(vol.Coerce(int), vol.Range(min=0))
     sys.modules["homeassistant.helpers.config_validation"] = ha_helpers_cv
 
     ha_helpers_storage = types.ModuleType("homeassistant.helpers.storage")
@@ -267,10 +278,42 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
     ha_ws = types.ModuleType("homeassistant.components.websocket_api")
 
-    def websocket_command(schema=None):  # type: ignore[override]
+    # What real HA extends every dict command schema with before validating. Its
+    # default PREVENT_EXTRA is what refuses a field the command never declared.
+    BASE_COMMAND_MESSAGE_SCHEMA = vol.Schema({vol.Required("id"): ha_helpers_cv.positive_int})
+
+    # The code HA answers with for a frame that never reaches a handler.
+    ERR_INVALID_FORMAT = "invalid_format"
+
+    # How many keys a frame for a type-only command may carry: `id` and `type`.
+    TYPE_ONLY_FRAME_KEYS = 2
+
+    def websocket_command(schema):  # type: ignore[override]
+        """Tag a handler with its command name and compiled schema, as HA does.
+
+        ``_ws_command`` carries the command string — the key real HA registers
+        the handler under, and so the one a test looks a handler up by.
+        ``_ws_schema`` carries what the connection applies to a frame before
+        dispatch, with ``False`` standing for a schema that declares nothing but
+        its ``type``: such a frame may carry no key beyond ``id`` and ``type``.
+        """
+        is_dict = isinstance(schema, dict)
+        command = schema["type"] if is_dict else schema.validators[0].schema["type"]
+
         def decorator(func):
-            func._ws_command = True
-            func._ws_schema = schema
+            if is_dict and len(schema) == 1:
+                func._ws_schema = False
+            elif is_dict:
+                func._ws_schema = BASE_COMMAND_MESSAGE_SCHEMA.extend(schema)
+            else:
+                # vol.All: extend the leading mapping, keep the trailing
+                # cross-field validators, which is where a cap or a
+                # mutually-exclusive-fields refusal lives.
+                func._ws_schema = vol.All(
+                    schema.validators[0].extend(BASE_COMMAND_MESSAGE_SCHEMA.schema),
+                    *schema.validators[1:],
+                )
+            func._ws_command = command
             return func
 
         return decorator
@@ -288,8 +331,42 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             error["data"] = data
         return {"id": _id, "type": "result", "success": False, "error": error}
 
+    def _validate_frame(handler, msg):
+        """Apply what an ``ActiveConnection`` applies to a frame before dispatch.
+
+        Returns ``(validated_msg, None)`` for a frame that would have reached the
+        handler on a real connection, and ``(None, error_envelope)`` for one it
+        would have refused — the handler body never runs for the latter. Without
+        this the offline suite would let handlers see payloads no client can
+        send, and any refusal expressed as a schema constraint would be invisible
+        to it.
+        """
+        # HA checks id and type before it even looks the command up: an id that
+        # is a positive int of exactly that type (so ``True`` is not an id), and
+        # a non-empty string type.
+        iden = msg.get("id") if isinstance(msg, dict) else None
+        type_ = msg.get("type") if isinstance(msg, dict) else None
+        if type(iden) is not int or iden <= 0 or type(type_) is not str or not type_:
+            return None, error_message(iden, ERR_INVALID_FORMAT, "Message incorrectly formatted.")
+
+        schema = handler._ws_schema
+        try:
+            if schema is False:
+                if len(msg) > TYPE_ONLY_FRAME_KEYS:
+                    raise vol.Invalid("extra keys not allowed")
+                return msg, None
+            return schema(msg), None
+        except vol.Invalid as err:
+            return None, error_message(iden, ERR_INVALID_FORMAT, humanize_error(msg, err))
+
     def async_register_command(hass: HomeAssistant, handler):  # type: ignore[override]
         registry = hass.data.setdefault("__ws_commands__", [])
+
+        if not hasattr(handler, "_ws_schema"):
+            # Real HA reads the same attributes off the handler and fails here
+            # too. Refusing loudly keeps an undecorated handler from becoming the
+            # one command in the suite that skips validation.
+            raise ValueError("handler is not decorated with @websocket_command")
 
         async def _wrapped(hass: HomeAssistant, conn, msg):  # type: ignore[override]
             local_conn = conn
@@ -305,7 +382,14 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
                 stub = _StubConn()
                 local_conn = stub
-            res = await handler(hass, local_conn, msg)
+            validated, refusal = _validate_frame(handler, msg)
+            if refusal is not None:
+                # HA answers a refused frame on the connection and stops there.
+                send = getattr(local_conn, "send_message", None)
+                if callable(send):
+                    send(refusal)
+                return refusal
+            res = await handler(hass, local_conn, validated)
             if res is not None:
                 return res
             # Prefer captured message from our stub, then from provided conn if it collects messages
@@ -319,7 +403,7 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
                 pass
             return None
 
-        # Preserve HA websocket metadata so tests can discover handlers by schema
+        # Preserve HA websocket metadata so tests can discover handlers by command
         for attr in ("_ws_schema", "_ws_command", "_ws_async_response"):
             try:
                 setattr(_wrapped, attr, getattr(handler, attr, None))
@@ -328,6 +412,8 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
         registry.append(_wrapped)
 
+    ha_ws.BASE_COMMAND_MESSAGE_SCHEMA = BASE_COMMAND_MESSAGE_SCHEMA
+    ha_ws.ERR_INVALID_FORMAT = ERR_INVALID_FORMAT
     ha_ws.websocket_command = websocket_command
     ha_ws.async_response = async_response
     ha_ws.result_message = result_message

--- a/tests/test_entry_removal_refusal_offline.py
+++ b/tests/test_entry_removal_refusal_offline.py
@@ -49,10 +49,7 @@ async def _send(hass: HomeAssistant, _id: int, type_: str, conn=None, **payload)
     """Dispatch one WS command through the stub registry, as a client would."""
 
     for handler in hass.data.get("__ws_commands__", []):
-        schema = getattr(handler, "_ws_schema", None)
-        if not callable(handler) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(handler) or getattr(handler, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_entry_unload_refusal_offline.py
+++ b/tests/test_entry_unload_refusal_offline.py
@@ -51,8 +51,7 @@ def _handler(hass: HomeAssistant, type_: str):
     """The registered handler for one command type, as HA would dispatch to it."""
 
     for handler in hass.data.get("__ws_commands__", []):
-        schema = getattr(handler, "_ws_schema", None)
-        if callable(handler) and isinstance(schema, dict) and schema.get("type") == type_:
+        if callable(handler) and getattr(handler, "_ws_command", None) == type_:
             return handler
     raise AssertionError(f"No handler registered for type {type_}")
 

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -31,10 +31,7 @@ SEEDED_LOCATIONS = 2
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)
@@ -123,12 +120,17 @@ async def test_ws_export_returns_document() -> None:
 
 @pytest.mark.asyncio
 async def test_ws_export_invalid_filter_field() -> None:
-    """Invalid-field case: a non-object filter is rejected as validation_error."""
+    """Invalid-field case: a non-object filter never reaches the handler.
+
+    ``haventory/export`` declares ``filter`` as a dict, so Home Assistant
+    refuses the frame with the transport-level ``invalid_format`` before
+    dispatch — not with the handler's own ``validation_error``.
+    """
 
     hass = _new_hass()
     res = await _send(hass, 1, "haventory/export", filter="not-an-object")
     assert res["success"] is False, res
-    assert res["error"]["code"] == "validation_error"
+    assert res["error"]["code"] == "invalid_format"
 
 
 # -----------------------------

--- a/tests/test_integration_bootstrap_offline.py
+++ b/tests/test_integration_bootstrap_offline.py
@@ -80,10 +80,7 @@ async def test_async_setup_entry_loads_repository_from_store_and_ws_reads() -> N
 
     async def _send(_id: int, type_: str, **payload):
         for h in handlers:
-            schema = getattr(h, "_ws_schema", None)
-            if not callable(h) or not isinstance(schema, dict):
-                continue
-            if schema.get("type") != type_:
+            if not callable(h) or getattr(h, "_ws_command", None) != type_:
                 continue
             req = {"id": _id, "type": type_}
             req.update(payload)

--- a/tests/test_item_input_validation_offline.py
+++ b/tests/test_item_input_validation_offline.py
@@ -94,8 +94,7 @@ def _get_handler(
     hass: HomeAssistant, type_: str
 ) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
     for h in hass.data.get("__ws_commands__", []):
-        schema = getattr(h, "_ws_schema", None)
-        if callable(h) and isinstance(schema, dict) and schema.get("type") == type_:
+        if callable(h) and getattr(h, "_ws_command", None) == type_:
             return h
     raise AssertionError("No handler for " + type_)
 

--- a/tests/test_item_status_offline.py
+++ b/tests/test_item_status_offline.py
@@ -259,10 +259,7 @@ async def test_domain_store_migrates_v4_store_on_load() -> None:
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_models_offline.py
+++ b/tests/test_models_offline.py
@@ -69,12 +69,8 @@ async def test_invalid_due_date_requires_checked_out() -> None:
 
 @pytest.mark.asyncio
 async def test_tag_normalization_and_update_clears_fields() -> None:
-    # Normalize tags on create and allow clearing via update. The null entry
-    # comes from the import path, whose documents are arbitrary JSON — the WS
-    # commands' `[str]` schema refuses it before any handler sees it.
-    item = create_item_from_create(
-        {"name": "Battery", "tags": ["Li-Ion", " li-ion ", None, "Spare"]}
-    )
+    # Normalize tags on create and allow clearing via update.
+    item = create_item_from_create({"name": "Battery", "tags": ["Li-Ion", " li-ion ", "Spare"]})
     assert item.tags == ["li-ion", "spare"]
 
     updated = apply_item_update(item, ItemUpdate(tags=[]))

--- a/tests/test_models_offline.py
+++ b/tests/test_models_offline.py
@@ -69,8 +69,12 @@ async def test_invalid_due_date_requires_checked_out() -> None:
 
 @pytest.mark.asyncio
 async def test_tag_normalization_and_update_clears_fields() -> None:
-    # Normalize tags on create and allow clearing via update
-    item = create_item_from_create({"name": "Battery", "tags": ["Li-Ion", " li-ion ", "Spare"]})
+    # Normalize tags on create and allow clearing via update. The null entry
+    # comes from the import path, whose documents are arbitrary JSON — the WS
+    # commands' `[str]` schema refuses it before any handler sees it.
+    item = create_item_from_create(
+        {"name": "Battery", "tags": ["Li-Ion", " li-ion ", None, "Spare"]}
+    )
     assert item.tags == ["li-ion", "spare"]
 
     updated = apply_item_update(item, ItemUpdate(tags=[]))

--- a/tests/test_storage_concurrency_offline.py
+++ b/tests/test_storage_concurrency_offline.py
@@ -409,10 +409,7 @@ async def test_ws_mutations_use_immediate_persistence(monkeypatch):
     async def _send(_id: int, type_: str, **payload):
         handlers = hass.data.get("__ws_commands__", [])
         for h in handlers:
-            schema = getattr(h, "_ws_schema", None)
-            if not callable(h) or not isinstance(schema, dict):
-                continue
-            if schema.get("type") != type_:
+            if not callable(h) or getattr(h, "_ws_command", None) != type_:
                 continue
             req = {"id": _id, "type": type_}
             req.update(payload)

--- a/tests/test_ws_areas_offline.py
+++ b/tests/test_ws_areas_offline.py
@@ -18,10 +18,7 @@ from homeassistant.core import HomeAssistant
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_ws_bulk_offline.py
+++ b/tests/test_ws_bulk_offline.py
@@ -18,10 +18,7 @@ from homeassistant.core import HomeAssistant
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)
@@ -102,12 +99,18 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
     assert res["success"] is True and res["result"]["results"] == {}
     assert calls["count"] == 0  # nothing to persist
 
-    # Invalid operations type
+    # Invalid operations type: the command declares `operations` as a list, so
+    # Home Assistant refuses the frame before the handler runs.
     res = await _send(hass, 2, "haventory/items/bulk", operations="oops")
+    assert res["success"] is False and res["error"]["code"] == "invalid_format"
+
+    # The shape of each entry is the handler's to check — the schema only knows
+    # `operations` is a list.
+    res = await _send(hass, 3, "haventory/items/bulk", operations=["oops"])
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
     # Duplicate op_id: last result should be in the map
-    created = await _send(hass, 3, "haventory/item/create", name="X", quantity=1)
+    created = await _send(hass, 4, "haventory/item/create", name="X", quantity=1)
     iid = created["result"]["id"]
     FINAL_QTY = 3
     ops = [
@@ -122,7 +125,7 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
             "payload": {"item_id": iid, "quantity": FINAL_QTY},
         },
     ]
-    res = await _send(hass, 4, "haventory/items/bulk", operations=ops)
+    res = await _send(hass, 5, "haventory/items/bulk", operations=ops)
     assert res["success"] is True
     assert res["result"]["results"]["dup"]["success"] is True
     assert res["result"]["results"]["dup"]["result"]["quantity"] == FINAL_QTY

--- a/tests/test_ws_distinct_values_offline.py
+++ b/tests/test_ws_distinct_values_offline.py
@@ -4,14 +4,13 @@ Scenarios:
 - distinct_values returns distinct categories and tags with usage counts
 - categories are grouped case-insensitively with a representative display label
 - an empty repository yields empty lists
-- unknown/extra request fields are rejected by the voluptuous schema
-  (vol.PREVENT_EXTRA, matching real Home Assistant command validation)
+- unknown/extra request fields are refused before the handler runs, as real
+  Home Assistant refuses them
 """
 
 from __future__ import annotations
 
 import pytest
-import voluptuous as vol
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
@@ -23,10 +22,7 @@ from homeassistant.core import HomeAssistant
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)
@@ -129,21 +125,20 @@ async def test_distinct_values_returns_custom_field_keys() -> None:
     assert res["result"]["custom_field_keys"] == ["serial", "Voltage", "warranty_until"]
 
 
-def test_distinct_values_schema_rejects_unknown_field() -> None:
-    """Unknown request fields are rejected (vol.PREVENT_EXTRA, as in real HA).
+@pytest.mark.asyncio
+async def test_distinct_values_rejects_unknown_field() -> None:
+    """Unknown request fields are refused before the handler runs.
 
-    The offline stub does not apply the command schema, so we reconstruct the
-    schema exactly as Home Assistant does (extending a base that requires `id`
-    and defaults to PREVENT_EXTRA) and assert an extra field is rejected.
+    ``haventory/distinct_values`` declares nothing but its type, which Home
+    Assistant compiles to the ``False`` schema: `id` and `type` are the only
+    keys such a frame may carry.
     """
 
-    schema_dict = ws_distinct_values._ws_schema
-    assert isinstance(schema_dict, dict)
-    full = vol.Schema({vol.Required("id"): int, **schema_dict})
+    hass = _fresh_hass()
+    assert ws_distinct_values._ws_schema is False
 
-    # Valid request passes.
-    full({"id": 1, "type": "haventory/distinct_values"})
+    assert (await _send(hass, 1, "haventory/distinct_values"))["success"] is True
 
-    # Unknown field is rejected.
-    with pytest.raises(vol.Invalid):
-        full({"id": 1, "type": "haventory/distinct_values", "bogus": 1})
+    res = await _send(hass, 2, "haventory/distinct_values", bogus=1)
+    assert res["success"] is False
+    assert res["error"]["code"] == "invalid_format"

--- a/tests/test_ws_effective_area_offline.py
+++ b/tests/test_ws_effective_area_offline.py
@@ -19,10 +19,7 @@ from homeassistant.core import HomeAssistant
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_ws_error_mapping_offline.py
+++ b/tests/test_ws_error_mapping_offline.py
@@ -34,10 +34,7 @@ def _get_handler(
 ) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") == type_:
+        if callable(h) and getattr(h, "_ws_command", None) == type_:
             return h
     raise AssertionError("No handler found for type " + type_)
 

--- a/tests/test_ws_guard_offline.py
+++ b/tests/test_ws_guard_offline.py
@@ -24,10 +24,7 @@ def _get_handler(
 ) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") == type_:
+        if callable(h) and getattr(h, "_ws_command", None) == type_:
             return h
     raise AssertionError("No handler found for type " + type_)
 

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -21,10 +21,7 @@ from homeassistant.core import HomeAssistant
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -6,6 +6,7 @@ Scenarios:
 - list items with pagination cursor passthrough
 - error mapping for validation/not_found/conflict with contextual data
 - optimistic concurrency: with and without expected_version
+- tag normalization on the one command whose schema admits a null tag
 """
 
 from __future__ import annotations
@@ -56,6 +57,38 @@ async def test_item_create_get_update_delete_success() -> None:
     # Delete
     res = await _send(hass, 4, "haventory/item/delete", item_id=item_id)
     assert res["success"] is True and res["result"] is None
+
+
+@pytest.mark.asyncio
+async def test_item_update_normalizes_a_tag_list_carrying_a_null() -> None:
+    """`item/update` is the one command that can carry a null tag to the model.
+
+    Every other command taking tags declares `[str]`, which Home Assistant
+    refuses a null against before dispatch. `item/update` types each field as
+    `object` and leaves the shape to `apply_item_update`, so `normalize_tags`
+    has to drop the null rather than store it — a stored `None` would break
+    every tag index and filter that assumes strings.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    created = await _send(hass, 1, "haventory/item/create", name="Battery")
+    item_id = created["result"]["id"]
+
+    res = await _send(
+        hass, 2, "haventory/item/update", item_id=item_id, tags=["Li-Ion", None, " spare "]
+    )
+
+    assert res["success"] is True
+    assert res["result"]["tags"] == ["li-ion", "spare"]
+
+    # The narrow schemas hold the line for the commands that declare `[str]`.
+    refused = await _send(hass, 3, "haventory/item/add_tags", item_id=item_id, tags=["x", None])
+    assert refused["success"] is False
+    assert refused["error"]["code"] == "invalid_format"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_locations_offline.py
+++ b/tests/test_ws_locations_offline.py
@@ -20,12 +20,9 @@ from homeassistant.core import HomeAssistant
 
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
-    # Prefer exact type match on the handler schema
+    # Exact match on the command each handler is registered under
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_ws_logging_offline.py
+++ b/tests/test_ws_logging_offline.py
@@ -39,10 +39,7 @@ RATE_LIMIT_LOGGER = "custom_components.haventory.rate_limit"
 async def _send(hass: HomeAssistant, _id: int, type_: str, conn: object = None, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)
@@ -279,7 +276,9 @@ async def test_a_retrying_client_leaves_no_tracebacks(caplog) -> None:
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
     retries = 12
-    for i in range(retries):
+    # Frame ids start at 1: Home Assistant refuses a non-positive id outright,
+    # so a 0 would never reach the handler whose logging is under test.
+    for i in range(1, retries + 1):
         assert (await _send(hass, i, "haventory/stats"))["error"]["code"] == "storage_error"
 
     records = _records(caplog)

--- a/tests/test_ws_rate_limit_offline.py
+++ b/tests/test_ws_rate_limit_offline.py
@@ -70,10 +70,7 @@ def _get_handler(
 ) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") == type_:
+        if callable(h) and getattr(h, "_ws_command", None) == type_:
             return h
     raise AssertionError("No handler found for type " + type_)
 

--- a/tests/test_ws_schema_validation_offline.py
+++ b/tests/test_ws_schema_validation_offline.py
@@ -1,0 +1,265 @@
+"""Offline tests for the WS stub's command-schema validation.
+
+The offline suite dispatches WebSocket frames through the stub in
+``tests/conftest.py`` rather than through a real ``ActiveConnection``. These
+tests pin the one property that makes such a dispatch worth trusting: a frame
+the real connection would refuse is refused here too, before the handler body
+runs. Without it a handler can appear to tolerate input no client can send, and
+a refusal expressed purely as a schema constraint is invisible to this suite —
+neither assertable nor able to regress visibly.
+
+Scenarios:
+- a valid frame reaches the handler, carrying the schema's transformed payload
+- a missing required field, a wrong-typed field and an undeclared field are each
+  refused as `invalid_format` with the handler body never entered
+- a command declaring nothing but its type accepts no key beyond id and type
+- the id/type envelope is checked ahead of the command schema
+- a `vol.All` schema's cross-field validator refuses through the same path
+- a real haventory command refuses a wrong-typed field and mutates nothing
+- registering a handler that carries no schema is refused outright
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import voluptuous as vol
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.ws import setup as ws_setup
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+
+INVALID_FORMAT = "invalid_format"
+PROBE_DEFAULT_LIMIT = 25
+
+
+class _ConnCollect:
+    """Capture stub standing in for HA's ActiveConnection."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def send_message(self, msg: dict[str, Any]) -> None:
+        self.messages.append(msg)
+
+
+class _Probe:
+    """A registered command that records whether its body ran, and on what."""
+
+    def __init__(self, hass: HomeAssistant, schema: Any) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        @websocket_api.websocket_command(schema)
+        @websocket_api.async_response
+        async def _handler(_hass: HomeAssistant, conn: Any, msg: dict[str, Any]) -> dict[str, Any]:
+            self.calls.append(msg)
+            return websocket_api.result_message(msg["id"], {"ok": True})
+
+        websocket_api.async_register_command(hass, _handler)
+        self.command = _handler._ws_command
+        self.schema = _handler._ws_schema
+        self._hass = hass
+
+    @property
+    def ran(self) -> bool:
+        return bool(self.calls)
+
+    async def send(self, frame: dict[str, Any]) -> dict[str, Any]:
+        """Dispatch one frame the way a client's would arrive."""
+
+        for handler in self._hass.data.get("__ws_commands__", []):
+            if getattr(handler, "_ws_command", None) == self.command:
+                return await handler(self._hass, _ConnCollect(), frame)
+        raise AssertionError("probe command was not registered")
+
+
+async def _send(hass: HomeAssistant, _id: int, type_: str, **payload: Any) -> dict[str, Any]:
+    for h in hass.data.get("__ws_commands__", []):
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
+            continue
+        return await h(hass, None, {"id": _id, "type": type_, **payload})
+    raise AssertionError("No handler responded for type " + type_)
+
+
+def _fresh_hass() -> HomeAssistant:
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_a_valid_frame_reaches_the_handler() -> None:
+    """Happy path: the handler runs, and sees what the schema produced."""
+
+    probe = _Probe(
+        HomeAssistant(),
+        {
+            vol.Required("type"): "test/probe",
+            vol.Required("name"): str,
+            vol.Optional("limit", default=PROBE_DEFAULT_LIMIT): int,
+        },
+    )
+
+    res = await probe.send({"id": 1, "type": "test/probe", "name": "Hammer"})
+
+    assert res["success"] is True
+    assert probe.ran
+    # The schema's default is applied on the way in, exactly as it would be for
+    # a frame HA validated — a handler must not have to re-derive it.
+    assert probe.calls[0]["limit"] == PROBE_DEFAULT_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_a_missing_required_field_never_runs_the_handler() -> None:
+    """The acceptance case: a schema violation is refused before dispatch."""
+
+    probe = _Probe(
+        HomeAssistant(),
+        {vol.Required("type"): "test/probe", vol.Required("name"): str},
+    )
+
+    res = await probe.send({"id": 1, "type": "test/probe"})
+
+    assert res["success"] is False
+    assert res["error"]["code"] == INVALID_FORMAT
+    assert not probe.ran
+
+
+@pytest.mark.asyncio
+async def test_a_wrong_typed_or_undeclared_field_is_refused() -> None:
+    """Both halves of a voluptuous mapping schema hold: types and PREVENT_EXTRA."""
+
+    probe = _Probe(
+        HomeAssistant(),
+        {vol.Required("type"): "test/probe", vol.Optional("quantity"): int},
+    )
+
+    wrong_type = await probe.send({"id": 1, "type": "test/probe", "quantity": "many"})
+    assert wrong_type["error"]["code"] == INVALID_FORMAT
+
+    undeclared = await probe.send({"id": 2, "type": "test/probe", "bogus": 1})
+    assert undeclared["error"]["code"] == INVALID_FORMAT
+
+    assert not probe.ran
+
+
+@pytest.mark.asyncio
+async def test_a_type_only_command_takes_no_other_key() -> None:
+    """A schema of just `type` compiles to False, HA's "id and type only" marker."""
+
+    probe = _Probe(HomeAssistant(), {"type": "test/probe"})
+    assert probe.schema is False
+
+    assert (await probe.send({"id": 1, "type": "test/probe"}))["success"] is True
+    assert probe.ran
+
+    res = await probe.send({"id": 2, "type": "test/probe", "extra": True})
+    assert res["error"]["code"] == INVALID_FORMAT
+    assert len(probe.calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "frame",
+    [
+        {"type": "test/probe"},
+        {"id": 0, "type": "test/probe"},
+        {"id": -1, "type": "test/probe"},
+        {"id": "1", "type": "test/probe"},
+        {"id": True, "type": "test/probe"},
+        {"id": 1, "type": ""},
+        {"id": 1},
+    ],
+    ids=["no-id", "zero-id", "negative-id", "string-id", "bool-id", "empty-type", "no-type"],
+)
+async def test_the_envelope_is_checked_ahead_of_the_command_schema(frame: dict) -> None:
+    """HA validates id and type before it even looks the command up."""
+
+    probe = _Probe(HomeAssistant(), {"type": "test/probe"})
+
+    res = await probe.send(frame)
+
+    assert res["success"] is False
+    assert res["error"]["code"] == INVALID_FORMAT
+    assert res["error"]["message"] == "Message incorrectly formatted."
+    assert not probe.ran
+
+
+@pytest.mark.asyncio
+async def test_a_cross_field_validator_refuses_through_the_same_path() -> None:
+    """`vol.All` schemas validate too — a cap or a mutual exclusion is a refusal.
+
+    This is the shape a constraint spanning two fields has to take, so the
+    offline suite has to carry it through to the same `invalid_format` answer.
+    """
+
+    def _at_most_one_bound(msg: dict[str, Any]) -> dict[str, Any]:
+        if "minimum" in msg and "maximum" in msg:
+            raise vol.Invalid("minimum and maximum are mutually exclusive")
+        return msg
+
+    probe = _Probe(
+        HomeAssistant(),
+        vol.All(
+            vol.Schema(
+                {
+                    vol.Required("type"): "test/probe",
+                    vol.Optional("minimum"): int,
+                    vol.Optional("maximum"): int,
+                }
+            ),
+            _at_most_one_bound,
+        ),
+    )
+
+    assert (await probe.send({"id": 1, "type": "test/probe", "minimum": 1}))["success"] is True
+
+    res = await probe.send({"id": 2, "type": "test/probe", "minimum": 1, "maximum": 9})
+    assert res["error"]["code"] == INVALID_FORMAT
+    assert len(probe.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_is_answered_on_the_connection() -> None:
+    """HA replies to a refused frame on the wire, not only to its caller."""
+
+    hass = HomeAssistant()
+    probe = _Probe(hass, {vol.Required("type"): "test/probe", vol.Required("name"): str})
+    conn = _ConnCollect()
+
+    for handler in hass.data["__ws_commands__"]:
+        if getattr(handler, "_ws_command", None) == probe.command:
+            res = await handler(hass, conn, {"id": 1, "type": "test/probe"})
+            break
+
+    assert conn.messages == [res]
+    assert res["error"]["code"] == INVALID_FORMAT
+
+
+@pytest.mark.asyncio
+async def test_a_real_command_refuses_a_wrong_typed_field_and_mutates_nothing() -> None:
+    """The same guard over a shipped command, end to end."""
+
+    hass = _fresh_hass()
+    repo = hass.data[DOMAIN]["repository"]
+
+    res = await _send(hass, 1, "haventory/item/create", name="Hammer", quantity="many")
+
+    assert res["success"] is False
+    assert res["error"]["code"] == INVALID_FORMAT
+    assert repo.get_counts()["items_total"] == 0
+
+
+def test_registering_a_handler_without_a_schema_is_refused() -> None:
+    """An undecorated handler must not become the one command that skips validation."""
+
+    async def _bare(_hass: HomeAssistant, _conn: Any, _msg: dict[str, Any]) -> None:
+        raise AssertionError("must never be registered, let alone dispatched to")
+
+    with pytest.raises(ValueError, match="websocket_command"):
+        websocket_api.async_register_command(HomeAssistant(), _bare)

--- a/tests/test_ws_storage_error_offline.py
+++ b/tests/test_ws_storage_error_offline.py
@@ -46,10 +46,7 @@ class _ConnStub:
 async def _send(hass: HomeAssistant, _id: int, type_: str, conn: object = None, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -112,10 +112,7 @@ def _get_handler(
 ) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") == type_:
+        if callable(h) and getattr(h, "_ws_command", None) == type_:
             return h
     raise AssertionError("No handler found for type " + type_)
 

--- a/tests/test_ws_utils_offline.py
+++ b/tests/test_ws_utils_offline.py
@@ -29,10 +29,7 @@ class _StubConn:
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)

--- a/tests/test_ws_wrappers_offline.py
+++ b/tests/test_ws_wrappers_offline.py
@@ -28,10 +28,7 @@ class _StubConn:
 async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     handlers = hass.data.get("__ws_commands__", [])
     for h in handlers:
-        schema = getattr(h, "_ws_schema", None)
-        if not callable(h) or not isinstance(schema, dict):
-            continue
-        if schema.get("type") != type_:
+        if not callable(h) or getattr(h, "_ws_command", None) != type_:
             continue
         req = {"id": _id, "type": type_}
         req.update(payload)
@@ -59,7 +56,7 @@ async def test_add_remove_tags_success_and_normalization() -> None:
         2,
         "haventory/item/add_tags",
         item_id=item_id,
-        tags=["  Alpha ", "beta", "ALPHA", "Beta", None],
+        tags=["  Alpha ", "beta", "ALPHA", "Beta"],
     )
     assert res["success"] is True
     # normalized unique order: ["alpha", "beta"]
@@ -74,6 +71,13 @@ async def test_add_remove_tags_success_and_normalization() -> None:
         tags=["  BETA ", "gamma"],
     )
     assert res["success"] is True
+    assert res["result"]["tags"] == ["alpha"]
+
+    # A non-string tag is refused by the command's `[str]` schema, so the
+    # handler never runs and the item keeps the tags it had.
+    res = await _send(hass, 4, "haventory/item/add_tags", item_id=item_id, tags=["gamma", None])
+    assert res["success"] is False and res["error"]["code"] == "invalid_format"
+    res = await _send(hass, 5, "haventory/item/get", item_id=item_id)
     assert res["result"]["tags"] == ["alpha"]
 
 


### PR DESCRIPTION
Closes #282

## What

`tests/conftest.py` recorded each command's schema on the handler (`_ws_schema`) and never applied it. Offline WS tests therefore called handler bodies with payloads a real `ActiveConnection` would have refused before dispatch, and any refusal expressed purely as a schema constraint was invisible to the fast suite — it could neither be asserted nor regress visibly.

This takes option (1) from the issue: teach the stub to validate, mirroring `websocket_api` in Home Assistant 2026.6.0 (the pinned floor).

## How

- **`websocket_command`** compiles the schema the way HA's decorator does: `_ws_command` carries the command string (the key HA registers the handler under, so the key a test looks one up by), `_ws_schema` carries what the connection applies — `BASE_COMMAND_MESSAGE_SCHEMA.extend(schema)` for a dict, or `False` for a command declaring nothing but its `type`. `vol.All` schemas are supported, so a cross-field cap or mutual exclusion validates through the same path.
- **`async_register_command`** applies, before dispatch: the envelope check (`id` a positive `int` of exactly that type, `type` a non-empty `str`), then the command schema — `len(msg) > 2` for the `False` case. A refused frame is answered with `invalid_format` on the connection and **the handler body never runs**; a validated frame reaches the handler carrying the schema's output (defaults applied). Registering a handler with no schema now raises instead of silently skipping validation.
- Offline handler discovery moves from the raw schema dict to `_ws_command` (21 call sites, mechanical).

## What it surfaced

Exactly what the issue predicted — three tests asserted payloads a real client cannot send:

| Test | Was | Is |
| --- | --- | --- |
| `haventory/export` with `filter="not-an-object"` | `validation_error` | `invalid_format` — the schema declares `filter` as a dict |
| `haventory/items/bulk` with `operations="oops"` | `validation_error` | `invalid_format` — the schema declares `operations` as a list. Gained a per-operation case (`operations=["oops"]`), which is the part the schema does *not* reach and the handler still owns |
| `haventory/item/add_tags` with `tags=[…, None]` | normalized silently | refused — its schema declares `[str]`. The `normalize_tags` null-skip it stood in for moved to `tests/test_ws_items_offline.py`, onto `haventory/item/update` (see below) |

Plus one artefact: the retrying-client logging test sent frame id `0`, which HA refuses outright — its ids now start at 1.

`test_distinct_values_schema_rejects_unknown_field` hand-reconstructed HA's schema *because* the stub did not validate; it is now a real dispatch, and pins `_ws_schema is False` for a type-only command.

## Review follow-up (`edb0184`)

The null tag first landed in `tests/test_models_offline.py` under a comment naming the import path as its source. **That was wrong** and is corrected here: `import_export._validate_item_doc` refuses a non-string tag (`tags must be an array of strings`) and `_validate_document` returns on the error before any `normalize_tags` call, and the store load does not normalize at all (`tags=list(item_data.get("tags", []) or [])`).

The path that *can* carry one is **`haventory/item/update`**. Alone among the tag-taking commands it types each field as `object` rather than `[str]`, leaving the shape to `apply_item_update` — so `tags=["Li-Ion", null, " spare "]` validates, dispatches, and normalizes to `["li-ion", "spare"]`. Asserted there through a real frame, with the `add_tags` refusal alongside it to pin the contrast. Verified non-vacuous: deleting the `if raw is None: continue` in `normalize_tags` fails exactly that test.

Two `ws.py` guards this PR proved unreachable — `ws_export`'s `filter` dict check and `_validate_bulk_ops`'s `operations` list check, both behind strict schemas, both now uncovered — are filed as #293 rather than fixed here.

## New tests — `tests/test_ws_schema_validation_offline.py`

The acceptance criterion, plus its neighbours (15 cases):

- happy path: a valid frame reaches the handler, carrying the schema's defaults
- **a missing required field is refused with the handler body never entered** (acceptance)
- wrong-typed and undeclared (`PREVENT_EXTRA`) fields refused, handler not entered
- a type-only command takes no key beyond `id`/`type`
- the envelope is checked ahead of the command schema (7 parametrized frames: no/zero/negative/string/bool id, empty/absent type)
- a `vol.All` cross-field validator refuses through the same path — the shape #197's caps will need
- the refusal is answered on the connection, not only returned to the caller
- end to end over a shipped command: `haventory/item/create` with `quantity="many"` is `invalid_format` and the repository stays empty
- registering an undecorated handler raises

## Scope

The WS API is unchanged, so `docs/backend_api_contract.md` and `docs/data_shapes.md` need no edit — the contract already documents `invalid_format` as the transport-level refusal (line 39). `CONTRIBUTING.md` gains one line so the next offline WS test is written against frames a real client could send.

No companion issues: #197 *depends* on this one (and is sequenced after it), #208 is the wider stub sweep this was deliberately filed out of (commented there with what the stub still cannot model), and #293 is the follow-up above.

## Gate results

Backend (repo root):

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q   582 passed, 22 skipped
uv run ruff check .                                 All checks passed!
uv run ruff format --check .                        108 files already formatted
uv run mypy                                         Success: no issues found in 14 source files
```

Frontend (`cards/haventory-card`) — untouched by this change, run as the commit gate requires:

```
npm audit --audit-level=high   found 0 vulnerabilities
npx eslint .                   clean
npm run typecheck              clean
npx vitest run                 51 files, 1102 tests passed
npm run build                  460.52 kB │ gzip: 106.59 kB
```

## Deferred verification

- ~~**The phacc integration suite (`tests/integration/`) was not run.**~~ **Cleared by CI:** it cannot run on this Windows host (`scripts/test_integration.sh` needs a POSIX venv layout and HA core imports `fcntl`), but the `integration` job ran it green against real HA 2026.6.0. The only change on that path is a top-level `import voluptuous`, which HA depends on anyway.
- **No live-HA smoke.** Nothing shipped changed — the diff is `tests/` plus one `CONTRIBUTING.md` line — so there is no runtime behaviour to observe in a real Home Assistant.
- **HA fidelity was checked against the source, not executed.** `websocket_command`, `BASE_COMMAND_MESSAGE_SCHEMA`, `cv.positive_int`, the `async_handle` envelope conditions and `ERR_INVALID_FORMAT` were each read from `home-assistant/core` at tag `2026.6.0` (the `hacs.json` floor) — re-verified during review against the published `homeassistant-2026.6.0-py3-none-any.whl`: the decorator is line-for-line, `BASE_COMMAND_MESSAGE_SCHEMA` and `positive_int` verbatim, and the envelope conditions logically equivalent over `0 / -1 / True / "1" / None / 1.0`. The `negative-id` case is correct *because* 2026.6.0 carries an explicit `cur_id < 0`; without it that frame answers `id_reuse`. If the floor moves, re-check `decorators.websocket_command` and `connection.async_handle` — they are what this stub tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
