### PR TITLE
feat(card): configurable quick-filter pills

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,16 +596,32 @@ throughout.
 ```yaml
 type: custom:haventory-card
 title: Pantry   # optional; overrides the integration-wide card title
+quick_filters:  # optional; which quick-filter pills this card offers
+  - low_stock
+  - checked_out
 ```
 
-`title` is the only option the card reads. Any other key is ignored rather than rejected,
-so a stale dashboard config never breaks the card.
+| Key | Type | Default | What it does |
+|---|---|---|---|
+| `title` | string | the integration-wide card title | Names this card, for this dashboard only. |
+| `quick_filters` | list | every pill | Which quick-filter pills the card and its full view offer: `total`, `low_stock`, `overdue`, `inspection_due`, `checked_out`. |
 
-Without it, the card uses the name set under Settings → Devices & services → HAventory →
-**Configure** (asked for at setup too, and defaulting to "HAventory"), so one setting
-renames every card. Per-dashboard `title:` wins over it — use that when two dashboards
-should name the same inventory differently. An open dashboard picks up a changed name on
-its next refresh or reload; the change is not pushed live.
+Those two are the only options the card reads. Any other key is ignored rather than
+rejected, so a stale dashboard config never breaks the card — and the same holds inside
+`quick_filters`: an unknown pill name is dropped, and a value that is not a list reads as
+the key being absent.
+
+Without `title`, the card uses the name set under Settings → Devices & services →
+HAventory → **Configure** (asked for at setup too, and defaulting to "HAventory"), so one
+setting renames every card. Per-dashboard `title:` wins over it — use that when two
+dashboards should name the same inventory differently. An open dashboard picks up a
+changed name on its next refresh or reload; the change is not pushed live.
+
+`quick_filters` says which pills are *allowed*; a pill still only shows when it has
+something to count, so `low_stock` draws nothing while nothing is low. Omitting the key
+offers all of them, which is what every dashboard written before this option gets. An
+explicit empty list is a choice and offers none. The sidebar panel has no dashboard config
+of its own, so it always offers all of them.
 
 ### CI/CD & Ops
 

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -63,6 +63,72 @@ describe('hv-card-shell: header', () => {
     expect(sr.querySelector('[data-testid="badge-total"]')?.textContent?.trim()).toBe('1 item');
   });
 
