### PR TITLE
fix(card): make the Statuses tab usable on touch — stacking guard, real targets, legible swatches, editable default

### DIFF
--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1291,6 +1291,19 @@ describe('hv-organize-dialog: statuses', () => {
     expect(css).toMatch(/\.status-slug \{[^}]*flex: 0 1 auto[^}]*text-overflow: ellipsis/);
   });
 
+  // Measured in the sidebar panel at 390px: the row needed 404px of a 362px
+  // box, so the trash button for "Lent out to the neighbours" sat 28px past the
+  // dialog's right edge — off the screen, with no way to scroll to it.
+  it('lets a long status label elide so the row actions stay inside the dialog', () => {
+    const css = dialogCss();
+    // The chip is flex:none everywhere else; in a status row it has to give way.
+    expect(css).toMatch(/\.status-row \.hv-status-chip \{[^}]*flex: 0 1 auto/);
+    expect(css).toMatch(/\.status-row \.hv-status-chip \{[^}]*min-width: 0/);
+    // The slug still empties first — a shrink factor of 1 would take from both
+    // in proportion to their widths and cut the label while the slug held on.
+    expect(css).toMatch(/\.status-row \.status-slug \{[^}]*flex-shrink: 20/);
+  });
+
   // Five children on one row left the select ~44px wide, showing "O⌄" — the one
   // thing the guard exists to make legible before a destructive click.
   it('stacks the delete guard on a phone and keeps the reassign select readable', () => {

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -2,7 +2,7 @@ import './hv-organize-dialog';
 import { makeMockHass, makeItem } from '../test.utils';
 import { Store } from '../store/store';
 import type { HVOrganizeDialog, OrganizeTab } from './hv-organize-dialog';
-import type { AreaRef, Item, Location } from '../store/types';
+import type { AreaRef, Item, Location, StatusDefinition } from '../store/types';
 
 function loc(id: string, name: string, parentId: string | null = null, areaId: string | null = null): Location {
   const display = parentId ? `${parentId} / ${name}` : name;
@@ -31,6 +31,7 @@ async function mount(
     items?: Item[];
     locations?: Location[];
     areas?: AreaRef[];
+    statuses?: StatusDefinition[];
     tab?: OrganizeTab;
     mobile?: boolean;
   } = {},
@@ -39,6 +40,7 @@ async function mount(
     items: opts.items ?? [],
     locations: opts.locations ?? [],
     areas: opts.areas ?? AREAS,
+    ...(opts.statuses ? { statuses: opts.statuses } : {}),
   });
   const store = new Store(hass, { retryBaseMs: 0 });
   await store.init();
@@ -61,6 +63,15 @@ const settle = async (el: HVOrganizeDialog) => {
 
 const q = (sr: ShadowRoot, sel: string) => sr.querySelector(sel) as HTMLElement | null;
 const all = (sr: ShadowRoot, sel: string) => [...sr.querySelectorAll(sel)] as HTMLElement[];
+
+/** jsdom lays out no shadow DOM, so geometry is asserted on the stylesheet. */
+const dialogCss = () => {
+  const styles = (customElements.get('hv-organize-dialog') as typeof HVOrganizeDialog).styles;
+  return (Array.isArray(styles) ? styles : [styles])
+    .map((s) => String(s.cssText))
+    .join('\n')
+    .replace(/\s+/g, ' ');
+};
 
 describe('hv-organize-dialog: shell', () => {
   it('renders nothing when closed', async () => {
@@ -914,11 +925,7 @@ describe('hv-organize-dialog: mobile value actions', () => {
   // stylesheet. At 375px the filter, the count and the create button shared a
   // 335px row and the field came out 110px wide — its own placeholder clipped.
   it('gives the filter field a row of its own', () => {
-    const styles = (customElements.get('hv-organize-dialog') as typeof HVOrganizeDialog).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = dialogCss();
     expect(css).toMatch(/:host\(\[mobile\]\) \.toolbar \{[^}]*flex-wrap: wrap/);
     expect(css).toMatch(/:host\(\[mobile\]\) \.search \{[^}]*flex-basis: 100%/);
     // …with the count keeping the button company on the second row.
@@ -1056,12 +1063,39 @@ describe('hv-organize-dialog: statuses', () => {
     ).toBe(true);
   });
 
-  it('offers no delete for the default status', async () => {
-    const { sr } = await mount({ tab: 'statuses' });
+  // The backend takes label, colour and icon changes for any slug, the default
+  // included — a household that wants a quieter "OK", or one in its own
+  // language, has to be able to say so. Only the delete stays withheld.
+  it('withholds delete from the default status but not the rename', async () => {
+    const { el, sr } = await mount({ tab: 'statuses' });
 
     const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'ok');
-    expect(row?.querySelector('[data-testid="status-remove"]')).toBe(null);
     expect(row?.querySelector('[data-testid="status-default"]')).not.toBe(null);
+    expect(row?.querySelector('[data-testid="status-remove"]')).toBe(null);
+
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(q(sr, '[data-testid="status-editor"]')).not.toBe(null);
+    expect((q(sr, '[data-testid="status-label"]') as HTMLInputElement).value).toBe('OK');
+  });
+
+  it('renames the default status without the backend hearing about any item', async () => {
+    const { el, sr, hass } = await mount({ tab: 'statuses' });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'ok');
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+    const input = q(sr, '[data-testid="status-label"]') as HTMLInputElement;
+    input.value = 'In Ordnung';
+    input.dispatchEvent(new Event('input'));
+    (q(sr, '[data-testid="status-save"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(hass.__messages.find((m) => m.type === 'haventory/status/update')).toMatchObject({
+      slug: 'ok',
+      label: 'In Ordnung',
+    });
   });
 
   // The backend refuses this regardless; the guard is the explanation, and the
@@ -1126,5 +1160,212 @@ describe('hv-organize-dialog: statuses', () => {
       color: 'blue_strong',
       icon: 'hand',
     });
+  });
+
+  // A tone is a tint plus the ink that reads on it. Painting only the tint left
+  // the five light tones near-identical on white and near-black in dark, where
+  // they are washes never meant to stand on their own.
+  it('paints each swatch as a miniature chip carrying the glyph being chosen', async () => {
+    const { el, sr } = await mount({ tab: 'statuses' });
+    (q(sr, '[data-testid="organize-new-status"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const swatches = all(sr, '[data-testid="status-color"]');
+    expect(swatches).toHaveLength(10);
+    for (const s of swatches) {
+      expect(s.querySelector('svg')?.getAttribute('data-icon')).toBe('check');
+    }
+    // Both halves of the tone: the fill comes from the class, the ink with it.
+    expect(swatches.map((s) => s.dataset.value)).toContain('amber_strong');
+    expect(
+      swatches.find((s) => s.dataset.value === 'amber_strong')?.classList.contains('tone-amber-strong'),
+    ).toBe(true);
+
+    (
+      all(sr, '[data-testid="status-icon"]').find((b) => b.dataset.value === 'truck') as HTMLButtonElement
+    ).click();
+    await settle(el);
+
+    for (const s of all(sr, '[data-testid="status-color"]')) {
+      expect(s.querySelector('svg')?.getAttribute('data-icon')).toBe('truck');
+    }
+  });
+
+  // An import can define a status naming a glyph this bundle has never carried.
+  // The swatch still has to put ink on its tint, or the tone is half-shown again.
+  it('letters a swatch whose glyph this bundle does not carry', async () => {
+    const { el, sr } = await mount({
+      tab: 'statuses',
+      statuses: [
+        { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
+        { slug: 'sold', label: 'Sold', order: 1, color: 'red', icon: 'not-a-glyph' },
+      ],
+    });
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'sold');
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    for (const s of all(sr, '[data-testid="status-color"]')) {
+      expect(s.querySelector('svg')).toBe(null);
+      expect(s.querySelector('.letters')?.textContent).toBe('Aa');
+    }
+  });
+
+  // Two statuses labelled the same are indistinguishable in every row badge,
+  // filter chip and select — only the slug tells them apart, and the slug is
+  // what this editor hides.
+  it('warns when a label collides with one already in use, without blocking it', async () => {
+    const { el, sr } = await mount({ tab: 'statuses' });
+    (q(sr, '[data-testid="organize-new-status"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const input = q(sr, '[data-testid="status-label"]') as HTMLInputElement;
+    input.value = '  missing ';
+    input.dispatchEvent(new Event('input'));
+    await settle(el);
+
+    expect(q(sr, '[data-testid="status-duplicate-hint"]')?.textContent).toContain('Missing');
+    // A warning, not a refusal: creating anyway stays available.
+    expect((q(sr, '[data-testid="status-save"]') as HTMLButtonElement).disabled).toBe(false);
+    // The slug dedupe stays as the backstop the backend needs.
+    expect(q(sr, '[data-testid="status-slug-preview"]')?.textContent?.trim()).toBe('missing_2');
+  });
+
+  it('drops the hint once the label is its own again', async () => {
+    const { el, sr } = await mount({ tab: 'statuses' });
+    (q(sr, '[data-testid="organize-new-status"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const input = q(sr, '[data-testid="status-label"]') as HTMLInputElement;
+    input.value = 'Missing';
+    input.dispatchEvent(new Event('input'));
+    await settle(el);
+    expect(q(sr, '[data-testid="status-duplicate-hint"]')).not.toBe(null);
+
+    input.value = 'Lent out';
+    input.dispatchEvent(new Event('input'));
+    await settle(el);
+    expect(q(sr, '[data-testid="status-duplicate-hint"]')).toBe(null);
+  });
+
+  it('does not call a status a duplicate of itself while it is being edited', async () => {
+    const { el, sr } = await mount({ tab: 'statuses' });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect((q(sr, '[data-testid="status-label"]') as HTMLInputElement).value).toBe('Missing');
+    expect(q(sr, '[data-testid="status-duplicate-hint"]')).toBe(null);
+  });
+
+  // The preview exists for people writing automations, and it was eliding the
+  // identifier it exists to show while the row still had free width.
+  it('shows the derived slug in full, and titles both places it appears', async () => {
+    const { el, sr } = await mount({ tab: 'statuses' });
+    (q(sr, '[data-testid="organize-new-status"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const input = q(sr, '[data-testid="status-label"]') as HTMLInputElement;
+    input.value = 'Lent out to the neighbours';
+    input.dispatchEvent(new Event('input'));
+    await settle(el);
+
+    const preview = q(sr, '[data-testid="status-slug-preview"]');
+    expect(preview?.textContent?.trim()).toBe('lent_out_to_the_neighbours');
+    expect(preview?.getAttribute('title')).toBe('lent_out_to_the_neighbours');
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'needs_repair');
+    expect(row?.querySelector('[data-testid="status-slug"]')?.getAttribute('title')).toBe(
+      'needs_repair',
+    );
+  });
+
+  it('lets the slug wrap under the name field rather than eliding beside it', () => {
+    const css = dialogCss();
+    expect(css).toMatch(/\.status-name \{[^}]*flex-wrap: wrap/);
+    // Not shrinkable, so it wraps to a line of its own instead of being cut…
+    expect(css).toMatch(/\.status-name \.status-slug \{[^}]*flex: 0 0 auto/);
+    // …while the list row keeps the elision that stops a long slug pushing the
+    // delete button off the dialog.
+    expect(css).toMatch(/\.status-slug \{[^}]*flex: 0 1 auto[^}]*text-overflow: ellipsis/);
+  });
+
+  // Five children on one row left the select ~44px wide, showing "O⌄" — the one
+  // thing the guard exists to make legible before a destructive click.
+  it('stacks the delete guard on a phone and keeps the reassign select readable', () => {
+    const css = dialogCss();
+    expect(css).toMatch(/\.guard \{[^}]*flex-wrap: wrap/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.status-guard \{[^}]*flex-direction: column/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.status-guard \{[^}]*align-items: stretch/);
+    expect(css).toMatch(/\.status-guard \.guard-message \{[^}]*flex: 1 1 100%/);
+    expect(css).toMatch(/\.guard-target select\.control \{[^}]*min-width: 140px/);
+  });
+
+  // The sentence naming where 40 items are about to go carried .note's tertiary
+  // grey, which measures 2.5:1 over the guard's fill. It is the guard's own
+  // message, so it takes the guard's ink.
+  it('inks the guard message with the guard, not with a note grey', async () => {
+    const { el, sr } = await mount({
+      tab: 'statuses',
+      items: [makeItem({ id: 'i8', name: 'Ladder', status: 'missing' })],
+    });
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-remove"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const message = q(sr, '[data-testid="status-guard-message"]');
+    expect(message?.textContent).toContain('1 item');
+    expect(message?.classList.contains('note')).toBe(false);
+  });
+
+  it('marks the guard so its stacking cannot reach the location guard', async () => {
+    const { el, sr } = await mount({
+      tab: 'statuses',
+      items: [makeItem({ id: 'i9', name: 'Ladder', status: 'missing' })],
+    });
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-remove"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const guard = q(sr, '[data-testid="status-guard"]');
+    expect(guard?.classList.contains('status-guard')).toBe(true);
+    expect(guard?.querySelector('.guard-target select')).not.toBe(null);
+  });
+
+  // DOM-measured on a phone before this pass: chevrons 15×15 stacked a pixel
+  // apart, edit/delete 26×26, swatches 26×22, the count link 14px tall. WCAG
+  // 2.2 asks 24px of every pointer; a finger wants the platform's 44.
+  it('sizes every statuses-tab control for a finger', () => {
+    const css = dialogCss();
+    for (const [selector, size] of [
+      ['\\.move button', '24px'],
+      ['\\.swatch', '26px'],
+    ] as const) {
+      expect(css, selector).toMatch(new RegExp(`${selector} \\{[^}]*height: ${size}`));
+    }
+    expect(css).toMatch(/\.status-row \.count-link \{[^}]*min-height: 24px/);
+
+    for (const selector of [
+      '\\.move button',
+      '\\.swatch',
+      '\\.swatches \\.glyph',
+      '\\.status-row \\.row-actions button',
+    ]) {
+      expect(css, selector).toMatch(
+        new RegExp(
+          `:host\\(\\[mobile\\]\\) ${selector} \\{[^}]*width: var\\(--hv-tap-min, 44px\\)[^}]*height: var\\(--hv-tap-min, 44px\\)`,
+        ),
+      );
+    }
+    expect(css).toMatch(
+      /:host\(\[mobile\]\) \.status-row \.count-link \{[^}]*min-height: var\(--hv-tap-min, 44px\)/,
+    );
+  });
+
+  // The colour row compressed ten swatches onto one line while the icon row
+  // wrapped; at touch size neither fits, so both must wrap.
+  it('wraps the swatch rows instead of squeezing them onto one line', () => {
+    expect(dialogCss()).toMatch(/\.swatches \{[^}]*flex-wrap: wrap/);
   });
 });

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -9,7 +9,9 @@ import {
   DEFAULT_STATUS,
   STATUS_COLORS,
   STATUS_ICONS,
+  knownIcon,
   renderStatusChip,
+  slugFromLabel,
   statusCount,
   statusLabel,
   statusList,
@@ -243,13 +245,25 @@ export class HVOrganizeDialog extends LitElement {
         flex: none;
         gap: 1px;
       }
+      /* Sized rather than left at the glyph: two chevrons stacked a pixel apart
+         are one target to a finger, and WCAG 2.2 asks 24px of every pointer.
+         The token is what a host declares when the card is narrow; the fallback
+         covers the sidebar panel, which declares none. */
       .move button {
+        display: inline-grid;
+        place-items: center;
+        width: 24px;
+        height: 24px;
         border: none;
         background: none;
         color: var(--hv-text-tertiary);
         cursor: pointer;
         padding: 0;
         line-height: 0;
+      }
+      :host([mobile]) .move button {
+        width: var(--hv-tap-min, 44px);
+        height: var(--hv-tap-min, 44px);
       }
       .move button:hover:not([disabled]) {
         color: var(--hv-text);
@@ -261,9 +275,10 @@ export class HVOrganizeDialog extends LitElement {
       /* The identity items store. Shown because services.yaml and an export
          document carry it, muted because a household never needs to type it.
 
-         It is also the only part of the row that may be cut: at phone width a
-         long slug otherwise pushes the delete button past the dialog edge,
-         where it cannot be tapped at all. */
+         In a list row it is the one part that may be cut: at phone width a long
+         slug otherwise pushes the delete button past the dialog edge, where it
+         cannot be tapped at all. Both places carry it as a title attribute too,
+         because either can end up eliding it. */
       .status-slug {
         font: 400 12px var(--hv-font);
         color: var(--hv-text-tertiary);
@@ -273,18 +288,49 @@ export class HVOrganizeDialog extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
       }
+      .status-name {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .status-name .control {
+        flex: 1 1 180px;
+        width: auto;
+      }
+      /* The editor shows the slug for people writing automations, so here it
+         keeps its full width and drops to a line of its own rather than eliding
+         while the row still has room — the opposite of the list row above. */
+      .status-name .status-slug {
+        flex: 0 0 auto;
+        max-width: 100%;
+      }
       .swatches {
         display: flex;
         flex-wrap: wrap;
         gap: 6px;
         margin: 2px 0 4px;
       }
+      /* A tone is a pair — a tint and the ink that reads on it — so the swatch
+         shows both, with the glyph the status will carry standing in for the
+         label. A bare fill leaves the five light tints all but identical on
+         white, and in dark it leaves them washes with nothing behind them. */
       .swatch {
-        width: 26px;
-        height: 22px;
+        justify-content: center;
+        width: 34px;
+        height: 26px;
         border-radius: var(--hv-radius-chip);
         cursor: pointer;
         padding: 0;
+      }
+      :host([mobile]) .swatch {
+        width: var(--hv-tap-min, 44px);
+        height: var(--hv-tap-min, 44px);
+      }
+      /* The stand-in when a definition names a glyph this bundle does not
+         carry: the swatch still has to show ink on its tint. */
+      .swatch .letters {
+        font: 600 12px var(--hv-font);
       }
       .glyph {
         display: inline-grid;
@@ -299,6 +345,12 @@ export class HVOrganizeDialog extends LitElement {
       }
       .glyph:hover {
         background: var(--hv-hover-overlay);
+      }
+      /* Scoped to the picker rows: .glyph also marks the location guard's alert,
+         which is not a target and must not grow into one. */
+      :host([mobile]) .swatches .glyph {
+        width: var(--hv-tap-min, 44px);
+        height: var(--hv-tap-min, 44px);
       }
       .swatch.on,
       .glyph.on {
@@ -318,6 +370,17 @@ export class HVOrganizeDialog extends LitElement {
            it narrower — the slug beside it is what gives way instead. */
         white-space: nowrap;
         flex: none;
+      }
+      /* 12px text is a 14px-tall target; the box has to be told to be bigger
+         than its own line. Confined to the status rows, whose controls this
+         pass sized for touch. */
+      .status-row .count-link {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+      }
+      :host([mobile]) .status-row .count-link {
+        min-height: var(--hv-tap-min, 44px);
       }
       .draft-note {
         font: 400 12px var(--hv-font);
@@ -347,6 +410,10 @@ export class HVOrganizeDialog extends LitElement {
         background: none;
         color: var(--hv-text-secondary);
         padding: 0;
+      }
+      :host([mobile]) .status-row .row-actions button {
+        width: var(--hv-tap-min, 44px);
+        height: var(--hv-tap-min, 44px);
       }
       .row-actions button.danger {
         color: var(--hv-error);
@@ -433,6 +500,10 @@ export class HVOrganizeDialog extends LitElement {
       .guard {
         display: flex;
         align-items: flex-start;
+        /* The reassign guard puts three parts in here; unwrapped they share one
+           row and the select comes out ~44px wide, which hides the one thing
+           the guard exists to show. */
+        flex-wrap: wrap;
         gap: 9px;
         padding: 10px 12px;
         margin: 0 8px 8px;
@@ -445,6 +516,46 @@ export class HVOrganizeDialog extends LitElement {
       .guard .glyph {
         color: var(--hv-warn);
         flex: none;
+      }
+      /* Where the items go is the guard's own sentence, not a note beside one:
+         it takes a line to itself rather than competing with the select for
+         width, and the guard's ink rather than the tertiary grey a note carries
+         on a plain surface, which lands at 2.5:1 over this fill. */
+      .status-guard .guard-message {
+        flex: 1 1 100%;
+      }
+      .status-guard .actions {
+        flex: 1 1 auto;
+      }
+      :host([mobile]) .status-guard {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      /* Stacked, the three parts each take a line of their own; the basis above
+         is a width and means nothing once the main axis is vertical. */
+      :host([mobile]) .status-guard .guard-message,
+      :host([mobile]) .status-guard .actions {
+        flex: none;
+      }
+      .guard-target {
+        display: flex;
+        align-items: center;
+        /* Below ~330px the label and a readable select no longer share a line;
+           the select drops under it rather than overflowing the dialog. */
+        flex-wrap: wrap;
+        gap: 8px;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .guard-target > span {
+        flex: none;
+      }
+      /* A select showing "O⌄" names nothing. It grows into the row instead of
+         collapsing to its own arrow. */
+      .guard-target select.control {
+        flex: 1 1 auto;
+        width: auto;
+        min-width: 140px;
       }
       .track {
         height: 6px;
@@ -464,6 +575,17 @@ export class HVOrganizeDialog extends LitElement {
         border-radius: var(--hv-radius-input);
         background: var(--hv-error-bg);
         color: var(--hv-error-deep);
+        font-size: 12.5px;
+      }
+      /* Shaped like .failure and coloured a step softer: it reports something
+         the household may go ahead with, so it must not read as a refusal. */
+      .hint {
+        display: flex;
+        gap: 8px;
+        padding: 9px 11px;
+        border-radius: var(--hv-radius-input);
+        background: var(--hv-warn-bg);
+        color: var(--hv-warn-deep);
         font-size: 12.5px;
       }
       .note {
@@ -1425,28 +1547,21 @@ export class HVOrganizeDialog extends LitElement {
   }
 
   /**
-   * A slug from a label: lowercase, ASCII letters/digits/underscores, and never
-   * one already taken.
+   * The label of the status the one being typed would duplicate, or null.
    *
-   * The user never types this — a household should not have to think about the
-   * identifier — but it is what `services.yaml` and an export document carry, so
-   * it is shown beside the label for anyone writing an automation.
+   * Two statuses labelled the same are indistinguishable in every row badge,
+   * filter chip and select on the card — only the slug tells them apart, and
+   * the slug is what the editor hides. The status being edited is excluded:
+   * keeping its own name is not a collision.
    */
-  private _slugFrom(label: string): string {
-    const base =
-      label
-        .normalize('NFKD')
-        .replace(/[̀-ͯ]/g, '')
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, '')
-        .slice(0, 64) || 'status';
-    const taken = new Set(this._statusDefs.map((d) => d.slug));
-    if (!taken.has(base)) return base;
-    for (let n = 2; ; n += 1) {
-      const candidate = `${base.slice(0, 61)}_${n}`;
-      if (!taken.has(candidate)) return candidate;
-    }
+  private get _duplicateLabel(): string | null {
+    const typed = this._statusLabel.trim().toLowerCase();
+    if (!typed) return null;
+    const editing = this._editingStatus;
+    return (
+      this._statusDefs.find((d) => d.slug !== editing && d.label.trim().toLowerCase() === typed)
+        ?.label ?? null
+    );
   }
 
   private _startStatusEdit(slug: string | 'new') {
@@ -1471,7 +1586,7 @@ export class HVOrganizeDialog extends LitElement {
     try {
       if (editing === 'new') {
         await this.store?.createStatus({
-          slug: this._slugFrom(label),
+          slug: slugFromLabel(label, this.st?.statuses),
           label,
           color: this._statusColor,
           icon: this._statusIcon,
@@ -1552,7 +1667,7 @@ export class HVOrganizeDialog extends LitElement {
           const isDefault = d.slug === DEFAULT_STATUS;
           const count = this._statusCount(d.slug);
           return html`
-            <div class="value-row" data-testid="status-row" data-value=${d.slug}>
+            <div class="value-row status-row" data-testid="status-row" data-value=${d.slug}>
               <span class="move">
                 <button
                   data-testid="status-up"
@@ -1574,7 +1689,7 @@ export class HVOrganizeDialog extends LitElement {
                 </button>
               </span>
               ${renderStatusChip(d.slug, defs, { testid: 'status-chip' })}
-              <span class="status-slug" data-testid="status-slug">${d.slug}</span>
+              <span class="status-slug" data-testid="status-slug" title=${d.slug}>${d.slug}</span>
               <button class="count-link" data-testid="status-count" @click=${() =>
                 this._showStatus(d.slug)}>
                 ${counted(count, 'item')}
@@ -1582,15 +1697,18 @@ export class HVOrganizeDialog extends LitElement {
               <span class="row-actions">
                 ${isDefault
                   ? html`<span class="hv-chip quiet" data-testid="status-default">Default</span>`
+                  : null}
+                <button
+                  data-testid="status-edit"
+                  aria-label=${`Edit ${d.label}`}
+                  title="Edit"
+                  @click=${() => this._startStatusEdit(d.slug)}
+                >
+                  ${icon('pencil', 16)}
+                </button>
+                ${isDefault
+                  ? null
                   : html`
-                      <button
-                        data-testid="status-edit"
-                        aria-label=${`Edit ${d.label}`}
-                        title="Edit"
-                        @click=${() => this._startStatusEdit(d.slug)}
-                      >
-                        ${icon('pencil', 16)}
-                      </button>
                       <button
                         class="danger"
                         data-testid="status-remove"
@@ -1627,8 +1745,11 @@ export class HVOrganizeDialog extends LitElement {
 
   private _renderStatusEditor(slug: string | 'new') {
     const creating = slug === 'new';
+    const derived = creating ? slugFromLabel(this._statusLabel, this.st?.statuses) : slug;
+    const duplicate = this._duplicateLabel;
+    const glyph = knownIcon(this._statusIcon);
     return html`<div class="expander" data-testid="status-editor">
-      <label style="display:flex;align-items:center;gap:8px">
+      <label class="status-name">
         <span class="hv-sr-only">Status name</span>
         <input
           class="control"
@@ -1643,10 +1764,15 @@ export class HVOrganizeDialog extends LitElement {
             if (e.key === 'Enter') void this._saveStatus();
           }}
         />
-        <span class="status-slug" data-testid="status-slug-preview"
-          >${creating ? this._slugFrom(this._statusLabel || '') : slug}</span
+        <span class="status-slug" data-testid="status-slug-preview" title=${derived}
+          >${derived}</span
         >
       </label>
+      ${duplicate
+        ? html`<div class="hint" data-testid="status-duplicate-hint">
+            A status called “${duplicate}” already exists.
+          </div>`
+        : null}
 
       <span class="hv-label">Colour</span>
       <div class="swatches" data-testid="status-colors">
@@ -1662,7 +1788,9 @@ export class HVOrganizeDialog extends LitElement {
             @click=${() => {
               this._statusColor = c;
             }}
-          ></button>`,
+          >
+            ${glyph ? icon(glyph, 15) : html`<span class="letters">Aa</span>`}
+          </button>`,
         )}
       </div>
 
@@ -1715,11 +1843,11 @@ export class HVOrganizeDialog extends LitElement {
     if (!guard) return null;
     const label = statusLabel(guard.slug, this._statusDefs);
     const targets = this._statusDefs.filter((d) => d.slug !== guard.slug);
-    return html`<div class="expander guard" data-testid="status-guard" role="alert">
-      <span class="note"
+    return html`<div class="expander guard status-guard" data-testid="status-guard" role="alert">
+      <span class="guard-message" data-testid="status-guard-message"
         >“${label}” is on ${counted(guard.count, 'item')}. Choose where those items go.</span
       >
-      <label style="display:flex;align-items:center;gap:8px">
+      <label class="guard-target">
         <span>Move those items to</span>
         <select
           class="control"

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -288,6 +288,23 @@ export class HVOrganizeDialog extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
       }
+      /* Giving up its width before the chip does is what "the one part that may
+         be cut" means, and a plain shrink factor of 1 does not say it: flexbox
+         would take from both in proportion to their widths, eliding a label the
+         household wrote while the slug it never types still holds 60px. */
+      .status-row .status-slug {
+        flex-shrink: 20;
+      }
+      /* A label is a household's own words and can be long enough that the row
+         overruns on its own — the fixed parts beside it (a 44px reorder column,
+         the count, two 44px actions) leave a phone row barely 130px for it. The
+         chip elides too, once the slug has nothing left to give; unshrinkable,
+         it pushes the delete button past the dialog edge where no finger
+         reaches it. */
+      .status-row .hv-status-chip {
+        flex: 0 1 auto;
+        min-width: 0;
+      }
       .status-name {
         display: flex;
         align-items: center;

--- a/cards/haventory-card/src/ui/status.test.ts
+++ b/cards/haventory-card/src/ui/status.test.ts
@@ -5,7 +5,9 @@ import {
   BUILT_IN_STATUSES,
   DEFAULT_STATUS,
   itemStatus,
+  knownIcon,
   renderStatusChip,
+  slugFromLabel,
   statusCount,
   statusIconName,
   statusLabel,
@@ -68,6 +70,48 @@ describe('ui/status: rendering a slug', () => {
     ];
     expect(statusIconName('x', exotic)).toBeNull();
     expect(statusIconName('mystery', CUSTOM)).toBeNull();
+  });
+
+  // The organize dialog's swatches paint the glyph being chosen, so they narrow
+  // a stored name the same way a chip does rather than trusting it.
+  it('narrows a bare icon name to one the bundle carries', () => {
+    expect(knownIcon('hand')).toBe('hand');
+    expect(knownIcon('not-a-glyph')).toBeNull();
+    expect(knownIcon(undefined)).toBeNull();
+    expect(knownIcon(null)).toBeNull();
+  });
+});
+
+describe('ui/status: deriving a slug from a label', () => {
+  it('strips accents rather than turning them into separators', () => {
+    // NFKD splits the mark off the letter; without the strip the label would
+    // slug to "caf_" and a household writing an automation would never guess it.
+    expect(slugFromLabel('Café', CUSTOM)).toBe('cafe');
+    expect(slugFromLabel('Zu verschenken', CUSTOM)).toBe('zu_verschenken');
+    expect(slugFromLabel('Ausgeliehen — Nachbarn', CUSTOM)).toBe('ausgeliehen_nachbarn');
+  });
+
+  it('never mints an empty identifier', () => {
+    expect(slugFromLabel('', CUSTOM)).toBe('status');
+    expect(slugFromLabel('   ', CUSTOM)).toBe('status');
+    expect(slugFromLabel('!!!', CUSTOM)).toBe('status');
+  });
+
+  it('caps the identifier at 64 characters', () => {
+    expect(slugFromLabel('a'.repeat(80), CUSTOM)).toBe('a'.repeat(64));
+  });
+
+  it('walks the suffix past every slug already taken', () => {
+    const taken: StatusDefinition[] = [
+      ...CUSTOM,
+      { slug: 'lent_out_2', label: 'Lent out (again)', order: 2, color: 'blue', icon: 'hand' },
+    ];
+    expect(slugFromLabel('Lent out', taken)).toBe('lent_out_3');
+  });
+
+  it('derives against the built-ins until the backend has answered', () => {
+    expect(slugFromLabel('OK', null)).toBe('ok_2');
+    expect(slugFromLabel('Lent out', null)).toBe('lent_out');
   });
 });
 

--- a/cards/haventory-card/src/ui/status.ts
+++ b/cards/haventory-card/src/ui/status.ts
@@ -141,18 +141,63 @@ export function statusToneClass(
 }
 
 /**
+ * A stored icon name narrowed to one this bundle carries, or null.
+ *
+ * `IconName` is a compile-time set and a stored icon is just a string — an
+ * import or a newer backend can name a glyph this bundle has never heard of —
+ * so anything read back from a definition has to pass through here before it
+ * can be rendered.
+ */
+export function knownIcon(name: string | null | undefined): IconName | null {
+  return name != null && name in ICONS ? (name as IconName) : null;
+}
+
+/**
  * The glyph for a slug, or null when it names one this bundle does not carry.
  *
- * `IconName` is a compile-time set and a stored icon is just a string, so the
- * lookup has to narrow it. Null renders no glyph, which is the right outcome:
- * the chip still carries its label and its colour.
+ * Null renders no glyph, which is the right outcome: the chip still carries its
+ * label and its colour.
  */
 export function statusIconName(
   slug: string,
   defs: readonly StatusDefinition[] | null | undefined,
 ): IconName | null {
-  const name = definitionOf(slug, defs)?.icon;
-  return name !== undefined && name in ICONS ? (name as IconName) : null;
+  return knownIcon(definitionOf(slug, defs)?.icon);
+}
+
+/**
+ * A slug from a label: lowercase, ASCII letters/digits/underscores, and never
+ * one the vocabulary already carries.
+ *
+ * The user never types this — a household should not have to think about the
+ * identifier — but it is what `services.yaml` and an export document carry, so
+ * the editor shows it beside the label for anyone writing an automation.
+ *
+ * The numeric suffix is a backstop against the backend refusing a slug already
+ * taken, not the answer to a duplicate label: two statuses named the same thing
+ * are indistinguishable in every chip on the card, so the editor warns about
+ * that separately rather than leaving this walk to resolve it silently.
+ */
+export function slugFromLabel(
+  label: string,
+  defs: readonly StatusDefinition[] | null | undefined,
+): string {
+  const base =
+    label
+      .normalize('NFKD')
+      // The combining marks NFKD just split off; stripping them is what turns
+      // "Ausgeliehen" with an umlaut into ASCII rather than into underscores.
+      .replace(/[̀-ͯ]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 64) || 'status';
+  const taken = new Set(statusList(defs).map((d) => d.slug));
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n += 1) {
+    const candidate = `${base.slice(0, 61)}_${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Work package **P4** of the v0.4.0 UI-audit remediation (`dev/ui_audit_v040_fix_plan.md`) — items **B5, B10, B11, B12, B13, C21**. Wave 3; P1 (#308) and P3 (#311) are merged, so both the hard and the soft edge are satisfied.

The organize dialog's Statuses tab was built for a mouse on a wide screen and came apart on a phone. All changes are in `cards/haventory-card/src/components/hv-organize-dialog.ts` plus the shared `src/ui/status.ts`; the file has no `@media` queries, so every narrow-width rule rides the reflected `mobile` property, as the rest of the file does.

- **B5 — the delete guard stacks.** The guard put its message, its "Move those items to" select and its actions on one row; at 390px the select rendered ~44px wide showing `O⌄`, hiding the one thing the guard exists to state before a destructive click. `.guard` now wraps at every width, `:host([mobile]) .status-guard` stacks it into three lines, and the select carries `min-width: 140px` with `.guard-target` wrapping below ~330px so it never overflows. The stacking is keyed on a new `.status-guard` class rather than `.guard`, so the locations tab's guard is untouched.
  - *In passing*: the guard's own sentence carried `.note`'s `--hv-text-tertiary`, which measures **2.46:1** over `--hv-warn-bg` in light. It now takes the guard's `--hv-warn-deep` (6.67:1). It is the alert's own message, and the finding is inside the element B5 is about, so it was fixed rather than filed.
- **B10 — every control is a real target.** DOM-measured on a phone before this pass: chevrons **15×15** stacked a pixel apart, edit/delete 26×26, swatches 26×22, the count link 53×**14**. All are now ≥24px at every width and take `var(--hv-tap-min, 44px)` under `:host([mobile])`. The 44px fallback matters: `--hv-tap-min` reaches the dialog by inheritance from `hv-card-shell`'s `:host([mobile])`, but the **sidebar panel declares none**, and the panel is where the audit's measurements were taken. `.swatches` already wrapped — now pinned, since the fix depends on it.
- **B11 — swatches are miniature chips.** Each swatch paints the tone's ink on the tone's tint, carrying the glyph being chosen (or `Aa` when a definition names a glyph this bundle does not have). Painting only the tint left the five light tones near-identical on white and, in dark, washes with nothing behind them.
- **B12 — the default status is editable.** `ok` rendered the "Default" pill *instead of* the action buttons. It now renders the pill *and* the edit button; only delete stays withheld. The backend has always accepted label/colour/icon for any slug.
- **B13 — a colliding label warns.** A trimmed label that case-insensitively matches another status's shows an inline hint before Create. It warns rather than blocks, and the slug dedupe stays as the backstop the backend's slug-collision refusal needs. The status being edited is excluded from the comparison, so renaming a status without changing its name is not a collision.
- **C21 — the slug preview shows the slug.** It keeps its intrinsic width and wraps under the name field on narrow rather than eliding beside it, and both places a slug renders carry it as a `title`.
- **Consolidation.** `_slugFrom` moves to `ui/status.ts` as the pure `slugFromLabel(label, defs)` and is unit-tested directly; `knownIcon` joins it so the swatches narrow a stored glyph name the same way a chip does.

No WebSocket contract, backend or docs surface changes. P4 carries no issue wiring per the plan's §Campaign rules, so this PR closes nothing on its own.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 749 passed, 22 skipped · `uv run ruff check .` → all checks passed · `uv run ruff format --check .` → 115 files already formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean · `npx vitest run` → **1340 passed (54 files)** · `npm run build` → 528.29 kB

18 tests added. Reverting the component and re-running the suite fails **11 of the 13** new dialog tests, which is the intended TDD signal; the two that pass are the deliberate absent-case guard (no duplicate hint while editing a status under its own name) and the `.swatches { flex-wrap }` pin, which documents an existing rule the touch sizing now relies on.

Rewritten pin, as the plan directs: `offers no delete for the default status` becomes `withholds delete from the default status but not the rename` — it now asserts the pill **and** the edit affordance, and that the editor opens on `ok`. No assertion was dropped without a replacement.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — none needed; nothing here is visible in the WS contract.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Deviations from the package brief

**`.guard .glyph` was not deleted.** P4's scope calls it dead ("nothing renders it"). It is not: the locations tab's delete guard renders `<span class="glyph">${icon('alert', 17)}</span>`, and deleting the rule would drop that mark from `--hv-warn` to secondary grey. The rule stays, and the mobile icon-picker sizing is written as `:host([mobile]) .swatches .glyph` so it cannot reach the guard's span.

That collision — `.glyph` meaning both "icon-picker button" and "guard alert mark", so the guard's icon draws inside a bordered 30×26 box with a pointer cursor — plus the same under-size `.count-link` / `.row-actions button` in the other three tabs, are filed as **#316** rather than folded in here, per §Campaign rules.

## Screenshots (card / UI changes)

None — this is a remote session with no dev HA container. Visual confirmation is delegated to the handover pass below, which is what the plan's §Verification marks **Required** for P4.

---

### Handover — required before merge

> Check out branch `claude/ui-audit-v040-p4-bs0j6l` (PR #317) of chrreiter/HAventory. Use the `run-haventory` skill to deploy the integration + card to the dev HA container. Seed the Statuses tab with a fixture like the audit's: the three built-ins plus `gesperrt` (red), `lent_out_to_the_neighbours` (blue, ~100 items), `sold` (neutral_strong, 1), `in_transit` (blue_strong, 0) and `giveaway` labelled "Zu verschenken" (amber_strong, ~40 items). Then, at **390px width in both light and dark**, open Organize → Statuses and check:
>
> 1. **Delete guard stacks.** Delete "Zu verschenken" (40 items). Expect three lines — the message, then "Move those items to" with the select beside it, then Cancel / "Reassign and delete". The select must show a full status label, not `O⌄`. The message must read at the guard's dark-amber ink, not a pale grey. Repeat at desktop width: the message takes its own line and the select stays readable.
> 2. **Touch targets, DOM-measured — do not eyeball.** With devtools, `getBoundingClientRect()` on `status-up`, `status-down`, `status-edit`, `status-remove`, `status-count` and `status-color`. Every one ≥24px in both dimensions; on the phone layout expect 44px on the chevrons, row actions and swatches. Confirm two adjacent chevrons no longer share an edge — tap "move down" on a middle row and check the row moves *down*.
> 3. **Swatches legible in dark.** Open the editor for a status. Each of the ten swatches shows the chosen glyph on its own tint; `neutral`, `green`, `amber` and `red` are told apart at a glance in dark, and light vs strong separate. Change the icon — every swatch's glyph follows.
> 4. **Default is editable.** The `ok` row shows a "Default" pill *and* a pencil, and no trash. Open it, rename to something else, save, and confirm the new label shows on item rows and in the filter chips. (On desktop the row actions only appear on hover — that is pre-existing.)
> 5. **Duplicate label warns.** New status → type `sold` (or `SOLD`). An inline hint names the existing "Sold" and Create stays enabled. Clear it to a unique name and the hint goes.
> 6. **Slug preview in full.** New status → type "Lent out to the neighbours". The preview reads `lent_out_to_the_neighbours` complete, wrapping under the field on the phone layout rather than eliding, and hovering it shows the same as a tooltip. The list row's slug still elides with the delete button reachable.
>
> If a check fails, fix it on this branch, re-run the offline gates (backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`; frontend, in `cards/haventory-card`: `npx eslint .`, `npm run typecheck`, `npx vitest run`, `npm run build`), and push. Report each check's outcome; **do not merge the PR**.
