### PR TITLE
feat(card): banners and row actions reach the full view and panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,10 @@ throughout.
   the household's own word in the household's own colour, so the sidebar's Status section
   and the filter chips are where statuses are priced and picked.
   An empty table names the reason and offers a way out — the same
-  wording and the same offers as the card's list.
+  wording and the same offers as the card's list. Every row carries the same ⋮ the card's
+  rows do — Check out with a due date, Check in, Change due date, Delete — so the surface
+  built for working through the whole inventory is not the one with the fewest actions per
+  row.
 
   At phone width the sidebar folds away and the surface hands its own breakpoint down to
   the edit form and the filter panel, so both take their phone layouts: one field per row,
@@ -590,7 +593,8 @@ throughout.
   something is wrong, plus banners for connection loss, rate limiting and the
   payload-free reload an import broadcasts. Because subscription events carry no sequence
   number, a dropped one is undetectable — so the card says the list may be stale and
-  offers an explicit Refresh.
+  offers an explicit Refresh. The banners are on **every** surface: the card, the expanded
+  view and the sidebar page, with the same wording and the same recovery actions.
 - Deletes use an in-app confirmation, not `window.confirm`.
 - Card auto-registered as a Lovelace resource on integration setup.
 - **Note:** after first install, a browser refresh (F5 / Ctrl+Shift+R) is required for the

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -13,11 +13,12 @@ import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
 import { DISCARD_PROMPT } from '../ui/discard';
+import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
+import type { BannerHooks } from '../ui/banners';
 import { HostSurfaces } from '../host-surfaces';
 import type { Store } from '../store/store';
 import type { Item, Location, StoreFilters, StoreState } from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
-import './hv-banner';
 import './hv-bottom-sheet';
 import './hv-filter-chips';
 import './hv-filter-panel';
@@ -66,6 +67,7 @@ export class HVCardShell extends LitElement {
     tokens,
     base,
     chip,
+    bannerStack,
     css`
       :host {
         display: block;
@@ -274,11 +276,6 @@ export class HVCardShell extends LitElement {
       }
       .panel-holder {
         margin: 0 16px 12px;
-      }
-      .banners {
-        display: grid;
-        gap: 6px;
-        padding: 0 16px 10px;
       }
       .footer {
         display: flex;
@@ -855,159 +852,6 @@ export class HVCardShell extends LitElement {
     `;
   }
 
