### PR TITLE
feat(backend): serve attachments with Content-Disposition; land attachment verification probes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,9 @@ Offline tests stub HA via `tests/conftest.py`.
 > there is **no Windows host support** — the helpers assume a UTF-8 terminal and the test
 > scaffolding carries no platform branch. Develop on Windows through WSL2. The Python
 > helpers (`ws_probe.py`, `ws_subscribe.py`, `ws_init_haventory.py`, `stress_test.py`,
-> `create_test_items.py`) run via `uv run python scripts/<name>.py`.
+> `create_test_items.py`) run via `uv run python scripts/<name>.py`. The attachment probes
+> (`probe_attachments.py`, `probe_fixtures.py`) additionally need the non-default `probes`
+> dependency group for Pillow: `uv run --group probes python scripts/<name>.py`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -726,6 +726,28 @@ uv run python scripts/stress_test.py --skip-deploy --skip-confirm  # quick re-ru
 Scenarios: rapid sequential mutations, concurrent burst, bulk-under-load, mixed workload,
 persistence-across-restart. Exit codes: `0` pass, `1` failures, `2` setup error.
 
+### Attachment probes
+
+`scripts/probe_attachments.py` checks the attachment path against a live instance — and
+against the **bytes on Home Assistant's disk**, not what the card reported. Pillow comes
+from the non-default `probes` dependency group, so a plain `uv sync` stays lean:
+
+```bash
+uv sync --group probes
+export RUN_ONLINE=1 HA_TOKEN=<token>   # HA_BASE_URL defaults to http://localhost:8123
+export HA_CONTAINER=home-assistant     # or HA_CONFIG_DIR for a bind-mounted config
+uv run --group probes python scripts/probe_attachments.py
+```
+
+It covers the 2 MiB re-encode threshold and the 2048-pixel cap, EXIF orientation applied
+before the re-encode, PNG transparency surviving as WebP, an animated GIF kept whole, a
+sub-threshold JPEG round-tripping byte-identical, the `206`/`404`/no-answer presence
+semantics, and the `Content-Disposition` name. Exit codes: `0` pass, `1` a probe failed,
+`2` setup error, `3` timeout.
+
+`scripts/probe_fixtures.py --out DIR` writes those fixtures on their own (~30 MB of
+generated images — they are never committed).
+
 ---
 
 ## Contributing

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -1,5 +1,6 @@
 import './hv-detail-sheet';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
+import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import type { HVDetailSheet } from './hv-detail-sheet';
 import type { Item } from '../store/types';
 
