### PR TITLE
feat(card): guarded attachment removal, escape discipline, first-run location create, visible upload progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,15 @@ throughout.
   (picked from a tree inside the form), checked-out with due date, next inspection (with the same
   +7 / +31 / +90 / +X quick offsets the check-out popover offers), and typed
   custom fields (text / number / yes-no / date). Saves send the item's expected version so
-  a concurrent edit surfaces as a conflict.
+  a concurrent edit surfaces as a conflict. Escape takes back one thing at a time: an open
+  picker first, then the form — and a form you have typed into asks before it discards.
+  With no locations yet, the location picker creates the first one and files the item in
+  it, rather than pointing at a menu three steps away.
+- **Photos and manuals** attach from the same form, once the item exists — an upload is
+  filed against an item id, and the create form says so instead of leaving the sections
+  unexplained. Each queue reports itself under the section that started it, with a moving
+  indicator while a file is in flight; a refused file keeps its error and Retry until you
+  dismiss them. Removing an attachment asks first, because the file goes with it.
 - **Full view** — a fullscreen workspace with a coloured app bar, a **browse sidebar**, and
   a sortable table. Only columns the backend can sort by get a clickable header. A browser
   that has made no choice yet shows every optional column — quantity, status, category,

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -11,7 +11,7 @@ import { emptyKindFor } from '../ui/empty-state';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { HostSurfaces } from '../host-surfaces';
 import type { Store } from '../store/store';
-import type { Item, StoreFilters, StoreState } from '../store/types';
+import type { Item, Location, StoreFilters, StoreState } from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import './hv-banner';
 import './hv-bottom-sheet';
@@ -541,6 +541,16 @@ export class HVCardShell extends LitElement {
     this._editing = next;
   }
 
