### PR TITLE
fix(card): a dirty editor always asks before discarding, on every close path

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,10 @@ throughout.
   custom fields (text / number / yes-no / date). Saves send the item's expected version so
   a concurrent edit surfaces as a conflict; a save that does not land says so in the form
   you are looking at and leaves your edits in it. Escape takes back one thing at a time: an open
-  picker first, then the form — and a form you have typed into asks before it discards.
+  picker first, then the form. **Nothing throws typed edits away without asking** — Cancel,
+  the ✕, Escape, tapping the scrim or swiping a phone sheet down, switching to another row,
+  and closing the expanded view all raise the same question, and answering "keep" leaves the
+  form exactly as it was.
   With no locations yet, the location picker creates the first one and files the item in
   it, rather than pointing at a menu three steps away.
 - **Photos and manuals** attach from the same form, once the item exists — an upload is

--- a/cards/haventory-card/src/components/hv-bottom-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-bottom-sheet.test.ts
@@ -33,7 +33,11 @@ describe('hv-bottom-sheet', () => {
     expect(el.shadowRoot?.querySelector('[data-testid="sheet-handle"]')).toBe(null);
   });
 
-  it('closes and emits cancel from the scrim and from Escape', async () => {
+  // The sheet reports a dismissal and leaves the closing to the host, whose
+  // state the `open` binding comes from. Closing itself put it out of step with
+  // that binding — Lit had committed `true` and would never write it back — so
+  // a host that wanted to ask something first had nowhere to put the sheet back.
+  it('emits cancel from the scrim and from Escape without closing itself', async () => {
     for (const trigger of ['scrim', 'escape'] as const) {
       const el = await mount();
       let fired = 0;
@@ -51,7 +55,7 @@ describe('hv-bottom-sheet', () => {
       }
 
       expect(fired, `cancel via ${trigger}`).toBe(1);
-      expect(el.open).toBe(false);
+      expect(el.open, `still up after ${trigger}`).toBe(true);
       el.remove();
     }
   });
@@ -122,7 +126,8 @@ describe('hv-bottom-sheet: drag to dismiss', () => {
     await (await grip(el)).drag(100, 400);
 
     expect(cancelled).toBe(1);
-    expect(el.open).toBe(false);
+    // Reported, not acted on: the host closes, so a dirty form can be asked about.
+    expect(el.open).toBe(true);
   });
 
   it('springs back from a drag too short to mean it', async () => {
@@ -196,7 +201,7 @@ describe('hv-bottom-sheet: drag to dismiss', () => {
     opener.remove();
   });
 
-  it('closes on Escape raised from inside the sheet', async () => {
+  it('reports Escape raised from inside the sheet', async () => {
     const el = await mount();
     let cancels = 0;
     el.addEventListener('cancel', () => { cancels += 1; });
@@ -207,6 +212,28 @@ describe('hv-bottom-sheet: drag to dismiss', () => {
     await el.updateComplete;
 
     expect(cancels).toBe(1);
+    expect(el.open).toBe(true);
+  });
+
+  // The whole point of not self-closing: a host can hold the sheet up while it
+  // asks a question, and the binding it holds it with still agrees with the DOM.
+  it('stays up when the host declines to close it, and goes down when it does', async () => {
+    const el = await mount();
+    let allow = false;
+    el.addEventListener('cancel', () => {
+      if (allow) el.open = false;
+    });
+    const scrim = () => (el.shadowRoot?.querySelector('.scrim') as HTMLElement | null)?.click();
+
+    scrim();
+    await el.updateComplete;
+    expect(el.open).toBe(true);
+    expect(el.shadowRoot?.querySelector('[data-testid="bottom-sheet"]')).toBeTruthy();
+
+    allow = true;
+    scrim();
+    await el.updateComplete;
     expect(el.open).toBe(false);
+    expect(el.shadowRoot?.querySelector('[data-testid="bottom-sheet"]')).toBe(null);
   });
 });

--- a/cards/haventory-card/src/components/hv-bottom-sheet.ts
+++ b/cards/haventory-card/src/components/hv-bottom-sheet.ts
@@ -123,8 +123,17 @@ export class HVBottomSheet extends LitElement {
     }
   }
 
+  /**
+   * Report the dismissal and leave the closing to whoever opened the sheet.
+   *
+   * The host binds `open` from its own state, so a sheet that closed itself
+   * here would be out of step with that binding — Lit compares against the
+   * value it last committed, sees no change, and never sets the property back.
+   * A host with a question to ask first — a form with unsaved typing in it —
+   * could then only put the sheet back up by writing the property behind the
+   * binding's back.
+   */
   private _cancel = () => {
-    this.open = false;
     this.dispatchEvent(new CustomEvent('cancel', { bubbles: true, composed: true }));
   };
 

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1,5 +1,6 @@
 import './hv-card-shell';
 import { makeMockHass, makeItem, stubViewport } from '../test.utils';
+import { DISCARD_PROMPT } from '../ui/discard';
 import { base, tokens } from '../ui/tokens';
 import { Store } from '../store/store';
 import type { HVCardShell } from './hv-card-shell';
@@ -872,6 +873,90 @@ describe('hv-card-shell: adding an item on a phone', () => {
     const list = sr.querySelector('hv-list') as HTMLElement & { addingNew: boolean };
     expect(list.addingNew).toBe(true);
   });
+
+  // The sheet's scrim, its swipe and its ✕ all threw a half-typed new item away
+  // without a word, while switching rows on the same shell had always asked.
+  describe('a half-filled new item is asked about before it goes', () => {
+    async function dirtyAddSheet() {
+      const mounted = await mountShell({ items: [makeItem({ id: '1' })], mobile: true });
+      const { el, sr } = mounted;
+      (sr.querySelector('[data-testid="add-item"]') as HTMLButtonElement).click();
+      await settle(el);
+      const form = sr.querySelector('hv-item-editor') as HTMLElement;
+      const name = form.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+      name.value = 'Half typed';
+      name.dispatchEvent(new Event('input'));
+      await settle(el);
+      return mounted;
+    }
+
+    const hostGuard = (sr: ShadowRoot) =>
+      sr.querySelector('[data-testid="host-confirm"]') as HTMLElement & { open: boolean };
+    const typed = (sr: ShadowRoot) =>
+      (
+        sr.querySelector('hv-item-editor')?.shadowRoot?.querySelector(
+          '[data-testid="editor-name"]',
+        ) as HTMLInputElement | null
+      )?.value;
+
+    const dismiss = {
+      'close button': (sr: ShadowRoot) =>
+        (sr.querySelector('[data-testid="add-sheet-close"]') as HTMLButtonElement).click(),
+      scrim: (sr: ShadowRoot) =>
+        (addSheet(sr)?.shadowRoot?.querySelector('.scrim') as HTMLElement).click(),
+    } as const;
+
+    it.each(Object.keys(dismiss) as (keyof typeof dismiss)[])(
+      '%s asks, and the sheet stays up with the typing in it',
+      async (how) => {
+        const { el, sr } = await dirtyAddSheet();
+
+        dismiss[how](sr);
+        await settle(el);
+
+        expect(hostGuard(sr).open).toBe(true);
+        expect(addSheet(sr)?.open).toBe(true);
+        expect(typed(sr)).toBe('Half typed');
+
+        (
+          hostGuard(sr).shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement
+        ).click();
+        await settle(el);
+        expect(addSheet(sr)?.open).toBe(false);
+      },
+    );
+
+    it('keeps the sheet and the typing when the question is declined', async () => {
+      const { el, sr } = await dirtyAddSheet();
+
+      dismiss.scrim(sr);
+      await settle(el);
+      (
+        hostGuard(sr).shadowRoot?.querySelector('[data-testid="confirm-cancel"]') as HTMLButtonElement
+      ).click();
+      await settle(el);
+
+      expect(addSheet(sr)?.open).toBe(true);
+      expect(typed(sr)).toBe('Half typed');
+    });
+
+    it('asks the same question every other surface asks', async () => {
+      const { el, sr } = await dirtyAddSheet();
+      dismiss.scrim(sr);
+      await settle(el);
+
+      const panel = hostGuard(sr).shadowRoot as ShadowRoot;
+      expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
+        DISCARD_PROMPT.heading,
+      );
+      expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
+        DISCARD_PROMPT.message,
+      );
+      expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
+        DISCARD_PROMPT.confirmLabel,
+      );
+    });
+  });
 });
 
 describe('hv-card-shell: mobile', () => {
@@ -1233,6 +1318,14 @@ describe('hv-card-shell: the open editor survives a refetch', () => {
     await settle(el);
 
     (editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-cancel"]') as HTMLButtonElement).click();
+    await settle(el);
+    // Typed edits are on the form, so Cancel asks; the pin survives the question
+    // and is released by the answer.
+    const guard = editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-discard-confirm"]') as HTMLElement & {
+      open: boolean;
+    };
+    expect(guard.open).toBe(true);
+    (guard.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement).click();
     await settle(el);
 
     expect(editor(sr)).toBe(null);

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -12,6 +12,7 @@ import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
+import { DISCARD_PROMPT } from '../ui/discard';
 import { HostSurfaces } from '../host-surfaces';
 import type { Store } from '../store/store';
 import type { Item, Location, StoreFilters, StoreState } from '../store/types';
@@ -619,10 +620,7 @@ export class HVCardShell extends LitElement {
     if (this._editing === next) return;
     if (this._editing !== null && this._editor?.dirty) {
       this.surfaces.confirm({
-        heading: 'Discard your changes?',
-        message: 'The item you are editing has unsaved changes.',
-        confirmLabel: 'Discard',
-        destructive: true,
+        ...DISCARD_PROMPT,
         onConfirm: () => {
           this._editorError = null;
           this._editing = next;
@@ -1265,10 +1263,7 @@ export class HVCardShell extends LitElement {
             label="New item"
             ?open=${this._editing === 'new'}
             data-testid="add-sheet"
-            @cancel=${() => {
-              this._editing = null;
-              this._editorError = null;
-            }}
+            @cancel=${() => this._startEdit(null)}
           >
             <div class="sheet-head">
               <span class="heading">New item</span>
@@ -1277,10 +1272,7 @@ export class HVCardShell extends LitElement {
                 style="margin-left:auto"
                 data-testid="add-sheet-close"
                 aria-label="Close"
-                @click=${() => {
-                  this._editing = null;
-                  this._editorError = null;
-                }}
+                @click=${() => this._startEdit(null)}
               >
                 ${icon('close', 18)}
               </button>

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -1,5 +1,6 @@
 import './hv-detail-sheet';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
+import { DISCARD_PROMPT } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import type { HVDetailSheet } from './hv-detail-sheet';
 import type { HVBottomSheet } from './hv-bottom-sheet';
@@ -349,6 +350,185 @@ describe('hv-detail-sheet: edit view', () => {
     await el.updateComplete;
 
     expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
+  });
+});
+
+// The sheet published a `dirty` getter and nothing read it: a scrim tap, a
+// swipe-down or the Back arrow took the typing with them. The sheet answers for
+// the form it hosts — a host outside cannot see into this shadow root.
+describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
+  /** Open the edit form and type into it. */
+  async function dirtySheet() {
+    const el = await mount({ id: '1', name: 'A' });
+    (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement;
+    const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+    name.value = 'A longer name';
+    name.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    expect(el.dirty).toBe(true);
+    return el;
+  }
+
+  const guard = (el: HVDetailSheet) =>
+    q(el, '[data-testid="sheet-discard-confirm"]') as HTMLElement & { open: boolean };
+  const press = (el: HVDetailSheet, testid: 'confirm-accept' | 'confirm-cancel') =>
+    (guard(el).shadowRoot?.querySelector(`[data-testid="${testid}"]`) as HTMLButtonElement).click();
+
+  /** The three ways out, each landing on the sheet's own cancel path. */
+  const dismissals = {
+    scrim: (el: HVDetailSheet) =>
+      ((q(el, 'hv-bottom-sheet') as HVBottomSheet).shadowRoot?.querySelector('.scrim') as HTMLElement).click(),
+    escape: (el: HVDetailSheet) =>
+      (
+        (q(el, 'hv-bottom-sheet') as HVBottomSheet).shadowRoot?.querySelector(
+          '[data-testid="bottom-sheet"]',
+        ) as HTMLElement
+      ).dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })),
+    swipe: (el: HVDetailSheet) => {
+      const sheet = q(el, 'hv-bottom-sheet') as HVBottomSheet;
+      const node = sheet.shadowRoot?.querySelector('[data-testid="sheet-grip"]') as HTMLElement | null;
+      // Edit mode hides the grip, so the swipe is raised on the panel the
+      // gesture handlers would have received it through.
+      if (!node) return;
+      node.setPointerCapture = () => {};
+      for (const [type, clientY] of [
+        ['pointerdown', 100],
+        ['pointermove', 480],
+        ['pointerup', 480],
+      ] as const) {
+        node.dispatchEvent(new MouseEvent(type, { clientY, bubbles: true }));
+      }
+    },
+  } as const;
+
+  it.each(['scrim', 'escape'] as const)('%s asks, and the sheet stays up until it is answered', async (how) => {
+    const el = await dirtySheet();
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    dismissals[how](el);
+    await el.updateComplete;
+
+    expect(guard(el).open).toBe(true);
+    expect(cancels).toBe(0);
+    expect(el.open).toBe(true);
+    expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
+
+    press(el, 'confirm-accept');
+    await el.updateComplete;
+    expect(cancels).toBe(1);
+    expect(el.open).toBe(false);
+  });
+
+  it.each(['scrim', 'escape'] as const)('%s keeps the form when the question is declined', async (how) => {
+    const el = await dirtySheet();
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    dismissals[how](el);
+    await el.updateComplete;
+    press(el, 'confirm-cancel');
+    await el.updateComplete;
+
+    expect(cancels).toBe(0);
+    expect(el.open).toBe(true);
+    const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement;
+    expect((editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement).value).toBe(
+      'A longer name',
+    );
+  });
+
+  // The grip is hidden in edit mode, so the drag is exercised on the read view:
+  // clean there, and it must not start asking about nothing.
+  it('dismisses a clean read view on a swipe without a question', async () => {
+    const el = await mount({ id: '1', name: 'A' });
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    dismissals.swipe(el);
+    await el.updateComplete;
+
+    expect(guard(el).open).toBe(false);
+    expect(cancels).toBe(1);
+    expect(el.open).toBe(false);
+  });
+
+  it('asks before the Back arrow drops the form for the read view', async () => {
+    const el = await dirtySheet();
+
+    (q(el, '[data-testid="sheet-back"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(guard(el).open).toBe(true);
+    expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
+
+    press(el, 'confirm-accept');
+    await el.updateComplete;
+    // Back lands on the read view; the sheet itself stays up.
+    expect(el.open).toBe(true);
+    expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
+  });
+
+  it('asks the same question the form asks itself', async () => {
+    const el = await dirtySheet();
+    dismissals.scrim(el);
+    await el.updateComplete;
+
+    const panel = guard(el).shadowRoot as ShadowRoot;
+    expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
+      DISCARD_PROMPT.heading,
+    );
+    expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
+      DISCARD_PROMPT.message,
+    );
+    expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
+      DISCARD_PROMPT.confirmLabel,
+    );
+  });
+
+  // Every cancel in the card is composed. Backing out of the date step used to
+  // reach the host as "the sheet closed" and took the item down with it.
+  it('keeps the sheet up when the check-out date step is backed out of', async () => {
+    const el = await mount({ id: '1', name: 'A' });
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    (q(el, '[data-testid="sheet-check-out"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const step = q(el, '[data-testid="sheet-checkout"]') as HTMLElement;
+    (step.shadowRoot?.querySelector('[data-testid="checkout-cancel"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(cancels).toBe(0);
+    expect(el.open).toBe(true);
+    expect(q(el, '[data-testid="sheet-checkout"]')).toBe(null);
+    expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
+  });
+
+  it('closes a clean form on the scrim without asking', async () => {
+    const el = await mount({ id: '1', name: 'A' });
+    (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    dismissals.scrim(el);
+    await el.updateComplete;
+
+    expect(guard(el).open).toBe(false);
+    expect(cancels).toBe(1);
+    expect(el.open).toBe(false);
   });
 });
 

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -19,9 +19,12 @@ import {
 } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import { DialogFocus } from '../ui/dialog-focus';
+import { DISCARD_PROMPT } from '../ui/discard';
+import { ViewportNarrow } from '../ui/responsive';
 import type { AreaRef, Item, Location, LocationTreeNode, MediaConfig, ScalarValue, StatusDefinition } from '../store/types';
 import './hv-bottom-sheet';
 import './hv-checkout-popover';
+import './hv-confirm';
 import './hv-item-editor';
 import type { HVBottomSheet } from './hv-bottom-sheet';
 import type { HVItemEditor } from './hv-item-editor';
@@ -453,8 +456,16 @@ export class HVDetailSheet extends LitElement {
   @state() private _checkoutOpen = false;
   /** Index of the picture shown full-size, or null when the lightbox is closed. */
   @state() private _lightbox: number | null = null;
+  /**
+   * Where the sheet goes once a discard is confirmed, or null while nothing is
+   * being asked. The two answers differ: leaving the form lands on the read
+   * view, dismissing the sheet takes the whole surface down.
+   */
+  @state() private _pendingDiscard: 'read' | 'close' | null = null;
 
   private readonly _urls = new MediaUrls(this);
+  /** Window width, for the confirm this sheet raises over itself. */
+  private readonly _viewport = new ViewportNarrow(this);
   /** Returns focus to the thumbnail the lightbox was opened from. */
   private readonly _lightboxFocus = new DialogFocus();
   /**
@@ -480,6 +491,7 @@ export class HVDetailSheet extends LitElement {
       this._mode = 'read';
       this._checkoutOpen = false;
       this._lightbox = null;
+      this._pendingDiscard = null;
     }
     if (this._lightbox !== null) {
       // The lightbox survives a same-item refresh, and one of those refreshes
@@ -530,6 +542,23 @@ export class HVDetailSheet extends LitElement {
     this.open = false;
     this.dispatchEvent(new CustomEvent('cancel', { bubbles: true, composed: true }));
   };
+
+  /**
+   * Every way out of this sheet, with the form's typing accounted for.
+   *
+   * The sheet answers for the editor it hosts: a host outside cannot see into
+   * this shadow root, and the scrim, the swipe and Escape all arrive here
+   * first. `read` is the Back arrow and the form's own cancel — the sheet stays
+   * up on its read view; `close` is a dismissal and takes the sheet with it.
+   */
+  private _leaveEdit(to: 'read' | 'close') {
+    if (this.dirty) {
+      this._pendingDiscard = to;
+      return;
+    }
+    if (to === 'read') this._mode = 'read';
+    else this._close();
+  }
 
   private _renderCustomFact(key: string, value: ScalarValue) {
     const type = inferType(value);
@@ -728,7 +757,7 @@ export class HVDetailSheet extends LitElement {
 
     return html`
       <div class="bar">
-        <button class="tap" data-testid="sheet-close" aria-label="Close" @click=${this._close}>
+        <button class="tap" data-testid="sheet-close" aria-label="Close" @click=${() => this._leaveEdit('close')}>
           ${icon('close', 22)}
         </button>
         <span class="crumb hv-chip-line" data-testid="sheet-path" title=${pathTitle(parts)}
@@ -851,7 +880,11 @@ export class HVDetailSheet extends LitElement {
                 this._checkoutOpen = false;
                 this._emit('set-due-date', { dueDate: (e.detail as { dueDate: string | null }).dueDate });
               }}
-              @cancel=${() => {
+              @cancel=${(e: Event) => {
+                // Composed, like every cancel in the card: unstopped it reaches
+                // the host as "the sheet closed" and takes the item down with
+                // the date step the user was only backing out of.
+                e.stopPropagation();
                 this._checkoutOpen = false;
               }}
             ></hv-checkout-popover>
@@ -897,9 +930,7 @@ export class HVDetailSheet extends LitElement {
           class="tap"
           data-testid="sheet-back"
           aria-label="Back"
-          @click=${() => {
-            this._mode = 'read';
-          }}
+          @click=${() => this._leaveEdit('read')}
         >
           ${icon('arrowLeft', 21)}
         </button>
@@ -948,15 +979,45 @@ export class HVDetailSheet extends LitElement {
   render() {
     const item = this.item;
     return html`<hv-bottom-sheet
-      data-testid="detail-sheet"
-      ?open=${this.open && !!item}
-      ?noHandle=${this._mode === 'edit'}
-      label=${item?.name ?? 'Item'}
-      @cancel=${this._close}
-    >
-      ${item ? (this._mode === 'edit' ? this._renderEdit(item) : this._renderRead(item)) : null}
-      ${item ? this._renderLightbox(item) : null}
-    </hv-bottom-sheet>`;
+        data-testid="detail-sheet"
+        ?open=${this.open && !!item}
+        ?noHandle=${this._mode === 'edit'}
+        label=${item?.name ?? 'Item'}
+        @cancel=${(e: Event) => {
+          // The inner sheet's cancel is composed, so it would reach the host as
+          // "the detail sheet closed" — before this sheet has decided whether it
+          // is closing at all. The host hears only the one _close sends.
+          e.stopPropagation();
+          this._leaveEdit('close');
+        }}
+      >
+        ${item ? (this._mode === 'edit' ? this._renderEdit(item) : this._renderRead(item)) : null}
+        ${item ? this._renderLightbox(item) : null}
+      </hv-bottom-sheet>
+
+      <!-- Outside the sheet, and its events stopped here: the host listens for
+           a cancel event on this element to take the sheet down, and an answer
+           of "no, keep my typing" must not read as that. -->
+      <hv-confirm
+        data-testid="sheet-discard-confirm"
+        ?open=${this._pendingDiscard !== null}
+        ?mobile=${this._viewport.narrow}
+        .heading=${DISCARD_PROMPT.heading}
+        .message=${DISCARD_PROMPT.message}
+        .confirmLabel=${DISCARD_PROMPT.confirmLabel}
+        destructive
+        @confirm=${(e: Event) => {
+          e.stopPropagation();
+          const to = this._pendingDiscard;
+          this._pendingDiscard = null;
+          this._mode = 'read';
+          if (to === 'close') this._close();
+        }}
+        @cancel=${(e: Event) => {
+          e.stopPropagation();
+          this._pendingDiscard = null;
+        }}
+      ></hv-confirm>`;
   }
 }
 

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,6 +1,7 @@
 import './hv-full-view';
 import { makeMockHass, makeItem, stubViewport } from '../test.utils';
 import { deepActiveElement } from '../ui/dialog-focus';
+import { DISCARD_PROMPT } from '../ui/discard';
 import { NARROW_QUERY } from '../ui/responsive';
 import { Store } from '../store/store';
 import type { HVFullView } from './hv-full-view';
@@ -1222,6 +1223,12 @@ describe('hv-full-view: editing', () => {
       ] as HTMLButtonElement[];
       rows[rows.length - 1].click();
       await settle(el);
+      // The refused save left the typed name in the form, so the switch asks
+      // before it takes it away.
+      const guard = q(sr, '[data-testid="full-discard-confirm"]') as HTMLElement & { open: boolean };
+      expect(guard.open).toBe(true);
+      (guard.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement).click();
+      await settle(el);
 
       expect(q(sr, '[data-testid="full-editor"]')?.shadowRoot?.textContent).toContain('Other — editing');
       expect(errorText(sr)).toBeUndefined();
@@ -1299,6 +1306,173 @@ describe('hv-full-view: editing', () => {
     const column = 400 - 64;
     expect(Math.min((Number(ceiling?.[1]) / 100) * 400, column - reserved)).toBeLessThanOrEqual(
       column - 68 - 41,
+    );
+  });
+});
+
+// Switching rows, the backdrop and Escape all wiped a form mid-sentence. The
+// card's row switch had asked since it shipped; this surface asked nowhere.
+describe('hv-full-view: leaving a dirty form always asks', () => {
+  /** Open the first row's editor and type into it. */
+  async function dirtyEditor(items: Item[]) {
+    const mounted = await mount({ items });
+    const { el, sr } = mounted;
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+    const editor = q(sr, '[data-testid="full-editor"]') as HTMLElement;
+    const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+    name.value = 'Typed but unsaved';
+    name.dispatchEvent(new Event('input'));
+    await settle(el);
+    return mounted;
+  }
+
+  const guard = (sr: ShadowRoot) =>
+    q(sr, '[data-testid="full-discard-confirm"]') as HTMLElement & { open: boolean };
+  const answer = (sr: ShadowRoot, which: 'confirm-accept' | 'confirm-cancel') =>
+    (guard(sr).shadowRoot?.querySelector(`[data-testid="${which}"]`) as HTMLButtonElement).click();
+  const editorName = (sr: ShadowRoot) =>
+    (
+      (q(sr, '[data-testid="full-editor"]') as HTMLElement | null)?.shadowRoot?.querySelector(
+        '[data-testid="editor-name"]',
+      ) as HTMLInputElement | null
+    )?.value;
+
+  const two = () => [makeItem({ id: '1', name: 'First' }), makeItem({ id: '2', name: 'Second' })];
+
+  /** Every way out of the open form on this surface. */
+  const leave = {
+    'row switch': (sr: ShadowRoot) => {
+      const rows = [
+        ...((q(sr, '[data-testid="full-table"]') as HTMLElement).shadowRoot?.querySelectorAll(
+          '[data-testid="table-edit"]',
+        ) ?? []),
+      ] as HTMLButtonElement[];
+      rows[rows.length - 1].click();
+    },
+    backdrop: (sr: ShadowRoot) => (q(sr, '.backdrop') as HTMLElement).click(),
+    escape: (sr: ShadowRoot) =>
+      (q(sr, '[data-testid="full-view"]') as HTMLElement).dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      ),
+    close: (sr: ShadowRoot) => (q(sr, '[data-testid="expand-toggle"]') as HTMLButtonElement).click(),
+  } as const;
+
+  it.each(Object.keys(leave) as (keyof typeof leave)[])(
+    '%s asks first and changes nothing until it is answered',
+    async (how) => {
+      const { el, sr } = await dirtyEditor(two());
+      let closes = 0;
+      el.addEventListener('close', () => {
+        closes += 1;
+      });
+
+      leave[how](sr);
+      await settle(el);
+
+      expect(guard(sr).open).toBe(true);
+      expect(closes).toBe(0);
+      expect(el.open).toBe(true);
+      expect(editorName(sr)).toBe('Typed but unsaved');
+    },
+  );
+
+  it.each(Object.keys(leave) as (keyof typeof leave)[])(
+    '%s keeps the typing when the question is declined',
+    async (how) => {
+      const { el, sr } = await dirtyEditor(two());
+
+      leave[how](sr);
+      await settle(el);
+      answer(sr, 'confirm-cancel');
+      await settle(el);
+
+      expect(guard(sr).open).toBe(false);
+      expect(el.open).toBe(true);
+      expect(editorName(sr)).toBe('Typed but unsaved');
+    },
+  );
+
+  it('opens the other row once the discard is confirmed', async () => {
+    const { el, sr } = await dirtyEditor(two());
+
+    leave['row switch'](sr);
+    await settle(el);
+    answer(sr, 'confirm-accept');
+    await settle(el);
+
+    expect(q(sr, '[data-testid="full-editor"]')?.shadowRoot?.textContent).toContain('Second — editing');
+    expect(editorName(sr)).toBe('Second');
+  });
+
+  it.each(['backdrop', 'escape', 'close'] as const)(
+    'closes the view once %s is confirmed',
+    async (how) => {
+      const { el, sr } = await dirtyEditor(two());
+      let closes = 0;
+      el.addEventListener('close', () => {
+        closes += 1;
+      });
+
+      leave[how](sr);
+      await settle(el);
+      answer(sr, 'confirm-accept');
+      await settle(el);
+
+      expect(closes).toBe(1);
+      expect(el.open).toBe(false);
+    },
+  );
+
+  it('leaves a clean form without a word', async () => {
+    const { el, sr } = await mount({ items: two() });
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    leave['row switch'](sr);
+    await settle(el);
+
+    expect(guard(sr).open).toBe(false);
+    expect(editorName(sr)).toBe('Second');
+  });
+
+  // The panel has no backdrop, no Escape and no close button, but it switches
+  // rows in the same table.
+  it('asks on a row switch in the embedded panel too', async () => {
+    const { el, sr } = await mount({ items: two(), embedded: true });
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+    const name = (q(sr, '[data-testid="full-editor"]') as HTMLElement).shadowRoot?.querySelector(
+      '[data-testid="editor-name"]',
+    ) as HTMLInputElement;
+    name.value = 'Typed but unsaved';
+    name.dispatchEvent(new Event('input'));
+    await settle(el);
+
+    leave['row switch'](sr);
+    await settle(el);
+
+    expect(guard(sr).open).toBe(true);
+    expect(editorName(sr)).toBe('Typed but unsaved');
+  });
+
+  it('asks the same question the form asks itself', async () => {
+    const { el, sr } = await dirtyEditor(two());
+    leave.backdrop(sr);
+    await settle(el);
+
+    const panel = guard(sr).shadowRoot as ShadowRoot;
+    expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
+      DISCARD_PROMPT.heading,
+    );
+    expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
+      DISCARD_PROMPT.message,
+    );
+    expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
+      DISCARD_PROMPT.confirmLabel,
     );
   });
 });

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -18,6 +18,7 @@ import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
+import { DISCARD_PROMPT } from '../ui/discard';
 import { NARROW_QUERY } from '../ui/responsive';
 import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
@@ -37,6 +38,7 @@ import './hv-filter-panel';
 import './hv-item-editor';
 import './hv-location-tree';
 import './hv-overflow-menu';
+import type { HVItemEditor } from './hv-item-editor';
 import type { HVLocationTree } from './hv-location-tree';
 import type { HVFilterPanel } from './hv-filter-panel';
 
@@ -819,6 +821,11 @@ export class HVFullView extends LitElement {
   @state() private _bulkProgress: BulkProgress | null = null;
   @state() private _bulkResult: BulkResultView | null = null;
   @state() private _pendingDelete = false;
+  /**
+   * Where the surface goes once a discard is confirmed, or null while nothing
+   * is being asked: another row, the create form, or the view closing.
+   */
+  @state() private _pendingDiscard: string | 'new' | 'close' | null = null;
   @state() private _loadingAll = false;
   /** Set while a batch is running so Cancel can stop it between chunks. */
   private _bulkCancelled = false;
@@ -879,6 +886,7 @@ export class HVFullView extends LitElement {
         this._filtersOpen = false;
         this._editing = null;
         this._editorError = null;
+        this._pendingDiscard = null;
         this._creatingLocation = false;
         this._locationError = null;
         this._selecting = false;
@@ -912,6 +920,36 @@ export class HVFullView extends LitElement {
     this.open = false;
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   };
+
+  private get _editor(): HVItemEditor | null {
+    return this.shadowRoot?.querySelector('hv-item-editor') ?? null;
+  }
+
+  /**
+   * Leave the open form — for another row, for the create form, or by closing
+   * the whole surface — asking first if there is typing to lose.
+   *
+   * The form asks for its own Cancel, ✕ and Escape, but only about closing.
+   * Everything here has somewhere else to be afterwards, so the question is
+   * raised on this side and the destination held until it is answered. Same
+   * wording either way: `ui/discard` owns it.
+   */
+  private _leaveEditor(to: string | 'new' | 'close') {
+    if (this._editing !== null && this._editor?.dirty) {
+      this._pendingDiscard = to;
+      return;
+    }
+    this._applyLeave(to);
+  }
+
+  private _applyLeave(to: string | 'new' | 'close') {
+    if (to === 'close') {
+      this._close();
+      return;
+    }
+    this._editing = to;
+    this._editorError = null;
+  }
 
   // ---------- Focus trap ----------
   /**
@@ -961,6 +999,8 @@ export class HVFullView extends LitElement {
       this._pinnedItem = null;
       this._editing = null;
       this._editorError = null;
+      // Nothing left to discard, so the question — if one was up — is moot.
+      this._pendingDiscard = null;
       return;
     }
     const listed = this.st?.items.find((i) => i.id === editing);
@@ -986,8 +1026,7 @@ export class HVFullView extends LitElement {
         break;
       case 'edit':
       case 'open-item':
-        this._editing = item.id;
-        this._editorError = null;
+        this._leaveEditor(item.id);
         break;
     }
   }
@@ -1506,10 +1545,7 @@ export class HVFullView extends LitElement {
       locationName: (st?.locationsFlatCache ?? []).find((l) => l.id === filters.locationId)?.name ?? null,
       onAction: (id: EmptyOffer['id']) => {
         if (id === 'clear-filters') this.store?.clearFilters();
-        else if (id === 'add-item') {
-          this._editing = 'new';
-          this._editorError = null;
-        }
+        else if (id === 'add-item') this._leaveEditor('new');
         else if (id === 'refresh') void this.store?.refreshAll();
         else
           this.dispatchEvent(
@@ -1600,7 +1636,12 @@ export class HVFullView extends LitElement {
 
     return html`
       ${modal
-        ? html`<div class="backdrop" role="presentation" style="z-index: ${z};" @click=${this._close}></div>`
+        ? html`<div
+            class="backdrop"
+            role="presentation"
+            style="z-index: ${z};"
+            @click=${() => this._leaveEditor('close')}
+          ></div>`
         : null}
       <div
         class="shell"
@@ -1609,7 +1650,7 @@ export class HVFullView extends LitElement {
         aria-label=${this.heading}
         data-testid="full-view"
         style=${modal ? `z-index: ${z + 1};` : ''}
-        @keydown=${modal ? onEscape(() => this._close()) : nothing}
+        @keydown=${modal ? onEscape(() => this._leaveEditor('close')) : nothing}
       >
         ${modal ? html`<span class="sentinel" tabindex="0" @focus=${() => this._focusLast()}></span>` : null}
         ${this._selecting ? this._renderSelectionBar() : this._renderAppBar()}
@@ -1706,7 +1747,12 @@ export class HVFullView extends LitElement {
         <div class="appbar">
           ${this.embedded
             ? this._renderMenuButton()
-            : html`<button class="tap" data-testid="expand-toggle" aria-label="Close full view" @click=${this._close}>
+            : html`<button
+                class="tap"
+                data-testid="expand-toggle"
+                aria-label="Close full view"
+                @click=${() => this._leaveEditor('close')}
+              >
                 ${icon('close', 20)}
               </button>`}
           <h2>${this.heading}</h2>
@@ -1772,10 +1818,7 @@ export class HVFullView extends LitElement {
           <button
             class="add"
             data-testid="full-add-item"
-            @click=${() => {
-              this._editing = 'new';
-              this._editorError = null;
-            }}
+            @click=${() => this._leaveEditor('new')}
           >
             ${icon('plus', 16)}Add item
           </button>
@@ -1970,6 +2013,24 @@ export class HVFullView extends LitElement {
           }}
           @cancel=${() => {
             this._pendingDelete = false;
+          }}
+        ></hv-confirm>
+
+        <hv-confirm
+          data-testid="full-discard-confirm"
+          ?open=${this._pendingDiscard !== null}
+          ?mobile=${this._narrow}
+          .heading=${DISCARD_PROMPT.heading}
+          .message=${DISCARD_PROMPT.message}
+          .confirmLabel=${DISCARD_PROMPT.confirmLabel}
+          destructive
+          @confirm=${() => {
+            const to = this._pendingDiscard;
+            this._pendingDiscard = null;
+            if (to !== null) this._applyLeave(to);
+          }}
+          @cancel=${() => {
+            this._pendingDiscard = null;
           }}
         ></hv-confirm>
     `;

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1,5 +1,6 @@
 import './hv-item-editor';
-import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
+import { makeAttachment, makeItem, makeManual, makeMediaBindings, stubViewport } from '../test.utils';
+import { DISCARD_PROMPT } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { addDays } from '../ui/relative-time';
 import type { HVItemEditor } from './hv-item-editor';
@@ -470,7 +471,9 @@ describe('hv-item-editor: saving', () => {
   it('names the save chord for the keyboard it can actually detect', async () => {
     const el = await mount(makeItem({ id: '1', name: 'A' }));
     const hint = q(el, '[data-testid="editor-key-hint"]')?.textContent ?? '';
-    expect(hint).toContain('Esc discards');
+    // Esc no longer discards: it asks whenever there is typing to lose, exactly
+    // as Cancel and the ✕ do, so the hint stops promising the old outcome.
+    expect(hint).toContain('Esc closes');
     expect(hint).toContain('Ctrl+Enter saves');
     expect(hint).not.toContain('⌘');
   });
@@ -1129,6 +1132,98 @@ describe('hv-item-editor: Escape takes back one thing at a time', () => {
     expect(cancels.count).toBe(1);
     expect((await dialog(el, 'editor-discard-confirm')).open).toBe(false);
   });
+});
+
+// Escape asked and the two buttons beside it did not, so the same decision had
+// a cheap way out and an expensive one depending on which control was nearest.
+describe('hv-item-editor: every close this form owns asks the same question', () => {
+  const paths = ['editor-cancel', 'editor-close'] as const;
+
+  it.each(paths)('%s asks before throwing typed edits away', async (testid) => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+    await type(el, 'editor-name', 'A longer name');
+
+    (q(el, `[data-testid="${testid}"]`) as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    const guard = await dialog(el, 'editor-discard-confirm');
+    expect(guard.open).toBe(true);
+    expect(guard.shadowRoot?.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
+      DISCARD_PROMPT.message,
+    );
+    expect(cancels).toBe(0);
+
+    (guard.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(cancels).toBe(1);
+  });
+
+  it.each(paths)('%s keeps the typing when the question is declined', async (testid) => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+    await type(el, 'editor-name', 'A longer name');
+
+    (q(el, `[data-testid="${testid}"]`) as HTMLButtonElement).click();
+    await el.updateComplete;
+    const guard = await dialog(el, 'editor-discard-confirm');
+    (guard.shadowRoot?.querySelector('[data-testid="confirm-cancel"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(cancels).toBe(0);
+    expect((q(el, '[data-testid="editor-name"]') as HTMLInputElement).value).toBe('A longer name');
+  });
+
+  it.each(paths)('%s closes a clean form without asking', async (testid) => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    (q(el, `[data-testid="${testid}"]`) as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(cancels).toBe(1);
+    expect((await dialog(el, 'editor-discard-confirm')).open).toBe(false);
+  });
+
+  // A host with somewhere to go afterwards asks this instead of firing `cancel`
+  // blind: false means the form has taken the question on itself.
+  it('reports whether a host may tear the form down', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    expect(el.requestClose()).toBe(true);
+
+    await type(el, 'editor-name', 'A longer name');
+    expect(el.requestClose()).toBe(false);
+    await el.updateComplete;
+    expect((await dialog(el, 'editor-discard-confirm')).open).toBe(true);
+  });
+
+  // Both dialogs are fixed to the window, so they take their phone form from the
+  // viewport — the form's own `mobile` is the card element's width and would put
+  // a bottom sheet on a desktop monitor whenever the card sat in a narrow column.
+  it.each(['editor-discard-confirm', 'editor-remove-confirm'] as const)(
+    '%s takes its phone form from the viewport, not the card',
+    async (confirmId) => {
+      for (const narrow of [true, false]) {
+        const restore = stubViewport(narrow);
+        try {
+          const el = await mount(makeItem({ id: '1', name: 'A' }), { mobile: !narrow });
+          expect((await dialog(el, confirmId)).hasAttribute('mobile')).toBe(narrow);
+          el.remove();
+        } finally {
+          restore();
+        }
+      }
+    },
+  );
 });
 
 // The first minute of a fresh install: an item form whose most important field

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -14,6 +14,8 @@ import {
 } from '../ui/relative-time';
 import { saveShortcutLabel } from '../ui/keyboard';
 import { counted } from '../ui/plural';
+import { DISCARD_PROMPT } from '../ui/discard';
+import { ViewportNarrow } from '../ui/responsive';
 import { nextZBase } from '../utils/zindex';
 import {
   customFieldsFrom,
@@ -1098,6 +1100,8 @@ export class HVItemEditor extends LitElement {
   @state() private _createdLocations: Location[] = [];
 
   private readonly _urls = new MediaUrls(this);
+  /** Window width, for the two dialogs this form raises over itself. */
+  private readonly _viewport = new ViewportNarrow(this);
   private _uploadSeq = 0;
   /**
    * The item id `_model` was built from. `undefined` until the first update,
@@ -1199,6 +1203,26 @@ export class HVItemEditor extends LitElement {
   };
 
   /**
+   * Ask the form to close, and say whether the caller may tear it down now.
+   *
+   * `false` means the form has raised the discard question itself: the caller
+   * does nothing further and waits for the `cancel` event a confirmed discard
+   * sends, which is the same event Cancel sends on a clean form. A host with
+   * somewhere else to go afterwards — another row, a whole surface closing —
+   * asks its own copy of the question instead, from `ui/discard`.
+   */
+  requestClose(): boolean {
+    if (!this.dirty) return true;
+    this._confirmDiscard = true;
+    return false;
+  }
+
+  /** Every close this form owns: Cancel, the ✕, and Escape with nothing over it. */
+  private _requestCancel = () => {
+    if (this.requestClose()) this._cancel();
+  };
+
+  /**
    * Escape takes back one thing at a time.
    *
    * Whatever the form has open on top of itself goes first — a dropdown is what
@@ -1217,10 +1241,8 @@ export class HVItemEditor extends LitElement {
         this._checkoutOpen = false;
       } else if (this._locationOpen) {
         this._closeLocation();
-      } else if (this.dirty) {
-        this._confirmDiscard = true;
       } else {
-        this._cancel();
+        this._requestCancel();
       }
     } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
@@ -2517,7 +2539,7 @@ export class HVItemEditor extends LitElement {
                 class="hv-icon-button"
                 data-testid="editor-close"
                 aria-label="Close editor"
-                @click=${this._cancel}
+                @click=${this._requestCancel}
               >
                 ${icon('close', 18)}
               </button>
@@ -2583,9 +2605,11 @@ export class HVItemEditor extends LitElement {
               ${this.mobile
                 ? null
                 : html`<span class="hint" data-testid="editor-key-hint">
-                    Esc discards · ${saveShortcutLabel()} saves
+                    Esc closes · ${saveShortcutLabel()} saves
                   </span>`}
-              <button class="hv-text-button" data-testid="editor-cancel" @click=${this._cancel}>Cancel</button>
+              <button class="hv-text-button" data-testid="editor-cancel" @click=${this._requestCancel}>
+                Cancel
+              </button>
               <button class="save" data-testid="editor-save" ?disabled=${this.busy} @click=${this._save}>
                 ${this.busy ? 'Saving…' : 'Save'}
               </button>
@@ -2597,10 +2621,15 @@ export class HVItemEditor extends LitElement {
       <!-- Outside the form's own keydown scope, and their events stopped here:
            a host listens for the cancel event on this editor to close it, and a
            dialog saying "no, keep the photo" must not read as "close the
-           form". -->
+           form".
+
+           The mobile flag below is the viewport, not this form's own mobile
+           property: both dialogs are fixed to the window, so the card's width
+           says nothing about the room they have. -->
       <hv-confirm
         data-testid="editor-remove-confirm"
         ?open=${this._confirmRemove !== null}
+        ?mobile=${this._viewport.narrow}
         .heading=${REMOVE_COPY[this._confirmRemove?.kind ?? 'picture'].heading}
         .message=${REMOVE_COPY[this._confirmRemove?.kind ?? 'picture'].message}
         confirmLabel="Remove"
@@ -2621,9 +2650,10 @@ export class HVItemEditor extends LitElement {
       <hv-confirm
         data-testid="editor-discard-confirm"
         ?open=${this._confirmDiscard}
-        heading="Discard your changes?"
-        message="What you have typed since the last save is lost."
-        confirmLabel="Discard"
+        ?mobile=${this._viewport.narrow}
+        .heading=${DISCARD_PROMPT.heading}
+        .message=${DISCARD_PROMPT.message}
+        .confirmLabel=${DISCARD_PROMPT.confirmLabel}
         destructive
         @confirm=${(e: Event) => {
           e.stopPropagation();

--- a/cards/haventory-card/src/ui/discard.ts
+++ b/cards/haventory-card/src/ui/discard.ts
@@ -1,0 +1,18 @@
+/**
+ * The one question asked before typed edits are thrown away.
+ *
+ * Every path that would lose a dirty form asks it: the form's own Cancel, ✕ and
+ * Escape, a sheet's scrim tap and swipe-down, a switch to another row, the full
+ * view's backdrop, Escape and close button. One wording, so the same decision
+ * never reads as a different question depending on which control the user
+ * reached for.
+ *
+ * Spread into `HostSurfaces.confirm()` alongside an `onConfirm`, or bound field
+ * by field onto an `hv-confirm`.
+ */
+export const DISCARD_PROMPT = {
+  heading: 'Discard your changes?',
+  message: 'What you have typed since the last save is lost.',
+  confirmLabel: 'Discard',
+  destructive: true,
+} as const;

--- a/cards/haventory-card/src/ui/responsive.test.ts
+++ b/cards/haventory-card/src/ui/responsive.test.ts
@@ -1,4 +1,4 @@
-import { MOBILE_BREAKPOINT, NARROW_QUERY, ResponsiveController } from './responsive';
+import { MOBILE_BREAKPOINT, NARROW_QUERY, ResponsiveController, ViewportNarrow } from './responsive';
 
 function makeHost() {
   const el = document.createElement('div') as HTMLDivElement & {
@@ -82,5 +82,77 @@ describe('NARROW_QUERY', () => {
   it('is a viewport query, distinct from the card-element breakpoint', () => {
     expect(NARROW_QUERY).toBe('(max-width: 700px)');
     expect(NARROW_QUERY).not.toContain(String(MOBILE_BREAKPOINT));
+  });
+});
+
+describe('ViewportNarrow', () => {
+  /** A matchMedia whose answer the test can change and then announce. */
+  function stub(initial: boolean) {
+    const listeners: ((e: MediaQueryListEvent) => void)[] = [];
+    const original = window.matchMedia;
+    let asked: string | null = null;
+    window.matchMedia = ((media: string) => {
+      asked = media;
+      return {
+        matches: initial,
+        media,
+        addEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) => listeners.push(fn),
+        removeEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) => {
+          const at = listeners.indexOf(fn);
+          if (at >= 0) listeners.splice(at, 1);
+        },
+      };
+    }) as unknown as typeof window.matchMedia;
+    return {
+      get query() {
+        return asked;
+      },
+      get listeners() {
+        return listeners.length;
+      },
+      announce(matches: boolean) {
+        for (const fn of [...listeners]) fn({ matches } as MediaQueryListEvent);
+      },
+      restore: () => {
+        window.matchMedia = original;
+      },
+    };
+  }
+
+  it('reads the viewport query on connect and re-renders on a change', () => {
+    const media = stub(true);
+    try {
+      const host = makeHost();
+      const c = new ViewportNarrow(host as never);
+      expect(c.narrow).toBe(false); // nothing asked until the host connects
+
+      c.hostConnected();
+      expect(media.query).toBe(NARROW_QUERY);
+      expect(c.narrow).toBe(true);
+
+      media.announce(false);
+      expect(c.narrow).toBe(false);
+      expect(host.updates).toBe(1);
+
+      c.hostDisconnected();
+      expect(media.listeners).toBe(0);
+    } finally {
+      media.restore();
+    }
+  });
+
+  // jsdom answers no media query, and a host that cannot say how wide the window
+  // is has no business claiming it is a phone.
+  it('stays on the desktop answer when matchMedia is missing', () => {
+    const original = window.matchMedia;
+    (window as unknown as { matchMedia: undefined }).matchMedia = undefined;
+    try {
+      const c = new ViewportNarrow(makeHost() as never);
+      c.hostConnected();
+      expect(c.narrow).toBe(false);
+      expect(() => c.hostDisconnected()).not.toThrow();
+    } finally {
+      window.matchMedia = original;
+    }
   });
 });

--- a/cards/haventory-card/src/ui/responsive.ts
+++ b/cards/haventory-card/src/ui/responsive.ts
@@ -25,6 +25,51 @@ export const MOBILE_BREAKPOINT = 600;
 export const NARROW_QUERY = '(max-width: 700px)';
 
 /**
+ * Follows `NARROW_QUERY` for a component that draws a `position: fixed` surface
+ * of its own.
+ *
+ * A component already handed a `mobile` property cannot answer this from it:
+ * that property is the card element's width on the card's side of the tree, and
+ * a fixed overlay is laid out against the window whatever the card measures.
+ * The property keeps governing in-flow layout; the overlay asks this.
+ *
+ * `matchMedia` is missing in jsdom unless a test provides one; without it the
+ * answer stays `false`, which is the desktop form — the honest default for a
+ * host that cannot say how wide the window is.
+ */
+export class ViewportNarrow implements ReactiveController {
+  private readonly host: ReactiveControllerHost;
+  private query: MediaQueryList | null = null;
+  private matches = false;
+
+  constructor(host: ReactiveControllerHost) {
+    this.host = host;
+    host.addController(this);
+  }
+
+  /** True on a phone-width viewport. */
+  get narrow(): boolean {
+    return this.matches;
+  }
+
+  hostConnected(): void {
+    this.query ??= window.matchMedia?.(NARROW_QUERY) ?? null;
+    if (!this.query) return;
+    this.matches = this.query.matches;
+    this.query.addEventListener('change', this.onChange);
+  }
+
+  hostDisconnected(): void {
+    this.query?.removeEventListener('change', this.onChange);
+  }
+
+  private readonly onChange = (e: MediaQueryListEvent) => {
+    this.matches = e.matches;
+    this.host.requestUpdate();
+  };
+}
+
+/**
  * Drives the card's mobile/desktop mode from its own rendered width.
  *
  * Media queries are unreliable inside HA dashboards — a card can be narrow in a

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -450,8 +450,13 @@ Any other key in that record is ignored, so an older or newer payload never brea
   expanded view's 70dvh cap), so Save and Cancel land below the fold on all three. The
   editor solves that once; no host grows a pinned footer of its own. The bar bleeds past
   `.grid`'s side padding so its opaque background reaches the form's edges.
-- **Only one expander at a time.** Opening another while the current one is dirty asks
-  first.
+- **No path discards typed edits without asking.** Cancel, the ✕ and Escape are the form's
+  own, so `hv-item-editor` answers for them itself and hosts do not repeat the check; a host
+  with somewhere to go afterwards — another row, a sheet coming down, the expanded view
+  closing — calls `requestClose()` or asks its own copy. Either way the wording comes from
+  `ui/discard`, so the same decision never reads as two different questions. The phone sheets
+  are part of this: `hv-bottom-sheet` reports a scrim tap or a swipe-down and leaves the
+  closing to its host, which is what lets `hv-detail-sheet` answer for the form inside it.
 - **Optimistic writes** stay as they were; a rejected save keeps the expander open with the
   user's text in it, and conflicts render as a banner with *View latest* / *Re-apply*.
 - **Bulk work is chunked**, so progress is determinate and cancel stops cleanly after the


### PR DESCRIPTION
## Summary

P8 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`), and the first of Session C.

Fixes **F10, F11, F12** from the register in `dev/v040_frontend_completeness_plan.md`. None is filed as an issue, so there is no `Closes` line.

Escape asked before throwing typed edits away. The Cancel button and the ✕ standing next to it did not, and neither did anything outside the form — a scrim tap, a swipe-down, a row switch, the backdrop, the expanded view's close. The same decision had a cheap way out and an expensive one depending on which control the user reached for. Decision 12 in the plan: no path discards typed edits without asking, one question, one wording.

### The wording

`src/ui/discard.ts` holds it. The shell's row-switch prompt said something different from the form's own; both read from the constant now, and every new prompt binds it field by field. Tests pin the rendered text against the constant on each surface rather than repeating the string.

### Inside the form (F10)

Cancel, the ✕ and Escape route through one guard. For a host that has somewhere to go afterwards the form offers `requestClose()`: `false` means it has taken the question on itself and the host waits for the `cancel` a confirmed discard sends. The footer hint stops promising "Esc discards" — Esc closes, and asks when there is something to lose.

The form's two confirms also stop taking their phone form from `mobile`, which is the card *element's* width: both are fixed to the window, so a narrow card in a wide window would have drawn a bottom sheet on a desktop monitor, and a card wide enough on a phone drew a centred box. They read the viewport, through a small `ViewportNarrow` controller added beside `NARROW_QUERY` in `ui/responsive.ts`. (This is the wiring P7's follow-up note left to this package.)

### The phone sheets (F11)

`hv-bottom-sheet` used to close itself and then announce it. That put it out of step with the `open` binding it is driven by — Lit had committed `true`, saw no change, and would never write the property back — so a host wanting to ask a question first had no way to put the sheet back up except writing behind the binding's back. It now reports the dismissal and leaves the closing to the host; both hosts already closed on the event, so nothing else changes.

That is what lets `hv-detail-sheet` answer for the form inside it, which the shell cannot see into. Scrim, swipe, Escape and the ✕ ask before the sheet goes; the Back arrow asks before the form is dropped for the read view. The inner sheet's `cancel` is composed, so it is stopped at the sheet's boundary — otherwise the host heard "the detail sheet closed" while the sheet was still asking.

### The full view and panel (F12)

Row switch, backdrop, Escape and the app-bar close consult the open form and hold their destination until the question is answered — another row, the create form, or the view closing. The panel has no backdrop, Escape or close button but switches rows in the same table, and gets that path from the same code. The card's add sheet routes its ✕ and its scrim through the row-switch guard that was already there.

P1's pinned-row behaviour still holds: the pin survives the question and is released by the answer.

### One more leak, stopped in passing

The check-out date step's `cancel` is composed like every other cancel in the card, and nothing stopped it: backing out of the date step on a phone reached the host as "the sheet closed" and took the whole item down with it. One line, in a handler this PR was already rewriting, with a test.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1562 passed), `npm run build`

New coverage, one case per path in the matrix and its clean-form twin: the form's Cancel and ✕ (asks, declining keeps the typing, a clean form closes silently); `requestClose()`'s answer both ways; the confirms' phone form following the viewport and not the card; the sheet's scrim, Escape and Back arrow, with the sheet staying up until the question is answered and a clean read view still swiping away in one gesture; the date step no longer closing the sheet; the full view's row switch, backdrop, Escape and close, on the modal and the embedded variant; the add sheet's ✕ and scrim. Three surfaces additionally pin their rendered prompt against `DISCARD_PROMPT`, so the wordings cannot drift apart again.

Rewritten rather than deleted, per the campaign rule: `hv-bottom-sheet`'s four pins on self-closing now assert that it reports and stays up, plus a new one for a host that declines and then allows; the editor's hint pin reads "Esc closes"; P1's "releases the pin on cancel" and the full view's "drops the error again when the next edit opens" both answer the new question before asserting what they always asserted.

Docs: the README's editing bullet states the rule instead of naming Escape alone; `docs/frontend_architecture.md` gains the ownership split — the form answers for its own controls, hosts with somewhere to go call `requestClose()` or ask their own copy, and the sheet reports rather than closes.

### Delegated to the local verification session

Everything that needs a pointer, a finger or a real viewport. Checklist P8 in the plan's §Verification: the eight-path matrix with a dirty form — editor Cancel, editor ✕, Escape, sheet scrim tap, sheet swipe-down at 390px, full-view row switch, full-view backdrop, full-view Escape — every path asking, "Discard" proceeding, "keep" asking nothing twice, and the same paths with a clean form closing silently. Wording identical everywhere.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`README.md`, `docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

## Follow-ups

- Draft autosave ([#334](https://github.com/chrreiter/HAventory/issues/334)) is the feature that would make most of these questions unnecessary. Out of scope here by decision 12: the guards land first.
- `hv-full-view` and `HostSurfaces` still each hold their own `matchMedia(NARROW_QUERY)` subscription alongside the new controller. Folding them in is mechanical but touches regions P9 and P10 rework, so it is better done after this session's stack lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Stzf72H6aEA8vk1NFMQpr)_