### PR TITLE
fix(card): editor geometry and type reconciliation; always-visible actions; honest custom-fields tally

### DIFF
--- a/cards/haventory-card/src/components/hv-chip-input.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.ts
@@ -74,7 +74,7 @@ export class HVChipInput extends LitElement {
         border: none;
         outline: none;
         background: none;
-        font: 400 var(--hv-input-font, 12.5px) var(--hv-font);
+        font: 400 var(--hv-input-font, 13.5px) var(--hv-font);
         color: var(--hv-text);
       }
       .suggestions {

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -823,25 +823,36 @@ describe('hv-item-editor: typed custom fields', () => {
     ]);
   });
 
-  it('keeps Save and Cancel in reach on a phone', async () => {
-    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+  // The bar was pinned only when the card said "phone". Every host that can
+  // scroll the form puts it below the fold — the card's list, the phone sheet,
+  // and the expanded view, which caps the form at 70dvh — so the editor solves
+  // it once for all of them instead of each host growing a footer of its own.
+  it('keeps Save and Cancel in reach on every host', async () => {
+    const css = editorCss();
 
     // Sticky has to sit on the wrapping cell: an element sticks only within its
-    // containing block, and `.actions`' parent is exactly as tall as it is.
-    expect(css).toMatch(/:host\(\[mobile\]\) \.actions-cell \{[^}]*position: sticky/);
-    expect(css).toMatch(/:host\(\[mobile\]\) \.actions-cell \{[^}]*bottom: -14px/);
-    expect(css).not.toMatch(/:host\(\[mobile\]\) \.actions \{[^}]*position: sticky/);
+    // containing block, and the actions' parent is exactly as tall as they are.
+    expect(css).toMatch(/[^)] \.actions-cell \{[^}]*position: sticky/);
+    expect(css).toMatch(/[^)] \.actions-cell \{[^}]*bottom: -14px/);
+    expect(css).not.toMatch(/\.actions \{[^}]*position: sticky/);
+    // Not gated on the phone flag any more — that was the whole bug.
+    expect(css).not.toMatch(/:host\(\[mobile\]\) \.actions-cell \{[^}]*position: sticky/);
 
-    // ...and the markup has to carry the class the rule needs.
-    const el = await mount(makeItem({ id: '1' }), { mobile: true });
-    const cell = q(el, '.actions-cell');
-    expect(cell).toBeTruthy();
-    expect(cell?.querySelector('[data-testid="editor-save"]')).toBeTruthy();
-    expect(cell?.querySelector('[data-testid="editor-cancel"]')).toBeTruthy();
+    // The opaque bar bleeds past the form's side padding, or the rows it covers
+    // show through in a strip either side of it.
+    expect(css).toMatch(/[^)] \.actions-cell \{[^}]*margin: 0 -18px/);
+    expect(css).toMatch(/[^)] \.actions-cell \{[^}]*padding: 10px 18px 14px/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.actions-cell \{[^}]*margin: 0 -16px/);
+
+    // ...and the markup has to carry the class the rule needs, on both hosts.
+    for (const mobile of [false, true]) {
+      const el = await mount(makeItem({ id: '1' }), { mobile });
+      const cell = q(el, '.actions-cell');
+      expect(cell, `mobile=${mobile}`).toBeTruthy();
+      expect(cell?.querySelector('[data-testid="editor-save"]')).toBeTruthy();
+      expect(cell?.querySelector('[data-testid="editor-cancel"]')).toBeTruthy();
+      el.remove();
+    }
   });
 
   it('lays a row out from its own width, not from the card-wide mobile flag', () => {
@@ -2406,5 +2417,144 @@ describe('hv-item-editor: dropping files onto the editor', () => {
 
     expect(photos.classList.contains('dropping')).toBe(false);
     expect(media.uploads).toHaveLength(0);
+  });
+});
+
+// The form was authored for a 600–900px card and then given a 1080p surface to
+// fill. Everything below is a measurement that stopped being true there.
+describe('hv-item-editor: geometry and type', () => {
+  it('gives the two numbers a number-sized field', () => {
+    const css = editorCss();
+    // Name takes what is left; 2fr/1fr/1fr handed a two-digit quantity ~400px.
+    expect(css).toMatch(/[^)] \.grid \{[^}]*grid-template-columns: minmax\(0, 1fr\) 140px 160px/);
+    // The phone collapse is untouched — one field per row, as before.
+    expect(css).toMatch(/:host\(\[mobile\]\) \.grid \{[^}]*grid-template-columns: 1fr/);
+  });
+
+  // A stretched cell shared out the row's surplus between its label row and its
+  // control row, which is how the status select landed at exactly the midpoint
+  // between an input and the textarea beside it.
+  it('packs a cell to the top instead of splitting the row surplus', () => {
+    expect(editorCss()).toMatch(/[^)] \.cell \{[^}]*align-content: start/);
+  });
+
+  it('draws the two state boxes as siblings', () => {
+    const css = editorCss();
+    // Even halves: at 2fr/1fr the inspection offsets wrapped onto three rows.
+    expect(css).toMatch(/[^)] \.state \{[^}]*grid-template-columns: minmax\(0, 1fr\) minmax\(0, 1fr\)/);
+    // No bottom-aligning a label-less button against a labelled field, which
+    // put the dead air between the caption and the first control.
+    expect(css).not.toMatch(/\.checkout-body \{[^}]*align-items: end/);
+  });
+
+  // Both boxes are caption + body and nothing else, so the hint belongs to the
+  // field it explains rather than hanging under the box.
+  it('puts the due-date hint inside the field it is about', async () => {
+    const el = await mount(makeItem({ id: '1', checked_out: false }));
+    const hint = q(el, '[data-testid="editor-due-hint"]');
+    expect(hint).toBeTruthy();
+    expect(hint?.closest('.cell')?.querySelector('[data-testid="editor-due-date"]')).toBeTruthy();
+  });
+
+  it('drops the hint once there is a check-out to be due', async () => {
+    const el = await mount(makeItem({ id: '1', checked_out: true }));
+    expect(q(el, '[data-testid="editor-due-hint"]')).toBe(null);
+  });
+});
+
+describe('hv-item-editor: one label recipe, one note size', () => {
+  it('gives every section label the shared recipe', async () => {
+    const css = editorCss();
+    // What is left of `.group-caption` is layout for its icon; the type comes
+    // from `.hv-label`, the same recipe TAGS, PHOTOS and DOCUMENTS use.
+    expect(css).not.toMatch(/\.group-caption \{[^}]*font-weight/);
+    expect(css).not.toMatch(/\.group-caption \{[^}]*text-transform/);
+
+    const el = await mount(makeItem({ id: '1' }));
+    for (const testid of ['editor-checkout-caption', 'editor-inspection-caption']) {
+      expect(q(el, `[data-testid="${testid}"]`)?.classList.contains('hv-label'), testid).toBe(true);
+    }
+  });
+
+  it('reads its small print at one size', () => {
+    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
+    const sheets = Array.isArray(styles) ? styles : [styles];
+    // This component's own block; the shared sheets ahead of it answer for
+    // every surface and are not this form's to consolidate.
+    const own = String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+
+    expect(own).toMatch(/:host \{[^}]*--hv-editor-note: 12px/);
+    // One declaration, and nothing left of the 11.5/12.5px band around it.
+    expect(own.match(/--hv-editor-note:/g)).toHaveLength(1);
+    expect(own).not.toContain('font-size: 11.5px');
+    expect(own).not.toContain('font-size: 12.5px');
+  });
+
+  // A note riding inside a label needs to step out of the uppercase treatment;
+  // it did that with the file's only inline style attribute.
+  it('carries the tags note as a class, not an inline style', async () => {
+    const el = await mount(makeItem({ id: '1' }));
+    expect(el.shadowRoot?.innerHTML).not.toContain('style="text-transform');
+    const note = el.shadowRoot?.querySelector('.label-note');
+    expect(note?.textContent).toContain('stored lowercase');
+  });
+
+  // The tag field sat a point smaller than every input beside it.
+  it('sets the tag input at the same size as the other fields', () => {
+    const styles = (customElements.get('hv-chip-input') as unknown as { styles: { cssText: string }[] }).styles;
+    const css = (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+    expect(css).toContain('font: 400 var(--hv-input-font, 13.5px) var(--hv-font)');
+  });
+
+  // The label-to-content gap is the cell's, so a section that added its own
+  // margin sat further from its label than every field around it.
+  it('leaves the label gap to the cell', () => {
+    const css = editorCss();
+    expect(css).not.toMatch(/\.photos \{[^}]*margin-top/);
+    expect(css).not.toMatch(/\.documents \{[^}]*margin: 4px/);
+  });
+});
+
+// "0 of 2 keys in use" reads as a quota. There is none: the denominator was the
+// count of distinct keys anywhere in the inventory, and the fallback made it
+// the numerator whenever that lookup was empty, so it could only ever say
+// "N of N".
+describe('hv-item-editor: the custom-fields tally states a fact', () => {
+  it('counts the fields that are set, and nothing else', async () => {
+    const el = await mount(
+      makeItem({ id: '1', custom_fields: { serial: 'A1', warranty_until: '2030-01-01' } }),
+      { customFieldKeys: ['serial', 'warranty_until', 'voltage'] },
+    );
+    expect(q(el, '[data-testid="editor-cf-tally"]')?.textContent?.trim()).toBe('2 fields set');
+  });
+
+  it('says nothing about keys when the item has none', async () => {
+    const el = await mount(makeItem({ id: '1', custom_fields: {} }), {
+      customFieldKeys: ['serial', 'voltage'],
+    });
+    const tally = q(el, '[data-testid="editor-cf-tally"]')?.textContent?.trim();
+    expect(tally).toBe('0 fields set');
+    expect(tally).not.toContain('in use');
+  });
+
+  // The inventory-wide keys are still offered, framed as what they are.
+  it('still offers the keys other items use', async () => {
+    const el = await mount(makeItem({ id: '1', custom_fields: {} }), {
+      customFieldKeys: ['serial', 'voltage'],
+    });
+    expect(q(el, '.key-hints')?.textContent).toContain('Key suggestions');
+  });
+});
+
+// "Checkout" above a button reading "Check out…", in a card that says "Check
+// out" everywhere else.
+describe('hv-item-editor: one verb for checking out', () => {
+  it('heads the box with the verb its own button uses', async () => {
+    const el = await mount(makeItem({ id: '1' }));
+    expect(q(el, '[data-testid="editor-checkout-caption"]')?.textContent?.trim()).toBe('Check out');
+    expect(q(el, '[data-testid="editor-checked-out"]')?.textContent).toContain('Check out');
   });
 });

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -133,6 +133,14 @@ export class HVItemEditor extends LitElement {
     css`
       :host {
         display: block;
+        /*
+         * The form's small print, at one size. Labels are 11px (the shared
+         * hv-label recipe and the photo picker's caption); everything that is a
+         * note about a field
+         * — hints, tallies, sizes, errors, the upload queue — reads at this one
+         * instead of the 11/11.5/12/12.5px band they used to spread across.
+         */
+        --hv-editor-note: 12px;
         background: var(--hv-row-hover);
         border-left: 3px solid var(--hv-primary);
       }
@@ -156,13 +164,17 @@ export class HVItemEditor extends LitElement {
       }
       .head .meta {
         margin-left: auto;
-        font-size: 11.5px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-text-tertiary);
         white-space: nowrap;
       }
+      /* Name takes what is left; the two numbers take what a number needs.
+         The proportional tracks were authored for a 600–900px card, where 1fr
+         landed near 180px — in the expanded view at 1080p they handed a
+         three-digit quantity a field about 400px wide. */
       .grid {
         display: grid;
-        grid-template-columns: 2fr 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) 140px 160px;
         gap: 12px;
         padding: 8px 18px 14px;
       }
@@ -181,8 +193,16 @@ export class HVItemEditor extends LitElement {
       :host([mobile]) .cell.span3 {
         grid-column: span 1;
       }
+      /* Packed to the top rather than sharing out the row's surplus. A grid
+         item stretches by default, so a cell holding a label and a control grew
+         to whatever the tallest cell in the row needed — the Description
+         textarea — and its two auto rows split the difference between them.
+         That is why the status select came out taller than an input and shorter
+         than the textarea beside it: exactly the midpoint. The same hazard is
+         guarded one level down on the state row; this closes it at the top. */
       .cell {
         display: grid;
+        align-content: start;
         gap: 4px;
         min-width: 0;
       }
@@ -191,7 +211,10 @@ export class HVItemEditor extends LitElement {
          three fields are never read as three peer settings of the same kind. */
       .state {
         display: grid;
-        grid-template-columns: 2fr 1fr;
+        /* Even halves. At 2fr/1fr the inspection box was narrow enough that its
+           three offset chips wrapped onto three rows beside a check-out box
+           with room to spare. */
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         gap: 12px;
         align-items: start;
       }
@@ -206,15 +229,13 @@ export class HVItemEditor extends LitElement {
         border-radius: var(--hv-radius-input);
         padding: 9px 11px 11px;
       }
+      /* Layout only: the type is the shared hv-label recipe, which every
+         other label in this form already uses. Two recipes differing by one
+         weight step read as two kinds of label. */
       .group-caption {
         display: flex;
         align-items: center;
         gap: 5px;
-        font-size: 11px;
-        font-weight: 600;
-        letter-spacing: 0.5px;
-        text-transform: uppercase;
-        color: var(--hv-text-secondary);
       }
       .group-caption .hv-icon {
         flex: none;
@@ -225,9 +246,13 @@ export class HVItemEditor extends LitElement {
         gap: 12px;
         min-width: 0;
       }
+      /* Not bottom-aligned: the button carries no label, so lining its bottom
+         edge up with the dated field beside it put the dead air above it,
+         between the box's caption and its first control. The cell's own
+         align-content: start now lands it directly under the caption, level
+         with the label opposite, and the surplus falls below both. */
       .checkout-body {
         grid-template-columns: 1fr 1fr;
-        align-items: end;
       }
       /* Checking out is something you do, not a setting you hold — the same
          button the detail sheet has offered all along, in the same words. */
@@ -246,7 +271,7 @@ export class HVItemEditor extends LitElement {
         opacity: 0.85;
       }
       .group-hint {
-        font-size: 11.5px;
+        font-size: var(--hv-editor-note);
         line-height: 1.4;
         color: var(--hv-text-tertiary);
       }
@@ -365,7 +390,7 @@ export class HVItemEditor extends LitElement {
         border-color: var(--hv-error);
       }
       .field-error {
-        font-size: 12px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-error);
       }
       .tree-holder,
@@ -460,7 +485,7 @@ export class HVItemEditor extends LitElement {
       }
       .option-empty {
         padding: 8px 12px;
-        font-size: 12.5px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-text-tertiary);
       }
       .toggle {
@@ -578,8 +603,17 @@ export class HVItemEditor extends LitElement {
         padding: 8px 13px;
         font: 500 12.5px var(--hv-font);
       }
+      /* A note riding inside a label: it says something about the field rather
+         than naming it, so it steps out of the label's uppercase treatment
+         while keeping its line. */
+      .label-note {
+        text-transform: none;
+        letter-spacing: 0;
+        font-weight: 400;
+        color: var(--hv-text-tertiary);
+      }
       .key-hints {
-        font-size: 11.5px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-text-tertiary);
       }
       .key-hints button {
@@ -633,20 +667,30 @@ export class HVItemEditor extends LitElement {
         padding-top: 4px;
         flex-wrap: wrap;
       }
-      /* Save and Cancel sat at the bottom of a form inside a nested scroller,
-         so on a phone they were reliably below the fold — you had to scroll an
-         inner container to commit an edit you had already finished.
-         Sticky goes on the wrapping cell rather than on .actions itself: an
-         element only sticks within its containing block, and .actions' parent
-         is exactly as tall as .actions, so it would have had nowhere to move.
-         The cell's containing block is the form grid, which is tall. */
-      :host([mobile]) .actions-cell {
+      /* Save, Delete and Cancel sit at the bottom of a form inside a nested
+         scroller, so they land below the fold on any host tall enough to need
+         scrolling — a phone sheet, the card's list, and the expanded view,
+         which caps the form at 70dvh. The editor answers that itself rather
+         than each host growing a pinned footer of its own.
+         Sticky goes on the wrapping cell rather than on .actions: an element
+         only sticks within its containing block, and .actions' parent is
+         exactly as tall as .actions, so it would have had nowhere to move.
+         The cell's containing block is the form grid, which is tall.
+         The negative side margins and the matching padding bleed the opaque
+         bar out to the form's edges — .grid's 18px side padding would otherwise
+         leave the rows it covers showing in two strips either side of it. */
+      .actions-cell {
         position: sticky;
         bottom: -14px;
         z-index: 1;
         background: var(--hv-surface);
-        padding: 10px 0 14px;
+        margin: 0 -18px;
+        padding: 10px 18px 14px;
         border-top: 1px solid var(--hv-row-divider);
+      }
+      :host([mobile]) .actions-cell {
+        margin: 0 -16px;
+        padding: 10px 16px 14px;
       }
       /* The auto margin lives on a spacer of its own, not on the hint: the hint
          is gone on a phone (no keyboard to press Esc with), and with the margin
@@ -656,7 +700,7 @@ export class HVItemEditor extends LitElement {
         margin-left: auto;
       }
       .actions .hint {
-        font-size: 11.5px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-text-tertiary);
       }
       /* The property that drops the hint describes how wide the surface is,
@@ -692,13 +736,12 @@ export class HVItemEditor extends LitElement {
         border-radius: var(--hv-radius-input);
         background: var(--hv-error-bg);
         color: var(--hv-error-deep);
-        font-size: 12.5px;
+        font-size: var(--hv-editor-note);
       }
       .photos {
         display: flex;
         flex-wrap: wrap;
         gap: 8px;
-        margin-top: 4px;
       }
       .photos figure {
         position: relative;
@@ -804,7 +847,7 @@ export class HVItemEditor extends LitElement {
       }
       .documents {
         list-style: none;
-        margin: 4px 0 0;
+        margin: 0;
         padding: 0;
         display: grid;
         gap: 6px;
@@ -837,7 +880,7 @@ export class HVItemEditor extends LitElement {
       }
       .documents .doc-size {
         flex: none;
-        font-size: 11.5px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-text-secondary);
       }
       .documents .doc-open,
@@ -866,7 +909,7 @@ export class HVItemEditor extends LitElement {
         border: 1px dashed var(--hv-input-border);
         border-radius: var(--hv-radius-chip);
         color: var(--hv-text-secondary);
-        font-size: 12.5px;
+        font-size: var(--hv-editor-note);
         cursor: pointer;
       }
       .upload-list {
@@ -875,7 +918,7 @@ export class HVItemEditor extends LitElement {
         padding: 0;
         display: grid;
         gap: 5px;
-        font-size: 11.5px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-text-secondary);
       }
       .upload-list li {
@@ -910,7 +953,7 @@ export class HVItemEditor extends LitElement {
         background: none;
         padding: 0 4px;
         color: var(--hv-primary-dark);
-        font: 500 11.5px var(--hv-font);
+        font: 500 var(--hv-editor-note) var(--hv-font);
         cursor: pointer;
       }
       .upload-list li .dismiss {
@@ -958,7 +1001,7 @@ export class HVItemEditor extends LitElement {
          against an item id and there is none yet. Said once, where the photo
          grid will be, rather than left as an unexplained absence. */
       .attach-hint {
-        font-size: 12px;
+        font-size: var(--hv-editor-note);
         color: var(--hv-text-tertiary);
       }
     `,
@@ -1581,8 +1624,8 @@ export class HVItemEditor extends LitElement {
     return html`<div class="cell span3">
       <div class="state">
         <div class="group" role="group" aria-labelledby="editor-checkout-caption">
-          <span class="group-caption" id="editor-checkout-caption" data-testid="editor-checkout-caption">
-            ${icon('account', 14)} Checkout
+          <span class="hv-label group-caption" id="editor-checkout-caption" data-testid="editor-checkout-caption">
+            ${icon('account', 14)} Check out
           </span>
           <div class="group-body checkout-body">
             <div class="cell">
@@ -1607,11 +1650,11 @@ export class HVItemEditor extends LitElement {
                 .value=${model.dueDate}
                 @input=${(e: Event) => this._patch({ dueDate: (e.target as HTMLInputElement).value })}
               />
+              ${model.checkedOut
+                ? null
+                : html`<span class="group-hint" data-testid="editor-due-hint">${DUE_DATE_HINT}</span>`}
             </div>
           </div>
-          ${model.checkedOut
-            ? null
-            : html`<span class="group-hint" data-testid="editor-due-hint">${DUE_DATE_HINT}</span>`}
           <hv-checkout-popover
             data-testid="editor-checkout"
             .item=${this.item}
@@ -1634,7 +1677,7 @@ export class HVItemEditor extends LitElement {
           ></hv-checkout-popover>
         </div>
         <div class="group">
-          <label class="group-caption" for="editor-inspection" data-testid="editor-inspection-caption">
+          <label class="hv-label group-caption" for="editor-inspection" data-testid="editor-inspection-caption">
             ${icon('calendar', 14)} Next inspection
           </label>
           <div class="group-body">
@@ -1749,9 +1792,7 @@ export class HVItemEditor extends LitElement {
       <div class="custom">
         <div class="custom-head">
           <span class="hv-label">Custom fields</span>
-          <span class="hv-tally" data-testid="editor-cf-tally">
-            ${used} of ${counted(this.customFieldKeys.length || used, 'key')} in use
-          </span>
+          <span class="hv-tally" data-testid="editor-cf-tally">${counted(used, 'field')} set</span>
         </div>
         ${rows.map((row) => {
           const error = this._errorFor(`custom:${row.id}`);
@@ -2503,7 +2544,9 @@ export class HVItemEditor extends LitElement {
           ${this._renderLocationField()} ${this._renderCategoryField()}
           ${this.mobile ? this._renderStatusField() : null}
           <div class="cell span3">
-            <span class="hv-label">Tags <span style="text-transform:none;letter-spacing:0;font-weight:400;color:var(--hv-text-tertiary)">· stored lowercase</span></span>
+            <span class="hv-label"
+              >Tags <span class="label-note">· stored lowercase</span></span
+            >
             <hv-chip-input
               data-testid="editor-tags"
               .values=${model.tags}

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -135,10 +135,12 @@ export class HVItemEditor extends LitElement {
         display: block;
         /*
          * The form's small print, at one size. Labels are 11px (the shared
-         * hv-label recipe and the photo picker's caption); everything that is a
-         * note about a field
-         * — hints, tallies, sizes, errors, the upload queue — reads at this one
-         * instead of the 11/11.5/12/12.5px band they used to spread across.
+         * hv-label recipe and the photo picker's caption); everything this
+         * form declares as a note about a field — hints, sizes, errors, the
+         * upload queue — reads at this one instead of the 11.5/12/12.5px band
+         * they used to spread across. The custom-fields tally is the one piece
+         * of small print here that is not this form's to size: it is the same
+         * facet count the sidebar shows, priced once in the shared sheet.
          */
         --hv-editor-note: 12px;
         background: var(--hv-row-hover);

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -445,7 +445,11 @@ Any other key in that record is ignored, so an older or newer payload never brea
 
 - **One edit form.** `hv-item-editor` is used by the inline expander, the full view and the
   mobile sheet. On mobile it stacks and collapses description / dates / custom fields
-  behind a single "More fields" disclosure.
+  behind a single "More fields" disclosure. Its action bar is sticky on **every** host, not
+  only the phone: each of them scrolls the form in a box (the card's list, the sheet, the
+  expanded view's 70dvh cap), so Save and Cancel land below the fold on all three. The
+  editor solves that once; no host grows a pinned footer of its own. The bar bleeds past
+  `.grid`'s side padding so its opaque background reaches the form's edges.
 - **Only one expander at a time.** Opening another while the current one is dirty asks
   first.
 - **Optimistic writes** stay as they were; a rejected save keeps the expander open with the


### PR DESCRIPTION
## Summary

P7 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`), and the last of Session B.

**Stacked PR — merge in order: #341 → #342 → this.** Base is #342 (P6), which is based on #341 (P5). After #342 squash-merges, this branch is rebased onto `main` (`git rebase --onto origin/main claude/session-b-frontend-packages-83a5lr-p6`) before it merges; the local verification session does that rebase as part of its pass.

Fixes **F5, F6, F7, F8, F9** and the editor half of **F24** from the register in `dev/v040_frontend_completeness_plan.md`. None is filed as an issue yet, so there is no `Closes` line.

The form was authored for a card 600–900px wide and then given the expanded view and the sidebar page to fill. Most of what follows is a measurement that stopped being true there.

### F5 — the action bar is always visible

Sticky was gated on `:host([mobile])`, but the mechanics never needed the phone: every host scrolls the form in a box of its own — the card's list at `min(80dvh, 760px)`, the sheet, and the expanded view at 70dvh — so Save, Delete and Cancel were below the fold on all three. The gate goes; the editor solves it once and no host grows a pinned footer of its own (decision 11). The comment about the containing block never had to face the gutter on a phone: `.grid`'s 18px side padding left the opaque bar short of the edges, with the rows it covers showing in a strip either side, so the bar bleeds full-width with matching padding back.

### F6/F7 — widths and the stretch cascade

- Quantity and Low-stock take **number-sized tracks** (140px / 160px) and Name takes `minmax(0, 1fr)`. `2fr 1fr 1fr` was authored where `1fr` ≈ 180px; at 1080p it handed a two-digit number about 400px. The phone collapse to one column is untouched.
- `.cell` gains `align-content: start`. A grid item stretches by default, so a cell holding a label and a control grew to the row's tallest cell — the Description textarea — and its two auto rows split the difference. That is precisely why the status select came out taller than an input and shorter than the textarea: the midpoint. The same hazard was already guarded one level down on `.state`; this closes it at the top.

### F8 — one label recipe, one note size, two sibling boxes

- `.group-caption` keeps only the layout for its icon; the type is `.hv-label`, the recipe every other label in the form already uses. Two recipes differing by one weight step read as two kinds of label.
- The small print consolidates on **one note size**, declared once as `--hv-editor-note` on the host with a comment saying what it covers — the band spanned 11/11.5/12/12.5px across hints, tallies, sizes, errors and the upload queue. Labels stay at 11px.
- `hv-chip-input`'s input rises to `13.5px`, matching `.hv-input`, so the tag field stops being a point smaller than every field beside it. The Tags suffix loses the file's only inline `style=` for a class. The redundant `margin-top`s on `.photos` and `.documents` go, so every section's label-to-content gap is the cell's.
- The state boxes take **even halves** (the inspection offsets wrapped onto three rows at `2fr 1fr`), the Checkout box drops `align-items: end` — with `align-content: start` the button now sits under its caption, level with the label opposite, and the surplus falls below both — and the due-date hint **moves into the field it explains**, so both boxes are caption + body and nothing else, at every check-out state.

### F9 — the tally states a fact

"0 of 2 keys in use" reads as a quota, and there is none: the denominator counted distinct keys anywhere in the inventory, and the `|| used` fallback made it the numerator whenever that lookup was empty — so it could only ever say "N of N". It reads `${counted(used, 'field')} set` now. The inventory-wide keys stay where they are already framed correctly, as "Key suggestions".

### F24 (editor half)

The box headed "Checkout" over a button reading "Check out…" is headed "Check out".

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1522 passed), `npm run build`

New coverage: the numeric tracks with the phone collapse still intact; `align-content: start` on the cell; the state row's even halves and the absence of the bottom-aligning rule; the due-date hint inside its field, and gone once there is a check-out to be due; the section captions carrying the shared label class and `.group-caption` carrying no type; one note-size declaration with nothing left of the 11.5/12.5px band in the component's own sheet; no inline style attribute in the rendered form; the chip input's font; the dropped margins; the tally at two fields and at none, with the key suggestions still offered; the caption and its button reading the same verb.

The sticky pin asserted the rule *is* phone-scoped and was rewritten to assert the opposite — unscoped, not present under `:host([mobile])`, and full-bleed on both hosts — rather than deleted, per the campaign rule.

Docs: `docs/frontend_architecture.md`'s "one edit form" bullet now states where the action bar sticks and why it is the editor's problem rather than each host's.

### Delegated to the local verification session

Everything measured on a screen. Checklist P7 in the plan's §Verification: the action bar visible without scrolling at 1080p and staying pinned and opaque edge to edge while the form scrolls; the numeric fields at their new width; the status select at input height beside the taller Description; one label size across TAGS / PHOTOS / DOCUMENTS / CHECK OUT / NEXT INSPECTION and one note size below them; the tag input matching its neighbours; neither state box carrying dead air above its first control, with the offset chips wrapping at most once at card width; the tally reading "N fields set". Screenshots light + dark, desktop + 390px.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

## Follow-ups

- `hv-item-editor`'s two internal confirms still take the centred form on a phone (carried over from #341's note). They cannot be handed the editor's `mobile` property, which is the card-element measurement; P8 reworks the discard confirm and is where that wiring belongs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012JmwzY4tcD4cU1QHmCLmxm)_