### PR TITLE
fix(card): deliver shell state to the inline editor through hv-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,8 @@ throughout.
   (picked from a tree inside the form), checked-out with due date, next inspection (with the same
   +7 / +31 / +90 / +X quick offsets the check-out popover offers), and typed
   custom fields (text / number / yes-no / date). Saves send the item's expected version so
-  a concurrent edit surfaces as a conflict. Escape takes back one thing at a time: an open
+  a concurrent edit surfaces as a conflict; a save that does not land says so in the form
+  you are looking at and leaves your edits in it. Escape takes back one thing at a time: an open
   picker first, then the form — and a form you have typed into asks before it discards.
   With no locations yet, the location picker creates the first one and files the item in
   it, rather than pointing at a menu three steps away.

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1221,6 +1221,24 @@ describe('hv-card-shell: inline editor reactivity', () => {
     expect(sr.querySelector('hv-filter-panel')).toBeTruthy();
     expect(list(sr).editorEpoch).toBe(before);
   });
+
+  // The other half of the same contract, and the one a reader is likelier to
+  // get backwards: the location tree is state the open form renders, so when it
+  // is replaced the list has to redraw. Changing a filter refetches that tree,
+  // which is why a filter chip moves the epoch rather than leaving it alone.
+  it('moves the epoch when the location tree the open form reads is replaced', async () => {
+    const { el, hass, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Drill' })] });
+    await openEditor(el, sr, '1');
+    const before = list(sr).editorEpoch;
+
+    hass.__setLocations([loc('L1', 'Garage')]);
+    hass.__emit('locations', 'created', { location_id: 'L1' });
+    await settle(el);
+    await settle(el);
+
+    expect(list(sr).editorEpoch).not.toBe(before);
+    expect(editor(sr)?.locationTree.map((n) => n.id)).toEqual(['L1']);
+  });
 });
 
 describe('hv-card-shell: mobile detail sheet', () => {

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1073,6 +1073,156 @@ describe('hv-card-shell: inline editing', () => {
   });
 });
 