+  // The pills are filter toggles, not decoration; a dashboard that never checks
+  // anything out has no use for the checked-out one. The config decides what is
+  // on offer, the count still decides whether there is anything to say.
+  describe('configurable quick-filter pills', () => {
+    const stocked = () => [
+      makeItem({ id: '1', name: 'AA Batteries', quantity: 2, low_stock_threshold: 8 }),
+      makeItem({ id: '2', name: 'Impact Driver', checked_out: true }),
+    ];
+
+    it('draws every pill by default', async () => {
+      const { sr } = await mountShell({ items: stocked() });
+      expect(sr.querySelector('[data-testid="badge-total"]')).toBeTruthy();
+      expect(sr.querySelector('[data-testid="badge-low"]')).toBeTruthy();
+      expect(sr.querySelector('[data-testid="badge-out"]')).toBeTruthy();
+    });
+
+    it('draws only the pills the config names', async () => {
+      const { el, sr } = await mountShell({ items: stocked() });
+      el.quickFilters = ['low_stock'];
+      await el.updateComplete;
+
+      expect(sr.querySelector('[data-testid="badge-low"]')).toBeTruthy();
+      expect(sr.querySelector('[data-testid="badge-total"]')).toBe(null);
+      expect(sr.querySelector('[data-testid="badge-out"]')).toBe(null);
+    });
+
+    // Allowed is not the same as shown: the count gate is unchanged.
+    it('still hides an allowed pill whose count is zero', async () => {
+      const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
+      el.quickFilters = ['low_stock', 'checked_out'];
+      await el.updateComplete;
+
+      expect(sr.querySelector('[data-testid="badge-low"]')).toBe(null);
+      expect(sr.querySelector('[data-testid="badge-out"]')).toBe(null);
+    });
+
+    // On a phone the wrapper takes a row of its own, so a band with nothing
+    // allowed in it would be a blank strip under the title.
+    it('draws no badge row on a phone when the subset leaves nothing to show', async () => {
+      const { el, sr } = await mountShell({ items: stocked(), mobile: true });
+      el.quickFilters = ['overdue'];
+      await el.updateComplete;
+
+      expect(sr.querySelector('.badges')).toBe(null);
+    });
+
+    it('keeps the phone badge row when the subset still has something to show', async () => {
+      const { el, sr } = await mountShell({ items: stocked(), mobile: true });
+      el.quickFilters = ['low_stock'];
+      await el.updateComplete;
+
+      expect(sr.querySelector('[data-testid="badge-low"]')).toBeTruthy();
+    });
+
+    it('hands the same list to the full view, so both surfaces agree', async () => {
+      const { el, sr } = await mountShell({ items: stocked() });
+      el.quickFilters = ['low_stock'];
+      await el.updateComplete;
+
+      const full = sr.querySelector('[data-testid="card-full-view"]') as HTMLElement & {
+        quickFilters: string[] | null;
+      };
+      expect(full.quickFilters).toEqual(['low_stock']);
+    });
+  });
+
   it('hides a stat badge that would read zero', async () => {
     const { sr } = await mountShell({ items: [makeItem({ id: '1' })] });
     expect(sr.querySelector('[data-testid="badge-low"]')).toBe(null);

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -9,6 +9,8 @@ import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters } from '../store/store';
 import { emptyKindFor } from '../ui/empty-state';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
+import { quickFilterAllowed } from '../ui/quick-filters';
+import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
 import { HostSurfaces } from '../host-surfaces';
 import type { Store } from '../store/store';
@@ -347,6 +349,11 @@ export class HVCardShell extends LitElement {
   @property({ type: String }) heading = DEFAULT_CARD_TITLE;
   /** Force a layout instead of measuring; `null` measures. */
   @property({ attribute: false }) forceMobile: boolean | null = null;
+  /**
+   * Which quick-filter pills this dashboard offers, or `null` for all of them.
+   * Passed on to the full view unchanged — one vocabulary on both surfaces.
+   */
+  @property({ attribute: false }) quickFilters: QuickFilterKey[] | null = null;
 
   @state() private _filterPanelOpen = false;
   @state() private _filterSheetOpen = false;
@@ -783,21 +790,25 @@ export class HVCardShell extends LitElement {
     const counts = st?.statsCounts;
     if (!counts) return null;
     const f = st?.filters;
+    // A pill shows when the dashboard allows it *and* its count clears the gate
+    // it always had — the config decides what is on offer, the count decides
+    // whether there is anything to say.
+    const allows = (key: QuickFilterKey) => quickFilterAllowed(this.quickFilters, key);
+    const lowStock = allows('low_stock') && counts.low_stock_count > 0;
+    const overdue = allows('overdue') && (counts.overdue_count ?? 0) > 0;
+    const inspection = allows('inspection_due') && (counts.inspection_overdue_count ?? 0) > 0;
+    const checkedOut = allows('checked_out') && counts.checked_out_count > 0;
     // On mobile the wrapper takes a row of its own, so an empty one would leave
-    // a blank band under the title rather than nothing at all.
-    const anyBadge =
-      !this.mobile ||
-      counts.low_stock_count > 0 ||
-      (counts.overdue_count ?? 0) > 0 ||
-      (counts.inspection_overdue_count ?? 0) > 0 ||
-      counts.checked_out_count > 0;
+    // a blank band under the title rather than nothing at all. The total is not
+    // among them: it does not render on a phone at all.
+    const anyBadge = !this.mobile || lowStock || overdue || inspection || checkedOut;
     if (!anyBadge) return null;
     return html`
       <div class="badges">
-        ${this.mobile
+        ${this.mobile || !allows('total')
           ? null
           : html`<span class="hv-chip badge quiet" data-testid="badge-total">${counted(counts.items_total, 'item')}</span>`}
-        ${counts.low_stock_count > 0
+        ${lowStock
           ? html`<button
               class="hv-chip badge toggle warning ${f?.lowStockOnly ? 'on' : ''}"
               data-testid="badge-low"
@@ -808,7 +819,7 @@ export class HVCardShell extends LitElement {
               ${counts.low_stock_count} low
             </button>`
           : null}
-        ${(counts.overdue_count ?? 0) > 0
+        ${overdue
           ? html`<button
               class="hv-chip badge toggle error ${f?.overdueOnly ? 'on' : ''}"
               data-testid="badge-overdue"
@@ -819,7 +830,7 @@ export class HVCardShell extends LitElement {
               ${counts.overdue_count} overdue
             </button>`
           : null}
-        ${(counts.inspection_overdue_count ?? 0) > 0
+        ${inspection
           ? html`<button
               class="hv-chip badge toggle warning ${f?.inspectionDueOnly ? 'on' : ''}"
               data-testid="badge-inspection"
@@ -830,7 +841,7 @@ export class HVCardShell extends LitElement {
               ${counts.inspection_overdue_count} to inspect
             </button>`
           : null}
-        ${counts.checked_out_count > 0
+        ${checkedOut
           ? html`<button
               class="hv-chip badge toggle state ${f?.checkedOutOnly ? 'on' : ''}"
               data-testid="badge-out"
@@ -1188,6 +1199,7 @@ export class HVCardShell extends LitElement {
         .store=${this.store}
         .heading=${this.heading}
         .columns=${this.surfaces.columns}
+        .quickFilters=${this.quickFilters}
         .menuEntries=${this.surfaces.menuEntries()}
         ?startSelecting=${this._startSelecting}
         @close=${() => {

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1480,6 +1480,39 @@ describe('hv-full-view: app bar filters', () => {
     expect(q(sr, '[data-testid="full-badge-inspection"]')).toBe(null);
   });
 
+  // One vocabulary on both surfaces: the card hands its `quick_filters` config
+  // down, and the panel — which has no YAML — takes the default of all of them.
+  describe('the dashboard\'s pill choice', () => {
+    const stocked = () => [
+      makeItem({ id: '1', quantity: 0, low_stock_threshold: 5 }),
+      makeItem({ id: '2', checked_out: true }),
+    ];
+
+    it('draws every pill by default', async () => {
+      const { sr } = await mount({ items: stocked() });
+      expect(q(sr, '[data-testid="full-badge-low"]')).toBeTruthy();
+      expect(q(sr, '[data-testid="full-badge-out"]')).toBeTruthy();
+    });
+
+    it('draws only the pills the config names', async () => {
+      const { el, sr } = await mount({ items: stocked() });
+      el.quickFilters = ['low_stock'];
+      await el.updateComplete;
+
+      expect(q(sr, '[data-testid="full-badge-low"]')).toBeTruthy();
+      expect(q(sr, '[data-testid="full-badge-out"]')).toBe(null);
+    });
+
+    it('still hides an allowed pill whose count is zero', async () => {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
+      el.quickFilters = ['low_stock', 'checked_out'];
+      await el.updateComplete;
+
+      expect(q(sr, '[data-testid="full-badge-low"]')).toBe(null);
+      expect(q(sr, '[data-testid="full-badge-out"]')).toBe(null);
+    });
+  });
+
   // "82 out" reads as "82 out of stock", which is the opposite of what it counts.
   it('spells out what the checked-out pill counts', async () => {
     const { sr } = await mount({ items: flagged });

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -15,6 +15,8 @@ import { deepFocusables } from '../ui/dialog-focus';
 import { areaNameById, effectiveAreaIdForLocation } from '../ui/area';
 import { renderAreaChip } from '../ui/location-path';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
+import { quickFilterAllowed } from '../ui/quick-filters';
+import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
 import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
@@ -748,6 +750,12 @@ export class HVFullView extends LitElement {
   @property({ type: Boolean, reflect: true }) open = false;
   @property({ type: String }) heading = DEFAULT_CARD_TITLE;
   @property({ attribute: false }) columns: ColumnKey[] = [];
+  /**
+   * Which quick-filter pills this dashboard offers, or `null` for all of them.
+   * The card passes its own config down; the sidebar panel has no YAML to
+   * configure, so it takes the default.
+   */
+  @property({ attribute: false }) quickFilters: QuickFilterKey[] | null = null;
   /** Extra entries the host adds to the app bar's ⋮ menu. */
   @property({ attribute: false }) menuEntries: OverflowMenuEntry[] = [];
   /** Open straight into selection mode (the card's "Select items…" entry). */
@@ -1679,6 +1687,9 @@ export class HVFullView extends LitElement {
     const st = this.st;
     const filters = st?.filters ?? defaultFilters();
     const counts = st?.statsCounts;
+    // The dashboard decides what is on offer; the count still decides whether
+    // there is anything to say. Same vocabulary the card's badges read.
+    const allowsPill = (key: QuickFilterKey) => quickFilterAllowed(this.quickFilters, key);
     return html`
         <div class="appbar">
           ${this.embedded
@@ -1702,7 +1713,7 @@ export class HVFullView extends LitElement {
             />
           </label>
           <span class="spacer"></span>
-          ${counts && counts.low_stock_count > 0
+          ${allowsPill('low_stock') && counts && counts.low_stock_count > 0
             ? html`<button
                 class="hv-chip pill warning ${filters.lowStockOnly ? 'on' : ''}"
                 data-testid="full-badge-low"
@@ -1713,7 +1724,7 @@ export class HVFullView extends LitElement {
                 ${counts.low_stock_count} low
               </button>`
             : null}
-          ${counts && (counts.overdue_count ?? 0) > 0
+          ${allowsPill('overdue') && counts && (counts.overdue_count ?? 0) > 0
             ? html`<button
                 class="hv-chip pill error ${filters.overdueOnly ? 'on' : ''}"
                 data-testid="full-badge-overdue"
@@ -1724,7 +1735,7 @@ export class HVFullView extends LitElement {
                 ${counts.overdue_count} overdue
               </button>`
             : null}
-          ${counts && (counts.inspection_overdue_count ?? 0) > 0
+          ${allowsPill('inspection_due') && counts && (counts.inspection_overdue_count ?? 0) > 0
             ? html`<button
                 class="hv-chip pill warning ${filters.inspectionDueOnly ? 'on' : ''}"
                 data-testid="full-badge-inspection"
@@ -1735,7 +1746,7 @@ export class HVFullView extends LitElement {
                 ${counts.inspection_overdue_count} to inspect
               </button>`
             : null}
-          ${counts && counts.checked_out_count > 0
+          ${allowsPill('checked_out') && counts && counts.checked_out_count > 0
             ? html`<button
                 class="hv-chip pill ${filters.checkedOutOnly ? 'on' : ''}"
                 data-testid="full-badge-out"

--- a/cards/haventory-card/src/haventory-card.test.ts
+++ b/cards/haventory-card/src/haventory-card.test.ts
@@ -97,6 +97,40 @@ describe('haventory-card: the Lovelace element', () => {
     expect(() => el.setConfig('nope')).toThrow(/Invalid config/);
   });
 
+  // The pills are filter toggles, not decoration, so a dashboard can say which
+  // it offers. Nothing about the key may break a dashboard that never sets it.
+  describe('quick_filters', () => {
+    const shellOf = (sr: ShadowRoot) =>
+      sr.querySelector('[data-testid="card-shell"]') as HTMLElement & {
+        quickFilters: string[] | null;
+      };
+
+    it('offers every pill when the key is omitted', async () => {
+      const { sr } = await mountCard({});
+      expect(shellOf(sr).quickFilters).toBe(null);
+    });
+
+    it('passes a chosen subset down to the shell', async () => {
+      const { sr } = await mountCard({ quick_filters: ['low_stock', 'overdue'] });
+      expect(shellOf(sr).quickFilters).toEqual(['low_stock', 'overdue']);
+    });
+
+    it('drops an unknown entry without dropping the rest', async () => {
+      const { sr } = await mountCard({ quick_filters: ['low_stock', 'sideways'] });
+      expect(shellOf(sr).quickFilters).toEqual(['low_stock']);
+    });
+
+    it('reads a non-list value as the key being absent, and never throws', async () => {
+      const { sr } = await mountCard({ quick_filters: 'low_stock' });
+      expect(shellOf(sr).quickFilters).toBe(null);
+    });
+
+    it('honours an explicit empty list', async () => {
+      const { sr } = await mountCard({ quick_filters: [] });
+      expect(shellOf(sr).quickFilters).toEqual([]);
+    });
+  });
+
   it('reports a card size for the dashboard layout', async () => {
     const { el } = await mountCard();
     expect(el.getCardSize()).toBeGreaterThan(0);

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -3,6 +3,8 @@ import type { HassLike } from './store/types';
 import { Store } from './store/store';
 import { resolveColorScheme } from './ui/theme';
 import { DEFAULT_CARD_TITLE } from './ui/card-title';
+import { normalizeQuickFilters } from './ui/quick-filters';
+import type { QuickFilterKey } from './ui/quick-filters';
 import { registerBrandIcon } from './ui/brand-icon';
 import { defineCardElement } from './register';
 import './components/hv-card-shell';
@@ -20,7 +22,7 @@ export class HAventoryCard extends LitElement {
     }
   `;
 
-  private config?: { title?: string };
+  private config?: { title?: string; quickFilters?: QuickFilterKey[] | null };
 
   private store?: Store;
   private _storeUnsub?: () => void;
@@ -31,12 +33,15 @@ export class HAventoryCard extends LitElement {
     if (cfg !== null && typeof cfg !== 'object') {
       throw new Error('Invalid config');
     }
-    const obj = (cfg || {}) as { title?: unknown };
-    // Only `title` means anything here. Anything else in the YAML — a key from
-    // a future version, or a stale one — is ignored rather than rejected, so a
-    // dashboard never breaks on a config the card simply does not read.
+    const obj = (cfg || {}) as { title?: unknown; quick_filters?: unknown };
+    // Only `title` and `quick_filters` mean anything here. Anything else in the
+    // YAML — a key from a future version, or a stale one — is ignored rather
+    // than rejected, so a dashboard never breaks on a config the card simply
+    // does not read. The same holds inside `quick_filters`: an unknown pill name
+    // is dropped, and a value that is not a list reads as the key being absent.
     this.config = {
       title: typeof obj.title === 'string' ? obj.title : undefined,
+      quickFilters: normalizeQuickFilters(obj.quick_filters),
     };
     this.requestUpdate();
   }
@@ -113,6 +118,7 @@ export class HAventoryCard extends LitElement {
         data-testid="card-shell"
         .store=${this.store}
         .heading=${this._heading()}
+        .quickFilters=${this.config?.quickFilters ?? null}
       ></hv-card-shell>
     `;
   }

--- a/cards/haventory-card/src/ui/quick-filters.test.ts
+++ b/cards/haventory-card/src/ui/quick-filters.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { QUICK_FILTER_KEYS, normalizeQuickFilters, quickFilterAllowed } from './quick-filters';
+
+describe('normalizeQuickFilters', () => {
+  it('reads an omitted key as "no choice made"', () => {
+    expect(normalizeQuickFilters(undefined)).toBe(null);
+    expect(normalizeQuickFilters(null)).toBe(null);
+  });
+
+  // A dashboard must not break on a value this card does not understand — the
+  // same philosophy setConfig already applies to every other key.
+  it('reads garbage as "no choice made" rather than throwing', () => {
+    expect(normalizeQuickFilters('low_stock')).toBe(null);
+    expect(normalizeQuickFilters(42)).toBe(null);
+    expect(normalizeQuickFilters({ low_stock: true })).toBe(null);
+  });
+
+  it('keeps the known names, in the order given, deduped', () => {
+    expect(normalizeQuickFilters(['overdue', 'total', 'overdue'])).toEqual(['overdue', 'total']);
+  });
+
+  it('drops unknown entries without dropping the list', () => {
+    expect(normalizeQuickFilters(['low_stock', 'bogus', 7, null])).toEqual(['low_stock']);
+  });
+
+  // An empty list is a choice — "offer none" — and is not the same as omitting
+  // the key, which offers all.
+  it('honours an explicit empty list', () => {
+    expect(normalizeQuickFilters([])).toEqual([]);
+  });
+
+  it('accepts every name it documents', () => {
+    expect(normalizeQuickFilters([...QUICK_FILTER_KEYS])).toEqual([...QUICK_FILTER_KEYS]);
+  });
+});
+
+describe('quickFilterAllowed', () => {
+  it('allows everything when nothing was configured', () => {
+    for (const key of QUICK_FILTER_KEYS) expect(quickFilterAllowed(null, key)).toBe(true);
+  });
+
+  it('allows only what the list names', () => {
+    expect(quickFilterAllowed(['low_stock'], 'low_stock')).toBe(true);
+    expect(quickFilterAllowed(['low_stock'], 'overdue')).toBe(false);
+    expect(quickFilterAllowed([], 'total')).toBe(false);
+  });
+});

--- a/cards/haventory-card/src/ui/quick-filters.ts
+++ b/cards/haventory-card/src/ui/quick-filters.ts
@@ -1,0 +1,47 @@
+/**
+ * Which quick-filter pills a dashboard offers.
+ *
+ * The pills are filter toggles, not decoration, and a dashboard that never
+ * checks anything out has no use for the checked-out one. The card config names
+ * the pills it wants; `null` — the omitted key — means every pill, which is what
+ * every existing dashboard gets.
+ *
+ * This only decides what is *allowed*. Whether an allowed pill actually shows is
+ * still the count's call: a pill reading "0 low" was never drawn and is not
+ * drawn now. Both surfaces read the same list, so the card and the full view
+ * offer one vocabulary rather than two.
+ */
+
+export const QUICK_FILTER_KEYS = [
+  'total',
+  'low_stock',
+  'overdue',
+  'inspection_due',
+  'checked_out',
+] as const;
+
+export type QuickFilterKey = (typeof QUICK_FILTER_KEYS)[number];
+
+/**
+ * Read the `quick_filters` config value.
+ *
+ * Anything that is not a list of known names reads as "not configured" rather
+ * than as an error: a dashboard must not break on a key this card does not
+ * understand, which is the same philosophy `setConfig` already applies to every
+ * other key. An explicit empty list is a choice, though, and is honoured.
+ */
+export function normalizeQuickFilters(value: unknown): QuickFilterKey[] | null {
+  if (!Array.isArray(value)) return null;
+  const known = new Set<string>(QUICK_FILTER_KEYS);
+  const out: QuickFilterKey[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !known.has(entry)) continue;
+    if (!out.includes(entry as QuickFilterKey)) out.push(entry as QuickFilterKey);
+  }
+  return out;
+}
+
+/** True when this pill may be drawn at all — the count still has the last word. */
+export function quickFilterAllowed(allowed: QuickFilterKey[] | null, key: QuickFilterKey): boolean {
+  return allowed === null || allowed.includes(key);
+}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -23,9 +23,17 @@ the `Store` (created on the first `hass` assignment), the Lovelace interface
 substance:
 
 ```ts
-setConfig(cfg) → { title?: string }   // every other key is ignored, not rejected
+setConfig(cfg) → { title?: string; quickFilters?: QuickFilterKey[] | null }
+                                      // every other key is ignored, not rejected
 render()       → <hv-card-shell>
 ```
+
+`quick_filters` names the quick-filter pills the dashboard offers (`ui/quick-filters.ts`
+holds the vocabulary). `null` — the omitted key, or anything that is not a list — means
+all of them. The shell passes it to `hv-full-view` unchanged, so the card's badges and the
+full view's pills offer one vocabulary; the sidebar panel, which has no dashboard config,
+takes the default. It decides what is *allowed*: whether an allowed pill draws is still
+the count's call.
 
 It also publishes the active HA theme as `color-scheme` on the host, which every nested
 component inherits.


### PR DESCRIPTION
## Summary

P4 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`), and the last of Session A.

**Stacked PR — merge in order: #336 → #337 → #338 → this.** Base is #338 (P3). After #338 squash-merges, this branch is rebased onto `main` (`git rebase --onto origin/main claude/session-a-frontend-packages-s4u4m3-p3`) before it merges; the local verification session does that rebase as part of its pass.

A new optional card-config key, `quick_filters`: a list drawn from `total`, `low_stock`, `overdue`, `inspection_due`, `checked_out`.

- **Nothing breaks on it.** Omitted = all pills, which is what every existing dashboard gets. An unknown entry is dropped, a non-list value reads as the key being absent, and neither throws — `setConfig`'s stated philosophy, applied inside the key as well as around it. An explicit empty list is a choice and offers none.
- **Allowed is not shown.** The config governs which pills are *offered*; the count gate each pill always had still decides whether it draws. A pill reading "0 low" was never drawn and is not drawn now. The phone badge band still collapses to nothing rather than leaving a blank strip under the title — now counting only the allowed pills.
- **One vocabulary, both surfaces** (decision 5). The shell hands the list to `hv-full-view`, so the card's app-bar badges and the full view's count pills agree. `total` has no full-view pill to gate; that surface has four. The sidebar panel has no dashboard config of its own and takes the default.

The vocabulary and the two predicates live in `src/ui/quick-filters.ts` so neither surface owns the list.

Closes #241

Note for later: the visual config editor staged in #222 picks this key up when it is built. Nothing is built for it here.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1485 passed), `npm run build`

New coverage: `normalizeQuickFilters` / `quickFilterAllowed` as units (omitted, garbage, dedupe, unknown entries, explicit empty, every documented name); `setConfig` through the real `haventory-card` element — omitted / subset / unknown entry / non-list garbage / empty list, none throwing; the shell — default draws all, a subset draws only those, an allowed-but-zero pill still hides, the phone band collapses when the subset leaves nothing and survives when it does not, and the list reaches the full view; the full view — default, subset, and the count gate still holding.

Docs: README's card-configuration section gains a config table, a YAML example and the allowed-vs-shown distinction; `docs/frontend_architecture.md`'s entry-point section states the `setConfig` shape and where the vocabulary lives.

### Delegated to the local verification session

Editing the card YAML in the dev dashboard: no key → all pills, a two-entry list → exactly those, an unknown entry ignored without console errors, on the shell and the full view alike. Screenshots light + dark of a subset config. Checklist P4 in the plan's §Verification.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (README config table + example, `docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_015S8wt52QKqXQvTjBLoz6ah)_