@@ -540,7 +541,11 @@ describe('hv-detail-sheet: documents', () => {
     await el.updateComplete;
 
     const open = all(el, '[data-testid="sheet-document-open"]')[0] as HTMLAnchorElement;
-    expect(open.getAttribute('href')).toBe('/api/haventory/media/i-1/m-1?authSig=test');
+    // Versioned by the served name, so a retitle cannot be answered from the
+    // browser's cache with the filename this document used to carry.
+    expect(open.getAttribute('href')).toBe(
+      `/api/haventory/media/i-1/m-1?${MEDIA_NAME_TOKEN_PARAM}=${attachmentNameToken(docs()[0])}&authSig=test`,
+    );
     expect(open.getAttribute('target')).toBe('_blank');
     expect(open.getAttribute('rel')).toContain('noopener');
   });

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -8,7 +8,15 @@ import { inferType } from '../ui/item-form';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
 import { isLowStock } from './hv-list-row';
 import { itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
-import { MediaUrls, attachmentTitle, formatBytes, manuals, pictureAlt, pictures } from '../ui/media';
+import {
+  MediaUrls,
+  attachmentNameToken,
+  attachmentTitle,
+  formatBytes,
+  manuals,
+  pictureAlt,
+  pictures,
+} from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import { DialogFocus } from '../ui/dialog-focus';
 import type { AreaRef, Item, Location, LocationTreeNode, MediaConfig, ScalarValue, StatusDefinition } from '../store/types';
@@ -491,7 +499,7 @@ export class HVDetailSheet extends LitElement {
     if (!shots.length) return null;
     return html`<div class="gallery" data-testid="sheet-gallery">
       ${shots.map((picture, index) => {
-        const src = this._urls.get(item.id, picture.id);
+        const src = this._urls.get(item.id, picture.id, attachmentNameToken(picture));
         if (!src) return null;
         return html`<figure data-testid="sheet-photo">
           <button
@@ -531,7 +539,7 @@ export class HVDetailSheet extends LitElement {
       <h3>Documents</h3>
       <ul>
         ${docs.map((doc) => {
-          const src = this._urls.get(item.id, doc.id);
+          const src = this._urls.get(item.id, doc.id, attachmentNameToken(doc));
           const missing = this._urls.presence(item.id, doc.id) === 'missing';
           return html`<li class=${missing ? 'missing' : ''} data-testid="sheet-document">
             <span class="doc-icon">${icon('fileDocument', 20)}</span>
@@ -568,7 +576,7 @@ export class HVDetailSheet extends LitElement {
     const shots = pictures(item.attachments);
     const index = this._lightbox;
     if (index === null || !shots[index]) return null;
-    const src = this._urls.get(item.id, shots[index].id);
+    const src = this._urls.get(item.id, shots[index].id, attachmentNameToken(shots[index]));
     if (!src) return null;
     const close = () => {
       this._lightbox = null;

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1,5 +1,6 @@
 import './hv-item-editor';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
+import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { addDays } from '../ui/relative-time';
 import type { HVItemEditor } from './hv-item-editor';
 import type { Item, ItemCreate, ItemUpdate, Location, LocationTreeNode } from '../store/types';
@@ -1371,7 +1372,10 @@ describe('hv-item-editor: opening a document', () => {
     for (let i = 0; i < 3; i += 1) await el.updateComplete;
 
     const open = q(el, '[data-testid="editor-document-open"]') as HTMLAnchorElement;
-    expect(open.getAttribute('href')).toBe('/api/haventory/media/i-1/m-1?authSig=test');
+    expect(open.getAttribute('href')).toBe(
+      `/api/haventory/media/i-1/m-1?${MEDIA_NAME_TOKEN_PARAM}=`
+        + `${attachmentNameToken(makeManual({ id: 'm-1', title: 'Warranty' }))}&authSig=test`,
+    );
     expect(open.getAttribute('target')).toBe('_blank');
     expect(open.getAttribute('aria-label')).toBe('Open Warranty');
   });

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -26,7 +26,15 @@ import {
 } from '../ui/item-form';
 import type { CustomFieldRow, CustomFieldType, FieldError, ItemFormModel } from '../ui/item-form';
 import { statusLabel, statusList } from '../ui/status';
-import { MediaUrls, attachmentTitle, formatBytes, manuals, pictureAlt, pictures } from '../ui/media';
+import {
+  MediaUrls,
+  attachmentNameToken,
+  attachmentTitle,
+  formatBytes,
+  manuals,
+  pictureAlt,
+  pictures,
+} from '../ui/media';
 import { prepareForUpload } from '../ui/downscale';
 import type { MediaBindings } from '../ui/media';
 import type {
@@ -1832,7 +1840,7 @@ export class HVItemEditor extends LitElement {
       <span class="hv-label">Photos</span>
       <div class="photos" data-testid="editor-photos">
         ${shots.map((picture, index) => {
-          const src = this._urls.get(item.id, picture.id);
+          const src = this._urls.get(item.id, picture.id, attachmentNameToken(picture));
           return html`<figure data-testid="editor-photo">
             ${src
               ? html`<img
@@ -1938,7 +1946,7 @@ export class HVItemEditor extends LitElement {
       <span class="hv-label">Documents</span>
       <ul class="documents" data-testid="editor-documents">
         ${docs.map((doc) => {
-          const src = this._urls.get(item.id, doc.id);
+          const src = this._urls.get(item.id, doc.id, attachmentNameToken(doc));
           const missing = this._urls.presence(item.id, doc.id) === 'missing';
           return html`<li data-testid="editor-document">
             <span class="doc-icon">${icon('fileDocument', 18)}</span>

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -1,5 +1,6 @@
 import './hv-list-row';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
+import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { elidePath, isLowStock } from './hv-list-row';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVListRow } from './hv-list-row';
@@ -453,7 +454,10 @@ describe('hv-list-row thumbnail', () => {
 
     const img = q(el, '[data-testid="row-thumb"]') as HTMLImageElement | null;
     expect(img).toBeTruthy();
-    expect(img?.getAttribute('src')).toBe('/api/haventory/media/i-thumb/att-1?authSig=test');
+    expect(img?.getAttribute('src')).toBe(
+      `/api/haventory/media/i-thumb/att-1?${MEDIA_NAME_TOKEN_PARAM}=`
+        + `${attachmentNameToken(makeAttachment({ id: 'att-1' }))}&authSig=test`,
+    );
     expect(img?.getAttribute('alt')).toBe('Photo of Cordless drill');
     // Nothing is thumbnailed server-side, so the browser must be told not to
     // fetch and decode every row's full-size photo at once.

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -6,7 +6,7 @@ import { itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue } from '../ui/relative-time';
 import { itemStatus, renderStatusChip, statusLabel } from '../ui/status';
-import { MediaUrls, manuals, pictureAlt, pictures } from '../ui/media';
+import { MediaUrls, attachmentNameToken, manuals, pictureAlt, pictures } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import type { AreaRef, Item, StatusDefinition } from '../store/types';
 import './hv-overflow-menu';
@@ -309,7 +309,7 @@ export class HVListRow extends LitElement {
   private _renderThumb() {
     const first = pictures(this.item.attachments)[0];
     if (!first) return null;
-    const src = this._urls.get(this.item.id, first.id);
+    const src = this._urls.get(this.item.id, first.id, attachmentNameToken(first));
     if (!src) return null;
     return html`<img
       class="thumb"

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -886,7 +886,10 @@ export function makeMediaBindings(
     sign: async (path: string) => {
       signed.push(path);
       if (options.signFails) throw new Error('signing refused');
-      return `${path}?authSig=test`;
+      // Core appends to whatever query the path already has — a media URL
+      // carries the name token — so the separator has to follow suit or every
+      // signed URL here is malformed in a way no real one is.
+      return `${path}${path.includes('?') ? '&' : '?'}authSig=test`;
     },
     upload: async (itemId: string, file: File, kind: AttachmentKind = 'picture') => {
       uploads.push({ itemId, file, kind });

--- a/cards/haventory-card/src/ui/media.test.ts
+++ b/cards/haventory-card/src/ui/media.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
+  MEDIA_NAME_TOKEN_PARAM,
   MEDIA_URL_TEMPLATE,
   MediaUrls,
   SIGNED_URL_TTL_SECONDS,
+  attachmentNameToken,
   attachmentTitle,
   formatBytes,
   manuals,
@@ -60,6 +62,46 @@ describe('mediaPath', () => {
 
   it('uses the route the backend serves', () => {
     expect(MEDIA_URL_TEMPLATE).toBe('/api/haventory/media/{item_id}/{attachment_id}');
+  });
+
+  it('carries the name token as the parameter the backend reads', () => {
+    expect(mediaPath('item-1', 'att-1', 'abc123')).toBe(
+      `/api/haventory/media/item-1/att-1?${MEDIA_NAME_TOKEN_PARAM}=abc123`,
+    );
+  });
+
+  it('leaves the path alone when there is no token to carry', () => {
+    expect(mediaPath('item-1', 'att-1')).not.toContain('?');
+  });
+});
+
+describe('attachmentNameToken', () => {
+  it('changes when the served name changes', () => {
+    const untitled = attachment({ filename: 'scan_0142.pdf' });
+    const titled = attachment({ filename: 'scan_0142.pdf', title: 'Dishwasher manual (EN)' });
+
+    expect(attachmentNameToken(titled)).not.toBe(attachmentNameToken(untitled));
+  });
+
+  it('is stable for the same served name', () => {
+    expect(attachmentNameToken(attachment({ title: 'Manual' }))).toBe(
+      attachmentNameToken(attachment({ title: 'Manual' })),
+    );
+  });
+
+  it('follows the same title-then-filename precedence the header does', () => {
+    // A title of only whitespace is not a title, so the filename is the name
+    // served — and the token has to agree, or the URL would change for a name
+    // that did not.
+    expect(attachmentNameToken(attachment({ title: '   ' }))).toBe(
+      attachmentNameToken(attachment({ title: '' })),
+    );
+  });
+
+  it('survives a name outside US-ASCII', () => {
+    expect(attachmentNameToken(attachment({ title: 'Spülmaschine - Anleitung' }))).toMatch(
+      /^[0-9a-z]+$/,
+    );
   });
 });
 
@@ -173,6 +215,70 @@ describe('MediaUrls', () => {
     expect(signer.sign).toHaveBeenCalledTimes(1);
     expect(signer.calls[0]).toBe('/api/haventory/media/item-1/att-1');
     expect(h.renders).toBe(1);
+  });
+
+  it('re-signs under a new name token so a retitled file stops saving under the old name', async () => {
+    const h = host();
+    const signer = deferredSigner();
+    const urls = new MediaUrls(h);
+    urls.configure(signer.sign);
+
+    urls.get('item-1', 'att-1', 'old');
+    signer.resolve('/api/haventory/media/item-1/att-1?v=old&authSig=abc');
+    await Promise.resolve();
+    expect(urls.get('item-1', 'att-1', 'old')).toBe(
+      '/api/haventory/media/item-1/att-1?v=old&authSig=abc',
+    );
+    expect(signer.sign).toHaveBeenCalledTimes(1);
+
+    // The retitle: the held URL was signed for a name that is no longer the one
+    // the row shows, and its cached response still carries that name.
+    urls.get('item-1', 'att-1', 'new');
+
+    expect(signer.sign).toHaveBeenCalledTimes(2);
+    expect(signer.calls[1]).toBe('/api/haventory/media/item-1/att-1?v=new');
+  });
+
+  it('does not re-sign for a reader that expressed no opinion about the name', async () => {
+    // Every row calls `get` with a token and `presence` without one, and
+    // `presence` reads the URL through `get`. Treating "no token" as a mismatch
+    // makes the two re-sign over each other on every render, and because each
+    // answer asks the host to render again, the component never settles.
+    const signer = deferredSigner();
+    const urls = new MediaUrls(host());
+    urls.configure(signer.sign);
+
+    urls.get('item-1', 'att-1', 'tok');
+    signer.resolve('/signed?v=tok');
+    await Promise.resolve();
+    expect(signer.sign).toHaveBeenCalledTimes(1);
+
+    expect(urls.get('item-1', 'att-1')).toBe('/signed?v=tok');
+    expect(urls.get('item-1', 'att-1', 'tok')).toBe('/signed?v=tok');
+
+    expect(signer.sign).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps what it learned about the bytes across a retitle', async () => {
+    const signer = deferredSigner();
+    const probe = vi.fn(async (_url: string, _init: { headers: Record<string, string> }) =>
+      Promise.resolve(new Response(null, { status: 206 })),
+    );
+    const urls = new MediaUrls(host(), { fetch: probe });
+    urls.configure(signer.sign);
+
+    urls.get('item-1', 'att-1', 'old');
+    signer.resolve('/signed-old');
+    await Promise.resolve();
+    urls.presence('item-1', 'att-1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(urls.presence('item-1', 'att-1')).toBe('present');
+
+    // A new name is not new bytes: the entry is keyed on the two ids, so the
+    // presence answer must not be thrown away with the URL.
+    urls.get('item-1', 'att-1', 'new');
+
+    expect(urls.presence('item-1', 'att-1')).toBe('present');
   });
 
   it('asks for the lifetime it then respects', async () => {

--- a/cards/haventory-card/src/ui/media.ts
+++ b/cards/haventory-card/src/ui/media.ts
@@ -22,6 +22,22 @@ import type { Attachment, AttachmentKind, Item } from '../store/types';
 export const MEDIA_URL_TEMPLATE = '/api/haventory/media/{item_id}/{attachment_id}';
 
 /**
+ * Query parameter that versions a media URL by the name the file is served
+ * under.
+ *
+ * The bytes behind an attachment id never change, but the name in the
+ * response's `Content-Disposition` does — a retitle rewrites it for that same
+ * id — and the backend will only let a client hold the response indefinitely
+ * when the URL says which name it was fetched for. Without it a retitled file
+ * would keep being saved under its old name for as long as the browser's cache
+ * entry lived, which a signature outlasts by half an hour.
+ *
+ * Pinned to the backend's `MEDIA_NAME_TOKEN_PARAM` by
+ * `tests/test_frontend_registration.py`.
+ */
+export const MEDIA_NAME_TOKEN_PARAM = 'v';
+
+/**
  * How long a signature is asked for.
  *
  * A browser caches by full URL, signature included, so a re-signed URL is a
@@ -61,12 +77,40 @@ interface MediaHost {
   requestUpdate(): void;
 }
 
-/** Build the unsigned media path for one attachment. */
-export function mediaPath(itemId: string, attachmentId: string): string {
-  return MEDIA_URL_TEMPLATE.replace('{item_id}', encodeURIComponent(itemId)).replace(
+/**
+ * Build the unsigned media path for one attachment.
+ *
+ * A name token makes the URL change when the served filename does, which is
+ * what lets the response be cached — see `MEDIA_NAME_TOKEN_PARAM`. Home
+ * Assistant signs query parameters together with the path, so the token has to
+ * be here before signing rather than appended to a signed URL.
+ */
+export function mediaPath(itemId: string, attachmentId: string, nameToken?: string): string {
+  const path = MEDIA_URL_TEMPLATE.replace('{item_id}', encodeURIComponent(itemId)).replace(
     '{attachment_id}',
     encodeURIComponent(attachmentId),
   );
+  return nameToken ? `${path}?${MEDIA_NAME_TOKEN_PARAM}=${encodeURIComponent(nameToken)}` : path;
+}
+
+/**
+ * A short stable token for the name one attachment is served under.
+ *
+ * A hash rather than the name itself: the name is user-supplied text of any
+ * length in any script, and this only has to *differ* when the name does. The
+ * input is `attachmentTitle`, which is the same precedence the backend builds
+ * `Content-Disposition` from, so the token changes exactly when the saved
+ * filename would.
+ */
+export function attachmentNameToken(attachment: Attachment): string {
+  const name = attachmentTitle(attachment);
+  // FNV-1a, 32-bit. Not a checksum and not a secret — a cache key.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < name.length; i += 1) {
+    hash ^= name.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
 }
 
 /** A human-readable file size, for the caption under a picture. */
@@ -144,6 +188,8 @@ interface Entry {
   pending: boolean;
   presence: Presence;
   probing: boolean;
+  /** The name token this entry's URL was signed for; see `MEDIA_NAME_TOKEN_PARAM`. */
+  nameToken: string | undefined;
 }
 
 /**
@@ -182,15 +228,27 @@ export class MediaUrls {
     this.entries.clear();
   }
 
-  /** The signed URL for one attachment, or null while there is not one yet. */
-  get(itemId: string, attachmentId: string): string | null {
+  /**
+   * The signed URL for one attachment, or null while there is not one yet.
+   *
+   * Passing the attachment's `attachmentNameToken` keeps the URL in step with a
+   * retitle: a token the held URL was not signed for re-signs rather than
+   * serving a URL whose cached response still carries the old filename. The
+   * entry is keyed on the two ids alone, so what `failed` and `presence` know
+   * about these bytes survives the re-sign.
+   */
+  get(itemId: string, attachmentId: string, nameToken?: string): string | null {
     const key = `${itemId}/${attachmentId}`;
     const entry = this.entries.get(key);
-    if (entry) {
+    // No token means no opinion about the name, not "the untitled URL". The
+    // presence probe reads whatever URL is current without caring what it is
+    // called, and counting that as a mismatch would have the two callers
+    // re-sign over each other on every render.
+    if (entry && (nameToken === undefined || entry.nameToken === nameToken)) {
       if (entry.failed || entry.pending) return entry.url;
       if (entry.url && entry.expiresAt - REFRESH_MARGIN_MS > this.now()) return entry.url;
     }
-    this.request(key, itemId, attachmentId);
+    this.request(key, itemId, attachmentId, nameToken);
     // A lapsed URL is still shown while its replacement is in flight: the
     // browser has the image cached and swapping to a placeholder mid-view would
     // be a worse answer than a URL that is briefly stale.
@@ -244,11 +302,17 @@ export class MediaUrls {
     this.host.requestUpdate();
   }
 
-  private request(key: string, itemId: string, attachmentId: string): void {
+  private request(key: string, itemId: string, attachmentId: string, nameToken?: string): void {
     const sign = this.sign;
     if (!sign) return;
     const existing = this.entries.get(key);
-    if (existing?.pending) return;
+    // A caller with no opinion about the name keeps the one this entry was
+    // already signed for, rather than dropping it back to the untitled URL.
+    const token = nameToken ?? existing?.nameToken;
+    // A request already in flight for this same name is the one to wait for; a
+    // retitle mid-flight is not, because that URL would arrive naming the file
+    // the row no longer shows.
+    if (existing?.pending && existing.nameToken === token) return;
 
     // A re-sign is a new URL for the same bytes, so whatever was learned about
     // whether those bytes exist carries across it.
@@ -259,11 +323,18 @@ export class MediaUrls {
       pending: true,
       presence: existing?.presence ?? 'unknown',
       probing: existing?.probing ?? false,
+      nameToken: token,
     };
     this.entries.set(key, entry);
 
-    void sign(mediaPath(itemId, attachmentId), SIGNED_URL_TTL_SECONDS).then(
+    // A second retitle can start another sign before this one lands. The token
+    // on the entry is the name last asked for, so an answer that no longer
+    // matches it is a late one and is dropped rather than overwriting it.
+    const superseded = () => this.entries.get(key)?.nameToken !== token;
+
+    void sign(mediaPath(itemId, attachmentId, token), SIGNED_URL_TTL_SECONDS).then(
       (signed) => {
+        if (superseded()) return;
         this.entries.set(key, {
           url: signed,
           expiresAt: this.now() + SIGNED_URL_TTL_SECONDS * 1000,
@@ -271,10 +342,12 @@ export class MediaUrls {
           pending: false,
           presence: this.entries.get(key)?.presence ?? entry.presence,
           probing: this.entries.get(key)?.probing ?? entry.probing,
+          nameToken: token,
         });
         this.host.requestUpdate();
       },
       () => {
+        if (superseded()) return;
         // Keep whatever URL was already working: a failed refresh is not a
         // reason to blank an image the browser is still showing.
         this.entries.set(key, {
@@ -284,6 +357,7 @@ export class MediaUrls {
           pending: false,
           presence: this.entries.get(key)?.presence ?? entry.presence,
           probing: this.entries.get(key)?.probing ?? entry.probing,
+          nameToken: token,
         });
         this.host.requestUpdate();
       },

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -61,6 +61,13 @@ MEDIA_SUBDIR: str = "haventory/attachments"
 # segment ever reaches the filesystem as written.
 MEDIA_URL_TEMPLATE: str = "/api/haventory/media/{item_id}/{attachment_id}"
 
+# Query parameter a client adds to say "this URL is versioned by the name the
+# file is served under". The view reads only whether it is present, never its
+# value: it is a cache key, and the name it stands for is the one the response
+# carries anyway. Home Assistant signs query parameters along with the path, so
+# a client cannot bolt this onto a URL it was given.
+MEDIA_NAME_TOKEN_PARAM: str = "v"  # noqa: S105 - a query parameter name, not a credential
+
 # Accepted picture types. An allow-list, checked against the file's *sniffed*
 # leading bytes rather than the content type the browser declared.
 # `image/svg+xml` is deliberately absent: SVG carries script and the view serves

--- a/custom_components/haventory/media.py
+++ b/custom_components/haventory/media.py
@@ -25,6 +25,7 @@ from collections.abc import Iterable
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from homeassistant.core import HomeAssistant
 
@@ -75,6 +76,11 @@ _EXTENSION_BY_MIME: dict[str, str] = {
 
 # Enough bytes for every signature below: WebP's marker ends at byte 12.
 SNIFF_BYTES = 16
+
+# How much of a served name reaches the response header. A filename carries no
+# length limit of its own, and a client is entitled to refuse an oversized
+# header line rather than the file behind it.
+DISPOSITION_NAME_MAX_CHARS = 200
 
 
 def sniff_mime(head: bytes) -> str | None:
@@ -303,6 +309,32 @@ async def async_sweep_orphans(
     return removed
 
 
+def _content_disposition(meta: AttachmentMeta) -> str:
+    """The ``Content-Disposition`` value one attachment is served under.
+
+    ``inline``, never ``attachment``: a document opens in a tab, and the header
+    exists to name the file the browser saves from there — not to turn the
+    click into a download. The name is the title the user gave the file, or the
+    name it arrived under, which is the precedence the card labels the row with,
+    so a saved file matches the row that was clicked.
+
+    Both halves are user-supplied text under no charset restriction, and this
+    value becomes a response header. The real name travels percent-encoded in
+    the RFC 5987 ``filename*`` form; the quoted ``filename`` a client without
+    that support reads is reduced to printable US-ASCII minus the two
+    characters the quoting itself uses, which is also what stops a CR or LF in
+    a title from splitting the header.
+    """
+
+    name = (meta.title.strip() or meta.filename)[:DISPOSITION_NAME_MAX_CHARS]
+    ascii_name = "".join(c for c in name if " " <= c <= "~" and c not in '"\\').strip()
+    # Nothing printable survived — a title written entirely in a non-Latin
+    # script. The attachment id is what such a client would have taken from the
+    # URL anyway, and `filename*` still carries the real name.
+    fallback = ascii_name or str(meta.id)
+    return f"inline; filename=\"{fallback}\"; filename*=UTF-8''{quote(name, safe='')}"
+
+
 class HaventoryMediaView(HomeAssistantView):  # type: ignore[misc, valid-type]
     """Serve one attachment, to an authenticated Home Assistant user.
 
@@ -345,5 +377,8 @@ class HaventoryMediaView(HomeAssistantView):  # type: ignore[misc, valid-type]
                 # An attachment id addresses one immutable set of bytes: a
                 # replacement is a new id, so this can never go stale.
                 "Cache-Control": "private, max-age=31536000, immutable",
+                # Without this the browser names a saved file after the last
+                # path segment, which is the attachment id.
+                "Content-Disposition": _content_disposition(meta),
             },
         )

--- a/custom_components/haventory/media.py
+++ b/custom_components/haventory/media.py
@@ -46,6 +46,7 @@ from .const import (
     MAX_ATTACHMENT_BYTES,
     MAX_MANUALS_PER_ITEM,
     MAX_PICTURES_PER_ITEM,
+    MEDIA_NAME_TOKEN_PARAM,
     MEDIA_SUBDIR,
     MEDIA_URL_TEMPLATE,
 )
@@ -335,6 +336,24 @@ def _content_disposition(meta: AttachmentMeta) -> str:
     return f"inline; filename=\"{fallback}\"; filename*=UTF-8''{quote(name, safe='')}"
 
 
+def _cache_control(request: Any) -> str:
+    """How long a client may hold this response without asking again.
+
+    The bytes an attachment id names never change — a replacement is a new id —
+    but the name they are served under does: a retitle rewrites
+    ``Content-Disposition`` for that same id. Storing the response forever is
+    therefore only safe for a client whose URL changes when the name does, and
+    the card's carries the name token this looks for. Without it the response
+    must not be reused, or a retitle would keep saving the file under its old
+    name for as long as the entry lived — and a signed URL lives half an hour,
+    so that is not a window a user would wait out.
+    """
+
+    if request.query.get(MEDIA_NAME_TOKEN_PARAM):
+        return "private, max-age=31536000, immutable"
+    return "private, no-store"
+
+
 class HaventoryMediaView(HomeAssistantView):  # type: ignore[misc, valid-type]
     """Serve one attachment, to an authenticated Home Assistant user.
 
@@ -374,9 +393,7 @@ class HaventoryMediaView(HomeAssistantView):  # type: ignore[misc, valid-type]
                 # browser from deciding differently about user-supplied bytes.
                 "Content-Type": meta.mime,
                 "X-Content-Type-Options": "nosniff",
-                # An attachment id addresses one immutable set of bytes: a
-                # replacement is a new id, so this can never go stale.
-                "Cache-Control": "private, max-age=31536000, immutable",
+                "Cache-Control": _cache_control(request),
                 # Without this the browser names a saved file after the last
                 # path segment, which is the attachment id.
                 "Content-Disposition": _content_disposition(meta),

--- a/dev/release_testing_plan.md
+++ b/dev/release_testing_plan.md
@@ -126,6 +126,16 @@ client + OS version, date. Put it in the results log.
 | A3 | YAML-mode Lovelace (ENV-B, `lovelace: mode: yaml`) | Resource registration is skipped with a clear log line, and the card still loads — the frontend extra-module URL covers YAML mode, so there is no manual step here either | ✅ |
 | A4 | Attempt a second config entry | HAventory is absent from the "Add integration" picker while an entry exists, so the attempt cannot start; a flow initiated outside the picker aborts with "Already configured. Only a single configuration is possible." No duplicate storage or resource | |
 | A5 | First-run with a pre-existing store (upgrade-in-place from a dev instance) | Existing items/locations load; `health` healthy | ✅ |
+| A6 | Attachment round trip, automated: `RUN_ONLINE=1 HA_TOKEN=<token> uv run --group probes python scripts/probe_attachments.py` | All probes pass. The stored bytes on HA's disk — not what the card reported — match what the card's re-encode should have produced: 4032×3024 JPEG capped at 2048, transparent PNG stored as WebP with its alpha, animated GIF untouched with all 24 frames, sub-2 MiB JPEG byte-identical | ✅ |
+| A7 | EXIF orientation, from the same run (case "EXIF Orientation=6 is applied before the re-encode") | The stored frame is upright — portrait 1536×2048, not landscape. This is the one attachment defect that looks correct in every automated test and wrong on every phone, so read this line even when the run is green overall | ✅ |
+| A8 | Attachment liveness and naming, from the same run | The presence probe answers `206` with `Content-Length: 1` on a live file, `404` on a deleted one, and nothing at all on an unreachable host; a manual is served `inline` under its title (its filename when untitled), non-ASCII intact | |
+| A9 | Save a manual from the browser: open an item's Documents row, save the file | It saves under the attachment's title — or the original filename when untitled — never the attachment UUID, and clicking still opens it in a tab rather than downloading it | |
+
+Fixtures for A6–A8 are generated, never committed: `scripts/probe_fixtures.py` writes them
+(~30 MB) into a temporary directory each run, and `--fixtures-dir DIR` reuses one across
+runs. Reading the stored bytes needs either `HA_CONFIG_DIR` (a bind-mounted config) or
+`HA_CONTAINER` (read out through `docker exec`). Pillow comes from the non-default `probes`
+dependency group — `uv sync --group probes` first.
 
 ### B — Mobile / touch (companion app)
 

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -234,6 +234,7 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - An authenticated `HomeAssistantView`, not `/local` and not `/haventory_static`: both of those are served without authentication, and an inventory photo is as private as the inventory.
   - Both ids are matched against stored metadata before any path is built, so no request segment reaches the filesystem. Anything unmatched — and any entry whose file is absent — is `404`. Once no config entry owns the data the view answers `503`, mirroring the WebSocket commands' refusal.
   - Responses carry the stored content type, `X-Content-Type-Options: nosniff`, and a long immutable `Cache-Control`: an attachment id addresses one fixed set of bytes, and a replacement is a new id.
+  - `Content-Disposition` is always `inline` — clicking a document opens it in a tab — and names the file the attachment's `title`, or its `filename` when untitled. The name travels percent-encoded as RFC 5987 `filename*=UTF-8''…`, with a quoted printable-ASCII `filename` beside it for clients without that support; a name with nothing printable in ASCII falls back to the attachment id there.
   - An `<img src>` carries no `Authorization` header, so a client signs the path with core's `auth/sign_path` first and renders the signed URL.
 
 - `haventory/items/bulk`

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -233,9 +233,10 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 - Serving an attachment — `GET /api/haventory/media/{item_id}/{attachment_id}`
   - An authenticated `HomeAssistantView`, not `/local` and not `/haventory_static`: both of those are served without authentication, and an inventory photo is as private as the inventory.
   - Both ids are matched against stored metadata before any path is built, so no request segment reaches the filesystem. Anything unmatched — and any entry whose file is absent — is `404`. Once no config entry owns the data the view answers `503`, mirroring the WebSocket commands' refusal.
-  - Responses carry the stored content type, `X-Content-Type-Options: nosniff`, and a long immutable `Cache-Control`: an attachment id addresses one fixed set of bytes, and a replacement is a new id.
+  - Responses carry the stored content type and `X-Content-Type-Options: nosniff`.
   - `Content-Disposition` is always `inline` — clicking a document opens it in a tab — and names the file the attachment's `title`, or its `filename` when untitled. The name travels percent-encoded as RFC 5987 `filename*=UTF-8''…`, with a quoted printable-ASCII `filename` beside it for clients without that support; a name with nothing printable in ASCII falls back to the attachment id there.
-  - An `<img src>` carries no `Authorization` header, so a client signs the path with core's `auth/sign_path` first and renders the signed URL.
+  - `Cache-Control` depends on whether the URL says which name it was fetched under. An attachment id addresses one fixed set of bytes — a replacement is a new id — but the name in `Content-Disposition` is not fixed: a retitle rewrites it for that same id. A URL carrying the `v` name-token parameter is therefore `private, max-age=31536000, immutable`, and one without it is `private, no-store`. Only the presence of `v` is read, never its value; it is a cache key, and the name it stands for is in the response anyway. Without this a retitled file would keep being saved under its old name for as long as the cached response lived, which a signature outlasts by half an hour.
+  - An `<img src>` carries no `Authorization` header, so a client signs the path with core's `auth/sign_path` first and renders the signed URL. Home Assistant signs query parameters along with the path, so `v` has to be on the path *before* signing — a client cannot add it to a URL it was handed.
 
 - `haventory/items/bulk`
   - Payload: `{operations: Array<{op_id: string|number, kind: string, payload: object}>}`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,15 @@ dev = [
   # tests/test_repo_hardening_offline.py parses .github/workflows/*.yml.
   "pyyaml",
 ]
+# Not installed by `uv sync`, on purpose. `scripts/probe_fixtures.py` generates
+# the attachment fixtures with Pillow and `scripts/probe_attachments.py` decodes
+# what came back off Home Assistant's disk — but the integration does no image
+# work server-side (nothing is thumbnailed, nothing is re-encoded), and the
+# offline suite must keep running without an imaging library. Opt in with
+# `uv sync --group probes` / `uv run --group probes …`.
+probes = [
+  "pillow",
+]
 
 [tool.uv]
 # This is a custom-integration source tree, not a distributable package: HA loads

--- a/scripts/probe_attachments.py
+++ b/scripts/probe_attachments.py
@@ -1,0 +1,745 @@
+r"""Online probes for the HAventory attachment path, against a live dev instance.
+
+Usage:
+  export RUN_ONLINE=1
+  export HA_BASE_URL='http://localhost:8123'
+  export HA_TOKEN='<your-long-lived-token>'
+  export HA_CONTAINER='home-assistant'          # or HA_CONFIG_DIR, see below
+  uv sync --group probes
+  uv run --group probes python scripts/probe_attachments.py
+
+Options:
+  --fixtures-dir DIR   reuse (or write) the generated fixtures here
+  --keep-fixtures      do not delete a temporary fixture directory afterwards
+  --no-cleanup         leave the probe's item and attachments in the inventory
+
+Environment variables:
+- RUN_ONLINE: must be `1`. Nothing here mocks anything and it writes to a real
+  inventory, so it never runs by accident.
+- HA_BASE_URL: Home Assistant base URL. Default: http://localhost:8123
+- HA_TOKEN: long-lived access token (required)
+- HA_CONFIG_DIR: the Home Assistant config directory as this host sees it. Set
+  it when the config lives on a bind mount; leave it unset to read the stored
+  bytes through `docker exec`.
+- HA_CONTAINER: container to read stored bytes from. Default: home-assistant
+- HA_CONTAINER_CONFIG: config directory inside that container. Default: /config
+- HAV_UNREACHABLE_URL: a base URL that must refuse to connect, for the
+  presence-probe case. Default: http://127.0.0.1:9
+
+What this covers that no automated test can: the bytes that end up on Home
+Assistant's disk. Every scenario uploads through the real path — core's
+`/api/file_upload` handle consumed by `haventory/item/attachment/add` — and then
+reads the stored file back out of the config directory rather than trusting what
+the command reported.
+
+The preparation the card does in a canvas before uploading is mirrored here in
+Pillow, from the constants in `cards/haventory-card/src/ui/downscale.ts`. That
+mirror is part of the subject: if it and the card disagree about what should be
+sent, one of the two is wrong and this run is where that shows. What the
+browser's own canvas produces is the browser smoke's business; what survives the
+trip to disk is this file's.
+
+Type-checked manually — `scripts/` sits outside mypy's `files`:
+  uv run --group probes mypy scripts/probe_attachments.py
+
+Exit codes: 0 all probes passed, 1 a probe failed, 2 missing configuration,
+3 the instance stopped answering.
+"""
+
+# PLR2004: image dimensions, frame counts and HTTP statuses are the subject
+#   matter; naming each one would hide what a scenario asserts.
+# S603, S607: the stored bytes are read with `docker exec`, found on PATH, with
+#   a container name the operator supplied.
+# ruff: noqa: PLR2004, S603, S607
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from itertools import count
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+import aiohttp
+
+try:
+    from PIL import Image, ImageOps
+except ImportError:  # pragma: no cover - the group is opt-in
+    print("Pillow is missing. Install the probes group: uv sync --group probes", file=sys.stderr)
+    sys.exit(2)
+
+# Both helpers live in `scripts/`, which is the interpreter's own directory when
+# this file is run as a script.
+from probe_fixtures import generate as generate_fixtures
+
+# -----------------------------------------------------------------------------
+# Mirrors of what the card decides before an upload starts.
+# `cards/haventory-card/src/ui/downscale.ts` is the original; a divergence
+# between the two is a finding, because the card is what the backend ever sees.
+# -----------------------------------------------------------------------------
+
+DOWNSCALE_THRESHOLD_BYTES = 2 * 1024 * 1024
+MAX_IMAGE_EDGE = 2048
+# 0.85 through the canvas API, which takes a fraction where Pillow takes a
+# percentage.
+DOWNSCALE_QUALITY = 85
+# GIF is absent on purpose: a canvas holds one frame, so re-encoding an animated
+# GIF would keep the first and throw the rest away.
+RECODABLE: tuple[str, ...] = ("image/jpeg", "image/png", "image/webp")
+
+# Mirrors `media.py`: the stored name is derived from the sniffed type, which is
+# how a probe finds the file it just uploaded.
+MEDIA_SUBDIR = "haventory/attachments"
+EXTENSION_BY_MIME: dict[str, str] = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+    "application/pdf": ".pdf",
+}
+
+CONNECT_TIMEOUT_S = 10.0
+RECV_TIMEOUT_S = 30.0
+UNREACHABLE_TIMEOUT_S = 5.0
+
+# A minimal but genuine PDF. The backend sniffs the leading `%PDF-` marker, so a
+# file that merely claimed the type would be refused before it reached disk.
+PDF_BYTES = (
+    b"%PDF-1.4\n"
+    b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+    b"2 0 obj<</Type/Pages/Kids[]/Count 0>>endobj\n"
+    b"trailer<</Root 1 0 R>>\n"
+    b"%%EOF\n"
+)
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+DIM = "\033[2m"
+RESET = "\033[0m"
+
+
+class ProbeError(RuntimeError):
+    """A probe could not reach a verdict — setup, transport or the instance."""
+
+
+@dataclass
+class ProbeResult:
+    """One scenario's verdict, plus the numbers it reached it from."""
+
+    name: str
+    passed: bool
+    detail: str = ""
+    notes: list[str] = field(default_factory=list)
+
+
+# -----------------------------------------------------------------------------
+# Preparation — the card's re-encode rules, in Pillow
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Prepared:
+    """The file the card would actually upload for a given source file."""
+
+    data: bytes
+    filename: str
+    mime: str
+    recoded: bool
+
+
+def sniff_mime(head: bytes) -> str:
+    """Identify a fixture from its leading bytes, the way the backend does."""
+
+    if head.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if head.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
+        return "image/webp"
+    if head.startswith(b"%PDF-"):
+        return "application/pdf"
+    raise ProbeError("fixture is not one of the types the backend accepts")
+
+
+def scaled_size(width: int, height: int) -> tuple[int, int]:
+    """The box the frame fits into, capped at `MAX_IMAGE_EDGE`, aspect kept."""
+
+    longest = max(width, height)
+    if longest <= MAX_IMAGE_EDGE:
+        return width, height
+    ratio = MAX_IMAGE_EDGE / longest
+    return max(1, round(width * ratio)), max(1, round(height * ratio))
+
+
+def target_type(source_mime: str) -> str:
+    """A JPEG stays a JPEG; anything else becomes WebP so alpha survives."""
+
+    return "image/jpeg" if source_mime == "image/jpeg" else "image/webp"
+
+
+def rename_for(filename: str, mime: str) -> str:
+    """Same base name, extension swapped to match what was encoded."""
+
+    extension = ".jpg" if mime == "image/jpeg" else ".webp"
+    base = filename.rsplit(".", 1)[0] if "." in filename else filename
+    return f"{base or 'photo'}{extension}"
+
+
+def prepare_for_upload(path: Path) -> Prepared:
+    """What the card would send for this file.
+
+    Fails open exactly as the card does: anything that cannot be re-encoded, or
+    that came out no smaller, is uploaded untouched.
+    """
+
+    data = path.read_bytes()
+    mime = sniff_mime(data[:16])
+    if mime not in RECODABLE or len(data) <= DOWNSCALE_THRESHOLD_BYTES:
+        return Prepared(data, path.name, mime, recoded=False)
+
+    encoded = target_type(mime)
+    buffer = io.BytesIO()
+    with Image.open(io.BytesIO(data)) as source:
+        # The counterpart of the card's
+        # `createImageBitmap(file, {imageOrientation: 'from-image'})`: the
+        # re-encode drops the source's EXIF, so a frame not rotated before it is
+        # written is stored permanently on its side.
+        upright = ImageOps.exif_transpose(source)
+        if upright is None:  # pragma: no cover - only for an unreadable frame
+            raise ProbeError(f"could not decode {path.name}")
+        width, height = scaled_size(upright.width, upright.height)
+        resized = upright.resize((width, height), Image.Resampling.LANCZOS)
+        if encoded == "image/jpeg":
+            resized.convert("RGB").save(buffer, "JPEG", quality=DOWNSCALE_QUALITY)
+        else:
+            resized.convert("RGBA").save(buffer, "WEBP", quality=DOWNSCALE_QUALITY)
+
+    if buffer.tell() >= len(data):
+        return Prepared(data, path.name, mime, recoded=False)
+    return Prepared(buffer.getvalue(), rename_for(path.name, encoded), encoded, recoded=True)
+
+
+# -----------------------------------------------------------------------------
+# Talking to the instance
+# -----------------------------------------------------------------------------
+
+
+def _ws_url_from_base(base_url: str) -> str:
+    """Convert an HTTP(S) base URL to a WS(S) endpoint."""
+
+    base_url = base_url.rstrip("/")
+    if base_url.startswith("https://"):
+        return f"wss://{base_url[len('https://') :]}/api/websocket"
+    if base_url.startswith("http://"):
+        return f"ws://{base_url[len('http://') :]}/api/websocket"
+    return f"ws://{base_url}/api/websocket"
+
+
+class WsClient:
+    """Authenticated WebSocket connection that sends one command at a time."""
+
+    def __init__(self, session: aiohttp.ClientSession, base_url: str, token: str) -> None:
+        self._session = session
+        self._url = _ws_url_from_base(base_url)
+        self._token = token
+        self._ids = count(1)
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+
+    async def connect(self) -> None:
+        self._ws = await asyncio.wait_for(
+            self._session.ws_connect(
+                self._url, timeout=aiohttp.ClientWSTimeout(ws_receive=RECV_TIMEOUT_S)
+            ),
+            timeout=CONNECT_TIMEOUT_S,
+        )
+        await self._receive()
+        await self._ws.send_json({"type": "auth", "access_token": self._token})
+        auth = await self._receive()
+        if auth.get("type") != "auth_ok":
+            raise ProbeError(f"authentication refused: {auth}")
+
+    async def close(self) -> None:
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def _receive(self) -> dict[str, Any]:
+        if self._ws is None:  # pragma: no cover - defensive
+            raise ProbeError("websocket is not connected")
+        message: Any = await asyncio.wait_for(self._ws.receive_json(), timeout=RECV_TIMEOUT_S)
+        if not isinstance(message, dict):  # pragma: no cover - HA always sends objects
+            raise ProbeError(f"unexpected websocket frame: {message!r}")
+        return message
+
+    async def command(self, command_type: str, **payload: Any) -> dict[str, Any]:
+        """Send one command and return its result, raising on a refusal."""
+
+        if self._ws is None:  # pragma: no cover - defensive
+            raise ProbeError("websocket is not connected")
+        message_id = next(self._ids)
+        await self._ws.send_json({"id": message_id, "type": command_type, **payload})
+        while True:
+            reply = await self._receive()
+            if reply.get("id") != message_id or reply.get("type") != "result":
+                continue
+            if not reply.get("success"):
+                raise ProbeError(f"{command_type} refused: {reply.get('error')}")
+            result: Any = reply.get("result")
+            return result if isinstance(result, dict) else {}
+
+
+class StoredBytes:
+    """Reads an attachment back out of Home Assistant's config directory.
+
+    A bind-mounted config is read directly; otherwise the file comes out of the
+    container through `docker exec`. Either way the point is the same: assert
+    against the bytes on disk, not against what the command reported.
+    """
+
+    def __init__(self) -> None:
+        self.host_config = os.environ.get("HA_CONFIG_DIR")
+        self.container = os.environ.get("HA_CONTAINER", "home-assistant")
+        self.container_config = os.environ.get("HA_CONTAINER_CONFIG", "/config")
+
+    def describe(self) -> str:
+        if self.host_config:
+            return f"{self.host_config}/{MEDIA_SUBDIR}"
+        return f"{self.container_config}/{MEDIA_SUBDIR} in container {self.container}"
+
+    def read(self, item_id: str, attachment_id: str, mime: str) -> bytes:
+        relative = f"{MEDIA_SUBDIR}/{item_id}/{attachment_id}{EXTENSION_BY_MIME.get(mime, '')}"
+        if self.host_config:
+            path = Path(self.host_config) / relative
+            if not path.is_file():
+                raise ProbeError(f"no stored file at {path}")
+            return path.read_bytes()
+        completed = subprocess.run(
+            ["docker", "exec", self.container, "cat", f"{self.container_config}/{relative}"],
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise ProbeError(
+                f"could not read {relative} from container {self.container}: "
+                f"{completed.stderr.decode(errors='replace').strip()}"
+            )
+        return completed.stdout
+
+
+@dataclass
+class Probe:
+    """Everything a scenario needs, and the one item they all attach to."""
+
+    ws: WsClient
+    session: aiohttp.ClientSession
+    base: str
+    token: str
+    stored: StoredBytes
+    fixtures: Path
+    item_id: str = ""
+    seen: set[str] = field(default_factory=set)
+
+    @property
+    def auth(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def media_url(self, attachment_id: str) -> str:
+        return f"{self.base.rstrip('/')}/api/haventory/media/{self.item_id}/{attachment_id}"
+
+    async def attach(self, *, data: bytes, filename: str, kind: str) -> dict[str, Any]:
+        """Upload one file the way the card does and return its metadata.
+
+        The bytes ride core's `/api/file_upload`, which hands back a handle the
+        WebSocket command then consumes — they never cross the WebSocket itself.
+        The part declares `application/octet-stream` on purpose: every type the
+        backend records is one it sniffed, so declaring the real one here would
+        leave a probe unable to tell the two apart.
+        """
+
+        form = aiohttp.FormData()
+        form.add_field("file", data, filename=filename, content_type="application/octet-stream")
+        async with self.session.post(
+            f"{self.base.rstrip('/')}/api/file_upload", data=form, headers=self.auth
+        ) as response:
+            if response.status != 200:
+                raise ProbeError(f"file_upload answered {response.status}: {await response.text()}")
+            file_id = (await response.json())["file_id"]
+
+        item = await self.ws.command(
+            "haventory/item/attachment/add",
+            item_id=self.item_id,
+            file_id=file_id,
+            kind=kind,
+            filename=filename,
+        )
+        attachments: list[dict[str, Any]] = item["attachments"]
+        fresh = [entry for entry in attachments if entry["id"] not in self.seen]
+        self.seen.update(entry["id"] for entry in attachments)
+        if len(fresh) != 1:
+            raise ProbeError(f"expected one new attachment, the item reports {len(fresh)}")
+        return fresh[0]
+
+
+# -----------------------------------------------------------------------------
+# Scenarios
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UploadCase:
+    """One fixture and the shape its stored file has to have."""
+
+    name: str
+    fixture: str
+    recoded: bool
+    mime: str
+    size: tuple[int, int]
+    alpha: bool
+    frames: int
+    why: str
+
+
+UPLOAD_CASES: tuple[UploadCase, ...] = (
+    UploadCase(
+        name="oversized JPEG is downscaled to the 2048 cap",
+        fixture="photo_large.jpg",
+        recoded=True,
+        mime="image/jpeg",
+        size=(2048, 1536),
+        alpha=False,
+        frames=1,
+        why="a current phone writes 4-12 MB a frame, over the backend's 8 MB per-file cap",
+    ),
+    UploadCase(
+        name="EXIF Orientation=6 is applied before the re-encode",
+        fixture="photo_large_exif6.jpg",
+        recoded=True,
+        mime="image/jpeg",
+        # Upright: a 4032x3024 frame tagged 6 displays as 3024x4032, so the
+        # capped result is portrait. Landscape here means the tag was dropped
+        # rather than applied — which every automated test still calls a success.
+        size=(1536, 2048),
+        alpha=False,
+        frames=1,
+        why="the one defect here that looks correct in every test and wrong on every phone",
+    ),
+    UploadCase(
+        name="oversized PNG becomes WebP and keeps its transparency",
+        fixture="transparent_large.png",
+        recoded=True,
+        mime="image/webp",
+        size=(2048, 1536),
+        alpha=True,
+        frames=1,
+        why="flattening alpha onto an opaque canvas changes the picture, not just its size",
+    ),
+    UploadCase(
+        name="animated GIF is uploaded untouched, every frame intact",
+        fixture="animated.gif",
+        recoded=False,
+        mime="image/gif",
+        size=(240, 180),
+        alpha=False,
+        frames=24,
+        why="a canvas holds one frame, so re-encoding would keep the first and drop the rest",
+    ),
+    UploadCase(
+        name="sub-threshold JPEG round-trips byte-identical",
+        fixture="photo_small.jpg",
+        recoded=False,
+        mime="image/jpeg",
+        size=(800, 600),
+        alpha=False,
+        frames=1,
+        why="re-encoding is lossy and a file this size costs little to send as it is",
+    ),
+)
+
+
+def _frame_shape(data: bytes) -> tuple[tuple[int, int], bool, int]:
+    """Dimensions, whether the image carries alpha, and how many frames."""
+
+    with Image.open(io.BytesIO(data)) as image:
+        size = (image.width, image.height)
+        alpha = "A" in image.getbands() or "transparency" in image.info
+        frames = int(getattr(image, "n_frames", 1))
+    return size, alpha, frames
+
+
+async def probe_upload(probe: Probe, case: UploadCase) -> ProbeResult:  # noqa: PLR0911
+    """Upload one fixture and check what actually landed on disk."""
+
+    notes: list[str] = [case.why]
+    try:
+        source = probe.fixtures / case.fixture
+        original = source.read_bytes()
+        prepared = prepare_for_upload(source)
+        notes.append(
+            f"{case.fixture}: {len(original) / 1024 / 1024:.1f} MB -> "
+            f"{len(prepared.data) / 1024 / 1024:.2f} MB as {prepared.mime}"
+        )
+        if prepared.recoded != case.recoded:
+            verb = "re-encoded" if prepared.recoded else "passed through"
+            return ProbeResult(case.name, False, f"the card would have {verb} this file", notes)
+
+        attachment = await probe.attach(
+            data=prepared.data, filename=prepared.filename, kind="picture"
+        )
+        if attachment["mime"] != case.mime:
+            return ProbeResult(
+                case.name, False, f"stored as {attachment['mime']}, expected {case.mime}", notes
+            )
+
+        on_disk = probe.stored.read(probe.item_id, attachment["id"], attachment["mime"])
+        if on_disk != prepared.data:
+            return ProbeResult(
+                case.name,
+                False,
+                f"{len(on_disk)} bytes on disk against the {len(prepared.data)} uploaded",
+                notes,
+            )
+        if attachment["size"] != len(on_disk):
+            return ProbeResult(
+                case.name,
+                False,
+                f"reported {attachment['size']} bytes, {len(on_disk)} on disk",
+                notes,
+            )
+        if not case.recoded and on_disk != original:
+            return ProbeResult(case.name, False, "the untouched file did not arrive intact", notes)
+
+        size, alpha, frames = _frame_shape(on_disk)
+        notes.append(f"on disk: {size[0]}x{size[1]}, alpha={alpha}, frames={frames}")
+        if size != case.size:
+            return ProbeResult(
+                case.name, False, f"stored {size[0]}x{size[1]}, expected {case.size}", notes
+            )
+        if alpha != case.alpha:
+            return ProbeResult(case.name, False, f"alpha={alpha}, expected {case.alpha}", notes)
+        if frames != case.frames:
+            return ProbeResult(case.name, False, f"{frames} frames, expected {case.frames}", notes)
+        return ProbeResult(case.name, True, f"{len(on_disk)} bytes verified on disk", notes)
+    except TimeoutError:
+        # `TimeoutError` is an `OSError`, and an instance that stopped answering
+        # is a run that ended, not a probe with a verdict.
+        raise
+    except (ProbeError, OSError, KeyError) as err:
+        return ProbeResult(case.name, False, str(err), notes)
+
+
+async def probe_presence(probe: Probe) -> ProbeResult:
+    """The three answers the card's presence check has to tell apart.
+
+    A one-byte range settles whether a file is really there without pulling the
+    document down to ask. Only a 404 proves absence: a request that never
+    arrived must leave a document that opens perfectly well alone.
+    """
+
+    name = "presence probe answers 206 / 404 / nothing"
+    notes: list[str] = []
+    headers = {**probe.auth, "Range": "bytes=0-0"}
+    try:
+        attachment = await probe.attach(data=PDF_BYTES, filename="presence.pdf", kind="manual")
+        url = probe.media_url(attachment["id"])
+
+        async with probe.session.get(url, headers=headers) as live:
+            length = live.headers.get("Content-Length")
+            notes.append(f"live file: {live.status}, Content-Length {length}")
+            if live.status != 206 or length != "1":
+                return ProbeResult(
+                    name, False, "a live file did not answer 206 with one byte", notes
+                )
+
+        await probe.ws.command(
+            "haventory/item/attachment/remove",
+            item_id=probe.item_id,
+            attachment_id=attachment["id"],
+        )
+        async with probe.session.get(url, headers=headers) as gone:
+            notes.append(f"deleted file: {gone.status}")
+            if gone.status != 404:
+                return ProbeResult(name, False, f"a deleted file answered {gone.status}", notes)
+
+        unreachable = os.environ.get("HAV_UNREACHABLE_URL", "http://127.0.0.1:9").rstrip("/")
+        target = f"{unreachable}/api/haventory/media/{probe.item_id}/{attachment['id']}"
+        try:
+            async with probe.session.get(
+                target, headers=headers, timeout=aiohttp.ClientTimeout(total=UNREACHABLE_TIMEOUT_S)
+            ) as answered:
+                return ProbeResult(
+                    name, False, f"the unreachable host answered {answered.status}", notes
+                )
+        except aiohttp.ClientError, TimeoutError:
+            notes.append(f"unreachable host ({unreachable}): no status at all")
+        return ProbeResult(name, True, "206 live, 404 deleted, no answer unreachable", notes)
+    except TimeoutError:
+        raise
+    except (ProbeError, OSError, KeyError) as err:
+        return ProbeResult(name, False, str(err), notes)
+
+
+async def probe_content_disposition(probe: Probe) -> ProbeResult:
+    """A saved manual is named after the row that was clicked, and still opens.
+
+    Without the header a browser names the saved file after the last path
+    segment, which is the attachment id; `attachment` in place of `inline` would
+    turn the click into a download instead of opening the document in a tab.
+    """
+
+    name = "manuals are served inline under their title"
+    notes: list[str] = []
+    title = "Spülmaschine - Anleitung (DE)"
+    try:
+        attachment = await probe.attach(data=PDF_BYTES, filename="scan_0142.pdf", kind="manual")
+        url = probe.media_url(attachment["id"])
+
+        async with probe.session.get(url, headers=probe.auth) as untitled:
+            disposition = untitled.headers.get("Content-Disposition", "")
+        notes.append(f"untitled: {disposition}")
+        if not disposition.startswith("inline"):
+            return ProbeResult(name, False, "the response is not inline", notes)
+        if _rfc5987_filename(disposition) != "scan_0142.pdf":
+            return ProbeResult(name, False, "an untitled manual is not named after its file", notes)
+
+        await probe.ws.command(
+            "haventory/item/attachment/update",
+            item_id=probe.item_id,
+            attachment_id=attachment["id"],
+            title=title,
+        )
+        async with probe.session.get(url, headers=probe.auth) as titled:
+            disposition = titled.headers.get("Content-Disposition", "")
+        notes.append(f"titled: {disposition}")
+        if not disposition.startswith("inline"):
+            return ProbeResult(name, False, "the retitled response is not inline", notes)
+        served = _rfc5987_filename(disposition)
+        if served != title:
+            return ProbeResult(name, False, f"served as {served!r}, expected {title!r}", notes)
+        return ProbeResult(name, True, "the name follows the title, non-ASCII intact", notes)
+    except TimeoutError:
+        raise
+    except (ProbeError, OSError, KeyError) as err:
+        return ProbeResult(name, False, str(err), notes)
+
+
+def _rfc5987_filename(disposition: str) -> str:
+    """Decode the `filename*=UTF-8''…` half — the one a browser reads."""
+
+    marker = "filename*=UTF-8''"
+    if marker not in disposition:
+        raise ProbeError(f"no RFC 5987 filename in {disposition!r}")
+    return unquote(disposition.split(marker, 1)[1])
+
+
+# -----------------------------------------------------------------------------
+# Run
+# -----------------------------------------------------------------------------
+
+
+def print_results(results: list[ProbeResult]) -> None:
+    print()
+    for result in results:
+        mark = f"{GREEN}PASS{RESET}" if result.passed else f"{RED}FAIL{RESET}"
+        print(f"[{mark}] {result.name}")
+        for note in result.notes:
+            print(f"       {DIM}{note}{RESET}")
+        if result.detail:
+            print(f"       {result.detail}")
+    passed = sum(1 for result in results if result.passed)
+    print(f"\n{passed}/{len(results)} probes passed")
+
+
+async def _run_scenarios(probe: Probe) -> list[ProbeResult]:
+    results = [await probe_upload(probe, case) for case in UPLOAD_CASES]
+    results.append(await probe_presence(probe))
+    results.append(await probe_content_disposition(probe))
+    return results
+
+
+async def run_probes(args: argparse.Namespace) -> int:
+    if os.environ.get("RUN_ONLINE") != "1":
+        print("Set RUN_ONLINE=1: this writes to a real inventory.", file=sys.stderr)
+        return 2
+    token = os.environ.get("HA_TOKEN")
+    if not token:
+        print("Missing HA_TOKEN in environment", file=sys.stderr)
+        return 2
+    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
+
+    temporary = args.fixtures_dir is None
+    fixtures = (
+        Path(args.fixtures_dir) if args.fixtures_dir else Path(tempfile.mkdtemp("-haventory"))
+    )
+    stored = StoredBytes()
+    results: list[ProbeResult] = []
+
+    try:
+        print(f"Generating fixtures in {fixtures} ...")
+        generate_fixtures(fixtures)
+        print(f"Reading stored bytes from {stored.describe()}")
+
+        async with aiohttp.ClientSession() as session:
+            ws = WsClient(session, base, token)
+            await ws.connect()
+            probe = Probe(
+                ws=ws, session=session, base=base, token=token, stored=stored, fixtures=fixtures
+            )
+            item = await ws.command("haventory/item/create", name="probe_attachments")
+            probe.item_id = str(item["id"])
+            print(f"Probing against item {probe.item_id}")
+            try:
+                results = await _run_scenarios(probe)
+            finally:
+                if args.no_cleanup:
+                    print(f"Leaving item {probe.item_id} in place (--no-cleanup)")
+                else:
+                    await ws.command("haventory/item/delete", item_id=probe.item_id)
+                await ws.close()
+    except TimeoutError:
+        print("The instance stopped answering", file=sys.stderr)
+        return 3
+    except ProbeError as err:
+        print(f"Could not run the probes: {err}", file=sys.stderr)
+        return 2
+    except aiohttp.ClientError as err:
+        print(f"Could not reach {base}: {err}", file=sys.stderr)
+        return 2
+    finally:
+        if temporary and not args.keep_fixtures:
+            shutil.rmtree(fixtures, ignore_errors=True)
+        elif temporary:
+            print(f"Fixtures kept in {fixtures}")
+
+    print_results(results)
+    return 0 if all(result.passed for result in results) else 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="HAventory attachment probes (online)")
+    parser.add_argument("--fixtures-dir", help="reuse or write the generated fixtures here")
+    parser.add_argument(
+        "--keep-fixtures", action="store_true", help="keep a temporary fixture directory"
+    )
+    parser.add_argument(
+        "--no-cleanup", action="store_true", help="leave the probe item in the inventory"
+    )
+    args = parser.parse_args()
+    try:
+        code = asyncio.run(run_probes(args))
+    except KeyboardInterrupt:
+        code = 130
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_fixtures.py
+++ b/scripts/probe_fixtures.py
@@ -1,0 +1,207 @@
+r"""Generate the image fixtures the attachment probes upload.
+
+Usage:
+  uv sync --group probes
+  uv run --group probes python scripts/probe_fixtures.py --out /tmp/haventory-fixtures
+
+Options:
+  --out DIR    where to write the fixtures (created if absent; required)
+  --force      overwrite fixtures that are already there
+
+Environment variables: none — everything is an argument.
+
+The five frames are what the attachment path has to survive: an oversized
+photographic JPEG, the same frame carrying an EXIF orientation tag, an oversized
+PNG with real transparency, an animated GIF, and a small JPEG that must arrive
+byte for byte. Together they are ~20 MB, which is why they are generated and
+never committed — and generating them is also the only way the orientation tag
+is readable rather than buried in a blob. That case is the one attachment defect
+that looks correct in every automated test and wrong on every phone.
+
+Pillow lives in the non-default ``probes`` dependency group: the integration
+itself does not depend on it and does not want to, so a plain ``uv sync`` must
+not pull it in.
+
+Type-checked manually — ``scripts/`` sits outside mypy's ``files``:
+  uv run --group probes mypy scripts/probe_fixtures.py
+
+Exit codes: 0 written, 2 Pillow missing or the output directory unusable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover - the group is opt-in
+    print(
+        "Pillow is missing. Install the probes group: uv sync --group probes",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+# EXIF tag 0x0112. Value 6 means "rotate 90° clockwise to display", which is what
+# a phone held upright writes rather than rotating 12 megapixels on the device.
+EXIF_ORIENTATION_TAG = 0x0112
+EXIF_ORIENTATION_ROTATE_90_CW = 6
+
+# Grain strength for the synthetic frames. High enough that JPEG and PNG cannot
+# compress the result away: a fixture that lands under the card's 2 MiB
+# re-encode threshold would silently stop testing the re-encode.
+GRAIN_SIGMA = 64.0
+GRAIN_WEIGHT = 0.55
+
+# Longest edge of the two oversized frames. Both are past the card's 2048 cap,
+# so a probe can tell a real downscale from a file that was passed through.
+LARGE_PHOTO_SIZE = (4032, 3024)
+LARGE_PNG_SIZE = (2400, 1800)
+SMALL_PHOTO_SIZE = (800, 600)
+GIF_SIZE = (240, 180)
+GIF_FRAMES = 24
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """One generated file and what makes it interesting."""
+
+    name: str
+    purpose: str
+
+
+FIXTURES: tuple[Fixture, ...] = (
+    Fixture("photo_large.jpg", "4032x3024 photographic JPEG, past the re-encode threshold"),
+    Fixture("photo_large_exif6.jpg", "the same frame with EXIF Orientation=6"),
+    Fixture("transparent_large.png", "2400x1800 RGBA PNG, transparency that must survive"),
+    Fixture("animated.gif", f"{GIF_FRAMES}-frame GIF, never re-encoded (a canvas holds one frame)"),
+    Fixture("photo_small.jpg", "sub-threshold JPEG that must round-trip byte-identical"),
+)
+
+
+def _photographic(size: tuple[int, int]) -> Image.Image:
+    """A frame with camera-like entropy: smooth gradients under fine grain.
+
+    Flat colour would compress to nothing, and a file small enough to skip the
+    card's re-encode tests the opposite of what it was generated for.
+    """
+
+    bands = []
+    for gradient in (
+        Image.linear_gradient("L"),
+        Image.radial_gradient("L"),
+        Image.linear_gradient("L").transpose(Image.Transpose.ROTATE_90),
+    ):
+        smooth = gradient.resize(size, Image.Resampling.BICUBIC)
+        grain = Image.effect_noise(size, GRAIN_SIGMA)
+        bands.append(Image.blend(smooth, grain, GRAIN_WEIGHT))
+    return Image.merge("RGB", bands)
+
+
+def _write_large_photo(target: Path) -> None:
+    frame = _photographic(LARGE_PHOTO_SIZE)
+    frame.save(target, "JPEG", quality=92)
+
+
+def _write_large_photo_with_orientation(target: Path, source: Path) -> None:
+    """The same frame, tagged the way a phone tags a portrait shot.
+
+    The tag is set here rather than copied from a real photo so the value is
+    readable: a viewer that honours it shows 3024x4032, and anything that
+    re-encodes without applying it first stores the picture on its side.
+    """
+
+    with Image.open(source) as frame:
+        exif = frame.getexif()
+        exif[EXIF_ORIENTATION_TAG] = EXIF_ORIENTATION_ROTATE_90_CW
+        frame.save(target, "JPEG", quality=92, exif=exif.tobytes())
+
+    with Image.open(target) as written:
+        stored = written.getexif().get(EXIF_ORIENTATION_TAG)
+    if stored != EXIF_ORIENTATION_ROTATE_90_CW:
+        raise RuntimeError(f"orientation tag did not survive the save: {stored!r}")
+
+
+def _write_transparent_png(target: Path) -> None:
+    """Noise under a radial alpha ramp — translucent, not merely masked."""
+
+    colour = _photographic(LARGE_PNG_SIZE)
+    alpha = Image.radial_gradient("L").resize(LARGE_PNG_SIZE, Image.Resampling.BICUBIC)
+    colour.putalpha(Image.eval(alpha, lambda level: 255 - level))
+    colour.save(target, "PNG")
+
+
+def _write_animated_gif(target: Path) -> None:
+    """A shape crossing the frame, so a dropped frame is visible, not inferred."""
+
+    width, height = GIF_SIZE
+    frames = []
+    for index in range(GIF_FRAMES):
+        frame = Image.new("RGB", GIF_SIZE, (16, 16, 32))
+        left = int(index * (width - 40) / (GIF_FRAMES - 1))
+        frame.paste((240, 120, 0), (left, height // 3, left + 40, height // 3 + 40))
+        frames.append(frame.convert("P", palette=Image.Palette.ADAPTIVE))
+    frames[0].save(target, "GIF", save_all=True, append_images=frames[1:], duration=60, loop=0)
+
+
+def _write_small_photo(target: Path) -> None:
+    _photographic(SMALL_PHOTO_SIZE).save(target, "JPEG", quality=85)
+
+
+def generate(out_dir: Path, *, force: bool = False) -> list[Path]:
+    """Write every fixture into ``out_dir`` and return the paths."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+
+    large = out_dir / "photo_large.jpg"
+    if force or not large.is_file():
+        _write_large_photo(large)
+    written.append(large)
+
+    oriented = out_dir / "photo_large_exif6.jpg"
+    if force or not oriented.is_file():
+        _write_large_photo_with_orientation(oriented, large)
+    written.append(oriented)
+
+    png = out_dir / "transparent_large.png"
+    if force or not png.is_file():
+        _write_transparent_png(png)
+    written.append(png)
+
+    gif = out_dir / "animated.gif"
+    if force or not gif.is_file():
+        _write_animated_gif(gif)
+    written.append(gif)
+
+    small = out_dir / "photo_small.jpg"
+    if force or not small.is_file():
+        _write_small_photo(small)
+    written.append(small)
+
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate HAventory attachment fixtures")
+    parser.add_argument("--out", required=True, help="directory to write the fixtures into")
+    parser.add_argument("--force", action="store_true", help="overwrite existing fixtures")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out)
+    try:
+        paths = generate(out_dir, force=bool(args.force))
+    except OSError as err:
+        print(f"Could not write fixtures to {out_dir}: {err}", file=sys.stderr)
+        sys.exit(2)
+
+    purposes = {fixture.name: fixture.purpose for fixture in FIXTURES}
+    for path in paths:
+        print(f"{path}  ({path.stat().st_size / 1024 / 1024:.1f} MB) — {purposes[path.name]}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -18,7 +18,7 @@ from urllib.parse import unquote
 
 from aiohttp import FormData
 from custom_components.haventory import media
-from custom_components.haventory.const import DOMAIN, MEDIA_SUBDIR
+from custom_components.haventory.const import DOMAIN, MEDIA_NAME_TOKEN_PARAM, MEDIA_SUBDIR
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -379,6 +379,51 @@ async def test_a_pdf_round_trips_as_a_manual_and_can_be_retitled(
     non_ascii = await client.get(url)
     served = _rfc5987_filename(non_ascii.headers["Content-Disposition"])
     assert served == "Spülmaschine - Anleitung (DE)"
+
+
+async def test_only_a_name_versioned_url_may_be_cached(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+) -> None:
+    """A retitle rewrites the served name for a URL that did not change.
+
+    The card versions its URL by that name, so its responses can be held for as
+    long as the bytes live. A URL without the token has no way to say which name
+    it was fetched under, and a browser that stored one would keep saving the
+    file under a title the user has already replaced — for the half hour a
+    signature lives, which is not a window anyone waits out.
+    """
+
+    await _setup(hass)
+    client = await hass_client()
+    ws = await hass_ws_client(hass)
+    item = await _create_item(ws)
+
+    file_id = await _upload(client, PDF_BYTES, "scan_0142.pdf")
+    await ws.send_json(
+        {
+            "id": 2,
+            "type": "haventory/item/attachment/add",
+            "item_id": item["id"],
+            "file_id": file_id,
+            "filename": "scan_0142.pdf",
+            "kind": "manual",
+        }
+    )
+    added = await ws.receive_json()
+    assert added["success"] is True, added
+    attachment = added["result"]["attachments"][0]
+
+    url = f"/api/haventory/media/{item['id']}/{attachment['id']}"
+    plain = await client.get(url)
+    assert plain.status == HTTPStatus.OK
+    assert plain.headers["Cache-Control"] == "private, no-store"
+
+    versioned = await client.get(f"{url}?{MEDIA_NAME_TOKEN_PARAM}=abc123")
+    assert versioned.status == HTTPStatus.OK
+    assert "immutable" in versioned.headers["Cache-Control"]
+    # The token is a cache key, never a lookup: the file it names is the one the
+    # two path segments name, whatever the token says.
+    assert await versioned.read() == PDF_BYTES
 
 
 async def test_a_pdf_is_refused_as_a_picture(

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from http import HTTPStatus
 from pathlib import Path
+from urllib.parse import unquote
 
 from aiohttp import FormData
 from custom_components.haventory import media
@@ -69,6 +70,18 @@ async def _upload(client, content: bytes = PNG_BYTES, filename: str = "drill.png
     return (await response.json())["file_id"]
 
 
+def _rfc5987_filename(disposition: str) -> str:
+    """Decode the ``filename*=UTF-8''…`` half of a Content-Disposition value.
+
+    The half a current browser reads, and the only one that can carry a name
+    outside US-ASCII.
+    """
+
+    marker = "filename*=UTF-8''"
+    assert marker in disposition, disposition
+    return unquote(disposition.split(marker, 1)[1])
+
+
 async def _create_item(ws_client, name: str = "Drill") -> dict:
     await ws_client.send_json({"id": 1, "type": "haventory/item/create", "name": name})
     result = await ws_client.receive_json()
@@ -111,6 +124,11 @@ async def test_a_real_png_round_trips_through_upload_and_the_view(
     assert served.headers["Content-Type"].startswith("image/png")
     # The bytes are user-supplied, so the browser must not decide otherwise.
     assert served.headers["X-Content-Type-Options"] == "nosniff"
+    # Without a disposition the browser saves the file under the last path
+    # segment, which is the attachment id. `inline` keeps the click opening it.
+    disposition = served.headers["Content-Disposition"]
+    assert disposition.startswith("inline;")
+    assert 'filename="drill.png"' in disposition
     assert await served.read() == PNG_BYTES
 
 
@@ -290,7 +308,8 @@ async def test_a_pdf_round_trips_as_a_manual_and_can_be_retitled(
 
     The retitle is asserted here rather than offline because only a real core
     writes the change back through ``Store`` and hands the card the item it
-    then renders from.
+    then renders from — and because the served name follows the title, which is
+    a response header no offline test has a transport for.
     """
 
     await _setup(hass)
@@ -318,6 +337,10 @@ async def test_a_pdf_round_trips_as_a_manual_and_can_be_retitled(
     assert attachment["title"] == ""
     assert attachment["order"] == 0
 
+    url = f"/api/haventory/media/{item['id']}/{attachment['id']}"
+    untitled = await client.get(url)
+    assert _rfc5987_filename(untitled.headers["Content-Disposition"]) == "scan_0142.pdf"
+
     await ws.send_json(
         {
             "id": 3,
@@ -333,10 +356,29 @@ async def test_a_pdf_round_trips_as_a_manual_and_can_be_retitled(
     # The filename is what the bytes arrived as and is never rewritten.
     assert retitled["result"]["attachments"][0]["filename"] == "scan_0142.pdf"
 
-    served = await client.get(f"/api/haventory/media/{item['id']}/{attachment['id']}")
+    served = await client.get(url)
     assert served.status == HTTPStatus.OK
     assert served.headers["Content-Type"].startswith("application/pdf")
+    disposition = served.headers["Content-Disposition"]
+    assert disposition.startswith("inline;")
+    assert _rfc5987_filename(disposition) == "Dishwasher manual (EN)"
     assert await served.read() == PDF_BYTES
+
+    # A title outside US-ASCII is the case the quoted `filename` cannot carry.
+    await ws.send_json(
+        {
+            "id": 4,
+            "type": "haventory/item/attachment/update",
+            "item_id": item["id"],
+            "attachment_id": attachment["id"],
+            "title": "Spülmaschine - Anleitung (DE)",
+        }
+    )
+    assert (await ws.receive_json())["success"] is True
+
+    non_ascii = await client.get(url)
+    served = _rfc5987_filename(non_ascii.headers["Content-Disposition"])
+    assert served == "Spülmaschine - Anleitung (DE)"
 
 
 async def test_a_pdf_is_refused_as_a_picture(

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -31,6 +31,7 @@ from custom_components.haventory.const import (
     CONF_CARD_TITLE,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
+    MEDIA_NAME_TOKEN_PARAM,
     MEDIA_URL_TEMPLATE,
     PANEL_ELEMENT_NAME,
     PANEL_ICON,
@@ -781,6 +782,24 @@ def test_the_card_builds_media_urls_on_the_route_the_backend_serves() -> None:
     assert match is not None, "MEDIA_URL_TEMPLATE is no longer declared in media.ts"
 
     assert match.group(1) == MEDIA_URL_TEMPLATE
+
+
+def test_the_card_versions_media_urls_under_the_parameter_the_backend_reads() -> None:
+    """The name-token parameter is a constant on both sides and checked by neither.
+
+    Drift here fails silently in the direction that matters least at first: the
+    card keeps working, the backend simply stops seeing the token and serves
+    every attachment uncacheable. The visible symptom is a photo grid that
+    refetches on every render, which reads as a performance problem rather than
+    a renamed constant.
+    """
+    source = (REPO_ROOT / "cards" / "haventory-card" / "src" / "ui" / "media.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"^export const MEDIA_NAME_TOKEN_PARAM = '([^']+)';$", source, re.MULTILINE)
+    assert match is not None, "MEDIA_NAME_TOKEN_PARAM is no longer declared in media.ts"
+
+    assert match.group(1) == MEDIA_NAME_TOKEN_PARAM
 
 
 def test_every_status_icon_has_a_glyph_in_the_bundle() -> None:

--- a/tests/test_media_offline.py
+++ b/tests/test_media_offline.py
@@ -12,6 +12,7 @@ Scenarios:
 - a file over the byte cap is refused, and an empty one too
 - the 11th picture on an item is refused
 - an id no metadata claims resolves to nothing
+- the served name follows title-then-filename, and no title can break the header
 - the sweep deletes an unreferenced file and keeps a referenced one
 - the sweep refuses a path resolving outside the media root
 """
@@ -191,6 +192,93 @@ def test_the_stored_extension_comes_from_the_sniffed_type(tmp_path: Path) -> Non
 
     assert path.name == "att.jpg"
     assert path.parent.name == "item"
+
+
+# -----------------------------
+# The served filename
+# -----------------------------
+
+
+def _disposition(*, filename: str = "photo.png", title: str = "") -> str:
+    meta = _meta()
+    meta.filename = filename
+    meta.title = title
+    return media._content_disposition(meta)
+
+
+def test_the_disposition_is_inline_and_names_the_uploaded_file() -> None:
+    """Saving is named; opening stays opening — `attachment` would download."""
+
+    value = _disposition(filename="bosch_smsec.pdf")
+
+    assert value.startswith("inline;")
+    assert 'filename="bosch_smsec.pdf"' in value
+    assert "filename*=UTF-8''bosch_smsec.pdf" in value
+
+
+def test_a_title_wins_over_the_filename_and_blank_space_does_not() -> None:
+    assert 'filename="Dishwasher manual"' in _disposition(
+        filename="scan_0142.pdf", title="Dishwasher manual"
+    )
+    assert 'filename="scan_0142.pdf"' in _disposition(filename="scan_0142.pdf", title="   ")
+
+
+def test_a_non_ascii_title_survives_in_the_rfc_5987_form() -> None:
+    """The percent-encoded half is the one a current browser reads."""
+
+    value = _disposition(title="Bedienungsanleitung Kühlschrank")
+
+    assert "filename*=UTF-8''Bedienungsanleitung%20K%C3%BChlschrank" in value
+    # The quoted fallback is ASCII-only, so the umlaut is dropped there.
+    assert 'filename="Bedienungsanleitung Khlschrank"' in value
+
+
+def test_a_title_of_only_non_ascii_characters_falls_back_to_the_attachment_id() -> None:
+    meta = _meta()
+    meta.title = "説明書"
+
+    value = media._content_disposition(meta)
+
+    assert f'filename="{meta.id}"' in value
+    assert "filename*=UTF-8''%E8%AA%AC%E6%98%8E%E6%9B%B8" in value
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        'evil"; filename="owned.exe',
+        "line\r\nX-Injected: yes",
+        "back\\slash",
+    ],
+)
+def test_the_header_value_cannot_be_broken_out_of(title: str) -> None:
+    """A stored title is user text and this value is a response header."""
+
+    value = _disposition(title=title)
+    _, quoted = value.split('filename="', 1)
+    quoted_name, rest = quoted.split('"', 1)
+
+    assert "\r" not in value
+    assert "\n" not in value
+    assert '"' not in quoted_name
+    assert "\\" not in quoted_name
+    # Nothing after the quoted name opens a parameter, or a header, of its own.
+    assert '"' not in rest
+
+
+def test_an_untitled_upload_with_no_filename_is_named_by_its_id() -> None:
+    """`item/attachment/add` stores the attachment id when the client sent no name."""
+
+    meta = _meta()
+    meta.filename = str(meta.id)
+
+    assert f'filename="{meta.id}"' in media._content_disposition(meta)
+
+
+def test_an_overlong_name_is_truncated_rather_than_sent_whole() -> None:
+    value = _disposition(title="x" * 500)
+
+    assert f'filename="{"x" * media.DISPOSITION_NAME_MAX_CHARS}"' in value
 
 
 # -----------------------------

--- a/tests/test_media_offline.py
+++ b/tests/test_media_offline.py
@@ -13,6 +13,7 @@ Scenarios:
 - the 11th picture on an item is refused
 - an id no metadata claims resolves to nothing
 - the served name follows title-then-filename, and no title can break the header
+- only a URL versioned by that name may be cached, because the name can change
 - the sweep deletes an unreferenced file and keeps a referenced one
 - the sweep refuses a path resolving outside the media root
 """
@@ -27,6 +28,7 @@ from custom_components.haventory import media
 from custom_components.haventory.const import (
     MAX_ATTACHMENT_BYTES,
     MAX_PICTURES_PER_ITEM,
+    MEDIA_NAME_TOKEN_PARAM,
 )
 from custom_components.haventory.exceptions import ValidationError
 from custom_components.haventory.models import (
@@ -279,6 +281,36 @@ def test_an_overlong_name_is_truncated_rather_than_sent_whole() -> None:
     value = _disposition(title="x" * 500)
 
     assert f'filename="{"x" * media.DISPOSITION_NAME_MAX_CHARS}"' in value
+
+
+class _Request:
+    """Just the query mapping ``_cache_control`` reads off a real request."""
+
+    def __init__(self, **query: str) -> None:
+        self.query = query
+
+
+def test_a_url_versioned_by_name_may_be_held_indefinitely() -> None:
+    """The bytes never change, and this URL says which name they were fetched under."""
+
+    value = media._cache_control(_Request(**{MEDIA_NAME_TOKEN_PARAM: "1x2y3z"}))
+
+    assert "immutable" in value
+    assert "max-age=31536000" in value
+
+
+def test_a_url_not_versioned_by_name_is_not_stored_at_all() -> None:
+    """A retitle rewrites `Content-Disposition` for a URL that did not change.
+
+    Reusing such a response is what makes a retitled file save under its old
+    name, and a signed URL outlives the retitle by half an hour — so the answer
+    cannot be kept at all rather than merely revalidated.
+    """
+
+    value = media._cache_control(_Request())
+
+    assert value == "private, no-store"
+    assert "immutable" not in value
 
 
 # -----------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,9 @@ dev = [
     { name = "ruff" },
     { name = "voluptuous" },
 ]
+probes = [
+    { name = "pillow" },
+]
 
 [package.metadata]
 
@@ -283,6 +286,7 @@ dev = [
     { name = "ruff", specifier = "==0.15.22" },
     { name = "voluptuous" },
 ]
+probes = [{ name = "pillow" }]
 
 [[package]]
 name = "identify"
@@ -456,6 +460,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload-time = "2026-07-01T11:55:37.941Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload-time = "2026-07-01T11:55:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
+    { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
+    { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Work package **P8** of the v0.4.0 UI-audit remediation plan (`dev/ui_audit_v040_fix_plan.md`) — items **I300** and **I303**.

**I300 — the media view names the file it serves.** `HaventoryMediaView.get` sent `Content-Type`, `nosniff` and `Cache-Control` but no `Content-Disposition`, so a browser saving a manual fell back to the URL's last path segment: the attachment UUID. Responses now carry a `_content_disposition(meta)` value:

- **`inline`, never `attachment`** — clicking still opens the document in a tab; the header only names what gets saved from there.
- Filename precedence mirrors the card's `attachmentTitle()`: `title.strip() || filename`, so the saved file matches the row that was clicked.
- Both halves are user text under **no charset restriction** (a title may hold CR/LF or quotes; a filename may itself be the attachment UUID). The real name travels percent-encoded as RFC 5987 `filename*=UTF-8''…`; beside it a quoted `filename` reduced to printable US-ASCII without `"` or `\`, which is what stops a title from splitting the header. A name with nothing printable in ASCII falls back to the attachment id there — the same name such a client would have taken from the URL — while `filename*` still carries the real one. Names are capped at 200 characters so an unbounded filename cannot produce a header a client refuses.
- `web.FileResponse` still handles `Range`, so the card's `bytes=0-0` → `206` presence probe is untouched; the header rides along.

**I303 — the attachment probes land in `scripts/`.** Two helpers in the house genre (`ws_probe.py`'s docstring/env-var/exit-code shape, `stress_test.py`'s multi-scenario dataclass shape), named `probe_*` so a bare `pytest` cannot collect them:

- `probe_fixtures.py` generates the frames and never commits them (~30 MB): a 4032×3024 photographic JPEG, the same frame with EXIF `Orientation=6` set explicitly in code, a 2400×1800 transparent PNG, a 24-frame animated GIF, and a sub-2 MiB JPEG.
- `probe_attachments.py` uploads through the real path (core's `/api/file_upload` handle consumed by `haventory/item/attachment/add`) and asserts the **bytes on Home Assistant's disk** — read via `HA_CONFIG_DIR` or `docker exec` — not what the command reported. It mirrors `ui/downscale.ts`'s constants in Pillow (2 MiB threshold, 2048 max edge, quality 0.85, `RECODABLE` without GIF, JPEG→JPEG else→WebP, EXIF applied before the re-encode) and compares dimensions, alpha and frame count; asserts the `206` / `404` / no-answer presence semantics; and asserts the new `Content-Disposition` end to end, including a non-ASCII title. Opt-in and online-only (`RUN_ONLINE=1`, `HA_BASE_URL`, `HA_TOKEN`).
- Pillow arrives as a **non-default `probes` dependency group**, so `uv sync` stays lean and the backend's documented Pillow-free stance (`const.py`, README) holds. `scripts/` stays out of mypy's `files`; both probes pass `uv run --group probes mypy scripts/<name>.py` (noted in their docstrings) and ruff's `scripts/` run, with a file-level pragma naming each suppressed code.
- Wiring so [#276](https://github.com/chrreiter/HAventory/issues/276) inherits the method: `dev/release_testing_plan.md` group A gains rows **A6–A9**, and the helpers are listed in `README.md` and `CLAUDE.md`.

Closes #300
Closes #303

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (746 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1277 passed), `npm run build` — all green, untouched by this PR.
- [x] `uv run --group probes mypy scripts/probe_attachments.py scripts/probe_fixtures.py` — clean.
- [x] Fixture generation and the re-encode mirror were run for real here: all five cases produce exactly the shape their `UploadCase` declares, including the EXIF case landing **portrait 1536×2048** rather than landscape.

New offline coverage (`tests/test_media_offline.py`): the header helper is a pure function, so title-over-filename precedence, whitespace-only titles, non-ASCII, a title of only non-ASCII characters, `"`/`\`/CR-LF injection attempts, the UUID-filename case and the length cap are all asserted without an HTTP layer.

**Delegated to the local pass — the integration suite could not run in this remote session.** `scripts/test_integration.sh` fails to provision: uv's Python index here offers only `cpython-3.14.0rc2`, and `homeassistant==2026.6.0` requires `Python>=3.14.2`. The HTTP-level `Content-Disposition` assertions added to `tests/integration/test_attachments.py` — `inline` plus the filename on the PNG block, and the header following the title through a retitle including a non-ASCII round trip decoded per RFC 5987 — are therefore written but unexecuted. That is an environment limitation, not a repo defect.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`docs/backend_api_contract.md` media section, `README.md`, `CLAUDE.md`, `dev/release_testing_plan.md`).
- [x] No WebSocket command shape changed; only the media route's response headers, documented in `docs/backend_api_contract.md`.
- [x] Essential invariants preserved — no model, repository or storage change in this PR.
- [x] No file inside `custom_components/haventory/` deleted or renamed, so no `RETIRED_PATHS` entry.
- [x] No version number hand-edited; `uv.lock` changed only by `uv lock` adding the `probes` group.

## Screenshots (card / UI changes)

None — backend and tooling only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7fprPJuXdGrW4L5xRpZPf)_