### PR TITLE
feat(card): adjustable column order; surface rejected saves in the full view

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,10 @@ throughout.
   a sortable table. Only columns the backend can sort by get a clickable header. A browser
   that has made no choice yet shows every optional column — quantity, status, category,
   location, tags, due, next inspection, updated — and the ⋮ → **Columns** picker is where
-  you thin that down; the table scrolls sideways rather than dropping a column you kept.
+  you thin that down and put the ones you keep in the order you want them, with the up/down
+  buttons beside each shown column and a **Reset order** back to the canonical one. The
+  order and the selection are one per-browser preference; the table scrolls sideways rather
+  than dropping a column you kept.
   The Status column names every row, OK included, and the name's amber status chip stands
   down while it is shown so no row says the same word twice. The
   sidebar leads with the location tree carrying the backend's own per-location counts and
@@ -658,9 +661,9 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
   counts and drills down to the items filed under each.
 - Dedicated **tag browser** (header → "Tags"): lists used tags with item counts and drills
   down to the items carrying each.
-- **Column selection** (header → "Columns"): choose which optional columns (quantity,
-  category, location, tags, due date) show in the standard vs expanded view; the choice is
-  persisted in `localStorage` (`haventory:columns:v1`, per browser).
+- **Column selection and order** (header → "Columns"): choose which optional columns
+  (quantity, category, location, tags, due date) show in the expanded view, and in which
+  order; the choice is persisted in `localStorage` (`haventory:columns:v1`, per browser).
 - **Custom fields UI** in the item dialog: define/edit/remove typed fields
   (string/number/boolean/date) with type-appropriate inputs; existing field keys across the
   dataset are offered as suggestions.

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -9,9 +9,10 @@ import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters } from '../store/store';
 import { emptyKindFor } from '../ui/empty-state';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
+import { editorErrorText } from '../ui/editor-error';
 import { HostSurfaces } from '../host-surfaces';
 import type { Store } from '../store/store';
-import type { ErrorEntry, Item, Location, StoreFilters, StoreState } from '../store/types';
+import type { Item, Location, StoreFilters, StoreState } from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import './hv-banner';
 import './hv-bottom-sheet';
