### PR TITLE
fix(card): scroll organize-dialog disclosures into view; touch parity across all tabs

### DIFF
--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -594,6 +594,35 @@ describe('hv-location-tree: manage mode', () => {
     expect(seen).toEqual(['edit', 'delete']);
     expect(editId).toBe('garage');
   });
+
+  // The organize dialog sizes its own rows for a finger, but the Locations tab
+  // is this component and its stylesheet is out of that dialog's reach: DOM-
+  // measured at 390px, the count link came to 14px tall and the ⋮ to 26×26
+  // beside 44px controls on the other three tabs.
+  it('sizes the managed row for a finger, matching the dialog it renders in', () => {
+    const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
+    const css = (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+
+    // WCAG 2.2 asks 24px of any pointer, wherever the count is a link.
+    expect(css).toMatch(/\.count\.link \{[^}]*min-height: 24px/);
+    expect(css).toMatch(/\.row\.manage\.touch \.count\.link \{[^}]*min-height: var\(--hv-tap-min, 44px\)/);
+    expect(css).toMatch(
+      /\.row\.manage\.touch \.action \{[^}]*width: var\(--hv-tap-min, 44px\)[^}]*height: var\(--hv-tap-min, 44px\)/,
+    );
+    // Browsing is a list to read down; 44px counts would stretch it past what a
+    // phone shows at once, so the bump stops at the managing tree.
+    expect(css).not.toMatch(/:host\(\[mobile\]\) \.count/);
+  });
+
+  it('marks the row so the touch sizing has something to hang on', async () => {
+    const el = await mount({ manage: true, mobile: true });
+    expect(rows(el)[0].className).toContain('manage');
+    expect(rows(el)[0].className).toContain('touch');
+    expect(q(el, '[data-testid="tree-more"]')).toBeTruthy();
+  });
 });
 
 // A first run has no locations at all, and the picker is where the concept is

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -131,9 +131,22 @@ export class HVLocationTree extends LitElement {
         padding: 0 2px;
         font: 400 12px var(--hv-font);
         color: var(--hv-primary-dark);
+        /* 12px text is a 14px-tall target; the box has to be told to be bigger
+           than its own line. WCAG 2.2 asks 24px of any pointer, and the count
+           is a target wherever it is a link — the browsing sidebar included. */
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
       }
       .count.link:hover {
         text-decoration: underline;
+      }
+      /* A phone reaching for a managed row needs the full 44px, and the row it
+         sits in grows to hold it. Confined to the managing tree: the browsing
+         sidebar is a list to read down, and 44px counts would stretch it past
+         what a phone can show at once. */
+      .row.manage.touch .count.link {
+        min-height: var(--hv-tap-min, 44px);
       }
       /* Left-packed like a value row (name, then count) instead of the name
          pushing the count to the far edge. */
