### PR TITLE
feat(card): attach files by dropping them on the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,9 +506,12 @@ throughout.
   it, rather than pointing at a menu three steps away.
 - **Photos and manuals** attach from the same form, once the item exists — an upload is
   filed against an item id, and the create form says so instead of leaving the sections
-  unexplained. Each queue reports itself under the section that started it, with a moving
-  indicator while a file is in flight; a refused file keeps its error and Retry until you
-  dismiss them. Removing an attachment asks first, because the file goes with it.
+  unexplained. On a desktop you can also **drop files straight onto the Photos or Documents
+  section**; the file's own type decides which it becomes, so a PDF dropped on the photo
+  strip attaches as a manual. Each queue reports itself under the section that started it,
+  with a moving indicator while a file is in flight; a refused file keeps its error and
+  Retry until you dismiss them. Removing an attachment asks first, because the file goes
+  with it.
 - **Full view** — a fullscreen workspace with a coloured app bar, a **browse sidebar**, and
   a sortable table. Only columns the backend can sort by get a clickable header. A browser
   that has made no choice yet shows every optional column — quantity, status, category,

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -2255,3 +2255,156 @@ describe('hv-item-editor: why attachments wait for the first save', () => {
     expect(q(el, '[data-testid="editor-attachment-hint"]')).toBe(null);
   });
 });
