### PR TITLE
feat(card): organize is one click away; dense status rows; one delete confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,8 +534,9 @@ throughout.
   row reads "4 / 37" — matches over total — so you can see where the matches are rather
   than a total that never moves. The counts ignore the *location* filter, since the sidebar
   is how you pick one. Each heading also offers a create action: Locations opens an inline
-  name field, while Categories and Tags open the organize dialog on their own tab — a
-  category exists through the items using it, so that is where making one is explained.
+  name field, while Categories, Tags and Status open the organize dialog on their own tab —
+  a category exists through the items using it, so that is where making one is explained.
+  The app bar carries an Organize button of its own, beside the ⋮ that also lists it.
   From the second selected tag on, the Tags heading carries the same any/all control the
   filter panel has, since that is the mode governing what the sidebar just selected. The
   app bar's stat pills are the card's: low in amber, overdue in red, to-inspect in amber,
@@ -554,7 +555,8 @@ throughout.
   determinate and cancellable, and the result is reported *per operation*: "39 of 42
   succeeded", every failure named with its reason and a retry scoped to just those.
   Select-all covers loaded rows only and says so, with an explicit "load the rest" path.
-- **Organize dialog** — Locations / Categories / Tags in one place, each tab stating its
+- **Organize dialog** — Locations / Categories / Tags / Statuses in one place, reached from
+  the full view's app bar as well as its ⋮ menu, each tab stating its
   total above the list and each row offering the same moves: an "N items" link that opens
   the filtered list in the full view, plus rename, merge and delete. Locations keep their collapsible tree and edit inline, with a guarded
   delete that explains what is in the way. Category and tag rename, merge and removal are

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1644,6 +1644,27 @@ describe('hv-card-shell: full view', () => {
     expect(organize().tab).toBe('locations');
   });
 
