### PR TITLE
fix(card): keep unsaved edits and upload errors across same-item refreshes

### DIFF
--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -321,6 +321,33 @@ describe('hv-detail-sheet: edit view', () => {
     await el.updateComplete;
     expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
   });
+
+  // On a phone every attachment mutation broadcasts, and the host re-binds
+  // `.item` from the fresh copy — closing the form the user is standing in.
+  it('stays in the edit form when the same item comes back with a new version', async () => {
+    const el = await mount({ id: '1', name: 'A', version: 3 });
+    (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    el.item = makeItem({ id: '1', name: 'A', version: 4 });
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
+    expect(q(el, '[data-testid="sheet-qty"]')).toBeNull();
+  });
+
+  it('returns to the read view when the sheet is re-opened on the same item', async () => {
+    const el = await mount({ id: '1', name: 'A' });
+    (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    el.open = false;
+    await el.updateComplete;
+    el.open = true;
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
+  });
 });
 
 describe('hv-detail-sheet: pictures', () => {
@@ -443,6 +470,26 @@ describe('hv-detail-sheet: pictures', () => {
     await el.updateComplete;
 
     expect(q(el, '[data-testid="sheet-lightbox"]')).toBeNull();
+  });
+
+  // Setting a cover or removing another photo re-broadcasts the same item; the
+  // photo on screen has no reason to go with it.
+  it('keeps the lightbox open when the same item comes back with a new version', async () => {
+    const el = await mount(
+      { id: 'i-1', name: 'Drill', version: 3, attachments: shots() },
+      { media: makeMediaBindings() },
+    );
+    await el.updateComplete;
+    all(el, '[data-testid="sheet-photo-open"]')[1].click();
+    await el.updateComplete;
+
+    el.item = makeItem({ id: 'i-1', name: 'Drill', version: 4, attachments: shots() });
+    await el.updateComplete;
+    await el.updateComplete;
+
+    const lightbox = q(el, '[data-testid="sheet-lightbox"]');
+    expect(lightbox).toBeTruthy();
+    expect(lightbox?.getAttribute('aria-label')).toBe('Drill — photo 2 of 2');
   });
 });
 

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -406,11 +406,26 @@ export class HVDetailSheet extends LitElement {
   private readonly _urls = new MediaUrls(this);
   /** Returns focus to the thumbnail the lightbox was opened from. */
   private readonly _lightboxFocus = new DialogFocus();
+  /**
+   * The item id the sheet is showing. `undefined` until the first update, so
+   * that pass settles the view the same way a move to another item does.
+   */
+  private _shownItemId: string | null | undefined;
 
+  /**
+   * Another item, or a re-open, always lands on the read view.
+   *
+   * Keyed on the item *id*, not on the `item` object: the host re-binds it from
+   * a fresh lookup on every store broadcast, so each attachment mutation hands
+   * the sheet a new object for the item it is already showing. Resetting on
+   * that would close the edit form — and the lightbox — under the user mid-tap.
+   */
   protected willUpdate(changed: Map<string, unknown>) {
     this._urls.configure(this.media?.sign ?? null);
-    // A fresh item, or a re-open, always lands on the read view.
-    if (changed.has('item') || (changed.has('open') && this.open)) {
+    const id = this.item?.id ?? null;
+    const moved = id !== this._shownItemId;
+    this._shownItemId = id;
+    if (moved || (changed.has('open') && this.open)) {
       this._mode = 'read';
       this._checkoutOpen = false;
       this._lightbox = null;

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1619,3 +1619,178 @@ describe('hv-item-editor: shrinking a photo before it is sent', () => {
     expect(media.uploads[0].file).toBe(pdf);
   });
 });
+
+// Every host re-binds `.item` from a fresh lookup on each store broadcast, so
+// an upload landing — or anyone else editing the same row — hands the open form
+// a new object for the item it is already on.
+describe('hv-item-editor: same-item refreshes', () => {
+  /** The broadcast arriving: same id, new object, version moved on. */
+  const refreshed = (el: HVItemEditor, partial: Partial<Item>) => {
+    el.item = makeItem({ id: 'i-1', name: 'Drill', ...partial });
+    return el.updateComplete;
+  };
+
+  it('keeps unsaved typing when the same item comes back with a new version', async () => {
+    const el = await mount(makeItem({ id: 'i-1', name: 'Drill', version: 3 }));
+    await type(el, 'editor-description', 'IMPORTANT NOTE typed but not yet saved');
+    expect(el.dirty).toBe(true);
+
+    await refreshed(el, { version: 4 });
+
+    const description = q(el, '[data-testid="editor-description"]') as HTMLInputElement;
+    expect(description.value).toBe('IMPORTANT NOTE typed but not yet saved');
+    expect(el.dirty).toBe(true);
+  });
+
+  // On a phone the description lives behind the More fields disclosure, so the
+  // refresh has to leave that open too or the typing survives out of sight.
+  it('leaves the mobile disclosure open around the text it holds', async () => {
+    const el = await mount(makeItem({ id: 'i-1', name: 'Drill', version: 3 }), { mobile: true });
+    (q(el, '[data-testid="editor-more-toggle"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await type(el, 'editor-description', 'typed on a phone');
+
+    await refreshed(el, { version: 4 });
+
+    expect((q(el, '[data-testid="editor-description"]') as HTMLInputElement)?.value).toBe(
+      'typed on a phone',
+    );
+    expect(q(el, '[data-testid="editor-more-toggle"]')?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('adopts the attachments the refreshed item carries', async () => {
+    const el = await mount(
+      makeItem({ id: 'i-1', name: 'Drill', version: 3, attachments: [makeAttachment({ id: 'att-1' })] }),
+      { media: makeMediaBindings() },
+    );
+    await el.updateComplete;
+    expect(all(el, '[data-testid="editor-photo"]')).toHaveLength(1);
+
+    await refreshed(el, {
+      version: 4,
+      attachments: [makeAttachment({ id: 'att-1' }), makeAttachment({ id: 'att-2' })],
+    });
+    await el.updateComplete;
+
+    expect(all(el, '[data-testid="editor-photo"]')).toHaveLength(2);
+  });
+
+  // The prop is the fresher copy the moment it reaches the version an upload
+  // returned; saving against the older one would come back `conflict`.
+  it('saves against the refreshed item once it has caught up with an upload', async () => {
+    const media = makeMediaBindings({
+      upload: async (itemId) => makeItem({ id: itemId, version: 7 }),
+    });
+    const el = await mount(makeItem({ id: 'i-1', name: 'Drill', version: 3 }), { media });
+
+    const input = q(el, '[data-testid="editor-photo-input"]') as HTMLInputElement;
+    Object.defineProperty(input, 'files', {
+      value: [new File(['x'], 'photo.png', { type: 'image/png' })],
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await el.updateComplete;
+
+    const saves = onSave(el);
+    q(el, '[data-testid="editor-save"]')?.click();
+    expect(saves[0].expectedVersion).toBe(7);
+
+    await refreshed(el, { version: 9 });
+    q(el, '[data-testid="editor-save"]')?.click();
+    expect(saves[1].expectedVersion).toBe(9);
+  });
+
+  it('rebuilds the form when the create form saves into a real item', async () => {
+    const el = await mount(null);
+    await type(el, 'editor-name', 'Drill');
+    expect(el.dirty).toBe(true);
+
+    await refreshed(el, { version: 1 });
+
+    expect(el.dirty).toBe(false);
+    expect((q(el, '[data-testid="editor-name"]') as HTMLInputElement).value).toBe('Drill');
+  });
+});
+
+describe('hv-item-editor: upload errors outlive their siblings', () => {
+  function pick(el: HVItemEditor, files: File[]) {
+    const input = q(el, '[data-testid="editor-photo-input"]') as HTMLInputElement;
+    Object.defineProperty(input, 'files', { value: files, configurable: true });
+    input.dispatchEvent(new Event('change'));
+  }
+
+  const png = (name: string) => new File(['x'], name, { type: 'image/png' });
+
+  /** Refuses anything named "broken", takes everything else. */
+  async function mountWithOneRefusal() {
+    const media = makeMediaBindings({
+      upload: async (itemId, file) => {
+        if (file.name.includes('broken')) {
+          throw new Error('file content is not one of the accepted types');
+        }
+        return makeItem({ id: itemId, version: 5 });
+      },
+    });
+    const el = await mount(makeItem({ id: 'i-1', version: 1 }), { media });
+
+    pick(el, [png('broken.jpg'), png('photo-3-landscape.jpg')]);
+    // A macrotask, so the whole sequential queue drains before the assertion.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // The sibling's success reaches the card as a broadcast, and the host hands
+    // the still-open editor a fresh object for the same item.
+    el.item = makeItem({ id: 'i-1', version: 5 });
+    await el.updateComplete;
+    return el;
+  }
+
+  it('keeps the refused file reported after the item refreshes', async () => {
+    const el = await mountWithOneRefusal();
+
+    const entries = all(el, '[data-testid="editor-upload"]');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].dataset.state).toBe('error');
+    expect(entries[0].textContent).toContain('broken.jpg');
+    expect(entries[0].textContent).toContain('not one of the accepted types');
+    expect(q(el, '[data-testid="editor-upload-retry"]')).toBeTruthy();
+  });
+
+  it('clears exactly the row whose dismiss was pressed', async () => {
+    const el = await mountWithOneRefusal();
+    pick(el, [png('also-broken.jpg')]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await el.updateComplete;
+    expect(all(el, '[data-testid="editor-upload"]')).toHaveLength(2);
+
+    (all(el, '[data-testid="editor-upload-dismiss"]')[0] as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    const left = all(el, '[data-testid="editor-upload"]');
+    expect(left).toHaveLength(1);
+    expect(left[0].textContent).toContain('also-broken.jpg');
+  });
+
+  // Nothing else clears the queue any more, so a row with no Retry — a failed
+  // reorder or removal — would otherwise stay for the life of the form.
+  it('offers a dismiss on an error row that carries no file to retry', async () => {
+    const media = makeMediaBindings({
+      remove: async () => {
+        throw new Error('gone already');
+      },
+    });
+    const el = await mount(
+      makeItem({ id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] }),
+      { media },
+    );
+    await el.updateComplete;
+
+    q(el, '[data-testid="editor-photo-remove"]')?.click();
+    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+    expect(q(el, '[data-testid="editor-upload-retry"]')).toBeNull();
+
+    (q(el, '[data-testid="editor-upload-dismiss"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="editor-upload"]')).toBeNull();
+  });
+});

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -845,13 +845,22 @@ export class HVItemEditor extends LitElement {
       .upload-list li.failed .state {
         color: var(--hv-error);
       }
-      .upload-list li .retry {
+      .upload-list li .retry,
+      .upload-list li .dismiss {
         margin-left: auto;
         border: none;
         background: none;
         padding: 0 4px;
         color: var(--hv-primary-dark);
         font: 500 11.5px var(--hv-font);
+        cursor: pointer;
+      }
+      .upload-list li .dismiss {
+        color: var(--hv-text-secondary);
+      }
+      /* Retry already claimed the free space; the dismiss follows it. */
+      .upload-list li .retry ~ .dismiss {
+        margin-left: 0;
       }
     `,
   ];
@@ -904,7 +913,11 @@ export class HVItemEditor extends LitElement {
   /** The inspection field's "+X days" row is showing, and owns the date. */
   @state() private _inspectionCustomOpen = false;
   @state() private _inspectionCustomDays = DEFAULT_CUSTOM_DAYS;
-  /** Files the picker is working through; a finished one leaves the list. */
+  /**
+   * Files the picker is working through. A finished one leaves the list; a
+   * failed one stays until it is retried or dismissed, so a sibling's success
+   * cannot carry away the only report the user gets of a refused file.
+   */
   @state() private _uploads: UploadEntry[] = [];
   /**
    * The item as the backend now holds it, once an upload has moved past the
@@ -915,6 +928,12 @@ export class HVItemEditor extends LitElement {
 
   private readonly _urls = new MediaUrls(this);
   private _uploadSeq = 0;
+  /**
+   * The item id `_model` was built from. `undefined` until the first update,
+   * which is what makes that first pass build the form; `null` is the create
+   * form, a real id every other case.
+   */
+  private _formItemId: string | null | undefined;
 
   /** The item to save against: whatever the last upload returned, else the input. */
   private get _current(): Item | null {
@@ -931,9 +950,22 @@ export class HVItemEditor extends LitElement {
     this.renderRoot.querySelector<HTMLInputElement>('[data-testid="editor-name"]')?.focus();
   }
 
-  protected willUpdate(changed: Map<string, unknown>) {
+  /**
+   * The form belongs to an item *id*, not to one `item` object.
+   *
+   * Every host re-binds `.item` from a fresh lookup on each store broadcast, so
+   * an upload finishing — or anyone editing the same row elsewhere — hands this
+   * component a new object for the item the user is still typing into.
+   * Rebuilding on that would throw away everything typed since the last save,
+   * so the reset is keyed on the id: a different one (including the null→id hop
+   * a create makes the moment it saves) is a different form, and everything
+   * else is a refresh the open form absorbs.
+   */
+  protected willUpdate() {
     this._urls.configure(this.media?.sign ?? null);
-    if (changed.has('item')) {
+    const id = this.item?.id ?? null;
+    if (id !== this._formItemId) {
+      this._formItemId = id;
       this._model = formFromItem(this.item);
       this._errors = [];
       this._showErrors = false;
@@ -943,6 +975,14 @@ export class HVItemEditor extends LitElement {
       this._uploads = [];
       this._uploaded = null;
       this._closeCategory();
+      return;
+    }
+    // `_uploaded` stands in for `item` only while the prop lags an upload's
+    // result. Once the prop is at that version or past it, it is the fresher of
+    // the two — holding the older copy would render stale attachments and send
+    // a superseded `expectedVersion` on the next save.
+    if (this._uploaded && this.item && this.item.version >= this._uploaded.version) {
+      this._uploaded = null;
     }
   }
 
@@ -1667,6 +1707,15 @@ export class HVItemEditor extends LitElement {
   }
 
   /**
+   * Drop one entry from the queue, and only that one. An upload clears its own
+   * row when it succeeds and a different item rebuilds the form; nothing else
+   * touches the queue, so an error row is the user's to dismiss.
+   */
+  private _dismissUpload(id: string) {
+    this._uploads = this._uploads.filter((u) => u.id !== id);
+  }
+
+  /**
    * Move one attachment within its kind, and adopt the item that comes back.
    *
    * `delta` of `-Infinity` is "make this the cover" — the same command, since
@@ -1972,6 +2021,16 @@ export class HVItemEditor extends LitElement {
                   @click=${() => void this._retryUpload(entry.id)}
                 >
                   Retry
+                </button>`
+              : null}
+            ${entry.state === 'error'
+              ? html`<button
+                  class="dismiss"
+                  data-testid="editor-upload-dismiss"
+                  aria-label=${`Dismiss the error for ${entry.name}`}
+                  @click=${() => this._dismissUpload(entry.id)}
+                >
+                  ${icon('close', 13)}
                 </button>`
               : null}
           </li>`,


### PR DESCRIPTION
## Summary

Work package **P2** of the v0.4.0 UI-audit remediation plan (`dev/ui_audit_v040_fix_plan.md`) — audit items **A1 (blocker)** and **B4**.

Both `hv-item-editor` and `hv-detail-sheet` reset themselves on `item` *object identity*. Every host re-binds `.item` from a fresh `items.find(...)` on each store broadcast (`hv-full-view`, `hv-card-shell`, `hv-detail-sheet`), so an upload landing — or anyone editing the same row elsewhere — rebuilt the surface under the user.

- **A1** — typed-but-unsaved text in the open editor was thrown away, and on a phone every attachment mutation (upload, make-cover, reorder, remove) closed the edit form outright.
- **B4** — the same reset wiped `_uploads`, so a refused file's error row and its Retry vanished the moment a later sibling in the batch succeeded; the user was told nothing.

**The fix**: key both resets on the item **id**, not the object.

- A different id — including the `null → id` hop a create makes the moment it saves — is a different form and resets everything as before. Anything else is a refresh the open surface absorbs: `_model`, `_errors`, popover state and `_uploads` are kept, while the incoming item is adopted as the fresh attachment/version source.
- `_uploaded` is dropped once the `item` prop reaches its version. Stated as an invariant in a comment: `_uploaded` stands in for `item` only while the prop lags an upload's result, so once the prop has caught up, holding the older copy would render stale attachments and send a superseded `expectedVersion`.
- The save path is untouched — `_current = _uploaded ?? item` supplying `expectedVersion` remains the version-conflict mechanism, and keeping `_model` across an external same-id edit is what routes that edit into the conflict path instead of a silent rebuild.
- The sheet still lands on the read view on a re-open (`open` flipping true), which is now pinned by a test.

Because `willUpdate` was the **only** place the upload queue was ever cleared, an error row would otherwise live for the life of the form. Error rows gain a **dismiss (×)** control that clears exactly that entry; Retry is unchanged, and rows with no file to retry (a failed reorder/removal) get the dismiss too.

Scope was deliberately kept minimal — this is the highest-semantic-risk change in the campaign. Tap-target sizing for Retry/dismiss and the upload-progress indicator are P5's; the lightbox index clamp is P6's.

No issue is closed by this PR: per the campaign's issue wiring, `Closes` lines belong to P5 (#301) and P8 (#300, #303).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green locally on this branch, and re-run independently by the local verification session.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (737 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (15 source files, no issues)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (54 files, **1264** tests passed — 1253 before, 11 new), `npm run build`

New tests (`hv-item-editor.test.ts`, `hv-detail-sheet.test.ts`):

- Same-id refresh keeps typed description text and `dirty` — on desktop, and on mobile where it must also leave the More-fields disclosure open around the text.
- Same-id refresh adopts the refreshed item's attachment list.
- Save carries the upload's version while the prop lags, then the prop's version once it has caught up (the `_uploaded` invariant).
- `null → id`: the create form still rebuilds when it saves into a real item.
- Sheet stays in the edit form on a same-id refresh; keeps the lightbox open on the same photo; still returns to read on a different item and on a re-open.
- A refused file's error + Retry survive a sibling's success *and* the item refresh that follows; dismiss clears exactly the pressed row; an error row with no retryable file still offers dismiss.

Existing reset pins all swap **different** ids and stay green as written — no assertion was deleted.

## Live verification (local pass) — ✅ all three checks pass

Executed against the Docker dev HA at `2e90e6b` (schema v6, 1004 items). The served bundle's SHA matched a fresh rebuild from HEAD, so the browser was exercising this branch's code.

1. **Unsaved edits survive an upload** — typed the note into the description, picked a photo without saving. After the upload landed the description read back verbatim, the editor was still open, and the new thumbnail was in the grid. Save then succeeded (v2 → v3), no `conflict`, description persisted, photo still attached.
2. **Mobile edit form survives an attachment mutation** — 390×844 with touch, asserted the narrow branch (`hv-card-shell[mobile]`) first. "Make cover", reorder chevron and remove × each kept the form open *and* landed their effect (photo → position 0, first two swapped, 3 → 2 photos). Lightbox: opened from the read view, then an `item/update` for that same item issued from a separate WS connection outside the browser — the lightbox stayed open on the same photo.
3. **A refused file's error outlives its siblings** — `broken.jpg` (text bytes, `.jpg` name, `image/jpeg` declared) clears the card's preflight and fails on the backend's byte sniffing, so it is a genuine server-side refusal. Batch `[broken.jpg, valid-teal.jpg, valid-amber.jpg]`: both valid photos attached, exactly one row left naming `broken.jpg` with the backend's own text, plus Retry and ×. × removed that row and nothing else; Retry fired a real new `POST /api/file_upload`, failed again, and the row survived with both controls.

No defect found, so nothing was pushed — the branch is still at `2e90e6b`. Test data was removed from the dev instance.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — none apply: this is card-internal state handling with no WS contract or README surface. Invalidated comments on `_uploads` and both `willUpdate`s were rewritten to state the constraint that now holds.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — N/A, no backend change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None — the change is behavioral, not visual. The dismiss × is the only new pixel, and P5 resizes it to a ≥24 px target.

## Follow-ups

The local pass's `log_sweep.py` flagged one blocking finding, pre-existing on `main` from #294 and unrelated to this diff: `ws.py:1524` exits core's `process_uploaded_file` context manager on the event loop, and its teardown runs a synchronous `shutil.rmtree`. Filed as #310.