### PR TITLE
fix(card): keep the open editor and its edits across filter, search and sort changes

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1073,6 +1073,135 @@ describe('hv-card-shell: inline editing', () => {
   });
 });
 
+// Typing in the search box, toggling a filter and changing the sort all run
+// through `Store.setFilters`. It used to blank the item list, which sent
+// `hv-list` into its skeleton branch and replaced the scroller the open form
+// lives in — the element was rebuilt from the stored item and everything typed
+// into it was gone, while the form still looked open.
+describe('hv-card-shell: the open editor survives a refetch', () => {
+  const list = (sr: ShadowRoot) => sr.querySelector('hv-list') as HTMLElement;
+  const editor = (sr: ShadowRoot) =>
+    (list(sr).shadowRoot?.querySelector('hv-item-editor') as HTMLElement | null) ?? null;
+  const nameField = (sr: ShadowRoot) =>
+    editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+
+  const openAndType = async (el: HVCardShell, sr: ShadowRoot, id: string, typed: string) => {
+    const row = [...(list(sr).shadowRoot?.querySelectorAll('hv-list-row') ?? [])]
+      .map((r) => r as HTMLElement & { item: Item })
+      .find((r) => r.item.id === id)!;
+    (row.shadowRoot?.querySelector('[data-testid="row-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+    const field = nameField(sr);
+    field.value = typed;
+    field.dispatchEvent(new Event('input'));
+    await settle(el);
+    return editor(sr)!;
+  };
+
+  const twoItems = () => [
+    makeItem({ id: '1', name: 'Target', quantity: 9, low_stock_threshold: 1 }),
+    makeItem({ id: '2', name: 'Decoy', quantity: 0, low_stock_threshold: 4 }),
+  ];
+
+  it('survives typing in the search box', async () => {
+    const { el, store, sr } = await mountShell({ items: twoItems() });
+    const before = await openAndType(el, sr, '1', 'Target EDITED');
+
+    store.setFilters({ q: 'Tar' });
+    await settle(el);
+    await settle(el);
+
+    expect(editor(sr)).toBe(before);
+    expect(nameField(sr).value).toBe('Target EDITED');
+  });
+
+  it('survives a filter toggle', async () => {
+    const { el, store, sr } = await mountShell({ items: twoItems() });
+    const before = await openAndType(el, sr, '1', 'Target EDITED');
+
+    store.setFilters({ lowStockOnly: true });
+    await settle(el);
+    await settle(el);
+
+    expect(editor(sr)).toBe(before);
+    expect(nameField(sr).value).toBe('Target EDITED');
+  });
+
+  // The sort patch is the one `setFilters` skips the tree refresh for, so it
+  // moves no editor-epoch input — which is how the issue proved this is not the
+  // epoch's doing.
+  it('survives a sort change', async () => {
+    const { el, store, sr } = await mountShell({ items: twoItems() });
+    const before = await openAndType(el, sr, '1', 'Target EDITED');
+
+    store.setFilters({ sort: { field: 'name', order: 'desc' } });
+    await settle(el);
+    await settle(el);
+
+    expect(editor(sr)).toBe(before);
+    expect(nameField(sr).value).toBe('Target EDITED');
+  });
+
+  it('pins the row, and says so, when the filter stops matching it', async () => {
+    const { el, store, sr } = await mountShell({ items: twoItems() });
+    const before = await openAndType(el, sr, '1', 'Target EDITED');
+
+    // Item 1 has stock to spare, so "low stock only" excludes exactly it.
+    store.setFilters({ lowStockOnly: true });
+    await settle(el);
+    await settle(el);
+
+    expect(store.state.value.items.map((i) => i.id)).toEqual(['2']);
+    expect(editor(sr)).toBe(before);
+    expect(nameField(sr).value).toBe('Target EDITED');
+    expect(
+      list(sr).shadowRoot?.querySelector('[data-testid="pinned-editor-hint"]')?.textContent,
+    ).toContain('No longer matches the current filters');
+  });
+
+  it('releases the pin on cancel', async () => {
+    const { el, store, sr } = await mountShell({ items: twoItems() });
+    await openAndType(el, sr, '1', 'Target EDITED');
+    store.setFilters({ lowStockOnly: true });
+    await settle(el);
+    await settle(el);
+
+    (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-cancel"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(editor(sr)).toBe(null);
+    expect(list(sr).shadowRoot?.querySelector('[data-testid="pinned-editor-hint"]')).toBe(null);
+  });
+
+  it('releases the pin on save', async () => {
+    const { el, store, sr } = await mountShell({ items: twoItems() });
+    await openAndType(el, sr, '1', 'Target EDITED');
+    store.setFilters({ lowStockOnly: true });
+    await settle(el);
+    await settle(el);
+
+    (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).click();
+    await settle(el);
+    await settle(el);
+
+    expect(store.state.value.items.find((i) => i.id === '1')?.name).toBe('Target EDITED');
+    expect(editor(sr)).toBe(null);
+    expect(list(sr).shadowRoot?.querySelector('[data-testid="pinned-editor-hint"]')).toBe(null);
+  });
+
+  // A pin is for a row that fell off the page, not for one that is gone.
+  it('closes rather than pins when the item is deleted', async () => {
+    const { el, store, sr } = await mountShell({ items: twoItems() });
+    await openAndType(el, sr, '1', 'Target EDITED');
+
+    await store.deleteItem('1', 1);
+    await settle(el);
+
+    expect(editor(sr)).toBe(null);
+    expect(list(sr).shadowRoot?.querySelector('[data-testid="pinned-editor-hint"]')).toBe(null);
+  });
+});
+
 // The inline expander is the one surface that renders the editor through
 // `hv-list`'s template callback rather than directly, so it is the only one
 // where shell state can reach the host and stop there. Everything below is

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -390,6 +390,16 @@ export class HVCardShell extends LitElement {
   private _media: MediaBindings | null = null;
   /** Identities `_editorEpoch` was last bumped for; see `_syncEditorEpoch`. */
   private _editorInputs: unknown[] = [];
+  /**
+   * The last copy of the row being edited, kept for as long as the form is open.
+   *
+   * A filter change refetches, and the edited row can drop out of the result.
+   * The editor rebuilds its model whenever the item id it was handed changes,
+   * so handing it `null` there would wipe the typed edits just as surely as
+   * unmounting it. `_syncPinnedItem` keeps this at the freshest copy the store
+   * has listed.
+   */
+  private _pinnedItem: Item | null = null;
 
   /**
    * Picture access for every surface below, built once per store.
@@ -446,7 +456,31 @@ export class HVCardShell extends LitElement {
     if (changed.has('forceMobile')) this.responsive.setForced(this.forceMobile);
     // Reflect the mode so child selectors and :host([mobile]) rules apply.
     this.toggleAttribute('mobile', this.mobile);
+    this._syncPinnedItem();
     this._syncEditorEpoch();
+  }
+
+  /**
+   * Hold on to the row being edited, and close the form when it is really gone.
+   *
+   * Falling off the current page and being deleted look identical from the item
+   * list alone; the store is the only place that knows which happened, so it is
+   * asked rather than guessed at.
+   */
+  private _syncPinnedItem() {
+    const editing = this._editing;
+    if (editing === null || editing === 'new') {
+      this._pinnedItem = null;
+      return;
+    }
+    if (this.store?.wasRemoved(editing)) {
+      this._pinnedItem = null;
+      this._editing = null;
+      this._editorError = null;
+      return;
+    }
+    const listed = this.st?.items.find((i) => i.id === editing);
+    if (listed) this._pinnedItem = listed;
   }
 
   /**
@@ -525,6 +559,12 @@ export class HVCardShell extends LitElement {
 
   private _itemById(itemId: string): Item | undefined {
     return this.st?.items.find((i) => i.id === itemId);
+  }
+
+  /** The item an open editor edits — the listed row, or the pinned copy of it. */
+  private _editorItem(itemId: string | null): Item | null {
+    if (itemId === null) return null;
+    return this._itemById(itemId) ?? (this._pinnedItem?.id === itemId ? this._pinnedItem : null);
   }
 
   private _onRowAction(item: Item, detail: { action?: string; anchor?: DOMRect }) {
@@ -627,7 +667,9 @@ export class HVCardShell extends LitElement {
 
   private _onEditorDelete = (e: CustomEvent) => {
     const { itemId } = e.detail as { itemId: string };
-    const item = this._itemById(itemId);
+    // The pinned copy counts: a row filtered off the page is still deletable
+    // from the form that is still open on it.
+    const item = this._editorItem(itemId);
     if (!item) return;
     this._requestDelete(item);
   };
@@ -646,7 +688,7 @@ export class HVCardShell extends LitElement {
       .media=${this.media}
       .mediaConfig=${st?.mediaConfig ?? null}
       ?noHeader=${opts.noHeader ?? false}
-      .item=${itemId ? (this._itemById(itemId) ?? null) : null}
+      .item=${this._editorItem(itemId)}
       .locations=${st?.locationsFlatCache ?? null}
       .locationTree=${st?.locationTreeCache ?? []}
       .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
@@ -1100,6 +1142,7 @@ export class HVCardShell extends LitElement {
         .editorTemplate=${this._renderEditor}
         .editorEpoch=${this._editorEpoch}
         .editingItemId=${this._editing === 'new' ? null : this._editing}
+        .pinnedItem=${this._pinnedItem}
         .addingNew=${!mobile && this._editing === 'new'}
         .emptyKind=${emptyKindFor(this.st)}
         .emptyLocationName=${(st?.locationsFlatCache ?? []).find((l) => l.id === filters.locationId)?.name ??

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1068,7 +1068,35 @@ describe('hv-full-view: editing', () => {
     expect(q(sr, '[data-testid="full-editor"]')).toBeTruthy();
   });
 
-  it('closes the editor when a filter change drops the item from the list', async () => {
+  // A row that stops matching is not a row that stopped existing: the typed
+  // edits are still worth saving, so the form is pinned and says why.
+  it('pins the editor when a filter change drops the item from the list', async () => {
+    const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Wood Glue' })] });
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const editor = q(sr, '[data-testid="full-editor"]') as HTMLElement & { item: { name: string } | null };
+    const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+    name.value = 'Wood Glue EDITED';
+    name.dispatchEvent(new Event('input', { bubbles: true }));
+    await settle(el);
+
+    store.setFilters({ q: 'matches nothing at all' });
+    await settle(el);
+    await settle(el);
+
+    expect(q(sr, '[data-testid="full-editor"]')).toBe(editor);
+    expect(editor.item?.name).toBe('Wood Glue');
+    expect(
+      (editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement).value,
+    ).toBe('Wood Glue EDITED');
+    expect(q(sr, '[data-testid="pinned-editor-hint"]')?.textContent).toContain(
+      'No longer matches the current filters',
+    );
+  });
+
+  it('releases the pin when the editor is cancelled', async () => {
     const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Wood Glue' })] });
     const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
     (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
@@ -1077,8 +1105,15 @@ describe('hv-full-view: editing', () => {
     store.setFilters({ q: 'matches nothing at all' });
     await settle(el);
     await settle(el);
+    expect(q(sr, '[data-testid="pinned-editor-hint"]')).toBeTruthy();
+
+    q(sr, '[data-testid="full-editor"]')?.dispatchEvent(
+      new CustomEvent('cancel', { bubbles: true, composed: true }),
+    );
+    await settle(el);
 
     expect(q(sr, '[data-testid="full-editor"]')).toBe(null);
+    expect(q(sr, '[data-testid="pinned-editor-hint"]')).toBe(null);
   });
 
   // The form sits in a column flex beside a table that wants every pixel. An

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -695,6 +695,17 @@ export class HVFullView extends LitElement {
         max-height: min(70dvh, calc(100% - 116px));
         overflow-y: auto;
       }
+      /*
+       * The row being edited can stop matching the filter the user just changed.
+       * The form stays open on it so the typed edits survive; the hint is what
+       * stops that from reading as a table that failed to filter.
+       */
+      .pinned-hint {
+        margin: 0;
+        padding: 6px 16px;
+        font-size: 12px;
+        color: var(--hv-text-secondary);
+      }
       .new-location {
         display: flex;
         gap: 6px;
@@ -764,6 +775,15 @@ export class HVFullView extends LitElement {
   @state() private _searchDraft = '';
   @state() private _editing: string | 'new' | null = null;
   @state() private _editorBusy = false;
+  /**
+   * The last copy of the row being edited, kept for as long as the form is open.
+   *
+   * Same reason the card's shell keeps one: a filter change refetches, the
+   * edited row can drop out of the result, and the editor rebuilds its model
+   * from whatever item it is handed — so handing it `null` there discards the
+   * typed edits.
+   */
+  @state() private _pinnedItem: Item | null = null;
   @state() private _creatingLocation = false;
   @state() private _locationError: string | null = null;
   /**
@@ -837,20 +857,7 @@ export class HVFullView extends LitElement {
       this._storeUnsub?.();
       this._storeUnsub = this.store.state.onChange(() => this.requestUpdate());
     }
-    // An editor whose item has left the store — deleted here, by another
-    // client, or filtered out of the list — would otherwise render `.item` as
-    // null, which is the create form. Gated on `loading`: a filter change
-    // empties the list while the next page is fetched, and that absence says
-    // nothing yet.
-    if (
-      this._editing !== null &&
-      this._editing !== 'new' &&
-      this.st !== null &&
-      !this.st.loading &&
-      !this.st.items.some((i) => i.id === this._editing)
-    ) {
-      this._editing = null;
-    }
+    this._syncPinnedItem();
     if (changed.has('open')) {
       if (this.open) {
         this._zBase = nextZBase();
@@ -923,6 +930,35 @@ export class HVFullView extends LitElement {
 
   private _setFilters(patch: Partial<StoreFilters>) {
     this.store?.setFilters(patch);
+  }
+
+  /**
+   * Hold on to the row being edited, and close the form when it is really gone.
+   *
+   * Falling off the current page and being deleted look identical from the item
+   * list alone; the store is the only place that knows which happened, so it is
+   * asked rather than guessed at.
+   */
+  private _syncPinnedItem() {
+    const editing = this._editing;
+    if (editing === null || editing === 'new') {
+      this._pinnedItem = null;
+      return;
+    }
+    if (this.store?.wasRemoved(editing)) {
+      this._pinnedItem = null;
+      this._editing = null;
+      return;
+    }
+    const listed = this.st?.items.find((i) => i.id === editing);
+    if (listed) this._pinnedItem = listed;
+  }
+
+  /** The item the open editor edits — the listed row, or the pinned copy of it. */
+  private get _editorItem(): Item | null {
+    if (this._editing === null || this._editing === 'new') return null;
+    const id = this._editing;
+    return this.st?.items.find((i) => i.id === id) ?? (this._pinnedItem?.id === id ? this._pinnedItem : null);
   }
 
   private _onRowEvent(name: string, detail: { itemId?: string }) {
@@ -1759,15 +1795,18 @@ export class HVFullView extends LitElement {
             </div>
             ${this._editing !== null
               ? html`<div class="editor-holder">
+                  ${this._editing !== 'new' && !st?.items.some((i) => i.id === this._editing)
+                    ? html`<p class="pinned-hint" data-testid="pinned-editor-hint">
+                        No longer matches the current filters
+                      </p>`
+                    : null}
                   <hv-item-editor
                     .statuses=${this.st?.statuses ?? null}
                     data-testid="full-editor"
                     .areas=${st?.areasCache?.areas ?? []}
                     .media=${this.media}
                     .mediaConfig=${st?.mediaConfig ?? null}
-                    .item=${this._editing === 'new'
-                      ? null
-                      : (st?.items.find((i) => i.id === this._editing) ?? null)}
+                    .item=${this._editorItem}
                     .locations=${st?.locationsFlatCache ?? null}
                     .locationTree=${st?.locationTreeCache ?? []}
                     .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}

--- a/cards/haventory-card/src/components/hv-list.test.ts
+++ b/cards/haventory-card/src/components/hv-list.test.ts
@@ -119,6 +119,72 @@ describe('hv-list: which branch renders', () => {
     expect(el.shadowRoot?.querySelector('[data-testid="list-skeleton"]')).toBe(null);
   });
 
+  // The kept rows are the honest display only if they are labelled as stale.
+  it('marks the kept rows busy and shows the refresh signal', async () => {
+    const el = await mount({ loading: true });
+    const rows = el.shadowRoot?.querySelector('[data-testid="list-rows"]') as HTMLElement;
+    expect(rows.getAttribute('aria-busy')).toBe('true');
+    expect(el.shadowRoot?.querySelector('[data-testid="list-refreshing"]')).toBeTruthy();
+  });
+
+  it('drops the busy marks once the refresh lands', async () => {
+    const el = await mount({ loading: false });
+    const rows = el.shadowRoot?.querySelector('[data-testid="list-rows"]') as HTMLElement;
+    expect(rows.getAttribute('aria-busy')).toBe('false');
+    expect(el.shadowRoot?.querySelector('[data-testid="list-refreshing"]')).toBe(null);
+  });
+
+  // A filter can legitimately exclude the row being edited. Unmounting the form
+  // there discards whatever was typed into it, so the row is pinned instead.
+  it('pins the edited row when the list stops carrying it', async () => {
+    const pinned = makeItem({ id: 'a', name: 'A' });
+    const el = await mount({
+      editingItemId: 'a',
+      pinnedItem: pinned,
+      editorTemplate: (id) => html`<div data-testid="stub-editor">${id}</div>`,
+    });
+    el.items = [makeItem({ id: 'b', name: 'B' })];
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('[data-testid="stub-editor"]')?.textContent).toBe('a');
+    expect(el.shadowRoot?.querySelector('[data-testid="pinned-editor-hint"]')?.textContent).toContain(
+      'No longer matches the current filters',
+    );
+  });
+
+  it('draws no pin hint while the edited row is still listed', async () => {
+    const el = await mount({
+      editingItemId: 'a',
+      editorTemplate: (id) => html`<div data-testid="stub-editor">${id}</div>`,
+    });
+    expect(el.shadowRoot?.querySelector('[data-testid="stub-editor"]')).toBeTruthy();
+    expect(el.shadowRoot?.querySelector('[data-testid="pinned-editor-hint"]')).toBe(null);
+  });
+
+  it('keeps a pinned editor instead of falling back to the empty state', async () => {
+    const el = await mount({
+      items: [],
+      loading: false,
+      editingItemId: 'a',
+      pinnedItem: makeItem({ id: 'a', name: 'A' }),
+      editorTemplate: (id) => html`<div data-testid="stub-editor">${id}</div>`,
+    });
+    expect(el.shadowRoot?.querySelector('[data-testid="stub-editor"]')).toBeTruthy();
+    expect(el.shadowRoot?.querySelector('[data-testid="empty-state"]')).toBe(null);
+  });
+
+  it('keeps a pinned editor instead of falling back to the skeleton', async () => {
+    const el = await mount({
+      items: [],
+      loading: true,
+      editingItemId: 'a',
+      pinnedItem: makeItem({ id: 'a', name: 'A' }),
+      editorTemplate: (id) => html`<div data-testid="stub-editor">${id}</div>`,
+    });
+    expect(el.shadowRoot?.querySelector('[data-testid="stub-editor"]')).toBeTruthy();
+    expect(el.shadowRoot?.querySelector('[data-testid="list-skeleton"]')).toBe(null);
+  });
+
   it('names the empty situation once loading has finished', async () => {
     const el = await mount({ items: [], loading: false, emptyKind: 'no-matches' });
     const empty = el.shadowRoot?.querySelector('[data-testid="empty-state"]') as HTMLElement;

--- a/cards/haventory-card/src/components/hv-list.ts
+++ b/cards/haventory-card/src/components/hv-list.ts
@@ -1,4 +1,4 @@
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, nothing } from 'lit';
 import type { PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -26,10 +26,58 @@ export class HVList extends LitElement {
     css`
       :host {
         display: block;
+        position: relative;
       }
       .scroller {
         overflow-y: auto;
         overscroll-behavior: contain;
+      }
+      /*
+       * A refetch keeps the rows it already has, so the only thing left to say
+       * is that fresher ones are on the way. Absolutely positioned over the
+       * list's top edge: a bar in the flow would move every row by two pixels
+       * on each keystroke in the search box.
+       */
+      .refreshing {
+        position: absolute;
+        inset: 0 0 auto 0;
+        height: 2px;
+        overflow: hidden;
+        background: var(--hv-row-divider);
+        pointer-events: none;
+      }
+      .refreshing::after {
+        content: '';
+        display: block;
+        height: 100%;
+        width: 40%;
+        background: var(--hv-primary);
+        opacity: 0.7;
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        .refreshing::after {
+          animation: sweep 1.1s ease-in-out infinite;
+        }
+      }
+      @keyframes sweep {
+        0% {
+          transform: translateX(-100%);
+        }
+        100% {
+          transform: translateX(250%);
+        }
+      }
+      /*
+       * The row being edited can stop matching the filter the user just changed.
+       * Pinning it keeps typed edits alive; the hint is what stops the pin from
+       * reading as a list that failed to filter.
+       */
+      .pinned-hint {
+        margin: 0;
+        padding: 6px 16px;
+        font-size: 12px;
+        color: var(--hv-text-secondary);
+        border-top: 1px solid var(--hv-row-divider);
       }
       :host(:not([fill])) .scroller {
         max-height: var(--hv-list-max-height, 420px);
@@ -143,6 +191,11 @@ export class HVList extends LitElement {
   @property({ attribute: false }) editorEpoch: unknown = 0;
   /** Row currently expanded into the editor; its own row is hidden while it is. */
   @property({ type: String }) editingItemId: string | null = null;
+  /**
+   * The host's copy of the row being edited, so the open form can outlive a
+   * refetch that stops listing it — see `_rows`.
+   */
+  @property({ attribute: false }) pinnedItem: Item | null = null;
   /** Pin an empty editor at the top of the list ("Add item"). */
   @property({ type: Boolean }) addingNew = false;
   /** Reflected so the stylesheet can give the open editor more room. */
@@ -174,8 +227,30 @@ export class HVList extends LitElement {
     });
   }
 
+  /**
+   * The rows to draw: the listed ones, plus the edited row if it has fallen off
+   * the page.
+   *
+   * Changing a filter refetches, and the row being edited can legitimately drop
+   * out of the result. It is put back at the top rather than rendered beside the
+   * list, because `repeat` only carries a DOM node across renders while its key
+   * stays in the same keyed set — moving the open form out of it would rebuild
+   * the element and discard everything typed into it, which is the whole bug.
+   */
+  private _rows(): { rows: Item[]; pinnedId: string | null } {
+    const id = this.editingItemId;
+    const pinned = this.pinnedItem;
+    if (id === null || !this.editorTemplate || pinned?.id !== id) return { rows: this.items, pinnedId: null };
+    if (this.items.some((it) => it.id === id)) return { rows: this.items, pinnedId: null };
+    return { rows: [pinned, ...this.items], pinnedId: id };
+  }
+
   render() {
-    if (this.loading && !this.items.length) {
+    // An open editor outranks the skeleton: replacing the scroller is what
+    // discards the form, and a filter that currently matches nothing is exactly
+    // when the pinned row has to survive.
+    const editorOpen = Boolean(this.editorTemplate) && (this.addingNew || this.editingItemId !== null);
+    if (this.loading && !this.items.length && !editorOpen) {
       return html`<div class="scroller" data-testid="list-skeleton" aria-busy="true">
         ${Array.from(
           { length: this.skeletonRows },
@@ -188,19 +263,31 @@ export class HVList extends LitElement {
     }
 
     const newEditor = this.addingNew && this.editorTemplate ? this.editorTemplate(null) : null;
-    if (!this.items.length && !newEditor) return this._renderEmpty();
+    const { rows, pinnedId } = this._rows();
+    if (!rows.length && !newEditor) return this._renderEmpty();
 
     return html`
-      <div class="scroller" role="rowgroup" data-testid="list-rows" @scroll=${this._onScroll}>
+      ${this.loading ? html`<div class="refreshing" data-testid="list-refreshing"></div>` : null}
+      <div
+        class="scroller"
+        role="rowgroup"
+        data-testid="list-rows"
+        aria-busy=${this.loading ? 'true' : 'false'}
+        @scroll=${this._onScroll}
+      >
         ${newEditor}
         ${repeat(
-          this.items,
+          rows,
           (it) => it.id,
           (it) =>
             this.editingItemId === it.id && this.editorTemplate
               ? // The expander carries the item's name in its own header, so
                 // showing the collapsed row as well would just be a duplicate.
-                this.editorTemplate(it.id)
+                html`${it.id === pinnedId
+                  ? html`<p class="pinned-hint" data-testid="pinned-editor-hint">
+                      No longer matches the current filters
+                    </p>`
+                  : nothing}${this.editorTemplate(it.id)}`
               : html`<hv-list-row
                   .statuses=${this.statuses}
                   .item=${it}

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -184,7 +184,7 @@ describe('Store', () => {
     expect(moved?.location_id).toBe('loc2');
   });
 
-  it('handles filter changes and resets list', async () => {
+  it('handles filter changes and restarts paging', async () => {
     const items = Array.from({ length: 30 }, (_, i) => makeItem({ id: `${i}`, name: `Item ${i}` }));
     const hass = makeMockHass({ items });
     const store = new Store(hass);
@@ -194,9 +194,79 @@ describe('Store', () => {
     expect(initialCount).toBe(30);
 
     store.setFilters({ q: 'search term' });
-    // Should reset items and cursor
     expect(store.state.value.filters.q).toBe('search term');
     expect(store.state.value.cursor).toBe(null);
+  });
+
+  // Blanking the list here is what tore the card's scroller down mid-edit and
+  // took the open editor with it. The refetch replaces the rows when it lands.
+  it('keeps the loaded rows and the total while a filter refetch is in flight', async () => {
+    const items = Array.from({ length: 3 }, (_, i) => makeItem({ id: `${i}`, name: `Item ${i}` }));
+    const hass = makeMockHass({ items });
+    const store = new Store(hass);
+    await store.init();
+    const before = store.state.value.items;
+    const total = store.state.value.total;
+    expect(total).toBe(3);
+
+    store.setFilters({ q: 'Item 1' });
+    expect(store.state.value.items).toBe(before);
+    expect(store.state.value.total).toBe(total);
+    expect(store.state.value.loading).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(store.state.value.loading).toBe(false);
+    expect(store.state.value.items.map((i) => i.name)).toEqual(['Item 1']);
+  });
+
+  it('still clears the selection on a filter change', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: 'a' }), makeItem({ id: 'b' })] });
+    const store = new Store(hass);
+    await store.init();
+    store.setSelected(['a', 'b']);
+    expect(store.state.value.selection.size).toBe(2);
+
+    store.setFilters({ q: 'a' });
+    expect(store.state.value.selection.size).toBe(0);
+  });
+
+  // Two disappearances look identical from the item list: a row that fell off
+  // the filtered page, and one that is gone. Only the second closes an editor.
+  describe('wasRemoved', () => {
+    it('reports nothing removed for a row that is merely filtered out', async () => {
+      const hass = makeMockHass({ items: [makeItem({ id: 'a', name: 'Alpha' }), makeItem({ id: 'b', name: 'Beta' })] });
+      const store = new Store(hass);
+      await store.init();
+
+      store.setFilters({ q: 'Alpha' });
+      await new Promise((r) => setTimeout(r, 10));
+      expect(store.state.value.items.map((i) => i.id)).toEqual(['a']);
+      expect(store.wasRemoved('b')).toBe(false);
+    });
+
+    it('reports a deleted row as removed', async () => {
+      const hass = makeMockHass({ items: [makeItem({ id: 'a' })] });
+      const store = new Store(hass);
+      await store.init();
+
+      await store.deleteItem('a', 1);
+      expect(store.wasRemoved('a')).toBe(true);
+    });
+
+    it('forgets a delete that was rolled back', async () => {
+      const hass = makeMockHass({ items: [makeItem({ id: 'a' })] });
+      const store = new Store(hass, { retryBaseMs: 0 });
+      await store.init();
+      const passthrough = hass.callWS.bind(hass);
+      hass.callWS = async <T,>(msg: Record<string, unknown>): Promise<T> => {
+        if (msg.type === 'haventory/item/delete') throw new Error('nope');
+        return passthrough<T>(msg);
+      };
+
+      await store.deleteItem('a', 1);
+      expect(store.state.value.items.map((i) => i.id)).toEqual(['a']);
+      expect(store.wasRemoved('a')).toBe(false);
+    });
   });
 
   it('dismisses errors from error queue', async () => {

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -106,6 +106,14 @@ const AREA_REGISTRY_RETRY_ATTEMPTS = 3;
 /** Event action the backend sends every open subscription as its entry tears down. */
 const BACKEND_UNAVAILABLE_ACTION = 'unavailable';
 
+/**
+ * Removed item ids kept for `wasRemoved`.
+ *
+ * Only a host holding an open editor asks, and it asks about one id, so the
+ * memory has to outlive a bulk delete of the surrounding rows and nothing more.
+ */
+const REMOVED_ID_MEMORY = 200;
+
 const NO_DEGRADATION: DegradedState = {
   rateLimited: false,
   connectionLost: false,
@@ -274,6 +282,10 @@ export class Store {
   private ws: WSClient;
   private stateObs: ReturnType<typeof createObservable<StoreState>>;
   private inflight: Map<string, Promise<unknown>> = new Map();
+  /** Ids removed since this store connected — see `noteRemoved`. */
+  private readonly removedIds = new Set<string>();
+  /** The same ids in removal order, so the oldest can be evicted. */
+  private readonly removedOrder: string[] = [];
   private itemsUnsub: Unsubscribe | null = null;
   private statsUnsub: Unsubscribe | null = null;
   private locationsUnsub: Unsubscribe | null = null;
@@ -657,10 +669,12 @@ export class Store {
       case 'checked_in':
       case 'quantity_changed': {
         if (idx >= 0) items[idx] = item; else items.unshift(item);
+        this.forgetRemoved(item.id);
         break;
       }
       case 'deleted': {
         if (idx >= 0) items.splice(idx, 1);
+        this.noteRemoved(item.id);
         break;
       }
     }
@@ -1007,11 +1021,13 @@ export class Store {
   setFilters(patch: Partial<StoreFilters>) {
     const next = { ...this.state.value.filters, ...patch };
     const locationChanged = next.locationId !== this.state.value.filters.locationId;
+    // The rows already loaded stay on screen until the refetch lands, marked as
+    // loading. Blanking them is what tore the scroller down mid-edit and took an
+    // open editor with it; `listItems(true)` replaces the array wholesale anyway,
+    // so nothing here has to clear it first.
     this.stateObs.set({
       filters: next,
       cursor: null,
-      items: [],
-      total: null,
       loading: true,
       // A row that is no longer listed cannot stay selected.
       selection: new Set<string>(),
@@ -1545,12 +1561,45 @@ export class Store {
     const items = this.state.value.items.slice();
     const idx = items.findIndex((x) => x.id === item.id);
     if (idx >= 0) items[idx] = item; else items.unshift(item);
+    // A rolled-back delete puts the row back, so it is no longer gone.
+    this.forgetRemoved(item.id);
     this.stateObs.set({ items });
   }
 
   private removeById(itemId: string) {
     const items = this.state.value.items.filter((x) => x.id !== itemId);
+    this.noteRemoved(itemId);
     this.stateObs.set({ items });
+  }
+
+  /**
+   * Remember an id the backend no longer has, newest last and bounded.
+   *
+   * A host with an open editor has to tell two disappearances apart: the row
+   * fell out of the filtered page, where the typed edits are still worth
+   * keeping, or the item is gone, where the form has nothing left to save
+   * against. Only a real removal is recorded — a refetch that stops listing an
+   * id says nothing about whether it still exists.
+   */
+  private noteRemoved(itemId: string) {
+    if (this.removedIds.has(itemId)) return;
+    this.removedIds.add(itemId);
+    this.removedOrder.push(itemId);
+    while (this.removedOrder.length > REMOVED_ID_MEMORY) {
+      const evicted = this.removedOrder.shift();
+      if (evicted !== undefined) this.removedIds.delete(evicted);
+    }
+  }
+
+  private forgetRemoved(itemId: string) {
+    if (!this.removedIds.delete(itemId)) return;
+    const idx = this.removedOrder.indexOf(itemId);
+    if (idx >= 0) this.removedOrder.splice(idx, 1);
+  }
+
+  /** True when this id was removed rather than merely filtered off the page. */
+  wasRemoved(itemId: string): boolean {
+    return this.removedIds.has(itemId);
   }
 }
 

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -704,6 +704,7 @@ function applyMockFilter(list: Item[], rawFilter: unknown): Item[] {
     status?: string;
     checked_out?: boolean;
     orphaned_only?: boolean;
+    low_stock_only?: boolean;
     overdue_only?: boolean;
     inspection_overdue_only?: boolean;
     location_id?: string | null;
@@ -738,6 +739,14 @@ function applyMockFilter(list: Item[], rawFilter: unknown): Item[] {
     if (filter.status && (it.status ?? 'ok') !== filter.status) return false;
     if (typeof filter.checked_out === 'boolean' && it.checked_out !== filter.checked_out) return false;
     if (filter.orphaned_only && it.location_id !== null) return false;
+    // Low stock needs a threshold to be below: an item without one is never low,
+    // which is also how the stats counts read it.
+    if (
+      filter.low_stock_only &&
+      !(typeof it.low_stock_threshold === 'number' && it.quantity <= it.low_stock_threshold)
+    ) {
+      return false;
+    }
     if (filter.overdue_only && !isMockOverdue(it)) return false;
     if (filter.inspection_overdue_only && !isMockInspectionDue(it)) return false;
     // Canonical 'Z' timestamps compare lexicographically; both bounds are exclusive.


### PR DESCRIPTION
## Summary

P1 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`). Session A ships P1 → P2 → P3 → P4 as a **stacked** set of PRs; this is the base of the stack and merges first.

`Store.setFilters` blanked the item list before refetching. With no items and `loading` true, `hv-list` took its skeleton branch and replaced the scroller the inline editor lives in — the form was rebuilt from the stored item and everything typed into it was gone, while it still looked open. Typing in the search box, toggling a filter and changing the sort all run through that one call.

What changed:

- **The rows stay** (decision 1). `setFilters` keeps `items`/`total` and only resets the cursor; `listItems(true)` replaces the array when it lands. The kept rows are labelled: `aria-busy` on the scroller and a 2px refresh bar over the list's top edge — no spinner rows, no layout shift. The skeleton is left for the case it describes, nothing loaded yet, and now also yields to an open editor.
- **The edited row is pinned when it stops matching** (decision 2). The card's shell hands `hv-list` a retained copy of the row, rendered inside the same `repeat` keyed set — moving the open form out of that set rebuilds the element and loses the edits, which is the bug in another shape. The pinned row carries "No longer matches the current filters" and releases on save or cancel. The full view keeps its own copy for the same reason.
- **Telling "fell off the page" from "deleted" apart.** The item list alone cannot; the store now records removals and answers `wasRemoved(id)`, and a row that is really gone still closes the form. This replaces `hv-full-view`'s rule that closed the editor whenever its item left the list — scope 5 of the package: the full view had the same class of bug, reached by a different route.

The editor element itself is untouched (`hv-item-editor.ts` first changes in P3).

Closes #332

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1434 passed), `npm run build`

New coverage:

- Store: `setFilters` keeps the loaded rows and the total, flips `loading`, still clears the selection; `wasRemoved` is false for a filtered-out row, true for a deleted one, and forgets a delete that rolled back.
- `hv-list`: kept rows carry `aria-busy` and the refresh signal; the pin renders with its hint; a pinned editor outranks both the empty state and the skeleton.
- Shell: the regression matrix from the issue — search, a low-stock toggle, a sort change — each asserting the **same** editor element and the typed value intact; plus pin/release on cancel and on save, and close-not-pin on delete.
- Full view: the pin replaces the old "close when the item leaves the list" assertion, rewritten rather than dropped.

`test.utils`' mock filter gained `low_stock_only`, which it did not implement — the issue's matrix needs that toggle to actually narrow the list.

### Delegated to the local verification session

Everything visual and anything needing a real browser: that the refresh bar reads as quiet rather than as a failure, that the pinned row does not jump disruptively, and the issue's own DOM-stamping repro against the dev container. Checklist P1 in the plan's §Verification.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed — no doc statement is falsified by this (`docs/frontend_architecture.md`'s "rows, skeletons, empty states" is still true).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_015S8wt52QKqXQvTjBLoz6ah)_