+
+// jsdom builds a `DragEvent` with no `DataTransfer` behind it, so the files ride
+// on a plain object. What is worth asserting here is the routing — which kind
+// each dropped file becomes, and that nothing new appears on the upload path.
+// The browser's own drag machinery is the handover's job.
+describe('hv-item-editor: dropping files onto the editor', () => {
+  const png = (name = 'photo.png') => new File(['x'], name, { type: 'image/png' });
+  const pdf = (name = 'manual.pdf') => new File(['x'], name, { type: 'application/pdf' });
+
+  function dragEvent(type: string, files: File[]) {
+    const e = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(e, 'dataTransfer', {
+      value: { files, dropEffect: 'none' },
+      configurable: true,
+    });
+    return e as DragEvent;
+  }
+
+  async function dropOn(el: HVItemEditor, testid: string, files: File[]) {
+    const target = q(el, `[data-testid="${testid}"]`) as HTMLElement;
+    target.dispatchEvent(dragEvent('drop', files));
+    // A macrotask, so the prepare-then-send chain drains first.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await el.updateComplete;
+  }
+
+  it('attaches an image dropped on the photo strip as a photo', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), { media });
+
+    await dropOn(el, 'editor-photos', [png()]);
+
+    expect(media.uploads.map((u) => [u.file.name, u.kind])).toEqual([['photo.png', 'picture']]);
+  });
+
+  it('attaches a document dropped on the document list as a manual', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), { media });
+
+    await dropOn(el, 'editor-documents', [pdf()]);
+
+    expect(media.uploads.map((u) => [u.file.name, u.kind])).toEqual([['manual.pdf', 'manual']]);
+  });
+
+  // The file decides, not the cell it crossed: refusing a PDF because it landed
+  // on the photo strip would be arguing with something the user can see.
+  it('attaches a document dropped on the photo strip as a manual', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), { media });
+
+    await dropOn(el, 'editor-photos', [pdf()]);
+
+    expect(media.uploads.map((u) => u.kind)).toEqual(['manual']);
+  });
+
+  it('attaches an image dropped on the document list as a photo', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), { media });
+
+    await dropOn(el, 'editor-documents', [png()]);
+
+    expect(media.uploads.map((u) => u.kind)).toEqual(['picture']);
+  });
+
+  it('routes a mixed multi-file drop file by file', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), { media });
+
+    await dropOn(el, 'editor-photos', [png('a.png'), pdf('b.pdf'), png('c.png')]);
+
+    expect(media.uploads.map((u) => [u.file.name, u.kind])).toEqual([
+      ['a.png', 'picture'],
+      ['c.png', 'picture'],
+      ['b.pdf', 'manual'],
+    ]);
+  });
+
+  // The existing preflight is the one place that knows what the backend takes,
+  // so a refused file is refused in the same words a picked one would be.
+  it('sends a dropped file through the same preflight a picked one gets', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), {
+      media,
+      mediaConfig: {
+        picture_mime_types: ['image/png'],
+        manual_mime_types: ['application/pdf'],
+        max_attachment_bytes: 16,
+      } as HVItemEditor['mediaConfig'],
+    });
+
+    await dropOn(el, 'editor-documents', [new File(['x'], 'notes.txt', { type: 'text/plain' })]);
+
+    expect(media.uploads).toHaveLength(0);
+    expect(q(el, '[data-testid="editor-upload"]')?.textContent).toContain('not an accepted');
+  });
+
+  it('cancels dragover so the browser does not navigate to the file', async () => {
+    const el = await mount(makeItem({ id: 'i-1' }), { media: makeMediaBindings() });
+    const over = dragEvent('dragover', [png()]);
+
+    (q(el, '[data-testid="editor-photos"]') as HTMLElement).dispatchEvent(over);
+
+    expect(over.defaultPrevented).toBe(true);
+    expect(over.dataTransfer?.dropEffect).toBe('copy');
+  });
+
+  // A drop a few pixels wide of the target would otherwise replace the page with
+  // the file and take the whole open form with it.
+  it('swallows a drop that missed the targets', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), { media });
+    const root = q(el, '[data-testid="item-editor"]') as HTMLElement;
+
+    const over = dragEvent('dragover', [png()]);
+    root.dispatchEvent(over);
+    const drop = dragEvent('drop', [png()]);
+    root.dispatchEvent(drop);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(over.defaultPrevented).toBe(true);
+    expect(drop.defaultPrevented).toBe(true);
+    expect(media.uploads).toHaveLength(0);
+  });
+
+  it('marks the section a drag is over, and unmarks it on the way out', async () => {
+    const el = await mount(makeItem({ id: 'i-1' }), { media: makeMediaBindings() });
+    const photos = q(el, '[data-testid="editor-photos"]') as HTMLElement;
+
+    photos.dispatchEvent(dragEvent('dragover', [png()]));
+    await el.updateComplete;
+    expect(photos.classList.contains('dropping')).toBe(true);
+
+    photos.dispatchEvent(new Event('dragleave', { bubbles: true }));
+    await el.updateComplete;
+    expect(photos.classList.contains('dropping')).toBe(false);
+  });
+
+  // There is no drag on touch, so an over-state could only ever fire by accident
+  // — the phone layout carries no target at all rather than one that declines.
+  // The root guard stays: `mobile` is the card element's width, and a narrow
+  // card in a desktop window still has a mouse with a file on the end of it.
+  it('renders no drop target on a phone', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(makeItem({ id: 'i-1' }), { media, mobile: true });
+    const photos = q(el, '[data-testid="editor-photos"]') as HTMLElement;
+
+    photos.dispatchEvent(dragEvent('dragover', [png()]));
+    await dropOn(el, 'editor-photos', [png()]);
+
+    expect(photos.classList.contains('dropping')).toBe(false);
+    expect(media.uploads).toHaveLength(0);
+  });
+});

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -809,6 +809,17 @@ export class HVItemEditor extends LitElement {
         display: grid;
         gap: 6px;
       }
