### PR TITLE
fix(card): host dialogs switch on the viewport, not the card width; phone-sheet parity for the small dialogs

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1,5 +1,5 @@
 import './hv-card-shell';
-import { makeMockHass, makeItem } from '../test.utils';
+import { makeMockHass, makeItem, stubViewport } from '../test.utils';
 import { base, tokens } from '../ui/tokens';
 import { Store } from '../store/store';
 import type { HVCardShell } from './hv-card-shell';
@@ -1660,6 +1660,61 @@ describe('hv-card-shell: full view', () => {
 
     expect((sr.querySelector('hv-column-picker') as HTMLElement & { open: boolean }).open).toBe(true);
     expect(seen).toEqual([]);
+  });
+});
+
+// A dialog is `position: fixed`, so it is laid out against the window and not
+// against the card that opened it. Feeding it the card's measured width put the
+// organize dialog in its full-bleed phone page on a desktop monitor, from every
+// surface — a card in a dashboard column is 300–500px wide, and expanding it
+// changed nothing because the measured element was still the card underneath.
+describe('hv-card-shell: host dialogs follow the viewport, not the card', () => {
+  const HOSTED = ['host-columns', 'host-confirm', 'host-organize', 'host-import', 'host-diagnostics'];
+
+  it('leaves them centred for a narrow card in a wide window', async () => {
+    const restore = stubViewport(false);
+    try {
+      const { sr } = await mountShell({ items: [makeItem({ id: '1' })], mobile: true });
+      for (const id of HOSTED) {
+        expect(sr.querySelector(`[data-testid="${id}"]`)?.hasAttribute('mobile'), id).toBe(false);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('gives every one of them the phone form on a phone viewport', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { sr } = await mountShell({ items: [makeItem({ id: '1' })], mobile: false });
+      for (const id of HOSTED) {
+        expect(sr.querySelector(`[data-testid="${id}"]`)?.hasAttribute('mobile'), id).toBe(true);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('stops listening to the viewport once the card is gone', async () => {
+    const removed: string[] = [];
+    const original = window.matchMedia;
+    window.matchMedia = ((media: string) => ({
+      matches: true,
+      media,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: (type: string) => removed.push(type),
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    try {
+      const { el } = await mountShell({ items: [] });
+      el.remove();
+      expect(removed).toContain('change');
+    } finally {
+      window.matchMedia = original;
+    }
   });
 });
 

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -380,7 +380,6 @@ export class HVCardShell extends LitElement {
 
   /** The dialogs both hosts share — confirm, organize, import, diagnostics. */
   readonly surfaces = new HostSurfaces(this, () => this.store, {
-    isMobile: () => this.mobile,
     onItemDeleted: (itemId) => {
       if (this._editing === itemId) this._editing = null;
       if (this._detailItemId === itemId) this._detailItemId = null;
@@ -440,6 +439,7 @@ export class HVCardShell extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+    this.surfaces.connect();
     this._filterPanelOpen = readPanelPref();
     if (this.store && !this._storeUnsub) {
       // The parent passes a stable `store` object, so a property binding would
@@ -450,6 +450,7 @@ export class HVCardShell extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    this.surfaces.disconnect();
     this._storeUnsub?.();
     this._storeUnsub = undefined;
   }

--- a/cards/haventory-card/src/components/hv-column-picker.test.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.test.ts
@@ -180,11 +180,15 @@ describe('hv-column-picker', () => {
     const el = await mount({ columns: [] });
     const styles = (customElements.get('hv-column-picker') as typeof HVColumnPicker).styles;
     const sheets = Array.isArray(styles) ? styles : [styles];
-    // The component's own block is last; the tokens sheet ahead of it is where
-    // HA's variables are legitimately read.
-    const own = String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+    // The component's own block — the tokens sheet ahead of it is where HA's
+    // variables are legitimately read, and the shared phone-sheet block after
+    // it declares no colours at all.
+    const own = sheets
+      .map((s) => String(s.cssText).replace(/\s+/g, ' '))
+      .find((c) => c.includes('.option {')) as string;
 
     expect(sheets.length).toBeGreaterThan(1);
+    expect(own, 'the component block').toBeTruthy();
     expect(own).toMatch(/\.panel \{[^}]*border-radius: var\(--hv-radius-dialog\)/);
     expect(own).toMatch(/\.option \{[^}]*min-height: var\(--hv-tap-min, 34px\)/);
     // Nothing reaches past the tokens to HA's own variables any more.

--- a/cards/haventory-card/src/components/hv-column-picker.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { dialogSheet } from '../ui/dialog-sheet';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { nextZBase } from '../utils/zindex';
@@ -38,7 +39,7 @@ export class HVColumnPicker extends LitElement {
         inset: 0;
         background: rgba(0, 0, 0, 0.35);
       }
-      .panel-wrap {
+      .wrap {
         position: fixed;
         inset: 0;
         display: grid;
@@ -148,9 +149,12 @@ export class HVColumnPicker extends LitElement {
         margin-right: auto;
       }
     `,
+    dialogSheet,
   ];
 
   @property({ type: Boolean, reflect: true }) open: boolean = false;
+  /** Phone viewport: rise from the bottom edge instead of centring. */
+  @property({ type: Boolean, reflect: true }) mobile = false;
   @property({ attribute: false }) columns: ColumnKey[] = [];
   @property({ type: String }) heading: string = 'Columns';
 
@@ -224,7 +228,7 @@ export class HVColumnPicker extends LitElement {
     const isCanonical = ordered.join() === canonicalOrder(ordered).join();
     return html`
       <div class="backdrop" role="presentation" style="z-index: ${this._zBase ?? 9998};" @click=${this._close}></div>
-      <div class="panel-wrap" role="none" style="z-index: ${(this._zBase ?? 9998) + 1};">
+      <div class="wrap" role="none" style="z-index: ${(this._zBase ?? 9998) + 1};">
         <div class="panel" role="dialog" aria-modal="true" aria-label="Column selection"
           @keydown=${onEscape(() => this._close())}>
           <h2>${this.heading}</h2>

--- a/cards/haventory-card/src/components/hv-confirm.ts
+++ b/cards/haventory-card/src/components/hv-confirm.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { dialogSheet } from '../ui/dialog-sheet';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { nextZBase } from '../utils/zindex';
@@ -84,9 +85,12 @@ export class HVConfirm extends LitElement {
         opacity: 0.9;
       }
     `,
+    dialogSheet,
   ];
 
   @property({ type: Boolean, reflect: true }) open = false;
+  /** Phone viewport: rise from the bottom edge instead of centring. */
+  @property({ type: Boolean, reflect: true }) mobile = false;
   @property({ type: String }) heading = 'Are you sure?';
   @property({ type: String }) message = '';
   /** Optional warning strip rendered above the actions. */

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { dialogSheet } from '../ui/dialog-sheet';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
@@ -206,9 +207,12 @@ export class HVDiagnosticsPanel extends LitElement {
         font: 500 13.5px var(--hv-font);
       }
     `,
+    dialogSheet,
   ];
 
   @property({ type: Boolean, reflect: true }) open = false;
+  /** Phone viewport: rise from the bottom edge instead of centring. */
+  @property({ type: Boolean, reflect: true }) mobile = false;
   @property({ attribute: false }) health: HealthResult | null = null;
   @property({ attribute: false }) counts: StatsCounts | null = null;
   @property({ attribute: false }) version: VersionInfo | null = null;

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,7 +1,7 @@
 import './hv-full-view';
-import { NARROW_QUERY } from './hv-full-view';
-import { makeMockHass, makeItem } from '../test.utils';
+import { makeMockHass, makeItem, stubViewport } from '../test.utils';
 import { deepActiveElement } from '../ui/dialog-focus';
+import { NARROW_QUERY } from '../ui/responsive';
 import { Store } from '../store/store';
 import type { HVFullView } from './hv-full-view';
 import type { Item, Location, StatusDefinition } from '../store/types';
@@ -1272,24 +1272,6 @@ describe('hv-full-view: editing', () => {
 // so at 375px the expanded view drew the editor's three-column desktop grid in
 // 156px + 78px + 78px, with "Low-stock at" wrapping over its own field.
 describe('hv-full-view: phone-width children', () => {
-  /** jsdom's matchMedia always reports false, so the breakpoint is stubbed. */
-  const stubViewport = (matches: boolean) => {
-    const original = window.matchMedia;
-    window.matchMedia = ((media: string) => ({
-      matches,
-      media,
-      onchange: null,
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      addListener: () => {},
-      removeListener: () => {},
-      dispatchEvent: () => false,
-    })) as unknown as typeof window.matchMedia;
-    return () => {
-      window.matchMedia = original;
-    };
-  };
-
   it('tells the item editor when it is on a phone', async () => {
     const restore = stubViewport(true);
     try {
@@ -1685,6 +1667,28 @@ describe('hv-full-view: selection and bulk actions', () => {
     await settle(el);
     await settle(el);
     expect(store.state.value.items).toHaveLength(0);
+  });
+
+  // This view's own confirm belongs to the same family as the dialogs the host
+  // owns: one width flips every overlay, so a phone never shows a centred box
+  // over sheets.
+  it('raises its delete confirm as a sheet on a phone viewport', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
+      el.menuEntries = withSelectEntry.entries;
+      await settle(el);
+      await enterSelection(el, sr);
+
+      (table(sr).shadowRoot?.querySelector('[data-testid="table-select-all"]') as HTMLButtonElement).click();
+      await settle(el);
+      (bulkBar(sr).shadowRoot?.querySelector('[data-action="delete"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      expect(q(sr, '[data-testid="bulk-confirm"]')?.hasAttribute('mobile')).toBe(true);
+    } finally {
+      restore();
+    }
   });
 
   it('leaves everything alone when the delete is cancelled', async () => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -18,6 +18,7 @@ import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
+import { NARROW_QUERY } from '../ui/responsive';
 import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
@@ -40,22 +41,6 @@ import type { HVLocationTree } from './hv-location-tree';
 import type { HVFilterPanel } from './hv-filter-panel';
 
 const SEARCH_DEBOUNCE_MS = 200;
-
-/**
- * The phone breakpoint, in JS.
- *
- * This surface fills the viewport rather than being sized by the card, so its
- * own layout switches on the `@media (max-width: 700px)` block below. Its two
- * biggest children take their layout from a `mobile` *property* instead, which
- * only the card ever set — so at 375px the expanded view drew the item editor's
- * three-column desktop grid in 156px + 78px + 78px, with "Low-stock at" wrapping
- * over its own field and Category too narrow to show a value. A media query
- * cannot set a property, so the same breakpoint is read here and handed down.
- *
- * Keep this string and the media query in agreement. Exported so the sidebar
- * panel can put the dialogs it hosts on the same breakpoint as this view.
- */
-export const NARROW_QUERY = '(max-width: 700px)';
 
 /** The sidebar's collapsible sections, in the order they appear. */
 type SidebarSection = 'locations' | 'status' | 'categories' | 'tags';
@@ -814,7 +799,16 @@ export class HVFullView extends LitElement {
     categories: true,
     tags: true,
   };
-  /** True on a phone-width viewport — see NARROW_QUERY. */
+  /**
+   * True on a phone-width viewport (`NARROW_QUERY`).
+   *
+   * This surface switches its own layout on the matching `@media` block below,
+   * but its two biggest children take theirs from a `mobile` *property*, which
+   * only the card ever set — so at 375px the expanded view drew the item
+   * editor's three-column desktop grid in 156px + 78px + 78px, with "Low-stock
+   * at" wrapping over its own field. A media query cannot set a property, so
+   * the same breakpoint is read here and handed down.
+   */
   @state() private _narrow = false;
   /**
    * The staged filter set's match count, so the phone footer's button can say
@@ -1934,6 +1928,7 @@ export class HVFullView extends LitElement {
         <hv-confirm
           data-testid="bulk-confirm"
           ?open=${this._pendingDelete}
+          ?mobile=${this._narrow}
           .heading=${`Delete ${counted(selection.size, 'item')}?`}
           message="This cannot be undone. Items are removed for every connected client. Locations and tags are not affected."
           .warning=${this._checkedOutWarning}

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
+import { dialogSheet } from '../ui/dialog-sheet';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
@@ -301,9 +302,12 @@ export class HVImportSheet extends LitElement {
         gap: 10px;
       }
     `,
+    dialogSheet,
   ];
 
   @property({ type: Boolean, reflect: true }) open = false;
+  /** Phone viewport: rise from the bottom edge instead of centring. */
+  @property({ type: Boolean, reflect: true }) mobile = false;
   @property({ attribute: false }) preview: ImportPreview | null = null;
   @property({ attribute: false }) summary: ImportSummary | null = null;
   @property({ type: Boolean }) busy = false;

--- a/cards/haventory-card/src/components/hv-overflow-menu.test.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.test.ts
@@ -1,5 +1,6 @@
 import './hv-overflow-menu';
 import type { HVOverflowMenu } from './hv-overflow-menu';
+import { NARROW_QUERY } from '../ui/responsive';
 
 async function mount(entries: HVOverflowMenu['entries']) {
   const el = document.createElement('hv-overflow-menu') as HVOverflowMenu;
@@ -71,10 +72,20 @@ describe('hv-overflow-menu: narrow screens', () => {
       .map((s) => String(s.cssText))
       .join('\n')
       .replace(/\s+/g, ' ');
-    const start = css.indexOf('@media (max-width: 600px)');
+    const start = css.indexOf(`@media ${NARROW_QUERY}`);
     expect(start, 'no narrow-viewport block').toBeGreaterThan(-1);
     return css.slice(start);
   };
+
+  // The card once carried three phone breakpoints — this menu at 600px, the
+  // card element at 600px and the full view's viewport at 700px — so a window
+  // between them showed a sheet menu over centred dialogs. Every overlay now
+  // flips at the one viewport width; CSS cannot read the constant, so the two
+  // spellings are pinned to each other here.
+  it('rises at the same viewport width as every other overlay', () => {
+    expect(NARROW_QUERY).toBe('(max-width: 700px)');
+    expect(narrow()).toContain('@media (max-width: 700px)');
+  });
 
   // A 250px anchored dropdown covered most of the list it was acting on, and
   // "Export current view" wrapped onto two lines inside it.

--- a/cards/haventory-card/src/components/hv-overflow-menu.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.ts
@@ -139,12 +139,17 @@ export class HVOverflowMenu extends LitElement {
          position: fixed it is placed against the viewport, so the viewport is
          what decides whether there is room — and it keeps the component free
          of a mobile property that all three of its callers would have to
-         thread through. */
+         thread through.
+
+         The width is NARROW_QUERY from ui/responsive.ts, which CSS cannot
+         read; a test pins the two spellings together. Every overlay the card
+         hosts flips at that one width, so a viewport never shows a sheet menu
+         over a centred dialog. */
       /* The dropdown form needs no scrim; only the sheet dims the page. */
       .scrim {
         display: none;
       }
-      @media (max-width: 600px) {
+      @media (max-width: 700px) {
         .menu {
           position: fixed;
           inset: auto 0 0 0;
@@ -167,9 +172,9 @@ export class HVOverflowMenu extends LitElement {
          * as a menu with no surface of its own. A sibling with its own z-index
          * paints where a backdrop belongs.
          *
-         * pointer-events: none is load-bearing: the menu closes on any outside
-         * pointerdown, and that check asks whether the event's composed path
-         * includes this element — a scrim that swallowed the tap would be
+         * pointer-events: none is what keeps the menu closable: it closes on any
+         * outside pointerdown, and that check asks whether the event's composed
+         * path includes this element — a scrim that swallowed the tap would be
          * inside the path and would stop the menu closing when you tapped away
          * from it.
          */

--- a/cards/haventory-card/src/haventory-panel.test.ts
+++ b/cards/haventory-card/src/haventory-panel.test.ts
@@ -1,5 +1,5 @@
 import './haventory-panel';
-import { makeMockHass, makeItem } from './test.utils';
+import { makeMockHass, makeItem, stubViewport } from './test.utils';
 import { COLUMN_PREFS_STORAGE_KEY, DEFAULT_COLUMNS } from './store/columns';
 import type { HAventoryPanel } from './haventory-panel';
 
@@ -346,6 +346,33 @@ describe('haventory-panel: the shared dialog surfaces', () => {
     raise(view(), { id: 'diagnostics' });
     await settle(el);
     expect(dialog(sr, 'host-diagnostics').open).toBe(true);
+  });
+
+  // The panel used to hold its own `matchMedia` subscription and hand the answer
+  // to the dialogs; it now shares the one the surfaces keep, so the page and the
+  // card agree at a single width without either owning the query.
+  it('hands every dialog the phone form on a phone viewport', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { sr } = await mountPanel();
+      for (const id of ['host-columns', 'host-confirm', 'host-organize', 'host-import', 'host-diagnostics']) {
+        expect(dialog(sr, id).hasAttribute('mobile'), id).toBe(true);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps them centred on a desktop viewport', async () => {
+    const restore = stubViewport(false);
+    try {
+      const { sr } = await mountPanel();
+      for (const id of ['host-columns', 'host-confirm', 'host-organize', 'host-import', 'host-diagnostics']) {
+        expect(dialog(sr, id).hasAttribute('mobile'), id).toBe(false);
+      }
+    } finally {
+      restore();
+    }
   });
 });
 

--- a/cards/haventory-card/src/haventory-panel.ts
+++ b/cards/haventory-card/src/haventory-panel.ts
@@ -8,7 +8,6 @@ import { defineCardElement } from './register';
 import { HostSurfaces } from './host-surfaces';
 import type { OrganizeTab } from './components/hv-organize-dialog';
 import './components/hv-full-view';
-import { NARROW_QUERY } from './components/hv-full-view';
 
 /** The slice of Home Assistant's panel object this element reads. */
 interface PanelInfo {
@@ -54,19 +53,16 @@ export class HAventoryPanel extends LitElement {
   private store?: Store;
   private _storeUnsub?: () => void;
   private _hass?: HassLike;
-  private _phoneQuery?: MediaQueryList | null;
-  private readonly _onPhoneChange = () => this.requestUpdate();
 
   /**
    * No `onItemDeleted` hook — the embedded view closes its own editor when the
    * item vanishes. No `onBrowse` — the full view here is the page itself, so
    * there is nothing to open when the organize dialog hands back a filter.
+   *
+   * The dialogs read the viewport themselves, and deliberately not HA's
+   * `narrow` — that flag is about the sidebar and flips at a tablet width.
    */
-  readonly surfaces = new HostSurfaces(this, () => this.store, {
-    // The dialogs share the embedded view's own phone breakpoint, not HA's
-    // `narrow` — that flag is about the sidebar and flips at a tablet width.
-    isMobile: () => this._phoneQuery?.matches ?? false,
-  });
+  readonly surfaces = new HostSurfaces(this, () => this.store);
 
   get hass(): HassLike | undefined {
     return this._hass;
@@ -97,8 +93,7 @@ export class HAventoryPanel extends LitElement {
         this.requestUpdate();
       });
     }
-    this._phoneQuery ??= window.matchMedia?.(NARROW_QUERY) ?? null;
-    this._phoneQuery?.addEventListener('change', this._onPhoneChange);
+    this.surfaces.connect();
     this._syncColorScheme();
   }
 
@@ -108,7 +103,7 @@ export class HAventoryPanel extends LitElement {
       this._storeUnsub();
       this._storeUnsub = undefined;
     }
-    this._phoneQuery?.removeEventListener('change', this._onPhoneChange);
+    this.surfaces.disconnect();
   }
 
   firstUpdated(): void {

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -6,6 +6,7 @@ import { activeFilterCount, defaultFilters } from './store/store';
 import type { Store } from './store/store';
 import type { ImportPolicy, ImportPreview, ImportSummary } from './store/types';
 import { counted, plural } from './ui/plural';
+import { NARROW_QUERY } from './ui/responsive';
 import type { OrganizeTab } from './components/hv-organize-dialog';
 import type { OverflowMenuEntry } from './components/hv-overflow-menu';
 import './components/hv-column-picker';
@@ -30,8 +31,6 @@ interface ConfirmSpec {
 
 /** The ways a host differs; everything else in these surfaces is identical. */
 interface SurfaceHooks {
-  /** Phone layout for the dialogs that adapt. Defaults to desktop. */
-  isMobile?: () => boolean;
   /**
    * A confirmed delete has been sent. The host closes any editor or sheet still
    * pointing at the item, before the store broadcasts its disappearance.
@@ -72,6 +71,22 @@ export class HostSurfaces {
   private readonly host: SurfaceHost;
   private readonly getStore: () => Store | undefined;
   private readonly hooks: SurfaceHooks;
+  /**
+   * The phone predicate for every dialog here, measured against the viewport.
+   *
+   * Not the card's width: these are `position: fixed`, so they are laid out
+   * against the window whatever the card measures. The card side used to hand
+   * its own measurement in, which put the organize dialog in its full-bleed
+   * phone page whenever the card sat in a normal dashboard column — on a
+   * desktop monitor, from a card, from the expanded view and unchanged by
+   * expanding, because the measured element was still the card underneath.
+   */
+  private narrowQuery: MediaQueryList | null = null;
+  private narrow = false;
+  private readonly onNarrowChange = (e: MediaQueryListEvent) => {
+    this.narrow = e.matches;
+    this.host.requestUpdate();
+  };
   private pickerOpen = false;
   private confirmSpec: ConfirmSpec | null = null;
   private organizeOpen = false;
@@ -87,6 +102,27 @@ export class HostSurfaces {
     this.host = host;
     this.getStore = getStore;
     this.hooks = hooks;
+  }
+
+  /**
+   * Start watching the viewport. Hosts call this from `connectedCallback`, and
+   * `disconnect()` from the matching teardown — an instance is a plain object
+   * rather than a reactive controller, so it has no lifecycle of its own, and a
+   * listener left behind would keep waking a detached element.
+   *
+   * `matchMedia` is missing in jsdom unless a test provides one; without it the
+   * dialogs take their desktop form, which is the honest default for a host
+   * that cannot say how wide it is.
+   */
+  connect(): void {
+    this.narrowQuery ??= window.matchMedia?.(NARROW_QUERY) ?? null;
+    if (!this.narrowQuery) return;
+    this.narrow = this.narrowQuery.matches;
+    this.narrowQuery.addEventListener('change', this.onNarrowChange);
+  }
+
+  disconnect(): void {
+    this.narrowQuery?.removeEventListener('change', this.onNarrowChange);
   }
 
   /**
@@ -227,10 +263,12 @@ export class HostSurfaces {
   /** Every dialog these surfaces own. Render once, after the host's main UI. */
   renderSurfaces(): TemplateResult {
     const st = this.getStore()?.state.value ?? null;
-    const mobile = this.hooks.isMobile?.() ?? false;
+    const mobile = this.narrow;
     return html`
       <hv-column-picker
+        data-testid="host-columns"
         .open=${this.pickerOpen}
+        ?mobile=${mobile}
         .columns=${this.columns}
         heading="Full view columns"
         @change=${(e: CustomEvent) => this.setColumns((e.detail as { columns: ColumnKey[] }).columns)}
@@ -243,6 +281,7 @@ export class HostSurfaces {
       <hv-confirm
         data-testid="host-confirm"
         ?open=${this.confirmSpec !== null}
+        ?mobile=${mobile}
         .heading=${this.confirmSpec?.heading ?? ''}
         .message=${this.confirmSpec?.message ?? ''}
         .confirmLabel=${this.confirmSpec?.confirmLabel ?? 'Delete'}
@@ -274,6 +313,7 @@ export class HostSurfaces {
       <hv-import-sheet
         data-testid="host-import"
         ?open=${this.importOpen}
+        ?mobile=${mobile}
         .preview=${this.importPreview}
         .summary=${this.importSummary}
         .busy=${this.importBusy}
@@ -298,6 +338,7 @@ export class HostSurfaces {
       <hv-diagnostics-panel
         data-testid="host-diagnostics"
         ?open=${this.diagnosticsOpen}
+        ?mobile=${mobile}
         .health=${st?.healthCache ?? null}
         .counts=${st?.statsCounts ?? null}
         .version=${st?.versionInfo ?? null}

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -922,3 +922,29 @@ export function makeMediaBindings(
     },
   };
 }
+
+/**
+ * Pin `window.matchMedia` to one answer for the length of a test, and hand back
+ * the restore.
+ *
+ * jsdom performs no layout, so every media query it is asked about reports
+ * `false` — which reads as "desktop viewport" to the overlays that switch on
+ * one, and leaves their phone form untestable. Call the restore in a `finally`
+ * so the next test starts from the real implementation.
+ */
+export function stubViewport(matches: boolean): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = ((media: string) => ({
+    matches,
+    media,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}

--- a/cards/haventory-card/src/ui/dialog-sheet.test.ts
+++ b/cards/haventory-card/src/ui/dialog-sheet.test.ts
@@ -1,0 +1,79 @@
+import type { CSSResult } from 'lit';
+import '../components/hv-column-picker';
+import '../components/hv-confirm';
+import '../components/hv-diagnostics-panel';
+import '../components/hv-import-sheet';
+
+/**
+ * The four host dialogs, which have to end up alike: on a phone the card raises
+ * its filter panel, its detail sheet and its ⋮ menu from the bottom edge, and
+ * these four arrived as small centred boxes in the middle of the same screen.
+ */
+const DIALOGS = ['hv-column-picker', 'hv-confirm', 'hv-import-sheet', 'hv-diagnostics-panel'] as const;
+
+const cssOf = (tag: string) => {
+  const styles = (customElements.get(tag) as unknown as { styles: CSSResult | CSSResult[] }).styles;
+  return (Array.isArray(styles) ? styles : [styles])
+    .map((s) => String(s.cssText))
+    .join('\n')
+    .replace(/\s+/g, ' ');
+};
+
+const mount = async (tag: string, mobile: boolean) => {
+  const el = document.createElement(tag) as HTMLElement & { open: boolean; mobile: boolean };
+  el.open = true;
+  el.mobile = mobile;
+  document.body.appendChild(el);
+  await customElements.whenDefined(tag);
+  await (el as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+  return el;
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('host dialogs: one phone presentation', () => {
+  it('rises from the bottom edge, full width, under mobile', () => {
+    for (const tag of DIALOGS) {
+      const css = cssOf(tag);
+      expect(css, tag).toMatch(/:host\(\[mobile\]\) \.wrap \{[^}]*place-items: end stretch/);
+      expect(css, tag).toMatch(/:host\(\[mobile\]\) \.panel \{[^}]*width: 100%/);
+      expect(css, tag).toMatch(
+        /:host\(\[mobile\]\) \.panel \{[^}]*border-radius: var\(--hv-radius-sheet\) var\(--hv-radius-sheet\) 0 0/,
+      );
+      expect(css, tag).toMatch(/:host\(\[mobile\]\) \.panel \{[^}]*box-shadow: var\(--hv-shadow-sheet\)/);
+    }
+  });
+
+  it('keeps the centred dialog when it is not on a phone', () => {
+    for (const tag of DIALOGS) {
+      const css = cssOf(tag);
+      expect(css, tag).toMatch(/[^)] \.wrap \{[^}]*place-items: center/);
+      expect(css, tag).toMatch(/[^)] \.panel \{[^}]*border-radius: var\(--hv-radius-dialog\)/);
+    }
+  });
+
+  // The flag has to reach the shadow root as an attribute or none of the rules
+  // above can match — a property alone selects nothing.
+  it('reflects the flag so :host([mobile]) applies', async () => {
+    for (const tag of DIALOGS) {
+      const phone = await mount(tag, true);
+      expect(phone.hasAttribute('mobile'), tag).toBe(true);
+      phone.remove();
+
+      const desktop = await mount(tag, false);
+      expect(desktop.hasAttribute('mobile'), tag).toBe(false);
+      desktop.remove();
+    }
+  });
+
+  // A sheet sits against the bottom edge, where a phone's home indicator is.
+  it('clears the safe area under the bottom row of actions', () => {
+    for (const tag of DIALOGS) {
+      expect(cssOf(tag), tag).toMatch(
+        /:host\(\[mobile\]\) \.panel \{[^}]*padding-bottom: max\(12px, env\(safe-area-inset-bottom\)\)/,
+      );
+    }
+  });
+});

--- a/cards/haventory-card/src/ui/dialog-sheet.ts
+++ b/cards/haventory-card/src/ui/dialog-sheet.ts
@@ -1,0 +1,55 @@
+import { css } from 'lit';
+
+/**
+ * The phone presentation shared by the host dialogs: `hv-column-picker`,
+ * `hv-confirm`, `hv-import-sheet` and `hv-diagnostics-panel`.
+ *
+ * A centred 330–500px box is a desktop shape. At 390px it leaves a strip of
+ * page either side of a dialog that is effectively full width anyway, and it
+ * arrives from the middle of the screen while the filter panel, the detail
+ * sheet and the ⋮ menu all rise from the bottom edge — the same interaction
+ * with two different manners. Under `mobile` these four take the bottom-sheet
+ * form instead, so one gesture vocabulary covers every surface on a phone.
+ *
+ * Added to a component's `static styles` rather than wrapping `hv-bottom-sheet`:
+ * each of these dialogs already owns its focus handling, Escape binding and
+ * z-order (`nextZBase()`, which is what keeps a confirm above the sheet that
+ * raised it), and moving their content into a slot would rebuild all three for
+ * a change that is presentational. Each host declares the same two class names
+ * — `.wrap` for the centring layer, `.panel` for the box — and this restyles
+ * those.
+ */
+export const dialogSheet = css`
+  :host([mobile]) .wrap {
+    padding: 0;
+    /* Stretched across the bottom edge, not centred in the middle of it. */
+    place-items: end stretch;
+  }
+  :host([mobile]) .panel {
+    width: 100%;
+    max-width: none;
+    /* dvh, not vh: on a phone vh resolves against the viewport with the browser
+       chrome retracted, so a tall sheet could stand higher than the screen
+       actually showing and push its actions under the URL bar. */
+    max-height: 92dvh;
+    border-radius: var(--hv-radius-sheet) var(--hv-radius-sheet) 0 0;
+    box-shadow: var(--hv-shadow-sheet);
+    /* Clears the home indicator on a phone that reports one, and gives the
+       bottom row of actions a thumb's worth of air on one that does not. */
+    padding-bottom: max(12px, env(safe-area-inset-bottom));
+    animation: hv-sheet-rise var(--hv-motion-sheet) var(--hv-ease-out);
+  }
+  :host([mobile]) .backdrop {
+    background: var(--hv-scrim);
+  }
+  @keyframes hv-sheet-rise {
+    from {
+      transform: translateY(16px);
+      opacity: 0;
+    }
+    to {
+      transform: none;
+      opacity: 1;
+    }
+  }
+`;

--- a/cards/haventory-card/src/ui/responsive.test.ts
+++ b/cards/haventory-card/src/ui/responsive.test.ts
@@ -1,4 +1,4 @@
-import { MOBILE_BREAKPOINT, ResponsiveController } from './responsive';
+import { MOBILE_BREAKPOINT, NARROW_QUERY, ResponsiveController } from './responsive';
 
 function makeHost() {
   const el = document.createElement('div') as HTMLDivElement & {
@@ -72,5 +72,15 @@ describe('ResponsiveController', () => {
     expect(c.mobile).toBe(false);
     c.setWidth(420);
     expect(c.mobile).toBe(true);
+  });
+});
+
+// Two breakpoints, two questions: the card's own width decides in-card layout,
+// the viewport decides what an overlay does. Feeding the card measurement to a
+// dialog is what put the full-bleed organize page on a desktop monitor.
+describe('NARROW_QUERY', () => {
+  it('is a viewport query, distinct from the card-element breakpoint', () => {
+    expect(NARROW_QUERY).toBe('(max-width: 700px)');
+    expect(NARROW_QUERY).not.toContain(String(MOBILE_BREAKPOINT));
   });
 });

--- a/cards/haventory-card/src/ui/responsive.ts
+++ b/cards/haventory-card/src/ui/responsive.ts
@@ -7,6 +7,24 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 export const MOBILE_BREAKPOINT = 600;
 
 /**
+ * Viewport width at or below which a surface that covers the screen takes its
+ * phone form.
+ *
+ * Two breakpoints live here because they answer two different questions.
+ * `MOBILE_BREAKPOINT` measures the card *element*, which is what in-card layout
+ * depends on: a card in a dashboard column is 300–500px wide inside a 1920px
+ * window, and its list, steppers and in-card sheets have to lay out for that
+ * width. An overlay is placed against the viewport instead — `position: fixed`
+ * ignores the card entirely — so the card's width says nothing about the room
+ * an overlay has. Dialogs, menus and sheets use this query; everything drawn
+ * inside the card's own box keeps the element measurement.
+ *
+ * `hv-full-view` and `hv-overflow-menu` spell the same width as a CSS `@media`
+ * block, which cannot read a constant. Tests pin the two spellings together.
+ */
+export const NARROW_QUERY = '(max-width: 700px)';
+
+/**
  * Drives the card's mobile/desktop mode from its own rendered width.
  *
  * Media queries are unreliable inside HA dashboards — a card can be narrow in a

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -57,7 +57,10 @@ Both hosts hold a `HostSurfaces` instance (`src/host-surfaces.ts`): every surfac
 the delete/discard confirmation, the organize dialog, the import sheet, the diagnostics
 panel with its refresh state, and the shared ⋮ menu-entry builder. On the card side the
 instance lives in `hv-card-shell`; on the panel it lives in the panel element directly.
-Host differences enter as constructor hooks (`isMobile`, `onItemDeleted`, `onBrowse`).
+Host differences enter as constructor hooks (`onItemDeleted`, `onBrowse`). The phone form of
+those dialogs is not one of them: the instance watches the viewport itself (`NARROW_QUERY`,
+started and stopped from each host's connected/disconnected callbacks) and hands the same
+answer to all five, so the card and the panel cannot disagree about what a phone is.
 
 ---
 
@@ -115,18 +118,33 @@ open `hv-organize-dialog` on the matching tab (`menu-action` with `{ id: 'organi
 
 ### Two different "is this a phone?" signals
 
-Most components take a `mobile` **property** fed by `hv-card-shell`'s *measured width* — a
-card in a narrow dashboard column is a phone layout regardless of the viewport. `hv-full-view`
-is the exception: it is fixed to the viewport, so it switches on a `@media (max-width: 700px)`
-query instead.
+Two questions, two answers, and they are not interchangeable:
 
-That split bit once. `hv-item-editor` and `hv-filter-panel` are property-driven but are also
+- **How wide is the card?** `MOBILE_BREAKPOINT` (600px), measured on the element by
+  `ResponsiveController` and handed down as a `mobile` **property**. Everything drawn inside
+  the card's own box reads this — the list, the steppers, the in-card sheets — because a card
+  in a narrow dashboard column is a phone layout however wide the window is.
+- **How wide is the window?** `NARROW_QUERY` (`(max-width: 700px)`, `ui/responsive.ts`), read
+  with `matchMedia` and as a CSS `@media` block. Everything `position: fixed` reads this:
+  `hv-full-view`, `hv-overflow-menu`, and the five dialogs `HostSurfaces` owns. A fixed
+  overlay is laid out against the window, so the card's width says nothing about the room it
+  has.
+
+Each split bit once. `hv-item-editor` and `hv-filter-panel` are property-driven but are also
 children of `hv-full-view`, which never set the property — so at 375px the expanded view drew
-the editor's three-column desktop grid in 156px + 78px + 78px. `hv-full-view` now reads the
-same breakpoint with `matchMedia` (`NARROW_QUERY`, kept in step with the media query) and
-hands it down. Note what came with it: `hv-filter-panel` in `mobile` mode *stages* its edits
-and drops its own footer, expecting the host to provide one, so the expanded view also grew
-the Clear all / Cancel / "Show N items" row the card's filter sheet has.
+the editor's three-column desktop grid in 156px + 78px + 78px; `hv-full-view` now reads the
+viewport query and hands the property down. Note what came with it: `hv-filter-panel` in
+`mobile` mode *stages* its edits and drops its own footer, expecting the host to provide one,
+so the expanded view also grew the Clear all / Cancel / "Show N items" row the card's filter
+sheet has. In the other direction, `HostSurfaces` was fed the card's measurement, so the
+organize dialog took its full-bleed phone page on a desktop monitor whenever the card sat in
+a normal column — and expanding the card changed nothing, because the measured element was
+still the card underneath.
+
+On a phone viewport the four smaller dialogs — column picker, confirm, import, diagnostics —
+rise from the bottom edge like every other phone surface, through the shared
+`ui/dialog-sheet.ts` block rather than four private ones. The organize dialog keeps its
+full-bleed page, which is what a four-tab management surface needs at that width.
 
 ### Shared wording
 
@@ -285,7 +303,8 @@ re-render it — so each container subscribes to `store.state.onChange` itself i
 | `tokens.ts` | Every design token as a `--hv-*` custom property, bound to the HA theme variable first with the mock hex as fallback, plus dark-mode and reduced-motion overrides. `base` adds the pill/icon-button/chip/input primitives. Composed as `static styles = [tokens, base, css\`…\`]`. |
 | `icons.ts` | ~30 MDI glyphs as inline path data, rendered as `<svg fill="currentColor">`. See the deviation note below. |
 | `brand-icon.ts` | The HAventory mark as one path, published to HA's icon registry (`window.customIcons`) under the `haventory:` prefix so the sidebar entry can name it. The backend's `PANEL_ICON` is the matching string. |
-| `responsive.ts` | `ResponsiveController` — a Lit reactive controller that drives mobile mode from the card's own measured width (≤600px). |
+| `responsive.ts` | The two phone predicates: `ResponsiveController` (a Lit reactive controller driving mobile mode from the card's own measured width, ≤600px) and `NARROW_QUERY`, the viewport query every fixed overlay switches on. |
+| `dialog-sheet.ts` | The bottom-sheet presentation the host dialogs share under `mobile`, as one `css` block added to each of their `static styles`. |
 | `relative-time.ts` | "2 h ago" / "Jul 31" formatting, overdue checks, and the `+N days` arithmetic the check-out chips use. |
 | `item-form.ts` | Form model and payload building for the edit surfaces: validation per field, typed custom fields, tag normalization, and the `custom_fields_set` / `custom_fields_unset` diff. |
 | `value-rewrite.ts` | Tag/category rename, merge and removal as batches of item updates. |


### PR DESCRIPTION
## Summary

P5 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`). Session B ships P5 → P6 → P7 as a **stacked** set of PRs; this is the base of the stack and merges first.

Fixes **F2, F19, F20** from the register in `dev/v040_frontend_completeness_plan.md`. None of the three is filed as an issue yet, so there is no `Closes` line.

A dialog is `position: fixed` — it is laid out against the window, not against the card that opened it. `HostSurfaces` was handed the card's own measured width (`isMobile: () => this.mobile`), so the organize dialog took its full-bleed phone page whenever the card sat in a normal dashboard column: on a desktop monitor, from the card, and unchanged by expanding the card, because the measured element was still the card underneath.

- **One predicate, one owner** (decision 8). `NARROW_QUERY` moves out of `hv-full-view.ts` into `ui/responsive.ts`, beside the card-element breakpoint it must not be confused with — the comment there states which question each answers, because getting them the wrong way round is exactly what this package fixes. `HostSurfaces` keeps the `matchMedia` subscription and hands one answer to all five dialogs; hosts start and stop it from their connected/disconnected callbacks, since the instance is a plain object with no lifecycle of its own. The panel drops its private copy of the same query. The card's list, steppers and in-card sheets keep the element measurement.
- **Phone sheets for the small four** (F19). Columns, Import, Diagnostics and the confirm rise from the bottom edge, like the filter panel, the detail sheet and the ⋮ menu already do. One shared block in `ui/dialog-sheet.ts` rather than four private ones, so they cannot drift; each dialog keeps its own focus handling, Escape binding and `nextZBase()` z-order, which is what keeps a confirm above the sheet that raised it. The organize dialog keeps its full-bleed page — a four-tab management surface needs the width.
- **One breakpoint** (F20). The ⋮ menu's own `@media (max-width: 600px)` moves to the shared 700px. Three phone signals left a band of window widths where a sheet menu stood over centred dialogs; now one width flips every overlay.
- The full view's own bulk-delete confirm joins the same family, taking the flag from the query the view already reads.

`hv-column-picker`'s `.panel-wrap` is renamed `.wrap`, so the four hosts name the centring layer the same thing the shared block selects.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1498 passed), `npm run build`

New coverage:

- The regression this package exists for, on both hosts: a narrow card in a wide window leaves all five dialogs centred; a phone viewport gives all five the sheet form. `forceMobile` pins the element controller and is deliberately not the lever here — the `matchMedia` stub is.
- `ui/dialog-sheet.test.ts` asserts the four end up alike: the same bottom-edge geometry, the same centred form without the flag, the flag reflected as an attribute (a property alone selects nothing), and the safe-area inset under the bottom row of actions.
- The shell stops listening to the viewport once it is removed.
- The ⋮ menu's narrow block and `NARROW_QUERY` are pinned to each other; CSS cannot read the constant.
- The full view raises its bulk-delete confirm as a sheet on a phone viewport.

Two existing pins were rewritten rather than dropped: the menu's narrow-block reader now looks up the shared width, and the column picker's design-token pin picks the component's own block by content instead of by position in the styles array.

`test.utils.ts` gains the `matchMedia` stub the full view's tests already carried privately; three test files now share it.

Docs: `docs/frontend_architecture.md` — the `HostSurfaces` hook list, the "two different phone signals" section (rewritten around the two questions and both times the split bit), and the `ui/` module table.

### Delegated to the local verification session

Everything a browser has to answer. Checklist P5 in the plan's §Verification: Organize as a centred popup from the card ⋮, the expanded view and the panel with the card in a narrow column; at 390px, Organize full-bleed with its back arrow while Columns, Import, Diagnostics and a delete confirm each rise as bottom sheets; a confirm stacked over a sheet staying on top and working.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

## Follow-ups

- `hv-item-editor`'s two internal confirms still take the centred form on a phone. They cannot simply be handed the editor's `mobile` property, which is the card-element measurement — that would reintroduce this package's bug in miniature. P8 reworks the discard confirm and is where that wiring belongs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012JmwzY4tcD4cU1QHmCLmxm)_