### PR TITLE
fix(card): sticky name column, name-first table layout, anchored document marker

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -65,20 +65,17 @@ describe('hv-data-table: narrow screens', () => {
     expect(css).toMatch(/:host \{[^}]*min-width: 0/);
   });
 
-  // Making the host the sideways scroller was not enough on its own: the rows
-  // live in a vertical scroll box inside it, declaring overflow on one axis
-  // makes the other compute to auto, and that box is exactly as wide as its own
-  // content. So a horizontal swipe starting over a row landed on a scroll
-  // container with nothing to scroll, and `overscroll-behavior: contain` on
-  // both axes meant it was not handed on either. The host measured scrollWidth
-  // 874 against clientWidth 390 and never moved off scrollLeft 0.
-  it('contains the vertical overscroll only, so a sideways swipe reaches the host', () => {
+  // A swipe that runs out of table must not scroll the dashboard behind this
+  // surface, on either axis — and with one scroll container there is one place
+  // to say so. Split across two boxes it was the row group that swallowed the
+  // sideways gesture: it is exactly as wide as its own content, so it had
+  // nothing to scroll and contained the overscroll rather than handing it on.
+  // The host measured scrollWidth 874 against clientWidth 390 and never moved
+  // off scrollLeft 0.
+  it('contains the overscroll on the box that owns both axes', () => {
     const css = tableCss();
-    expect(css).toMatch(/\.body \{[^}]*overscroll-behavior-y: contain/);
-    expect(css).not.toMatch(/\.body \{[^}]*overscroll-behavior: contain/);
-    // The host still contains its own, which is what keeps a flick that runs
-    // out of table off the dashboard behind it.
-    expect(css).toMatch(/:host \{[^}]*overscroll-behavior-x: contain/);
+    expect(css).toMatch(/:host \{[^}]*overscroll-behavior: contain/);
+    expect(css).not.toMatch(/\.body \{[^}]*overscroll-behavior/);
   });
 
   it('sizes the header and body to the grid minimum so they scroll together', () => {
@@ -98,10 +95,82 @@ describe('hv-data-table: narrow screens', () => {
     expect(tableCss()).toMatch(/\.head button\.sort \{[^}]*min-height: var\(--hv-tap-min, auto\)/);
   });
 
-  it('keeps rows scrolling vertically inside the body', () => {
-    // The horizontal scroller is the host; the body stays the vertical one, so
-    // the header does not scroll away with the rows.
-    expect(tableCss()).toMatch(/\.body \{[^}]*overflow-y: auto/);
+  // jsdom computes no layout, so nothing here can watch a cell hold its place;
+  // what is assertable is that the rules resolve against the box that scrolls.
+  // A sticky cell resolves its offsets against the nearest scroll container, so
+  // rows in a vertical scroll box of their own would pin `left` to a box that
+  // never moves sideways — passing every offline check while doing nothing.
+  it('scrolls both axes on one box, so a pinned cell has something to pin to', () => {
+    const css = tableCss();
+    expect(css).toMatch(/:host \{[^}]*overflow-y: auto/);
+    expect(css).not.toMatch(/\.body \{[^}]*overflow/);
+    // Its own height rather than the leftover space, or it would stretch to the
+    // visible height and leave the scroll nothing to move.
+    expect(css).toMatch(/\.body \{ flex: none; \}/);
+  });
+
+  it('holds the header against the top of that same box', () => {
+    const css = tableCss();
+    expect(css).toMatch(/\.head \{[^}]*position: sticky/);
+    expect(css).toMatch(/\.head \{[^}]*top: 0/);
+    // Opaque, or the rows read through it as they pass underneath.
+    expect(css).toMatch(/\.head \{[^}]*background: var\(--hv-surface\)/);
+  });
+
+  it('pins the name column and its header at the phone breakpoint', () => {
+    const css = tableCss();
+    // The same width the full view drops its sidebar at.
+    expect(css).toMatch(/@media \(max-width: 700px\) \{ \.name-head, \.name-cell, \.select-cell \{/);
+    expect(css).toMatch(
+      /\.name-head, \.name-cell, \.select-cell \{[^}]*position: sticky[^}]*left: 0/,
+    );
+    // Opaque and full height, or the columns passing underneath show through.
+    expect(css).toMatch(
+      /\.name-head, \.name-cell, \.select-cell \{[^}]*align-self: stretch[^}]*background: var\(--hv-surface\)/,
+    );
+    // The row's own left padding travels with the pinned cell.
+    expect(css).toMatch(
+      /\.name-head, \.name-cell, \.select-cell \{[^}]*margin-left: calc\(-1 \* var\(--hv-table-pad-x\)\)[^}]*padding-left: var\(--hv-table-pad-x\)/,
+    );
+  });
+
+  it('offsets the pinned name past the checkbox track while selecting', () => {
+    // Built from the template's own track width, so the two cannot disagree —
+    // an offset short of the track would leave the name over the checkboxes.
+    // The gap between the two pinned cells travels with the name, or the
+    // columns underneath show through it.
+    expect(tableCss()).toMatch(
+      /:host\(\[selectable\]\) \.name-head, :host\(\[selectable\]\) \.name-cell \{ left: calc\(var\(--hv-table-pad-x\) \+ 40px\); margin-left: calc\(-1 \* var\(--hv-table-gap\)\); padding-left: var\(--hv-table-gap\)/,
+    );
+  });
+
+  // The wash is painted on the row, which the pinned cells cover; a colour
+  // would not do, because the dark half of the wash is translucent.
+  it('repaints the row wash on the pinned cells', () => {
+    expect(tableCss()).toMatch(
+      /\.row:hover \.name-cell,[^{]*\.row\.selected \.select-cell \{ background-image: linear-gradient\(var\(--hv-row-hover\), var\(--hv-row-hover\)\)/,
+    );
+  });
+
+  // Nothing said the table scrolled but a chip clipped at the right edge. The
+  // cover rides with the content and the shade with the box, so the shade shows
+  // exactly while there is something further right.
+  it('fades the edge it can still be scrolled towards', () => {
+    const css = tableCss();
+    expect(css).toMatch(
+      /:host \{ background: linear-gradient\(var\(--hv-surface\), var\(--hv-surface\)\) right \/ 28px 100% no-repeat local/,
+    );
+    // The shade underneath it, and a dark theme reads a black wash as nothing.
+    expect(css).toMatch(/light-dark\(rgba\(0, 0, 0, 0\.16\), rgba\(0, 0, 0, 0\.5\)\)/);
+    expect(css).toMatch(/no-repeat scroll; \}/);
+  });
+
+  it('reflects the selecting flag, which is all the pinning rules can read', async () => {
+    const el = await mount([{ id: '1' }], { selectable: true });
+    expect(el.hasAttribute('selectable')).toBe(true);
+    el.selectable = false;
+    await el.updateComplete;
+    expect(el.hasAttribute('selectable')).toBe(false);
   });
 });
 
@@ -255,14 +324,25 @@ describe('hv-data-table: rows', () => {
     ).toBe(true);
   });
 
+  // The host is the box that scrolls, so the host is where the position can be
+  // read — and a scroll event fires on that box and does not bubble.
   it('reports scroll position so the host can page in more', async () => {
     const el = await mount([{ id: '1' }]);
     let ratio: number | null = null;
     el.addEventListener('near-end', (e) => {
       ratio = (e as CustomEvent).detail.ratio;
     });
-    (q(el, '[data-testid="table-body"]') as HTMLElement).dispatchEvent(new Event('scroll'));
+    el.dispatchEvent(new Event('scroll'));
     expect(typeof ratio).toBe('number');
+  });
+
+  it('stops reporting once it is off the page', async () => {
+    const el = await mount([{ id: '1' }]);
+    let seen = 0;
+    el.addEventListener('near-end', () => (seen += 1));
+    el.remove();
+    el.dispatchEvent(new Event('scroll'));
+    expect(seen).toBe(0);
   });
 
   it('shows the host-supplied empty message', async () => {

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -1,11 +1,16 @@
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue, relativeTime } from '../ui/relative-time';
-import { COLUMN_DEFS, normalizeColumns, tableTemplateFor } from '../store/columns';
+import {
+  COLUMN_DEFS,
+  SELECT_COLUMN_WIDTH,
+  normalizeColumns,
+  tableTemplateFor,
+} from '../store/columns';
 import { getDefaultOrderFor } from '../store/sort';
 import type { AreaRef, StatusDefinition } from '../store/types';
 import type { ColumnKey } from '../store/columns';
@@ -33,16 +38,35 @@ export class HVDataTable extends LitElement {
         flex-direction: column;
         min-height: 0;
         min-width: 0;
-        /* The column template has a hard minimum — 1020px for the default set,
-           1060px with the selection column — and a grid whose tracks do not fit
-           overflows its own box rather than shrinking. With overflow visible
-           that spilled content was simply clipped by the shell: at 375px the
-           rows measured clientWidth 634 against scrollWidth 854, and the Tags,
-           Due and Updated columns could not be reached by any gesture. The
-           table scrolls sideways instead, which keeps whichever columns the
-           user chose rather than quietly dropping them on small screens. */
+        /* The row's own metrics, named because the sticky offsets below are
+           built from them: a pinned cell carries the row's left padding, and
+           in selecting mode the name also carries the gap after the checkbox
+           track. */
+        --hv-table-gap: 8px;
+        --hv-table-pad-x: 20px;
+        /* The one scroll container on this surface, in both axes.
+
+           Sideways because the column template has a hard minimum — about
+           1260px for the default set, 1308px with the selection column — and a
+           grid whose tracks do not fit overflows its own box rather than
+           shrinking. With overflow visible that spilled content was simply
+           clipped by the shell: at 375px the rows measured clientWidth 634
+           against scrollWidth 854, and the Tags, Due and Updated columns could
+           not be reached by any gesture. Scrolling keeps whichever columns the
+           user chose rather than quietly dropping them on small screens.
+
+           Vertically here rather than on the row group, because a sticky cell
+           resolves its offsets against the nearest scroll container: with the
+           rows inside a box of their own that scrolls, left: 0 on a name cell
+           resolves against a box that never moves sideways and pins the cell to
+           nothing. One container for both axes is what makes the name column
+           below hold. The header keeps its place with position: sticky instead
+           of by sitting outside the scrolled box. */
         overflow-x: auto;
-        overscroll-behavior-x: contain;
+        overflow-y: auto;
+        /* A flick that runs past the last row or the last column must not
+           scroll the dashboard behind this surface. */
+        overscroll-behavior: contain;
       }
       /* Sizing the two boxes to the grid's own minimum is what makes the
          scroll work: left at the container's width they would stay 375px wide
@@ -53,15 +77,21 @@ export class HVDataTable extends LitElement {
       .body {
         min-width: min-content;
       }
+      /* Its own height, not the leftover space: the host is what scrolls, and a
+         row group stretched to the visible height would have nothing to give
+         the scroll. */
+      .body {
+        flex: none;
+      }
       .head,
       .row {
         display: grid;
-        gap: 8px;
+        gap: var(--hv-table-gap);
         align-items: center;
-        padding: 10px 20px;
+        padding: 10px var(--hv-table-pad-x);
       }
       .head {
-        padding: 7px 20px;
+        padding: 7px var(--hv-table-pad-x);
         border-bottom: 1px solid var(--hv-divider);
         font-size: 11.5px;
         font-weight: 500;
@@ -69,6 +99,12 @@ export class HVDataTable extends LitElement {
         text-transform: uppercase;
         color: var(--hv-text-secondary);
         flex: none;
+        /* Held against the top of the scroll container the rows now share with
+           it. Opaque, or the rows would read through it as they pass under. */
+        position: sticky;
+        top: 0;
+        z-index: 3;
+        background: var(--hv-surface);
       }
       /* This reset must stay keyed to the sort buttons' own class. Written as
          .head button it also reaches the select-all box, which is a button in
@@ -92,27 +128,6 @@ export class HVDataTable extends LitElement {
       .head button.sort.sorted {
         color: var(--hv-primary-dark);
       }
-      .body {
-        flex: 1;
-        min-height: 0;
-        overflow-y: auto;
-        /*
-         * Contain the vertical overscroll — a flick that runs past the last row
-         * must not scroll the dashboard behind this surface — but only the
-         * vertical.
-         *
-         * The shorthand set both axes, and that is what stopped the sideways
-         * scroll above from working at all. Declaring overflow on one axis
-         * makes the other compute to auto, so this box is a horizontal scroll
-         * container too; it is exactly as wide as its own content, so it has
-         * nothing to scroll, and contain on that axis means a horizontal swipe
-         * starting over a row is neither used nor handed on. The host measured
-         * scrollWidth 874 against clientWidth 390 and stayed at scrollLeft 0
-         * through the whole gesture, so the Tags, Due and Updated columns could
-         * not be reached by any gesture — only by setting scrollLeft in script.
-         */
-        overscroll-behavior-y: contain;
-      }
       .row {
         border-bottom: 1px solid var(--hv-row-divider);
         font-size: 13.5px;
@@ -124,17 +139,87 @@ export class HVDataTable extends LitElement {
       .row.selected {
         background: var(--hv-row-hover);
       }
-      .name-cell {
+      .name-cell,
+      .select-cell,
+      .name-head {
         display: flex;
         align-items: center;
-        gap: 8px;
         min-width: 0;
+      }
+      .name-cell {
+        gap: 8px;
       }
       .name {
         font-weight: 500;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+      /*
+       * A phone shows about a third of this table — the template's floor is
+       * around 1260px — so the identity column holds while the rest scrolls
+       * under it, and the right edge says there is more to reach.
+       *
+       * The offsets are the row's own metrics, so nothing shifts as the swipe
+       * starts: a cell pinned where it already sits simply stops moving. The
+       * pinned cells take the row's left padding with them (negative margin,
+       * matching padding) so the name never ends up flush against the edge,
+       * and they stretch to the row's full height with an opaque fill, or the
+       * columns passing beneath would show through them.
+       *
+       * These resolve against the host, which is the scroll container for both
+       * axes — see the overflow note there.
+       */
+      @media (max-width: 700px) {
+        .name-head,
+        .name-cell,
+        .select-cell {
+          position: sticky;
+          left: 0;
+          z-index: 1;
+          align-self: stretch;
+          margin-left: calc(-1 * var(--hv-table-pad-x));
+          padding-left: var(--hv-table-pad-x);
+          background: var(--hv-surface);
+        }
+        /* Behind the checkbox track, which is pinned first — and the gap
+           between the two travels with the name, or the columns underneath
+           would show through the 8px between the two pinned cells. */
+        :host([selectable]) .name-head,
+        :host([selectable]) .name-cell {
+          left: calc(var(--hv-table-pad-x) + ${unsafeCSS(SELECT_COLUMN_WIDTH)});
+          margin-left: calc(-1 * var(--hv-table-gap));
+          padding-left: var(--hv-table-gap);
+        }
+        /* The row's wash is painted on the row, which the pinned cells cover.
+           A second layer over their own fill restores it — and it has to be a
+           layer rather than a colour, because the dark half of the wash is
+           translucent and would take the opacity with it. */
+        .row:hover .name-cell,
+        .row:hover .select-cell,
+        .row.selected .name-cell,
+        .row.selected .select-cell {
+          background-image: linear-gradient(var(--hv-row-hover), var(--hv-row-hover));
+        }
+        /*
+         * The overflow affordance: a shade at the right edge, and a cover in
+         * the surface colour parked at the right end of the *content*. The
+         * cover scrolls with the rows (background-attachment: local) while the
+         * shade stays with the box (scroll), so the shade shows exactly while
+         * there is something further right, and the two coincide — hiding it —
+         * when there is not. A table that fits shows nothing at all.
+         */
+        :host {
+          background:
+            linear-gradient(var(--hv-surface), var(--hv-surface)) right / 28px 100% no-repeat
+              local,
+            linear-gradient(
+                to left,
+                light-dark(rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.5)),
+                rgba(0, 0, 0, 0)
+              )
+              right / 28px 100% no-repeat scroll;
+        }
       }
       .cell {
         min-width: 0;
@@ -243,7 +328,9 @@ export class HVDataTable extends LitElement {
   @property({ attribute: false }) items: Item[] = [];
   @property({ attribute: false }) columns: ColumnKey[] = [];
   @property({ attribute: false }) sort!: Sort;
-  @property({ type: Boolean }) selectable = false;
+  /** Reflected: the sticky name column offsets itself past the checkbox track
+   * from CSS, which can only see an attribute. */
+  @property({ type: Boolean, reflect: true }) selectable = false;
   /** HA areas, to name the one each item's location resolves to. */
   @property({ attribute: false }) areas: AreaRef[] = [];
   @property({ attribute: false }) selection: Set<string> = new Set();
@@ -261,7 +348,24 @@ export class HVDataTable extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     if (!this.hasAttribute('role')) this.setAttribute('role', 'table');
+    this.addEventListener('scroll', this._onScroll);
   }
+
+  disconnectedCallback(): void {
+    this.removeEventListener('scroll', this._onScroll);
+    super.disconnectedCallback();
+  }
+
+  /**
+   * Paging: the host is the scrolled box, so the host is where the position can
+   * be read. A scroll event fires on the box that scrolled and does not bubble,
+   * which is why this is bound on the element rather than in the template.
+   */
+  private _onScroll = () => {
+    this._emit('near-end', {
+      ratio: (this.scrollTop + this.clientHeight) / Math.max(1, this.scrollHeight),
+    });
+  };
 
   private get _columns(): ColumnKey[] {
     return normalizeColumns(this.columns);
@@ -408,18 +512,20 @@ export class HVDataTable extends LitElement {
     return html`
       <div class="head" role="row" style="grid-template-columns: ${template}">
         ${this.selectable
-          ? html`<button
-              class="box ${allSelected ? 'on' : someSelected ? 'mixed' : ''}"
-              role="checkbox"
-              aria-checked=${allSelected ? 'true' : someSelected ? 'mixed' : 'false'}
-              aria-label="Select all loaded rows"
-              data-testid="table-select-all"
-              @click=${() => this._emit(allSelected ? 'clear-selection' : 'select-all-loaded')}
-            >
-              ${allSelected ? icon('check', 13) : someSelected ? icon('minus', 13) : null}
-            </button>`
+          ? html`<span class="select-cell"
+              ><button
+                class="box ${allSelected ? 'on' : someSelected ? 'mixed' : ''}"
+                role="checkbox"
+                aria-checked=${allSelected ? 'true' : someSelected ? 'mixed' : 'false'}
+                aria-label="Select all loaded rows"
+                data-testid="table-select-all"
+                @click=${() => this._emit(allSelected ? 'clear-selection' : 'select-all-loaded')}
+              >
+                ${allSelected ? icon('check', 13) : someSelected ? icon('minus', 13) : null}
+              </button></span
+            >`
           : null}
-        <span role="columnheader">${this._sortHeader('name', 'Name')}</span>
+        <span class="name-head" role="columnheader">${this._sortHeader('name', 'Name')}</span>
         ${columns.map((key) => {
           const def = COLUMN_DEFS.find((d) => d.key === key)!;
           return html`<span role="columnheader"
@@ -429,17 +535,7 @@ export class HVDataTable extends LitElement {
         <span role="columnheader"></span>
       </div>
 
-      <div
-        class="body"
-        role="rowgroup"
-        data-testid="table-body"
-        @scroll=${(e: Event) => {
-          const el = e.currentTarget as HTMLElement;
-          this._emit('near-end', {
-            ratio: (el.scrollTop + el.clientHeight) / Math.max(1, el.scrollHeight),
-          });
-        }}
-      >
+      <div class="body" role="rowgroup" data-testid="table-body">
         ${this.items.length
           ? repeat(
               this.items,
@@ -457,19 +553,21 @@ export class HVDataTable extends LitElement {
                     this._emit(this.selectable ? 'toggle-select' : 'open-item', { itemId: item.id })}
                 >
                   ${this.selectable
-                    ? html`<button
-                        class="box ${this.selection.has(item.id) ? 'on' : ''}"
-                        role="checkbox"
-                        aria-checked=${String(this.selection.has(item.id))}
-                        aria-label=${`Select ${item.name}`}
-                        data-testid="table-row-select"
-                        @click=${(e: Event) => {
-                          e.stopPropagation();
-                          this._emit('toggle-select', { itemId: item.id });
-                        }}
-                      >
-                        ${this.selection.has(item.id) ? icon('check', 13) : null}
-                      </button>`
+                    ? html`<span class="select-cell"
+                        ><button
+                          class="box ${this.selection.has(item.id) ? 'on' : ''}"
+                          role="checkbox"
+                          aria-checked=${String(this.selection.has(item.id))}
+                          aria-label=${`Select ${item.name}`}
+                          data-testid="table-row-select"
+                          @click=${(e: Event) => {
+                            e.stopPropagation();
+                            this._emit('toggle-select', { itemId: item.id });
+                          }}
+                        >
+                          ${this.selection.has(item.id) ? icon('check', 13) : null}
+                        </button></span
+                      >`
                     : null}
                   <span class="name-cell" role="cell">
                     <span class="name" data-testid="table-name" title=${item.name}>${item.name}</span>

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -520,4 +520,31 @@ describe('hv-list-row: document marker', () => {
 
     expect(q(el, '[data-testid="row-has-document"]')).toBeTruthy();
   });
+
+  // Left on the row it was anchored to the free space: against the name on a
+  // row with a thumbnail, and out at the quantity stepper on one without.
+  it('sits on the line the name owns, whatever else the row carries', async () => {
+    const el = await mount({ attachments: [makeManual({ id: 'm-1' })] });
+    await el.updateComplete;
+
+    const mark = q(el, '[data-testid="row-has-document"]');
+    const line = mark?.parentElement;
+    expect(line?.classList.contains('name-line')).toBe(true);
+    expect(line?.querySelector('[data-testid="row-name"]')).toBeTruthy();
+    // Immediately after the name, so it reads as belonging to it.
+    expect(mark?.previousElementSibling?.getAttribute('data-testid')).toBe('row-name');
+  });
+
+  // A flex item takes an automatic minimum width from its content, so the name
+  // stops eliding the moment it shares a line with the mark unless it gives
+  // that minimum up.
+  it('leaves the name able to shrink on that line', () => {
+    const styles = (customElements.get('hv-list-row') as typeof HVListRow).styles;
+    const css = (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.name-line \{[^}]*display: flex/);
+    expect(css).toMatch(/\.name \{[^}]*min-width: 0[^}]*text-overflow: ellipsis/);
+  });
 });

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -111,14 +111,28 @@ export class HVListRow extends LitElement {
         place-items: center;
         color: var(--hv-text-tertiary);
       }
+      /* The mark belongs to the name, so it sits on the name's own line and
+         follows wherever the name ends. Left on the row it was anchored to the
+         free space instead: on a row with a thumbnail it landed against the
+         truncated name, and on one without it floated out to the far edge,
+         where it read as part of the quantity stepper. */
+      .name-line {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+      }
       /* Both lines must be block containers with inline content, or the
          ellipsis is silently ignored: overflow does not apply to an inline box,
-         and text-overflow does not apply to a flex container. As spans inside a
-         blockified flex item these were the first case, and .secondary was
-         explicitly the second — so a long path hard-cut mid-character with no
-         "…" to say anything had been dropped. */
+         and text-overflow does not apply to a flex container. .name is a flex
+         item on the line above, which blockifies it and gives it an automatic
+         minimum width it must give up to shrink at all; .secondary is a span
+         inside a blockified flex item and was explicitly the second case — so
+         a long path hard-cut mid-character with no "…" to say anything had
+         been dropped. */
       .name {
         display: block;
+        min-width: 0;
         font-size: 14px;
         font-weight: 500;
         overflow: hidden;
@@ -478,7 +492,18 @@ export class HVListRow extends LitElement {
           : null}
         ${this._renderThumb()}
         <span class="names">
-          <span class="name" data-testid="row-name" title=${item.name}>${item.name}</span>
+          <span class="name-line">
+            <span class="name" data-testid="row-name" title=${item.name}>${item.name}</span>
+            ${manuals(item.attachments).length
+              ? html`<span
+                  class="doc-marker"
+                  data-testid="row-has-document"
+                  title="Has a document"
+                  aria-label="Has a document"
+                  >${icon('fileDocument', 14)}</span
+                >`
+              : null}
+          </span>
           <span
             class="secondary ${this.mobile ? mobileState : 'hv-chip-line'} ${overdue &&
             this.mobile
@@ -507,15 +532,6 @@ export class HVListRow extends LitElement {
                       >`}
           </span>
         </span>
-        ${manuals(item.attachments).length
-          ? html`<span
-              class="doc-marker"
-              data-testid="row-has-document"
-              title="Has a document"
-              aria-label="Has a document"
-              >${icon('fileDocument', 14)}</span
-            >`
-          : null}
         ${this.pending
           ? html`<span class="hv-chip warning" data-testid="row-pending">Pending</span>`
           : null}

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -3,6 +3,7 @@ import {
   COLUMN_DEFS,
   COLUMN_PREFS_STORAGE_KEY,
   DEFAULT_COLUMNS,
+  SELECT_COLUMN_WIDTH,
   loadColumnPrefs,
   normalizeColumns,
   saveColumnPrefs,
@@ -98,19 +99,61 @@ function minWidthOf(template: string): number {
     .reduce((a, b) => a + b, 0);
 }
 
+/** The growth factor of a track: the `fr` in a `minmax()`, or 0 for a fixed one. */
+function growthOf(template: string, index: number): number {
+  const track = template.split(/\s+(?![^(]*\))/)[index];
+  return Number(/,\s*([\d.]+)fr\)$/.exec(track)?.[1] ?? 0);
+}
+
 describe('table column widths', () => {
   // Pinned as a number so that adding a column, or widening one, shows up here
   // as a deliberate change rather than as another phone-width overflow.
   it('cannot lay the default table out narrower than a phone', () => {
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1132);
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1172);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1148);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1188);
   });
 
   it('only fits a phone when almost every column is turned off', () => {
-    // Name (180) + Qty (70) + the actions gutter (110). That clears 375px with
-    // 15px to spare and still overflows a 320px screen — so trimming columns
-    // was never a reliable answer, and it would have discarded a choice the
-    // user made. The table scrolls sideways instead.
-    expect(minWidthOf(tableTemplateFor(['quantity'], { selectable: false }))).toBe(360);
+    // Name (220) + Qty (70) + the actions gutter (110). That overflows a 375px
+    // screen on its own — so trimming columns was never a reliable answer, and
+    // it would have discarded a choice the user made. The table scrolls
+    // sideways instead, and pins the name column while it does.
+    expect(minWidthOf(tableTemplateFor(['quantity'], { selectable: false }))).toBe(400);
+  });
+
+  // With every column on, the flexible tracks all sit at their floor and the
+  // name loses to a column of tags: the audit frame read "Kärc…" beside two
+  // full tag chips. The name also carries the inline Low and Checked-out chips,
+  // which take their width before it gets any.
+  it('floors the name column above every flexible column beside it', () => {
+    const template = tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false });
+    const tracks = template.split(/\s+(?![^(]*\))/);
+    const nameMin = Number(/^minmax\((\d+)px,/.exec(tracks[0])![1]);
+    const flexible = tracks
+      .slice(1)
+      .map((t) => Number(/^minmax\((\d+)px,/.exec(t)?.[1] ?? 0))
+      .filter((min) => min > 0);
+
+    expect(flexible.length).toBe(3);
+    for (const min of flexible) expect(nameMin).toBeGreaterThan(min);
+  });
+
+  // Free width goes to the name first: a row identified by its tags and not by
+  // its name cannot be scanned.
+  it('grows the name column faster than the tags column', () => {
+    const template = tableTemplateFor(['category', 'location', 'tags'], { selectable: false });
+    // 0 is the name; the tags track is the last flexible one before the gutter.
+    expect(growthOf(template, 0)).toBeGreaterThan(growthOf(template, 3));
+    expect(growthOf(template, 3)).toBe(1);
+  });
+
+  // The pinned name cell offsets itself by the checkbox track, and an offset
+  // that disagreed with the template would sit over the checkboxes or short of
+  // them.
+  it('leads a selectable table with the track the sticky offset is built from', () => {
+    expect(tableTemplateFor([], { selectable: true }).startsWith(`${SELECT_COLUMN_WIDTH} `)).toBe(
+      true,
+    );
+    expect(tableTemplateFor([], { selectable: false }).startsWith('minmax(')).toBe(true);
   });
 });

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -39,7 +39,10 @@ export const COLUMN_DEFS: readonly ColumnDef[] = [
   { key: 'status', label: 'Status', tableSize: '112px' },
   { key: 'category', label: 'Category', tableSize: 'minmax(110px, 1fr)' },
   { key: 'location', label: 'Location', tableSize: 'minmax(110px, 1fr)' },
-  { key: 'tags', label: 'Tags', tableSize: 'minmax(120px, 1.4fr)' },
+  // The narrowest of the flexible columns, and the only one that yields to the
+  // name: a row identified by its tags and not by its name cannot be scanned,
+  // and tags are the column a reader can most afford to see one of.
+  { key: 'tags', label: 'Tags', tableSize: 'minmax(96px, 1fr)' },
   { key: 'due_date', label: 'Due', tableSize: '100px', sortField: 'due_date' },
   {
     key: 'inspection_date',
@@ -79,11 +82,27 @@ const COLUMN_TABLE_SIZE: Record<ColumnKey, string> = Object.fromEntries(
 /**
  * grid-template-columns for the full-view table: an optional selection column,
  * the name, the chosen columns, then room for the hover actions.
+ *
+ * The name track outweighs every flexible column beside it, in both halves of
+ * its `minmax`: the name is the row's identity, and it also carries the inline
+ * Low and Checked-out chips, which take their width before the name gets any.
+ * With the full column set the flexible tracks all sit at their minimum
+ * anyway — there the floor is the whole answer, and the growth factor decides
+ * only what a wider window hands out.
  */
+export const NAME_COLUMN_SIZE = 'minmax(220px, 3fr)';
+
+/**
+ * The selection column's track. Exported because the table pins the name cell
+ * to the right of it while scrolling sideways, and an offset that disagreed
+ * with the track would leave the name over the checkboxes or short of them.
+ */
+export const SELECT_COLUMN_WIDTH = '40px';
+
 export function tableTemplateFor(columns: ColumnKey[], opts: { selectable: boolean }): string {
   const cols = [
-    ...(opts.selectable ? ['40px'] : []),
-    'minmax(180px, 2fr)',
+    ...(opts.selectable ? [SELECT_COLUMN_WIDTH] : []),
+    NAME_COLUMN_SIZE,
     ...normalizeColumns(columns).map((k) => COLUMN_TABLE_SIZE[k]),
     '110px',
   ];

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -135,6 +135,21 @@ describe('ui/chip: the shared fragment', () => {
     }
   });
 
+  // A household names its own statuses, so a label can outrun the column it
+  // sits in — the table's 112px status column hard-cut "Lent out to the ne".
+  // A cell's own text-overflow cannot reach into an inline-flex chip, so the
+  // elision has to be on the label, and the chip has to be allowed to shrink
+  // for it to have anywhere to elide to.
+  it('elides a status label rather than cutting it mid-word', () => {
+    const css = String(chip.cssText).replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.hv-status-chip \{[^}]*max-width: 100%/);
+    expect(css).toMatch(
+      /\.hv-status-chip > \.hv-chip-text \{[^}]*min-width: 0[^}]*overflow: hidden[^}]*text-overflow: ellipsis/,
+    );
+    // Once, in the fragment — not restated by the surfaces that chip a status.
+    for (const tag of CHIPPED) expect(ownCss(tag), tag).not.toMatch(/\.hv-chip-text\b/);
+  });
+
   // A strong fill is one hue in both themes, so the ink that reads on it is
   // fixed too. A light-dark() pair there flips the ink while the fill stays put
   // — which is how white ends up on amber at 1.9:1.

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -154,6 +154,20 @@ export const chip = css`
     gap: 4px;
     background: var(--hv-tone-neutral-bg);
     color: var(--hv-tone-neutral-fg);
+    /* A household names its own statuses, so a label can outrun the column it
+       sits in. The chip must be allowed to shrink for the label to elide at
+       all — the metrics above hold every chip at flex: none, which is right
+       beside other chips and wrong inside a cell narrower than this one. */
+    max-width: 100%;
+  }
+  /* Elision has to happen on the label, not on the cell around it: the chip is
+     an inline-flex box, and text-overflow on an ancestor cannot reach into one
+     — the label was hard-cut mid-word instead. As a flex item the label is a
+     block container already, so only the shrink and the overflow are needed. */
+  .hv-status-chip > .hv-chip-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .hv-status-chip.tone-neutral {
     background: var(--hv-tone-neutral-bg);

--- a/cards/haventory-card/src/ui/status.test.ts
+++ b/cards/haventory-card/src/ui/status.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { render } from 'lit';
 import type { StatsCounts, StatusDefinition } from '../store/types';
 import {
   BUILT_IN_STATUSES,
   DEFAULT_STATUS,
   itemStatus,
+  renderStatusChip,
   statusCount,
   statusIconName,
   statusLabel,
@@ -116,5 +118,37 @@ describe('ui/status: pricing a slug', () => {
   it('prices nothing before any counts have arrived', () => {
     expect(statusCount(null, 'ok')).toBeNull();
     expect(statusCount(undefined, 'missing')).toBeNull();
+  });
+});
+
+describe('renderStatusChip', () => {
+  function chipOf(slug: string, defs: StatusDefinition[] | null = CUSTOM) {
+    const host = document.createElement('div');
+    render(renderStatusChip(slug, defs), host);
+    return host.querySelector('.hv-status-chip');
+  }
+
+  it('paints the tone from the definition and names the status', () => {
+    const chip = chipOf('lent_out');
+    expect(chip?.classList.contains('tone-blue-strong')).toBe(true);
+    expect(chip?.textContent?.trim()).toBe('Lent out');
+    expect(chip?.querySelector('svg')?.getAttribute('data-icon')).toBe('hand');
+  });
+
+  // A cell's own text-overflow cannot reach inside an inline-flex chip, so a
+  // label longer than its column hard-cut mid-word. The wrapper is what the
+  // shared rule in ui/chip.ts elides — and every surface that chips a status
+  // gets it from here rather than restating it.
+  it('wraps the label so it can elide inside a narrow cell', () => {
+    const label = chipOf('lent_out')?.querySelector('.hv-chip-text');
+    expect(label?.textContent).toBe('Lent out');
+    // The glyph stays outside it: a chip that elided its own mark would be
+    // eliding the half that costs nothing to keep.
+    expect(label?.querySelector('svg')).toBe(null);
+  });
+
+  it('wraps a label it has no definition for just the same', () => {
+    // An import can define a status this card has not been told about yet.
+    expect(chipOf('mystery')?.querySelector('.hv-chip-text')?.textContent).toBe('mystery');
   });
 });

--- a/cards/haventory-card/src/ui/status.ts
+++ b/cards/haventory-card/src/ui/status.ts
@@ -162,6 +162,11 @@ export function statusIconName(
  *
  * The glyph is decorative: it repeats what the label already says, and a status
  * whose icon this bundle does not carry simply renders without one.
+ *
+ * The label is wrapped rather than left as a bare text node so it can elide:
+ * the chip is an inline-flex box, and a cell's own `text-overflow` cannot reach
+ * inside one — a household label longer than its column hard-cut mid-word. The
+ * rule lives in `ui/chip.ts`, so every surface that chips a status inherits it.
  */
 export function renderStatusChip(
   slug: string,
@@ -172,6 +177,8 @@ export function renderStatusChip(
   return html`<span
     class="hv-status-chip ${statusToneClass(slug, defs)}"
     data-testid=${ifDefined(options.testid)}
-    >${glyph ? icon(glyph, 12) : null}${statusLabel(slug, defs)}</span
+    >${glyph ? icon(glyph, 12) : null}<span class="hv-chip-text"
+      >${statusLabel(slug, defs)}</span
+    ></span
   >`;
 }

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -388,6 +388,12 @@ than a plain one.
 `DEFAULT_COLUMNS` is every key: a browser that has made no choice sees the whole record,
 and the picker is what thins it. The full set is wider than a phone and wider than many
 desktops, which `hv-data-table` answers by scrolling sideways rather than dropping columns.
+The name track (`NAME_COLUMN_SIZE`) outweighs every flexible column beside it in both
+halves of its `minmax`, because the row's identity is the one column that cannot be
+allowed to lose — and at phone width the table pins it, so it holds while the rest scrolls
+under it. The pinning is why `hv-data-table` scrolls **both** axes on its host rather than
+scrolling the rows in a box of their own: a sticky cell resolves its offsets against the
+nearest scroll container, and a nested one that never moves sideways pins nothing.
 
 Preferences persist in `localStorage` under `haventory:columns:v1` as `{ expanded: [...] }`.
 Any other key in that record is ignored, so an older or newer payload never breaks the load.


### PR DESCRIPTION
## Summary

Work package **P7** of the v0.4.0 UI-audit remediation plan (`dev/ui_audit_v040_fix_plan.md`) — audit findings **B16**, **B17** and **C23**. Frontend only; no backend or WS-contract change.

- **B17 — column priority** (`store/columns.ts`). The name track now outweighs every flexible column beside it in *both* halves of its `minmax`: `minmax(220px, 3fr)` against tags' `minmax(96px, 1fr)`. With the full column set every flexible track sits at its floor anyway, so the floor is what actually decides the audit's "Kärc…" beside two full tag chips; the growth factor decides what a wider window hands out. The template's hard minimum moves 1244px → 1260px (1308px with the selection column), pinned in `columns.test.ts`.
- **B17 — chip ellipsis** (`ui/status.ts` + `ui/chip.ts`). `renderStatusChip` wraps its label so it can elide, and the rule lives in the shared chip fragment — a cell's own `text-overflow` cannot reach inside an inline-flex chip, which is why "Lent out to the ne" was hard-cut mid-word. Every surface that chips a status inherits it; measured live, the chip now fills its 112px cell exactly and elides instead of overflowing.
- **B16 — sticky name column + scroll affordance** (`hv-data-table.ts`), at the phone breakpoint the full view already uses (`max-width: 700px`). The trap the plan flagged is real: sticky resolves its offsets against the nearest scroll container, and the rows lived in a vertical scroll box that never moved sideways, so `left: 0` pinned nothing. The host is now the scroll container for **both** axes, the header keeps its place with `position: sticky` instead of by sitting outside the scrolled box, and near-end paging reads the host it now scrolls on. The pinned cells stretch to the row's full height with an opaque fill (hover/selected washes repainted as a layer, because the dark half of the wash is translucent), carry the row's own left padding with them so nothing shifts as the swipe starts, and in selecting mode the checkbox track pins first with the name offset past it from the template's own constant. The edge shade rides `background-attachment`: the cover scrolls with the content and the shade with the box, so it shows exactly while there is something further right and nothing at all when the table fits.
- **C23 — document marker** (`hv-list-row.ts`). Moved onto the name's own line, so it no longer floats out to the quantity stepper on rows without a thumbnail. No thumbnail placeholder was added — the decision documented on `.thumb` stands.

`docs/frontend_architecture.md` gains the column-priority and one-scroll-container constraints.

Closes nothing on its own — P7 has no issue of its own; the plan's traceability table is the record.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (737 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all clean (untouched, but the gate is required).
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1293 passed), `npm run build` — all green.

New/rewritten offline coverage: `tableTemplateFor` track floors and growth factors, and the selection track the sticky offset is built from; cssText pins for the one-scroll-container structure, the sticky header, the pinned cells and their offsets, the repainted row wash and the edge shade; the reflected `selectable` attribute the pinning rules read; near-end paging on the host (and that it stops once detached); the status chip's label wrapper and its shared elision rule; the document marker's anchoring and the name's ability to shrink beside it. Three existing pins were deliberately rewritten rather than deleted — the two that asserted the split scroll containers, and the near-end test that dispatched on the row group.

**jsdom computes no layout**, so every offline assertion here is necessarily a cssText pin, and a sticky rule resolving against the wrong container would pass all of them. So the structure was also driven in Chromium (headless, the real built bundle) at 390px and 1280px, light and dark, with and without selecting mode: the name cell and its header hold at the container's left edge across a 600px horizontal and 200px vertical scroll (they scrolled to −376px before), the header holds at the top, the checkbox and the name pin adjacent with no bleed-through between them, the status chip stops at its cell edge with the label clipped, and the edge shade is present at 390px and absent at 1280px. That is a harness, not the app — the live pass below is the acceptance.

## Handover — required before merge

Per §Verification: P7, this PR needs a local pass on the Docker dev HA (screenshots and DOM measurement), which a remote session cannot do. The checks delegated to it:

- Phone width: swipe the table left — the name column holds with an opaque background and an edge fade is visible; status chips ellipsize with `…`.
- Desktop with default columns: the name column is readable on the audit's long-name fixtures while tags yield.
- Selecting mode: checkbox and name both pinned.

## Screenshots (card / UI changes)

Captured against the built bundle in a bare harness rather than the app, so they are deliberately left for the live pass above.


---
_Generated by [Claude Code](https://claude.ai/code/session_017spyezGZdZTYQmv1S6xa2f)_