@@ -1346,18 +1347,6 @@ export class HVCardShell extends LitElement {
   private get _filterPanel(): HVFilterPanel | null {
     return this.shadowRoot?.querySelector('hv-filter-panel') ?? null;
   }
-}
-
-/**
- * What an open editor says about a save that did not land.
- *
- * A conflict's own message names version numbers, which say nothing to someone
- * looking at a form; the card's banner already frames that case in words and
- * carries the ways out of it, so the form repeats that sentence rather than
- * giving a second, differently worded account of the same event.
- */
-function editorErrorText(entry: ErrorEntry): string {
-  return entry.kind === 'conflict' ? 'Someone else changed this item.' : entry.message;
 }
 
 function readPanelPref(): boolean {

--- a/cards/haventory-card/src/components/hv-column-picker.test.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.test.ts
@@ -92,6 +92,16 @@ describe('hv-column-picker', () => {
       expect(received).toEqual(['quantity', 'tags', 'status']);
     });
 
+    // The rows are stacked and the glyphs are vertical chevrons, so the words
+    // are too — the same pair the organize dialog's reorder rows carry.
+    it('names each direction the way its glyph and its list read', async () => {
+      const el = await mount({ columns: ['quantity', 'status'] });
+      expect(arrow(el, 'up', 'status').getAttribute('aria-label')).toBe('Move Status up');
+      expect(arrow(el, 'up', 'status').getAttribute('title')).toBe('Move up');
+      expect(arrow(el, 'down', 'quantity').getAttribute('aria-label')).toBe('Move Qty down');
+      expect(arrow(el, 'down', 'quantity').getAttribute('title')).toBe('Move down');
+    });
+
     it('disables the direction the first and last rows cannot go', async () => {
       const el = await mount({ columns: ['quantity', 'status', 'tags'] });
       expect(arrow(el, 'up', 'quantity').disabled).toBe(true);

--- a/cards/haventory-card/src/components/hv-column-picker.test.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.test.ts
@@ -25,6 +25,14 @@ afterEach(() => { document.body.innerHTML = ''; });
 const option = (el: Picker, key: string) =>
   el.shadowRoot?.querySelector(`[data-testid="column-option"][data-key="${key}"]`) as HTMLButtonElement;
 
+const arrow = (el: Picker, dir: 'up' | 'down', key: string) =>
+  el.shadowRoot?.querySelector(`[data-testid="column-${dir}"][data-key="${key}"]`) as HTMLButtonElement;
+
+const keysOf = (el: Picker) =>
+  Array.from(el.shadowRoot?.querySelectorAll('[data-testid="column-option"]') ?? []).map((r) =>
+    r.getAttribute('data-key'),
+  );
+
 describe('hv-column-picker', () => {
   it('reflects the current selection as ticked boxes', async () => {
     const el = await mount({ columns: ['quantity', 'location'] });
@@ -36,7 +44,18 @@ describe('hv-column-picker', () => {
     expect(checked).toEqual(['quantity', 'location']);
   });
 
-  it('emits change with the added column (canonical order) when a box is ticked', async () => {
+  // The shown columns lead, in the order the table draws them; the ones that
+  // are off follow in canonical order, so switching one on is predictable.
+  it('lists the shown columns first, in their chosen order', async () => {
+    const el = await mount({ columns: ['location', 'quantity'] });
+    const keys = keysOf(el);
+    expect(keys.slice(0, 2)).toEqual(['location', 'quantity']);
+    expect(keys.slice(2)).toEqual(['status', 'category', 'tags', 'due_date', 'inspection_date', 'updated_at']);
+  });
+
+  // A re-enabled column joins at the end: dropping it back into its canonical
+  // slot would move a column the user never touched.
+  it('appends a column switched back on', async () => {
     const el = await mount({ columns: ['location'] });
     let received: ColumnKey[] | null = null;
     el.addEventListener('change', (e) => {
@@ -44,8 +63,7 @@ describe('hv-column-picker', () => {
     });
 
     option(el, 'quantity').click();
-    // canonical order: quantity before location
-    expect(received).toEqual(['quantity', 'location']);
+    expect(received).toEqual(['location', 'quantity']);
   });
 
   it('emits change removing a column when unticked', async () => {
@@ -57,6 +75,61 @@ describe('hv-column-picker', () => {
 
     option(el, 'category').click();
     expect(received).toEqual(['quantity']);
+  });
+
+  describe('reordering', () => {
+    it('emits the permuted order when a column is moved', async () => {
+      const el = await mount({ columns: ['quantity', 'status', 'tags'] });
+      let received: ColumnKey[] | null = null;
+      el.addEventListener('change', (e) => {
+        received = (e as CustomEvent<{ columns: ColumnKey[] }>).detail.columns;
+      });
+
+      arrow(el, 'down', 'quantity').click();
+      expect(received).toEqual(['status', 'quantity', 'tags']);
+
+      arrow(el, 'up', 'tags').click();
+      expect(received).toEqual(['quantity', 'tags', 'status']);
+    });
+
+    it('disables the direction the first and last rows cannot go', async () => {
+      const el = await mount({ columns: ['quantity', 'status', 'tags'] });
+      expect(arrow(el, 'up', 'quantity').disabled).toBe(true);
+      expect(arrow(el, 'down', 'quantity').disabled).toBe(false);
+      expect(arrow(el, 'down', 'tags').disabled).toBe(true);
+      expect(arrow(el, 'up', 'tags').disabled).toBe(false);
+    });
+
+    // A column that is off has no position, so promising it one would be a
+    // promise the toggle then does not keep.
+    it('offers no move buttons on a column that is switched off', async () => {
+      const el = await mount({ columns: ['quantity'] });
+      expect(arrow(el, 'up', 'tags')).toBe(null);
+      expect(arrow(el, 'down', 'tags')).toBe(null);
+    });
+
+    it('resets to the canonical order, keeping the same columns', async () => {
+      const el = await mount({ columns: ['tags', 'quantity'] });
+      let received: ColumnKey[] | null = null;
+      el.addEventListener('change', (e) => {
+        received = (e as CustomEvent<{ columns: ColumnKey[] }>).detail.columns;
+      });
+
+      const reset = el.shadowRoot?.querySelector(
+        '[data-testid="column-picker-reset-order"]',
+      ) as HTMLButtonElement;
+      expect(reset.disabled).toBe(false);
+      reset.click();
+      expect(received).toEqual(['quantity', 'tags']);
+    });
+
+    it('offers nothing to reset while the order is already canonical', async () => {
+      const el = await mount({ columns: ['quantity', 'tags'] });
+      const reset = el.shadowRoot?.querySelector(
+        '[data-testid="column-picker-reset-order"]',
+      ) as HTMLButtonElement;
+      expect(reset.disabled).toBe(true);
+    });
   });
 
   it('closes on Done', async () => {

--- a/cards/haventory-card/src/components/hv-column-picker.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.ts
@@ -250,8 +250,8 @@ export class HVColumnPicker extends LitElement {
                         <button
                           data-testid="column-up"
                           data-key=${r.key}
-                          aria-label=${`Move ${r.label} left`}
-                          title="Move left"
+                          aria-label=${`Move ${r.label} up`}
+                          title="Move up"
                           ?disabled=${index === 0}
                           @click=${() => this._move(r.key, -1)}
                         >
@@ -260,8 +260,8 @@ export class HVColumnPicker extends LitElement {
                         <button
                           data-testid="column-down"
                           data-key=${r.key}
-                          aria-label=${`Move ${r.label} right`}
-                          title="Move right"
+                          aria-label=${`Move ${r.label} down`}
+                          title="Move down"
                           ?disabled=${index === shown - 1}
                           @click=${() => this._move(r.key, 1)}
                         >

--- a/cards/haventory-card/src/components/hv-column-picker.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.ts
@@ -6,14 +6,19 @@ import { icon } from '../ui/icons';
 import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
 import type { ColumnKey } from '../store/columns';
-import { COLUMN_DEFS, normalizeColumns } from '../store/columns';
+import { COLUMN_DEFS, canonicalOrder, moveColumn, normalizeColumns } from '../store/columns';
 
 /**
- * Small modal to choose which optional columns show in a given view.
+ * Small modal to choose which optional columns show in a given view, and in
+ * which order.
  *
- * Presentational: it reflects `columns` (the current selection) and emits a
- * `change` event with the new selection whenever a column is toggled. The
- * container owns persistence.
+ * Presentational: it reflects `columns` (the current selection, in the order it
+ * is drawn) and emits a `change` event with the new selection whenever a column
+ * is toggled or moved. The container owns persistence.
+ *
+ * Up/down buttons rather than a drag handle, matching the organize dialog's
+ * status rows and the editor's photo strip: they work from the keyboard without
+ * a second implementation beside the pointer one.
  *
  * This was the one surface that never adopted the card's design tokens: it
  * styled itself straight from HA's variables, with its own 8px radius, native
@@ -66,6 +71,9 @@ export class HVColumnPicker extends LitElement {
       }
       li {
         margin: 0;
+        display: flex;
+        align-items: center;
+        gap: 2px;
       }
       /* The same control the filter panel's checkboxes use, so a tick means the
          same thing — and picks up --hv-tap-min on a phone. */
@@ -73,7 +81,8 @@ export class HVColumnPicker extends LitElement {
         display: flex;
         align-items: center;
         gap: 10px;
-        width: 100%;
+        flex: 1;
+        min-width: 0;
         box-sizing: border-box;
         min-height: var(--hv-tap-min, 34px);
         border: none;
@@ -86,6 +95,33 @@ export class HVColumnPicker extends LitElement {
       }
       .option:hover {
         background: var(--hv-hover-overlay);
+      }
+      .move {
+        display: flex;
+        flex: none;
+        gap: 2px;
+      }
+      /* WCAG 2.2 asks 24px of every pointer target; the token is what a host
+         declares when the card is narrow, and the fallback covers the panel,
+         which declares none. */
+      .move button {
+        display: inline-grid;
+        place-items: center;
+        width: var(--hv-tap-min, 28px);
+        height: var(--hv-tap-min, 28px);
+        border: none;
+        background: none;
+        color: var(--hv-text-tertiary);
+        cursor: pointer;
+        padding: 0;
+        line-height: 0;
+      }
+      .move button:hover:not([disabled]) {
+        color: var(--hv-text);
+      }
+      .move button[disabled] {
+        opacity: 0.3;
+        cursor: default;
       }
       .box {
         display: inline-grid;
@@ -107,6 +143,11 @@ export class HVColumnPicker extends LitElement {
         align-items: center;
         gap: 8px;
         padding-top: 8px;
+      }
+      /* Left of the confirming button, because it undoes work inside the dialog
+         rather than closing it. */
+      .actions .reset {
+        margin-right: auto;
       }
     `,
   ];
@@ -138,17 +179,51 @@ export class HVColumnPicker extends LitElement {
     this.open = false;
   };
 
+  private _emit(columns: ColumnKey[]): void {
+    this.dispatchEvent(new CustomEvent('change', { detail: { columns }, bubbles: true, composed: true }));
+  }
+
+  /**
+   * A column switched on joins the list at the end rather than at its canonical
+   * index: the order on screen is the user's, and dropping a re-enabled column
+   * back into the middle of it would move a column they never touched.
+   */
   private _toggle(key: ColumnKey, checked: boolean): void {
-    const current = new Set(normalizeColumns(this.columns));
-    if (checked) current.add(key);
-    else current.delete(key);
-    const next = normalizeColumns([...current]);
-    this.dispatchEvent(new CustomEvent('change', { detail: { columns: next }, bubbles: true, composed: true }));
+    const current = normalizeColumns(this.columns);
+    this._emit(checked ? [...current, key] : current.filter((k) => k !== key));
+  }
+
+  private _move(key: ColumnKey, delta: -1 | 1): void {
+    this._emit(moveColumn(this.columns, key, delta));
+  }
+
+  /**
+   * The rows to draw: the chosen columns in their chosen order, then the ones
+   * that are off, in canonical order.
+   *
+   * Only a shown column has a position, so only those carry move buttons —
+   * ordering an invisible column is a promise about where it would land that
+   * the toggle then does not keep.
+   */
+  private _rows(): { key: ColumnKey; label: string; on: boolean }[] {
+    const selected = normalizeColumns(this.columns);
+    const labelOf = (key: ColumnKey) => COLUMN_DEFS.find((c) => c.key === key)!.label;
+    return [
+      ...selected.map((key) => ({ key, label: labelOf(key), on: true })),
+      ...COLUMN_DEFS.filter((c) => !selected.includes(c.key)).map((c) => ({
+        key: c.key,
+        label: c.label,
+        on: false,
+      })),
+    ];
   }
 
   render() {
     if (!this.open) return null;
-    const selected = new Set(normalizeColumns(this.columns));
+    const rows = this._rows();
+    const shown = rows.filter((r) => r.on).length;
+    const ordered = normalizeColumns(this.columns);
+    const isCanonical = ordered.join() === canonicalOrder(ordered).join();
     return html`
       <div class="backdrop" role="presentation" style="z-index: ${this._zBase ?? 9998};" @click=${this._close}></div>
       <div class="panel-wrap" role="none" style="z-index: ${(this._zBase ?? 9998) + 1};">
@@ -156,26 +231,57 @@ export class HVColumnPicker extends LitElement {
           @keydown=${onEscape(() => this._close())}>
           <h2>${this.heading}</h2>
           <ul data-testid="column-options">
-            ${COLUMN_DEFS.map((c) => {
-              const on = selected.has(c.key);
-              return html`
+            ${rows.map(
+              (r, index) => html`
                 <li>
                   <button
                     class="option"
                     role="checkbox"
-                    aria-checked=${String(on)}
+                    aria-checked=${String(r.on)}
                     data-testid="column-option"
-                    data-key=${c.key}
-                    @click=${() => this._toggle(c.key, !on)}
+                    data-key=${r.key}
+                    @click=${() => this._toggle(r.key, !r.on)}
                   >
-                    <span class="box ${on ? 'on' : ''}">${on ? icon('check', 12) : null}</span>
-                    <span>${c.label}</span>
+                    <span class="box ${r.on ? 'on' : ''}">${r.on ? icon('check', 12) : null}</span>
+                    <span>${r.label}</span>
                   </button>
+                  ${r.on
+                    ? html`<span class="move">
+                        <button
+                          data-testid="column-up"
+                          data-key=${r.key}
+                          aria-label=${`Move ${r.label} left`}
+                          title="Move left"
+                          ?disabled=${index === 0}
+                          @click=${() => this._move(r.key, -1)}
+                        >
+                          ${icon('chevronUp', 15)}
+                        </button>
+                        <button
+                          data-testid="column-down"
+                          data-key=${r.key}
+                          aria-label=${`Move ${r.label} right`}
+                          title="Move right"
+                          ?disabled=${index === shown - 1}
+                          @click=${() => this._move(r.key, 1)}
+                        >
+                          ${icon('chevronDown', 15)}
+                        </button>
+                      </span>`
+                    : null}
                 </li>
-              `;
-            })}
+              `,
+            )}
           </ul>
           <div class="actions">
+            <button
+              class="hv-text-button reset"
+              data-testid="column-picker-reset-order"
+              ?disabled=${isCanonical}
+              @click=${() => this._emit(canonicalOrder(ordered))}
+            >
+              Reset order
+            </button>
             <button class="hv-pill" data-testid="column-picker-done" @click=${this._close}>Done</button>
           </div>
         </div>

--- a/cards/haventory-card/src/components/hv-column-picker.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.ts
@@ -20,11 +20,9 @@ import { COLUMN_DEFS, canonicalOrder, moveColumn, normalizeColumns } from '../st
  * status rows and the editor's photo strip: they work from the keyboard without
  * a second implementation beside the pointer one.
  *
- * This was the one surface that never adopted the card's design tokens: it
- * styled itself straight from HA's variables, with its own 8px radius, native
- * checkboxes and a filled "Done" at a fourth border radius — so it read as a
- * different application, and its 32px rows were the only targets on a phone
- * that ignored the 44px minimum everything else honours.
+ * Styled from the card's design tokens alone — nothing here reaches past them
+ * to Home Assistant's own variables, and every row and button honours the touch
+ * minimum a narrow host declares, the same as any other target in the card.
  */
 @customElement('hv-column-picker')
 export class HVColumnPicker extends LitElement {

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -193,6 +193,40 @@ describe('hv-data-table: columns', () => {
     expect(q(el, '[data-testid="cell-category"]')).toBe(null);
   });
 
+  // The order is the user's, set in the column picker and stored per browser.
+  it('draws the columns in the order it is given', async () => {
+    const el = await mount([{ id: '1', quantity: 3, category: 'Hardware' }], {
+      columns: ['category', 'quantity'],
+    });
+    const headers = all(el, '[role="columnheader"]').map((h) => h.textContent?.trim());
+    // Name leads, the trailing actions header is empty.
+    expect(headers.slice(0, 3)).toEqual(['Name', 'Category', 'Qty']);
+
+    const cells = all(el, '[data-testid^="cell-"]').map((c) => c.dataset.testid);
+    expect(cells).toEqual(['cell-category', 'cell-quantity']);
+  });
+
+  // Sort bindings hang off the column definition, not off a position, so a
+  // permutation must not hand a header the neighbour's field.
+  it("keeps each header's sort field across a permutation", async () => {
+    const el = await mount([{ id: '1' }], { columns: ['updated_at', 'due_date', 'quantity'] });
+    const fields = all(el, '[data-testid="table-sort"]').map((h) => h.dataset.field);
+    expect(fields).toEqual(['name', 'updated_at', 'due_date', 'quantity']);
+  });
+
+  // The name is the row's identity and the trailing actions are where the hand
+  // goes; neither is in the optional set, so neither can be moved.
+  it('keeps the name column first and the actions last whatever the order', async () => {
+    const el = await mount([{ id: '1', name: 'Sander' }], { columns: ['tags', 'quantity'] });
+    const headers = all(el, '[role="columnheader"]');
+    expect(headers[0].textContent?.trim()).toBe('Name');
+    expect(headers[headers.length - 1].textContent?.trim()).toBe('');
+
+    const row = q(el, '[data-testid="table-row"]') as HTMLElement;
+    expect((row.firstElementChild as HTMLElement).classList.contains('name-cell')).toBe(true);
+    expect((row.lastElementChild as HTMLElement).classList.contains('actions')).toBe(true);
+  });
+
   it('dashes an empty cell rather than leaving a gap', async () => {
     const el = await mount([{ id: '1', category: null, tags: [], due_date: null }]);
     expect(q(el, '[data-testid="cell-category"]')?.textContent).toBe('—');

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1096,6 +1096,102 @@ describe('hv-full-view: editing', () => {
     );
   });
 
+  // This surface fills the screen, so the card's banner list is not behind it:
+  // without a sentence inside the form the user is left with a form that did not
+  // close and no account of why.
+  describe('a rejected save', () => {
+    const openEditor = async (el: HVFullView, sr: ShadowRoot) => {
+      const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+      (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
+      await settle(el);
+      return q(sr, '[data-testid="full-editor"]') as HTMLElement & { busy: boolean };
+    };
+    const save = async (el: HVFullView, sr: ShadowRoot) => {
+      const editor = q(sr, '[data-testid="full-editor"]') as HTMLElement;
+      const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+      name.value = 'New';
+      name.dispatchEvent(new Event('input'));
+      (editor.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).click();
+      await settle(el);
+      await settle(el);
+    };
+    const errorText = (sr: ShadowRoot) =>
+      (q(sr, '[data-testid="full-editor"]') as HTMLElement | null)?.shadowRoot?.querySelector(
+        '[data-testid="editor-error"]',
+      )?.textContent;
+
+    it('names itself inside the open form and clears the busy state', async () => {
+      const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Old' })] });
+      store['ws'].updateItem = async () => {
+        throw { code: 'storage_error', message: 'the store is read-only' };
+      };
+
+      const editor = await openEditor(el, sr);
+      await save(el, sr);
+
+      expect(errorText(sr)).toContain('the store is read-only');
+      expect(editor.busy).toBe(false);
+      expect(
+        (editor.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).textContent?.trim(),
+      ).toBe('Save');
+    });
+
+    // Version numbers say nothing to someone looking at a form, and the two
+    // hosts of the editor share the sentence rather than each writing one.
+    it('says a conflict in the same words the card does', async () => {
+      const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Old' })] });
+      store['ws'].updateItem = async () => {
+        throw { code: 'conflict', message: 'version conflict: expected 1, actual 2' };
+      };
+
+      await openEditor(el, sr);
+      await save(el, sr);
+
+      expect(errorText(sr)).toContain('Someone else changed this item');
+    });
+
+    it('clears once the save lands', async () => {
+      const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Old' })] });
+      const reject = async () => {
+        throw { code: 'storage_error', message: 'the store is read-only' };
+      };
+      store['ws'].updateItem = reject;
+
+      await openEditor(el, sr);
+      await save(el, sr);
+      expect(errorText(sr)).toContain('the store is read-only');
+
+      store['ws'].updateItem = async (id: string) => ({ ...makeItem({ id, name: 'New' }), version: 2 });
+      await save(el, sr);
+
+      expect(q(sr, '[data-testid="full-editor"]')).toBe(null);
+    });
+
+    it('drops the error again when the next edit opens', async () => {
+      const { el, store, sr } = await mount({
+        items: [makeItem({ id: '1', name: 'Old' }), makeItem({ id: '2', name: 'Other' })],
+      });
+      store['ws'].updateItem = async () => {
+        throw { code: 'storage_error', message: 'the store is read-only' };
+      };
+
+      await openEditor(el, sr);
+      await save(el, sr);
+      expect(errorText(sr)).toContain('the store is read-only');
+
+      const rows = [
+        ...((q(sr, '[data-testid="full-table"]') as HTMLElement).shadowRoot?.querySelectorAll(
+          '[data-testid="table-edit"]',
+        ) ?? []),
+      ] as HTMLButtonElement[];
+      rows[rows.length - 1].click();
+      await settle(el);
+
+      expect(q(sr, '[data-testid="full-editor"]')?.shadowRoot?.textContent).toContain('Other — editing');
+      expect(errorText(sr)).toBeUndefined();
+    });
+  });
+
   it('releases the pin when the editor is cancelled', async () => {
     const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Wood Glue' })] });
     const table = q(sr, '[data-testid="full-table"]') as HTMLElement;

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -15,6 +15,7 @@ import { deepFocusables } from '../ui/dialog-focus';
 import { areaNameById, effectiveAreaIdForLocation } from '../ui/area';
 import { renderAreaChip } from '../ui/location-path';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
+import { editorErrorText } from '../ui/editor-error';
 import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
@@ -776,6 +777,14 @@ export class HVFullView extends LitElement {
   @state() private _editing: string | 'new' | null = null;
   @state() private _editorBusy = false;
   /**
+   * What the open form says about a save the store refused.
+   *
+   * This surface fills the screen, so the card's banner list is not behind it —
+   * without this the user is left with a form that did not close and no account
+   * of why.
+   */
+  @state() private _editorError: string | null = null;
+  /**
    * The last copy of the row being edited, kept for as long as the form is open.
    *
    * Same reason the card's shell keeps one: a filter change refetches, the
@@ -867,6 +876,7 @@ export class HVFullView extends LitElement {
       } else {
         this._filtersOpen = false;
         this._editing = null;
+        this._editorError = null;
         this._creatingLocation = false;
         this._locationError = null;
         this._selecting = false;
@@ -948,6 +958,7 @@ export class HVFullView extends LitElement {
     if (this.store?.wasRemoved(editing)) {
       this._pinnedItem = null;
       this._editing = null;
+      this._editorError = null;
       return;
     }
     const listed = this.st?.items.find((i) => i.id === editing);
@@ -974,6 +985,7 @@ export class HVFullView extends LitElement {
       case 'edit':
       case 'open-item':
         this._editing = item.id;
+        this._editorError = null;
         break;
     }
   }
@@ -986,6 +998,7 @@ export class HVFullView extends LitElement {
       create?: Parameters<Store['createItem']>[0];
     };
     this._editorBusy = true;
+    this._editorError = null;
     const before = this.st?.errorQueue.length ?? 0;
     try {
       if (detail.itemId && detail.changes) {
@@ -996,7 +1009,13 @@ export class HVFullView extends LitElement {
     } finally {
       this._editorBusy = false;
     }
-    if ((this.st?.errorQueue.length ?? 0) === before) this._editing = null;
+    // The store reports failures through its error queue rather than throwing,
+    // so a new entry is how we know the save did not land. The form stays open
+    // on the user's edits and names the failure inside itself.
+    const queue = this.st?.errorQueue ?? [];
+    const failed = queue.length > before;
+    this._editorError = failed ? editorErrorText(queue[queue.length - 1]) : null;
+    if (!failed) this._editing = null;
   };
 
   // ---------- Bulk actions ----------
@@ -1467,7 +1486,10 @@ export class HVFullView extends LitElement {
       locationName: (st?.locationsFlatCache ?? []).find((l) => l.id === filters.locationId)?.name ?? null,
       onAction: (id: EmptyOffer['id']) => {
         if (id === 'clear-filters') this.store?.clearFilters();
-        else if (id === 'add-item') this._editing = 'new';
+        else if (id === 'add-item') {
+          this._editing = 'new';
+          this._editorError = null;
+        }
         else if (id === 'refresh') void this.store?.refreshAll();
         else
           this.dispatchEvent(
@@ -1729,6 +1751,7 @@ export class HVFullView extends LitElement {
             data-testid="full-add-item"
             @click=${() => {
               this._editing = 'new';
+              this._editorError = null;
             }}
           >
             ${icon('plus', 16)}Add item
@@ -1814,10 +1837,12 @@ export class HVFullView extends LitElement {
                     .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
                     .createLocation=${this._createLocationForEditor}
                     .busy=${this._editorBusy}
+                    .errorMessage=${this._editorError}
                     ?mobile=${this._narrow}
                     @save=${this._onEditorSave}
                     @cancel=${() => {
                       this._editing = null;
+                      this._editorError = null;
                     }}
                     @delete-item=${(e: CustomEvent) =>
                       this.dispatchEvent(

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -4,22 +4,53 @@ import {
   COLUMN_PREFS_STORAGE_KEY,
   DEFAULT_COLUMNS,
   SELECT_COLUMN_WIDTH,
+  canonicalOrder,
   loadColumnPrefs,
+  moveColumn,
   normalizeColumns,
   saveColumnPrefs,
   tableTemplateFor,
 } from './columns';
+import type { ColumnKey } from './columns';
 
 describe('columns model', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it('normalizes to canonical order, dedupes, and drops unknown keys', () => {
+  // The order is the user's: the picker moves a column and stores where it
+  // landed, so normalizing can only validate and dedupe, never re-sort.
+  it('keeps the given order, dedupes, and drops unknown keys', () => {
     expect(normalizeColumns(['location', 'quantity', 'quantity', 'bogus', 'tags']))
-      .toEqual(['quantity', 'location', 'tags']);
+      .toEqual(['location', 'quantity', 'tags']);
     expect(normalizeColumns('nope')).toEqual([]);
     expect(normalizeColumns(undefined)).toEqual([]);
+  });
+
+  it('restores the canonical order on request, keeping only the chosen columns', () => {
+    expect(canonicalOrder(['tags', 'quantity', 'location'])).toEqual(['quantity', 'location', 'tags']);
+    expect(canonicalOrder(['tags', 'bogus' as ColumnKey])).toEqual(['tags']);
+  });
+
+  describe('moveColumn', () => {
+    it('swaps a column with its neighbour', () => {
+      expect(moveColumn(['quantity', 'status', 'tags'], 'status', -1)).toEqual([
+        'status',
+        'quantity',
+        'tags',
+      ]);
+      expect(moveColumn(['quantity', 'status', 'tags'], 'status', 1)).toEqual([
+        'quantity',
+        'tags',
+        'status',
+      ]);
+    });
+
+    it('refuses to move past either end, or to move a column that is off', () => {
+      expect(moveColumn(['quantity', 'status'], 'quantity', -1)).toEqual(['quantity', 'status']);
+      expect(moveColumn(['quantity', 'status'], 'status', 1)).toEqual(['quantity', 'status']);
+      expect(moveColumn(['quantity', 'status'], 'tags', -1)).toEqual(['quantity', 'status']);
+    });
   });
 
   it('returns defaults when nothing is stored', () => {
@@ -31,9 +62,19 @@ describe('columns model', () => {
     expect(DEFAULT_COLUMNS).toEqual(COLUMN_DEFS.map((c) => c.key));
   });
 
-  it('round-trips a saved selection (normalized)', () => {
+  it('round-trips a saved order', () => {
     saveColumnPrefs(['tags', 'due_date', 'quantity']);
-    expect(loadColumnPrefs()).toEqual(['quantity', 'tags', 'due_date']);
+    expect(loadColumnPrefs()).toEqual(['tags', 'due_date', 'quantity']);
+  });
+
+  // Selections written before ordering existed were already canonical, so they
+  // load as the same table they described.
+  it('reads a selection stored before ordering existed unchanged', () => {
+    localStorage.setItem(
+      COLUMN_PREFS_STORAGE_KEY,
+      JSON.stringify({ expanded: ['quantity', 'category', 'updated_at'] }),
+    );
+    expect(loadColumnPrefs()).toEqual(['quantity', 'category', 'updated_at']);
   });
 
   it('falls back to defaults on corrupt stored JSON', () => {

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -31,7 +31,7 @@ export interface ColumnDef {
   sortField?: 'quantity' | 'due_date' | 'inspection_date' | 'updated_at';
 }
 
-/** Canonical column order. Selections are normalized to this order. */
+/** Canonical column order — the default, and what "Reset order" restores. */
 export const COLUMN_DEFS: readonly ColumnDef[] = [
   { key: 'quantity', label: 'Qty', tableSize: '70px', sortField: 'quantity' },
   // Wide enough for the "Needs repair" chip on one line: a status that wrapped
@@ -68,11 +68,47 @@ export const DEFAULT_COLUMNS: readonly ColumnKey[] = COLUMN_DEFS.map((c) => c.ke
 
 export const COLUMN_PREFS_STORAGE_KEY = 'haventory:columns:v1';
 
-/** Filter to known keys, dedupe, and enforce the canonical order. */
+/**
+ * Filter to known keys and dedupe, **keeping the order given**.
+ *
+ * The order is the user's — the picker can move a column up or down and that
+ * choice is stored alongside which columns are on. Selections written before
+ * ordering existed were already in canonical order, so they load unchanged.
+ */
 export function normalizeColumns(keys: unknown): ColumnKey[] {
   if (!Array.isArray(keys)) return [];
-  const wanted = new Set(keys.filter((k): k is ColumnKey => COLUMN_ORDER.includes(k as ColumnKey)));
+  const seen = new Set<ColumnKey>();
+  const out: ColumnKey[] = [];
+  for (const k of keys) {
+    if (!COLUMN_ORDER.includes(k as ColumnKey)) continue;
+    const key = k as ColumnKey;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(key);
+  }
+  return out;
+}
+
+/** The canonical order, restricted to the columns currently switched on. */
+export function canonicalOrder(keys: ColumnKey[]): ColumnKey[] {
+  const wanted = new Set(normalizeColumns(keys));
   return COLUMN_ORDER.filter((k) => wanted.has(k));
+}
+
+/**
+ * Move one column one place up or down within the selection.
+ *
+ * Returns the same array when the move is impossible, so a caller can tell "no
+ * change" without comparing element by element.
+ */
+export function moveColumn(keys: ColumnKey[], key: ColumnKey, delta: -1 | 1): ColumnKey[] {
+  const order = normalizeColumns(keys);
+  const from = order.indexOf(key);
+  const to = from + delta;
+  if (from < 0 || to < 0 || to >= order.length) return order;
+  const next = [...order];
+  next.splice(to, 0, ...next.splice(from, 1));
+  return next;
 }
 
 const COLUMN_TABLE_SIZE: Record<ColumnKey, string> = Object.fromEntries(

--- a/cards/haventory-card/src/ui/editor-error.test.ts
+++ b/cards/haventory-card/src/ui/editor-error.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { editorErrorText } from './editor-error';
+import type { ErrorEntry } from '../store/types';
+
+const entry = (patch: Partial<ErrorEntry>): ErrorEntry => ({
+  id: 'e1',
+  code: 'storage_error',
+  message: 'the store is read-only',
+  ...patch,
+});
+
+describe('editorErrorText', () => {
+  it('passes an ordinary failure through in the words the store used', () => {
+    expect(editorErrorText(entry({}))).toBe('the store is read-only');
+  });
+
+  // A conflict's own message names version numbers, which say nothing to
+  // someone looking at a form; the banner already frames the case in words.
+  it('reframes a conflict without naming versions', () => {
+    const text = editorErrorText(
+      entry({ kind: 'conflict', code: 'conflict', message: 'version conflict: expected 1, actual 2' }),
+    );
+    expect(text).toBe('Someone else changed this item.');
+    expect(text).not.toMatch(/\d/);
+  });
+});

--- a/cards/haventory-card/src/ui/editor-error.ts
+++ b/cards/haventory-card/src/ui/editor-error.ts
@@ -1,0 +1,17 @@
+import type { ErrorEntry } from '../store/types';
+
+/**
+ * What an open editor says about a save that did not land.
+ *
+ * A conflict's own message names version numbers, which say nothing to someone
+ * looking at a form; the card's banner already frames that case in words and
+ * carries the ways out of it, so the form repeats that sentence rather than
+ * giving a second, differently worded account of the same event.
+ *
+ * Shared, because both hosts of the editor answer the same question and a form
+ * that named the failure differently depending on which surface it was open on
+ * would be describing the surface, not the failure.
+ */
+export function editorErrorText(entry: ErrorEntry): string {
+  return entry.kind === 'conflict' ? 'Someone else changed this item.' : entry.message;
+}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -385,8 +385,11 @@ backend can actually sort by it — a `sortField`. Category, location and tags h
 their headers are not clickable: a header that looks interactive but does nothing is worse
 than a plain one.
 
-`DEFAULT_COLUMNS` is every key: a browser that has made no choice sees the whole record,
-and the picker is what thins it. The full set is wider than a phone and wider than many
+`DEFAULT_COLUMNS` is every key, in the canonical order: a browser that has made no choice
+sees the whole record, and the picker is what thins it and reorders it. The stored array
+*is* the order — `normalizeColumns` validates and dedupes without re-sorting, so a
+selection written before ordering existed (always canonical) loads as the same table it
+described, and `canonicalOrder` is what "Reset order" restores. The full set is wider than a phone and wider than many
 desktops, which `hv-data-table` answers by scrolling sideways rather than dropping columns.
 The name track (`NAME_COLUMN_SIZE`) outweighs every flexible column beside it in both
 halves of its `minmax`, because the row's identity is the one column that cannot be


### PR DESCRIPTION
## Summary

P2 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`).

**Stacked PR — merge in order.** Base is #336 (P1). After #336 squash-merges, this branch is rebased onto `main` (`git rebase --onto origin/main claude/session-a-frontend-packages-s4u4m3`) before it merges; the local verification session does that rebase as part of its pass.

### #328 — a rejected save is silent in the full view

`_onEditorSave` already detected the failure (it compares the error queue's length before and after) and kept the form open; it just never said anything. It now sets `_editorError` from the newest queue entry and binds it to the editor's `.errorMessage`, cleared when an editor opens, cancels, saves clean, or the view closes.

`editorErrorText` moves verbatim out of `hv-card-shell.ts` into `src/ui/editor-error.ts`, so both hosts of the editor build the same sentence — a conflict reads "Someone else changed this item." on either surface rather than naming version numbers at one of them. That import swap is the only shell edit.

Per decision 3, the full view does **not** gain the shell's banner list here: the inline sentence is the save-failure surface, and the queue's "View latest" / "Re-apply my change" actions arrive with P9.

### #242 — column order is the user's

- `normalizeColumns` keeps the order it is given, still validating and deduping. Canonical order stays the default and the reset. Selections written before ordering existed were already canonical, so they load unchanged — covered by a test.
- New `canonicalOrder` (restore) and `moveColumn` (one step, refusing to run off either end) beside it.
- The picker draws the shown columns first in table order with up/down buttons per row — the organize dialog's idiom — plus a **Reset order** that is disabled while the order already is canonical. A column switched back on joins at the **end** rather than dropping into its canonical slot, which would move a column the user placed. Columns that are off carry no move buttons: ordering an invisible column promises a position the toggle then does not keep.
- Buttons take `var(--hv-tap-min, 28px)`, so they meet the touch sizing the rest of the card honours.
- `hv-data-table` already walked the given array for both headers and cells, so it follows the order with no change; the sticky name column and the trailing actions are outside the optional set and stay put. Both are now pinned by tests.
- Persistence is unchanged — same key, same guarded localStorage access; the stored array simply *is* the order now.

Closes #328
Closes #242

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1453 passed), `npm run build`

New coverage: `editorErrorText` as a unit (plain message through, conflict reframed with no digits); full view — a rejected save renders `editor-error` and clears busy, a conflict uses the shared sentence, the error clears on a clean save and when the next edit opens; `normalizeColumns` order preservation and the legacy round-trip, `canonicalOrder`, `moveColumn` including the refusals; picker — permuted order emitted, ends disabled, no arrows on a column that is off, reset behaviour; table — headers and cells follow a permutation, sort fields stay with their own columns, name first and actions last.

Two existing pins asserted canonical re-sorting and were rewritten to assert the order is kept, per the campaign's rule about replacing rather than deleting assertions.

Docs: README's full-view description and its column-selection bullet, plus `docs/frontend_architecture.md`'s column-preferences section.

### Delegated to the local verification session

Reload persistence of a reordered table (per browser), the sticky name column and actions at phone width after a permutation, and the version-bump-from-a-second-surface path for the error sentence. Checklist P2 in the plan's §Verification.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (README, `docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_015S8wt52QKqXQvTjBLoz6ah)_