+      /* Desktop only: there is no drag on touch, so the over-state could only
+         ever fire by accident there — the mobile branch renders no target at
+         all. Outset so an empty section still has an edge to aim at, and drawn
+         with outline rather than border so nothing inside shifts as the drag
+         crosses in. */
+      .photos.dropping,
+      .documents.dropping {
+        outline: 2px dashed var(--hv-primary);
+        outline-offset: 4px;
+        border-radius: var(--hv-radius-input);
+      }
       .documents li {
         display: flex;
         align-items: center;
@@ -1024,6 +1035,8 @@ export class HVItemEditor extends LitElement {
   @state() private _uploaded: Item | null = null;
   /** The attachment awaiting a yes, and what kind it is. */
   @state() private _confirmRemove: { id: string; kind: AttachmentKind } | null = null;
+  /** Which attachment section a drag is currently over, for the over-state. */
+  @state() private _dropTarget: AttachmentKind | null = null;
   /** Escape on a dirty form asks before it throws the typing away. */
   @state() private _confirmDiscard = false;
   /** Why creating a first location from the picker failed. */
@@ -2059,9 +2072,16 @@ export class HVItemEditor extends LitElement {
     const shots = pictures(item.attachments);
     const accepted = this.mediaConfig?.picture_mime_types.join(',') ?? 'image/*';
 
+    const drop = this._dropBindings('picture');
     return html`<div class="cell span3">
       <span class="hv-label">Photos</span>
-      <div class="photos" data-testid="editor-photos">
+      <div
+        class="photos ${!this.mobile && this._dropTarget === 'picture' ? 'dropping' : ''}"
+        data-testid="editor-photos"
+        @dragover=${drop.over}
+        @dragleave=${drop.leave}
+        @drop=${drop.drop}
+      >
         ${shots.map((picture, index) => {
           const src = this._urls.get(item.id, picture.id, attachmentNameToken(picture));
           return html`<figure data-testid="editor-photo">
@@ -2137,6 +2157,80 @@ export class HVItemEditor extends LitElement {
   }
 
   /**
+   * Which section a dropped file belongs in, decided by the file and not by
+   * where it landed.
+   *
+   * A PDF dragged onto the photo strip is a manual — refusing it because of the
+   * cell it crossed would be arguing with something the user can see. Anything
+   * that is neither is left to `_preflight`, which is the one place that knows
+   * what the backend accepts and phrases the refusal.
+   */
+  private _kindFor(file: File): AttachmentKind {
+    return file.type.startsWith('image/') ? 'picture' : 'manual';
+  }
+
+  /**
+   * Attach dropped files, routing each by its own type.
+   *
+   * `_uploadFiles` runs a queue per call, and the two queues would interleave
+   * their version bumps, so a mixed drop is sent as pictures first and then
+   * manuals rather than as one call per file.
+   */
+  private async _onDrop(e: DragEvent) {
+    e.preventDefault();
+    this._dropTarget = null;
+    if (this.mobile) return;
+    const files = Array.from(e.dataTransfer?.files ?? []);
+    if (!files.length) return;
+    const pictureFiles = files.filter((f) => this._kindFor(f) === 'picture');
+    const manualFiles = files.filter((f) => this._kindFor(f) === 'manual');
+    if (pictureFiles.length) await this._uploadFiles(pictureFiles, 'picture');
+    if (manualFiles.length) await this._uploadFiles(manualFiles, 'manual');
+  }
+
+  /**
+   * `dragover` must be cancelled or the browser treats the drop as navigation
+   * and replaces the page with the dropped file — taking the whole open form
+   * with it. Home Assistant's frontend does not block that, so the editor root
+   * cancels both events whatever the layout: `mobile` here is the card
+   * element's width, and a narrow card in a desktop window still has a mouse
+   * with a file on the end of it.
+   */
+  private _onRootDragOver(e: DragEvent) {
+    e.preventDefault();
+  }
+
+  private _onRootDrop(e: DragEvent) {
+    e.preventDefault();
+    this._dropTarget = null;
+  }
+
+  private _onDragOver(e: DragEvent, target: AttachmentKind) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+    this._dropTarget = target;
+  }
+
+  private _onDragLeave(target: AttachmentKind) {
+    if (this._dropTarget === target) this._dropTarget = null;
+  }
+
+  /**
+   * The drag-and-drop bindings a section's drop target needs, or none at all on
+   * a phone: there is no drag on touch, so an over-state could only ever fire by
+   * accident. Lit removes a listener bound to `undefined`, so the mobile branch
+   * really carries no target rather than a target that declines.
+   */
+  private _dropBindings(kind: AttachmentKind) {
+    if (this.mobile) return { over: undefined, leave: undefined, drop: undefined };
+    return {
+      over: (e: DragEvent) => this._onDragOver(e, kind),
+      leave: () => this._onDragLeave(kind),
+      drop: (e: DragEvent) => void this._onDrop(e),
+    };
+  }
+
+  /**
    * Rename one document.
    *
    * On `change`, not `input`: a keystroke-per-command would bump the item's
@@ -2176,9 +2270,16 @@ export class HVItemEditor extends LitElement {
     const docs = manuals(item.attachments);
     const accepted = this.mediaConfig?.manual_mime_types?.join(',') ?? 'application/pdf';
 
+    const drop = this._dropBindings('manual');
     return html`<div class="cell span3">
       <span class="hv-label">Documents</span>
-      <ul class="documents" data-testid="editor-documents">
+      <ul
+        class="documents ${!this.mobile && this._dropTarget === 'manual' ? 'dropping' : ''}"
+        data-testid="editor-documents"
+        @dragover=${drop.over}
+        @dragleave=${drop.leave}
+        @drop=${drop.drop}
+      >
         ${docs.map((doc) => {
           const src = this._urls.get(item.id, doc.id, attachmentNameToken(doc));
           const missing = this._urls.presence(item.id, doc.id) === 'missing';
@@ -2344,7 +2445,12 @@ export class HVItemEditor extends LitElement {
     const overdue = isOverdue(this.item?.due_date);
 
     return html`
-      <div data-testid="item-editor" @keydown=${this._onKeydown}>
+      <div
+        data-testid="item-editor"
+        @keydown=${this._onKeydown}
+        @dragover=${this._onRootDragOver}
+        @drop=${this._onRootDrop}
+      >
         ${this.noHeader
           ? null
           : html`<div class="head">

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -465,8 +465,10 @@ Things jsdom cannot do, and how the tests handle it:
   the reflected `mobile` attribute), never a computed style.
 - **No layout** — `ResponsiveController` is driven through `setWidth()` / `setForced()`
   rather than a real `ResizeObserver`.
-- **No drag and drop** — dragging items onto tree nodes (an optional item in the handoff)
-  is not implemented.
+- **No real drag and drop** — jsdom builds a `DragEvent` with no `DataTransfer` behind it,
+  so the editor's file-drop tests carry a plain-object `dataTransfer` and assert the
+  routing (which kind each dropped file becomes) rather than the browser's drag machinery.
+  Dragging items onto tree nodes (an optional item in the handoff) is not implemented.
 
 Run:
 


### PR DESCRIPTION
## Summary

P3 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`).

**Stacked PR — merge in order.** Base is #337 (P2), which is based on #336 (P1). After #337 squash-merges, this branch is rebased onto `main` (`git rebase --onto origin/main claude/session-a-frontend-packages-s4u4m3-p2`) before it merges; the local verification session does that rebase as part of its pass.

Dropping one or several files on the open editor's Photos or Documents section attaches them exactly as picking them would.

- **The file decides the kind, not the cell.** A PDF dropped on the photo strip attaches as a manual; an image dropped on Documents attaches as a photo. Refusing a PDF because of the cell it crossed would be arguing with something the user can see. Anything that is neither goes to `_preflight`, the one place that knows what the backend accepts, and is refused in the words a picked file would be refused in.
- **Everything routes through `_uploadFiles`** — same preflight, same client-side downscale, same per-file retry. A mixed drop sends pictures first and then manuals rather than one call per file, because each call runs its own sequential queue and two queues would race each other's version bumps.
- **A visible over-state** on the section being dragged over, drawn with `outline` so nothing inside shifts as the drag crosses in.
- **`dragover` cancels** on the drop targets *and* on the editor root, so a drop that misses by a few pixels is a no-op rather than the browser navigating the tab to the file and taking the open form with the page — HA's frontend does not block that. The root guard is deliberately **not** layout-gated: `mobile` measures the card element, and a narrow card in a desktop window still has a mouse with a file on the end of it.
- **A phone renders no drop target at all**, rather than one that declines: Lit removes a listener bound to `undefined`, so `:host([mobile])` really carries nothing to fire by accident.

Closes #296

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1463 passed), `npm run build`

jsdom builds a `DragEvent` with no `DataTransfer` behind it, so the tests carry a plain-object `dataTransfer` and assert the routing rather than the browser's drag machinery: all four cell × type combinations, a mixed multi-file drop, a refused type reaching the existing preflight message, `preventDefault` on `dragover` with `dropEffect` set, the missed-drop no-op at the root, the over-state appearing and clearing, and the mobile no-op.

Docs: README's photos-and-manuals bullet; `docs/frontend_architecture.md`'s "things jsdom cannot do" now states what the drop tests do instead.

### Delegated to the local verification session

Real drag and drop cannot be proven in jsdom. Checklist P3 in the plan's §Verification: four OS-file-manager × cell combinations, a multi-file drop queueing sequentially, a drop missed beside the target not navigating the tab away, the over-state appearing and clearing, and no target at 390px.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (README, `docs/frontend_architecture.md`).
- [x] No WebSocket API change — the upload path is untouched.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_015S8wt52QKqXQvTjBLoz6ah)_