### PR TITLE
fix(card): AA state-chip ink, distinct blue tones, status-toned filter chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,9 +524,10 @@ throughout.
   From the second selected tag on, the Tags heading carries the same any/all control the
   filter panel has, since that is the mode governing what the sidebar just selected. The
   app bar's stat pills are the card's: low in amber, overdue in red, to-inspect in amber,
-  checked out, each click-to-filter. Beside them, **Missing** and **Needs repair** price the
-  two flagged statuses in the status chip's own amber; each appears only while something
-  carries that flag, and the two are mutually exclusive because the filter takes one status.
+  checked out, each click-to-filter. All four are derived from the item and mean the same
+  thing in every household, which is what lets them share the bar's fixed hues; a status is
+  the household's own word in the household's own colour, so the sidebar's Status section
+  and the filter chips are where statuses are priced and picked.
   An empty table names the reason and offers a way out — the same
   wording and the same offers as the card's list.
 

--- a/cards/haventory-card/src/components/hv-banner.ts
+++ b/cards/haventory-card/src/components/hv-banner.ts
@@ -55,7 +55,7 @@ export class HVBanner extends LitElement {
       }
       .banner.info {
         background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
+        color: var(--hv-on-primary-tint);
       }
       .banner.info .glyph {
         color: var(--hv-primary-dark);

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -253,7 +253,7 @@ export class HVCardShell extends LitElement {
       .icon-toggle.on {
         border-color: var(--hv-primary);
         background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
+        color: var(--hv-on-primary-tint);
       }
       .icon-toggle .dot {
         position: absolute;

--- a/cards/haventory-card/src/components/hv-filter-chips.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 import './hv-filter-chips';
 import { chipsFor, clearedValueFor } from './hv-filter-chips';
 import { defaultFilters } from '../store/store';
-import type { Location, StoreFilters } from '../store/types';
+import type { Location, StatusDefinition, StoreFilters } from '../store/types';
 
 type Chips = HTMLElement & {
   filters: StoreFilters;
   locations: Location[] | null;
+  statuses: StatusDefinition[] | null;
   areas: { id: string; name: string }[];
   updateComplete?: Promise<unknown>;
 };
@@ -136,16 +137,34 @@ describe('chipsFor', () => {
     expect(chips).toEqual([{ key: 'inspectionDueOnly', label: 'Inspection due', tone: 'warning' }]);
   });
 
-  it('names the status filter, with the warning tone on the flagged values only', () => {
+  // Amber means "chore" everywhere else on the card, so painting every
+  // non-default status with it said something about the household's vocabulary
+  // that the household never said.
+  it('names the status filter and carries the status own tone, not the chore hue', () => {
     expect(chipsFor({ ...defaultFilters(), status: 'missing' })).toEqual([
-      { key: 'status', label: 'Status: Missing', tone: 'warning' },
-    ]);
-    expect(chipsFor({ ...defaultFilters(), status: 'needs_repair' })).toEqual([
-      { key: 'status', label: 'Status: Needs repair', tone: 'warning' },
+      { key: 'status', label: 'Status: Missing', tone: 'primary', toneClass: 'tone-amber' },
     ]);
     expect(chipsFor({ ...defaultFilters(), status: 'ok' })).toEqual([
-      { key: 'status', label: 'Status: OK', tone: 'primary' },
+      { key: 'status', label: 'Status: OK', tone: 'primary', toneClass: 'tone-green' },
     ]);
+  });
+
+  it('takes the tone from the household definitions when they have answered', () => {
+    const statuses: StatusDefinition[] = [
+      { slug: 'sold', label: 'Verkauft', order: 3, color: 'blue_strong', icon: 'box' },
+    ];
+    expect(chipsFor({ ...defaultFilters(), status: 'sold' }, { statuses })).toEqual([
+      { key: 'status', label: 'Status: Verkauft', tone: 'primary', toneClass: 'tone-blue-strong' },
+    ]);
+  });
+
+  // A slug this card has not been told about — an import defined it, or another
+  // client created it since `haventory/config` was last read.
+  it('falls back to the neutral tone for a status it has no definition for', () => {
+    expect(chipsFor({ ...defaultFilters(), status: 'no_such' })[0]).toMatchObject({
+      label: 'Status: no_such',
+      toneClass: 'tone-neutral',
+    });
   });
 
   it('emits one chip per date bound so a range can be half-undone', () => {
@@ -227,6 +246,35 @@ describe('hv-filter-chips', () => {
     (el.shadowRoot?.querySelector('[data-testid="filter-chips-clear"]') as HTMLButtonElement).click();
 
     expect(fired).toBe(1);
+  });
+
+  // The status chip is the one on this row whose colour is the household's, so
+  // it is drawn as the same status chip the rows below carry rather than out of
+  // the fixed primary/warning pair every other applied filter uses.
+  it('draws the status chip in the status vocabulary and the rest in the fixed one', async () => {
+    const el = await mount({
+      filters: { ...defaultFilters(), status: 'sold', overdueOnly: true },
+      statuses: [{ slug: 'sold', label: 'Verkauft', order: 3, color: 'green_strong', icon: 'box' }],
+    });
+    const chips = [...(el.shadowRoot?.querySelectorAll('[data-testid="filter-chip"]') ?? [])];
+    const status = chips.find((c) => (c as HTMLElement).dataset.key === 'status') as HTMLElement;
+    const overdue = chips.find((c) => (c as HTMLElement).dataset.key === 'overdueOnly') as HTMLElement;
+
+    expect([...status.classList]).toEqual(['hv-status-chip', 'chip', 'tone-green-strong']);
+    expect(status.classList.contains('warning')).toBe(false);
+    expect([...overdue.classList]).toEqual(['hv-chip', 'chip', 'warning']);
+  });
+
+  it('still hands the host the patch that clears a status chip', async () => {
+    const el = await mount({ filters: { ...defaultFilters(), status: 'missing' } });
+    let detail: { key: string; patch: Partial<StoreFilters> } | null = null;
+    el.addEventListener('remove-filter', (e) => {
+      detail = (e as CustomEvent).detail;
+    });
+
+    (el.shadowRoot?.querySelector('[data-testid="filter-chip"]') as HTMLButtonElement).click();
+
+    expect(detail).toEqual({ key: 'status', patch: { status: null } });
   });
 
   it('gives every chip an accessible name saying what it clears', async () => {

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -5,7 +5,7 @@ import { chip } from '../ui/chip';
 import { locationPathParts, pathTitle } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { formatDate } from '../ui/relative-time';
-import { statusLabel } from '../ui/status';
+import { statusLabel, statusToneClass } from '../ui/status';
 import type { Location, StatusDefinition, StoreFilters } from '../store/types';
 
 /** Which filter a chip clears. Matches the keys of `StoreFilters`. */
@@ -31,6 +31,13 @@ export interface FilterChip {
   key: FilterChipKey;
   label: string;
   tone: 'primary' | 'warning';
+  /**
+   * A `tone-*` class from the status vocabulary, for the one chip whose colour
+   * a household picks rather than the card. Set, it replaces `tone` entirely:
+   * the two palettes are deliberately disjoint (see `ui/chip.ts`), so a chip
+   * cannot carry one of each.
+   */
+  toneClass?: string;
 }
 
 /**
@@ -85,8 +92,11 @@ export function chipsFor(
     chips.push({
       key: 'status',
       label: `Status: ${statusLabel(filters.status, ctx.statuses)}`,
-      // OK is the unremarkable state; the two flagged values carry the warning tone.
-      tone: filters.status === 'ok' ? 'primary' : 'warning',
+      // The status the household chose, in the colour the household gave it —
+      // the same chip the rows below this one carry. `tone` is the fallback for
+      // a consumer that ignores `toneClass`.
+      tone: 'primary',
+      toneClass: statusToneClass(filters.status, ctx.statuses),
     });
   if (filters.orphansOnly) chips.push({ key: 'orphansOnly', label: 'No location', tone: 'primary' });
   // One chip per bound rather than one per field: each is separately clearable,
@@ -184,7 +194,9 @@ export class HVFilterChips extends LitElement {
       <div class="row" data-testid="filter-chips">
         ${chips.map(
           (entry) => html`<button
-            class="hv-chip chip ${entry.tone === 'warning' ? 'warning' : 'state'}"
+            class=${entry.toneClass
+              ? `hv-status-chip chip ${entry.toneClass}`
+              : `hv-chip chip ${entry.tone === 'warning' ? 'warning' : 'state'}`}
             data-testid="filter-chip"
             data-key=${entry.key}
             aria-label=${`Clear filter ${entry.label}`}

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1300,58 +1300,23 @@ describe('hv-full-view: app bar filters', () => {
     expect(q(sr, '[data-testid="full-badge-overdue"]')?.getAttribute('aria-pressed')).toBe('true');
   });
 
-  // The bar priced every derived exception — low, overdue, due for inspection,
-  // checked out — and none of the stored one, so the two flags a person sets by
-  // hand were the only ones with no way back to them from here.
-  it('carries the two flagged statuses, and filters on them', async () => {
+  // The bar's chips are the fixed chore/state vocabulary, all of them derived
+  // from the item. A status is the household's own word in the household's own
+  // colour, so pricing one here rendered it as a chore in the bar's amber and
+  // kept saying "missing" after the household had renamed and recoloured it.
+  // The sidebar facet and the filter chips own status navigation.
+  it('prices no status in the app bar, whatever the counts carry', async () => {
     const statuses = [
       makeItem({ id: '1', status: 'missing' }),
       makeItem({ id: '2', status: 'needs_repair' }),
-      makeItem({ id: '3', status: 'needs_repair' }),
-      makeItem({ id: '4' }),
+      makeItem({ id: '3', status: 'ok', quantity: 0, low_stock_threshold: 5 }),
     ];
-    const pill = (sr: ShadowRoot, value: string) =>
-      sr.querySelector(`[data-testid="full-badge-status"][data-value="${value}"]`) as HTMLButtonElement;
-    const { el, store, sr } = await mount({ items: statuses });
+    const { sr } = await mount({ items: statuses });
 
-    expect(pill(sr, 'missing').textContent?.replace(/\s+/g, ' ').trim()).toBe('1 missing');
-    expect(pill(sr, 'needs_repair').textContent?.replace(/\s+/g, ' ').trim()).toBe('2 needs repair');
-
-    pill(sr, 'missing').click();
-    await settle(el);
-    expect(store.state.value.filters.status).toBe('missing');
-    expect(pill(sr, 'missing').getAttribute('aria-pressed')).toBe('true');
-
-    pill(sr, 'missing').click();
-    await settle(el);
-    expect(store.state.value.filters.status).toBe(null);
-  });
-
-  // Single-select, so the two pills are mutually exclusive — pressing one while
-  // the other is on replaces it rather than asking for items that are both.
-  it('replaces the active status pill rather than adding to it', async () => {
-    const statuses = [makeItem({ id: '1', status: 'missing' }), makeItem({ id: '2', status: 'needs_repair' })];
-    const pill = (sr: ShadowRoot, value: string) =>
-      sr.querySelector(`[data-testid="full-badge-status"][data-value="${value}"]`) as HTMLButtonElement;
-    const { el, store, sr } = await mount({ items: statuses });
-
-    pill(sr, 'missing').click();
-    await settle(el);
-    pill(sr, 'needs_repair').click();
-    await settle(el);
-
-    expect(store.state.value.filters.status).toBe('needs_repair');
-    expect(pill(sr, 'missing').getAttribute('aria-pressed')).toBe('false');
-    expect(pill(sr, 'needs_repair').getAttribute('aria-pressed')).toBe('true');
-  });
-
-  // "OK" is not an exception, and on a healthy inventory a status pill at all
-  // would be the loudest thing on a bar with nothing to report.
-  it('drops each status pill when nothing carries that flag', async () => {
-    const { sr } = await mount({ items: [makeItem({ id: '1', status: 'missing' })] });
-    expect(q(sr, '[data-testid="full-badge-status"][data-value="missing"]')).toBeTruthy();
-    expect(q(sr, '[data-testid="full-badge-status"][data-value="needs_repair"]')).toBe(null);
-    expect(q(sr, '[data-testid="full-badge-status"][data-value="ok"]')).toBe(null);
+    expect(sr.querySelectorAll('[data-testid="full-badge-status"]')).toHaveLength(0);
+    // The derived exceptions stay: dropping the two status pills is not a
+    // retreat from pricing the bar.
+    expect(q(sr, '[data-testid="full-badge-low"]')).toBeTruthy();
   });
 
   it('drops the overdue pill when nothing is overdue', async () => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -508,7 +508,7 @@ export class HVFullView extends LitElement {
       }
       .value-row.on {
         background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
+        color: var(--hv-on-primary-tint);
         font-weight: 500;
         box-shadow: inset -3px 0 0 0 var(--hv-primary);
       }
@@ -565,7 +565,7 @@ export class HVFullView extends LitElement {
       .filters-button.on {
         border-color: var(--hv-primary);
         background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
+        color: var(--hv-on-primary-tint);
       }
       /* The empty state is slotted into the table, so it stays in this tree and
          is styled here — the same block the card's list draws, since the words
@@ -1593,32 +1593,16 @@ export class HVFullView extends LitElement {
   }
 
   /**
-   * One flagged status as an app-bar toggle, beside the derived counts.
+   * The app bar prices derived exceptions only — low stock, overdue, due for
+   * inspection, checked out. Every one of those is computed from the item and
+   * means the same thing in every household, which is what lets them share the
+   * bar's fixed amber/red vocabulary.
    *
-   * Only `missing` and `needs_repair` get one: they are the exceptions worth
-   * interrupting for, and an "OK" pill would price the other 99% of a healthy
-   * inventory. Single-select like every other status surface, so pressing one
-   * while the other is on replaces it rather than asking for items that are
-   * somehow both.
+   * A status is not one of those: a household names and colours its own, so a
+   * status tally here would speak that vocabulary in the bar's hues, saying
+   * "chore" about whatever the household actually meant. The sidebar facet and
+   * the filter chips price and navigate statuses, in the household's own tones.
    */
-  private _renderStatusPill(status: string, count: number | undefined) {
-    // Absent rather than zero: the same rule the overdue and inspection pills
-    // follow, so the bar only ever carries counts worth acting on.
-    if (!count) return null;
-    const on = (this.st?.filters ?? defaultFilters()).status === status;
-    const noun = statusLabel(status, this.st?.statuses).toLowerCase();
-    return html`<button
-      class="hv-chip pill warning ${on ? 'on' : ''}"
-      data-testid="full-badge-status"
-      data-value=${status}
-      aria-pressed=${String(on)}
-      title=${`Show only items marked ${noun}`}
-      @click=${() => this._setFilters({ status: on ? null : status })}
-    >
-      ${count} ${noun}
-    </button>`;
-  }
-
   private _renderAppBar() {
     const st = this.st;
     const filters = st?.filters ?? defaultFilters();
@@ -1690,8 +1674,6 @@ export class HVFullView extends LitElement {
                 ${counts.checked_out_count} checked out
               </button>`
             : null}
-          ${this._renderStatusPill('missing', counts?.missing_count)}
-          ${this._renderStatusPill('needs_repair', counts?.needs_repair_count)}
           <button
             class="add"
             data-testid="full-add-item"

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -431,7 +431,7 @@ export class HVItemEditor extends LitElement {
       }
       .option.selected {
         background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
+        color: var(--hv-on-primary-tint);
         font-weight: 500;
       }
       .option.active {

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -79,7 +79,7 @@ export class HVLocationTree extends LitElement {
       }
       .row.selected {
         background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
+        color: var(--hv-on-primary-tint);
         font-weight: 500;
         box-shadow: inset -3px 0 0 0 var(--hv-primary);
       }

--- a/cards/haventory-card/src/components/hv-overflow-menu.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.ts
@@ -54,7 +54,7 @@ export class HVOverflowMenu extends LitElement {
       }
       .trigger[aria-expanded='true'] {
         background: var(--hv-primary-tint);
-        color: var(--hv-primary-darker);
+        color: var(--hv-on-primary-tint);
       }
       .menu {
         position: absolute;

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -63,8 +63,25 @@ describe('ui/chip: the shared fragment', () => {
     expect(css).toMatch(/\.hv-chip\.state \{[^}]*var\(--hv-primary-tint\)/);
     expect(css).toMatch(/\.hv-chip\.warning \{[^}]*var\(--hv-warn-bg\)/);
     expect(css).toMatch(/\.hv-chip\.error \{[^}]*var\(--hv-error-bg\)/);
-    expect(css).toMatch(/\.hv-chip\.quiet, \.hv-area-chip\.quiet \{/);
+    // No fill of its own, so its label is read against the page — which is why
+    // it takes the secondary ink and not the tertiary grey.
+    expect(css).toMatch(
+      /\.hv-chip\.quiet, \.hv-area-chip\.quiet \{[^}]*background: none[^}]*color: var\(--hv-text-secondary\)/,
+    );
     expect(css).toMatch(/\.hv-chip\.toggle \{[^}]*cursor: pointer/);
+  });
+
+  // --hv-primary-darker on --hv-primary-tint measures 4.26:1, under the 4.5:1
+  // a 12px label asks. Both fills that pair with that tint take the ink minted
+  // for it; tone-contrast.test.ts checks the ratio the token resolves to.
+  it('inks every tint-backed fill with the ink minted for that tint', () => {
+    const css = String(chip.cssText).replace(/\s+/g, ' ');
+    for (const selector of ['\\.hv-chip\\.state', '\\.hv-chip\\.toggle\\.on']) {
+      expect(css, selector).toMatch(
+        new RegExp(`${selector} \\{[^}]*background: var\\(--hv-primary-tint\\)[^}]*color: var\\(--hv-on-primary-tint\\)`),
+      );
+    }
+    expect(css).not.toMatch(/--hv-primary-darker/);
   });
 
   // The whole point of the fragment: one size, not eleven. A component that

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -21,7 +21,9 @@ import { css } from 'lit';
  *   and spelled-out label, because an area is not one of the facts above.
  * - `.hv-status-chip` reports an item's status. It shares the metrics for the
  *   same reason and opts out of the hue vocabulary below, because a household
- *   chooses what colour each status is.
+ *   chooses what colour each status is. Opting out only holds if the two
+ *   palettes stay apart, so the status tones in `tokens` are offset from the
+ *   fills here — see the note on that block.
  *
  * Usage: `static styles = [tokens, base, chip, css\`...\`]`.
  */
@@ -80,10 +82,11 @@ export const chip = css`
 
      .hv-status-chip at the foot of this file is the one exception, taking its
      colour from the status definition instead. That is why it is a separate
-     class: a user-chosen hue inside this vocabulary would dissolve it. */
+     class: a user-chosen hue inside this vocabulary would dissolve it, which
+     is also why the tone palette it draws from is offset from these fills. */
   .hv-chip.state {
     background: var(--hv-primary-tint);
-    color: var(--hv-primary-darker);
+    color: var(--hv-on-primary-tint);
     border-color: transparent;
   }
   .hv-chip.warning {
@@ -102,7 +105,9 @@ export const chip = css`
   .hv-chip.quiet,
   .hv-area-chip.quiet {
     background: none;
-    color: var(--hv-text-tertiary);
+    /* Secondary rather than tertiary ink: with no fill of its own this label is
+       read against the page, where the tertiary grey lands at 2.7:1. */
+    color: var(--hv-text-secondary);
     border-color: var(--hv-divider);
   }
 
@@ -121,7 +126,7 @@ export const chip = css`
   }
   .hv-chip.toggle.on {
     background: var(--hv-primary-tint);
-    color: var(--hv-primary-darker);
+    color: var(--hv-on-primary-tint);
     border-color: transparent;
   }
   .hv-chip.toggle.warning.on {
@@ -146,6 +151,11 @@ export const chip = css`
    * status painted from that palette would claim a meaning its label already
    * carries — a green "OK" beside an amber "Low stock" would read as two points
    * on one scale rather than two unrelated facts.
+   *
+   * Opting out is a property of the tones, not of this class: a tone that
+   * resolved to one of the fills above would collide with it wherever the two
+   * share a row, so the blue tones in ui/tokens are held off both the state
+   * chip's tint and the primary fill every action wears.
    *
    * Each tone comes in a light and a strong form. Strong exists so an urgent
    * status can carry further than a routine one in a dense row.

--- a/cards/haventory-card/src/ui/tokens.ts
+++ b/cards/haventory-card/src/ui/tokens.ts
@@ -89,14 +89,18 @@ export const tokens = css`
      * action in --hv-primary, so a status sharing either fill would render a
      * household's free choice as one of the card's fixed meanings. Indigo is
      * far enough from both to read as a different thing at a glance while
-     * still answering to the name "blue". tone-contrast.test.ts pins the
-     * separation as well as the ratios.
+     * still answering to the name "blue". The light tint carries more of that
+     * distance than a 50-level indigo would: beside the state chip's tint the
+     * two inks separate plainly but the fills sit close, so the tint is a step
+     * deeper and more chromatic than its siblings on purpose.
+     * tone-contrast.test.ts pins the separation as a perceptual distance, not
+     * as mere inequality, alongside the ratios.
      */
     --hv-tone-neutral-bg: var(--hv-chip-bg);
     --hv-tone-neutral-fg: var(--hv-chip-text);
     --hv-tone-green-bg: light-dark(#e6f4ea, rgba(129, 199, 132, 0.16));
     --hv-tone-green-fg: light-dark(#1b5e20, #a5d6a7);
-    --hv-tone-blue-bg: light-dark(#e8eaf6, rgba(121, 134, 203, 0.26));
+    --hv-tone-blue-bg: light-dark(#dde0f7, rgba(121, 134, 203, 0.26));
     --hv-tone-blue-fg: light-dark(#1a237e, #9fa8da);
     --hv-tone-amber-bg: var(--hv-warn-bg);
     --hv-tone-amber-fg: var(--hv-warn-deep);

--- a/cards/haventory-card/src/ui/tokens.ts
+++ b/cards/haventory-card/src/ui/tokens.ts
@@ -43,6 +43,13 @@ export const tokens = css`
     --hv-primary-dark: light-dark(#0288d1, #4fc3f7);
     --hv-primary-darker: light-dark(#0277bd, #4fc3f7);
     --hv-primary-tint: light-dark(#e3f4fd, rgba(3, 169, 244, 0.16));
+    /* Ink for text laid on --hv-primary-tint — a state chip, a selected row, an
+       applied toggle. Not --hv-primary-darker, which is one step too light for
+       that tint at 4.26:1, under the 4.5:1 that 12px text asks: this pairs the
+       tint with the 900 shade of its own hue, the way every light status tone
+       below pairs with its own. The dark half is the light blue that already
+       reads on the translucent tint there. */
+    --hv-on-primary-tint: light-dark(#01579b, #4fc3f7);
     --hv-primary-tint-border: light-dark(#a8d8f0, rgba(3, 169, 244, 0.5));
     --hv-row-hover: light-dark(#f5f9fd, rgba(255, 255, 255, 0.04));
 
@@ -76,16 +83,21 @@ export const tokens = css`
      * A strong fill is one hue in both themes, so the ink that reads on it is
      * fixed too — the same constraint --hv-on-amber above is written for. All
      * five clear 4.5:1 against their ink.
+     *
+     * The blue pair is held deliberately off the card's own blues: the fixed
+     * vocabulary in chip.ts paints a state chip in --hv-primary-tint and every
+     * action in --hv-primary, so a status sharing either fill would render a
+     * household's free choice as one of the card's fixed meanings. Indigo is
+     * far enough from both to read as a different thing at a glance while
+     * still answering to the name "blue". tone-contrast.test.ts pins the
+     * separation as well as the ratios.
      */
     --hv-tone-neutral-bg: var(--hv-chip-bg);
     --hv-tone-neutral-fg: var(--hv-chip-text);
     --hv-tone-green-bg: light-dark(#e6f4ea, rgba(129, 199, 132, 0.16));
     --hv-tone-green-fg: light-dark(#1b5e20, #a5d6a7);
-    --hv-tone-blue-bg: var(--hv-primary-tint);
-    /* Not --hv-primary-darker: that blue is one step too light to carry 12px
-       text on this tint, at 4.26:1. Every other light tone pairs its tint with
-       the 900 shade of its own hue, and doing the same here clears AA. */
-    --hv-tone-blue-fg: light-dark(#01579b, #4fc3f7);
+    --hv-tone-blue-bg: light-dark(#e8eaf6, rgba(121, 134, 203, 0.26));
+    --hv-tone-blue-fg: light-dark(#1a237e, #9fa8da);
     --hv-tone-amber-bg: var(--hv-warn-bg);
     --hv-tone-amber-fg: var(--hv-warn-deep);
     --hv-tone-red-bg: var(--hv-error-bg);
@@ -95,7 +107,7 @@ export const tokens = css`
     --hv-tone-neutral-strong-fg: #fff;
     --hv-tone-green-strong-bg: #2e7d32;
     --hv-tone-green-strong-fg: #fff;
-    --hv-tone-blue-strong-bg: #0277bd;
+    --hv-tone-blue-strong-bg: #303f9f;
     --hv-tone-blue-strong-fg: #fff;
     --hv-tone-amber-strong-bg: var(--hv-amber);
     --hv-tone-amber-strong-fg: var(--hv-on-amber);

--- a/cards/haventory-card/src/ui/tone-contrast.test.ts
+++ b/cards/haventory-card/src/ui/tone-contrast.test.ts
@@ -99,6 +99,38 @@ const channel = (v: number) => {
   const c = v / 255;
   return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
 };
+
+/**
+ * CIE L*a*b*, D65 — the space the ΔE below is measured in.
+ *
+ * Contrast answers "can this be read", which is a different question from "are
+ * these two the same colour": two fills can differ by any amount of hue at an
+ * identical luminance and score 1:1 against each other. Lab is roughly
+ * perceptually uniform, so a plain distance in it stands in for how far apart
+ * two fills look.
+ */
+const WHITE_D65 = [0.95047, 1.0, 1.08883] as const;
+
+function lab([r, g, b]: Rgb): [number, number, number] {
+  const [lr, lg, lb] = [channel(r), channel(g), channel(b)];
+  const xyz = [
+    0.4124 * lr + 0.3576 * lg + 0.1805 * lb,
+    0.2126 * lr + 0.7152 * lg + 0.0722 * lb,
+    0.0193 * lr + 0.1192 * lg + 0.9505 * lb,
+  ];
+  const [fx, fy, fz] = xyz.map((v, i) => {
+    const t = v / WHITE_D65[i];
+    return t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116;
+  });
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+}
+
+/** ΔE*76 — straight-line distance in Lab. ~2.3 is the just-noticeable step. */
+function deltaE(a: Rgb, b: Rgb): number {
+  const [la, aa, ba] = lab(a);
+  const [lb, ab, bb] = lab(b);
+  return Math.hypot(la - lb, aa - ab, ba - bb);
+}
 const luminance = ([r, g, b]: Rgb) => 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
 const contrast = (a: Rgb, b: Rgb) => {
   const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
@@ -136,19 +168,34 @@ describe('status tone contrast', () => {
   // one of the card's fixed marks. The blue pair is where that nearly failed:
   // the light tone *was* the state chip's tint and the strong tone was byte-for-
   // byte the blue the card paints its own actions with.
-  it('keeps the blue tone clear of the blues the card reserves for itself', () => {
-    for (const theme of ['light', 'dark'] as const) {
-      expect(resolve('--hv-tone-blue-bg', theme, decls), theme).not.toEqual(
-        resolve('--hv-primary-tint', theme, decls),
-      );
-      expect(resolve('--hv-tone-blue-strong-bg', theme, decls), theme).not.toEqual(
-        resolve('--hv-primary-darker', theme, decls),
-      );
-      expect(resolve('--hv-tone-blue-strong-bg', theme, decls), theme).not.toEqual(
-        resolve('--hv-primary', theme, decls),
-      );
+  // Measured, not merely unequal: a nudge that left the two tokens holding
+  // different hex and the same colour would satisfy `not.toEqual` and ship the
+  // collision back. A ΔE floor of 8 is a few times the just-noticeable step —
+  // a difference nobody has to look for.
+  const MIN_SEPARATION = 8;
+  const PAIRS: [string, string][] = [
+    ['--hv-tone-blue-bg', '--hv-primary-tint'],
+    ['--hv-tone-blue-strong-bg', '--hv-primary-darker'],
+    ['--hv-tone-blue-strong-bg', '--hv-primary'],
+  ];
+
+  for (const theme of ['light', 'dark'] as const) {
+    for (const [tone, fixed] of PAIRS) {
+      it(`keeps ${tone} clear of ${fixed} in the ${theme} theme`, () => {
+        const surface = SURFACE[theme] as unknown as Rgb;
+        // Composited first: the dark tints are translucent, so the declared
+        // value is not what the two are compared as on screen.
+        const distance = deltaE(
+          over(resolve(tone, theme, decls), surface),
+          over(resolve(fixed, theme, decls), surface),
+        );
+        expect(
+          distance,
+          `${tone} vs ${fixed} (${theme}) is ΔE ${distance.toFixed(1)} — a status must not wear one of the card's own blues`,
+        ).toBeGreaterThanOrEqual(MIN_SEPARATION);
+      });
     }
-  });
+  }
 
   it('resolves a translucent tint against the surface rather than reading it as opaque', () => {
     // Guards the harness itself: amber's dark tint is 14% over the dark surface,

--- a/cards/haventory-card/src/ui/tone-contrast.test.ts
+++ b/cards/haventory-card/src/ui/tone-contrast.test.ts
@@ -132,10 +132,62 @@ describe('status tone contrast', () => {
     }
   }
 
+  // A tone is only "the household's own colour" if it cannot be mistaken for
+  // one of the card's fixed marks. The blue pair is where that nearly failed:
+  // the light tone *was* the state chip's tint and the strong tone was byte-for-
+  // byte the blue the card paints its own actions with.
+  it('keeps the blue tone clear of the blues the card reserves for itself', () => {
+    for (const theme of ['light', 'dark'] as const) {
+      expect(resolve('--hv-tone-blue-bg', theme, decls), theme).not.toEqual(
+        resolve('--hv-primary-tint', theme, decls),
+      );
+      expect(resolve('--hv-tone-blue-strong-bg', theme, decls), theme).not.toEqual(
+        resolve('--hv-primary-darker', theme, decls),
+      );
+      expect(resolve('--hv-tone-blue-strong-bg', theme, decls), theme).not.toEqual(
+        resolve('--hv-primary', theme, decls),
+      );
+    }
+  });
+
   it('resolves a translucent tint against the surface rather than reading it as opaque', () => {
     // Guards the harness itself: amber's dark tint is 14% over the dark surface,
     // so a reader that ignored alpha would measure a completely different colour.
     const fill = over(resolve('--hv-tone-amber-bg', 'dark', decls), SURFACE.dark as unknown as Rgb);
     expect(fill).toEqual([60, 47, 29]);
   });
+});
+
+/**
+ * The fixed vocabulary beside the household's: the fills in `ui/chip.ts` that
+ * mean the same thing in every install. They carry the same 12px label the
+ * tones above do and are measured the same way, so a token moved for one
+ * palette cannot quietly drop the other below AA.
+ */
+describe('chip variant contrast', () => {
+  const decls = declarations();
+
+  /** bg `null` = no fill of its own: the chip is read against the page. */
+  const VARIANTS: { variant: string; bg: string | null; fg: string }[] = [
+    { variant: 'state', bg: '--hv-primary-tint', fg: '--hv-on-primary-tint' },
+    { variant: 'warning', bg: '--hv-warn-bg', fg: '--hv-warn-deep' },
+    { variant: 'error', bg: '--hv-error-bg', fg: '--hv-error-deep' },
+    { variant: 'neutral', bg: '--hv-chip-bg', fg: '--hv-chip-text' },
+    { variant: 'quiet', bg: null, fg: '--hv-text-secondary' },
+  ];
+
+  for (const theme of ['light', 'dark'] as const) {
+    for (const { variant, bg, fg } of VARIANTS) {
+      it(`.hv-chip.${variant} clears WCAG AA in the ${theme} theme`, () => {
+        const surface = SURFACE[theme] as unknown as Rgb;
+        const fill = bg === null ? surface : over(resolve(bg, theme, decls), surface);
+        const ink = over(resolve(fg, theme, decls), fill);
+        const ratio = contrast(fill, ink);
+        expect(
+          ratio,
+          `.hv-chip.${variant} (${theme}) is ${ratio.toFixed(2)}:1 — chip text is 12px, so AA asks 4.5:1`,
+        ).toBeGreaterThanOrEqual(4.5);
+      });
+    }
+  }
 });


### PR DESCRIPTION
## Summary

Work package **P3** of `dev/ui_audit_v040_fix_plan.md` — items **B19, B20, C26, C27** and the
contrast half of **#301**. Wave 2; P1 (#308) and P2 (#306) are merged and this branch is cut
from `main` above them.

The chip colour system had drifted into saying things nobody meant. Four changes:

**1 — `--hv-on-primary-tint` (#301, contrast half).** `--hv-primary-darker` on
`--hv-primary-tint` measures **4.26:1**, under the 4.5:1 a 12px label asks — the failure
`tokens.ts` already documented in a comment. A new token pairs the tint with the 900 shade of
its own hue (light `#01579b`, the value `--hv-tone-blue-fg` already proved at 6.56:1); the
dark half is unchanged in effect, since `--hv-primary-dark` and `--hv-primary-darker` are the
same value there.

`--hv-primary-darker` itself does **not** move — it has ~18 users, including `.hv-pill.outline`
and the inverted app-bar uses (`.appbar.selecting`, `.appbar .add`), which sit on white or on
the primary fill and pass comfortably.

The plan scoped the swap to `chip.ts` ×2 plus the sidebar's active row. Auditing the token
pair, as #301 asks, turned up **nine** sites where `--hv-primary-darker` text sits on
`--hv-primary-tint`, all at the same 4.26:1 — so all nine take the new ink rather than leaving
seven of them failing:

| Site | What it is |
|---|---|
| `chip.ts` `.hv-chip.state` | the state chip ("Checked out") |
| `chip.ts` `.hv-chip.toggle.on` | an applied filter toggle |
| `hv-full-view` `.value-row.on` | the sidebar's selected facet row |
| `hv-full-view` `.filters-button.on` | the Filters button while filters are on |
| `hv-location-tree` `.row.selected` | the selected location |
| `hv-item-editor` `.option.selected` | the selected combo option |
| `hv-card-shell` `.icon-toggle.on` | an engaged app-bar toggle |
| `hv-overflow-menu` `.trigger[aria-expanded='true']` | the open ⋮ trigger |
| `hv-banner` `.banner.info` | the info banner |

Every remaining `--hv-primary-darker` text site sits on white or a raised surface, where the
ratio passes. One further failure surfaced while building the guard: `.hv-chip.quiet` has no
fill of its own (`background: none`) and was inked in `--hv-text-tertiary` — **2.7:1** against
the page. It takes `--hv-text-secondary` (4.9:1 light, 6.1:1 dark).

**2 — one coordinated blue shift (B20 + C27).** `--hv-tone-blue-bg` was literally
`var(--hv-primary-tint)` and `--hv-tone-blue-strong-bg` (`#0277bd`) was byte-identical to
`--hv-primary-darker`'s light half. A household's blue status therefore rendered as the card's
own "Checked out" chip, and its strong form as the card's primary action. Both halves move to
indigo — light `#dde0f7` / `#1a237e` (10.3:1), dark `rgba(121,134,203,0.26)` / `#9fa8da`
(5.0:1), strong `#303f9f` on white (9.0:1) — visibly off the card's blues in both directions
while still answering to the name "blue". The `chip.ts` vocabulary comments argued the status
chip opts out of the fixed hue vocabulary; they now state the constraint that actually makes
that true.

The light tint is a step deeper and more chromatic than a 50-level indigo would be, and that
is deliberate: the first pass used `#e8eaf6`, and the live verification measured its fill
against the state chip's tint at **ΔE 5.9** — legible, but with the ink carrying nearly all of
the distinction. `#dde0f7` takes the fills to **ΔE 10.6**, in line with the 10.2 the dark
theme already had.

**3 — B19: the app bar stops speaking the status vocabulary.** `_renderStatusPill` and its two
call sites are gone. The bar's four remaining pills (low, overdue, to-inspect, checked out) are
all *derived* from the item and mean the same thing in every household, which is what lets them
share the bar's fixed amber/red; a status is the household's own word in the household's own
colour, and a renamed, recoloured status kept being announced as "3 missing" in chore amber.
No opaque `.appbar .hv-status-chip` tone overrides were added — none are needed now.

**4 — C26: the applied "Status: X" chip** carried `tone: 'warning'` (chore amber) for every
non-`ok` status. It now renders with `statusToneClass` on the existing `<button>`, carried
through a new optional `toneClass` member on `FilterChip`. The hard-coded `'ok'` comparison is
gone with it. Both hosts already thread `.statuses` into `hv-filter-chips`.

**Guard.** `ui/tone-contrast.test.ts` gains a chip-variant table — `state`, `warning`, `error`,
`neutral`, `quiet` — asserted ≥4.5:1 in both themes, with an explicit "no fill = surface" case
for `quiet` (`parseColor` throws on `none`).

It also gains **measured** distinctness pins for the vocabulary split, rather than mere
inequality: ΔE\*76 in CIE Lab, composited onto the surface first so the translucent dark tints
are compared as they render, with a floor of 8 — a few times the ~2.3 just-noticeable step.
Contrast alone cannot catch a collision of this kind: two fills can differ by any amount of hue
at one luminance and still score 1:1 against each other. Measured separations:

| Pair | Light | Dark |
|---|---|---|
| `--hv-tone-blue-bg` vs `--hv-primary-tint` | ΔE 10.6 | ΔE 10.2 |
| `--hv-tone-blue-strong-bg` vs `--hv-primary-darker` | ΔE 34.5 | — |
| `--hv-tone-blue-strong-bg` vs `--hv-primary` | ΔE 50.9 | — |

Verified that both halves of the guard **fail** against the pre-change tokens (the blue
distinctness pin, `.hv-chip.state` light, and `.hv-chip.quiet` in both themes), and that the
ΔE floor fails against the first pass's `#e8eaf6` at 5.9.

Refs #301 — this is the contrast half; **P5 carries `Closes #301`** with the 24px tap targets.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green on the committed tree.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 737 passed, 22 skipped ·
      `uv run ruff check .` → all checks passed · `uv run ruff format --check .` → 113 files
      already formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean · `npm run typecheck` clean ·
      `npx vitest run` → **54 files, 1296 tests passed** · `npm run build` → 516.95 kB

New / rewritten tests:

- `ui/tone-contrast.test.ts` — chip-variant contrast table (5 variants × 2 themes), plus the
  Lab/ΔE harness and the distinctness floor (3 pairs × 2 themes).
- `ui/chip.test.ts` — pins both tint-backed fills to `--hv-on-primary-tint`, asserts
  `--hv-primary-darker` appears nowhere in the fragment, and pins the quiet chip's ink.
- `hv-filter-chips.test.ts` — the old "warning tone on the flagged values" pin is rewritten to
  assert the status's own tone; plus household-definition tone, unknown-slug → `tone-neutral`
  fallback, a DOM test that the status chip is a `hv-status-chip` while a sibling stays in the
  fixed vocabulary, and a regression check that the status chip still emits its clear patch.
- `hv-full-view.test.ts` — the three `full-badge-status` tests are replaced by one asserting no
  status is priced in the app bar, with the derived pills still present.

## Screenshots (card / UI changes)

**The plan's §Verification handover for P3 has been run and passed — this PR is clear to
merge on that count.**

Pass 1, against `2e8ce10`, 5 of 5: the tone-blue status chip reads as a different colour from
the "Checked out" state chip on both the panel table and the card list; the `blue_strong` chip
does not read as pressable beside the primary actions; the applied `Status: X` chip is an exact
tone match for the status chips in the rows beneath it and plainly apart from the amber chore
pills in the same frame; the app bar carries zero `full-badge-status` nodes with all four
derived pills intact; and the selected facet row, selected location row and info banner all
resolve to the new ink.

Pass 2, against `603b2b2` (the light-tint deepening), 2 of 2: the fills now separate on hue
alone — periwinkle beside pale sky — at the measured ΔE 10.6, so the ink is no longer carrying
the distinction; and the deeper tint still reads as a light tint in the colour picker, sitting
with the pastels 14.1 L\* clear of the lightest strong swatch and only 2.1 L\* below `neutral`,
which was already the row's darkest light swatch. It is the most chromatic of the five, which
is the trade this change makes on purpose.

No console errors in either theme on either pass. Served bundle hash confirmed against the
local build.

## Follow-ups

- #315 — `STATUS_COLORS`' ordering comment in `ui/status.ts` describes a "five-by-two picker
  grid", but `.swatches` is a wrapping flex row and renders all ten on one line. Comment
  accuracy only; the ordering itself is correct and backend-pinned. Not fixed here — this PR
  touches neither file, and P4 already rewrites that region.