+  // The button and the sidebar heading are new front doors onto the surface the
+  // ⋮ already reached; both have to arrive at the dialog, on the tab they name.
+  it('opens organize from the expanded view\'s app bar and Status heading', async () => {
+    const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
+    const organize = () =>
+      sr.querySelector('[data-testid="host-organize"]') as HTMLElement & { open: boolean; tab: string };
+
+    (sr.querySelector('[data-testid="expand-toggle"]') as HTMLButtonElement).click();
+    await settle(el);
+    const view = fullView(sr);
+
+    (view.shadowRoot?.querySelector('[data-testid="full-organize"]') as HTMLButtonElement).click();
+    await settle(el);
+    expect(organize().open).toBe(true);
+    expect(organize().tab).toBe('locations');
+
+    (view.shadowRoot?.querySelector('[data-testid="sidebar-new-status"]') as HTMLButtonElement).click();
+    await settle(el);
+    expect(organize().tab).toBe('statuses');
+  });
+
   it('answers the full view menu inside the shell, letting nothing escape', async () => {
     const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
     const seen: string[] = [];

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -726,6 +726,20 @@ describe('hv-full-view: sidebar facets', () => {
     expect(q(sr, '[data-testid="sidebar-new-tags"]')?.getAttribute('title')).toBe('New tag…');
   });
 
+  // Status was the fourth facet and the only heading with nothing on it, so the
+  // one vocabulary a household actually defines was the one you could not reach
+  // from the sidebar that shows it.
+  it('offers the same create action on the Status heading', async () => {
+    const { el, sr } = await mount({ items: faceted, locations: [loc('garage', 'Garage')] });
+    const seen: { id: string; tab?: string }[] = [];
+    el.addEventListener('menu-action', (e) => seen.push((e as CustomEvent).detail));
+
+    (q(sr, '[data-testid="sidebar-new-status"]') as HTMLButtonElement).click();
+
+    expect(seen).toEqual([{ id: 'organize', tab: 'statuses' }]);
+    expect(q(sr, '[data-testid="sidebar-new-status"]')?.getAttribute('title')).toBe('New status…');
+  });
+
   it('lines the three tallies up in one column', () => {
     // The Locations heading ends in a button and the other two in nothing, so
     // without a reserved slot its number sits an icon-button's width inboard.
@@ -932,6 +946,28 @@ describe('hv-full-view: context bar and table', () => {
 
     (q(sr, '[data-testid="columns-expanded"]') as HTMLButtonElement).click();
     expect(seen).toEqual(['columns']);
+  });
+
+  // Organizing was reachable only from inside the ⋮ menu, on the surface where
+  // there is room for a button — so the one place with space for it was the one
+  // place that hid it. The menu entry stays; the hosts' menu-order pins hold it.
+  it('opens Organize from a button on the app bar', async () => {
+    for (const embedded of [false, true]) {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
+      el.embedded = embedded;
+      await settle(el);
+      const seen: unknown[] = [];
+      el.addEventListener('menu-action', (e) => seen.push((e as CustomEvent).detail));
+
+      const button = q(sr, '[data-testid="full-organize"]') as HTMLButtonElement;
+      expect(button, embedded ? 'embedded' : 'modal').toBeTruthy();
+      expect(button.getAttribute('aria-label')).toBe('Organize');
+      button.click();
+
+      // No tab named: Organize opens where it always did, on Locations.
+      expect(seen).toEqual([{ id: 'organize' }]);
+      el.remove();
+    }
   });
 
   it('counts loaded rows against the filtered total', async () => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -1228,6 +1228,24 @@ export class HVFullView extends LitElement {
         <!-- The other sections tally how many rows they hold. Here that number
              is the size of the household's vocabulary, which says nothing
              about the inventory the facet navigates. -->
+        <span class="head-action">
+          <button
+            class="hv-icon-button"
+            data-testid="sidebar-new-status"
+            aria-label="New status…"
+            title="New status…"
+            @click=${() =>
+              this.dispatchEvent(
+                new CustomEvent('menu-action', {
+                  detail: { id: 'organize', tab: 'statuses' },
+                  bubbles: true,
+                  composed: true,
+                }),
+              )}
+          >
+            ${icon('plus', 20)}
+          </button>
+        </span>
       </div>
       <div id=${sectionPanelId('status')} ?hidden=${!this._sections.status}>
         ${this._sections.status
@@ -1760,6 +1778,18 @@ export class HVFullView extends LitElement {
             }}
           >
             ${icon('plus', 16)}Add item
+          </button>
+          <button
+            class="tap"
+            data-testid="full-organize"
+            aria-label="Organize"
+            title="Organize"
+            @click=${() =>
+              this.dispatchEvent(
+                new CustomEvent('menu-action', { detail: { id: 'organize' }, bubbles: true, composed: true }),
+              )}
+          >
+            ${icon('mapMarker', 20)}
           </button>
           <hv-overflow-menu
             onPrimary

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -617,6 +617,23 @@ describe('hv-location-tree: manage mode', () => {
     expect(css).not.toMatch(/:host\(\[mobile\]\) \.count/);
   });
 
+  // The Locations tab is this component, so the dialog cannot reach its rows
+  // with a selector. It reaches them with an inherited custom property instead,
+  // which is what keeps the tightening scoped: the sidebar, the filter panel
+  // and the editor's location field declare nothing and take the fallback.
+  it('takes the organize dialog\'s row rhythm only when it is hosted there', () => {
+    const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
+    const css = (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+
+    expect(css).toMatch(/\.row \{[^}]*padding: var\(--hv-organize-row-pad, 7px\) 12px/);
+    // Nothing here declares it — a tree that declared its own would answer for
+    // every host at once.
+    expect(css).not.toContain('--hv-organize-row-pad:');
+  });
+
   it('marks the row so the touch sizing has something to hang on', async () => {
     const el = await mount({ manage: true, mobile: true });
     expect(rows(el)[0].className).toContain('manage');

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -71,7 +71,12 @@ export class HVLocationTree extends LitElement {
         text-align: left;
         font: 400 13.5px var(--hv-font);
         color: var(--hv-text);
-        padding: 7px 12px;
+        /* The organize dialog declares this property, so the tree it hosts
+           keeps the same vertical rhythm as the value rows on its other three
+           tabs. Nothing else declares it, so every other host — the sidebar,
+           the filter panel, the editor's location field — takes the fallback
+           and is unaffected. */
+        padding: var(--hv-organize-row-pad, 7px) 12px;
         border-radius: var(--hv-radius-input);
       }
       .row:hover {

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -129,6 +129,18 @@ describe('hv-organize-dialog: shell', () => {
     expect(q(sr, '[data-testid="organize-back"]')).toBeTruthy();
     expect(q(sr, '[data-testid="organize-close"]')).toBe(null);
   });
+
+  // The surface answered to three names — "Organize…" in the menu, "Organize
+  // inventory" on a wide screen and "Organize" on a narrow one — so the heading
+  // never confirmed which thing the menu entry had opened.
+  it('calls itself Organize at every width', async () => {
+    for (const mobile of [false, true]) {
+      const { el, sr } = await mount({ mobile });
+      expect(q(sr, 'h2')?.textContent?.trim(), `mobile=${mobile}`).toBe('Organize');
+      expect(q(sr, '[data-testid="organize-dialog"]')?.getAttribute('aria-label')).toBe('Organize');
+      el.remove();
+    }
+  });
 });
 
 describe('hv-organize-dialog: locations', () => {
@@ -1141,17 +1153,54 @@ describe('hv-organize-dialog: statuses', () => {
     });
   });
 
-  it('confirms rather than guards when nothing carries the status', async () => {
+  // One question, one idiom, whichever branch it is: the unused status used to
+  // get a modal and the in-use one an inline disclosure, so the consequential
+  // path carried the lighter ceremony.
+  it('asks in the same disclosure when nothing carries the status', async () => {
     const { el, sr } = await mount({ tab: 'statuses' });
 
     const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
     (row?.querySelector('[data-testid="status-remove"]') as HTMLButtonElement).click();
     await settle(el);
 
+    const guard = q(sr, '[data-testid="status-guard"]');
+    expect(guard).toBeTruthy();
+    expect(guard?.textContent).toContain('No item carries this status');
+    // Nothing to reassign, so the select the in-use branch needs is absent...
+    expect(guard?.querySelector('[data-testid="status-reassign"]')).toBe(null);
+    // ...and the action says what it does rather than promising a reassign.
+    expect(q(sr, '[data-testid="status-guard-confirm"]')?.textContent?.trim()).toBe('Delete');
+    // The modal it used to raise is gone from the component entirely.
+    expect(q(sr, '[data-testid="organize-status-confirm"]')).toBe(null);
+  });
+
+  it('deletes an unused status once the disclosure is confirmed', async () => {
+    const { el, sr, hass } = await mount({ tab: 'statuses' });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-remove"]') as HTMLButtonElement).click();
+    await settle(el);
+    (q(sr, '[data-testid="status-guard-confirm"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const deleted = hass.__messages.filter((m) => m.type === 'haventory/status/delete');
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0].slug).toBe('missing');
+    // No reassign target travels with a status nothing carries.
+    expect(deleted[0].reassign_to ?? null).toBe(null);
+  });
+
+  it('backs out of an unused status delete', async () => {
+    const { el, sr, hass } = await mount({ tab: 'statuses' });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-remove"]') as HTMLButtonElement).click();
+    await settle(el);
+    (q(sr, '[data-testid="status-guard-cancel"]') as HTMLButtonElement).click();
+    await settle(el);
+
     expect(q(sr, '[data-testid="status-guard"]')).toBe(null);
-    expect(
-      (q(sr, '[data-testid="organize-status-confirm"]') as HTMLElement).hasAttribute('open'),
-    ).toBe(true);
+    expect(hass.__messages.some((m) => m.type === 'haventory/status/delete')).toBe(false);
   });
 
   it('sends the colour and glyph chosen in the picker', async () => {
@@ -1367,13 +1416,45 @@ describe('hv-organize-dialog: statuses', () => {
     expect(guard?.querySelector('.guard-target select')).not.toBe(null);
   });
 
-  // DOM-measured on a phone: chevrons 15×15 stacked a pixel apart, edit/delete
-  // 26×26, swatches 26×22, the count link 14px tall. WCAG 2.2 asks 24px of
-  // every pointer; a finger wants the platform's 44.
+  // The stacked pair was the whole of the gap: a status row stood ~71px tall
+  // against ~48px on the sibling tabs, and the arrows were 24px boxes around a
+  // 15px glyph that had to be aimed at.
+  it('lays the reorder pair out side by side, at a size a pointer can hit', () => {
+    const css = dialogCss();
+    expect(css).toMatch(/\.move \{[^}]*flex-direction: row/);
+    expect(css).toMatch(/\.move button \{[^}]*width: 28px/);
+    // A phone keeps them stacked — 88px of horizontal pair does not fit a row
+    // that also carries the chip, the slug, the count and two 44px actions.
+    expect(css).toMatch(/:host\(\[mobile\]\) \.move \{[^}]*flex-direction: column/);
+  });
+
+  it('draws a chevron big enough to read at the button it sits in', async () => {
+    const { sr } = await mount({ tab: 'statuses' });
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    for (const dir of ['up', 'down'] as const) {
+      const glyph = row?.querySelector(`[data-testid="status-${dir}"] svg`) as SVGElement;
+      expect(glyph?.getAttribute('width'), dir).toBe('18');
+    }
+  });
+
+  // One rhythm across all four tabs, from one declaration: the value rows read
+  // it directly and it inherits into the location tree the Locations tab hosts.
+  it('gives every tab one row rhythm, the hosted tree included', () => {
+    const css = dialogCss();
+    expect(css).toMatch(/:host \{[^}]*--hv-organize-row-pad: 8px/);
+    expect(css).toMatch(/\.value-row \{[^}]*padding: var\(--hv-organize-row-pad\) 8px/);
+    // Nothing re-declares it per tab, or the tabs could drift again.
+    expect(css.match(/--hv-organize-row-pad:/g)).toHaveLength(1);
+  });
+
+  // DOM-measured on a phone: edit/delete 26×26, swatches 26×22, the count link
+  // 14px tall. WCAG 2.2 asks 24px of every pointer; a finger wants the
+  // platform's 44. The reorder pair takes more than the minimum — a pair that
+  // has to be aimed at is the complaint it answers.
   it('sizes every row control for a finger, on all four tabs', () => {
     const css = dialogCss();
     for (const [selector, size] of [
-      ['\\.move button', '24px'],
+      ['\\.move button', '28px'],
       ['\\.swatch', '26px'],
     ] as const) {
       expect(css, selector).toMatch(new RegExp(`${selector} \\{[^}]*height: ${size}`));

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -71,9 +71,9 @@ interface RewriteState {
 }
 
 /**
- * "Organize inventory".
+ * "Organize".
  *
- * One dialog, three tabs: locations, categories and tags.
+ * One dialog, four tabs: locations, categories, tags and statuses.
  *
  * Locations edit in place with a guarded delete — a location that still holds
  * items or children gets an inline explanation, never a browser confirm.
@@ -90,6 +90,15 @@ export class HVOrganizeDialog extends LitElement {
     css`
       :host {
         display: block;
+        /*
+         * The vertical padding of every row in this dialog, declared once here
+         * so the four tabs cannot drift apart: the value rows below read it,
+         * and it inherits through the shadow boundary into the
+         * hv-location-tree the Locations tab hosts, which reads the same
+         * property with its own fallback. Nothing outside this dialog declares
+         * it, so the full-view sidebar's tree keeps its own spacing.
+         */
+        --hv-organize-row-pad: 8px;
       }
       .backdrop {
         position: fixed;
@@ -230,7 +239,7 @@ export class HVOrganizeDialog extends LitElement {
         display: flex;
         align-items: center;
         gap: 10px;
-        padding: 11px 8px;
+        padding: var(--hv-organize-row-pad) 8px;
         border-radius: var(--hv-radius-input);
       }
       .value-row:hover {
@@ -238,28 +247,38 @@ export class HVOrganizeDialog extends LitElement {
       }
       /* Two arrow buttons rather than a drag handle: this is the card's first
          reordering control, and buttons work from the keyboard without a
-         parallel implementation for it. */
+         parallel implementation for it.
+
+         Side by side, because stacked they made the row they sit in twice as
+         tall as the same row on every other tab — the pair was the whole of
+         that difference. */
       .move {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         flex: none;
-        gap: 1px;
+        gap: 3px;
       }
-      /* Sized rather than left at the glyph: two chevrons stacked a pixel apart
-         are one target to a finger, and WCAG 2.2 asks 24px of every pointer.
-         The token is what a host declares when the card is narrow; the fallback
-         covers the sidebar panel, which declares none. */
+      /* Sized rather than left at the glyph: WCAG 2.2 asks 24px of every
+         pointer, and a pair that has to be aimed at is the complaint this
+         answers, so they take more than the minimum. */
       .move button {
         display: inline-grid;
         place-items: center;
-        width: 24px;
-        height: 24px;
+        width: 28px;
+        height: 28px;
         border: none;
         background: none;
         color: var(--hv-text-tertiary);
         cursor: pointer;
         padding: 0;
         line-height: 0;
+      }
+      /* A phone keeps them stacked: a horizontal pair at the platform's 44px
+         is 88px of row, which does not fit beside the chip, the slug, the count
+         and two 44px actions. */
+      :host([mobile]) .move {
+        flex-direction: column;
+        gap: 1px;
       }
       :host([mobile]) .move button {
         width: var(--hv-tap-min, 44px);
@@ -675,7 +694,6 @@ export class HVOrganizeDialog extends LitElement {
   /** A delete refused because items still carry the slug, and how many. */
   @state() private _statusGuard: { slug: string; count: number } | null = null;
   @state() private _reassignTarget = '';
-  @state() private _confirmStatus: string | null = null;
 
   @state() private _creatingValue = false;
   @state() private _newValue = '';
@@ -1721,19 +1739,22 @@ export class HVOrganizeDialog extends LitElement {
   }
 
   /**
-   * Delete, guarding first when items still carry the slug.
+   * Ask before deleting, in one idiom whichever branch it is.
    *
-   * The backend refuses that case regardless; the guard is the explanation, and
-   * the reassign target is what turns the refusal into a completed move. Same
-   * shape as `_deleteLocation`.
+   * Both branches open the same inline disclosure. The in-use one carries the
+   * reassign select — the backend refuses a delete that would strand items, and
+   * picking where they go is what turns that refusal into a completed move —
+   * and the unused one carries the question alone. Splitting them across a
+   * disclosure and a modal gave the consequential path the lighter ceremony.
    */
-  private async _deleteStatus(slug: string, reassignTo?: string) {
+  private _askDeleteStatus(slug: string) {
     const count = this._statusCount(slug);
-    if (count > 0 && !reassignTo) {
-      this._statusGuard = { slug, count };
-      this._reassignTarget = this._statusDefs.find((d) => d.slug !== slug)?.slug ?? '';
-      return;
-    }
+    this._statusGuard = { slug, count };
+    this._reassignTarget = count > 0 ? (this._statusDefs.find((d) => d.slug !== slug)?.slug ?? '') : '';
+  }
+
+  /** Send the delete, reassigning the items that carry the slug if any do. */
+  private async _deleteStatus(slug: string, reassignTo?: string) {
     try {
       await this.store?.deleteStatus(slug, reassignTo);
       this._statusGuard = null;
@@ -1774,7 +1795,7 @@ export class HVOrganizeDialog extends LitElement {
                   ?disabled=${index === 0}
                   @click=${() => this._moveStatus(d.slug, -1)}
                 >
-                  ${icon('chevronUp', 15)}
+                  ${icon('chevronUp', 18)}
                 </button>
                 <button
                   data-testid="status-down"
@@ -1783,7 +1804,7 @@ export class HVOrganizeDialog extends LitElement {
                   ?disabled=${index === defs.length - 1}
                   @click=${() => this._moveStatus(d.slug, 1)}
                 >
-                  ${icon('chevronDown', 15)}
+                  ${icon('chevronDown', 18)}
                 </button>
               </span>
               ${renderStatusChip(d.slug, defs, { testid: 'status-chip' })}
@@ -1812,10 +1833,7 @@ export class HVOrganizeDialog extends LitElement {
                         data-testid="status-remove"
                         aria-label=${`Delete ${d.label}`}
                         title="Delete"
-                        @click=${() => {
-                          if (this._statusCount(d.slug) > 0) void this._deleteStatus(d.slug);
-                          else this._confirmStatus = d.slug;
-                        }}
+                        @click=${() => this._askDeleteStatus(d.slug)}
                       >
                         ${icon('del', 16)}
                       </button>
@@ -1941,23 +1959,28 @@ export class HVOrganizeDialog extends LitElement {
     if (!guard) return null;
     const label = statusLabel(guard.slug, this._statusDefs);
     const targets = this._statusDefs.filter((d) => d.slug !== guard.slug);
+    const inUse = guard.count > 0;
     return html`<div class="expander guard status-guard" data-testid="status-guard" role="alert">
       <span class="guard-message" data-testid="status-guard-message"
-        >“${label}” is on ${counted(guard.count, 'item')}. Choose where those items go.</span
+        >${inUse
+          ? html`“${label}” is on ${counted(guard.count, 'item')}. Choose where those items go.`
+          : html`Delete “${label}”? No item carries this status, so nothing else changes.`}</span
       >
-      <label class="guard-target">
-        <span>Move those items to</span>
-        <select
-          class="control"
-          data-testid="status-reassign"
-          .value=${this._reassignTarget}
-          @change=${(e: Event) => {
-            this._reassignTarget = (e.target as HTMLSelectElement).value;
-          }}
-        >
-          ${targets.map((d) => html`<option value=${d.slug}>${d.label}</option>`)}
-        </select>
-      </label>
+      ${inUse
+        ? html`<label class="guard-target">
+            <span>Move those items to</span>
+            <select
+              class="control"
+              data-testid="status-reassign"
+              .value=${this._reassignTarget}
+              @change=${(e: Event) => {
+                this._reassignTarget = (e.target as HTMLSelectElement).value;
+              }}
+            >
+              ${targets.map((d) => html`<option value=${d.slug}>${d.label}</option>`)}
+            </select>
+          </label>`
+        : null}
       <div class="actions">
         <span class="spacer"></span>
         <button
@@ -1972,9 +1995,9 @@ export class HVOrganizeDialog extends LitElement {
         <button
           class="hv-text-button danger"
           data-testid="status-guard-confirm"
-          @click=${() => this._deleteStatus(guard.slug, this._reassignTarget)}
+          @click=${() => this._deleteStatus(guard.slug, inUse ? this._reassignTarget : undefined)}
         >
-          Reassign and delete
+          ${inUse ? 'Reassign and delete' : 'Delete'}
         </button>
       </div>
     </div>`;
@@ -2150,7 +2173,7 @@ export class HVOrganizeDialog extends LitElement {
           class="panel"
           role="dialog"
           aria-modal="true"
-          aria-label="Organize inventory"
+          aria-label="Organize"
           data-testid="organize-dialog"
           @keydown=${onEscape(() => this._close())}
         >
@@ -2160,7 +2183,7 @@ export class HVOrganizeDialog extends LitElement {
                   ${icon('arrowLeft', 21)}
                 </button>`
               : null}
-            <h2>${this.mobile ? 'Organize' : 'Organize inventory'}</h2>
+            <h2>Organize</h2>
             ${this.mobile
               ? null
               : html`<button class="hv-icon-button" data-testid="organize-close" aria-label="Close" @click=${this._close}>
@@ -2198,25 +2221,9 @@ export class HVOrganizeDialog extends LitElement {
       </div>
 
       <hv-confirm
-        data-testid="organize-status-confirm"
-        ?open=${this._confirmStatus !== null}
-        .heading=${`Delete "${statusLabel(this._confirmStatus ?? '', this._statusDefs)}"?`}
-        message="No item carries this status, so nothing else changes."
-        confirmLabel="Delete"
-        destructive
-        @confirm=${() => {
-          const slug = this._confirmStatus;
-          this._confirmStatus = null;
-          if (slug) void this._deleteStatus(slug);
-        }}
-        @cancel=${() => {
-          this._confirmStatus = null;
-        }}
-      ></hv-confirm>
-
-      <hv-confirm
         data-testid="organize-confirm"
         ?open=${this._confirmRemove !== null}
+        ?mobile=${this.mobile}
         .heading=${`Remove "${this._confirmRemove}" from ${counted(removeCount, 'item')}?`}
         message="The value is cleared on every item that carries it. The items themselves are not deleted."
         confirmLabel="Remove"

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -107,14 +107,19 @@ than by a component of their own: they are flat lists of `distinct_values` entri
 rows only have to look like `hv-location-tree`'s — which, being in another shadow root,
 could not have shared the rule either way.
 
-Each of the three headings states how many of its thing there is, and offers a create
-action. Categories and tags come with their `distinct_values` length; locations are counted
-by `countLocations` in `store/location-tree.ts`, which walks every depth and takes the same
-optional filter needle `hv-location-tree` matches rows with, so the organize dialog's
-"N locations" can never disagree with the tree printed under it. Creating differs by facet
-because the backend does: a location is a real object and is created inline, while a
-category or tag exists only through the items using it, so those buttons ask the card to
-open `hv-organize-dialog` on the matching tab (`menu-action` with `{ id: 'organize', tab }`).
+Each of the four headings offers a create action, and the three that can be counted state
+how many of their thing there is — Status is the household's own vocabulary, whose size says
+nothing about the inventory the facet navigates. Categories and tags come with their
+`distinct_values` length; locations are counted by `countLocations` in
+`store/location-tree.ts`, which walks every depth and takes the same optional filter needle
+`hv-location-tree` matches rows with, so the organize dialog's "N locations" can never
+disagree with the tree printed under it. Creating differs by facet because the backend does:
+a location is a real object and is created inline, while a category, tag or status is made
+in the organize dialog, so those buttons ask the card to open `hv-organize-dialog` on the
+matching tab (`menu-action` with `{ id: 'organize', tab }`). The app bar carries an Organize
+button raising the same event with no tab, so the surface is one click from the view rather
+than two through the ⋮ — which keeps its entry, since the plain card's header has no room
+for a button.
 
 ### Two different "is this a phone?" signals
 
@@ -145,6 +150,12 @@ On a phone viewport the four smaller dialogs — column picker, confirm, import,
 rise from the bottom edge like every other phone surface, through the shared
 `ui/dialog-sheet.ts` block rather than four private ones. The organize dialog keeps its
 full-bleed page, which is what a four-tab management surface needs at that width.
+
+Inside that dialog one declaration governs row height: `--hv-organize-row-pad` on its host,
+read by its own value rows and inherited through the shadow boundary into the
+`hv-location-tree` its Locations tab hosts, which reads the same property with its own
+fallback. That is what keeps the tightening scoped — no other host declares it, so the
+sidebar tree, the filter panel's picker and the editor's location field are untouched.
 
 ### Shared wording
 


### PR DESCRIPTION
## Summary

P6 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`).

**Stacked PR — merge in order: #341 → this.** Base is #341 (P5). After #341 squash-merges, this branch is rebased onto `main` (`git rebase --onto origin/main claude/session-b-frontend-packages-83a5lr`) before it merges; the local verification session does that rebase as part of its pass.

Fixes **F1, F3, F18** and the organize half of **F24** from the register in `dev/v040_frontend_completeness_plan.md`. None is filed as an issue yet, so there is no `Closes` line.

### F1 — Organize is one click away

The full view's app bar gains an Organize button beside the ⋮ that still lists it. One edit covers the expanded view and the sidebar page, since they share the bar; the plain card keeps menu-only, its header has no room. The sidebar's **Status** heading — the one facet section with nothing on it, over the one vocabulary a household actually defines — gains the create action its three siblings have, opening the dialog on the Statuses tab.

### F3 — the status row comes down

A status row stood ~71px against ~48px on the sibling tabs, and the stacked reorder pair was the whole of that difference: two 24px boxes a pixel apart, around a 15px glyph, that had to be aimed at.

- The pair goes **side by side at 28px** with an 18px glyph (decision 9 — pointer drag stays #297's later one-answer decision). A phone keeps them **stacked at 44px**: 88px of horizontal pair does not fit a row that also carries the chip, the slug, the count and two 44px actions.
- Row padding becomes one declaration, `--hv-organize-row-pad` on the dialog host. The value rows read it directly and it inherits through the shadow boundary into the `hv-location-tree` the Locations tab hosts, which reads the same property with its own fallback — so all four tabs share a rhythm from one number, and no other host of that tree sees it. The sidebar tree, the filter panel's picker and the editor's location field are untouched, which is pinned by a test rather than argued.

Worth stating plainly against the plan's expectation: the **Locations tab was already the densest tab** (7px padding, ~40px rows, against ~48px on Categories and Tags). It moves 2px to join the shared value rather than tightening visibly. The four now agree; the tab that changes most is Statuses, 71px → ~44px.

### F18 — one delete idiom

Deleting a status asked two different ways: the inline disclosure when items carried it, an `hv-confirm` modal when none did — so the consequential branch had the *lighter* ceremony. Both branches now open the same disclosure (which scrolls itself into view, shipped in #329), with the reassign select only where there is something to reassign and the action reading "Delete" rather than promising a reassign. The modal and its state are deleted, not left unused.

### F24 (organize half) — one name

"Organize inventory" on a wide screen, "Organize" on a narrow one, "Organize…" in the menu. The heading and the dialog's accessible name are **Organize** at every width; the menu entry keeps the ellipsis, which is the card's mark for "opens elsewhere".

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1508 passed), `npm run build`

New coverage: the app-bar button on the modal and embedded variants, dispatching with no tab; the Status heading dispatching at the `statuses` tab; end-to-end through the shell — button opens the dialog on Locations, heading opens it on Statuses; the reorder pair's direction, size and phone stack; the 18px chevron read off the rendered SVG; the one-declaration row rhythm, including that nothing re-declares it per tab; the tree taking that rhythm only through the inherited property and declaring none itself; the unused-status delete asking inline, deleting on confirm with no reassign target, and backing out on cancel; the title at both widths.

Existing pins rewritten rather than dropped, per the campaign rule: the reorder-button size pin (24px → 28px, keeping its principle that sizing is not scoped to a status row — one dialog cannot offer two target sizes for one control), and the pin that asserted the zero-count branch raises a modal.

Docs: README's sidebar-heading and organize-dialog descriptions; `docs/frontend_architecture.md`'s facet-heading paragraph and a note on where the row rhythm is declared.

### Delegated to the local verification session

Checklist P6 in the plan's §Verification: the app-bar button and the Status head action on the expanded view and the panel; all four tabs at one row rhythm with the sidebar tree unchanged; the reorder pair comfortably clickable and a reorder surviving a reload; both delete branches asking inline; the arrows stacked at 44px at 390px.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (README, `docs/frontend_architecture.md`).
- [x] No WebSocket API change — `status/delete` is called with the same arguments in both branches.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_012JmwzY4tcD4cU1QHmCLmxm)_