-  /**
-   * Conditions that make the card untrustworthy, said out loud.
-   *
-   * Rate limiting can drop subscription events silently and events carry no
-   * sequence number, so the card cannot detect a gap on its own — the honest
-   * move is to say it might be stale and offer the re-read.
-   */
-  private _renderDegradedBanners() {
-    const degraded = this.st?.degraded;
-    if (!degraded) return null;
-    const banners = [];
-
-    if (degraded.connectionLost) {
-      banners.push(html`<hv-banner
-        kind="error"
-        glyph="wifiOff"
-        heading="Connection lost"
-        message=" · showing the data already loaded. Changes may not save."
-        data-testid="degraded-offline"
-      >
-        <button
-          slot="actions"
-          class="hv-pill outline"
-          data-testid="degraded-reconnect"
-          @click=${() => void this.surfaces.refresh()}
-        >
-          Reconnect
-        </button>
-      </hv-banner>`);
-    } else if (degraded.liveUpdates !== 'live') {
-      // Ranked above the generic rate-limit warning below: that one says events
-      // *may* have been dropped, this one says there are no events at all.
-      const retrying = degraded.liveUpdates === 'retrying';
-      const cause =
-        degraded.liveUpdatesReason === 'unavailable'
-          ? 'HAventory is not available'
-          : 'rate limited';
-      banners.push(html`<hv-banner
-        kind="warning"
-        glyph="clock"
-        heading="Live updates paused"
-        message=${retrying
-          ? ` · ${cause}. Retrying automatically; this list may be out of date until then.`
-          : ` · ${cause}. This list may be out of date until you refresh.`}
-        data-testid="degraded-live-updates"
-      >
-        ${retrying
-          ? null
-          : html`<button
-              slot="actions"
-              class="hv-pill outline"
-              data-testid="degraded-live-refresh"
-              @click=${() => void this.surfaces.refresh()}
-            >
-              Refresh
-            </button>`}
-      </hv-banner>`);
-    } else if (degraded.retrying > 0) {
-      banners.push(html`<hv-banner
-        kind="warning"
-        glyph="clock"
-        heading="Busy — retrying"
-        message=${` · ${counted(degraded.retrying, 'change')} queued`}
-        data-testid="degraded-retrying"
-      ></hv-banner>`);
-    } else if (degraded.rateLimited) {
-      banners.push(html`<hv-banner
-        kind="warning"
-        glyph="clock"
-        heading="Rate limited"
-        message=" · some live updates may have been dropped, so this list can be out of date."
-        data-testid="degraded-rate-limited"
-      >
-        <button
-          slot="actions"
-          class="hv-pill outline"
-          data-testid="degraded-refresh"
-          @click=${() => void this.surfaces.refresh()}
-        >
-          Refresh
-        </button>
-      </hv-banner>`);
-    }
-
-    if (degraded.reloading) {
-      banners.push(html`<hv-banner
-        kind="info"
-        glyph="refresh"
-        heading="Inventory was replaced by an import"
-        message=" · reloading…"
-        data-testid="degraded-reloading"
-      ></hv-banner>`);
-    }
-
-    return banners.length ? html`<div class="banners" data-testid="degraded-banners">${banners}</div>` : null;
-  }
-
-  private _renderBanners() {
-    const errors = this.st?.errorQueue ?? [];
-    if (!errors.length) return null;
-    return html`
-      <div class="banners" data-testid="banners">
-        ${errors.map((e) => {
-          const conflict = e.kind === 'conflict' && e.itemId;
-          return html`<hv-banner
-            kind=${conflict ? 'warning' : 'error'}
-            .heading=${conflict ? 'Someone else changed this item.' : null}
-            .message=${e.message}
-            data-testid="banner-entry"
-            data-code=${e.code}
-          >
-            ${conflict
-              ? html`<span slot="below">
-                  <button
-                    class="hv-pill outline"
-                    data-testid="banner-view-latest"
-                    @click=${() => {
-                      void this.store?.refreshItem(e.itemId!);
-                      this.store?.dismissError(e.id);
-                    }}
-                  >
-                    View latest
-                  </button>
-                  ${e.changes
-                    ? html`<button
-                        class="hv-pill"
-                        data-testid="banner-reapply"
-                        @click=${() => {
-                          void this.store?.updateItem(e.itemId!, e.changes!);
-                          this.store?.dismissError(e.id);
-                        }}
-                      >
-                        Re-apply my change
-                      </button>`
-                    : null}
-                </span>`
-              : null}
-            <button
-              slot="actions"
-              class="hv-icon-button"
-              data-testid="banner-dismiss"
-              aria-label="Dismiss"
-              @click=${() => this.store?.dismissError(e.id)}
-            >
-              ${icon('close', 16)}
-            </button>
-          </hv-banner>`;
-        })}
-      </div>
-    `;
-  }
-
-
   private _onEmptyAction = (e: CustomEvent) => {
     const { id } = e.detail as { id: string };
     if (id === 'clear-filters') this.store?.clearFilters();
@@ -1140,7 +984,7 @@ export class HVCardShell extends LitElement {
         : html`<div class="panel-holder" id=${FILTER_SURFACE_ID} ?hidden=${!this._filterPanelOpen}>
             ${this._filterPanelOpen ? this._renderFilterPanel(false) : null}
           </div>`}
-      ${this._renderDegradedBanners()} ${this._renderBanners()}
+      ${renderDegradedBanners(st, this._bannerHooks)} ${renderErrorBanners(st, this._bannerHooks)}
 
       <hv-list
         .statuses=${st?.statuses ?? null}
@@ -1347,6 +1191,11 @@ export class HVCardShell extends LitElement {
 
       ${this.surfaces.renderSurfaces()}
     `;
+  }
+
+  /** What the shared banner stacks act through; Reconnect and Refresh are ours. */
+  private get _bannerHooks(): BannerHooks {
+    return { store: this.store, onRefresh: () => void this.surfaces.refresh() };
   }
 
   private get _filterPanel(): HVFilterPanel | null {

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -1,6 +1,9 @@
 import './hv-data-table';
 import { makeItem } from '../test.utils';
+import { ACTIONS_COLUMN_WIDTH } from '../store/columns';
+import { rowMenuEntries } from './hv-list-row';
 import type { HVDataTable } from './hv-data-table';
+import type { OverflowMenuEntry } from './hv-overflow-menu';
 import type { Item, Sort } from '../store/types';
 
 async function mount(items: Partial<Item>[], props: Partial<HVDataTable> = {}) {
@@ -658,5 +661,98 @@ describe('hv-data-table: selection mode', () => {
     // Actions stay available; it is the row click that changes meaning.
     expect(q(el, '[data-testid="table-edit"]')).toBeTruthy();
     expect(q(el, '[data-testid="table-row-select"]')).toBeTruthy();
+  });
+});
+
+// Check out, Check in, a due date and Delete lived on the card's rows only, so
+// the surface built for working through the whole inventory offered the fewest
+// actions per row. Same component, same list, same events.
+describe('hv-data-table: row menu', () => {
+  const menu = (el: HVDataTable, index = 0) =>
+    all(el, '[data-testid="table-row-menu"]')[index] as HTMLElement & {
+      entries: OverflowMenuEntry[];
+      updateComplete: Promise<unknown>;
+    };
+
+  const labels = (el: HVDataTable, index = 0) =>
+    menu(el, index)
+      .entries.filter((e): e is Extract<OverflowMenuEntry, { id: string }> => 'id' in e)
+      .map((e) => e.id);
+
+  it('offers exactly what the card rows offer, for both check-out states', async () => {
+    const el = await mount([
+      { id: '1', name: 'In' },
+      { id: '2', name: 'Out', checked_out: true },
+    ]);
+
+    expect(labels(el, 0)).toEqual(['check-out', 'edit', 'delete']);
+    expect(labels(el, 1)).toEqual(['check-in', 'set-due-date', 'delete']);
+    // One list, so the two surfaces cannot drift.
+    expect(menu(el, 0).entries).toEqual(rowMenuEntries(makeItem({ id: '1', name: 'In' })));
+  });
+
+  it('reports the picked action, the row it came from, and where to anchor', async () => {
+    const el = await mount([{ id: '1', name: 'Drill' }]);
+    const seen: { itemId: string; action: string; anchor?: DOMRect }[] = [];
+    el.addEventListener('row-action', (e) => seen.push((e as CustomEvent).detail));
+
+    for (const id of ['check-out', 'edit', 'delete']) {
+      menu(el).dispatchEvent(new CustomEvent('select', { detail: { id }, bubbles: true, composed: true }));
+    }
+
+    expect(seen.map((d) => d.action)).toEqual(['check-out', 'edit', 'delete']);
+    expect(seen.every((d) => d.itemId === '1')).toBe(true);
+    expect(seen[0].anchor).toBeTruthy();
+  });
+
+  // The row's own click opens the item; a click on the menu is not that.
+  it('does not open the row behind the menu', async () => {
+    const el = await mount([{ id: '1' }]);
+    let opened = 0;
+    el.addEventListener('open-item', () => {
+      opened += 1;
+    });
+
+    menu(el).click();
+    expect(opened).toBe(0);
+  });
+
+  it('rides the same hover reveal as the rest of the actions cell', async () => {
+    const el = await mount([{ id: '1' }]);
+    expect(menu(el).closest('.actions')).toBeTruthy();
+    expect(tableCss()).toMatch(/\.actions \{[^}]*visibility: hidden/);
+    expect(tableCss()).toMatch(/\.row:hover \.actions, \.row:focus-within \.actions \{ visibility: visible/);
+  });
+
+  // 26px outlined here against 30px borderless on the card's rows: two answers
+  // to one control. The quantity pair keeps the outline, as the card's stepper
+  // does; Edit and the ⋮ are the plain pair on both surfaces.
+  it('draws Edit the way the card rows draw it', async () => {
+    const el = await mount([{ id: '1' }]);
+    expect(q(el, '[data-testid="table-edit"]')?.classList.contains('plain')).toBe(true);
+    expect(tableCss()).toMatch(/\.actions button\.plain \{[^}]*width: 30px/);
+    expect(tableCss()).toMatch(/\.actions button\.plain \{[^}]*border: none/);
+  });
+
+  // Fixed-width circles in a fixed track: too narrow and they come out as ovals.
+  it('reserves a track wide enough for all four controls', () => {
+    expect(Number(/^(\d+)px$/.exec(ACTIONS_COLUMN_WIDTH)?.[1])).toBeGreaterThanOrEqual(
+      26 + 26 + 30 + 34 + 3 * 2,
+    );
+  });
+
+  it('still deletes from the keyboard, with the menu offering the same thing', async () => {
+    const el = await mount([{ id: '1' }]);
+    const seen: string[] = [];
+    el.addEventListener('request-delete', () => seen.push('key'));
+    el.addEventListener('row-action', (e) => seen.push((e as CustomEvent).detail.action));
+
+    const row = q(el, '[data-testid="table-row"]') as HTMLElement;
+    row.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+    menu(el).dispatchEvent(
+      new CustomEvent('select', { detail: { id: 'delete' }, bubbles: true, composed: true }),
+    );
+
+    expect(seen).toEqual(['key', 'delete']);
   });
 });

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -14,7 +14,8 @@ import {
 import { getDefaultOrderFor } from '../store/sort';
 import type { AreaRef, StatusDefinition } from '../store/types';
 import type { ColumnKey } from '../store/columns';
-import { isLowStock } from './hv-list-row';
+import { isLowStock, rowMenuEntries } from './hv-list-row';
+import './hv-overflow-menu';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
 import { itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import type { Item, Sort, SortField } from '../store/types';
@@ -273,6 +274,7 @@ export class HVDataTable extends LitElement {
       .actions button {
         display: inline-grid;
         place-items: center;
+        flex: none;
         width: 26px;
         height: 26px;
         border: 1px solid var(--hv-divider);
@@ -286,6 +288,16 @@ export class HVDataTable extends LitElement {
       }
       .actions button[disabled] {
         opacity: 0.35;
+      }
+      /* Edit and the ⋮ are the plain pair, the quantity buttons the outlined
+         one — the same grammar the card's rows use, where the stepper carries
+         the border and the hover actions do not. Edit was a 26px outlined
+         circle here and a 30px borderless one there, which is two answers to
+         one control. */
+      .actions button.plain {
+        width: 30px;
+        height: 30px;
+        border: none;
       }
       .box {
         display: inline-grid;
@@ -606,6 +618,7 @@ export class HVDataTable extends LitElement {
                       ${icon('plus', 15)}
                     </button>
                     <button
+                      class="plain"
                       data-testid="table-edit"
                       aria-label=${`Edit ${item.name}`}
                       @click=${(e: Event) => {
@@ -613,8 +626,21 @@ export class HVDataTable extends LitElement {
                         this._emit('edit', { itemId: item.id });
                       }}
                     >
-                      ${icon('pencil', 15)}
+                      ${icon('pencil', 18)}
                     </button>
+                    <hv-overflow-menu
+                      data-testid="table-row-menu"
+                      label=${`Actions for ${item.name}`}
+                      .entries=${rowMenuEntries(item)}
+                      @click=${(e: Event) => e.stopPropagation()}
+                      @select=${(e: CustomEvent) => {
+                        e.stopPropagation();
+                        const { id } = e.detail as { id: string };
+                        // The check-out flow needs somewhere to anchor its popover.
+                        const anchor = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                        this._emit('row-action', { itemId: item.id, action: id, anchor });
+                      }}
+                    ></hv-overflow-menu>
                   </span>
                 </div>
               `,

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -385,14 +385,18 @@ describe('hv-full-view: embedded', () => {
     const { el, sr } = await mount({ items: [makeItem({ id: '1' }), makeItem({ id: '2' })] });
     const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
     const rows = [...(table.shadowRoot?.querySelectorAll('[data-testid="table-row"]') ?? [])];
-    const lastEdit = rows[rows.length - 1].querySelector('[data-testid="table-edit"]');
+    // The row menu is the row's last control, and its trigger lives one shadow
+    // root deeper still — which is the case this test exists for.
+    const lastMenu = rows[rows.length - 1]
+      .querySelector('[data-testid="table-row-menu"]')
+      ?.shadowRoot?.querySelector('.trigger');
 
     // Shift+Tab off the front lands on the leading sentinel, which sends focus
     // to the last thing inside the trap.
     (sr.querySelector('.sentinel') as HTMLElement).focus();
     await el.updateComplete;
 
-    expect(deepActiveElement()).toBe(lastEdit);
+    expect(deepActiveElement()).toBe(lastMenu);
   });
 
   it('opens on the first control of the surface, not on something nested in it', async () => {
@@ -1936,5 +1940,184 @@ describe('hv-full-view: selection and bulk actions', () => {
     expect(store.state.value.selection.size).toBe(0);
     expect(q(sr, '[data-testid="selection-bar"]')).toBe(null);
     expect(q(sr, '[data-testid="full-add-item"]')).toBeTruthy();
+  });
+});
+
+// A lost connection, paused live updates and a refused operation showed on the
+// card and nowhere else — and this surface and the panel are the ones that fill
+// the screen, so the card's copy is not behind them to be read.
+describe('hv-full-view: failures are visible here too', () => {
+  const banner = (sr: ShadowRoot, testid: string) => q(sr, `[data-testid="${testid}"]`);
+
+  it('says nothing while everything is fine', async () => {
+    const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+    expect(banner(sr, 'degraded-banners')).toBe(null);
+    expect(banner(sr, 'banners')).toBe(null);
+  });
+
+  it('says the connection is lost and asks its host for the re-read', async () => {
+    const { el, store, hass, sr } = await mount({ items: [makeItem({ id: '1' })] });
+    const actions: string[] = [];
+    el.addEventListener('menu-action', (e) => actions.push((e as CustomEvent).detail.id));
+
+    hass.__failNext(2, new Error('socket closed'));
+    await store.refreshStats().catch(() => undefined);
+    await store.refreshStats().catch(() => undefined);
+    await settle(el);
+
+    expect(banner(sr, 'degraded-offline')).toBeTruthy();
+    (banner(sr, 'degraded-reconnect') as HTMLButtonElement).click();
+    // The dialogs and the re-read live in the host's HostSurfaces, and both
+    // hosts already answer this entry.
+    expect(actions).toEqual(['refresh']);
+  });
+
+  it('carries the error queue with its conflict actions', async () => {
+    const { el, store, hass, sr } = await mount({ items: [makeItem({ id: '1', name: 'A' })] });
+    store['pushError']({ code: 'conflict', message: 'version conflict' }, { itemId: '1', changes: { name: 'B' } });
+    await settle(el);
+
+    expect((banner(sr, 'banner-entry') as HTMLElement).dataset.code).toBe('conflict');
+    expect(banner(sr, 'banner-view-latest')).toBeTruthy();
+
+    hass.__setConflict(false);
+    (banner(sr, 'banner-reapply') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(store.state.value.items.find((i) => i.id === '1')?.name).toBe('B');
+    expect(banner(sr, 'banner-entry')).toBe(null);
+  });
+
+  it('dismisses a plain error, which carries no conflict actions', async () => {
+    const { el, store, sr } = await mount({ items: [] });
+    store['pushError']({ code: 'storage_error', message: 'disk full' });
+    await settle(el);
+
+    expect(banner(sr, 'banner-view-latest')).toBe(null);
+    (banner(sr, 'banner-dismiss') as HTMLButtonElement).click();
+    await settle(el);
+    expect(banner(sr, 'banner-entry')).toBe(null);
+  });
+
+  // The panel renders nothing but this component's embedded variant, so this is
+  // the only place its banners can come from.
+  it('renders them in the embedded variant the panel uses', async () => {
+    const { el, store, sr } = await mount({ items: [], embedded: true });
+    store['pushError']({ code: 'storage_error', message: 'disk full' });
+    await settle(el);
+
+    expect(banner(sr, 'banner-entry')?.shadowRoot?.textContent).toContain('disk full');
+  });
+
+  // Two ways of saying a save failed would be one too many. The sentence in the
+  // form is the save's; the queue carries everything with nowhere else to be.
+  it('leaves the open form to speak for a refused save', async () => {
+    const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Old' })] });
+    store['ws'].updateItem = async () => {
+      throw { code: 'storage_error', message: 'the store is read-only' };
+    };
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+    const editor = q(sr, '[data-testid="full-editor"]') as HTMLElement;
+    (editor.shadowRoot?.querySelector('[data-testid="editor-save"]') as HTMLButtonElement).click();
+    await settle(el);
+    await settle(el);
+
+    expect(
+      (q(sr, '[data-testid="full-editor"]') as HTMLElement).shadowRoot?.querySelector(
+        '[data-testid="editor-error"]',
+      )?.textContent,
+    ).toContain('the store is read-only');
+    // And the queue still holds it, so dismissing the form does not lose it.
+    expect(banner(sr, 'banner-entry')).toBeTruthy();
+  });
+});
+
+// The table's rows had a Delete key and no visible equivalent, and none of the
+// three actions the card's rows offer.
+describe('hv-full-view: table row actions', () => {
+  const pick = (sr: ShadowRoot, id: string, row = 0) => {
+    const menus = [
+      ...((q(sr, '[data-testid="full-table"]') as HTMLElement).shadowRoot?.querySelectorAll(
+        '[data-testid="table-row-menu"]',
+      ) ?? []),
+    ];
+    menus[row].dispatchEvent(new CustomEvent('select', { detail: { id }, bubbles: true, composed: true }));
+  };
+
+  it('checks an item back in', async () => {
+    const { el, store, sr } = await mount({
+      items: [makeItem({ id: '1', name: 'Drill', checked_out: true })],
+    });
+
+    pick(sr, 'check-in');
+    await settle(el);
+
+    expect(store.state.value.items.find((i) => i.id === '1')?.checked_out).toBe(false);
+  });
+
+  it('asks for a due date before checking out, and applies the one picked', async () => {
+    const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Drill' })] });
+
+    pick(sr, 'check-out');
+    await settle(el);
+    const popover = q(sr, '[data-testid="full-checkout"]') as HTMLElement & { open: boolean };
+    expect(popover.open).toBe(true);
+
+    (popover.shadowRoot?.querySelector('[data-testid="checkout-no-date"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(popover.open).toBe(false);
+    expect(store.state.value.items.find((i) => i.id === '1')?.checked_out).toBe(true);
+  });
+
+  it('sets a due date on an item already out', async () => {
+    const { el, sr } = await mount({
+      items: [makeItem({ id: '1', name: 'Drill', checked_out: true })],
+    });
+
+    pick(sr, 'set-due-date');
+    await settle(el);
+
+    const popover = q(sr, '[data-testid="full-checkout"]') as HTMLElement & {
+      open: boolean;
+      mode: string;
+    };
+    expect(popover.open).toBe(true);
+    expect(popover.mode).toBe('set-due-date');
+  });
+
+  it('hands Delete to the host, which owns the confirmation', async () => {
+    const { el, sr } = await mount({ items: [makeItem({ id: '1', name: 'Drill' })] });
+    const asked: { itemId: string; name: string }[] = [];
+    el.addEventListener('request-delete', (e) => asked.push((e as CustomEvent).detail));
+
+    pick(sr, 'delete');
+    await settle(el);
+
+    expect(asked).toEqual([{ itemId: '1', name: 'Drill' }]);
+  });
+
+  it('opens the form from the menu, through the same dirty guard as a row click', async () => {
+    const { el, sr } = await mount({
+      items: [makeItem({ id: '1', name: 'First' }), makeItem({ id: '2', name: 'Second' })],
+    });
+    const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
+    (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+    const name = (q(sr, '[data-testid="full-editor"]') as HTMLElement).shadowRoot?.querySelector(
+      '[data-testid="editor-name"]',
+    ) as HTMLInputElement;
+    name.value = 'Typed but unsaved';
+    name.dispatchEvent(new Event('input'));
+    await settle(el);
+
+    pick(sr, 'edit', 1);
+    await settle(el);
+
+    expect((q(sr, '[data-testid="full-discard-confirm"]') as HTMLElement & { open: boolean }).open).toBe(
+      true,
+    );
   });
 });

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -19,6 +19,8 @@ import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
 import { DISCARD_PROMPT } from '../ui/discard';
+import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
+import type { BannerHooks } from '../ui/banners';
 import { NARROW_QUERY } from '../ui/responsive';
 import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
@@ -30,6 +32,7 @@ import { makeBulkOp } from '../store/store';
 import type { BulkOperation, BulkOutcome } from '../store/types';
 import type { BulkProgress, BulkResultView, BulkRunDetail } from './hv-bulk-bar';
 import './hv-bulk-bar';
+import './hv-checkout-popover';
 import './hv-confirm';
 import './hv-data-table';
 import type { MediaBindings } from '../ui/media';
@@ -74,6 +77,7 @@ export class HVFullView extends LitElement {
     tokens,
     base,
     chip,
+    bannerStack,
     css`
       :host {
         display: contents;
@@ -821,6 +825,12 @@ export class HVFullView extends LitElement {
   @state() private _bulkProgress: BulkProgress | null = null;
   @state() private _bulkResult: BulkResultView | null = null;
   @state() private _pendingDelete = false;
+  /** The row whose check-out / due-date step is open, and where to anchor it. */
+  @state() private _checkout: {
+    itemId: string;
+    mode: 'check-out' | 'set-due-date';
+    anchor: DOMRect | null;
+  } | null = null;
   /**
    * Where the surface goes once a discard is confirmed, or null while nothing
    * is being asked: another row, the create form, or the view closing.
@@ -926,6 +936,23 @@ export class HVFullView extends LitElement {
   }
 
   /**
+   * What the shared banner stacks act through.
+   *
+   * Reconnect and Refresh go out as the menu action the host already answers —
+   * the dialogs and the re-read live in its `HostSurfaces`, not here, and both
+   * hosts serve the same entry.
+   */
+  private get _bannerHooks(): BannerHooks {
+    return {
+      store: this.store,
+      onRefresh: () =>
+        this.dispatchEvent(
+          new CustomEvent('menu-action', { detail: { id: 'refresh' }, bubbles: true, composed: true }),
+        ),
+    };
+  }
+
+  /**
    * Leave the open form — for another row, for the create form, or by closing
    * the whole surface — asking first if there is typing to lose.
    *
@@ -1027,6 +1054,40 @@ export class HVFullView extends LitElement {
       case 'edit':
       case 'open-item':
         this._leaveEditor(item.id);
+        break;
+    }
+  }
+
+  /**
+   * The table rows' ⋮, answered the way the card's shell answers its own rows'.
+   *
+   * Same ids, same meanings — the entries come from one list — so a household
+   * learns Check out / Check in / due date / Delete once. Delete leaves for the
+   * host, which owns the confirmation and the store call; the Delete key on a
+   * row already went the same way.
+   */
+  private _onRowAction(detail: { itemId?: string; action?: string; anchor?: DOMRect }) {
+    const item = this.st?.items.find((i) => i.id === detail.itemId);
+    if (!item) return;
+    switch (detail.action) {
+      case 'check-out':
+      case 'set-due-date':
+        this._checkout = { itemId: item.id, mode: detail.action, anchor: detail.anchor ?? null };
+        break;
+      case 'check-in':
+        void this.store?.markCheckedIn(item.id, item.version);
+        break;
+      case 'edit':
+        this._leaveEditor(item.id);
+        break;
+      case 'delete':
+        this.dispatchEvent(
+          new CustomEvent('request-delete', {
+            detail: { itemId: item.id, name: item.name },
+            bubbles: true,
+            composed: true,
+          }),
+        );
         break;
     }
   }
@@ -1864,6 +1925,12 @@ export class HVFullView extends LitElement {
           ${this._renderSidebar()}
           <div class="main">
             ${this._renderContextBar()}
+            <!-- The open form's own sentence is the save-failure surface: the
+                 user's text is in front of it and the account of what happened
+                 belongs beside it. Everything else — a lost connection, paused
+                 live updates, a refused operation with nowhere else to be said —
+                 is this queue's, on the same terms as the card's. -->
+            ${renderDegradedBanners(st, this._bannerHooks)} ${renderErrorBanners(st, this._bannerHooks)}
             <div class="panel-holder" id=${FILTER_PANEL_ID} ?hidden=${!this._filtersOpen}>
               ${this._filtersOpen
                 ? html`
@@ -1952,6 +2019,8 @@ export class HVFullView extends LitElement {
               @decrement=${(e: CustomEvent) => this._onRowEvent('decrement', e.detail)}
               @edit=${(e: CustomEvent) => this._onRowEvent('edit', e.detail)}
               @open-item=${(e: CustomEvent) => this._onRowEvent('open-item', e.detail)}
+              @row-action=${(e: CustomEvent) =>
+                this._onRowAction(e.detail as { itemId?: string; action?: string; anchor?: DOMRect })}
               @toggle-select=${(e: CustomEvent) =>
                 this.store?.toggleSelected((e.detail as { itemId: string }).itemId)}
               @select-all-loaded=${() => this.store?.selectAllLoaded()}
@@ -2015,6 +2084,31 @@ export class HVFullView extends LitElement {
             this._pendingDelete = false;
           }}
         ></hv-confirm>
+
+        <hv-checkout-popover
+          data-testid="full-checkout"
+          ?open=${this._checkout !== null}
+          ?mobile=${this._narrow}
+          .mode=${this._checkout?.mode ?? 'check-out'}
+          .anchor=${this._checkout?.anchor ?? null}
+          .item=${this._checkout ? (st?.items.find((i) => i.id === this._checkout!.itemId) ?? null) : null}
+          @check-out=${(e: CustomEvent) => {
+            const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
+            const item = st?.items.find((i) => i.id === itemId);
+            this._checkout = null;
+            if (item) void this.store?.checkOut(item.id, dueDate, item.version);
+          }}
+          @set-due-date=${(e: CustomEvent) => {
+            const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
+            const item = st?.items.find((i) => i.id === itemId);
+            this._checkout = null;
+            // A due date only exists while an item is out, so this is a plain update.
+            if (item) void this.store?.updateItem(item.id, { due_date: dueDate }, item.version);
+          }}
+          @cancel=${() => {
+            this._checkout = null;
+          }}
+        ></hv-checkout-popover>
 
         <hv-confirm
           data-testid="full-discard-confirm"

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -18,6 +18,35 @@ export function isLowStock(item: Item): boolean {
 }
 
 /**
+ * What a row's ⋮ offers, which depends on whether the item is out and whether
+ * it has a due date.
+ *
+ * Shared with the full view's table rows, which used to offer nothing at all —
+ * so one list, one set of ids, and the hosts' existing `row-action` handlers
+ * answer both surfaces.
+ */
+export function rowMenuEntries(item: Item): OverflowMenuEntry[] {
+  if (item.checked_out) {
+    return [
+      { id: 'check-in', label: 'Check in', glyph: 'account' },
+      {
+        id: 'set-due-date',
+        label: item.due_date ? 'Change due date…' : 'Set due date…',
+        glyph: 'calendar',
+      },
+      { divider: true },
+      { id: 'delete', label: 'Delete item', glyph: 'del' },
+    ];
+  }
+  return [
+    { id: 'check-out', label: 'Check out…', glyph: 'account' },
+    { id: 'edit', label: 'Edit', glyph: 'pencil' },
+    { divider: true },
+    { id: 'delete', label: 'Delete item', glyph: 'del' },
+  ];
+}
+
+/**
  * Drop the middle of a long path so both ends survive a narrow row.
  *
  * A path reads root-first and clips from the right, so on a phone the half that
@@ -341,28 +370,6 @@ export class HVListRow extends LitElement {
     );
   }
 
-  /** Row menu contents depend on whether the item is out, and whether it has a due date. */
-  private _menuEntries(item: Item): OverflowMenuEntry[] {
-    if (item.checked_out) {
-      return [
-        { id: 'check-in', label: 'Check in', glyph: 'account' },
-        {
-          id: 'set-due-date',
-          label: item.due_date ? 'Change due date…' : 'Set due date…',
-          glyph: 'calendar',
-        },
-        { divider: true },
-        { id: 'delete', label: 'Delete item', glyph: 'del' },
-      ];
-    }
-    return [
-      { id: 'check-out', label: 'Check out…', glyph: 'account' },
-      { id: 'edit', label: 'Edit', glyph: 'pencil' },
-      { divider: true },
-      { id: 'delete', label: 'Delete item', glyph: 'del' },
-    ];
-  }
-
   private _onKeydown = (e: KeyboardEvent) => {
     switch (e.key) {
       case 'Enter':
@@ -571,7 +578,7 @@ export class HVListRow extends LitElement {
               <hv-overflow-menu
                 data-testid="row-menu"
                 label=${`Actions for ${item.name}`}
-                .entries=${this._menuEntries(item)}
+                .entries=${rowMenuEntries(item)}
                 @click=${(e: Event) => e.stopPropagation()}
                 @select=${(e: CustomEvent) => {
                   e.stopPropagation();

--- a/cards/haventory-card/src/haventory-panel.test.ts
+++ b/cards/haventory-card/src/haventory-panel.test.ts
@@ -416,3 +416,20 @@ describe('haventory-panel: the ⋮ menu', () => {
     expect(entry()?.disabled).toBe(false);
   });
 });
+
+// The panel renders nothing but the embedded full view, so a failure that is
+// invisible there is invisible on the whole sidebar page.
+describe('haventory-panel: failures reach the page', () => {
+  it('shows a refused operation on the page itself', async () => {
+    const { el, view } = await mountPanel({ items: [makeItem({ id: '1' })] });
+    const store = view().store as { pushError: (e: { code: string; message: string }) => void };
+    store.pushError({ code: 'storage_error', message: 'disk full' });
+    await settle(el);
+
+    const entry = view().shadowRoot?.querySelector('[data-testid="banner-entry"]') as HTMLElement | null;
+    expect(entry?.shadowRoot?.textContent).toContain('disk full');
+    // What the banner's actions do is pinned in hv-full-view's own suite; what
+    // matters here is that the panel has them at all.
+    expect(view().shadowRoot?.querySelector('[data-testid="banner-dismiss"]')).toBeTruthy();
+  });
+});

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -150,16 +150,16 @@ describe('table column widths', () => {
   // Pinned as a number so that adding a column, or widening one, shows up here
   // as a deliberate change rather than as another phone-width overflow.
   it('cannot lay the default table out narrower than a phone', () => {
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1148);
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1188);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1178);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1218);
   });
 
   it('only fits a phone when almost every column is turned off', () => {
-    // Name (220) + Qty (70) + the actions gutter (110). That overflows a 375px
+    // Name (220) + Qty (70) + the actions gutter (140). That overflows a 375px
     // screen on its own — so trimming columns was never a reliable answer, and
     // it would have discarded a choice the user made. The table scrolls
     // sideways instead, and pins the name column while it does.
-    expect(minWidthOf(tableTemplateFor(['quantity'], { selectable: false }))).toBe(400);
+    expect(minWidthOf(tableTemplateFor(['quantity'], { selectable: false }))).toBe(430);
   });
 
   // With every column on, the flexible tracks all sit at their floor and the

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -135,12 +135,20 @@ export const NAME_COLUMN_SIZE = 'minmax(220px, 3fr)';
  */
 export const SELECT_COLUMN_WIDTH = '40px';
 
+/**
+ * The trailing actions track. It has to hold four controls at their real sizes
+ * — two 26px quantity buttons, a 30px Edit and the 34px row menu, plus the gaps
+ * — because they are fixed-width circles: a track short of their sum squashes
+ * them into ovals rather than wrapping or scrolling.
+ */
+export const ACTIONS_COLUMN_WIDTH = '140px';
+
 export function tableTemplateFor(columns: ColumnKey[], opts: { selectable: boolean }): string {
   const cols = [
     ...(opts.selectable ? [SELECT_COLUMN_WIDTH] : []),
     NAME_COLUMN_SIZE,
     ...normalizeColumns(columns).map((k) => COLUMN_TABLE_SIZE[k]),
-    '110px',
+    ACTIONS_COLUMN_WIDTH,
   ];
   return cols.join(' ');
 }

--- a/cards/haventory-card/src/ui/banners.ts
+++ b/cards/haventory-card/src/ui/banners.ts
@@ -1,0 +1,186 @@
+import { css, html } from 'lit';
+import type { TemplateResult } from 'lit';
+import { icon } from './icons';
+import { counted } from './plural';
+import type { Store } from '../store/store';
+import type { StoreState } from '../store/types';
+// Registers the element this file emits. Kept here rather than left to each
+// host, so a surface cannot render the stack and get four unstyled divs.
+import '../components/hv-banner';
+
+/**
+ * The two stacks that say something is wrong: what the connection is doing, and
+ * what the last operations came back with.
+ *
+ * Both were the card's alone. On the expanded view and the sidebar panel — the
+ * surfaces that fill the screen, so the card's copy is not behind them — a lost
+ * connection, paused live updates and a refused operation all showed nothing at
+ * all. They render from here now, so the three surfaces cannot disagree about
+ * what a failure looks like or what can be done about it.
+ *
+ * A rejected *save* is the one failure this stack is not the primary voice for:
+ * the sentence inside the open form is, because that is where the user's text
+ * is. The queue still carries the entry, and the conflict actions here are what
+ * gets the two copies of the item back together.
+ */
+
+/** Layout for the two stacks. Hosts add this to their own styles. */
+export const bannerStack = css`
+  .banners {
+    display: grid;
+    gap: 6px;
+    padding: 0 16px 10px;
+  }
+`;
+
+/** What a banner needs its host to do. */
+export interface BannerHooks {
+  /** The store the conflict actions act on. */
+  store: Store | undefined;
+  /**
+   * Re-read everything. The card runs it through its `HostSurfaces`; the full
+   * view asks its host for the same menu action, since the surfaces live there.
+   */
+  onRefresh: () => void;
+}
+
+/**
+ * Conditions that make the surface untrustworthy, said out loud.
+ *
+ * Rate limiting can drop subscription events silently and events carry no
+ * sequence number, so a client cannot detect a gap on its own — the honest move
+ * is to say it might be stale and offer the re-read.
+ */
+export function renderDegradedBanners(st: StoreState | null, hooks: BannerHooks): TemplateResult | null {
+  const degraded = st?.degraded;
+  if (!degraded) return null;
+  const banners = [];
+
+  if (degraded.connectionLost) {
+    banners.push(html`<hv-banner
+      kind="error"
+      glyph="wifiOff"
+      heading="Connection lost"
+      message=" · showing the data already loaded. Changes may not save."
+      data-testid="degraded-offline"
+    >
+      <button slot="actions" class="hv-pill outline" data-testid="degraded-reconnect" @click=${hooks.onRefresh}>
+        Reconnect
+      </button>
+    </hv-banner>`);
+  } else if (degraded.liveUpdates !== 'live') {
+    // Ranked above the generic rate-limit warning below: that one says events
+    // *may* have been dropped, this one says there are no events at all.
+    const retrying = degraded.liveUpdates === 'retrying';
+    const cause = degraded.liveUpdatesReason === 'unavailable' ? 'HAventory is not available' : 'rate limited';
+    banners.push(html`<hv-banner
+      kind="warning"
+      glyph="clock"
+      heading="Live updates paused"
+      message=${retrying
+        ? ` · ${cause}. Retrying automatically; this list may be out of date until then.`
+        : ` · ${cause}. This list may be out of date until you refresh.`}
+      data-testid="degraded-live-updates"
+    >
+      ${retrying
+        ? null
+        : html`<button
+            slot="actions"
+            class="hv-pill outline"
+            data-testid="degraded-live-refresh"
+            @click=${hooks.onRefresh}
+          >
+            Refresh
+          </button>`}
+    </hv-banner>`);
+  } else if (degraded.retrying > 0) {
+    banners.push(html`<hv-banner
+      kind="warning"
+      glyph="clock"
+      heading="Busy — retrying"
+      message=${` · ${counted(degraded.retrying, 'change')} queued`}
+      data-testid="degraded-retrying"
+    ></hv-banner>`);
+  } else if (degraded.rateLimited) {
+    banners.push(html`<hv-banner
+      kind="warning"
+      glyph="clock"
+      heading="Rate limited"
+      message=" · some live updates may have been dropped, so this list can be out of date."
+      data-testid="degraded-rate-limited"
+    >
+      <button slot="actions" class="hv-pill outline" data-testid="degraded-refresh" @click=${hooks.onRefresh}>
+        Refresh
+      </button>
+    </hv-banner>`);
+  }
+
+  if (degraded.reloading) {
+    banners.push(html`<hv-banner
+      kind="info"
+      glyph="refresh"
+      heading="Inventory was replaced by an import"
+      message=" · reloading…"
+      data-testid="degraded-reloading"
+    ></hv-banner>`);
+  }
+
+  return banners.length ? html`<div class="banners" data-testid="degraded-banners">${banners}</div>` : null;
+}
+
+/** The queue of operations that came back refused, newest last. */
+export function renderErrorBanners(st: StoreState | null, hooks: BannerHooks): TemplateResult | null {
+  const errors = st?.errorQueue ?? [];
+  if (!errors.length) return null;
+  const store = hooks.store;
+  return html`
+    <div class="banners" data-testid="banners">
+      ${errors.map((e) => {
+        const conflict = e.kind === 'conflict' && e.itemId;
+        return html`<hv-banner
+          kind=${conflict ? 'warning' : 'error'}
+          .heading=${conflict ? 'Someone else changed this item.' : null}
+          .message=${e.message}
+          data-testid="banner-entry"
+          data-code=${e.code}
+        >
+          ${conflict
+            ? html`<span slot="below">
+                <button
+                  class="hv-pill outline"
+                  data-testid="banner-view-latest"
+                  @click=${() => {
+                    void store?.refreshItem(e.itemId!);
+                    store?.dismissError(e.id);
+                  }}
+                >
+                  View latest
+                </button>
+                ${e.changes
+                  ? html`<button
+                      class="hv-pill"
+                      data-testid="banner-reapply"
+                      @click=${() => {
+                        void store?.updateItem(e.itemId!, e.changes!);
+                        store?.dismissError(e.id);
+                      }}
+                    >
+                      Re-apply my change
+                    </button>`
+                  : null}
+              </span>`
+            : null}
+          <button
+            slot="actions"
+            class="hv-icon-button"
+            data-testid="banner-dismiss"
+            aria-label="Dismiss"
+            @click=${() => store?.dismissError(e.id)}
+          >
+            ${icon('close', 16)}
+          </button>
+        </hv-banner>`;
+      })}
+    </div>
+  `;
+}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -93,12 +93,16 @@ haventory-card                     Lovelace element; store owner
     ├── hv-import-sheet            input → preview → summary (+ invalid-document state)
     ├── hv-diagnostics-panel       health, drop counters, subscriptions, copy report
     ├── hv-confirm                 in-app confirmation (replaces window.confirm)
-    ├── hv-banner                  the one alert treatment
+    ├── hv-banner                  the one alert treatment; the degraded and error
+    │                              stacks are built in ui/banners.ts and rendered
+    │                              by the card and the full view alike
     └── hv-full-view               fullscreen workspace
         ├── hv-location-tree       sidebar's Locations section, manage-capable
         ├── hv-filter-panel        same panel, staged behind a commit row on a phone
         ├── hv-item-editor         inline above the table (the same one edit form)
-        ├── hv-data-table          sortable table + selection column
+        ├── hv-data-table          sortable table + selection column; rows carry the
+        │                          same ⋮ actions the card's rows do
+        ├── hv-checkout-popover    the row menu's due-date step
         └── hv-bulk-bar            bulk actions, progress, per-operation results
 ```
 
@@ -387,8 +391,8 @@ automatically up to four times, waiting the envelope's retry-after hint when it 
 (`retry_after_ms`, or `retry_after` in seconds, read from `data`, `context` or the top level
 and clamped to 30 s) and otherwise backing off exponentially. `degraded.liveUpdates` tracks
 this as `'live' | 'retrying' | 'paused'`, with `degraded.nextLiveRetryAt` for the scheduled
-attempt; the shell renders it as a non-blocking banner that clears itself when a retry gets
-back in. Once the budget is spent the state goes `'paused'`, the refusal reaches the error
+attempt; every surface renders it as a non-blocking banner that clears itself when a retry
+gets back in. Once the budget is spent the state goes `'paused'`, the refusal reaches the error
 queue once, and the banner's Refresh (i.e. `refreshAll()`) is the way back. Any other
 refusal is an outage: reported immediately, never retried.
 


### PR DESCRIPTION
## Summary

P9 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`), and the second of Session C.

**Stacked PR — merge in order: #345 → this.** Base is #345 (P8). After #345 squash-merges, this branch is rebased onto `main` (`git rebase --onto origin/main claude/session-c-frontend-packages-ea1f9o`) before it merges; the local verification session does that rebase as part of its pass.

Fixes **F13** and **F16** from the register in `dev/v040_frontend_completeness_plan.md`. Neither is filed as an issue, so there is no `Closes` line.

Two gaps with the same shape: the surfaces that fill the screen offered less than the card they were opened from.

### F13 — failures were the card's alone

Connection loss, paused live updates, the rate-limit warning, the import reload notice and every queued operation error rendered in `hv-card-shell` and nowhere else. The expanded view and the sidebar page cover the card, so on those two a failed operation was silent: nothing said, nothing offered.

Both stacks move to `src/ui/banners.ts` — the markup stays a render helper rather than becoming a component, so it lands in each host's own shadow root and the layout rule (`bannerStack`) travels with it. `hv-full-view` renders them in its modal and its embedded variant alike, so the panel gets them by rendering nothing but that variant. The conflict actions come along: *View latest* and *Re-apply my change* work there exactly as on the card.

Reconnect and Refresh leave the view as the `refresh` menu action both hosts already answer — the re-read and the dialogs live in their `HostSurfaces`, not in the view.

Decision 13's split is stated in one comment where the two meet: the sentence inside the open form is the save-failure surface, because that is where the user's text is; the queue carries everything with nowhere else to be said. A refused save produces both, and a test pins that.

### F16 — the table's rows had a Delete key and no visible equivalent

They also had none of Check out, Check in or the due date, which the card's rows have offered all along — so the surface built for working through the whole inventory was the one with the fewest actions per row.

The entries move to `rowMenuEntries` in `hv-list-row.ts`, and both surfaces render that one list through the same `hv-overflow-menu`. One list, one set of ids, one set of events, so the two menus cannot drift; a test asserts the table's entries *are* that function's output. The full view answers them the way the shell answers its own rows' — including a single-item `hv-checkout-popover` it had no reason to carry before, which is also what P11's bulk check-out will need. Delete leaves as `request-delete`, the event the Delete key already sent, so the host keeps owning the confirmation.

Edit was a 26px outlined circle in the table and a 30px borderless one on the card's rows. Both draw it the plain way now, and the quantity pair keeps its outline — the same grammar as the card, where the stepper is bordered and the hover actions are not. The trailing track goes 110px → 140px, which is what four fixed-width circles and their three gaps actually need; below that they lay out as ovals rather than wrapping.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1581 passed), `npm run build`

New coverage: the full view silent while all is well; the offline banner and its Reconnect raising the host's `refresh`; the error queue with its conflict pair, re-apply landing the change and clearing the entry; a plain error dismissing; the embedded variant carrying them, and the panel showing one on the page; a refused save producing the inline sentence *and* a queue entry. For the table: the entries for both check-out states and their identity with `rowMenuEntries`; each pick reporting action, row and anchor; the menu not opening the row behind it; the hover reveal; Edit drawn plain; the track wide enough for all four controls; the Delete key still firing alongside the menu's Delete. On the full view: check-in, check-out through the popover with the date applied, the due-date mode, Delete handed to the host, and Edit from the menu going through P8's dirty guard.

Rewritten rather than deleted, per the campaign rule: the two `store/columns` width pins (1148/1188 → 1178/1218 and 400 → 430) now measure the wider actions track, and the focus-trap pin lands on the row menu's trigger — one shadow root deeper than the Edit button it named before, which is the case that test exists for.

Docs: the README's degraded-states bullet says the banners are on every surface, and its full-view bullet names the row menu; `docs/frontend_architecture.md` updates the component map and the live-updates paragraph that said "the shell renders it".

### Delegated to the local verification session

Checklist P9 in the plan's §Verification: full view open, stop the HA container — banner appears; restart — it clears and data recovers. Reject a save by bumping the version from a second tab: inline sentence in the form **and** the queue banner, per the stated split. Table rows: ⋮ offers Check out / Check in / Set due date / Delete and each works; the Delete key still deletes with its confirm. Panel shows the same banners.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`README.md`, `docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

## Follow-ups

- The table's row menu repeats Edit, which the pencil beside it already offers. That is the card's row grammar too, so it is consistent rather than new; if the duplication is unwanted it should go from both surfaces at once.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Stzf72H6aEA8vk1NFMQpr)_