### PR TITLE
fix(card): price statuses from status_counts and survive payload-less item events

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,9 +510,11 @@ throughout.
   sidebar leads with the location tree carrying the backend's own per-location counts and
   an orphans row, then **Status**, **Categories** and **Tags** as sections of their own;
   each heading collapses from a chevron and states how many there are — locations counted
-  at every depth, Status excepted since it always holds the same three rows — and
-  Locations stays at the top. Status prices OK as whatever the two flagged counts leave
-  over. Category and status each pick one value and
+  at every depth, Status excepted because there that number would count the household's
+  vocabulary rather than anything in the inventory — and
+  Locations stays at the top. Every status row is priced from the backend's own per-status
+  counts, so a status nothing carries reads 0 rather than inheriting the rest of the
+  inventory. Category and status each pick one value and
   tags accumulate, matching how the backend treats them. With a filter on, each location
   row reads "4 / 37" — matches over total — so you can see where the matches are rather
   than a total that never moves. The counts ignore the *location* filter, since the sidebar

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -1,7 +1,7 @@
 import './hv-filter-panel';
 import type { HVFilterPanel } from './hv-filter-panel';
 import { defaultFilters } from '../store/store';
-import type { DistinctValues, Location, LocationTreeNode, StoreFilters } from '../store/types';
+import type { DistinctValues, Location, LocationTreeNode, StatusDefinition, StoreFilters } from '../store/types';
 
 const distinct: DistinctValues = {
   categories: [
@@ -143,7 +143,39 @@ describe('hv-filter-panel: status', () => {
     expect(seen[1]).toEqual({ status: null });
   });
 
-  it('prices the two flagged statuses from the stats counts', async () => {
+  // Every chip priced, so a user picking what to filter by can see which
+  // statuses hold anything — the SHOW ONLY row above has always done this.
+  it('prices every status from the per-slug counts, zeroes included', async () => {
+    const statuses: StatusDefinition[] = [
+      { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
+      { slug: 'lent_out', label: 'Lent out', order: 1, color: 'blue', icon: 'hand' },
+      { slug: 'in_transit', label: 'In transit', order: 2, color: 'blue_strong', icon: 'truck' },
+    ];
+    const el = await mount(
+      {},
+      {
+        statuses,
+        counts: {
+          items_total: 998,
+          low_stock_count: 0,
+          checked_out_count: 0,
+          locations_total: 0,
+          no_location_count: 0,
+          status_counts: { ok: 856, lent_out: 100, in_transit: 0 },
+        },
+      },
+    );
+    const chips = all(el, '[data-testid="filter-status"]');
+    expect(chips.map((c) => (c.textContent ?? '').replace(/\s+/g, ' ').trim())).toEqual([
+      'OK 856',
+      'Lent out 100',
+      'In transit 0',
+    ]);
+  });
+
+  // A backend too old to send the per-slug map still prices the two flagged
+  // built-ins in their own fields; nothing else is knowable there.
+  it('prices only the two flagged statuses when the per-slug map is absent', async () => {
     const el = await mount(
       {},
       {
@@ -247,6 +279,15 @@ describe('hv-filter-panel: tags', () => {
 });
 
 describe('hv-filter-panel: show only vs sort', () => {
+  // Sort is a daily toggle and the tag cloud renders every tag the household
+  // has, so on a phone anything under it is several screens into the sheet.
+  it('puts sort above the tag cloud', async () => {
+    const el = await mount();
+    const headings = all(el, '.hv-label').map((s) => s.textContent?.trim());
+
+    expect(headings).toEqual(['Where', 'Category', 'Show only', 'Status', 'Changed', 'Sort', 'Tags']);
+  });
+
   it('keeps low-stock-only and low-stock-first as separate controls', async () => {
     const el = await mount();
     const seen = changes(el);
@@ -275,7 +316,7 @@ describe('hv-filter-panel: show only vs sort', () => {
       },
     );
     const tallyOf = (testid: string) =>
-      q(el, `[data-testid="${testid}"]`).querySelector('.tally')?.textContent?.trim();
+      q(el, `[data-testid="${testid}"]`).querySelector('.hv-tally')?.textContent?.trim();
 
     expect(tallyOf('filter-low-stock-only')).toBe('102');
     expect(tallyOf('filter-checked-out')).toBe('82');
@@ -285,7 +326,7 @@ describe('hv-filter-panel: show only vs sort', () => {
 
   it('prints no tally at all when the counts have not arrived', async () => {
     const el = await mount();
-    expect(q(el, '[data-testid="filter-low-stock-only"]').querySelector('.tally')).toBe(null);
+    expect(q(el, '[data-testid="filter-low-stock-only"]').querySelector('.hv-tally')).toBe(null);
   });
 
   it('carries the same tallies into the phone layout', async () => {

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -6,8 +6,8 @@ import { locationPathParts, pathTitle } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
 import { activeFilterCount, defaultFilters } from '../store/store';
-import { DEFAULT_STATUS, statusLabel, statusList, statusToneClass } from '../ui/status';
-import type { DistinctValues, ItemStatus, Location, LocationTreeNode, SortField, StatsCounts, StatusDefinition, StoreFilters } from '../store/types';
+import { DEFAULT_STATUS, statusCount, statusLabel, statusList, statusToneClass } from '../ui/status';
+import type { DistinctValues, Location, LocationTreeNode, SortField, StatsCounts, StatusDefinition, StoreFilters } from '../store/types';
 import './hv-location-tree';
 
 /** Sort fields the backend supports, in the order the menu lists them. */
@@ -110,9 +110,6 @@ export class HVFilterPanel extends LitElement {
          rather than a value that has. */
       .chip.more {
         border-style: dashed;
-      }
-      .chip .tally {
-        opacity: 0.65;
       }
       .hint {
         font-size: 11px;
@@ -278,10 +275,10 @@ export class HVFilterPanel extends LitElement {
       :host([mobile]) .check .mark {
         width: 15px;
       }
-      .tally-right {
+      /* The row form of a facet reads label-first, so its tally is pushed to
+         the far edge; the chip form sits right after the label. */
+      .hv-tally.tally-right {
         margin-left: auto;
-        font-size: 12.5px;
-        opacity: 0.65;
       }
       select {
         font: inherit;
@@ -345,12 +342,12 @@ export class HVFilterPanel extends LitElement {
   /** Stage edits and apply on commit (mobile sheet) instead of applying live. */
   @property({ type: Boolean, reflect: true }) mobile = false;
   /**
-   * Whole-inventory stat counts, for the "Show only" tallies.
+   * Whole-inventory stat counts, which price both the "Show only" rows and the
+   * status chips.
    *
-   * Those four rows were the only facet controls in the card with no number
-   * beside them — and the renderer already had a slot for one, filled with a
-   * hardcoded `null`, while both app bars showed the same counts a few pixels
-   * away.
+   * Every facet in this panel carries a number, so a user can see what a filter
+   * is worth before applying it. Null until the first `haventory/stats` answer
+   * arrives, and then each tally is drawn only where the payload prices it.
    */
   @property({ attribute: false }) counts: StatsCounts | null = null;
 
@@ -458,7 +455,7 @@ export class HVFilterPanel extends LitElement {
       <span class="mark">${on ? icon('check', this.mobile ? 15 : 12) : null}</span>
       <span>${label}</span>
       ${opts.tally !== undefined && opts.tally !== null
-        ? html`<span class="tally-right">${opts.tally}</span>`
+        ? html`<span class="hv-tally tally-right">${opts.tally}</span>`
         : null}
     </button>`;
   }
@@ -545,7 +542,7 @@ export class HVFilterPanel extends LitElement {
               @click=${() => this._patch({ category: f.category === c.value ? null : c.value })}
             >
               ${f.category === c.value ? icon('check', 12) : null}${c.value}
-              <span class="tally">${c.count}</span>
+              <span class="hv-tally">${c.count}</span>
             </button>`,
           )}
           ${hidden > 0
@@ -556,7 +553,7 @@ export class HVFilterPanel extends LitElement {
                   this._showAllCategories = true;
                 }}
               >
-                More… <span class="tally">${hidden}</span>
+                More… <span class="hv-tally">${hidden}</span>
               </button>`
             : null}
         </div>
@@ -606,7 +603,7 @@ export class HVFilterPanel extends LitElement {
               @click=${() => this._toggleTag(t.value)}
             >
               ${selected.has(t.value) ? icon('check', 12) : null}${t.value}
-              <span class="tally">${t.count}</span>
+              <span class="hv-tally">${t.count}</span>
             </button>`,
           )}
           ${extras.map(
@@ -649,7 +646,7 @@ export class HVFilterPanel extends LitElement {
     const f = this.working;
     const c = this.counts;
     const tally = (n: number | null | undefined) =>
-      n === null || n === undefined ? null : html`<span class="tally">${n}</span>`;
+      n === null || n === undefined ? null : html`<span class="hv-tally">${n}</span>`;
     return html`
       <div class="group">
         <span class="hv-label">Show only</span>
@@ -712,16 +709,15 @@ export class HVFilterPanel extends LitElement {
   /**
    * The stored item status, as one single-select chip row.
    *
-   * Single-select because the backend filter takes exactly one status, and the
-   * two flagged values carry the same warning tone their row badges use. OK
-   * gets no tally: the counts payload prices the two exception states, and
-   * "everything else" is not a number worth a chip.
+   * Single-select because the backend filter takes exactly one status, and each
+   * chip carries the tone its household picked. Every chip is priced the same
+   * way, so a user choosing what to filter by can see which statuses are worth
+   * filtering by — a backend too old to price them all leaves the rest bare
+   * rather than guessing.
    */
   private _renderStatusGroup() {
     const f = this.working;
     const c = this.counts;
-    const tallyFor = (s: ItemStatus) =>
-      s === 'missing' ? c?.missing_count : s === 'needs_repair' ? c?.needs_repair_count : undefined;
     return html`
       <div class="group">
         <span class="hv-label">Status</span>
@@ -731,7 +727,7 @@ export class HVFilterPanel extends LitElement {
             // A chosen status shows its own colour; the rest stay outlines, so
             // the row reads as choices rather than as facts.
             const tone = on && s !== DEFAULT_STATUS ? statusToneClass(s, this.statuses) : '';
-            const tally = tallyFor(s);
+            const tally = statusCount(c, s);
             return html`<button
               class="hv-chip toggle chip hv-status-chip ${on ? 'on' : ''} ${tone}"
               data-testid="filter-status"
@@ -740,7 +736,7 @@ export class HVFilterPanel extends LitElement {
               @click=${() => this._patch({ status: on ? null : s })}
             >
               ${on ? icon('check', 12) : null}${statusLabel(s, this.statuses)}
-              ${tally === undefined || tally === null ? null : html`<span class="tally">${tally}</span>`}
+              ${tally === null ? null : html`<span class="hv-tally">${tally}</span>`}
             </button>`;
           })}
         </div>
@@ -863,9 +859,12 @@ export class HVFilterPanel extends LitElement {
     const count = activeFilterCount(this.working);
     return html`
       <div class="panel" data-testid="filter-panel">
-        ${this._renderLocationGroup()} ${this._renderCategoryGroup()} ${this._renderTagGroup()}
+        ${this._renderLocationGroup()} ${this._renderCategoryGroup()}
         ${this._renderShowOnlyGroup()} ${this._renderStatusGroup()} ${this._renderDateGroup()}
-        ${this._renderSortGroup()}
+        <!-- Sort sits above the tag cloud: a household's tag list grows without
+             limit and this one renders every tag in it, so anything below it is
+             several screens down inside the phone's filter sheet. -->
+        ${this._renderSortGroup()} ${this._renderTagGroup()}
         ${this.mobile
           ? null
           : html`<div class="footer">

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -4,7 +4,7 @@ import { makeMockHass, makeItem } from '../test.utils';
 import { deepActiveElement } from '../ui/dialog-focus';
 import { Store } from '../store/store';
 import type { HVFullView } from './hv-full-view';
-import type { Item, Location } from '../store/types';
+import type { Item, Location, StatusDefinition } from '../store/types';
 
 function loc(id: string, name: string, parentId: string | null = null): Location {
   const display = parentId ? `${parentId} / ${name}` : name;
@@ -27,6 +27,7 @@ async function mount(
     items?: Item[];
     locations?: Location[];
     areas?: { id: string; name: string }[];
+    statuses?: StatusDefinition[];
     embedded?: boolean;
     narrow?: boolean;
   } = {},
@@ -35,6 +36,7 @@ async function mount(
     items: opts.items ?? [],
     locations: opts.locations ?? [],
     areas: opts.areas ?? [],
+    ...(opts.statuses ? { statuses: opts.statuses } : {}),
   });
   const store = new Store(hass, { retryBaseMs: 0 });
   await store.init();
@@ -753,14 +755,36 @@ describe('hv-full-view: sidebar status', () => {
   const rows = (sr: ShadowRoot) =>
     [...sr.querySelectorAll('[data-testid="sidebar-status-row"]')] as HTMLElement[];
   const tallies = (sr: ShadowRoot) =>
-    rows(sr).map((r) => r.querySelector('.tally')?.textContent?.trim() ?? null);
+    rows(sr).map((r) => r.querySelector('.hv-tally')?.textContent?.trim() ?? null);
 
-  // The counts payload prices only the two flagged states; OK is the rest of
-  // the inventory, which is the one number here that has to be derived.
+  // Every row is priced from the per-slug map, so the facet says what the
+  // backend says rather than what the facet can derive.
   it('lists the three statuses with their counts', async () => {
     const { sr } = await mount({ items: flagged });
     expect(rows(sr).map((r) => r.dataset.value)).toEqual(['ok', 'missing', 'needs_repair']);
     expect(tallies(sr)).toEqual(['1', '1', '2']);
+  });
+
+  // The audit's fixture in miniature: custom slugs used to inherit "everything
+  // that is not missing or needs_repair", so an empty status claimed the whole
+  // inventory and then showed no rows when it was clicked.
+  it('prices a household vocabulary per slug, including one nothing carries', async () => {
+    const statuses: StatusDefinition[] = [
+      { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
+      { slug: 'lent_out', label: 'Lent out', order: 1, color: 'blue', icon: 'hand' },
+      { slug: 'in_transit', label: 'In transit', order: 2, color: 'blue_strong', icon: 'truck' },
+    ];
+    const items = [
+      makeItem({ id: '1', status: 'lent_out' }),
+      makeItem({ id: '2', status: 'lent_out' }),
+      makeItem({ id: '3' }),
+      makeItem({ id: '4' }),
+      makeItem({ id: '5' }),
+    ];
+    const { sr } = await mount({ items, statuses });
+
+    expect(rows(sr).map((r) => r.dataset.value)).toEqual(['ok', 'lent_out', 'in_transit']);
+    expect(tallies(sr)).toEqual(['3', '2', '0']);
   });
 
   it('filters to one status and clears it on a second press', async () => {
@@ -793,11 +817,23 @@ describe('hv-full-view: sidebar status', () => {
     ]);
   });
 
-  // An older backend sends neither count. Then no row claims a number, rather
-  // than every row claiming one derived from the halves that did arrive.
-  it('drops every tally when the backend prices no statuses', async () => {
+  // A backend too old to send the map still prices the two flagged built-ins in
+  // their own fields; the default is not knowable there, and stays unpriced
+  // rather than being derived from the halves that did arrive.
+  it('falls back to the legacy fields when the per-slug map is absent', async () => {
     const { el, store, sr } = await mount({ items: flagged });
     const counts = store.state.value.statsCounts as unknown as Record<string, unknown>;
+    delete counts.status_counts;
+    el.requestUpdate();
+    await settle(el);
+
+    expect(tallies(sr)).toEqual([null, '1', '2']);
+  });
+
+  it('drops every tally when the backend prices no statuses at all', async () => {
+    const { el, store, sr } = await mount({ items: flagged });
+    const counts = store.state.value.statsCounts as unknown as Record<string, unknown>;
+    delete counts.status_counts;
     delete counts.missing_count;
     delete counts.needs_repair_count;
     el.requestUpdate();
@@ -806,8 +842,8 @@ describe('hv-full-view: sidebar status', () => {
     expect(tallies(sr)).toEqual([null, null, null]);
   });
 
-  // Categories and tags tally how many rows they hold; this section always
-  // holds three, so the same number in that slot would be noise.
+  // Categories and tags tally how many rows they hold; here that number counts
+  // the household's vocabulary, not the inventory the facet navigates.
   it('heads the section without a tally', async () => {
     const { sr } = await mount({ items: flagged });
     expect(q(sr, '[data-testid="sidebar-status-tally"]')).toBe(null);

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -15,8 +15,7 @@ import { deepFocusables } from '../ui/dialog-focus';
 import { areaNameById, effectiveAreaIdForLocation } from '../ui/area';
 import { renderAreaChip } from '../ui/location-path';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
-import { statusLabel, statusList } from '../ui/status';
-import type { ItemStatus } from '../store/types';
+import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
 import type { ColumnKey } from '../store/columns';
@@ -519,14 +518,6 @@ export class HVFullView extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-      }
-      .value-row .tally {
-        flex: none;
-        font-size: 11.5px;
-        color: var(--hv-text-tertiary);
-      }
-      .value-row.on .tally {
-        color: inherit;
       }
       .section-empty {
         padding: 2px 16px 8px 34px;
@@ -1152,7 +1143,7 @@ export class HVFullView extends LitElement {
    *
    * Single-select, because the backend filter takes exactly one status, and
    * pressing the active row clears it — the same contract category has. Unlike
-   * the other two facets the rows are a closed set the backend defines rather
+   * the other two facets the rows are a closed set the household defines rather
    * than values discovered from the inventory, so there is nothing to create
    * and no empty state to fall back to.
    */
@@ -1160,28 +1151,18 @@ export class HVFullView extends LitElement {
     const st = this.st;
     const filters = st?.filters ?? defaultFilters();
     const counts = st?.statsCounts;
-    // Only the two flagged states are priced by the counts payload; OK is
-    // whatever is left of the inventory. An older backend sends neither, and
-    // then no row claims a number rather than every row claiming a wrong one.
-    const missing = counts?.missing_count;
-    const needsRepair = counts?.needs_repair_count;
-    const tallyFor = (s: ItemStatus): number | null => {
-      if (missing === undefined || needsRepair === undefined) return null;
-      if (s === 'missing') return missing;
-      if (s === 'needs_repair') return needsRepair;
-      return Math.max(0, counts!.items_total - missing - needsRepair);
-    };
     return html`
       <div class="sidebar-head">
         ${this._renderSectionToggle('status', 'Status')}
-        <!-- The other sections tally how many rows they hold; this one always
-             holds three, so the number would say the same thing forever. -->
+        <!-- The other sections tally how many rows they hold. Here that number
+             is the size of the household's vocabulary, which says nothing
+             about the inventory the facet navigates. -->
       </div>
       <div id=${sectionPanelId('status')} ?hidden=${!this._sections.status}>
         ${this._sections.status
           ? statusList(this.st?.statuses).map(({ slug: s }) => {
               const on = filters.status === s;
-              const tally = tallyFor(s);
+              const tally = statusCount(counts, s);
               return html`<button
                 class="value-row ${on ? 'on' : ''}"
                 data-testid="sidebar-status-row"
@@ -1191,7 +1172,7 @@ export class HVFullView extends LitElement {
               >
                 ${on ? icon('check', 15) : null}
                 <span class="label">${statusLabel(s, this.st?.statuses)}</span>
-                ${tally === null ? null : html`<span class="tally">${tally}</span>`}
+                ${tally === null ? null : html`<span class="hv-tally">${tally}</span>`}
               </button>`;
             })
           : null}
@@ -1262,7 +1243,7 @@ export class HVFullView extends LitElement {
                        typed is otherwise unreadable — there is nowhere else in
                        the sidebar it appears in full. -->
                   <span class="label" title=${v.value}>${v.value}</span>
-                  <span class="tally">${v.count}</span>
+                  <span class="hv-tally">${v.count}</span>
                 </button>`,
               )
             : html`<div class="section-empty" data-testid=${`sidebar-${section}-empty`}>

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -970,6 +970,28 @@ describe('hv-organize-dialog: statuses', () => {
     expect(row?.querySelector('[data-testid="status-count"]')?.textContent?.trim()).toBe('1 item');
   });
 
+  // The count is this tab's answer to "which items?", so it has to land on
+  // those items — the way a location count and a category count already do.
+  it('opens the items behind a status from its count', async () => {
+    const { el, store, sr } = await mount({
+      tab: 'statuses',
+      items: [ladder, makeItem({ id: 'i2', name: 'Rake' })],
+    });
+    let browsed = 0;
+    el.addEventListener('browse', () => {
+      browsed += 1;
+    });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-count"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(store.state.value.filters.status).toBe('missing');
+    // Organizing happens full-screen; so should the list it hands back.
+    expect(browsed).toBe(1);
+    expect(el.open).toBe(false);
+  });
+
   it('creates a status, deriving the slug from the label', async () => {
     const { el, sr, hass } = await mount({ tab: 'statuses' });
 

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -10,6 +10,7 @@ import {
   STATUS_COLORS,
   STATUS_ICONS,
   renderStatusChip,
+  statusCount,
   statusLabel,
   statusList,
 } from '../ui/status';
@@ -1411,9 +1412,16 @@ export class HVOrganizeDialog extends LitElement {
     return statusList(this.st?.statuses);
   }
 
-  /** How many items carry a slug. `haventory/stats` already reports this. */
+  /**
+   * How many items carry a slug.
+   *
+   * Every row here names a status this dialog just listed, so a slug the counts
+   * cannot price is one the payload has not caught up with — a row reading
+   * "0 items" for the moment it takes is better than a row with no count at
+   * all, because the count doubles as this tab's link into the items.
+   */
   private _statusCount(slug: string): number {
-    return this.st?.statsCounts?.status_counts?.[slug] ?? 0;
+    return statusCount(this.st?.statsCounts, slug) ?? 0;
   }
 
   /**
@@ -1613,9 +1621,8 @@ export class HVOrganizeDialog extends LitElement {
 
   /** Take the user to the items on a status, the way a value count does. */
   private _showStatus(slug: string) {
-    this.dispatchEvent(
-      new CustomEvent('browse', { detail: { status: slug }, bubbles: true, composed: true }),
-    );
+    this.store?.setFilters({ status: slug });
+    this._browse();
   }
 
   private _renderStatusEditor(slug: string | 'new') {

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -1249,4 +1249,24 @@ describe('Store: import reload signalling', () => {
     expect(seen).toContain(true);
     expect(store.state.value.degraded.reloading).toBe(false);
   });
+
+  // Deleting a status with a reassignment target moves every item carrying it
+  // in one call, so the backend announces the move with no item to merge. Read
+  // as a per-item event this threw and the card kept showing the old rows.
+  it('refetches on an item event that carries no item', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1', name: 'Ladder' })] });
+    const store = new Store(hass, fast);
+    await store.init();
+    hass.__setItems([makeItem({ id: '1', name: 'Ladder', status: 'ok' }), makeItem({ id: '2' })]);
+
+    const seen: boolean[] = [];
+    store.state.onChange(() => seen.push(store.state.value.degraded.reloading));
+
+    hass.__emit('items', 'updated', {});
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(seen).toContain(true);
+    expect(store.state.value.degraded.reloading).toBe(false);
+    expect(store.state.value.items.map((i) => i.id)).toEqual(['1', '2']);
+  });
 });

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -17,6 +17,7 @@ import type {
   Item,
   ItemCreate,
   ItemFilter,
+  ItemsEventPayload,
   ItemUpdate,
   ListItemsResult,
   LiveUpdatePause,
@@ -631,10 +632,13 @@ export class Store {
 
   private onItemsEvent(evt: AnyEventPayload) {
     if (evt.topic !== 'items') return;
-    if (evt.action === 'reloaded') {
-      // An import replaced the dataset wholesale — reload from scratch. The
-      // signal carries no payload, so there is nothing to merge; anything the
-      // user had open is now editing data that no longer exists.
+    const item = (evt as ItemsEventPayload).item;
+    if (evt.action === 'reloaded' || item === undefined) {
+      // The dataset moved wholesale and the signal carries no item to merge:
+      // an import replaced everything, or a status was deleted and every item
+      // carrying it reassigned in one call. Either way a merge is impossible —
+      // refetch, and say so while it is in flight, because anything the user
+      // has open may be editing data that no longer exists.
       this.setDegraded({ reloading: true });
       void this.listItems(true)
         .catch(() => undefined)
@@ -643,7 +647,6 @@ export class Store {
       this.scheduleTreeRefresh();
       return;
     }
-    const item = (evt as unknown as { item: Item }).item; // narrow by known payload structure
     const items = this.state.value.items.slice();
     const idx = items.findIndex((x) => x.id === item.id);
     switch (evt.action) {

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -437,7 +437,10 @@ export interface ImportSummary {
 // WS subscription event payloads
 export interface BaseEventPayload {
   domain: 'haventory';
-  topic: 'items' | 'locations' | 'stats';
+  // The four topics `haventory/subscribe` accepts. Only three have a payload
+  // shape below: a `statuses` event is a signal to re-read the vocabulary, not
+  // a patch to apply, so the store never narrows one.
+  topic: 'items' | 'locations' | 'stats' | 'statuses';
   action: string;
   ts: string;
 }
@@ -452,8 +455,10 @@ export type TeardownAction = 'unavailable';
 
 export interface ItemsEventPayload extends BaseEventPayload {
   topic: 'items';
-  // `item` is present for per-item actions; absent for the wholesale `reloaded`
-  // signal emitted after an import replaces the dataset.
+  // `item` is present for per-item actions and absent whenever the dataset
+  // moved wholesale — the `reloaded` signal after an import, and an `updated`
+  // signal after a status delete reassigned every item carrying the slug.
+  // Absence is a refetch signal: there is nothing to merge.
   item?: Item;
   action:
   | 'created'

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CSSResult } from 'lit';
 import { chip } from './chip';
-import { tokens } from './tokens';
+import { base, tokens } from './tokens';
 
 import '../components/hv-card-shell';
 import '../components/hv-chip-input';
@@ -145,6 +145,35 @@ describe('ui/chip: the shared fragment', () => {
         const declared = new RegExp(`--hv-tone-${hue}-strong-${part}: ([^;]+);`).exec(css);
         expect(declared, `${hue}-strong-${part}`).not.toBeNull();
         expect(declared?.[1], `${hue}-strong-${part}`).not.toMatch(/light-dark\(/);
+      }
+    }
+  });
+});
+
+/**
+ * The count beside a facet's name. Not a chip — it appears inside chips, on
+ * sidebar rows and on checkbox rows alike — but it shares the chip fragment's
+ * rule: one declaration, and no surface restating it in its own block.
+ */
+describe('ui/tokens: the shared tally', () => {
+  it('declares the tally once, in the fragment every surface takes', () => {
+    const css = String(base.cssText).replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.hv-tally \{[^}]*font-size: [\d.]+px/);
+    // Dimmed against whatever ink surrounds it, so it survives a filled status
+    // chip where a fixed grey would drop out of the household's own tone.
+    expect(css).toMatch(/\.hv-tally \{[^}]*opacity: /);
+    expect(css).not.toMatch(/\.hv-tally \{[^}]*color: /);
+  });
+
+  it('leaves the surfaces that price a facet restating nothing but position', () => {
+    for (const tag of ['hv-filter-panel', 'hv-full-view']) {
+      const css = ownCss(tag);
+      // The old local rules, in the shapes that disagreed on size and dimming.
+      expect(css, tag).not.toMatch(/\.chip \.tally\b/);
+      expect(css, tag).not.toMatch(/\.value-row \.tally\b/);
+      // A rule keyed on `.hv-tally` may only place it, never re-size or re-ink it.
+      for (const [, body] of css.matchAll(/\.hv-tally[^{]*\{([^}]*)\}/g)) {
+        expect(body, `${tag}: ${body}`).not.toMatch(/font-size|opacity|color/);
       }
     }
   });

--- a/cards/haventory-card/src/ui/status.test.ts
+++ b/cards/haventory-card/src/ui/status.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { StatusDefinition } from '../store/types';
+import type { StatsCounts, StatusDefinition } from '../store/types';
 import {
   BUILT_IN_STATUSES,
   DEFAULT_STATUS,
   itemStatus,
+  statusCount,
   statusIconName,
   statusLabel,
   statusList,
@@ -65,5 +66,55 @@ describe('ui/status: rendering a slug', () => {
     ];
     expect(statusIconName('x', exotic)).toBeNull();
     expect(statusIconName('mystery', CUSTOM)).toBeNull();
+  });
+});
+
+describe('ui/status: pricing a slug', () => {
+  const base: StatsCounts = {
+    items_total: 998,
+    low_stock_count: 0,
+    checked_out_count: 0,
+    locations_total: 0,
+    no_location_count: 0,
+  };
+
+  it('reads the per-slug map, zeroes included', () => {
+    const counts: StatsCounts = {
+      ...base,
+      missing_count: 3,
+      needs_repair_count: 3,
+      status_counts: { ok: 856, missing: 3, needs_repair: 3, lent_out: 100, in_transit: 0 },
+    };
+    expect(statusCount(counts, 'ok')).toBe(856);
+    expect(statusCount(counts, 'lent_out')).toBe(100);
+    // The one the old derivation reported as 998.
+    expect(statusCount(counts, 'in_transit')).toBe(0);
+  });
+
+  // The map prices every defined slug, so a slug missing from one that arrived
+  // is a status nothing defines — the vocabulary and the counts are a moment
+  // out of step, and no number is honest where a zero would look measured.
+  it('reports nothing for a slug the map that arrived does not carry', () => {
+    const counts: StatsCounts = { ...base, status_counts: { ok: 998 } };
+    expect(statusCount(counts, 'mystery')).toBeNull();
+  });
+
+  it('falls back to the legacy fields for exactly the two flagged built-ins', () => {
+    const counts: StatsCounts = { ...base, missing_count: 3, needs_repair_count: 4 };
+    expect(statusCount(counts, 'missing')).toBe(3);
+    expect(statusCount(counts, 'needs_repair')).toBe(4);
+    // Not derivable from the two halves that arrived, so it is not derived.
+    expect(statusCount(counts, 'ok')).toBeNull();
+    expect(statusCount(counts, 'lent_out')).toBeNull();
+  });
+
+  it('prices nothing when the payload carries neither shape', () => {
+    expect(statusCount(base, 'ok')).toBeNull();
+    expect(statusCount(base, 'missing')).toBeNull();
+  });
+
+  it('prices nothing before any counts have arrived', () => {
+    expect(statusCount(null, 'ok')).toBeNull();
+    expect(statusCount(undefined, 'missing')).toBeNull();
   });
 });

--- a/cards/haventory-card/src/ui/status.ts
+++ b/cards/haventory-card/src/ui/status.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import type { TemplateResult } from 'lit';
-import type { Item, StatusColor, StatusDefinition } from '../store/types';
+import type { Item, StatsCounts, StatusColor, StatusDefinition } from '../store/types';
 import { ICONS, icon } from './icons';
 import type { IconName } from './icons';
 
@@ -96,6 +96,34 @@ export function statusLabel(
   defs: readonly StatusDefinition[] | null | undefined,
 ): string {
   return definitionOf(slug, defs)?.label ?? slug;
+}
+
+/**
+ * How many items carry a slug, or `null` when the payload cannot say.
+ *
+ * One reading for every surface that prices a status — the sidebar facet, the
+ * filter chips, the organize tab — because three surfaces deriving the same
+ * number three ways is three chances to disagree with the backend.
+ *
+ * `status_counts` prices every *defined* slug, `ok` included, so a slug absent
+ * from a map that arrived names a status nothing defines: the card's
+ * vocabulary and its counts are momentarily out of step, and `null` (no tally)
+ * is the honest reading rather than a `0` that looks measured. A backend too
+ * old to send the map still prices the two flagged built-ins in their own
+ * fields; no other slug is knowable there.
+ *
+ * `null` means "no number to show", never "zero" — a caller that wants a zero
+ * instead says so at its own call site.
+ */
+export function statusCount(
+  counts: StatsCounts | null | undefined,
+  slug: string,
+): number | null {
+  const perSlug = counts?.status_counts;
+  if (perSlug) return perSlug[slug] ?? null;
+  if (slug === 'missing') return counts?.missing_count ?? null;
+  if (slug === 'needs_repair') return counts?.needs_repair_count ?? null;
+  return null;
 }
 
 /**

--- a/cards/haventory-card/src/ui/tokens.ts
+++ b/cards/haventory-card/src/ui/tokens.ts
@@ -282,6 +282,21 @@ export const base = css`
     outline: none;
   }
 
+  /*
+   * The count that follows a facet's name — on a chip, on a sidebar row, on a
+   * checkbox row. One rule so the same number reads the same size wherever the
+   * card prices a facet.
+   *
+   * It dims by opacity rather than by a fixed grey because it has to keep its
+   * relation to whatever ink surrounds it: inside a filled status chip that ink
+   * is the household's chosen tone, and a tertiary grey would drop out of it.
+   */
+  .hv-tally {
+    flex: none;
+    font-size: 11.5px;
+    opacity: 0.65;
+  }
+
   .hv-sr-only {
     position: absolute;
     width: 1px;

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -128,7 +128,7 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 
 - Event payloads (inside `event`):
   - Common: `{domain: "haventory", topic: "items"|"locations"|"stats"|"statuses", action: string, ts: string, ...payload}`
-  - Items topic payloads include `{item: <Item>}` and actions: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed`. The `reloaded` action (emitted after `import/execute`) carries **no** `item` and signals a wholesale dataset replacement.
+  - Items topic payloads include `{item: <Item>}` and actions: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed`. An items event **may omit `item`**, and its absence is a refetch signal rather than a patch: the dataset moved wholesale and there is nothing to merge. Two cases emit one today — `reloaded` after `import/execute` replaces the dataset, and `updated` after `status/delete` with `reassign_to` moves every item carrying the slug in a single call. A client must therefore key on the presence of `item`, not on the action name. Subscription filters are not applied to a payload-less items event: with no item to match, every open items subscription receives it whatever its `location_id`.
   - Locations topic payloads include `{location: <Location>}` and actions: `created`, `renamed`, `moved`, `deleted`. The `reloaded` action (emitted after `import/execute`) carries **no** `location`.
   - Statuses topic payloads carry `{status: <StatusDefinition>}` for actions `created`, `updated` and `deleted`, and `{statuses: <StatusDefinition[]>}` for `reordered`. The vocabulary is small and changes rarely, so a client may equally re-read `status/list` on any event rather than applying a per-action patch — which is also what keeps it correct across a reorder.
   - Stats topic payload `action: "counts"` with `{counts: <stats shape>}`.
@@ -301,7 +301,9 @@ except `status/delete` with a reassign target.
 - `haventory/status/delete`
   - Payload: `{slug: string, reassign_to?: string}`
   - Result: `{status: <StatusDefinition>, reassigned: number}`; emits `statuses/deleted`, and
-    when `reassigned` is non-zero also `items/updated` and `stats/counts`.
+    when `reassigned` is non-zero also `items/updated` and `stats/counts`. That `items/updated`
+    carries **no `item`**: the move is a bulk rewrite, so the event is a refetch signal rather
+    than a per-item patch (see "Event payloads").
   - **Refused while items still carry the slug and no `reassign_to` is given.** An item whose
     status names nothing would be coerced to the default on the next load, silently. With a
     target the items move and the definition is deleted in the same call, so no client can

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -357,7 +357,7 @@ Common envelope inside HA WS event wrapper:
 { "domain": "haventory", "topic": "items|locations|stats", "action": "...", "ts": "ISO8601Z", ... }
 ```
 
-- Items: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed` with `{item: <Item>}`; plus `reloaded` (no `item`) after an import replaces the dataset.
+- Items: `created`, `updated`, `moved`, `deleted`, `checked_out`, `checked_in`, `quantity_changed` with `{item: <Item>}`. `item` may be **absent** on any items event, and its absence means "refetch" rather than "patch this item": `reloaded` after an import replaces the dataset, and `updated` after `status/delete` with `reassign_to` rewrites every item carrying the slug at once.
 - Locations: `created`, `renamed`, `moved`, `deleted` with `{location: <Location>}`; plus `reloaded` (no `location`) after an import.
 - Stats: `counts` with `{counts: <Counts>}`.
 - Every topic: `unavailable` (common fields only), sent once per open subscription when the config entry serving it tears down. The subscription is over at that point; see the API contract's "While no entry is loaded".

--- a/tests/test_ws_statuses_offline.py
+++ b/tests/test_ws_statuses_offline.py
@@ -2,8 +2,10 @@
 
 Statuses are the one vocabulary items *reference*, so `status/delete` is the
 only command here that can orphan data. These tests pin its refusal, the
-reassign escape hatch, and the two topics a reassignment has to reach: cards
-showing the vocabulary, and cards showing the items that just moved.
+reassign escape hatch, the two topics a reassignment has to reach — cards
+showing the vocabulary, and cards showing the items that just moved — and the
+payload-less shape of that second broadcast, which is what tells a client to
+re-list rather than to patch one row.
 """
 
 from __future__ import annotations
@@ -35,16 +37,25 @@ async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
     raise AssertionError("No handler responded for type " + type_)
 
 
-def _record_broadcasts(monkeypatch) -> list[tuple[str, str]]:
-    """Capture (topic, action) pairs instead of delivering them."""
+Broadcast = tuple[str, str, dict | None]
 
-    seen: list[tuple[str, str]] = []
+
+def _record_broadcasts(monkeypatch) -> list[Broadcast]:
+    """Capture (topic, action, payload) triples instead of delivering them."""
+
+    seen: list[Broadcast] = []
 
     def fake(hass, *, topic, action, payload=None):
-        seen.append((topic, action))
+        seen.append((topic, action, payload))
 
     monkeypatch.setattr(ws_mod, "_broadcast_event", fake)
     return seen
+
+
+def _topics(seen: list[Broadcast]) -> list[tuple[str, str]]:
+    """The (topic, action) pairs alone, for assertions the payload does not concern."""
+
+    return [(topic, action) for topic, action, _payload in seen]
 
 
 # -----------------------------
@@ -82,7 +93,7 @@ async def test_create_defines_a_status_and_broadcasts(monkeypatch) -> None:
     assert res["result"]["slug"] == "lent_out"
     assert res["result"]["color"] == "blue"
     assert res["result"]["icon"] == DEFAULT_STATUS_ICON
-    assert ("statuses", "created") in seen
+    assert ("statuses", "created") in _topics(seen)
 
 
 @pytest.mark.asyncio
@@ -129,8 +140,8 @@ async def test_update_renames_without_touching_items(monkeypatch) -> None:
 
     assert res["success"] is True
     assert res["result"]["label"] == "Broken"
-    assert ("statuses", "updated") in seen
-    assert ("items", "updated") not in seen
+    assert ("statuses", "updated") in _topics(seen)
+    assert ("items", "updated") not in _topics(seen)
     still = await _send(hass, 3, "haventory/item/get", item_id=created["result"]["id"])
     assert still["result"]["version"] == before
 
@@ -154,7 +165,7 @@ async def test_reorder_rewrites_display_order(monkeypatch) -> None:
 
     assert res["success"] is True
     assert [d["slug"] for d in res["result"]] == ["needs_repair", "ok", "missing"]
-    assert ("statuses", "reordered") in seen
+    assert ("statuses", "reordered") in _topics(seen)
 
 
 @pytest.mark.asyncio
@@ -191,7 +202,7 @@ async def test_delete_removes_an_unused_status(monkeypatch) -> None:
 
     assert res["success"] is True
     assert res["result"]["reassigned"] == 0
-    assert ("statuses", "deleted") in seen
+    assert ("statuses", "deleted") in _topics(seen)
     listed = await _send(hass, 2, "haventory/status/list")
     assert [d["slug"] for d in listed["result"]] == ["ok", "missing"]
 
@@ -224,8 +235,13 @@ async def test_delete_with_a_target_moves_the_items_and_broadcasts_both(monkeypa
     assert res["result"]["reassigned"] == 1
     # Both, and for different readers: one card is showing the vocabulary, the
     # other is showing the items that just changed underneath it.
-    assert ("statuses", "deleted") in seen
-    assert ("items", "updated") in seen
+    assert ("statuses", "deleted") in _topics(seen)
+    assert ("items", "updated") in _topics(seen)
+    # The reassignment is one bulk rewrite, so the items event names no item.
+    # Clients key on that absence to mean "refetch, there is nothing to merge";
+    # attaching a payload here would silently turn a refetch into a one-item
+    # patch and strand every other moved row.
+    assert [payload for topic, _action, payload in seen if topic == "items"] == [None]
     moved = await _send(hass, 3, "haventory/item/get", item_id=item_id)
     assert moved["result"]["status"] == "ok"
     assert moved["result"]["version"] == created["result"]["version"] + 1

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -3,7 +3,9 @@
 Scenarios:
 - subscribe/unsubscribe lifecycle and echo policy
 - item events delivered with correct shape; stats counts emitted on mutations
-- location_id + include_subtree filters constrain delivered events
+- location_id + include_subtree filters constrain delivered events, and a
+  payload-less items event reaches every subscription regardless, because it is
+  a refetch signal rather than a per-item patch
 - inspection_overdue_only narrows item events the way item/list narrows a page
 """
 
@@ -17,7 +19,7 @@ import pytest
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
-from custom_components.haventory.ws import _subs_bucket
+from custom_components.haventory.ws import _broadcast_event, _subs_bucket
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
@@ -321,6 +323,22 @@ async def test_location_filters_subtree_and_direct_only() -> None:
         if m.get("type") == "event" and m.get("event", {}).get("topic") == "items"
     }
     assert ids == {SUB_ID_SUBTREE}
+
+    # A payload-less items event has no item to match a filter against, so it
+    # reaches every open items subscription whatever its location. That is the
+    # right behaviour, not an oversight of the filter: the event says the
+    # dataset moved wholesale and the client must re-list, and a subscription
+    # watching one shelf has just as much reason to re-list as any other.
+    conn.messages.clear()
+    _broadcast_event(hass, topic="items", action="updated", payload=None)
+    ids = {
+        m.get("id")
+        for m in conn.messages
+        if m.get("type") == "event" and m.get("event", {}).get("topic") == "items"
+    }
+    assert ids == {SUB_ID_SUBTREE, SUB_ID_DIRECT}
+    delivered = next(m for m in conn.messages if m.get("type") == "event")["event"]
+    assert "item" not in delivered
 
 
 def _utc_day_offset(days: int) -> str:


### PR DESCRIPTION
## Summary

Work package **P1** of the v0.4.0 UI-audit remediation plan (`dev/ui_audit_v040_fix_plan.md`) — audit items **A2** (blocker), **A3** (blocker), **B18**, **B6**, **C25**.

**A2 — payload-less items event crashed the store.** `status/delete` with `reassign_to` moves every item carrying the slug in one call, so the backend broadcasts `items/updated` with `payload=None` (`ws.py:2210`). `Store.onItemsEvent` read `evt.item.id` unconditionally and threw `TypeError: Cannot read properties of undefined (reading 'id')`, leaving every connected card showing rows and counts for a status that no longer existed until a manual refresh. Any items event without an `item` is now treated as the refetch signal it is — the same branch `reloaded` takes, `degraded.reloading` included — and the handler honours the already-optional `ItemsEventPayload.item` instead of casting past it. Fixed frontend-side per the plan's locked decision; the backend's payload-less broadcast is correct and unchanged.

**A3 + B18 — one `statusCount` helper.** Three surfaces priced a status three different ways. The sidebar facet derived "items_total − missing − needs_repair" for *every* slug, so each custom status claimed 998 of 1004 items — including `in_transit`, which had zero and then showed no rows when clicked. The filter chips priced only the two legacy slugs and left every custom status bare. All three now read `statusCount()` in `ui/status.ts`: `status_counts[slug]` when the map is present, the legacy `missing_count`/`needs_repair_count` fields for exactly those two slugs on an older backend, and `null` (no tally) where neither can say. The organize tab keeps its `?? 0` at its own call site, since its count doubles as the tab's link into the items.

`null` vs `0` for a slug absent from a map that arrived: the map prices every *defined* slug, so an absent one means the vocabulary and the counts are momentarily out of step — `null` is documented in the helper as "no number to show", never "zero".

**B6 — the status count link now applies its filter.** `_showStatus` dispatched `browse` with a detail the host discards (`host-surfaces.ts:271`) and never set the filter or closed the dialog; it now does what `_showValue`/`_showLocation` do. `host-surfaces.ts` untouched.

**C25 — sort above the tag cloud.** The cloud renders every tag in the household, so a daily toggle sat several screens down inside the phone's filter sheet. Sort moves above it; the other filter groups keep their order.

**Consolidation** — the count badges collapse onto one shared `.hv-tally` in `base` (they disagreed on size and dimming strategy). It dims by opacity rather than a fixed grey so it survives inside a filled status chip, where the surrounding ink is the household's own tone. `hv-item-editor.ts:497` adopts it in P5.

**Contract + shape pins (no backend behavior change).** `docs/backend_api_contract.md` and `docs/data_shapes.md` claimed `updated` always carries `{item}` and `reloaded` was the only payload-less items action; both now state that an items event may omit `item` and that absence is a refetch signal, naming `status/delete` with `reassign_to` as the second case, and note that subscription filters are bypassed when there is no item to match. Pinned offline both ways so a future backend change fails loudly.

No issue is closed by this PR (per the campaign's issue wiring — P5 carries `Closes #301`, P8 carries `Closes #300, #303`). Follow-up filed rather than fixed here: #307 (component-test harness dedupe — `mount`/`q`/`all`/cssText readers re-implemented across ~18 files).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green locally.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (737 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1266 passed), `npm run build`

New / rewritten coverage:

- `store.revamp.test.ts` — a payload-less `items/updated` refetches and flips `degraded.reloading`. Verified it reproduces the audit's crash against the pre-fix handler (`TypeError` at `store.ts:648`).
- `ui/status.test.ts` — `statusCount` across map-present (zero included), slug-absent-from-map, legacy-fields-only, neither, and no counts at all.
- `hv-full-view.test.ts` — the audit's fixture in miniature: a household vocabulary priced per slug including one nothing carries; the legacy-fallback pin rewritten to delete `status_counts` (it previously passed vacuously once the map existed).
- `hv-filter-panel.test.ts` — every chip priced from `status_counts`; the legacy-only case kept as its own test; section order pinned.
- `hv-organize-dialog.test.ts` — clicking `status-count` sets `filters.status`, dispatches `browse` once and closes the dialog.
- `ui/chip.test.ts` — `.hv-tally` declared once in `base`, with the two adopting components allowed to place it but not re-size or re-ink it.
- `tests/test_ws_statuses_offline.py` — `_record_broadcasts` now captures payloads; the reassign-delete's items broadcast is asserted to carry none.
- `tests/test_ws_subscriptions_offline.py` — a payload-less items event reaches every open items subscription regardless of its `location_id` filter.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md` — the sidebar facet's "prices OK as whatever the two flagged counts leave over" sentence and the "always holds the same three rows" clause were describing the bug; `docs/backend_api_contract.md`; `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync. (`ws.py` unchanged — the docs were wrong about it, not the other way round.)
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None — this session runs remotely, with no dev HA container or screenshot tooling. Visual confirmation is delegated to the handover pass below.

## Delegated to the local handover pass

Per §Verification: P1, these checks need the Docker dev HA and are **not** covered by this PR's gates:

- Seed a status with items; delete it with reassignment while a second card/panel is open. Expect no console error, and both surfaces' rows and counts settling without a manual refresh.
- Sidebar facet showing true per-status counts, including a status with 0.
- Filter-panel STATUS chips all priced.
- Organize count-link opening the full view **with** the filter applied and the dialog closed.

Do not merge before that pass.