+  /**
+   * The editor's first-run way out of an empty location picker: a root location
+   * with no area, handed back so the form can file the item in it at once.
+   */
+  private _createLocationForEditor = (name: string): Promise<Location> => {
+    const store = this.store;
+    if (!store) return Promise.reject(new Error('Not connected to Home Assistant yet.'));
+    return store.createLocation(name, null, null);
+  };
+
   private _onEditorSave = async (e: CustomEvent) => {
     const detail = e.detail as {
       itemId: string | null;
@@ -594,6 +604,7 @@ export class HVCardShell extends LitElement {
       .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
       .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
       .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
+      .createLocation=${this._createLocationForEditor}
       ?mobile=${this.mobile}
       .busy=${this._editorBusy}
       .errorMessage=${this._editorError}
@@ -1186,6 +1197,7 @@ export class HVCardShell extends LitElement {
             .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
             .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
             .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
+            .createLocation=${this._createLocationForEditor}
             .busy=${this._editorBusy}
             .errorMessage=${this._editorError}
             @cancel=${() => {

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -394,6 +394,9 @@ export class HVDetailSheet extends LitElement {
   @property({ attribute: false }) categorySuggestions: string[] = [];
   @property({ attribute: false }) tagSuggestions: string[] = [];
   @property({ attribute: false }) customFieldKeys: string[] = [];
+  /** Passed straight to the editor: creating a first location from its picker. */
+  @property({ attribute: false }) createLocation: ((name: string) => Promise<Location>) | null =
+    null;
   @property({ type: Boolean }) busy = false;
   @property({ type: String }) errorMessage: string | null = null;
 
@@ -815,6 +818,7 @@ export class HVDetailSheet extends LitElement {
         .categorySuggestions=${this.categorySuggestions}
         .tagSuggestions=${this.tagSuggestions}
         .customFieldKeys=${this.customFieldKeys}
+        .createLocation=${this.createLocation}
         .busy=${this.busy}
         .errorMessage=${this.errorMessage}
         @cancel=${() => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -19,7 +19,7 @@ import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
 import type { ColumnKey } from '../store/columns';
-import type { Item, LocationTreeNode, Sort, StoreFilters, StoreState } from '../store/types';
+import type { Item, Location, LocationTreeNode, Sort, StoreFilters, StoreState } from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import { makeBulkOp } from '../store/store';
 import type { BulkOperation, BulkOutcome } from '../store/types';
@@ -1090,6 +1090,20 @@ export class HVFullView extends LitElement {
     }
   }
 
+  /**
+   * The editor's first-run way out of an empty location picker.
+   *
+   * A root location with no area — the only placement that needs no tree to
+   * point at — and the created object handed back, because the form files the
+   * item in it as soon as it exists. Distinct from the sidebar's own creator
+   * above, which files under whatever the sidebar has selected.
+   */
+  private _createLocationForEditor = (name: string): Promise<Location> => {
+    const store = this.store;
+    if (!store) return Promise.reject(new Error('Not connected to Home Assistant yet.'));
+    return store.createLocation(name, null, null);
+  };
+
   // ---------- Sections ----------
   /**
    * One collapsible sidebar heading. The chevron and the words are one target —
@@ -1759,6 +1773,7 @@ export class HVFullView extends LitElement {
                     .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
                     .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
                     .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
+                    .createLocation=${this._createLocationForEditor}
                     .busy=${this._editorBusy}
                     ?mobile=${this._narrow}
                     @save=${this._onEditorSave}

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1181,6 +1181,54 @@ describe('hv-item-editor: creating the first location from the picker', () => {
     expect(saves[0].create?.location_id).toBe('loc-new');
   });
 
+  /** Type a name into the empty picker's create row and submit it. */
+  async function submitCreate(el: HVItemEditor, tree: HTMLElement, name: string) {
+    (tree.shadowRoot?.querySelector('[data-testid="tree-create"]') as HTMLButtonElement).click();
+    await (tree as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+    const input = tree.shadowRoot?.querySelector('[data-testid="tree-create-name"]') as HTMLInputElement;
+    input.value = name;
+    input.dispatchEvent(new Event('input'));
+    await (tree as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-create-submit"]') as HTMLButtonElement).click();
+    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+  }
+
+  // The inline expander reaches this form through a template callback `hv-list`
+  // re-invokes only when one of its own properties changes. A location create
+  // changes none of them, so `locations` can stay empty for as long as the form
+  // is open — and the field would name nothing it had just filled.
+  it('names the location it created even when the host list never catches up', async () => {
+    const el = await mount(null, { ...empty, createLocation: async () => created });
+    const tree = await openTree(el);
+    await submitCreate(el, tree, 'Shed');
+
+    expect(el.locations).toEqual([]);
+    expect(q(el, '[data-testid="editor-location"]')?.textContent).toContain('Shed');
+  });
+
+  it('lists what it created when the picker is reopened', async () => {
+    const el = await mount(null, { ...empty, createLocation: async () => created });
+    await submitCreate(el, await openTree(el), 'Shed');
+    const reopened = await openTree(el);
+
+    // Still the empty state would offer to create the same name a second time.
+    expect(reopened.shadowRoot?.querySelector('[data-testid="tree-empty"]')).toBe(null);
+    expect(reopened.shadowRoot?.textContent).toContain('Shed');
+  });
+
+  it('does not double the row once the host list carries it too', async () => {
+    const el = await mount(null, { ...empty, createLocation: async () => created });
+    await submitCreate(el, await openTree(el), 'Shed');
+
+    el.locations = [created];
+    el.locationTree = [{ ...created, direct_item_count: 0, subtree_item_count: 0, children: [] }];
+    await el.updateComplete;
+    const reopened = await openTree(el);
+
+    const rows = [...(reopened.shadowRoot?.querySelectorAll('[data-testid="tree-row"]') ?? [])];
+    expect(rows.filter((r) => r.textContent?.includes('Shed'))).toHaveLength(1);
+  });
+
   it('reports a refused name against the field instead of swallowing it', async () => {
     const el = await mount(null, {
       ...empty,

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -73,6 +73,29 @@ async function checkOut(el: HVItemEditor) {
   return popover;
 }
 
+/** The dialog behind a testid, awaited so its own render has run. */
+async function dialog(el: HVItemEditor, testid: string) {
+  const found = q(el, `[data-testid="${testid}"]`) as HTMLElement & {
+    updateComplete: Promise<unknown>;
+    open: boolean;
+  };
+  await found.updateComplete;
+  return found;
+}
+
+/** Press a remove control and answer the guard it opens. */
+async function removeAttachment(el: HVItemEditor, testid: string, answer: 'confirm' | 'cancel') {
+  (q(el, `[data-testid="${testid}"]`) as HTMLButtonElement).click();
+  await el.updateComplete;
+  const guard = await dialog(el, 'editor-remove-confirm');
+  (
+    guard.shadowRoot?.querySelector(
+      answer === 'confirm' ? '[data-testid="confirm-accept"]' : '[data-testid="confirm-cancel"]',
+    ) as HTMLButtonElement
+  ).click();
+  await el.updateComplete;
+}
+
 function onSave(el: HVItemEditor) {
   const saves: { itemId: string | null; expectedVersion?: number; changes?: ItemUpdate; create?: ItemCreate }[] =
     [];
@@ -998,6 +1021,190 @@ describe('hv-item-editor: opening', () => {
   });
 });
 
+// Escape-to-close-a-dropdown is muscle memory; here it used to cost the whole
+// form, dropdown and typing together.
+describe('hv-item-editor: Escape takes back one thing at a time', () => {
+  const esc = (el: HVItemEditor, from?: HTMLElement) =>
+    (from ?? (q(el, '[data-testid="item-editor"]') as HTMLElement)).dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }),
+    );
+
+  function onCancel(el: HVItemEditor) {
+    const seen = { count: 0 };
+    el.addEventListener('cancel', () => {
+      seen.count += 1;
+    });
+    return seen;
+  }
+
+  it('closes the location picker and leaves the form standing', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const cancels = onCancel(el);
+
+    (q(el, '[data-testid="editor-location"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(q(el, '[data-testid="editor-location-tree"]')).toBeTruthy();
+
+    esc(el);
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="editor-location-tree"]')).toBe(null);
+    expect(cancels.count).toBe(0);
+    // And the control that opened it takes the focus back.
+    expect(el.shadowRoot?.activeElement).toBe(q(el, '[data-testid="editor-location"]'));
+  });
+
+  // The popover renders in a shadow root of its own; without the key stopping
+  // there it reached this form's handler too and closed both.
+  it('closes the check-out popover and leaves the form standing', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const cancels = onCancel(el);
+
+    (q(el, '[data-testid="editor-checked-out"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const popover = (await dialog(el, 'editor-checkout')) as HTMLElement & { open: boolean };
+    expect(popover.open).toBe(true);
+
+    (popover.shadowRoot?.querySelector('[data-testid="checkout-popover"]') as HTMLElement).dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }),
+    );
+    await el.updateComplete;
+
+    expect(popover.open).toBe(false);
+    expect(cancels.count).toBe(0);
+  });
+
+  it('asks before discarding a form that has been typed into', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const cancels = onCancel(el);
+    await type(el, 'editor-name', 'A longer name');
+    expect(el.dirty).toBe(true);
+
+    esc(el);
+    await el.updateComplete;
+
+    const guard = await dialog(el, 'editor-discard-confirm');
+    expect(guard.open).toBe(true);
+    expect(cancels.count).toBe(0);
+
+    (guard.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(cancels.count).toBe(1);
+  });
+
+  it('keeps the form when the discard guard is dismissed', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const cancels = onCancel(el);
+    await type(el, 'editor-name', 'A longer name');
+
+    esc(el);
+    await el.updateComplete;
+    const guard = await dialog(el, 'editor-discard-confirm');
+    (guard.shadowRoot?.querySelector('[data-testid="confirm-cancel"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(cancels.count).toBe(0);
+    expect((q(el, '[data-testid="editor-name"]') as HTMLInputElement).value).toBe('A longer name');
+    expect(el.dirty).toBe(true);
+  });
+
+  it('closes a clean form on the spot, with nothing to ask about', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const cancels = onCancel(el);
+
+    esc(el);
+    await el.updateComplete;
+
+    expect(cancels.count).toBe(1);
+    expect((await dialog(el, 'editor-discard-confirm')).open).toBe(false);
+  });
+});
+
+// The first minute of a fresh install: an item form whose most important field
+// cannot be satisfied, and no way in sight to make it satisfiable.
+describe('hv-item-editor: creating the first location from the picker', () => {
+  const empty = { locationTree: [] as LocationTreeNode[], locations: [] as Location[] };
+
+  const created: Location = {
+    id: 'loc-new',
+    name: 'Shed',
+    parent_id: null,
+    area_id: null,
+    path: { id_path: ['loc-new'], name_path: ['Shed'], display_path: 'Shed', sort_key: 'shed' },
+  };
+
+  async function openTree(el: HVItemEditor) {
+    (q(el, '[data-testid="editor-location"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const tree = el.shadowRoot?.querySelector('hv-location-tree') as HTMLElement & {
+      updateComplete: Promise<unknown>;
+    };
+    await tree.updateComplete;
+    return tree;
+  }
+
+  it('offers no create affordance when the host cannot run the command', async () => {
+    const el = await mount(null, empty);
+    const tree = await openTree(el);
+
+    expect(tree.shadowRoot?.querySelector('[data-testid="tree-empty"]')).toBeTruthy();
+    expect(tree.shadowRoot?.querySelector('[data-testid="tree-create"]')).toBe(null);
+  });
+
+  it('creates the location and files the item in it', async () => {
+    const names: string[] = [];
+    const el = await mount(null, {
+      ...empty,
+      createLocation: async (name: string) => {
+        names.push(name);
+        return created;
+      },
+    });
+    const saves = onSave(el);
+    await type(el, 'editor-name', 'Ladder');
+    const tree = await openTree(el);
+
+    (tree.shadowRoot?.querySelector('[data-testid="tree-create"]') as HTMLButtonElement).click();
+    await tree.updateComplete;
+    const input = tree.shadowRoot?.querySelector('[data-testid="tree-create-name"]') as HTMLInputElement;
+    input.value = 'Shed';
+    input.dispatchEvent(new Event('input'));
+    await tree.updateComplete;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-create-submit"]') as HTMLButtonElement).click();
+    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+
+    expect(names).toEqual(['Shed']);
+    // Picked, and the picker closed behind it — the same shape as picking an
+    // existing location.
+    expect(el.shadowRoot?.querySelector('hv-location-tree')).toBe(null);
+    (q(el, '[data-testid="editor-save"]') as HTMLButtonElement).click();
+    expect(saves[0].create?.location_id).toBe('loc-new');
+  });
+
+  it('reports a refused name against the field instead of swallowing it', async () => {
+    const el = await mount(null, {
+      ...empty,
+      createLocation: async () => {
+        throw new Error('A location called Shed already exists');
+      },
+    });
+    const tree = await openTree(el);
+
+    (tree.shadowRoot?.querySelector('[data-testid="tree-create"]') as HTMLButtonElement).click();
+    await tree.updateComplete;
+    const input = tree.shadowRoot?.querySelector('[data-testid="tree-create-name"]') as HTMLInputElement;
+    input.value = 'Shed';
+    input.dispatchEvent(new Event('input'));
+    await tree.updateComplete;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-create-submit"]') as HTMLButtonElement).click();
+    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+
+    expect(q(el, '[data-testid="editor-location-error"]')?.textContent).toContain('already exists');
+    // The picker stays open so the name can be corrected where it was typed.
+    expect(el.shadowRoot?.querySelector('hv-location-tree')).toBeTruthy();
+  });
+});
+
 describe('hv-item-editor: pictures', () => {
   /** Drive the hidden file input the way a picker does. */
   function pick(el: HVItemEditor, files: File[]) {
@@ -1121,7 +1328,9 @@ describe('hv-item-editor: pictures', () => {
     expect(q(el, '[data-testid="editor-upload"]')?.textContent).toContain('2 photos is the limit');
   });
 
-  it('removes a picture and adopts the returned item', async () => {
+  // Deleting an attachment destroys the only copy of the file, so it asks —
+  // like every other destructive action on the card.
+  it('removes a picture once the guard is answered, and adopts the returned item', async () => {
     const media = makeMediaBindings({
       remove: async (itemId) => makeItem({ id: itemId, version: 9, attachments: [] }),
     });
@@ -1131,11 +1340,54 @@ describe('hv-item-editor: pictures', () => {
     );
     await el.updateComplete;
 
-    q(el, '[data-testid="editor-photo-remove"]')?.click();
+    (q(el, '[data-testid="editor-photo-remove"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    // Nothing is sent on the press itself.
+    expect(media.removals).toEqual([]);
+    expect((await dialog(el, 'editor-remove-confirm')).open).toBe(true);
+
+    (
+      (await dialog(el, 'editor-remove-confirm')).shadowRoot?.querySelector(
+        '[data-testid="confirm-accept"]',
+      ) as HTMLButtonElement
+    ).click();
     for (let i = 0; i < 4; i += 1) await el.updateComplete;
 
     expect(media.removals).toEqual([{ itemId: 'i-1', attachmentId: 'att-1' }]);
     expect(all(el, '[data-testid="editor-photo"]')).toHaveLength(0);
+  });
+
+  it('keeps the picture when the guard is dismissed', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] }), {
+      media,
+    });
+    await el.updateComplete;
+
+    await removeAttachment(el, 'editor-photo-remove', 'cancel');
+    for (let i = 0; i < 3; i += 1) await el.updateComplete;
+
+    expect(media.removals).toEqual([]);
+    expect(all(el, '[data-testid="editor-photo"]')).toHaveLength(1);
+  });
+
+  // The guard sits outside the form's own event scope: a host closes the editor
+  // on `cancel`, and answering "no, keep the photo" is not that.
+  it('keeps its guard events to itself', async () => {
+    const el = await mount(makeItem({ id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] }), {
+      media: makeMediaBindings(),
+    });
+    await el.updateComplete;
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    await removeAttachment(el, 'editor-photo-remove', 'cancel');
+    await removeAttachment(el, 'editor-photo-remove', 'confirm');
+    for (let i = 0; i < 3; i += 1) await el.updateComplete;
+
+    expect(cancels).toBe(0);
   });
 
   it('offers the camera from the same control that picks a file', async () => {
@@ -1323,12 +1575,28 @@ describe('hv-item-editor: documents', () => {
     );
     await el.updateComplete;
 
-    q(el, '[data-testid="editor-document-remove"]')?.click();
+    await removeAttachment(el, 'editor-document-remove', 'confirm');
     await new Promise((resolve) => setTimeout(resolve, 0));
     await el.updateComplete;
 
     expect(media.removals).toEqual([{ itemId: 'i-1', attachmentId: 'm-1' }]);
     expect(all(el, '[data-testid="editor-document"]')).toHaveLength(0);
+  });
+
+  it('names the document in the guard, not the photo copy', async () => {
+    const el = await mount(makeItem({ id: 'i-1', attachments: [makeManual({ id: 'm-1' })] }), {
+      media: makeMediaBindings(),
+    });
+    await el.updateComplete;
+
+    (q(el, '[data-testid="editor-document-remove"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const guard = await dialog(el, 'editor-remove-confirm');
+
+    expect(guard.shadowRoot?.querySelector('h2')?.textContent).toContain('document');
+    expect(guard.shadowRoot?.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
+      'deleted',
+    );
   });
 
   it('names the file that failed rather than the section it came from', async () => {
@@ -1526,7 +1794,7 @@ describe('hv-item-editor: photo order and the cover', () => {
     });
     await el.updateComplete;
 
-    q(el, '[data-testid="editor-photo-remove"]')?.click();
+    await removeAttachment(el, 'editor-photo-remove', 'confirm');
     await drain();
     await el.updateComplete;
 
@@ -1788,7 +2056,7 @@ describe('hv-item-editor: upload errors outlive their siblings', () => {
     );
     await el.updateComplete;
 
-    q(el, '[data-testid="editor-photo-remove"]')?.click();
+    await removeAttachment(el, 'editor-photo-remove', 'confirm');
     for (let i = 0; i < 4; i += 1) await el.updateComplete;
     expect(q(el, '[data-testid="editor-upload-retry"]')).toBeNull();
 
@@ -1796,5 +2064,146 @@ describe('hv-item-editor: upload errors outlive their siblings', () => {
     await el.updateComplete;
 
     expect(q(el, '[data-testid="editor-upload"]')).toBeNull();
+  });
+});
+
+// A multi-MB photo on a phone connection renders as one static word for twenty
+// seconds unless something moves, and the queue that reported it sat two
+// sections below the grid the user was watching.
+describe('hv-item-editor: the upload queue reports where the work is', () => {
+  function pick(el: HVItemEditor, testid: string, files: File[]) {
+    const input = q(el, `[data-testid="${testid}"]`) as HTMLInputElement;
+    Object.defineProperty(input, 'files', { value: files, configurable: true });
+    input.dispatchEvent(new Event('change'));
+  }
+
+  /** Hold the upload open so the queue can be inspected mid-flight. */
+  function stalledMedia() {
+    return makeMediaBindings({ upload: () => new Promise<Item>(() => {}) });
+  }
+
+  it('files each queue under the section that started it', async () => {
+    const el = await mount(makeItem({ id: 'i-1' }), { media: stalledMedia() });
+    await el.updateComplete;
+
+    pick(el, 'editor-photo-input', [new File(['x'], 'shelf.png', { type: 'image/png' })]);
+    pick(el, 'editor-manual-input', [new File(['x'], 'manual.pdf', { type: 'application/pdf' })]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await el.updateComplete;
+
+    const lists = all(el, '[data-testid="editor-upload-list"]');
+    expect(lists.map((l) => l.dataset.kind)).toEqual(['picture', 'manual']);
+    expect(lists[0].textContent).toContain('shelf.png');
+    expect(lists[0].textContent).not.toContain('manual.pdf');
+    expect(lists[1].textContent).toContain('manual.pdf');
+    // Each list sits inside the section whose picker filled it.
+    expect(lists[0].closest('.cell')?.querySelector('[data-testid="editor-photos"]')).toBeTruthy();
+    expect(lists[1].closest('.cell')?.querySelector('[data-testid="editor-documents"]')).toBeTruthy();
+  });
+
+  it('moves something while a file is in flight, and stops when it fails', async () => {
+    const el = await mount(makeItem({ id: 'i-1' }), { media: stalledMedia() });
+    await el.updateComplete;
+
+    pick(el, 'editor-photo-input', [new File(['x'], 'shelf.png', { type: 'image/png' })]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await el.updateComplete;
+
+    const row = q(el, '[data-testid="editor-upload"]') as HTMLElement;
+    expect(row.dataset.state).toBe('uploading');
+    const bar = q(el, '[data-testid="editor-upload-progress"]') as HTMLElement;
+    expect(bar).toBeTruthy();
+    // Indeterminate on purpose: the WebSocket path reports no bytes sent, so
+    // the bar must not carry a value it would have to invent.
+    expect(bar.getAttribute('role')).toBe('progressbar');
+    expect(bar.hasAttribute('aria-valuenow')).toBe(false);
+  });
+
+  it('drops the indicator once the row is an error someone has to read', async () => {
+    const el = await mount(makeItem({ id: 'i-1' }), {
+      media: makeMediaBindings({
+        upload: async () => {
+          throw new Error('file content is not one of the accepted types');
+        },
+      }),
+    });
+    await el.updateComplete;
+
+    pick(el, 'editor-photo-input', [new File(['x'], 'broken.jpg', { type: 'image/png' })]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await el.updateComplete;
+
+    expect((q(el, '[data-testid="editor-upload"]') as HTMLElement).dataset.state).toBe('error');
+    expect(q(el, '[data-testid="editor-upload-progress"]')).toBe(null);
+  });
+
+  it('leaves the motion to the people who asked for it', async () => {
+    const css = editorCss();
+    expect(css).toMatch(/@media \(prefers-reduced-motion: no-preference\) \{ \.progress \.fill \{[^}]*animation:/);
+    expect(css).toMatch(/@keyframes hv-upload-sweep/);
+  });
+});
+
+describe('hv-item-editor: touch targets and the shared tally', () => {
+  // WCAG 2.2 asks 24px of every pointer target; the remove X measured 22.
+  it('gives the photo remove control the pointer minimum', () => {
+    expect(editorCss()).toMatch(/\.photos \.remove \{[^}]*width: 24px;[^}]*height: 24px/);
+  });
+
+  it('grows the tile controls into a real strip on a phone', () => {
+    const css = editorCss();
+    expect(css).toMatch(/\.tile-controls \{[^}]*height: 24px/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.tile-controls \{[^}]*height: var\(--hv-tap-min, 24px\)/);
+  });
+
+  it('sizes the queue controls from the same token', () => {
+    const css = editorCss();
+    expect(css).toMatch(
+      /\.upload-list li \.retry,\s*\.upload-list li \.dismiss \{[^}]*min-height: var\(--hv-tap-min, 24px\)/,
+    );
+  });
+
+  // The count beside a facet is declared once, in the shared sheet.
+  it('prices its custom fields with the shared tally', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    expect(q(el, '[data-testid="editor-cf-tally"]')?.classList.contains('hv-tally')).toBe(true);
+    // This component's own sheet may place the tally and nothing more — size
+    // and dimming belong to the one declaration in `base`.
+    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
+    const own = String((styles as { cssText: string }[])[(styles as unknown[]).length - 1].cssText).replace(
+      /\s+/g,
+      ' ',
+    );
+    for (const [, body] of own.matchAll(/\.hv-tally[^{]*\{([^}]*)\}/g)) {
+      expect(body).not.toMatch(/font-size|opacity|color/);
+    }
+    expect(own).not.toMatch(/\.custom-head \.tally\b/);
+  });
+});
+
+// The create form has no PHOTOS section at all — an upload is filed against an
+// item id and there is none yet. Unexplained, that reads as a missing feature.
+describe('hv-item-editor: why attachments wait for the first save', () => {
+  it('says so where the photo grid will be', async () => {
+    const el = await mount(null, { media: makeMediaBindings() });
+
+    expect(q(el, '[data-testid="editor-photos"]')).toBe(null);
+    expect(q(el, '[data-testid="editor-attachment-hint"]')?.textContent).toContain('Save the item first');
+  });
+
+  it('says nothing once the sections are actually there', async () => {
+    const el = await mount(makeItem({ id: 'i-1' }), { media: makeMediaBindings() });
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="editor-attachment-hint"]')).toBe(null);
+    expect(q(el, '[data-testid="editor-photos"]')).toBeTruthy();
+  });
+
+  // A host that hands over no media bindings offers no attachments at any
+  // point, so there is nothing to explain the absence of.
+  it('stays quiet when the card carries no attachment support at all', async () => {
+    const el = await mount(null);
+
+    expect(q(el, '[data-testid="editor-attachment-hint"]')).toBe(null);
   });
 });

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -48,6 +48,7 @@ import type {
   StatusDefinition,
 } from '../store/types';
 import './hv-chip-input';
+import './hv-confirm';
 import './hv-location-tree';
 import './hv-checkout-popover';
 
@@ -93,11 +94,23 @@ interface UploadEntry {
   kind: AttachmentKind;
 }
 
-/** The message on a rejected upload, whatever shape the rejection arrived in. */
-function errorText(err: unknown): string {
+/** How each kind of attachment names itself in a confirmation. */
+const REMOVE_COPY: Record<AttachmentKind, { heading: string; message: string }> = {
+  picture: {
+    heading: 'Remove this photo?',
+    message: 'The photo file is deleted with it, and there is no way back.',
+  },
+  manual: {
+    heading: 'Remove this document?',
+    message: 'The document file is deleted with it, and there is no way back.',
+  },
+};
+
+/** The message on a rejected command, whatever shape the rejection arrived in. */
+function errorText(err: unknown, fallback = 'Upload failed.'): string {
   if (err instanceof Error && err.message) return err.message;
   const message = (err as { message?: unknown } | null)?.message;
-  return typeof message === 'string' && message ? message : 'Upload failed.';
+  return typeof message === 'string' && message ? message : fallback;
 }
 
 /**
@@ -502,10 +515,8 @@ export class HVItemEditor extends LitElement {
         align-items: center;
         gap: 8px;
       }
-      .custom-head .tally {
+      .custom-head .hv-tally {
         margin-left: auto;
-        font-size: 11.5px;
-        color: var(--hv-text-tertiary);
       }
       .cf-row {
         display: grid;
@@ -711,13 +722,21 @@ export class HVItemEditor extends LitElement {
         color: var(--hv-text-tertiary);
       }
       /* Under the thumbnail rather than over it: these sit on whatever photo
-         was uploaded, and no overlay treatment is legible against every one. */
+         was uploaded, and no overlay treatment is legible against every one.
+         The same 24px square the organize dialog's reorder buttons take, so
+         one reordering control is one size across the card. A finger gets the
+         strip's full height instead of the dialog's 44px square, because these
+         are three controls sharing the width of the thumbnail they belong to
+         and a square each would be wider than the tile. */
       .tile-controls {
         display: flex;
-        align-items: center;
+        align-items: stretch;
         justify-content: space-between;
         height: 24px;
         background: var(--hv-surface-raised);
+      }
+      :host([mobile]) .tile-controls {
+        height: var(--hv-tap-min, 24px);
       }
       .tile-controls button,
       .tile-controls .is-cover {
@@ -730,6 +749,10 @@ export class HVItemEditor extends LitElement {
         background: none;
         color: var(--hv-text-secondary);
       }
+      :host([mobile]) .tile-controls button,
+      :host([mobile]) .tile-controls .is-cover {
+        height: auto;
+      }
       .tile-controls button[disabled] {
         opacity: 0.3;
       }
@@ -738,14 +761,18 @@ export class HVItemEditor extends LitElement {
       .tile-controls .is-cover {
         color: var(--hv-amber);
       }
+      /* 24px is the floor WCAG asks of a pointer target, and also the ceiling
+         a control sitting *on* a 72px thumbnail can take: a full tap-min square
+         would cover a third of the photo it is asking about. The confirm step
+         behind it is what makes the small target survivable. */
       .photos .remove {
         position: absolute;
         top: 2px;
         right: 2px;
         display: inline-grid;
         place-items: center;
-        width: 22px;
-        height: 22px;
+        width: 24px;
+        height: 24px;
         padding: 0;
         border: none;
         border-radius: 50%;
@@ -836,13 +863,21 @@ export class HVItemEditor extends LitElement {
         margin: 6px 0 0;
         padding: 0;
         display: grid;
-        gap: 3px;
+        gap: 5px;
         font-size: 11.5px;
         color: var(--hv-text-secondary);
       }
       .upload-list li {
         display: flex;
-        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 4px 8px;
+      }
+      .upload-list li .kind {
+        flex: none;
+        display: inline-grid;
+        place-items: center;
+        color: var(--hv-text-tertiary);
       }
       .upload-list li .file {
         overflow: hidden;
@@ -855,7 +890,11 @@ export class HVItemEditor extends LitElement {
       }
       .upload-list li .retry,
       .upload-list li .dismiss {
+        display: inline-grid;
+        place-items: center;
         margin-left: auto;
+        min-width: var(--hv-tap-min, 24px);
+        min-height: var(--hv-tap-min, 24px);
         border: none;
         background: none;
         padding: 0 4px;
@@ -869,6 +908,47 @@ export class HVItemEditor extends LitElement {
       /* Retry already claimed the free space; the dismiss follows it. */
       .upload-list li .retry ~ .dismiss {
         margin-left: 0;
+      }
+      /* Nothing on the WebSocket path reports bytes sent, so the bar says
+         "working" and never lies about how far along it is. It takes the whole
+         row width on a line of its own, because on a phone the file name and
+         the state word already fill the first one. */
+      .progress {
+        flex: 0 0 100%;
+        position: relative;
+        overflow: hidden;
+        height: 3px;
+        border-radius: 999px;
+        background: var(--hv-divider);
+      }
+      .progress .fill {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 40%;
+        border-radius: inherit;
+        background: var(--hv-primary);
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        .progress .fill {
+          animation: hv-upload-sweep 1.3s ease-in-out infinite;
+        }
+      }
+      @keyframes hv-upload-sweep {
+        from {
+          transform: translateX(-100%);
+        }
+        to {
+          transform: translateX(250%);
+        }
+      }
+      /* Create mode has no attachment sections at all — an upload is filed
+         against an item id and there is none yet. Said once, where the photo
+         grid will be, rather than left as an unexplained absence. */
+      .attach-hint {
+        font-size: 12px;
+        color: var(--hv-text-tertiary);
       }
     `,
   ];
@@ -895,6 +975,15 @@ export class HVItemEditor extends LitElement {
   @property({ attribute: false }) media: MediaBindings | null = null;
   /** Caps and accepted types, so a doomed file is refused before it is sent. */
   @property({ attribute: false }) mediaConfig: MediaConfig | null = null;
+  /**
+   * Creating a location from inside the picker, for an inventory that has none
+   * yet — the form's most important field is otherwise unsatisfiable on a first
+   * run. Null leaves the empty picker as a plain statement: only a host holding
+   * the store can run the command, and an affordance that cannot is worse than
+   * none.
+   */
+  @property({ attribute: false }) createLocation: ((name: string) => Promise<Location>) | null =
+    null;
 
   @state() private _model: ItemFormModel = formFromItem(null);
   @state() private _errors: FieldError[] = [];
@@ -933,6 +1022,12 @@ export class HVItemEditor extends LitElement {
    * the pre-upload one would come back `conflict`.
    */
   @state() private _uploaded: Item | null = null;
+  /** The attachment awaiting a yes, and what kind it is. */
+  @state() private _confirmRemove: { id: string; kind: AttachmentKind } | null = null;
+  /** Escape on a dirty form asks before it throws the typing away. */
+  @state() private _confirmDiscard = false;
+  /** Why creating a first location from the picker failed. */
+  @state() private _locationError: string | null = null;
 
   private readonly _urls = new MediaUrls(this);
   private _uploadSeq = 0;
@@ -982,6 +1077,9 @@ export class HVItemEditor extends LitElement {
       this._checkoutOpen = false;
       this._uploads = [];
       this._uploaded = null;
+      this._confirmRemove = null;
+      this._confirmDiscard = false;
+      this._locationError = null;
       this._closeCategory();
       return;
     }
@@ -1031,16 +1129,47 @@ export class HVItemEditor extends LitElement {
     this.dispatchEvent(new CustomEvent('cancel', { bubbles: true, composed: true }));
   };
 
+  /**
+   * Escape takes back one thing at a time.
+   *
+   * Whatever the form has open on top of itself goes first — a dropdown is what
+   * the user just opened, and closing it is what the key is muscle memory for.
+   * With nothing open, Escape means the form, and typing that has not been
+   * saved is worth a question before it is thrown away. A clean form has
+   * nothing to lose and closes on the spot.
+   */
   private _onKeydown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault();
       e.stopPropagation();
-      this._cancel();
+      if (this._categoryOpen) {
+        this._closeCategory();
+      } else if (this._checkoutOpen) {
+        this._checkoutOpen = false;
+      } else if (this._locationOpen) {
+        this._closeLocation();
+      } else if (this.dirty) {
+        this._confirmDiscard = true;
+      } else {
+        this._cancel();
+      }
     } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       this._save();
     }
   };
+
+  /** Shut the location picker and put focus back on the control that opened it. */
+  private _closeLocation() {
+    this._locationOpen = false;
+    this._locationError = null;
+    this.renderRoot.querySelector<HTMLElement>('[data-testid="editor-location"]')?.focus();
+  }
+
+  /** Hand focus back to the form after a dialog over it closes. */
+  private _refocus() {
+    this.renderRoot.querySelector<HTMLElement>('[data-testid="editor-name"]')?.focus();
+  }
 
   // ---------- Field renderers ----------
   private _text(
@@ -1098,14 +1227,43 @@ export class HVItemEditor extends LitElement {
               showAll
               allLabel="No location"
               allIcon="close"
+              ?allowCreate=${this.createLocation !== null}
               @select=${(e: CustomEvent) => {
                 this._patch({ locationId: (e.detail as { locationId: string | null }).locationId });
                 this._locationOpen = false;
+                this._locationError = null;
+              }}
+              @create-location=${(e: CustomEvent) => {
+                e.stopPropagation();
+                void this._createLocation((e.detail as { name: string }).name);
               }}
             ></hv-location-tree>`
           : null}
       </div>
+      ${this._locationError
+        ? html`<span class="field-error" data-testid="editor-location-error">${this._locationError}</span>`
+        : null}
     </div>`;
+  }
+
+  /**
+   * Make the first location and file the item in it in one move.
+   *
+   * The picker is where a first-run user meets locations at all, so the one it
+   * creates is also the one they were reaching for — anything else would send
+   * them back through the same empty dropdown.
+   */
+  private async _createLocation(name: string) {
+    const create = this.createLocation;
+    if (!create) return;
+    this._locationError = null;
+    try {
+      const created = await create(name);
+      this._patch({ locationId: created.id });
+      this._locationOpen = false;
+    } catch (err) {
+      this._locationError = errorText(err, 'The location could not be created.');
+    }
   }
 
   /**
@@ -1526,7 +1684,7 @@ export class HVItemEditor extends LitElement {
       <div class="custom">
         <div class="custom-head">
           <span class="hv-label">Custom fields</span>
-          <span class="tally" data-testid="editor-cf-tally">
+          <span class="hv-tally" data-testid="editor-cf-tally">
             ${used} of ${counted(this.customFieldKeys.length || used, 'key')} in use
           </span>
         </div>
@@ -1651,6 +1809,27 @@ export class HVItemEditor extends LitElement {
   }
 
   /**
+   * Report a failed attachment command in the queue the uploads already use.
+   *
+   * A reorder, a removal and a retitle all fail the same way and have nowhere
+   * else to be seen — the item they act on is unchanged, so nothing on the form
+   * would move. The entry carries no `File`, so it offers dismiss and no Retry.
+   */
+  private _pushUploadError(prefix: string, kind: AttachmentKind, name: string, err: unknown) {
+    this._uploads = [
+      ...this._uploads,
+      {
+        id: `${prefix}-${(this._uploadSeq += 1)}`,
+        name,
+        state: 'error',
+        message: errorText(err),
+        file: null,
+        kind,
+      },
+    ];
+  }
+
+  /**
    * Upload the picked files, one at a time.
    *
    * Sequential rather than parallel: every upload bumps the item's version and
@@ -1743,20 +1922,17 @@ export class HVItemEditor extends LitElement {
     try {
       this._uploaded = await media.reorder(item.id, kind, ordered);
     } catch (err) {
-      this._uploads = [
-        ...this._uploads,
-        {
-          id: `reorder-${(this._uploadSeq += 1)}`,
-          name: 'Reorder photos',
-          state: 'error',
-          message: errorText(err),
-          file: null,
-          kind,
-        },
-      ];
+      this._pushUploadError('reorder', kind, 'Reorder photos', err);
     }
   }
 
+  /**
+   * Delete one attachment, once it has been confirmed.
+   *
+   * Every other destructive action on the card asks first, and this one destroys
+   * the only copy of a file the household may not have anywhere else — so the
+   * buttons open `_confirmRemove` and only this runs the command.
+   */
   private async _removeAttachment(attachmentId: string, kind: AttachmentKind) {
     const media = this.media;
     const item = this._current;
@@ -1764,17 +1940,12 @@ export class HVItemEditor extends LitElement {
     try {
       this._uploaded = await media.remove(item.id, attachmentId);
     } catch (err) {
-      this._uploads = [
-        ...this._uploads,
-        {
-          id: `remove-${(this._uploadSeq += 1)}`,
-          name: kind === 'manual' ? 'Remove document' : 'Remove photo',
-          state: 'error',
-          message: errorText(err),
-          file: null,
-          kind,
-        },
-      ];
+      this._pushUploadError(
+        'remove',
+        kind,
+        kind === 'manual' ? 'Remove document' : 'Remove photo',
+        err,
+      );
     }
   }
 
@@ -1856,7 +2027,9 @@ export class HVItemEditor extends LitElement {
               class="remove"
               data-testid="editor-photo-remove"
               aria-label=${`Remove ${pictureAlt(item.name, index, shots.length)}`}
-              @click=${() => void this._removeAttachment(picture.id, 'picture')}
+              @click=${() => {
+                this._confirmRemove = { id: picture.id, kind: 'picture' };
+              }}
             >
               ${icon('close', 15)}
             </button>
@@ -1880,6 +2053,25 @@ export class HVItemEditor extends LitElement {
           />
         </label>
       </div>
+      ${this._renderUploadList('picture')}
+    </div>`;
+  }
+
+  /**
+   * Why the photo grid is not here yet, in create mode.
+   *
+   * An attachment is filed against an item id and a new item has none, so the
+   * sections cannot exist before the first save. Unexplained, that absence
+   * reads as a missing feature at exactly the moment the user is holding the
+   * object they wanted to photograph.
+   */
+  private _renderCreateAttachmentHint() {
+    if (this.item !== null || !this.media) return null;
+    return html`<div class="cell span3">
+      <span class="hv-label">Photos and documents</span>
+      <span class="attach-hint" data-testid="editor-attachment-hint">
+        Save the item first to add photos and manuals.
+      </span>
     </div>`;
   }
 
@@ -1906,17 +2098,7 @@ export class HVItemEditor extends LitElement {
     try {
       this._uploaded = await media.retitle(item.id, attachmentId, title);
     } catch (err) {
-      this._uploads = [
-        ...this._uploads,
-        {
-          id: `retitle-${(this._uploadSeq += 1)}`,
-          name: 'Rename document',
-          state: 'error',
-          message: errorText(err),
-          file: null,
-          kind: 'manual',
-        },
-      ];
+      this._pushUploadError('retitle', 'manual', 'Rename document', err);
     }
   }
 
@@ -1980,7 +2162,9 @@ export class HVItemEditor extends LitElement {
               class="doc-remove"
               data-testid="editor-document-remove"
               aria-label=${`Remove ${attachmentTitle(doc)}`}
-              @click=${() => void this._removeAttachment(doc.id, 'manual')}
+              @click=${() => {
+                this._confirmRemove = { id: doc.id, kind: 'manual' };
+              }}
             >
               ${icon('close', 15)}
             </button>
@@ -1999,52 +2183,64 @@ export class HVItemEditor extends LitElement {
           @change=${(e: Event) => this._onPicked(e, 'manual')}
         />
       </label>
+      ${this._renderUploadList('manual')}
     </div>`;
   }
 
   /**
-   * What the upload queue is doing, for both pickers at once.
+   * What the upload queue is doing, under the section it is doing it to.
    *
-   * One list below both controls rather than one under each: the queue itself
-   * is shared, and a failed document would otherwise report itself under
-   * "Photos".
+   * A queue rendered below both pickers put a phone's photo uploads two
+   * sections away from the grid the user is watching them fill, and reported a
+   * refused document under "Photos". One list per kind keeps each report beside
+   * the control that started it.
    */
-  private _renderUploadList() {
-    if (!this._uploads.length) return null;
-    return html`<div class="cell span3">
-      <ul class="upload-list" data-testid="editor-upload-list">
-        ${this._uploads.map(
-          (entry) => html`<li
-            class=${entry.state === 'error' ? 'failed' : ''}
-            data-testid="editor-upload"
-            data-state=${entry.state}
-          >
-            <span class="file">${entry.name}</span>
-            <span class="state">${entry.state === 'error' ? entry.message : `${entry.state}…`}</span>
-            ${entry.state === 'error' && entry.file
-              ? html`<button
-                  class="retry"
-                  data-testid="editor-upload-retry"
-                  aria-label=${`Try ${entry.name} again`}
-                  @click=${() => void this._retryUpload(entry.id)}
-                >
-                  Retry
-                </button>`
-              : null}
-            ${entry.state === 'error'
-              ? html`<button
-                  class="dismiss"
-                  data-testid="editor-upload-dismiss"
-                  aria-label=${`Dismiss the error for ${entry.name}`}
-                  @click=${() => this._dismissUpload(entry.id)}
-                >
-                  ${icon('close', 13)}
-                </button>`
-              : null}
-          </li>`,
-        )}
-      </ul>
-    </div>`;
+  private _renderUploadList(kind: AttachmentKind) {
+    const entries = this._uploads.filter((u) => u.kind === kind);
+    if (!entries.length) return null;
+    const glyph = kind === 'manual' ? 'fileDocument' : 'camera';
+    return html`<ul class="upload-list" data-testid="editor-upload-list" data-kind=${kind}>
+      ${entries.map(
+        (entry) => html`<li
+          class=${entry.state === 'error' ? 'failed' : ''}
+          data-testid="editor-upload"
+          data-state=${entry.state}
+        >
+          <span class="kind">${icon(glyph, 14)}</span>
+          <span class="file">${entry.name}</span>
+          <span class="state">${entry.state === 'error' ? entry.message : `${entry.state}…`}</span>
+          ${entry.state === 'error' && entry.file
+            ? html`<button
+                class="retry"
+                data-testid="editor-upload-retry"
+                aria-label=${`Try ${entry.name} again`}
+                @click=${() => void this._retryUpload(entry.id)}
+              >
+                Retry
+              </button>`
+            : null}
+          ${entry.state === 'error'
+            ? html`<button
+                class="dismiss"
+                data-testid="editor-upload-dismiss"
+                aria-label=${`Dismiss the error for ${entry.name}`}
+                @click=${() => this._dismissUpload(entry.id)}
+              >
+                ${icon('close', 13)}
+              </button>`
+            : null}
+          ${entry.state === 'error'
+            ? null
+            : html`<span
+                class="progress"
+                role="progressbar"
+                aria-label=${`${entry.name}: ${entry.state}`}
+                data-testid="editor-upload-progress"
+                ><span class="fill"></span
+              ></span>`}
+        </li>`,
+      )}
+    </ul>`;
   }
 
   private _renderMoreFields() {
@@ -2157,7 +2353,7 @@ export class HVItemEditor extends LitElement {
               @change=${(e: CustomEvent) => this._patch({ tags: (e.detail as { values: string[] }).values })}
             ></hv-chip-input>
           </div>
-          ${this._renderPictures()} ${this._renderDocuments()} ${this._renderUploadList()}
+          ${this._renderPictures()} ${this._renderDocuments()} ${this._renderCreateAttachmentHint()}
           ${this.mobile
             ? html`<div class="cell span3">${this._renderMoreFields()}</div>`
             : html`${this._renderStateFields()} ${this._renderCustomFields()}`}
@@ -2194,6 +2390,49 @@ export class HVItemEditor extends LitElement {
           </div>
         </div>
       </div>
+
+      <!-- Outside the form's own keydown scope, and their events stopped here:
+           a host listens for the cancel event on this editor to close it, and a
+           dialog saying "no, keep the photo" must not read as "close the
+           form". -->
+      <hv-confirm
+        data-testid="editor-remove-confirm"
+        ?open=${this._confirmRemove !== null}
+        .heading=${REMOVE_COPY[this._confirmRemove?.kind ?? 'picture'].heading}
+        .message=${REMOVE_COPY[this._confirmRemove?.kind ?? 'picture'].message}
+        confirmLabel="Remove"
+        destructive
+        @confirm=${(e: Event) => {
+          e.stopPropagation();
+          const target = this._confirmRemove;
+          this._confirmRemove = null;
+          if (target) void this._removeAttachment(target.id, target.kind);
+        }}
+        @cancel=${(e: Event) => {
+          e.stopPropagation();
+          this._confirmRemove = null;
+          this._refocus();
+        }}
+      ></hv-confirm>
+
+      <hv-confirm
+        data-testid="editor-discard-confirm"
+        ?open=${this._confirmDiscard}
+        heading="Discard your changes?"
+        message="What you have typed since the last save is lost."
+        confirmLabel="Discard"
+        destructive
+        @confirm=${(e: Event) => {
+          e.stopPropagation();
+          this._confirmDiscard = false;
+          this._cancel();
+        }}
+        @cancel=${(e: Event) => {
+          e.stopPropagation();
+          this._confirmDiscard = false;
+          this._refocus();
+        }}
+      ></hv-confirm>
     `;
   }
 }

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -1028,6 +1028,18 @@ export class HVItemEditor extends LitElement {
   @state() private _confirmDiscard = false;
   /** Why creating a first location from the picker failed. */
   @state() private _locationError: string | null = null;
+  /**
+   * Locations this form created, until the `locations` prop carries them.
+   *
+   * The inline expander is handed to `hv-list` as a template callback, which it
+   * re-invokes only when one of its *own* properties changes. A location create
+   * changes neither the item list nor anything else that component binds, so
+   * the refreshed store state can reach the host without ever reaching this
+   * form — leaving the field it just filled reading "No location". The created
+   * `Location` is in hand regardless, so holding it is what makes the picker
+   * name what it created on every host.
+   */
+  @state() private _createdLocations: Location[] = [];
 
   private readonly _urls = new MediaUrls(this);
   private _uploadSeq = 0;
@@ -1080,6 +1092,7 @@ export class HVItemEditor extends LitElement {
       this._confirmRemove = null;
       this._confirmDiscard = false;
       this._locationError = null;
+      this._createdLocations = [];
       this._closeCategory();
       return;
     }
@@ -1199,8 +1212,48 @@ export class HVItemEditor extends LitElement {
     </div>`;
   }
 
+  /** The host's flat list, plus anything this form created that it still lacks. */
+  private get _knownLocations(): Location[] {
+    const known = this.locations ?? [];
+    if (!this._createdLocations.length) return known;
+    const extra = this._createdLocations.filter((c) => !known.some((l) => l.id === c.id));
+    return extra.length ? [...known, ...extra] : known;
+  }
+
+  /**
+   * The host's tree, plus the same additions as roots.
+   *
+   * The picker only ever creates a root with no area, so a created location
+   * needs no placement inside the existing nodes and carries no children.
+   */
+  private get _knownLocationTree(): LocationTreeNode[] {
+    const known = this.locationTree ?? [];
+    if (!this._createdLocations.length) return known;
+    const seen = new Set<string>();
+    const mark = (nodes: LocationTreeNode[]) => {
+      for (const n of nodes) {
+        seen.add(n.id);
+        mark(n.children ?? []);
+      }
+    };
+    mark(known);
+    const extra = this._createdLocations
+      .filter((c) => !seen.has(c.id))
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+        parent_id: c.parent_id,
+        area_id: c.area_id,
+        path: c.path,
+        direct_item_count: 0,
+        subtree_item_count: 0,
+        children: [],
+      }));
+    return extra.length ? [...known, ...extra] : known;
+  }
+
   private _renderLocationField() {
-    const locations = this.locations ?? [];
+    const locations = this._knownLocations;
     const loc = locations.find((l) => l.id === this._model.locationId);
     const parts = locationPathParts(loc, locations, this.areas, 'No location');
     return html`<div class="cell span2">
@@ -1221,7 +1274,7 @@ export class HVItemEditor extends LitElement {
         ${this._locationOpen
           ? html`<hv-location-tree
               data-testid="editor-location-tree"
-              .nodes=${this.locationTree}
+              .nodes=${this._knownLocationTree}
               .areas=${this.areas}
               .selectedId=${this._model.locationId}
               showAll
@@ -1259,6 +1312,7 @@ export class HVItemEditor extends LitElement {
     this._locationError = null;
     try {
       const created = await create(name);
+      this._createdLocations = [...this._createdLocations, created];
       this._patch({ locationId: created.id });
       this._locationOpen = false;
     } catch (err) {

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -595,3 +595,87 @@ describe('hv-location-tree: manage mode', () => {
     expect(editId).toBe('garage');
   });
 });
+
+// A first run has no locations at all, and the picker is where the concept is
+// first met — so the empty state carries the way in rather than naming a menu
+// three steps away.
+describe('hv-location-tree: the first location', () => {
+  it('stays a plain statement unless a host can act on it', async () => {
+    const el = await mount({ nodes: [] });
+
+    expect(q(el, '[data-testid="tree-empty"]')).toBeTruthy();
+    expect(q(el, '[data-testid="tree-create"]')).toBe(null);
+  });
+
+  it('emits the name it was given, once', async () => {
+    const el = await mount({ nodes: [], allowCreate: true });
+    const names: string[] = [];
+    el.addEventListener('create-location', (e) => names.push((e as CustomEvent).detail.name));
+
+    (q(el, '[data-testid="tree-create"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const input = q(el, '[data-testid="tree-create-name"]') as HTMLInputElement;
+    // Revealing the field puts the caret in it — one tap, not two.
+    expect(el.shadowRoot?.activeElement).toBe(input);
+    input.value = '  Shed  ';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    (q(el, '[data-testid="tree-create-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(names).toEqual(['Shed']);
+    // The field closes behind it rather than inviting a second one.
+    expect(q(el, '[data-testid="tree-create-name"]')).toBe(null);
+  });
+
+  it('takes Enter as the submit, and refuses a name that is only spaces', async () => {
+    const el = await mount({ nodes: [], allowCreate: true });
+    const names: string[] = [];
+    el.addEventListener('create-location', (e) => names.push((e as CustomEvent).detail.name));
+
+    (q(el, '[data-testid="tree-create"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const input = q(el, '[data-testid="tree-create-name"]') as HTMLInputElement;
+    input.value = '   ';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    expect((q(el, '[data-testid="tree-create-submit"]') as HTMLButtonElement).disabled).toBe(true);
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await el.updateComplete;
+    expect(names).toEqual([]);
+
+    input.value = 'Shed';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await el.updateComplete;
+    expect(names).toEqual(['Shed']);
+  });
+
+  // The tree is opened from inside a form whose own Escape discards it, so the
+  // field has to take that key rather than pass it on.
+  it('closes the field on Escape without letting the key travel', async () => {
+    const el = await mount({ nodes: [], allowCreate: true });
+    (q(el, '[data-testid="tree-create"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true, cancelable: true });
+    let escaped = false;
+    document.addEventListener('keydown', () => (escaped = true), { once: true });
+    (q(el, '[data-testid="tree-create-name"]') as HTMLInputElement).dispatchEvent(event);
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="tree-create-name"]')).toBe(null);
+    expect(q(el, '[data-testid="tree-create"]')).toBeTruthy();
+    expect(escaped).toBe(false);
+  });
+
+  // A filter that matches nothing is a different fact from an empty tree, and
+  // creating a location would not answer it.
+  it('offers nothing when a filter is what emptied the tree', async () => {
+    const el = await mount({ filterText: 'zzz', allowCreate: true });
+
+    expect(q(el, '[data-testid="tree-empty"]')?.textContent).toContain('No locations match');
+    expect(q(el, '[data-testid="tree-create"]')).toBe(null);
+  });
+});

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -217,6 +217,52 @@ export class HVLocationTree extends LitElement {
         font-size: 12.5px;
         color: var(--hv-text-tertiary);
       }
+      /* An inventory with no locations at all: the picker is the first place a
+         user meets the concept, so it offers the way in rather than naming a
+         menu three steps away. Only the empty state carries it — the organize
+         dialog stays the surface that manages a tree that exists. */
+      .create {
+        display: grid;
+        gap: 6px;
+        padding: 0 12px 10px;
+      }
+      .create-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .create-row .hv-input {
+        flex: 1;
+        min-width: 0;
+      }
+      .create-open {
+        justify-self: start;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        min-height: var(--hv-tap-min, 30px);
+        border: 1px dashed var(--hv-primary-tint-border);
+        background: none;
+        color: var(--hv-primary-dark);
+        border-radius: var(--hv-radius-input);
+        padding: 0 12px;
+        font: 500 12.5px var(--hv-font);
+        cursor: pointer;
+      }
+      .create-submit {
+        flex: none;
+        min-height: var(--hv-tap-min, 30px);
+        border: none;
+        border-radius: var(--hv-radius-chip);
+        background: var(--hv-primary);
+        color: var(--hv-text-on-primary);
+        padding: 0 14px;
+        font: 500 12.5px var(--hv-font);
+        cursor: pointer;
+      }
+      .create-submit[disabled] {
+        opacity: 0.5;
+      }
       .divider {
         height: 1px;
         background: var(--hv-row-divider);
@@ -284,6 +330,12 @@ export class HVLocationTree extends LitElement {
   @property({ type: String }) excludeSubtreeOf: string | null = null;
   /** Substring filter over name and display path. */
   @property({ type: String }) filterText = '';
+  /**
+   * Offer to create a first location from the empty state, emitting
+   * `create-location`. Only a host that can actually run the command sets it —
+   * an affordance that leads nowhere is worse than the plain statement.
+   */
+  @property({ type: Boolean }) allowCreate = false;
   /** Resolves the area ids on the nodes to names for the group headers. */
   @property({ attribute: false }) areas: AreaRef[] = [];
 
@@ -294,6 +346,17 @@ export class HVLocationTree extends LitElement {
    * user came for until they open every band would be the wrong default.
    */
   @state() private _collapsedAreas = new Set<string>();
+  /** The first-location field is showing, and what has been typed into it. */
+  @state() private _creating = false;
+  @state() private _newName = '';
+
+  /** Revealing the name field has to put the caret in it, or it asks for a
+   *  second tap before it can be typed into. */
+  protected updated(changed: Map<string, unknown>) {
+    if (changed.has('_creating') && this._creating) {
+      this.renderRoot.querySelector<HTMLInputElement>('[data-testid="tree-create-name"]')?.focus();
+    }
+  }
 
   /** Open the ancestors of `id`, and its area group, so a deep selection is visible. */
   revealPathTo(id: string | null) {
@@ -620,6 +683,73 @@ export class HVLocationTree extends LitElement {
     return Math.max(0, this.matchingTotalCount - filed);
   }
 
+  /**
+   * The way out of an empty tree: a name, and the location it becomes.
+   *
+   * The new location is filed at the root with no area — the only placement
+   * that needs no tree to point at, which is the situation this exists for.
+   * Creating it is the host's job; this emits the name and closes.
+   */
+  private _renderCreate() {
+    if (!this._creating) {
+      return html`<div class="create">
+        <button
+          class="create-open"
+          data-testid="tree-create"
+          @click=${() => {
+            this._creating = true;
+            this._newName = '';
+          }}
+        >
+          ${icon('plus', 15)} New location…
+        </button>
+      </div>`;
+    }
+    const name = this._newName.trim();
+    return html`<div class="create">
+      <div class="create-row">
+        <input
+          class="hv-input"
+          data-testid="tree-create-name"
+          aria-label="New location name"
+          placeholder="Location name"
+          .value=${this._newName}
+          @input=${(e: Event) => {
+            this._newName = (e.target as HTMLInputElement).value;
+          }}
+          @keydown=${(e: KeyboardEvent) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              this._submitCreate();
+            } else if (e.key === 'Escape') {
+              // The field is what Escape takes back here; the picker around it
+              // — and the form around that — are not what the user just opened.
+              e.preventDefault();
+              e.stopPropagation();
+              this._creating = false;
+            }
+          }}
+        />
+        <button
+          class="create-submit"
+          data-testid="tree-create-submit"
+          ?disabled=${!name}
+          @click=${() => this._submitCreate()}
+        >
+          Create
+        </button>
+      </div>
+    </div>`;
+  }
+
+  private _submitCreate() {
+    const name = this._newName.trim();
+    if (!name) return;
+    this._creating = false;
+    this._newName = '';
+    this._emit('create-location', { name });
+  }
+
   render() {
     const filtering = this.filterText.trim().length > 0;
     const { areaGroups, ungrouped } = groupRootsByArea(this.nodes, this.areas, {
@@ -651,9 +781,12 @@ export class HVLocationTree extends LitElement {
           : null}
         ${rendered.length
           ? rendered
-          : html`<div class="empty" data-testid="tree-empty">
-              ${this.filterText.trim() ? 'No locations match' : 'No locations yet'}
-            </div>`}
+          : html`
+              <div class="empty" data-testid="tree-empty">
+                ${filtering ? 'No locations match' : 'No locations yet'}
+              </div>
+              ${this.allowCreate && !filtering ? this._renderCreate() : null}
+            `}
         ${this.showOrphans
           ? html`
               <div class="divider"></div>

--- a/cards/haventory-card/src/ui/keyboard.test.ts
+++ b/cards/haventory-card/src/ui/keyboard.test.ts
@@ -1,4 +1,4 @@
-import { hasCommandKey, saveShortcutLabel } from './keyboard';
+import { hasCommandKey, onEscape, saveShortcutLabel } from './keyboard';
 
 describe('hasCommandKey', () => {
   it('reads the modern platform hint first', () => {
@@ -40,5 +40,32 @@ describe('saveShortcutLabel', () => {
     expect(saveShortcutLabel({ platform: 'MacIntel' })).toBe('⌘↵');
     expect(saveShortcutLabel({ platform: 'Win32' })).toBe('Ctrl+Enter');
     expect(saveShortcutLabel({})).toBe('Ctrl+Enter');
+  });
+});
+
+describe('onEscape', () => {
+  function press(key: string) {
+    let closed = 0;
+    let prevented = false;
+    let stopped = false;
+    const event = {
+      key,
+      preventDefault: () => (prevented = true),
+      stopPropagation: () => (stopped = true),
+    } as unknown as KeyboardEvent;
+    onEscape(() => (closed += 1))(event);
+    return { closed, prevented, stopped };
+  }
+
+  // One Escape dismisses one thing: without stopping the key, a popover opened
+  // from a form takes the form with it, and a dialog opened from another closes
+  // both.
+  it('takes the key out of circulation on the way to closing', () => {
+    expect(press('Escape')).toEqual({ closed: 1, prevented: true, stopped: true });
+  });
+
+  it('leaves every other key alone', () => {
+    expect(press('Enter')).toEqual({ closed: 0, prevented: false, stopped: false });
+    expect(press('Tab')).toEqual({ closed: 0, prevented: false, stopped: false });
   });
 });

--- a/cards/haventory-card/src/ui/keyboard.ts
+++ b/cards/haventory-card/src/ui/keyboard.ts
@@ -44,16 +44,20 @@ export function hasCommandKey(nav: KeyboardPlatform = navigator): boolean {
 /**
  * A `keydown` listener that closes a surface on Escape.
  *
- * `preventDefault` matters: without it the key also reaches whatever is behind
- * the surface, so dismissing a dialog opened from another one would close both.
+ * The key stops here: `preventDefault` keeps the browser from acting on it, and
+ * `stopPropagation` keeps whatever is behind the surface from closing too. One
+ * Escape dismisses one thing — a popover opened from a form must not take the
+ * form with it, and a dialog opened from another must not take both.
+ *
  * Only for surfaces where Escape means exactly "close" — anything that has to
- * discriminate (the item editor also handles Ctrl/Cmd+Enter, and its category
- * dropdown swallows Escape so the edit survives) writes its own.
+ * discriminate (the item editor also handles Ctrl/Cmd+Enter, and asks before
+ * discarding a dirty form) writes its own.
  */
 export function onEscape(close: () => void): (e: KeyboardEvent) => void {
   return (e: KeyboardEvent) => {
     if (e.key !== 'Escape') return;
     e.preventDefault();
+    e.stopPropagation();
     close();
   };
 }


### PR DESCRIPTION
## Summary

Work package **P5** of `dev/ui_audit_v040_fix_plan.md` — the editor's attachment and form UX. Items **B7, B8, B9, B14, C24** and the tap-target half of **#301**.

Closes #301

**B7 — removing an attachment asks first.** `editor-photo-remove` / `editor-document-remove` called `_removeAttachment` directly: the only destructive action on the card without a guard, and it destroys the only copy of the file. Both now open `hv-confirm` (the empty-status confirm's template) through a `_confirmRemove` state, and only the yes runs the command. The guards render outside the form's own keydown scope and stop their own `confirm`/`cancel` — a host closes the editor on `cancel`, and "no, keep the photo" must not read as "close the form".

**B8 — Escape takes back one thing at a time.** It used to discard the whole form even with a dropdown open, and even when the form had been typed into. Now: the category list, the check-out popover or the location picker first (with focus returned to the control that opened it), then the form — and a dirty form routes through `hv-confirm` before `_cancel()`. A clean form still closes on the spot. `ui/keyboard.ts`'s `onEscape` gains the `stopPropagation` its own docstring already claimed, so a popover dismissed inside a form no longer takes the form with it.

**B9 — the empty location picker is no longer a dead end.** `hv-location-tree` gains an `allowCreate` flag: with no locations and no filter, the empty state offers "New location…", takes a name (Enter or the button, Escape closes just the field) and emits `create-location`. The editor gains a `createLocation` binding — the shape `media` already uses — which `hv-full-view`, `hv-card-shell` and (via the shell) `hv-detail-sheet` wire to `store.createLocation(name, null, null)`. A root location with no area is the only placement that needs no tree to point at, and the created object comes back so the form files the item in it at once. A refused name reports against the field and leaves the picker open.

**B14 — upload progress is visible where the user is looking.** One queue under both pickers put a phone's photo uploads two sections below the grid, and reported a refused document under "Photos". Each queue now renders inside the section that started it (`data-kind` on the list), carries a photo/document glyph per row, and an indeterminate bar on rows still in flight. Indeterminate on purpose — no byte progress exists on the WS path, so the bar never claims one — and the animation sits behind `prefers-reduced-motion: no-preference`.

**C24 — the create form says why attachments wait.** One line where the PHOTOS section will be. The pinned "no pictures section while creating" test stays green: a hint, not a section.

**#301 tap targets.** `editor-photo-remove` 22px → 24px; the tile controls take the strip's full height on a phone (`--hv-tap-min`), sharing the thumbnail's width rather than the organize dialog's 44px square, which would be wider than the tile; the queue's Retry and dismiss sized from the same token. The doc buttons (30px), combo arrow (26px) and shared `.hv-text-button`/`.hv-icon-button` already cleared 24 — audited, unchanged. The one control still under 24 on desktop is `.key-hints button`, which is inline in a sentence and exempt under WCAG 2.5.8; it already takes `--hv-tap-min` on a coarse pointer.

**Consolidation.** The three copy-pasted error pushes (reorder / remove / retitle) collapse into `_pushUploadError`; the custom-field tally adopts P1's shared `.hv-tally`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green on the pushed commit.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 749 passed, 22 skipped · `uv run ruff check .` → All checks passed · `uv run ruff format --check .` → 115 files already formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean · `npm run typecheck` clean · `npx vitest run` → **1370 passed** (54 files, up from 1341) · `npm run build` → 539.27 kB

New coverage: confirm accept/cancel for both attachment kinds plus a pin that the guard's events stay inside the editor; the four Escape sequences (picker closes only, popover closes only, dirty asks then discards, dirty asks then keeps, clean closes); the first-location flow end to end (created, selected, saved) plus the no-binding and refused-name cases; `hv-location-tree`'s empty-state affordance (emit, Enter, whitespace-only refusal, Escape confinement, filter-emptied tree offers nothing); per-kind queue placement, the indeterminate bar's presence and absence, and the reduced-motion guard; the create-mode hint in all three states; cssText pins for the resized controls and the shared tally. Four existing pins were rewritten rather than deleted — the two remove-adopts-the-item tests and the two error-row tests now step through the guard.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `README.md`'s Editing bullet plus a new Photos and manuals bullet.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no backend or WS change in this PR, so none needed.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched; the save path and `_current`/`expectedVersion` are unchanged.

## Screenshots (card / UI changes)

None — this was implemented in a remote session with no dev HA container or screenshot tooling, per the campaign's session model. Visual confirmation is delegated to the handover pass below.

## Delegated to the local handover pass

Per §Verification: P5 (short smoke). A local session with the Docker dev HA and the `run-haventory` skill should confirm:

1. Escape with the location tree open closes only the tree; a second Escape on a dirty form asks before discarding.
2. Removing a photo opens the confirm — cancel preserves it, confirm deletes it. Same for a manual.
3. A throttled multi-MB upload shows a moving indicator **under PHOTOS**, not two sections down.
4. On an empty install the location picker offers "New location…", and creating one files the item in it.
5. `hv-confirm` stacks correctly over the mobile bottom sheet (it is `position: fixed` inside the sheet's subtree; `nextZBase()` puts it above, and the lightbox already relies on the same behavior — worth an eye at 390 px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQBS48fKivmhSYLxUmGPrT)_