+// The inline expander is the one surface that renders the editor through
+// `hv-list`'s template callback rather than directly, so it is the only one
+// where shell state can reach the host and stop there. Everything below is
+// about state the list itself does not bind.
+describe('hv-card-shell: inline editor reactivity', () => {
+  type EditorProps = {
+    locations: Location[] | null;
+    locationTree: { id: string }[];
+    tagSuggestions: string[];
+    busy: boolean;
+    errorMessage: string | null;
+  };
+  const list = (sr: ShadowRoot) => sr.querySelector('hv-list') as HTMLElement & { editorEpoch: unknown };
+  const editor = (sr: ShadowRoot) =>
+    list(sr).shadowRoot?.querySelector('hv-item-editor') as (HTMLElement & EditorProps) | null;
+  const row = (sr: ShadowRoot, id: string) =>
+    [...(list(sr).shadowRoot?.querySelectorAll('hv-list-row') ?? [])]
+      .map((r) => r as HTMLElement & { item: Item })
+      .find((r) => r.item.id === id) ?? null;
+  const openEditor = async (el: HVCardShell, sr: ShadowRoot, id: string) => {
+    (row(sr, id)!.shadowRoot?.querySelector('[data-testid="row-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+  };
+
+  it('delivers a location created elsewhere into the open expander', async () => {
+    const { el, hass, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Drill' })] });
+    await openEditor(el, sr, '1');
+    expect(editor(sr)?.locations ?? []).toHaveLength(0);
+
+    hass.__setLocations([loc('L1', 'Garage')]);
+    hass.__emit('locations', 'created', { location_id: 'L1' });
+    await settle(el);
+    await settle(el);
+
+    expect(editor(sr)?.locations?.map((l) => l.name)).toEqual(['Garage']);
+    expect(editor(sr)?.locationTree.map((n) => n.id)).toEqual(['L1']);
+  });
+
+  it('delivers a newly named tag into the open expander’s suggestions', async () => {
+    const { el, store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Drill' })] });
+    await openEditor(el, sr, '1');
+    expect(editor(sr)?.tagSuggestions).toEqual([]);
+
+    store.addDraftValue('tag', 'power-tools');
+    await settle(el);
+
+    expect(editor(sr)?.tagSuggestions).toEqual(['power-tools']);
+  });
+
+  it('carries the save busy state into the open expander', async () => {
+    const { el, store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Old' })] });
+    let land!: (item: Item) => void;
+    store['ws'].updateItem = () => new Promise<Item>((resolve) => (land = resolve));
+
+    await openEditor(el, sr, '1');
+    const nameInput = editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+    nameInput.value = 'New';
+    nameInput.dispatchEvent(new Event('input'));
+    (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const save = editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement;
+    expect(editor(sr)?.busy).toBe(true);
+    expect(save.textContent?.trim()).toBe('Saving…');
+    expect(save.disabled).toBe(true);
+
+    land(makeItem({ id: '1', name: 'New', version: 2 }));
+    await settle(el);
+  });
+
+  // The expander can be scrolled well past the card's banner list, so a save
+  // that did not land has to say so inside the form the user is still looking at.
+  it('shows a rejected save inside the open expander and clears the busy state', async () => {
+    const { el, store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Old' })] });
+    store['ws'].updateItem = async () => {
+      throw { code: 'storage_error', message: 'the store is read-only' };
+    };
+
+    await openEditor(el, sr, '1');
+    const nameInput = editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+    nameInput.value = 'New';
+    nameInput.dispatchEvent(new Event('input'));
+    (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).click();
+    await settle(el);
+    await settle(el);
+
+    const banner = editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-error"]');
+    expect(banner?.textContent).toContain('the store is read-only');
+    expect(editor(sr)?.busy).toBe(false);
+    expect(
+      (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).textContent?.trim(),
+    ).toBe('Save');
+  });
+
+  it('says a conflict in the same words the card banner uses', async () => {
+    const { el, store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Old' })] });
+    store['ws'].updateItem = async () => {
+      throw { code: 'conflict', message: 'version conflict: expected 1, actual 2' };
+    };
+
+    await openEditor(el, sr, '1');
+    const nameInput = editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+    nameInput.value = 'New';
+    nameInput.dispatchEvent(new Event('input'));
+    (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).click();
+    await settle(el);
+    await settle(el);
+
+    // Version numbers mean nothing inside a form; the card's banner already
+    // frames this case in words and the two surfaces have to agree.
+    expect(editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-error"]')?.textContent).toContain(
+      'Someone else changed this item',
+    );
+  });
+
+  it('drops the error again when the next edit opens', async () => {
+    const items = [makeItem({ id: '1', name: 'Old' }), makeItem({ id: '2', name: 'Other' })];
+    const { el, store, sr } = await mountShell({ items });
+    store['ws'].updateItem = async () => {
+      throw { code: 'storage_error', message: 'the store is read-only' };
+    };
+
+    await openEditor(el, sr, '1');
+    (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).click();
+    await settle(el);
+    await settle(el);
+    expect(editor(sr)?.errorMessage).toBe('the store is read-only');
+
+    (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-cancel"]') as HTMLButtonElement).click();
+    await settle(el);
+    await openEditor(el, sr, '2');
+    expect(editor(sr)?.errorMessage).toBe(null);
+  });
+
+  // The token is derived from what the editor reads, not stamped every render:
+  // a re-render for anything else must leave the list — and every row in it —
+  // exactly where it was.
+  it('leaves the list alone when the shell re-renders for something else', async () => {
+    const { el, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Drill' })] });
+    await openEditor(el, sr, '1');
+    const before = list(sr).editorEpoch;
+
+    (sr.querySelector('[data-testid="filter-toggle"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(sr.querySelector('hv-filter-panel')).toBeTruthy();
+    expect(list(sr).editorEpoch).toBe(before);
+  });
+});
+
 describe('hv-card-shell: mobile detail sheet', () => {
   const sheet = (sr: ShadowRoot) =>
     sr.querySelector('[data-testid="card-detail-sheet"]') as HTMLElement & { open: boolean; item: Item | null };

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -11,7 +11,7 @@ import { emptyKindFor } from '../ui/empty-state';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { HostSurfaces } from '../host-surfaces';
 import type { Store } from '../store/store';
-import type { Item, Location, StoreFilters, StoreState } from '../store/types';
+import type { ErrorEntry, Item, Location, StoreFilters, StoreState } from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import './hv-banner';
 import './hv-bottom-sheet';
@@ -357,6 +357,11 @@ export class HVCardShell extends LitElement {
   @state() private _editing: string | 'new' | null = null;
   @state() private _editorBusy = false;
   @state() private _editorError: string | null = null;
+  /**
+   * Changes whenever anything `_renderEditor` reads has changed identity — see
+   * `_syncEditorEpoch`, which is the list of what that is.
+   */
+  @state() private _editorEpoch = 0;
   /** Item shown in the mobile detail sheet. */
   @state() private _detailItemId: string | null = null;
   @state() private _fullViewOpen = false;
@@ -383,6 +388,8 @@ export class HVCardShell extends LitElement {
   private readonly responsive = new ResponsiveController(this);
   private _storeUnsub?: () => void;
   private _media: MediaBindings | null = null;
+  /** Identities `_editorEpoch` was last bumped for; see `_syncEditorEpoch`. */
+  private _editorInputs: unknown[] = [];
 
   /**
    * Picture access for every surface below, built once per store.
@@ -439,6 +446,39 @@ export class HVCardShell extends LitElement {
     if (changed.has('forceMobile')) this.responsive.setForced(this.forceMobile);
     // Reflect the mode so child selectors and :host([mobile]) rules apply.
     this.toggleAttribute('mobile', this.mobile);
+    this._syncEditorEpoch();
+  }
+
+  /**
+   * Move `_editorEpoch` on when the inline editor's inputs have.
+   *
+   * On the desktop card the editor is not rendered here: `hv-list` gets it as a
+   * template callback and re-runs it only when one of *its* properties changes.
+   * Everything below is state `_renderEditor` reads that the list does not
+   * bind, so without a signal of its own a store change reaches this element
+   * and stops — leaving an open form showing what was true when it opened.
+   *
+   * Identity comparison is enough — the store replaces each of these wholesale
+   * rather than mutating it. Comparing at all, rather than bumping on every
+   * update, is what keeps a filter chip or a keystroke in the search box from
+   * redrawing the list and every row in it.
+   */
+  private _syncEditorEpoch() {
+    const st = this.st;
+    const next: unknown[] = [
+      st?.areasCache,
+      st?.mediaConfig,
+      st?.locationsFlatCache,
+      st?.locationTreeCache,
+      st?.distinctValuesCache,
+      this.media,
+      this._editorBusy,
+      this._editorError,
+    ];
+    if (next.some((value, i) => value !== this._editorInputs[i])) {
+      this._editorInputs = next;
+      this._editorEpoch += 1;
+    }
   }
 
   protected updated() {
@@ -572,8 +612,12 @@ export class HVCardShell extends LitElement {
     }
     // The store reports failures through its error queue rather than throwing,
     // so a new entry is how we know the save did not land. Keep the expander
-    // open in that case so the user's edits are still there to retry.
-    const failed = (this.st?.errorQueue.length ?? 0) > errorsBefore;
+    // open in that case so the user's edits are still there to retry — and say
+    // why inside it, because the card's banner list is above a form tall enough
+    // to have scrolled it off the screen.
+    const queue = this.st?.errorQueue ?? [];
+    const failed = queue.length > errorsBefore;
+    this._editorError = failed ? editorErrorText(queue[queue.length - 1]) : null;
     if (!failed) this._editing = null;
   };
 
@@ -1050,6 +1094,7 @@ export class HVCardShell extends LitElement {
         .loading=${st?.loading ?? true}
         .mobile=${mobile}
         .editorTemplate=${this._renderEditor}
+        .editorEpoch=${this._editorEpoch}
         .editingItemId=${this._editing === 'new' ? null : this._editing}
         .addingNew=${!mobile && this._editing === 'new'}
         .emptyKind=${emptyKindFor(this.st)}
@@ -1254,6 +1299,18 @@ export class HVCardShell extends LitElement {
   private get _filterPanel(): HVFilterPanel | null {
     return this.shadowRoot?.querySelector('hv-filter-panel') ?? null;
   }
+}
+
+/**
+ * What an open editor says about a save that did not land.
+ *
+ * A conflict's own message names version numbers, which say nothing to someone
+ * looking at a form; the card's banner already frames that case in words and
+ * carries the ways out of it, so the form repeats that sentence rather than
+ * giving a second, differently worded account of the same event.
+ */
+function editorErrorText(entry: ErrorEntry): string {
+  return entry.kind === 'conflict' ? 'Someone else changed this item.' : entry.message;
 }
 
 function readPanelPref(): boolean {

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -460,8 +460,12 @@ export class HVCardShell extends LitElement {
    *
    * Identity comparison is enough — the store replaces each of these wholesale
    * rather than mutating it. Comparing at all, rather than bumping on every
-   * update, is what keeps a filter chip or a keystroke in the search box from
-   * redrawing the list and every row in it.
+   * update, is what keeps a re-render that changed none of them — a dialog
+   * opening, the filter panel expanding, a row being selected — from redrawing
+   * the list and every row in it.
+   *
+   * Changing a filter is not one of those: `setFilters` refetches the location
+   * tree, which the open form reads, so it moves the epoch and should.
    */
   private _syncEditorEpoch() {
     const st = this.st;

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -1031,13 +1031,11 @@ export class HVItemEditor extends LitElement {
   /**
    * Locations this form created, until the `locations` prop carries them.
    *
-   * The inline expander is handed to `hv-list` as a template callback, which it
-   * re-invokes only when one of its *own* properties changes. A location create
-   * changes neither the item list nor anything else that component binds, so
-   * the refreshed store state can reach the host without ever reaching this
-   * form — leaving the field it just filled reading "No location". The created
-   * `Location` is in hand regardless, so holding it is what makes the picker
-   * name what it created on every host.
+   * The picker fills the Location field the moment the create resolves, but the
+   * list it names from is a host property that reaches this form an update
+   * later at the earliest. The created `Location` is in hand regardless, so
+   * holding it is what keeps the field from reading "No location" in the gap —
+   * the same defence `_uploaded` gives the attachment list.
    */
   @state() private _createdLocations: Location[] = [];
 

--- a/cards/haventory-card/src/components/hv-list.test.ts
+++ b/cards/haventory-card/src/components/hv-list.test.ts
@@ -65,6 +65,31 @@ describe('hv-list: editing', () => {
     expect(el.hasAttribute('editing')).toBe(false);
   });
 
+  // The template is a stable callback, so Lit re-runs it only when one of this
+  // component's own properties changes. The token is how a host says its editor
+  // needs redrawing for a reason nothing here binds.
+  it('re-runs the editor template when the opaque token changes', async () => {
+    let runs = 0;
+    const el = await mount({
+      editingItemId: 'a',
+      editorTemplate: () => {
+        runs += 1;
+        return html`<div data-testid="stub-editor">${runs}</div>`;
+      },
+    });
+    expect(runs).toBe(1);
+
+    el.editorEpoch = 2;
+    await el.updateComplete;
+    expect(runs).toBe(2);
+    expect(el.shadowRoot?.querySelector('[data-testid="stub-editor"]')?.textContent).toBe('2');
+  });
+
+  it('does not treat the token as an editing signal', async () => {
+    const el = await mount({ editorEpoch: 7 });
+    expect(el.hasAttribute('editing')).toBe(false);
+  });
+
   it('gives the scroller more room while editing', () => {
     const css = (customElements.get('hv-list') as typeof HVList).styles;
     const text = (Array.isArray(css) ? css : [css]).map((s) => String(s.cssText)).join('\n');

--- a/cards/haventory-card/src/components/hv-list.ts
+++ b/cards/haventory-card/src/components/hv-list.ts
@@ -131,6 +131,16 @@ export class HVList extends LitElement {
    * needing to know anything about the edit form.
    */
   @property({ attribute: false }) editorTemplate: ((itemId: string | null) => unknown) | null = null;
+  /**
+   * Opaque token the host changes when the template would draw something new.
+   *
+   * The template is a stable callback, so Lit re-runs it only when one of this
+   * component's *own* reactive properties changes — and the form it returns
+   * reads host state that has nothing to do with a list of rows. Carrying the
+   * signal as a value nothing here reads is what keeps that ignorance intact:
+   * the host decides what counts as a change, this component only redraws.
+   */
+  @property({ attribute: false }) editorEpoch: unknown = 0;
   /** Row currently expanded into the editor; its own row is hidden while it is. */
   @property({ type: String }) editingItemId: string | null = null;
   /** Pin an empty editor at the top of the list ("Add item"). */


### PR DESCRIPTION
## Summary

Work package **F2** of `dev/v040_followup_fix_plan.md`.

`hv-card-shell` hands the item editor to `hv-list` as a template callback, and Lit re-runs that callback only when one of the **list's own** reactive properties changes. Everything else `_renderEditor` closes over reaches the shell and stops there, so an open inline expander renders what was true when it opened.

### The enumeration (step 1 of the issue's own instruction)

What `_renderEditor` reads beyond what `hv-list` binds, and whether it can change while the editor is open:

| Input | Can change while open? | Evidence |
|---|---|---|
| `st.locationsFlatCache`, `st.locationTreeCache` | **Yes** | The proven case — the #319 handover repro. A location create/rename/move from any surface refreshes both and touches nothing the list binds. A filter or search change refetches the tree too. |
| `st.distinctValuesCache` (category/tag suggestions, custom field keys) | **Yes** | Any item create/update/delete refreshes it; `addDraftValue` publishes a new cache with no item change at all. |
| `this._editorBusy` | **Yes** | Set true synchronously on save, false in `finally`. It only *appears* to work today because `store.updateItem` applies an optimistic item update, so `.items` changes coincidentally in the same tick — the coincidence the plan asked me to find rather than trust. A save whose optimistic path does not fire leaves the button reading "Save" through the whole round trip. |
| `this._editorError` | **Yes**, and worse — see below |
| `st.areasCache` | Yes (an HA area edit; `areas/list` is re-read on the core registry event) |
| `st.mediaConfig` | Only on `haventory/config` re-read — rare, but nothing prevents it |
| `this.media` | Rebuilt only when the `store` property is swapped |

### The fix

`hv-list` gains **one opaque `editorEpoch` property it never reads**; the shell bumps it when any of the inputs above changes identity (`_syncEditorEpoch`, called from `willUpdate`). The docstring constraint at `hv-list.ts` — the callback exists so the list needn't know anything about the edit form — stays true: the host decides what counts as a change, the list only redraws. Identity comparison rather than an unconditional bump is what keeps a re-render that changed none of the inputs from redrawing the list and every row in it.

### `_editorError` was dead state

Worth flagging explicitly. `_editorError` was **reset to `null` on six paths and set to a message on none**, so `hv-item-editor`'s `editor-error` banner could never render on any surface that binds it — the inline expander, the mobile add sheet and the detail sheet alike. That is why the P5 session could not force a missing error banner: there was no banner to miss, and a failed save showed only as the card's top-of-list `banner-entry`.

Since F2's own acceptance is "a rejected save shows its banner in the open inline editor", `_onEditorSave` now sets it from the newest error-queue entry. A conflict repeats the sentence the card's banner already uses as its heading ("Someone else changed this item.") rather than showing `version conflict: expected 1, actual 2` to someone looking at a form; the banner keeps the two recovery actions.

### `_createdLocations` — kept

Re-examined per the plan. It stays: `store.createLocation` resolves after the caches refresh, but the prop still reaches the form one Lit update later at the earliest, and the picker fills the Location field synchronously in that gap. Same defence `_uploaded` gives the attachment list. Its comment is restated as the invariant it holds, with the binding history dropped.

### Confirmed, not changed

The mobile "new" sheet, the mobile detail sheet and `hv-full-view` all render `hv-item-editor` directly from their own templates, so a host re-render already reaches them. Untouched.

Closes #322

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Eight new offline cases; **five fail on `main`** before the fix (the busy-state one passes today on the coincidence described above, and is pinned so it stops depending on it).

- `hv-card-shell.test.ts` → `inline editor reactivity`: a location created elsewhere reaches the open expander's `locations`/`locationTree`; a newly named tag reaches its suggestions; the busy state reaches it mid-save (button reads "Saving…", disabled); a rejected save renders `editor-error` in the form and clears busy; a conflict is worded as the card's banner words it; the error drops again when the next edit opens; replacing the location tree **does** move the epoch and reaches the open form; and the epoch does **not** move on a re-render that changed none of its inputs (the filter panel expanding).
- `hv-list.test.ts`: changing the opaque token alone re-runs the editor template; the token is not an editing signal (the `editing` flag pins stay green as written).

Both gates green:

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (749 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1400 passed, 54 files), `npm run build`

### Local verification — done

The F2 smoke from the plan's §Verification ran against the dev HA container (the implementation session was in the cloud and could not):

- **Location created from the empty picker** — pass, against a genuinely empty store. Field updates in place, the picker drops its empty state, typed fields survive, form stays open.
- **Rejected save reports itself in the open expander** — pass. Worth knowing for anyone re-running it: bumping the version from a second surface does **not** conflict, because the items event reaches the store and `_save` then sends the fresh version. The stale-version state was reached by dropping the subscription frame, which is also the honest condition — a missed event. With that, `editor-error` reads exactly "Someone else changed this item.", Save returns from "Saving…", and the card's banner carries the same sentence plus its two recovery actions. A non-conflict failure (item deleted from a second connection) carries the backend's own message verbatim.
- **Nothing else moved** — the epoch is exonerated, but the check surfaced a **pre-existing, unrelated bug**: see #332 below.

Commit `4cf08ce` came out of that pass: the epoch *does* move on a filter or search change (`setFilters` refetches the location tree, which the open form reads), so the comment claiming otherwise was wrong. Restated, and the uncovered half pinned by a test.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`README.md` — the editing bullet now says a failed save reports itself in the form).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no backend change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).
- [x] No file inside `custom_components/haventory/` deleted or renamed, so no `RETIRED_PATHS` entry.

## Screenshots (card / UI changes)

Captured during the local pass (not committed — the run-haventory skill directory is gitignored). The conflict frame shows both banners at once: the in-form one and the card's.

## Follow-ups

Out of scope for F2's file set, filed rather than fixed:

- **#328** — `hv-full-view` renders no banner list **and** binds no `.errorMessage` on its editor, so a save rejected from the full view is entirely silent: the form just stays open. The sibling half of the `_editorError` gap this PR fixes for the card shell.
- **#332** — changing a filter or typing in the search box discards an open editor's unsaved edits. `Store.setFilters` blanks the list (`items: []`, `loading: true`), `hv-list` takes its skeleton branch, and the open editor is torn down and rebuilt from the stored item — so the form looks open while every field has silently reverted. Independent of this PR: `main`'s bundle reproduces it identically, and a **sort** change (which moves no epoch input, leaving `editorEpoch` at 1) still destroys the editor. Needs two product decisions rather than a patch.

## Plan-file deletion

`dev/v040_followup_fix_plan.md` is left in place — F1 (#330) and F3 (#329) are both still open, so this is not the last of the three to close.