### PR TITLE
fix(ws): run upload consume and teardown off the event loop

### DIFF
--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -6,10 +6,10 @@ Adheres to the envelope: input {id, type, ...payload}, output result_message/err
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import logging
 from collections.abc import Awaitable, Callable
-from contextlib import ExitStack
 from datetime import UTC, datetime
 from typing import Any, TypedDict, cast
 
@@ -1521,16 +1521,21 @@ async def ws_item_attachment_add(
         raise ConflictError(f"version conflict: expected {expected}, actual {current.version}")
 
     attachment_id = new_uuid4()
-    with ExitStack() as stack:
-        try:
-            # Entered through the stack so only *this* call is guarded: a
-            # `ValueError` from anywhere else must not be relabelled as a
-            # missing upload. `file_upload` raises it for an id it does not
-            # know — an expired handle, or one an earlier call consumed.
-            source = stack.enter_context(process_uploaded_file(hass, msg["file_id"]))
-        except ValueError as exc:
-            raise NotFoundError("uploaded file not found; upload it again") from exc
+    # `file_upload` hands back a synchronous context manager whose teardown
+    # walks the upload's temp directory and deletes it, so both halves are
+    # dispatched to the executor: run on the loop, that walk stalls every other
+    # connection for as long as it takes — longest for the multi-megabyte photo
+    # bursts this command exists to carry.
+    upload_handle = process_uploaded_file(hass, msg["file_id"])
+    try:
+        # Only *this* call is guarded: a `ValueError` from anywhere else must not
+        # be relabelled as a missing upload. `file_upload` raises it for an id it
+        # does not know — an expired handle, or one an earlier call consumed.
+        source = await hass.async_add_executor_job(upload_handle.__enter__)
+    except ValueError as exc:
+        raise NotFoundError("uploaded file not found; upload it again") from exc
 
+    try:
         mime, size = await media_mod.async_consume_upload(
             hass,
             source=source,
@@ -1538,6 +1543,12 @@ async def ws_item_attachment_add(
             item_id=str(current.id),
             attachment_id=str(attachment_id),
         )
+    finally:
+        # The temp directory must not outlive the command on any path — accepted
+        # bytes, refused ones, or a client that drops the connection mid-upload.
+        # Shielded so a cancelled command still tears its upload down: nothing
+        # else collects these files.
+        await asyncio.shield(hass.async_add_executor_job(upload_handle.__exit__, None, None, None))
 
     meta = AttachmentMeta(
         id=attachment_id,

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -96,7 +96,7 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - `no_location_count` is the number of items without a location (`location_id == null`, i.e. the `orphaned_only` filter's population).
   - `overdue_count` is the number of items whose `due_date` is strictly before today in UTC (the `overdue_only` filter's population). It is derived from the calendar, not from stored state, so it can change without any mutation — no event is emitted when the date rolls over.
   - `inspection_overdue_count` is the number of items whose `inspection_date` — the date the item is next due for inspection — is strictly before today in UTC (the `inspection_overdue_only` filter's population). It counts the whole inventory, not just checked-out items, because an inspection is independent of any check-out. Calendar-derived in the same way as `overdue_count`, with the same no-event caveat.
-  - `missing_count` / `needs_repair_count` count items whose stored `status` is `missing` / `needs_repair` (the populations of the `status` filter's two non-default values). Stored state, not calendar-derived: they only change on a mutation, and every mutation emits `stats/counts`.
+  - `missing_count` / `needs_repair_count` count items whose stored `status` is `missing` / `needs_repair` — each the population of the `status` filter set to that slug. Stored state, not calendar-derived: they only change on a mutation, and every mutation emits `stats/counts`.
   - `status_counts` is the same figure for **every** defined slug, including `ok`. Additive to the two keys above rather than a replacement for them, so a client written against the earlier shape keeps working.
 
 - `haventory/distinct_values`

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -212,7 +212,7 @@ counts items at the node or any descendant (so it is always >= the direct count)
   - `tags_any?: string[]`
   - `tags_all?: string[]`
   - `category?: string`
-  - `status?: "ok"|"missing"|"needs_repair"` (exact match; unknown values are `validation_error`)
+  - `status?: <status slug>` (exact match against the live status set; unknown values are `validation_error`)
   - `checked_out?: boolean`
   - `low_stock_only?: boolean`
   - `orphaned_only?: boolean` (only items without a location, i.e. `location_id == null`)

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -12,10 +12,13 @@ is here is the transport and the view around it.
 
 from __future__ import annotations
 
+import shutil
+import threading
 from http import HTTPStatus
 from pathlib import Path
 from urllib.parse import unquote
 
+import pytest
 from aiohttp import FormData
 from custom_components.haventory import media
 from custom_components.haventory.const import DOMAIN, MEDIA_NAME_TOKEN_PARAM, MEDIA_SUBDIR
@@ -82,6 +85,29 @@ def _rfc5987_filename(disposition: str) -> str:
     return unquote(disposition.split(marker, 1)[1])
 
 
+@pytest.fixture
+def upload_teardowns(monkeypatch) -> list[tuple[int, Path]]:
+    """Record every temp-directory teardown as (thread id, directory).
+
+    Core's `file_upload` ends its context manager with a synchronous
+    `shutil.rmtree`, and which thread pays for that walk is the whole question.
+    Home Assistant's own blocking-call detector cannot answer it here: it skips
+    the `os.scandir`, `os.listdir` and `open` protections whenever `unittest` is
+    imported, which is every pytest run. A live instance is where that log line
+    appears, so this records the thread directly instead.
+    """
+
+    calls: list[tuple[int, Path]] = []
+    real_rmtree = shutil.rmtree
+
+    def _record(path, *args, **kwargs):
+        calls.append((threading.get_ident(), Path(path)))
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", _record)
+    return calls
+
+
 async def _create_item(ws_client, name: str = "Drill") -> dict:
     await ws_client.send_json({"id": 1, "type": "haventory/item/create", "name": name})
     result = await ws_client.receive_json()
@@ -130,6 +156,75 @@ async def test_a_real_png_round_trips_through_upload_and_the_view(
     assert disposition.startswith("inline;")
     assert 'filename="drill.png"' in disposition
     assert await served.read() == PNG_BYTES
+
+
+async def test_the_upload_handle_is_consumed_off_the_event_loop(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client,
+    upload_teardowns: list[tuple[int, Path]],
+) -> None:
+    """Every byte of the temp directory's teardown is paid by a worker thread.
+
+    On the loop it stalls every other connection for as long as the walk takes,
+    and the stall grows with the file — worst on the phone burst-uploading
+    photos, which is the case the feature exists for.
+    """
+
+    await _setup(hass)
+    client = await hass_client()
+    ws = await hass_ws_client(hass)
+    item = await _create_item(ws)
+    file_id = await _upload(client)
+
+    loop_thread = threading.get_ident()
+    await ws.send_json(
+        {
+            "id": 2,
+            "type": "haventory/item/attachment/add",
+            "item_id": item["id"],
+            "file_id": file_id,
+        }
+    )
+    added = await ws.receive_json()
+
+    assert added["success"] is True, added
+    assert len(upload_teardowns) == 1
+    torn_down_on, temp_dir = upload_teardowns[0]
+    assert torn_down_on != loop_thread
+    assert not temp_dir.exists()
+
+
+async def test_a_consumed_handle_cannot_be_used_again(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+) -> None:
+    """The upload is destroyed with the command, so the second call is a 404.
+
+    The same envelope an expired handle gets: `file_upload` no longer knows the
+    id, and the message tells the card to upload the bytes again rather than
+    retry a handle that can never come back.
+    """
+
+    await _setup(hass)
+    client = await hass_client()
+    ws = await hass_ws_client(hass)
+    item = await _create_item(ws)
+    file_id = await _upload(client)
+
+    add = {
+        "type": "haventory/item/attachment/add",
+        "item_id": item["id"],
+        "file_id": file_id,
+    }
+    await ws.send_json({"id": 2, **add})
+    assert (await ws.receive_json())["success"] is True
+
+    await ws.send_json({"id": 3, **add})
+    refused = await ws.receive_json()
+
+    assert refused["success"] is False
+    assert refused["error"]["code"] == "not_found"
+    assert refused["error"]["message"] == "uploaded file not found; upload it again"
 
 
 async def test_the_media_view_refuses_an_unauthenticated_request(
@@ -181,7 +276,10 @@ async def test_an_id_no_metadata_claims_is_a_404(
 
 
 async def test_a_non_image_is_refused_and_leaves_nothing_behind(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client,
+    upload_teardowns: list[tuple[int, Path]],
 ) -> None:
     """SVG carries script and the view serves it from the Home Assistant origin."""
 
@@ -193,6 +291,7 @@ async def test_a_non_image_is_refused_and_leaves_nothing_behind(
     file_id = await _upload(
         client, b'<svg xmlns="http://www.w3.org/2000/svg"><script/></svg>', "drawing.svg"
     )
+    loop_thread = threading.get_ident()
     await ws.send_json(
         {
             "id": 2,
@@ -206,6 +305,12 @@ async def test_a_non_image_is_refused_and_leaves_nothing_behind(
     assert refused["success"] is False
     assert refused["error"]["code"] == "validation_error"
     assert hass.data[DOMAIN]["repository"].get_item(item["id"]).attachments == []
+    # Refused bytes are torn down on the same terms as accepted ones: off the
+    # loop, and gone by the time the caller is told no.
+    assert len(upload_teardowns) == 1
+    torn_down_on, temp_dir = upload_teardowns[0]
+    assert torn_down_on != loop_thread
+    assert not temp_dir.exists()
 
 
 async def test_deleting_the_item_deletes_its_files(

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -16,8 +16,10 @@ code path: sniffing, the caps, the move onto disk, and the deletes.
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 import tempfile
+import threading
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -359,29 +361,41 @@ def _fake_upload(_hass, file_id: str):
     and destroys the directory afterwards. `_UPLOADS` is what the tests POST
     into; an id that is not in it raises `ValueError`, which is exactly how the
     real component reports an expired or already-consumed upload.
+
+    Both halves record the thread they ran on. The real teardown is a
+    synchronous `shutil.rmtree`, so neither may run on the event loop thread —
+    and the stub `HomeAssistant` dispatches `async_add_executor_job` to a
+    genuine worker, which is what makes the difference observable.
     """
 
     if file_id not in _UPLOADS:
         raise ValueError("File does not exist")
     source = _UPLOADS.pop(file_id)
+    _UPLOAD_THREADS["enter"] = threading.get_ident()
     try:
         yield source
     finally:
+        _UPLOAD_THREADS["exit"] = threading.get_ident()
         shutil.rmtree(source.parent, ignore_errors=True)
 
 
 _UPLOADS: dict[str, Path] = {}
+_UPLOAD_THREADS: dict[str, int] = {}
 
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
 
 
-def _stage_upload(file_id: str, content: bytes = PNG_BYTES) -> None:
-    """Put a file where the fake `process_uploaded_file` will find it."""
+def _stage_upload(file_id: str, content: bytes = PNG_BYTES) -> Path:
+    """Put a file where the fake `process_uploaded_file` will find it.
+
+    Returns the temp directory holding it, which the teardown must delete.
+    """
 
     directory = Path(tempfile.mkdtemp(prefix="haventory-upload-"))
     source = directory / "photo.png"
     source.write_bytes(content)
     _UPLOADS[file_id] = source
+    return directory
 
 
 @pytest.fixture
@@ -389,6 +403,7 @@ def upload(monkeypatch):
     """Route the attachment command through the fake upload component."""
 
     _UPLOADS.clear()
+    _UPLOAD_THREADS.clear()
     monkeypatch.setattr(ws_mod, "process_uploaded_file", _fake_upload)
     return _stage_upload
 
@@ -558,6 +573,111 @@ async def test_attachment_add_refuses_a_file_whose_bytes_are_not_an_image(upload
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
     assert _repo_of(hass).get_item(created["result"]["id"]).attachments == []
+
+
+@pytest.mark.asyncio
+async def test_attachment_add_consumes_the_upload_handle_off_the_event_loop(upload) -> None:
+    """Core's handle enters and leaves on a worker, never on the loop thread.
+
+    Its teardown deletes the upload's temp directory with a synchronous
+    `shutil.rmtree`; on the loop that stalls every other connection for as long
+    as the walk takes, and Home Assistant's blocking-call detector reports it
+    against this integration.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    directory = upload("upload-1")
+    loop_thread = threading.get_ident()
+
+    added = await _send(
+        hass,
+        2,
+        "haventory/item/attachment/add",
+        item_id=created["result"]["id"],
+        file_id="upload-1",
+    )
+
+    assert added["success"] is True
+    assert _UPLOAD_THREADS["enter"] != loop_thread
+    assert _UPLOAD_THREADS["exit"] != loop_thread
+    assert not directory.exists()
+
+
+@pytest.mark.asyncio
+async def test_attachment_add_tears_the_upload_down_off_the_loop_when_it_is_refused(
+    upload,
+) -> None:
+    """The failure path pays the same teardown, so it offloads it the same way."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    directory = upload("upload-1", b'<svg xmlns="http://www.w3.org/2000/svg"><script/></svg>')
+    loop_thread = threading.get_ident()
+
+    refused = await _send(
+        hass,
+        2,
+        "haventory/item/attachment/add",
+        item_id=created["result"]["id"],
+        file_id="upload-1",
+    )
+
+    assert refused["success"] is False
+    assert refused["error"]["code"] == "validation_error"
+    assert _UPLOAD_THREADS["exit"] != loop_thread
+    assert not directory.exists()
+
+
+@pytest.mark.asyncio
+async def test_attachment_add_tears_the_upload_down_when_the_command_is_cancelled(
+    upload, monkeypatch
+) -> None:
+    """A dropped connection mid-upload must not leave the bytes behind.
+
+    Nothing else collects an abandoned `file_upload` directory: the media sweep
+    only knows the integration's own media root.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    directory = upload("upload-1")
+
+    consuming = asyncio.Event()
+
+    async def _hang(*_args, **_kwargs):
+        consuming.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(media_mod, "async_consume_upload", _hang)
+
+    task = asyncio.create_task(
+        _send(
+            hass,
+            2,
+            "haventory/item/attachment/add",
+            item_id=created["result"]["id"],
+            file_id="upload-1",
+        )
+    )
+    await consuming.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not directory.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Work package **F1** of `dev/v040_followup_fix_plan.md` — backend only, no card files touched.

**#310 — the upload handle is consumed off the loop.** `ws_item_attachment_add` entered and
left core's `file_upload` context manager on the event loop. Its teardown is a synchronous
`shutil.rmtree`, so every photo and manual upload stalled the loop for as long as the temp
directory took to walk, and HA's blocking-call detector reported it against this integration
in every user's log. The `ExitStack` is now an explicit enter/`try`/`finally` with **both**
halves dispatched through `hass.async_add_executor_job`; the exit job is `asyncio.shield`ed
so a command cancelled mid-upload (a dropped WebSocket) still destroys the temp directory —
nothing else collects it.

Error semantics are unchanged, deliberately:
- the `ValueError → not_found("uploaded file not found; upload it again")` mapping stays
  scoped to the enter alone, message string untouched;
- the item (and its version) is still read *before* the upload is consumed, so a lost race
  does not also cost the user the bytes;
- teardown still happens before the repository mutation and the persist, on every path.

**`media.py` needed no change.** `async_consume_upload` already offloads both its read and
its write (`media.py:269-272`), as do `async_delete_attachments` and the orphan sweep — the
loop-blocking work was entirely in the handle's own lifecycle. The file is untouched.

**#309 — the filter docs.** `docs/data_shapes.md` documented `ItemFilter.status` as
`"ok"|"missing"|"needs_repair"`, which has not been the accepted set since statuses became
user-defined: `filter_items` validates against `Repository.status_slugs()`. Reworded to the
live-set idiom its neighbours (`:72`, `:86`) already use. `docs/backend_api_contract.md`'s
`item/list` section carried no copy of the enumeration; its `stats` section called
`missing`/`needs_repair` "the `status` filter's two non-default values", which asserts the
same closed set — reworded to name each count's population without bounding the vocabulary.

Closes #310
Closes #309

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped),
      `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (clean; `ws.py`
      is per-module strict)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` (1390 passed), `npm run build` — untouched by this PR, green anyway
- [x] Integration mode: `.venv-integration/bin/python -m pytest -o asyncio_mode=auto
      tests/integration` — **44 passed**

New pins, each verified to fail on `main` before the fix and pass after:

| Test | Asserts |
|---|---|
| `test_attachment_add_consumes_the_upload_handle_off_the_event_loop` (offline) | enter *and* exit ran on a thread that is not the loop thread; temp dir gone |
| `test_attachment_add_tears_the_upload_down_off_the_loop_when_it_is_refused` (offline) | same for the refused-bytes path |
| `test_attachment_add_tears_the_upload_down_when_the_command_is_cancelled` (offline) | cancelling the command mid-consume still destroys the temp dir |
| `test_the_upload_handle_is_consumed_off_the_event_loop` (integration) | against the real `file_upload`: teardown thread ≠ loop thread, temp dir gone |
| `test_a_non_image_is_refused_and_leaves_nothing_behind` (integration, extended) | the same two facts on the refusal path |
| `test_a_consumed_handle_cannot_be_used_again` (integration) | a second add on the same `file_id` still returns `not_found` with the unchanged message |

The offline fake `process_uploaded_file` now records the thread each half ran on; the stub
`HomeAssistant.async_add_executor_job` dispatches to a genuine worker, which is what makes
that observable. The expired-handle test is green as written.

Two notes for the reviewer:

- **The caplog "no `Detected blocking call`" assertion the plan sketched would be vacuous
  under phacc**, so it is not in the diff. HA skips the `os.scandir`, `os.listdir` and
  `open` loop protections whenever `unittest` is in `sys.modules` (`block_async_io.py`,
  `skip_for_tests`), and `shutil.rmtree` is not protected at all — the detector cannot fire
  for this call path in any pytest run. The integration tests therefore record the teardown
  thread directly. A **live** log sweep is where that acceptance criterion is actually met,
  and it is in the handover below.
- **`scripts/test_integration.sh` fails on the uv that ships in this cloud image** (0.8.17):
  its Python catalogue tops out at 3.14.0rc2 and `homeassistant==2026.6.0` requires
  `>=3.14.2`, so the resolve fails before any test runs. Upgrading uv (0.12.3) makes 3.14.7
  available and the suite provisions and passes. Nothing in the repo needs changing — but a
  local session on an older uv will hit the same wall and should update uv first.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added/updated (happy path + refusal + cancellation + expired-handle)
- [x] Docs updated where behavior changed
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — the wire contract is unchanged here; the doc edits correct staleness
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`)
- No file inside `custom_components/haventory/` was deleted or renamed, so no `RETIRED_PATHS` entry is needed

## Follow-ups

- #331 — `README.md:425` presents the per-item status vocabulary as the fixed built-in three,
  the same staleness #309 fixed in `docs/`. Out of F1's file scope (`ws.py`, `docs/`, tests),
  so it is filed rather than fixed here.

## Delegated to the local verification pass

Per the plan, F1 carries a **required** handover. A cloud session has no dev HA container,
so these are the checks it cannot make:

1. Real card flow: upload a photo and a PDF manual, then sweep the HA log — **zero**
   `Detected blocking call` entries (this is the acceptance the offline detector cannot give).
2. Temp directory gone after a successful upload and after a refused-bytes upload, on a
   real instance.
3. A consumed or expired `file_id` still returns "uploaded file not found; upload it again".

The plan's closing protocol also asks the local session of the **last still-open** package PR
to delete `dev/v040_followup_fix_plan.md`. F2 (#327) and F3 (#329) are open alongside this
one, so that check belongs to whichever verification pass runs last.

## Screenshots (card / UI changes)

None — no card change.
