### PR TITLE
chore(card): bump nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/cards/haventory-card/package-lock.json
+++ b/cards/haventory-card/package-lock.json
@@ -2136,7 +2136,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

A newly published high-severity advisory against `nanoid <3.3.17` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero) turned `npm audit --audit-level=high` red. That step is a CI gate, so **every branch went red at once, `main` included**, without a single source file changing. It is currently failing both frontend matrix legs on PR #319 (work package P5), and would fail P6 and everything after it.

The lockfile entry moves `3.3.16 → 3.3.18` and gains the `resolved`/`integrity` pair it was missing. `package.json` is untouched, and neither `vite` nor `postcss` moves — `npm audit fix --package-lock-only` resolves the nested entry on its own.

**Exposure**: `nanoid` arrives transitively and dev-only, via `vite → postcss`, so it never reaches the bundle a household loads. The risk is to the build host, not to a running card — which is why this is a lockfile chore rather than anything urgent for users. It is still worth landing promptly because it is the thing standing between the remaining UI-audit packages and a green CI.

This PR is deliberately standalone rather than folded into #319: the break is repo-wide and predates that branch, so fixing it there would have left `main` and every other branch red.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 749 passed, 22 skipped · `uv run ruff check .` → all checks passed · `uv run ruff format --check .` → 115 files already formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npm audit --audit-level=high` → **found 0 vulnerabilities** · `npx eslint .` → clean · `npm run typecheck` → clean · `npx vitest run` → 1341 passed (54 files) · `npm run build` → 529.19 kB, byte-identical to `main`

Verified after a clean `npm ci` from the amended lockfile, so the resolution is what a fresh CI checkout will get rather than an artifact of a locally patched tree.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — none apply; this is a dependency resolution with no behavior of its own, and the existing suite is the regression check.
- [x] Docs updated where behavior changed — no behavior changed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

No version number is hand-edited: the diff touches only the `node_modules/nanoid` entry, not the package's own `version` field, so release-please's ownership of the six version files is intact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HUEGuA2j32Y7vfzayh5xC2)_