@@ -205,6 +218,13 @@ export class HVLocationTree extends LitElement {
         background: none;
         color: var(--hv-primary-dark);
         padding: 0;
+      }
+      /* The touch layout's single ⋮ is the whole of a row's reach on a phone,
+         so it carries the tap target the organize dialog's other tabs give
+         their row actions. */
+      .row.manage.touch .action {
+        width: var(--hv-tap-min, 44px);
+        height: var(--hv-tap-min, 44px);
       }
       .action.danger {
         color: var(--hv-error);

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1440,8 +1440,9 @@ describe('hv-organize-dialog: disclosures come into view', () => {
 
   const scrolled = () => scrolls.map((s) => s.el);
 
-  // The destructive one: it is what stands between a tap and every item on a
-  // status being reassigned, and it was the case found in the live pass.
+  // The destructive one: it stands between a tap and every item on a status
+  // being reassigned, so rendering it off-screen makes delete look broken and
+  // invites the second tap.
   it('brings the status delete guard into view', async () => {
     const { el, sr } = await mount({ tab: 'statuses', items });
     const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
@@ -1453,8 +1454,8 @@ describe('hv-organize-dialog: disclosures come into view', () => {
     // screen does not move; no `behavior`, so there is no motion to gate on a
     // reduced-motion preference.
     expect(scrolls[0].options).toEqual({ block: 'nearest' });
-    // A guard announces itself where it stands and takes no focus.
-    expect(sr.activeElement).not.toBe(q(sr, '[data-testid="status-reassign"]'));
+    // A guard announces itself through role="alert" and takes no focus.
+    expect(q(sr, '[data-testid="status-guard"]')?.contains(sr.activeElement)).toBe(false);
   });
 
   // This one renders after the whole tree rather than beside its row, so it is
@@ -1466,6 +1467,7 @@ describe('hv-organize-dialog: disclosures come into view', () => {
     await settle(el);
 
     expect(scrolled()).toEqual([q(sr, '[data-testid="location-guard"]')]);
+    expect(q(sr, '[data-testid="location-guard"]')?.contains(sr.activeElement)).toBe(false);
   });
 
   it('brings the location editor into view and puts the caret in its name field', async () => {

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -571,6 +571,27 @@ describe('hv-organize-dialog: locations', () => {
     expect(store.state.value.locationsFlatCache).toHaveLength(2);
   });
 
+  // The mark sat on `.glyph`, the icon-picker button's class, so a span that
+  // does nothing rendered as a 30×26 bordered box under a pointer cursor.
+  it('inks the guard mark with warn and gives it nothing a button carries', async () => {
+    const items = [makeItem({ id: '1', location_id: 'shelf-a' })];
+    const { el, sr } = await mount({ items, locations });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+
+    (tree.shadowRoot?.querySelector('[data-testid="tree-delete"][data-id="garage"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const guard = q(sr, '[data-testid="location-guard"]');
+    expect(guard?.querySelector('.guard-mark')).not.toBe(null);
+    expect(guard?.querySelector('.glyph')).toBe(null);
+
+    const css = dialogCss();
+    expect(css).toMatch(/\.guard-mark \{[^}]*color: var\(--hv-warn\)/);
+    expect(css).toMatch(/\.guard-mark \{[^}]*flex: none/);
+    expect(css).not.toMatch(/\.guard-mark \{[^}]*border/);
+    expect(css).not.toMatch(/\.guard-mark \{[^}]*cursor/);
+  });
+
   it('deletes an empty location without a guard', async () => {
     const { el, store, sr } = await mount({ locations: [loc('spare', 'Spare')] });
     const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
@@ -1346,10 +1367,10 @@ describe('hv-organize-dialog: statuses', () => {
     expect(guard?.querySelector('.guard-target select')).not.toBe(null);
   });
 
-  // DOM-measured on a phone before this pass: chevrons 15×15 stacked a pixel
-  // apart, edit/delete 26×26, swatches 26×22, the count link 14px tall. WCAG
-  // 2.2 asks 24px of every pointer; a finger wants the platform's 44.
-  it('sizes every statuses-tab control for a finger', () => {
+  // DOM-measured on a phone: chevrons 15×15 stacked a pixel apart, edit/delete
+  // 26×26, swatches 26×22, the count link 14px tall. WCAG 2.2 asks 24px of
+  // every pointer; a finger wants the platform's 44.
+  it('sizes every row control for a finger, on all four tabs', () => {
     const css = dialogCss();
     for (const [selector, size] of [
       ['\\.move button', '24px'],
@@ -1357,28 +1378,173 @@ describe('hv-organize-dialog: statuses', () => {
     ] as const) {
       expect(css, selector).toMatch(new RegExp(`${selector} \\{[^}]*height: ${size}`));
     }
-    expect(css).toMatch(/\.status-row \.count-link \{[^}]*min-height: 24px/);
+    expect(css).toMatch(/\.count-link \{[^}]*min-height: 24px/);
 
-    for (const selector of [
-      '\\.move button',
-      '\\.swatch',
-      '\\.swatches \\.glyph',
-      '\\.status-row \\.row-actions button',
-    ]) {
+    for (const selector of ['\\.move button', '\\.swatch', '\\.glyph', '\\.row-actions button']) {
       expect(css, selector).toMatch(
         new RegExp(
           `:host\\(\\[mobile\\]\\) ${selector} \\{[^}]*width: var\\(--hv-tap-min, 44px\\)[^}]*height: var\\(--hv-tap-min, 44px\\)`,
         ),
       );
     }
-    expect(css).toMatch(
-      /:host\(\[mobile\]\) \.status-row \.count-link \{[^}]*min-height: var\(--hv-tap-min, 44px\)/,
-    );
+    expect(css).toMatch(/:host\(\[mobile\]\) \.count-link \{[^}]*min-height: var\(--hv-tap-min, 44px\)/);
+
+    // The count link and the row actions are the same controls on Locations,
+    // Categories and Tags, so none of the sizing is scoped to a status row —
+    // one dialog cannot offer two target sizes for one control.
+    expect(css).not.toMatch(/\.status-row \.count-link/);
+    expect(css).not.toMatch(/:host\(\[mobile\]\) \.status-row/);
+  });
+
+  // `.glyph` is the icon-picker button — a bordered box with a pointer cursor.
+  // Sharing it made the mobile picker sizing reach for `.swatches` to stay off
+  // the guard; with the mark on a class of its own, neither needs the scoping.
+  it('keeps .glyph meaning the icon-picker button alone', () => {
+    const css = dialogCss();
+    expect(css).not.toMatch(/\.swatches \.glyph/);
+    expect(css).not.toMatch(/\.guard \.glyph/);
   });
 
   // The colour row compressed ten swatches onto one line while the icon row
   // wrapped; at touch size neither fits, so both must wrap.
   it('wraps the swatch rows instead of squeezing them onto one line', () => {
     expect(dialogCss()).toMatch(/\.swatches \{[^}]*flex-wrap: wrap/);
+  });
+});
+
+// Every disclosure renders after the row that opened it, inside a `.body` that
+// scrolls, so one opened from a row near the bottom lands below the fold and
+// the tap reads as having done nothing.
+describe('hv-organize-dialog: disclosures come into view', () => {
+  const locations = [loc('garage', 'Garage', null, 'area-garage'), loc('shelf-a', 'Shelf A', 'garage')];
+  const items = [
+    makeItem({ id: '1', location_id: 'shelf-a', tags: ['battery'], category: 'Tools' }),
+    makeItem({ id: '2', tags: ['aa'], category: 'Consumables', status: 'missing' }),
+  ];
+
+  // jsdom performs no layout and implements no `scrollIntoView`, so these pin
+  // the call and its options; whether the element ends up visible is a live
+  // check.
+  type Scrollable = { scrollIntoView?: (options?: unknown) => void };
+  let scrolls: { el: Element; options: unknown }[] = [];
+  beforeEach(() => {
+    scrolls = [];
+    (Element.prototype as Scrollable).scrollIntoView = function (this: Element, options?: unknown) {
+      scrolls.push({ el: this, options });
+    };
+  });
+  afterEach(() => {
+    delete (Element.prototype as Scrollable).scrollIntoView;
+    document.body.innerHTML = '';
+  });
+
+  const scrolled = () => scrolls.map((s) => s.el);
+
+  // The destructive one: it is what stands between a tap and every item on a
+  // status being reassigned, and it was the case found in the live pass.
+  it('brings the status delete guard into view', async () => {
+    const { el, sr } = await mount({ tab: 'statuses', items });
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-remove"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolled()).toEqual([q(sr, '[data-testid="status-guard"]')]);
+    // 'nearest' scrolls no further than it must, so a disclosure already on
+    // screen does not move; no `behavior`, so there is no motion to gate on a
+    // reduced-motion preference.
+    expect(scrolls[0].options).toEqual({ block: 'nearest' });
+    // A guard announces itself where it stands and takes no focus.
+    expect(sr.activeElement).not.toBe(q(sr, '[data-testid="status-reassign"]'));
+  });
+
+  // This one renders after the whole tree rather than beside its row, so it is
+  // below the fold for any tree taller than the panel.
+  it('brings the location delete guard into view', async () => {
+    const { el, sr } = await mount({ items, locations });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-delete"][data-id="garage"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolled()).toEqual([q(sr, '[data-testid="location-guard"]')]);
+  });
+
+  it('brings the location editor into view and puts the caret in its name field', async () => {
+    const { el, sr } = await mount({ locations });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="garage"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolled()).toEqual([q(sr, '[data-testid="location-editor"]')]);
+    expect(sr.activeElement).toBe(q(sr, '[data-testid="location-name"]'));
+  });
+
+  it('brings the value editor into view and puts the caret in its target field', async () => {
+    const { el, sr } = await mount({ items, tab: 'tags' });
+    const row = all(sr, '[data-testid="value-row"]').find((r) => r.dataset.value === 'battery')!;
+    (row.querySelector('[data-testid="value-rename"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolled()).toEqual([q(sr, '[data-testid="value-editor"]')]);
+    expect(sr.activeElement).toBe(q(sr, '[data-testid="value-target"]'));
+  });
+
+  it('brings the status editor into view and puts the caret in its label field', async () => {
+    const { el, sr } = await mount({ tab: 'statuses', items });
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'ok');
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolled()).toEqual([q(sr, '[data-testid="status-editor"]')]);
+    expect(sr.activeElement).toBe(q(sr, '[data-testid="status-label"]'));
+  });
+
+  // The pane must not jump while the household is typing in the form it just
+  // opened, nor when anything else re-renders the dialog.
+  it('scrolls once per open, not on the re-renders that follow', async () => {
+    const { el, sr } = await mount({ locations });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="garage"]') as HTMLButtonElement).click();
+    await settle(el);
+    expect(scrolls).toHaveLength(1);
+
+    const name = q(sr, '[data-testid="location-name"]') as HTMLInputElement;
+    name.value = 'Big Garage';
+    name.dispatchEvent(new Event('input'));
+    await settle(el);
+
+    el.requestUpdate();
+    await settle(el);
+
+    expect(scrolls).toHaveLength(1);
+  });
+
+  it('scrolls again when a second row opens the same kind of disclosure', async () => {
+    const { el, sr } = await mount({ locations: [loc('garage', 'Garage'), loc('attic', 'Attic')] });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="garage"]') as HTMLButtonElement).click();
+    await settle(el);
+    (tree.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="attic"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolls).toHaveLength(2);
+    expect(scrolls[1].el).toBe(q(sr, '[data-testid="location-editor"]'));
+  });
+
+  // Re-opening the dialog is DialogFocus's moment: it puts focus on the panel,
+  // and a disclosure carried over from last time must not pull it away.
+  it('moves nothing when the dialog re-opens with a disclosure still expanded', async () => {
+    const { el, sr } = await mount({ tab: 'statuses', items });
+    (q(sr, '[data-testid="organize-new-status"]') as HTMLButtonElement).click();
+    await settle(el);
+    expect(scrolls).toHaveLength(1);
+
+    el.open = false;
+    await settle(el);
+    el.open = true;
+    await settle(el);
+
+    expect(q(sr, '[data-testid="status-editor"]')).not.toBe(null);
+    expect(scrolls).toHaveLength(1);
+    expect(sr.activeElement).toBe(q(sr, '[data-testid="organize-dialog"]'));
   });
 });

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1549,4 +1549,46 @@ describe('hv-organize-dialog: disclosures come into view', () => {
     expect(scrolls).toHaveLength(1);
     expect(sr.activeElement).toBe(q(sr, '[data-testid="organize-dialog"]'));
   });
+
+  // On a phone the ⋮ sheet replaces the row's separate buttons, so it is the
+  // only way into edit, merge and delete. DOM-measured at 390px: opened from
+  // the bottom row it stood 216px tall with 16px of it on screen.
+  it('brings the location ⋮ sheet into view', async () => {
+    const { el, sr } = await mount({ items, locations, mobile: true });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-more"][data-id="garage"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolled()).toEqual([q(sr, '[data-testid="location-sheet"]')]);
+    expect(scrolls[0].options).toEqual({ block: 'nearest' });
+    // A menu of what the row can do, not a form: it claims no field, so the
+    // caret stays where the tap left it.
+    expect(q(sr, '[data-testid="location-sheet"]')?.contains(sr.activeElement)).toBe(false);
+  });
+
+  it('brings the value ⋮ sheet into view', async () => {
+    const { el, sr } = await mount({ items, tab: 'tags', mobile: true });
+    const row = all(sr, '[data-testid="value-row"]').find((r) => r.dataset.value === 'battery')!;
+    (row.querySelector('[data-testid="value-more"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(scrolled()).toEqual([q(sr, '[data-testid="value-sheet"]')]);
+    expect(q(sr, '[data-testid="value-sheet"]')?.contains(sr.activeElement)).toBe(false);
+  });
+
+  // The sheet closes as the editor it launched opens, and it is the editor the
+  // household is now looking at.
+  it('follows the ⋮ sheet to the editor it opens', async () => {
+    const { el, sr } = await mount({ items, locations, mobile: true });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (tree.shadowRoot?.querySelector('[data-testid="tree-more"][data-id="garage"]') as HTMLButtonElement).click();
+    await settle(el);
+    (q(sr, '[data-testid="location-sheet-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(q(sr, '[data-testid="location-sheet"]')).toBe(null);
+    expect(scrolls).toHaveLength(2);
+    expect(scrolls[1].el).toBe(q(sr, '[data-testid="location-editor"]'));
+    expect(sr.activeElement).toBe(q(sr, '[data-testid="location-name"]'));
+  });
 });

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -363,9 +363,7 @@ export class HVOrganizeDialog extends LitElement {
       .glyph:hover {
         background: var(--hv-hover-overlay);
       }
-      /* Scoped to the picker rows: .glyph also marks the location guard's alert,
-         which is not a target and must not grow into one. */
-      :host([mobile]) .swatches .glyph {
+      :host([mobile]) .glyph {
         width: var(--hv-tap-min, 44px);
         height: var(--hv-tap-min, 44px);
       }
@@ -387,16 +385,14 @@ export class HVOrganizeDialog extends LitElement {
            it narrower — the slug beside it is what gives way instead. */
         white-space: nowrap;
         flex: none;
-      }
-      /* 12px text is a 14px-tall target; the box has to be told to be bigger
-         than its own line. Confined to the status rows, whose controls this
-         pass sized for touch. */
-      .status-row .count-link {
+        /* 12px text is a 14px-tall target, so the box is told to be bigger than
+           its own line: WCAG 2.2 asks 24px of any pointer. Every tab prints a
+           count, and one dialog cannot offer two sizes for one control. */
         display: inline-flex;
         align-items: center;
         min-height: 24px;
       }
-      :host([mobile]) .status-row .count-link {
+      :host([mobile]) .count-link {
         min-height: var(--hv-tap-min, 44px);
       }
       .draft-note {
@@ -428,7 +424,11 @@ export class HVOrganizeDialog extends LitElement {
         color: var(--hv-text-secondary);
         padding: 0;
       }
-      :host([mobile]) .status-row .row-actions button {
+      /* A phone row grows to hold a tappable action — a 44px child takes a
+         ~44px row to ~66px. That height is the cost of the target: sizing one
+         tab's actions and not the rest leaves 26px controls beside 44px ones
+         in the same dialog. */
+      :host([mobile]) .row-actions button {
         width: var(--hv-tap-min, 44px);
         height: var(--hv-tap-min, 44px);
       }
@@ -530,7 +530,9 @@ export class HVOrganizeDialog extends LitElement {
         font-size: 12.5px;
         line-height: 1.5;
       }
-      .guard .glyph {
+      /* A guard's alert mark is a statement, not a control: warn ink and a
+         width it will not give up, and nothing that would read as a button. */
+      .guard-mark {
         color: var(--hv-warn);
         flex: none;
       }
@@ -702,6 +704,78 @@ export class HVOrganizeDialog extends LitElement {
   /** Opening a surface must put focus in it, or Escape never reaches it. */
   private _dialogFocus = new DialogFocus();
 
+  /** Which disclosure of each kind the last render left on screen. */
+  private _shown = new Map<string, string | null>();
+
+  /**
+   * Every surface that expands *after* the row that opened it, inside the
+   * scrolling `.body`: what identifies the one currently open, the element to
+   * bring into view, and — for the forms — the field that takes focus.
+   *
+   * A guard is `role="alert"`, so it announces itself where it stands and takes
+   * no focus: it is a refusal to act, and pulling the caret out of the list
+   * would answer a tap the household did not make. The editors are forms, and a
+   * form opened from a row leaves the keyboard on that row's button unless its
+   * first field claims the caret.
+   */
+  private get _disclosures(): { testid: string; open: string | null; field?: string }[] {
+    const value = this._editingValue;
+    return [
+      { testid: 'location-editor', open: this._editingLocation, field: 'location-name' },
+      { testid: 'location-guard', open: this._guard?.locationId ?? null },
+      // The mode is half the identity: switching a row from rename to merge
+      // swaps the form under the same element.
+      {
+        testid: 'value-editor',
+        open: value ? `${value.mode}:${value.value}` : null,
+        field: 'value-target',
+      },
+      { testid: 'status-editor', open: this._editingStatus, field: 'status-label' },
+      { testid: 'status-guard', open: this._statusGuard?.slug ?? null },
+    ];
+  }
+
+  /**
+   * Bring a disclosure into view as it opens.
+   *
+   * Every one of them renders below its trigger inside a pane that scrolls, so
+   * one opened from a row near the bottom lands off-screen and the tap reads as
+   * having done nothing — worst on the two guards, which are what stands
+   * between a tap and a batch of items changing.
+   *
+   * `block: 'nearest'` scrolls only as far as it must, so a disclosure already
+   * on screen does not move under the user, and it names no `behavior`, so
+   * there is no motion to gate on a reduced-motion preference. Keyed on which
+   * disclosure is open rather than on the render, so typing inside an open
+   * editor never moves the pane.
+   */
+  private _revealDisclosures() {
+    if (!this.open) {
+      this._shown.clear();
+      return;
+    }
+    // A dialog re-opened with a disclosure still expanded is DialogFocus's
+    // moment, not this one's: the first render after open records what is on
+    // screen and moves nothing.
+    const seeding = this._shown.size === 0;
+    for (const disclosure of this._disclosures) {
+      const was = this._shown.get(disclosure.testid) ?? null;
+      this._shown.set(disclosure.testid, disclosure.open);
+      if (seeding || disclosure.open === null || disclosure.open === was) continue;
+      const el = this.renderRoot.querySelector<HTMLElement>(
+        `[data-testid="${disclosure.testid}"]`,
+      );
+      // Scrolling needs a layout, and an environment that performs none offers
+      // no `scrollIntoView` to call.
+      el?.scrollIntoView?.({ block: 'nearest' });
+      if (disclosure.field) {
+        this.renderRoot
+          .querySelector<HTMLElement>(`[data-testid="${disclosure.field}"]`)
+          ?.focus();
+      }
+    }
+  }
+
   protected updated() {
     this._dialogFocus.sync(this.open, () =>
       this.renderRoot.querySelector<HTMLElement>('[data-testid="organize-dialog"]'),
@@ -713,6 +787,7 @@ export class HVOrganizeDialog extends LitElement {
       '[data-testid="location-area"]',
     );
     if (areaSelect) areaSelect.value = this._locArea ?? '';
+    this._revealDisclosures();
   }
 
   protected willUpdate(changed: Map<string, unknown>) {
@@ -1365,7 +1440,7 @@ export class HVOrganizeDialog extends LitElement {
           : null}
         ${this._guard
           ? html`<div class="guard" role="alert" data-testid="location-guard">
-              <span class="glyph">${icon('alert', 17)}</span>
+              <span class="guard-mark">${icon('alert', 17)}</span>
               <span>${this._guard.message}</span>
             </div>`
           : null}

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -716,13 +716,19 @@ export class HVOrganizeDialog extends LitElement {
    * no focus: it is a refusal to act, and pulling the caret out of the list
    * would answer a tap the household did not make. The editors are forms, and a
    * form opened from a row leaves the keyboard on that row's button unless its
-   * first field claims the caret.
+   * first field claims the caret. The touch layout's ⋮ sheets are neither: a
+   * menu of what the row can do, which needs showing but claims no field.
    */
   private get _disclosures(): { testid: string; open: string | null; field?: string }[] {
     const value = this._editingValue;
     return [
       { testid: 'location-editor', open: this._editingLocation, field: 'location-name' },
       { testid: 'location-guard', open: this._guard?.locationId ?? null },
+      // On a phone the ⋮ sheet is the only way into edit, merge and delete, so
+      // it is the tap that has to land somewhere visible for any of them to be
+      // reachable at all.
+      { testid: 'location-sheet', open: this._sheetLocation },
+      { testid: 'value-sheet', open: this._sheetValue },
       // The mode is half the identity: switching a row from rename to merge
       // swaps the form under the same element.
       {

--- a/cards/haventory-card/src/ui/status.ts
+++ b/cards/haventory-card/src/ui/status.ts
@@ -33,10 +33,12 @@ export const BUILT_IN_STATUSES: readonly StatusDefinition[] = [
 
 /**
  * Every colour a status may take: five hues, each in a light and a strong form.
- * Ordered hue-major so a five-by-two picker grid reads as hue across, intensity
- * down. Pinned to the backend's `STATUS_COLORS` by
- * `tests/test_frontend_registration.py` — the backend refuses a value outside
- * its own list, and neither side can see the other.
+ * Ordered hue-major so the two intensities of a hue stay adjacent: the picker
+ * lays the swatches out as a wrapping row, and a neighbouring pair reads as one
+ * hue at two strengths wherever the line happens to break. Pinned to the
+ * backend's `STATUS_COLORS` by `tests/test_frontend_registration.py` — the
+ * backend refuses a value outside its own list, and neither side can see the
+ * other.
  */
 export const STATUS_COLORS: readonly StatusColor[] = [
   'neutral',


### PR DESCRIPTION
## Summary

Work package **F3** of `dev/v040_followup_fix_plan.md` — the organize dialog.

**#318 — disclosures come into view.** Five disclosures render *after* the row that opened them, inside the scrolling `.body`, and none scrolled itself into view; `src/` had no `scrollIntoView` call anywhere. Opened from a row near the bottom of a long list, one landed below the fold and the tap read as having done nothing — worst on the two delete guards, which are what stands between a tap and a batch of items changing.

`updated()` now composes a `_revealDisclosures()` pass with the existing `DialogFocus` sync and area-select write. It tracks which disclosure of each kind is open (`location-editor`, `location-guard`, `value-editor`, `status-editor`, `status-guard`) and, on a null→set transition or an identity change, calls `scrollIntoView({ block: 'nearest' })` on the element that just rendered:

- `nearest` so one already fully visible does not move under the user, and no `behavior`, so there is no motion to gate on `prefers-reduced-motion`.
- Keyed on which disclosure is open rather than on the render, so typing in an open editor never moves the pane.
- The three **editors** are forms: their first field takes the caret, so a keyboard user is not left on the row's button. The two **guards** keep `role="alert"` and take no focus.
- Re-opening the dialog with a disclosure still expanded stays `DialogFocus`'s moment — the first render after open records what is on screen and moves nothing.
- The location guard still renders after the tree; scroll-into-view is what makes it visible. Moving it beside the row was out of scope.

All five already carried stable testids, so none was added.

**#316 item 1 — touch parity, resolved as parity.** The Statuses tab's sizing is promoted to the shared selectors rather than duplicated per tab: `.status-row .count-link` → `.count-link` (24px floor, tap-min on mobile) and `:host([mobile]) .status-row .row-actions button` → `:host([mobile]) .row-actions button`. Count links and row actions now meet the same target size on Locations, Categories and Tags. Taller mobile rows on those three tabs are the accepted cost, per the decision recorded in the plan; the CSS comment states that tradeoff. The old comment ("Confined to the status rows…") became false and was rewritten.

**#316 item 2 — `.glyph` unpicked.** The location guard's alert mark carried `.glyph`, the icon-picker button's class, so a non-interactive span rendered as a 30×26 bordered box under a pointer cursor. It gets `.guard-mark` (warn ink, `flex: none`, nothing else); `.guard .glyph` is gone, and `.glyph` now means the picker button alone — so its mobile sizing no longer needs the defensive `.swatches` scoping that existed only to stay off the guard.

**#315 — `STATUS_COLORS` comment, resolved as option 1.** The "five-by-two picker grid, hue across, intensity down" claim described a layout `.swatches` (flex-wrap) never produces, and was self-inconsistent besides. Rewritten to state what hue-major ordering actually buys in a wrapping row: a hue's light and strong forms stay adjacent, so each pair reads as one hue at two strengths wherever the line breaks. The sentence about the backend pin in `tests/test_frontend_registration.py` is kept — it stays true. No layout change; `.swatches` stays a wrapping flex row, which the touch-target sizing depends on.

No backend, no WS contract surface, so no `docs/` change. No file inside `custom_components/haventory/` deleted or renamed, so no `RETIRED_PATHS` entry.

Closes #318
Closes #316
Closes #315

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 749 passed, 22 skipped · `uv run ruff check .` → all checks passed · `uv run ruff format --check .` → 115 files already formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean · `npx vitest run` → 1400 passed (54 files) · `npm run build` → bundle emitted

Eight new tests, all verified to fail with `_revealDisclosures()` removed:

- One per disclosure kind — status guard (with the `{ block: 'nearest' }` options pinned and the reassign select confirmed not focused), location guard, location editor, value editor, status editor. The three editor cases also assert the caret lands in the first field.
- The no-move cases: one scroll per open and none on the re-renders that follow (typing in the open editor, plus an unrelated `requestUpdate()`); a second row opening the same kind of disclosure scrolls again; a dialog re-opened with a disclosure still expanded moves nothing and leaves focus on the panel.

Rewritten pins rather than deleted ones: `sizes every statuses-tab control for a finger` becomes `sizes every row control for a finger, on all four tabs`, asserting the unscoped selectors *and* that no `.status-row`-scoped sizing survives. New pins cover `.guard-mark` (warn colour, `flex: none`, no border, no cursor), the guard's rendered class, and the absence of `.swatches .glyph` / `.guard .glyph`. Existing swatch pins are untouched and green.

### Delegated to the local verification pass

This is a cloud session — no Docker dev HA, no screenshot tooling — so everything below is handed to the local session, and jsdom cannot prove the acceptance criterion either way:

- Whether a disclosure actually **ends up visible**. jsdom performs no layout and implements no `scrollIntoView`; the offline tests stub it and assert the call. Same category as the sticky-column work.
- DOM measurement of count links and row-action buttons across all four tabs at 390px and desktop.
- The location guard's alert mark rendering with no border box and no pointer cursor.
- Screenshots of the accepted row-height increase.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed — no user-facing or contract behavior changed, so none needed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no backend change in this PR.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched.

## Screenshots (card / UI changes)

Deferred to the local verification pass, which has the dev HA container: light + dark at 390px of a Locations and a Tags row, so the accepted row-height increase is visible at merge time.

---
_Generated by [Claude Code](https://claude.ai/code/session_0114XKWjd21rCb7L6YBsK4Tn)_