### PR TITLE
feat(card): shared read view and lightbox on every surface

### DIFF
--- a/.claude/skills/run-haventory/visual_pass.mjs
+++ b/.claude/skills/run-haventory/visual_pass.mjs
@@ -358,12 +358,20 @@ const PANEL_MOBILE_SURFACES = [
   },
   {
     id: "05-row-editor",
+    // At this width the table is off the side of the screen, so it cannot be
+    // the read view: opening a row lands on the detail sheet, and the form is
+    // one tap deeper inside it. The pencil goes the same way as the row itself,
+    // which is the point of the one method that decides.
     open: [
       ["hover", `${PANEL} [data-testid="table-row"]`],
       ["click", `${PANEL} [data-testid="table-edit"]`],
+      ["wait", 800],
+      ["click", `${PANEL} [data-testid="sheet-edit-details"]`],
       ["wait", 600],
     ],
-    expect: `${PANEL} [data-testid="item-editor"]`,
+    // The sheet's own back arrow, not its host element: `hv-bottom-sheet` draws
+    // its panel in its shadow root and the host itself has no box to wait for.
+    expect: [`${PANEL} [data-testid="sheet-back"]`, `${PANEL} [data-testid="item-editor"]`],
   },
   {
     id: "06-overflow",

--- a/README.md
+++ b/README.md
@@ -514,7 +514,9 @@ throughout.
   strip attaches as a manual. Each queue reports itself under the section that started it,
   with a moving indicator while a file is in flight; a refused file keeps its error and
   Retry until you dismiss them. Removing an attachment asks first, because the file goes
-  with it.
+  with it. A thumbnail is 72px of a photo, so **clicking one opens it full-size** — arrows
+  and a counter to walk the strip, Escape to come back — on every surface the form appears
+  on, and from the detail sheet's gallery just the same.
 - **Full view** — a fullscreen workspace with a coloured app bar, a **browse sidebar**, and
   a sortable table. Only columns the backend can sort by get a clickable header. A browser
   that has made no choice yet shows every optional column — quantity, status, category,
@@ -556,6 +558,10 @@ throughout.
   At phone width the sidebar folds away and the surface hands its own breakpoint down to
   the edit form and the filter panel, so both take their phone layouts: one field per row,
   and filters staged behind a "Show N items" commit row exactly as in the card's sheet.
+  Tapping a row there opens the same **detail sheet** the card opens — photos, documents,
+  facts and check-out, with Edit one tap deeper — rather than dropping you straight into a
+  form. On a screen wide enough for the table, the table is the read view and a row click
+  opens the form as before.
 - **Multi-select and bulk actions** — move, add/remove tags, set category, adjust
   quantity, check out/in and delete over a selection. Work is chunked so progress is
   determinate and cancellable, and the result is reported *per operation*: "39 of 42

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -18,8 +18,24 @@ async function mount(item: Partial<Item>, props: Partial<HVDetailSheet> = {}) {
 }
 
 const q = (el: HVDetailSheet, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
+
+/**
+ * The lightbox is a component of its own — shared with the edit form on every
+ * host — so its panel sits one shadow root below this sheet's.
+ */
+const lightbox = (el: HVDetailSheet, sel = '[data-testid="lightbox"]') =>
+  (q(el, 'hv-lightbox')?.shadowRoot?.querySelector(sel) ?? null) as HTMLElement | null;
 const all = (el: HVDetailSheet, sel: string) =>
   [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
+
+/**
+ * A host's own update does not carry its children's, and the lightbox is a
+ * child now — so anything that opens or moves it needs its update too.
+ */
+const settle = async (el: HVDetailSheet) => {
+  await el.updateComplete;
+  await (q(el, 'hv-lightbox') as (HTMLElement & { updateComplete?: Promise<unknown> }) | null)?.updateComplete;
+};
 
 /** jsdom lays out no shadow DOM, so type sizes are asserted on the sheet. */
 const sheetCss = () => {
@@ -207,14 +223,14 @@ describe('hv-detail-sheet: read view', () => {
     expect(seen).toEqual(['request-delete']);
 
     (q(el, '[data-testid="sheet-check-out"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     // Nothing is checked out until the date step is answered.
     expect(seen).toEqual(['request-delete']);
     expect(q(el, '[data-testid="sheet-checkout"]')).toBeTruthy();
 
     const step = q(el, '[data-testid="sheet-checkout"]') as HTMLElement;
     (step.shadowRoot?.querySelector('[data-testid="checkout-no-date"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     expect(seen).toEqual(['request-delete', 'check-out-confirmed']);
     expect(q(el, '[data-testid="sheet-checkout"]')).toBe(null);
   });
@@ -237,7 +253,7 @@ describe('hv-detail-sheet: edit view', () => {
     expect(q(el, '[data-testid="sheet-editor"]')).toBe(null);
 
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
     // Still one sheet.
@@ -249,17 +265,17 @@ describe('hv-detail-sheet: edit view', () => {
   it('reaches the form from "Edit details" too', async () => {
     const el = await mount({ id: '1' });
     (q(el, '[data-testid="sheet-edit-details"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
   });
 
   it('goes back to the read view', async () => {
     const el = await mount({ id: '1' });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     (q(el, '[data-testid="sheet-back"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
   });
 
@@ -269,13 +285,13 @@ describe('hv-detail-sheet: edit view', () => {
     el.addEventListener('save', (e) => saves.push((e as CustomEvent).detail));
 
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement;
     const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
     name.value = 'New';
     name.dispatchEvent(new Event('input'));
-    await el.updateComplete;
+    await settle(el);
 
     (q(el, '[data-testid="sheet-save"]') as HTMLButtonElement).click();
     expect(saves).toHaveLength(1);
@@ -289,7 +305,7 @@ describe('hv-detail-sheet: edit view', () => {
     const seen = captured(el, ['request-delete', 'delete-item']);
 
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement;
     (editor.shadowRoot?.querySelector('[data-testid="editor-delete"]') as HTMLButtonElement).click();
@@ -304,24 +320,24 @@ describe('hv-detail-sheet: edit view', () => {
     expect(el.dirty).toBe(false);
 
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     expect(el.dirty).toBe(false);
 
     const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement;
     const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
     name.value = 'B';
     name.dispatchEvent(new Event('input'));
-    await el.updateComplete;
+    await settle(el);
     expect(el.dirty).toBe(true);
   });
 
   it('returns to the read view when a different item is loaded', async () => {
     const el = await mount({ id: '1', name: 'A' });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     el.item = makeItem({ id: '2', name: 'B' });
-    await el.updateComplete;
+    await settle(el);
     expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
   });
 
@@ -330,10 +346,10 @@ describe('hv-detail-sheet: edit view', () => {
   it('stays in the edit form when the same item comes back with a new version', async () => {
     const el = await mount({ id: '1', name: 'A', version: 3 });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     el.item = makeItem({ id: '1', name: 'A', version: 4 });
-    await el.updateComplete;
+    await settle(el);
 
     expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
     expect(q(el, '[data-testid="sheet-qty"]')).toBeNull();
@@ -342,12 +358,12 @@ describe('hv-detail-sheet: edit view', () => {
   it('returns to the read view when the sheet is re-opened on the same item', async () => {
     const el = await mount({ id: '1', name: 'A' });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     el.open = false;
-    await el.updateComplete;
+    await settle(el);
     el.open = true;
-    await el.updateComplete;
+    await settle(el);
 
     expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
   });
@@ -361,12 +377,12 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
   async function dirtySheet() {
     const el = await mount({ id: '1', name: 'A' });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement;
     const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
     name.value = 'A longer name';
     name.dispatchEvent(new Event('input'));
-    await el.updateComplete;
+    await settle(el);
     expect(el.dirty).toBe(true);
     return el;
   }
@@ -411,7 +427,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     });
 
     dismissals[how](el);
-    await el.updateComplete;
+    await settle(el);
 
     expect(guard(el).open).toBe(true);
     expect(cancels).toBe(0);
@@ -419,7 +435,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
 
     press(el, 'confirm-accept');
-    await el.updateComplete;
+    await settle(el);
     expect(cancels).toBe(1);
     expect(el.open).toBe(false);
   });
@@ -432,9 +448,9 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     });
 
     dismissals[how](el);
-    await el.updateComplete;
+    await settle(el);
     press(el, 'confirm-cancel');
-    await el.updateComplete;
+    await settle(el);
 
     expect(cancels).toBe(0);
     expect(el.open).toBe(true);
@@ -454,7 +470,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     });
 
     dismissals.swipe(el);
-    await el.updateComplete;
+    await settle(el);
 
     expect(guard(el).open).toBe(false);
     expect(cancels).toBe(1);
@@ -465,12 +481,12 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     const el = await dirtySheet();
 
     (q(el, '[data-testid="sheet-back"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     expect(guard(el).open).toBe(true);
     expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
 
     press(el, 'confirm-accept');
-    await el.updateComplete;
+    await settle(el);
     // Back lands on the read view; the sheet itself stays up.
     expect(el.open).toBe(true);
     expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
@@ -479,7 +495,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
   it('asks the same question the form asks itself', async () => {
     const el = await dirtySheet();
     dismissals.scrim(el);
-    await el.updateComplete;
+    await settle(el);
 
     const panel = guard(el).shadowRoot as ShadowRoot;
     expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
@@ -503,10 +519,10 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     });
 
     (q(el, '[data-testid="sheet-check-out"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     const step = q(el, '[data-testid="sheet-checkout"]') as HTMLElement;
     (step.shadowRoot?.querySelector('[data-testid="checkout-cancel"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
 
     expect(cancels).toBe(0);
     expect(el.open).toBe(true);
@@ -517,14 +533,14 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
   it('closes a clean form on the scrim without asking', async () => {
     const el = await mount({ id: '1', name: 'A' });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    await settle(el);
     let cancels = 0;
     el.addEventListener('cancel', () => {
       cancels += 1;
     });
 
     dismissals.scrim(el);
-    await el.updateComplete;
+    await settle(el);
 
     expect(guard(el).open).toBe(false);
     expect(cancels).toBe(1);
@@ -540,7 +556,7 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', name: 'Drill', attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
 
     const figures = all(el, '[data-testid="sheet-photo"]');
     expect(figures).toHaveLength(2);
@@ -562,7 +578,7 @@ describe('hv-detail-sheet: pictures', () => {
       { attachments: [makeAttachment({ kind: 'manual', mime: 'application/pdf' })] },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
 
     expect(q(el, '[data-testid="sheet-gallery"]')).toBeNull();
   });
@@ -572,14 +588,14 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', name: 'Drill', attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
 
     all(el, '[data-testid="sheet-photo-open"]')[1].click();
-    await el.updateComplete;
+    await settle(el);
 
-    const lightbox = q(el, '[data-testid="sheet-lightbox"]');
-    expect(lightbox).toBeTruthy();
-    expect(lightbox?.getAttribute('aria-label')).toBe('Drill — photo 2 of 2');
+    const panel = lightbox(el);
+    expect(panel).toBeTruthy();
+    expect(panel?.getAttribute('aria-label')).toBe('Drill — photo 2 of 2');
   });
 
   it('closes the lightbox on Escape and returns focus to the opener', async () => {
@@ -587,20 +603,20 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', name: 'Drill', attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
 
     const opener = all(el, '[data-testid="sheet-photo-open"]')[0];
     opener.focus();
     opener.click();
-    await el.updateComplete;
-    expect(q(el, '[data-testid="sheet-lightbox"]')).toBeTruthy();
+    await settle(el);
+    expect(lightbox(el)).toBeTruthy();
 
-    q(el, '[data-testid="sheet-lightbox"]')?.dispatchEvent(
+    lightbox(el)?.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
     );
-    await el.updateComplete;
+    await settle(el);
 
-    expect(q(el, '[data-testid="sheet-lightbox"]')).toBeNull();
+    expect(lightbox(el)).toBeNull();
     expect(el.shadowRoot?.activeElement).toBe(opener);
   });
 
@@ -611,15 +627,15 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
     const seen = captured(el, ['cancel']);
 
     all(el, '[data-testid="sheet-photo-open"]')[0].click();
-    await el.updateComplete;
-    q(el, '[data-testid="sheet-lightbox"]')?.dispatchEvent(
+    await settle(el);
+    lightbox(el)?.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
     );
-    await el.updateComplete;
+    await settle(el);
 
     expect(seen).toEqual([]);
   });
@@ -629,14 +645,14 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
 
     all(el, '[data-testid="sheet-photo-open"]')[0].click();
-    await el.updateComplete;
-    q(el, '[data-testid="sheet-lightbox-close"]')?.click();
-    await el.updateComplete;
+    await settle(el);
+    lightbox(el, '[data-testid="lightbox-close"]')?.click();
+    await settle(el);
 
-    expect(q(el, '[data-testid="sheet-lightbox"]')).toBeNull();
+    expect(lightbox(el)).toBeNull();
   });
 
   it('drops the lightbox when the sheet moves to another item', async () => {
@@ -644,14 +660,14 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
     all(el, '[data-testid="sheet-photo-open"]')[0].click();
-    await el.updateComplete;
+    await settle(el);
 
     el.item = makeItem({ id: 'i-2' });
-    await el.updateComplete;
+    await settle(el);
 
-    expect(q(el, '[data-testid="sheet-lightbox"]')).toBeNull();
+    expect(lightbox(el)).toBeNull();
   });
 
   // Setting a cover or removing another photo re-broadcasts the same item; the
@@ -661,17 +677,17 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', name: 'Drill', version: 3, attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
     all(el, '[data-testid="sheet-photo-open"]')[1].click();
-    await el.updateComplete;
+    await settle(el);
 
     el.item = makeItem({ id: 'i-1', name: 'Drill', version: 4, attachments: shots() });
-    await el.updateComplete;
-    await el.updateComplete;
+    await settle(el);
+    await settle(el);
 
-    const lightbox = q(el, '[data-testid="sheet-lightbox"]');
-    expect(lightbox).toBeTruthy();
-    expect(lightbox?.getAttribute('aria-label')).toBe('Drill — photo 2 of 2');
+    const panel = lightbox(el);
+    expect(panel).toBeTruthy();
+    expect(panel?.getAttribute('aria-label')).toBe('Drill — photo 2 of 2');
   });
 
   // The lightbox outlives a same-item refresh, and one of those refreshes is
@@ -681,9 +697,9 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', name: 'Drill', version: 3, attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
     all(el, '[data-testid="sheet-photo-open"]')[1].click();
-    await el.updateComplete;
+    await settle(el);
 
     el.item = makeItem({
       id: 'i-1',
@@ -691,12 +707,12 @@ describe('hv-detail-sheet: pictures', () => {
       version: 4,
       attachments: [makeAttachment({ id: 'att-1' })],
     });
-    await el.updateComplete;
-    await el.updateComplete;
+    await settle(el);
+    await settle(el);
 
-    const lightbox = q(el, '[data-testid="sheet-lightbox"]');
-    expect(lightbox).toBeTruthy();
-    expect(lightbox?.getAttribute('aria-label')).toBe('Photo of Drill');
+    const panel = lightbox(el);
+    expect(panel).toBeTruthy();
+    expect(panel?.getAttribute('aria-label')).toBe('Photo of Drill');
   });
 
   it('closes the lightbox when the last photo is removed under it', async () => {
@@ -704,41 +720,15 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', name: 'Drill', version: 3, attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
     all(el, '[data-testid="sheet-photo-open"]')[0].click();
-    await el.updateComplete;
+    await settle(el);
 
     el.item = makeItem({ id: 'i-1', name: 'Drill', version: 4, attachments: [] });
-    await el.updateComplete;
-    await el.updateComplete;
+    await settle(el);
+    await settle(el);
 
-    expect(q(el, '[data-testid="sheet-lightbox"]')).toBeNull();
-  });
-
-  // The lightbox chrome floats on the photo, so a white frame is the worst
-  // case its scrim has to survive: the counter is 13px text and wants 4.5:1
-  // against whatever it lands on, which the chevrons beside it do not.
-  it('keeps the lightbox controls readable over a white photo', () => {
-    const alpha = Number(
-      /--hv-lightbox-scrim: rgba\(0, 0, 0, ([\d.]+)\)/.exec(sheetCss())?.[1],
-    );
-    expect(alpha).toBeGreaterThan(0);
-
-    const channel = (c: number) => {
-      const s = c / 255;
-      return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
-    };
-    // The scrim over a pure white frame, which is what the white ink sits on.
-    const backing = channel(255 * (1 - alpha));
-    expect((1.05) / (backing + 0.05)).toBeGreaterThanOrEqual(4.5);
-  });
-
-  it('backs every lightbox control with that one scrim', () => {
-    const css = sheetCss();
-    for (const selector of ['\\.lightbox \\.close', '\\.lightbox \\.nav', '\\.lightbox \\.counter']) {
-      const rule = new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
-      expect(rule).toContain('background: var(--hv-lightbox-scrim)');
-    }
+    expect(lightbox(el)).toBeNull();
   });
 
   // That close takes the thumbnail focus would have gone back to with it, so
@@ -749,15 +739,15 @@ describe('hv-detail-sheet: pictures', () => {
       { id: 'i-1', name: 'Drill', version: 3, attachments: shots() },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
     const opener = all(el, '[data-testid="sheet-photo-open"]')[0];
     opener.focus();
     opener.click();
-    await el.updateComplete;
+    await settle(el);
 
     el.item = makeItem({ id: 'i-1', name: 'Drill', version: 4, attachments: [] });
-    await el.updateComplete;
-    await el.updateComplete;
+    await settle(el);
+    await settle(el);
 
     expect(opener.isConnected).toBe(false);
     const sheet = q(el, 'hv-bottom-sheet') as HVBottomSheet;
@@ -776,41 +766,41 @@ describe('hv-detail-sheet: lightbox navigation', () => {
 
   async function opened(index: number, attachments = shots()) {
     const el = await mount({ id: 'i-1', name: 'Drill', attachments }, { media: makeMediaBindings() });
-    await el.updateComplete;
+    await settle(el);
     all(el, '[data-testid="sheet-photo-open"]')[index].click();
-    await el.updateComplete;
+    await settle(el);
     return el;
   }
 
   const shown = (el: HVDetailSheet) =>
-    (q(el, '[data-testid="sheet-lightbox"] img') as HTMLImageElement | null)?.getAttribute('alt');
+    (lightbox(el, '[data-testid="lightbox"] img') as HTMLImageElement | null)?.getAttribute('alt');
   const counter = (el: HVDetailSheet) =>
-    q(el, '[data-testid="sheet-lightbox-counter"]')?.textContent?.trim();
+    lightbox(el, '[data-testid="lightbox-counter"]')?.textContent?.trim();
   const press = async (el: HVDetailSheet, key: string) => {
-    q(el, '[data-testid="sheet-lightbox"]')?.dispatchEvent(
+    lightbox(el)?.dispatchEvent(
       new KeyboardEvent('keydown', { key, bubbles: true }),
     );
-    await el.updateComplete;
+    await settle(el);
   };
 
   it('counts the photo out of the strip it belongs to', async () => {
     const el = await opened(1);
     expect(counter(el)).toBe('2 of 3');
     // A changed dialog label is not re-announced; the counter is.
-    expect(q(el, '[data-testid="sheet-lightbox-counter"]')?.getAttribute('aria-live')).toBe('polite');
+    expect(lightbox(el, '[data-testid="lightbox-counter"]')?.getAttribute('aria-live')).toBe('polite');
   });
 
   it('steps forward and back from the tap-edge buttons', async () => {
     const el = await opened(0);
     expect(shown(el)).toBe('Drill — photo 1 of 3');
 
-    (q(el, '[data-testid="sheet-lightbox-next"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    (lightbox(el, '[data-testid="lightbox-next"]') as HTMLButtonElement).click();
+    await settle(el);
     expect(shown(el)).toBe('Drill — photo 2 of 3');
     expect(counter(el)).toBe('2 of 3');
 
-    (q(el, '[data-testid="sheet-lightbox-prev"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    (lightbox(el, '[data-testid="lightbox-prev"]') as HTMLButtonElement).click();
+    await settle(el);
     expect(shown(el)).toBe('Drill — photo 1 of 3');
     expect(counter(el)).toBe('1 of 3');
   });
@@ -819,21 +809,21 @@ describe('hv-detail-sheet: lightbox navigation', () => {
   // that pressed it, which would drop focus out of the dialog.
   it('wraps at both ends rather than stopping', async () => {
     const el = await opened(0);
-    (q(el, '[data-testid="sheet-lightbox-prev"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    (lightbox(el, '[data-testid="lightbox-prev"]') as HTMLButtonElement).click();
+    await settle(el);
     expect(counter(el)).toBe('3 of 3');
 
-    (q(el, '[data-testid="sheet-lightbox-next"]') as HTMLButtonElement).click();
-    await el.updateComplete;
+    (lightbox(el, '[data-testid="lightbox-next"]') as HTMLButtonElement).click();
+    await settle(el);
     expect(counter(el)).toBe('1 of 3');
   });
 
   // The backdrop closes on click and the buttons sit on top of it.
   it('does not close the lightbox when a nav button is pressed', async () => {
     const el = await opened(0);
-    (q(el, '[data-testid="sheet-lightbox-next"]') as HTMLButtonElement).click();
-    await el.updateComplete;
-    expect(q(el, '[data-testid="sheet-lightbox"]')).toBeTruthy();
+    (lightbox(el, '[data-testid="lightbox-next"]') as HTMLButtonElement).click();
+    await settle(el);
+    expect(lightbox(el)).toBeTruthy();
   });
 
   it('moves with the arrow keys', async () => {
@@ -856,9 +846,9 @@ describe('hv-detail-sheet: lightbox navigation', () => {
 
   it('offers no navigation for a single photo', async () => {
     const el = await opened(0, [makeAttachment({ id: 'att-1' })]);
-    expect(q(el, '[data-testid="sheet-lightbox-prev"]')).toBeNull();
-    expect(q(el, '[data-testid="sheet-lightbox-next"]')).toBeNull();
-    expect(q(el, '[data-testid="sheet-lightbox-counter"]')).toBeNull();
+    expect(lightbox(el, '[data-testid="lightbox-prev"]')).toBeNull();
+    expect(lightbox(el, '[data-testid="lightbox-next"]')).toBeNull();
+    expect(lightbox(el, '[data-testid="lightbox-counter"]')).toBeNull();
     // The arrow key has nowhere to go and must not be swallowed by a dialog
     // that cannot act on it.
     await press(el, 'ArrowRight');
@@ -867,16 +857,16 @@ describe('hv-detail-sheet: lightbox navigation', () => {
 
   it('still closes on Escape with the navigation on screen', async () => {
     const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots() }, { media: makeMediaBindings() });
-    await el.updateComplete;
+    await settle(el);
     const opener = all(el, '[data-testid="sheet-photo-open"]')[1];
     opener.focus();
     opener.click();
-    await el.updateComplete;
+    await settle(el);
     const seen = captured(el, ['cancel']);
 
     await press(el, 'Escape');
 
-    expect(q(el, '[data-testid="sheet-lightbox"]')).toBeNull();
+    expect(lightbox(el)).toBeNull();
     expect(seen).toEqual([]);
     expect(el.shadowRoot?.activeElement).toBe(opener);
   });
@@ -903,7 +893,7 @@ describe('hv-detail-sheet: documents', () => {
   it('lists each manual with its title, falling back to the filename', async () => {
     serve(206);
     const el = await mount({ id: 'i-1', attachments: docs() }, { media: makeMediaBindings() });
-    await el.updateComplete;
+    await settle(el);
 
     const titles = all(el, '[data-testid="sheet-document-title"]').map((n) => n.textContent?.trim());
     expect(titles).toEqual(['Dishwasher manual (EN)', 'warranty.pdf']);
@@ -915,7 +905,7 @@ describe('hv-detail-sheet: documents', () => {
   it('names the file under a title only when the two differ', async () => {
     serve(206);
     const el = await mount({ id: 'i-1', attachments: docs() }, { media: makeMediaBindings() });
-    await el.updateComplete;
+    await settle(el);
 
     const [titled, untitled] = all(el, '[data-testid="sheet-document-meta"]').map((n) =>
       n.textContent?.trim(),
@@ -933,7 +923,7 @@ describe('hv-detail-sheet: documents', () => {
       { attachments: [makeAttachment({ id: 'att-1' })] },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
 
     expect(q(el, '[data-testid="sheet-documents"]')).toBeNull();
   });
@@ -943,7 +933,7 @@ describe('hv-detail-sheet: documents', () => {
   it('opens a document in a new tab through the signed URL', async () => {
     serve(206);
     const el = await mount({ id: 'i-1', attachments: docs() }, { media: makeMediaBindings() });
-    await el.updateComplete;
+    await settle(el);
 
     const open = all(el, '[data-testid="sheet-document-open"]')[0] as HTMLAnchorElement;
     // Versioned by the served name, so a retitle cannot be answered from the
@@ -958,7 +948,7 @@ describe('hv-detail-sheet: documents', () => {
   it('marks a reference whose file is gone instead of offering a dead link', async () => {
     serve(404);
     const el = await mount({ id: 'i-1', attachments: docs() }, { media: makeMediaBindings() });
-    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+    for (let i = 0; i < 4; i += 1) await settle(el);
 
     expect(all(el, '[data-testid="sheet-document-missing"]')).toHaveLength(2);
     expect(q(el, '[data-testid="sheet-document-open"]')).toBeNull();
@@ -976,7 +966,7 @@ describe('hv-detail-sheet: documents', () => {
       }),
     );
     const el = await mount({ id: 'i-1', attachments: docs() }, { media: makeMediaBindings() });
-    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+    for (let i = 0; i < 4; i += 1) await settle(el);
 
     expect(q(el, '[data-testid="sheet-document-missing"]')).toBeNull();
     expect(all(el, '[data-testid="sheet-document-open"]')).toHaveLength(2);
@@ -994,7 +984,7 @@ describe('hv-detail-sheet: documents', () => {
       },
       { media: makeMediaBindings() },
     );
-    await el.updateComplete;
+    await settle(el);
 
     expect(all(el, '[data-testid="sheet-document-title"]').map((n) => n.textContent?.trim())).toEqual(
       ['First', 'Second'],

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -18,7 +18,6 @@ import {
   pictures,
 } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
-import { DialogFocus } from '../ui/dialog-focus';
 import { DISCARD_PROMPT } from '../ui/discard';
 import { ViewportNarrow } from '../ui/responsive';
 import type { AreaRef, Item, Location, LocationTreeNode, MediaConfig, ScalarValue, StatusDefinition } from '../store/types';
@@ -26,15 +25,35 @@ import './hv-bottom-sheet';
 import './hv-checkout-popover';
 import './hv-confirm';
 import './hv-item-editor';
+import './hv-lightbox';
 import type { HVBottomSheet } from './hv-bottom-sheet';
 import type { HVItemEditor } from './hv-item-editor';
 
 /**
- * The mobile item surface: tap a row, get one sheet.
+ * The narrow item surface: tap a row, get one sheet.
  *
  * It lands on a read view — chips summarise state, the quantity hero is the
  * primary action — and swaps in place to the edit form. Nothing here opens a
  * second dialog; that is the whole point of the sheet.
+ *
+ * Both narrow surfaces host it — the card and the full view (and through it the
+ * sidebar panel) — so the contract is worth stating rather than reading off one
+ * host's bindings:
+ *
+ * - **In**: `item` and `open` say what to show; `locations`, `locationTree`,
+ *   `areas`, `statuses`, `categorySuggestions`, `tagSuggestions`,
+ *   `customFieldKeys`, `media` and `mediaConfig` are the store slices the read
+ *   view and the form it hosts read; `busy` and `errorMessage` are the host's
+ *   account of the save in flight, forwarded to the form.
+ * - **Out**: `save` (the editor's own detail, so a host's editor-save handler
+ *   takes it unchanged), `increment` / `decrement`, `check-in`,
+ *   `check-out-confirmed` and `set-due-date` with the picked date,
+ *   `request-delete` — every one carrying `itemId` — and `cancel` when the
+ *   sheet has finished closing.
+ * - The sheet answers for the form inside it: a dismissal with unsaved typing
+ *   raises the discard question here, and `cancel` follows only if it is
+ *   answered yes. A host must not try to guard the form from outside; it cannot
+ *   see into this shadow root.
  */
 @customElement('hv-detail-sheet')
 export class HVDetailSheet extends LitElement {
@@ -358,73 +377,6 @@ export class HVDetailSheet extends LitElement {
         color: var(--hv-text-secondary);
         text-decoration: line-through;
       }
-      .lightbox {
-        position: fixed;
-        inset: 0;
-        display: grid;
-        place-items: center;
-        /* Opaque rather than a scrim: a photo is what the surface is for, and
-           the sheet behind it competes at any transparency. */
-        background: #000;
-        z-index: 10;
-        /* Every control here floats on the photo, so its own backing is the
-           only contrast it is guaranteed. The worst case is a white frame,
-           where this resolves to #6B6B6B — 5.3:1 under the white ink, enough
-           for the counter, which is 13px text and therefore wants 4.5:1 rather
-           than the 3:1 the chevrons would settle for. One value for all three,
-           set by the strictest thing sitting on it. */
-        --hv-lightbox-scrim: rgba(0, 0, 0, 0.58);
-      }
-      .lightbox img {
-        max-width: 100vw;
-        max-height: 100vh;
-        object-fit: contain;
-      }
-      .lightbox .close {
-        position: absolute;
-        top: 8px;
-        right: 8px;
-        min-width: 44px;
-        min-height: 44px;
-        display: inline-grid;
-        place-items: center;
-        border: none;
-        border-radius: 50%;
-        background: var(--hv-lightbox-scrim);
-        color: #fff;
-      }
-      /* Both controls sit on the photo, which is any colour at all — hence the
-         scrim behind them rather than bare white glyphs. */
-      .lightbox .nav {
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        min-width: 44px;
-        min-height: 44px;
-        display: inline-grid;
-        place-items: center;
-        border: none;
-        border-radius: 50%;
-        background: var(--hv-lightbox-scrim);
-        color: #fff;
-      }
-      .lightbox .nav.prev {
-        left: 8px;
-      }
-      .lightbox .nav.next {
-        right: 8px;
-      }
-      .lightbox .counter {
-        position: absolute;
-        bottom: 12px;
-        left: 50%;
-        transform: translateX(-50%);
-        padding: 4px 12px;
-        border-radius: var(--hv-radius-chip);
-        background: var(--hv-lightbox-scrim);
-        color: #fff;
-        font: 500 13px var(--hv-font);
-      }
     `,
   ];
 
@@ -454,7 +406,7 @@ export class HVDetailSheet extends LitElement {
   @state() private _mode: 'read' | 'edit' = 'read';
   /** The check-out date step, shown inline in the sheet rather than as a popup. */
   @state() private _checkoutOpen = false;
-  /** Index of the picture shown full-size, or null when the lightbox is closed. */
+  /** Which picture the lightbox was opened on, or null when it is closed. */
   @state() private _lightbox: number | null = null;
   /**
    * Where the sheet goes once a discard is confirmed, or null while nothing is
@@ -466,8 +418,6 @@ export class HVDetailSheet extends LitElement {
   private readonly _urls = new MediaUrls(this);
   /** Window width, for the confirm this sheet raises over itself. */
   private readonly _viewport = new ViewportNarrow(this);
-  /** Returns focus to the thumbnail the lightbox was opened from. */
-  private readonly _lightboxFocus = new DialogFocus();
   /**
    * The item id the sheet is showing. `undefined` until the first update, so
    * that pass settles the view the same way a move to another item does.
@@ -493,25 +443,6 @@ export class HVDetailSheet extends LitElement {
       this._lightbox = null;
       this._pendingDiscard = null;
     }
-    if (this._lightbox !== null) {
-      // The lightbox survives a same-item refresh, and one of those refreshes
-      // is a photo being removed from under it. An index past the end renders
-      // nothing while still counting as open, which strands focus on a panel
-      // that is no longer there.
-      const count = pictures(this.item?.attachments).length;
-      this._lightbox = count === 0 ? null : Math.min(this._lightbox, count - 1);
-    }
-  }
-
-  protected updated() {
-    this._lightboxFocus.sync(
-      this._lightbox !== null,
-      () => this.shadowRoot?.querySelector<HTMLElement>('[data-testid="sheet-lightbox"]'),
-      // The thumbnail the lightbox was opened from is gone exactly when the
-      // lightbox closed because that photo was removed. The sheet is still on
-      // screen, so focus belongs on its panel rather than on the document.
-      () => this._sheet?.focusPanel(),
-    );
   }
 
   /** True when the edit form is open with unsaved changes. */
@@ -673,79 +604,6 @@ export class HVDetailSheet extends LitElement {
    * no-op — and a control that disabled itself under the finger that pressed it
    * would drop focus to the document, taking Escape and the arrow keys with it.
    */
-  private _renderLightbox(item: Item) {
-    const shots = pictures(item.attachments);
-    const index = this._lightbox;
-    if (index === null || !shots[index]) return null;
-    const src = this._urls.get(item.id, shots[index].id, attachmentNameToken(shots[index]));
-    if (!src) return null;
-    const close = () => {
-      this._lightbox = null;
-    };
-    const step = (delta: number) => {
-      this._lightbox = (index + delta + shots.length) % shots.length;
-    };
-    const nav = (delta: number) => (e: Event) => {
-      // The backdrop closes on click and these sit on top of it.
-      e.stopPropagation();
-      step(delta);
-    };
-    const many = shots.length > 1;
-    return html`<div
-      class="lightbox"
-      role="dialog"
-      aria-modal="true"
-      aria-label=${pictureAlt(item.name, index, shots.length)}
-      data-testid="sheet-lightbox"
-      tabindex="-1"
-      @keydown=${(e: KeyboardEvent) => {
-        if (e.key === 'Escape') {
-          // Stopped here, or the bottom sheet under it takes the same Escape
-          // and closes the whole item rather than the photo on top of it.
-          e.preventDefault();
-          e.stopPropagation();
-          close();
-          return;
-        }
-        if (!many) return;
-        if (e.key === 'ArrowLeft') step(-1);
-        else if (e.key === 'ArrowRight') step(1);
-        else return;
-        e.preventDefault();
-        e.stopPropagation();
-      }}
-      @click=${close}
-    >
-      <img src=${src} alt=${pictureAlt(item.name, index, shots.length)} />
-      <button class="close" data-testid="sheet-lightbox-close" aria-label="Close photo" @click=${close}>
-        ${icon('close', 22)}
-      </button>
-      ${many
-        ? html`<button
-              class="nav prev"
-              data-testid="sheet-lightbox-prev"
-              aria-label="Previous photo"
-              @click=${nav(-1)}
-            >
-              ${icon('chevronLeft', 26)}
-            </button>
-            <button
-              class="nav next"
-              data-testid="sheet-lightbox-next"
-              aria-label="Next photo"
-              @click=${nav(1)}
-            >
-              ${icon('chevronRight', 26)}
-            </button>
-            <!-- Announced rather than only drawn: the dialog's own label
-                 changes with the photo, and a changed label is not re-read. -->
-            <span class="counter" data-testid="sheet-lightbox-counter" aria-live="polite"
-              >${index + 1} of ${shots.length}</span
-            >`
-        : null}
-    </div>`;
-  }
-
   private _renderRead(item: Item) {
     const low = isLowStock(item);
     const overdue = isOverdue(item.due_date);
@@ -992,8 +850,19 @@ export class HVDetailSheet extends LitElement {
         }}
       >
         ${item ? (this._mode === 'edit' ? this._renderEdit(item) : this._renderRead(item)) : null}
-        ${item ? this._renderLightbox(item) : null}
       </hv-bottom-sheet>
+
+      <hv-lightbox
+        data-testid="sheet-lightbox-host"
+        .item=${item}
+        .media=${this.media}
+        .index=${this._lightbox}
+        .onOpenerGone=${() => this._sheet?.focusPanel()}
+        @close=${(e: Event) => {
+          e.stopPropagation();
+          this._lightbox = null;
+        }}
+      ></hv-lightbox>
 
       <!-- Outside the sheet, and its events stopped here: the host listens for
            a cancel event on this element to take the sheet down, and an answer

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -2121,3 +2121,109 @@ describe('hv-full-view: table row actions', () => {
     );
   });
 });
+
+// The card answers a tap on a row with the detail sheet; this surface answered
+// it with the edit form, so the sidebar page at phone width had no read view at
+// all — the table it would have been is off the side of the screen.
+describe('hv-full-view: the detail sheet is the narrow read view', () => {
+  const sheet = (sr: ShadowRoot) =>
+    q(sr, '[data-testid="full-detail-sheet"]') as
+      | (HTMLElement & { open: boolean; item: Item | null; updateComplete: Promise<unknown> })
+      | null;
+  const openRow = async (el: HVFullView, sr: ShadowRoot, index = 0) => {
+    const rows = [
+      ...((q(sr, '[data-testid="full-table"]') as HTMLElement).shadowRoot?.querySelectorAll(
+        '[data-testid="table-row"]',
+      ) ?? []),
+    ] as HTMLElement[];
+    rows[index].click();
+    await settle(el);
+    await settle(el);
+  };
+
+  it('opens the sheet on a row tap, not the form', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1', name: 'Drill' })] });
+      await openRow(el, sr);
+
+      expect(sheet(sr)?.open).toBe(true);
+      expect(sheet(sr)?.item?.name).toBe('Drill');
+      expect(q(sr, '[data-testid="full-editor"]')).toBe(null);
+    } finally {
+      restore();
+    }
+  });
+
+  it('puts Edit one tap deeper, inside the sheet', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1', name: 'Drill' })] });
+      await openRow(el, sr);
+
+      const inner = sheet(sr)!;
+      (inner.shadowRoot?.querySelector('[data-testid="sheet-edit"]') as HTMLButtonElement).click();
+      await inner.updateComplete;
+
+      expect(inner.shadowRoot?.querySelector('[data-testid="sheet-editor"]')).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+
+  it('saves through the surface that owns the store', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Old' })] });
+      await openRow(el, sr);
+
+      const inner = sheet(sr)!;
+      (inner.shadowRoot?.querySelector('[data-testid="sheet-edit"]') as HTMLButtonElement).click();
+      await inner.updateComplete;
+      const editor = inner.shadowRoot?.querySelector('[data-testid="sheet-editor"]') as HTMLElement;
+      const name = editor.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+      name.value = 'New';
+      name.dispatchEvent(new Event('input'));
+      await inner.updateComplete;
+      (inner.shadowRoot?.querySelector('[data-testid="sheet-save"]') as HTMLButtonElement).click();
+      await settle(el);
+      await settle(el);
+
+      expect(store.state.value.items.find((i) => i.id === '1')?.name).toBe('New');
+    } finally {
+      restore();
+    }
+  });
+
+  it('closes the sheet when the item it shows is deleted', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Drill' })] });
+      await openRow(el, sr);
+      expect(sheet(sr)?.open).toBe(true);
+
+      const item = store.state.value.items[0];
+      await store.deleteItem(item.id, item.version);
+      await settle(el);
+
+      expect(sheet(sr)?.open).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  // The table is its own read surface at a width that can show it, and the row
+  // says most of what the sheet would.
+  it('keeps the inline form on a desktop viewport', async () => {
+    const restore = stubViewport(false);
+    try {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1', name: 'Drill' })] });
+      await openRow(el, sr);
+
+      expect(q(sr, '[data-testid="full-detail-sheet"]')).toBe(null);
+      expect(q(sr, '[data-testid="full-editor"]')).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -35,6 +35,7 @@ import './hv-bulk-bar';
 import './hv-checkout-popover';
 import './hv-confirm';
 import './hv-data-table';
+import './hv-detail-sheet';
 import type { MediaBindings } from '../ui/media';
 import './hv-filter-chips';
 import './hv-filter-panel';
@@ -774,6 +775,14 @@ export class HVFullView extends LitElement {
   @state() private _filtersOpen = false;
   @state() private _searchDraft = '';
   @state() private _editing: string | 'new' | null = null;
+  /**
+   * The item the read sheet is showing, on a narrow viewport.
+   *
+   * There is no read view at this width otherwise: the table is one, but it is
+   * off the side of a phone, and tapping a row landed straight in the edit form
+   * — a surface the card answers the same tap with a sheet on.
+   */
+  @state() private _detailItemId: string | null = null;
   @state() private _editorBusy = false;
   /**
    * What the open form says about a save the store refused.
@@ -895,6 +904,7 @@ export class HVFullView extends LitElement {
       } else {
         this._filtersOpen = false;
         this._editing = null;
+        this._detailItemId = null;
         this._editorError = null;
         this._pendingDiscard = null;
         this._creatingLocation = false;
@@ -1017,6 +1027,11 @@ export class HVFullView extends LitElement {
    * asked rather than guessed at.
    */
   private _syncPinnedItem() {
+    // The read sheet holds an id too, and a deleted item leaves it showing
+    // nothing at all rather than closing.
+    if (this._detailItemId !== null && this.store?.wasRemoved(this._detailItemId)) {
+      this._detailItemId = null;
+    }
     const editing = this._editing;
     if (editing === null || editing === 'new') {
       this._pinnedItem = null;
@@ -1053,9 +1068,26 @@ export class HVFullView extends LitElement {
         break;
       case 'edit':
       case 'open-item':
-        this._leaveEditor(item.id);
+        this._openItem(item.id);
         break;
     }
+  }
+
+  /**
+   * Show an item: the read sheet on a narrow viewport, the inline form on a
+   * wide one, with Edit one tap deeper inside the sheet.
+   *
+   * The desktop table is its own read surface — the row already says most of
+   * what the sheet would — so there the form is the right answer to a row
+   * click. A phone sees one column of that table and no hover, and the card
+   * answers the same tap with the same sheet.
+   */
+  private _openItem(id: string) {
+    if (this._narrow) {
+      this._detailItemId = id;
+      return;
+    }
+    this._leaveEditor(id);
   }
 
   /**
@@ -1078,7 +1110,7 @@ export class HVFullView extends LitElement {
         void this.store?.markCheckedIn(item.id, item.version);
         break;
       case 'edit':
-        this._leaveEditor(item.id);
+        this._openItem(item.id);
         break;
       case 'delete':
         this.dispatchEvent(
@@ -2084,6 +2116,49 @@ export class HVFullView extends LitElement {
             this._pendingDelete = false;
           }}
         ></hv-confirm>
+
+        ${this._narrow
+          ? html`<hv-detail-sheet
+              data-testid="full-detail-sheet"
+              .statuses=${st?.statuses ?? null}
+              .areas=${st?.areasCache?.areas ?? []}
+              .media=${this.media}
+              .mediaConfig=${st?.mediaConfig ?? null}
+              ?open=${this._detailItemId !== null}
+              .item=${this._detailItemId ? (st?.items.find((i) => i.id === this._detailItemId) ?? null) : null}
+              .locations=${st?.locationsFlatCache ?? null}
+              .locationTree=${st?.locationTreeCache ?? []}
+              .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
+              .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
+              .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
+              .createLocation=${this._createLocationForEditor}
+              .busy=${this._editorBusy}
+              .errorMessage=${this._editorError}
+              @cancel=${() => {
+                this._detailItemId = null;
+                this._editorError = null;
+              }}
+              @increment=${(e: CustomEvent) => this._onRowEvent('increment', e.detail)}
+              @decrement=${(e: CustomEvent) => this._onRowEvent('decrement', e.detail)}
+              @check-in=${(e: CustomEvent) =>
+                this._onRowAction({ itemId: (e.detail as { itemId: string }).itemId, action: 'check-in' })}
+              @check-out-confirmed=${(e: CustomEvent) => {
+                const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
+                const item = st?.items.find((i) => i.id === itemId);
+                if (item) void this.store?.checkOut(item.id, dueDate, item.version);
+              }}
+              @set-due-date=${(e: CustomEvent) => {
+                const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
+                const item = st?.items.find((i) => i.id === itemId);
+                if (item) void this.store?.updateItem(item.id, { due_date: dueDate }, item.version);
+              }}
+              @request-delete=${(e: CustomEvent) =>
+                this.dispatchEvent(
+                  new CustomEvent('request-delete', { detail: e.detail, bubbles: true, composed: true }),
+                )}
+              @save=${this._onEditorSave}
+            ></hv-detail-sheet>`
+          : null}
 
         <hv-checkout-popover
           data-testid="full-checkout"

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -2653,3 +2653,74 @@ describe('hv-item-editor: one verb for checking out', () => {
     expect(q(el, '[data-testid="editor-checked-out"]')?.textContent).toContain('Check out');
   });
 });
+
+// The form's thumbnails were 72px squares of a photo and nothing more: the
+// lightbox existed on the phone's detail sheet and nowhere else, so on the card
+// and the expanded view there was no way to see a photo at a useful size.
+describe('hv-item-editor: photos open full-size', () => {
+  const shots = () => [makeAttachment({ id: 'att-1' }), makeAttachment({ id: 'att-2' })];
+
+  async function withPhotos() {
+    const el = await mount(makeItem({ id: 'i-1', name: 'Drill', attachments: shots() }), {
+      media: makeMediaBindings(),
+    });
+    await el.updateComplete;
+    await el.updateComplete;
+    return el;
+  }
+
+  const box = (el: HVItemEditor) =>
+    q(el, 'hv-lightbox')?.shadowRoot?.querySelector('[data-testid="lightbox"]') as HTMLElement | null;
+
+  const settleBox = async (el: HVItemEditor) => {
+    await el.updateComplete;
+    await (q(el, 'hv-lightbox') as (HTMLElement & { updateComplete?: Promise<unknown> }) | null)
+      ?.updateComplete;
+  };
+
+  it('opens the photo that was clicked', async () => {
+    const el = await withPhotos();
+
+    (all(el, '[data-testid="editor-photo-open"]')[1] as HTMLButtonElement).click();
+    await settleBox(el);
+    await settleBox(el);
+
+    expect(box(el)?.getAttribute('aria-label')).toBe('Drill — photo 2 of 2');
+  });
+
+  it('names each thumbnail for the photo it opens', async () => {
+    const el = await withPhotos();
+    expect(all(el, '[data-testid="editor-photo-open"]').map((b) => b.getAttribute('aria-label'))).toEqual([
+      'View Drill — photo 1 of 2',
+      'View Drill — photo 2 of 2',
+    ]);
+  });
+
+  it('closes again and leaves the form standing', async () => {
+    const el = await withPhotos();
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
+    (all(el, '[data-testid="editor-photo-open"]')[0] as HTMLButtonElement).click();
+    await settleBox(el);
+    await settleBox(el);
+    (
+      q(el, 'hv-lightbox')?.shadowRoot?.querySelector('[data-testid="lightbox-close"]') as HTMLButtonElement
+    ).click();
+    await settleBox(el);
+
+    expect(box(el)).toBe(null);
+    // Escape inside the lightbox must not read as Escape on the form.
+    expect(cancels).toBe(0);
+    expect(q(el, '[data-testid="item-editor"]')).toBeTruthy();
+  });
+
+  // Without a signed URL there is no photo to open, only the camera placeholder.
+  it('offers nothing to open where the URL has not arrived', async () => {
+    const el = await mount(makeItem({ id: 'i-1', attachments: shots() }), { media: null });
+    await el.updateComplete;
+    expect(q(el, '[data-testid="editor-photo-open"]')).toBe(null);
+  });
+});

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -51,6 +51,7 @@ import type {
 } from '../store/types';
 import './hv-chip-input';
 import './hv-confirm';
+import './hv-lightbox';
 import './hv-location-tree';
 import './hv-checkout-popover';
 
@@ -755,6 +756,14 @@ export class HVItemEditor extends LitElement {
         overflow: hidden;
         background: var(--hv-surface-raised);
       }
+      /* A 72px square of photo is not a photo; every surface that shows one
+         opens it full-size, and the strip is the one that did not. */
+      .photos .open {
+        display: block;
+        padding: 0;
+        border: none;
+        background: none;
+      }
       .photos img {
         width: 72px;
         height: 72px;
@@ -1084,6 +1093,8 @@ export class HVItemEditor extends LitElement {
   @state() private _confirmRemove: { id: string; kind: AttachmentKind } | null = null;
   /** Which attachment section a drag is currently over, for the over-state. */
   @state() private _dropTarget: AttachmentKind | null = null;
+  /** Which photo the lightbox was opened on, or null when it is closed. */
+  @state() private _lightbox: number | null = null;
   /** Escape on a dirty form asks before it throws the typing away. */
   @state() private _confirmDiscard = false;
   /** Why creating a first location from the picker failed. */
@@ -1151,6 +1162,7 @@ export class HVItemEditor extends LitElement {
       this._uploaded = null;
       this._confirmRemove = null;
       this._confirmDiscard = false;
+      this._lightbox = null;
       this._locationError = null;
       this._createdLocations = [];
       this._closeCategory();
@@ -2151,12 +2163,21 @@ export class HVItemEditor extends LitElement {
           const src = this._urls.get(item.id, picture.id, attachmentNameToken(picture));
           return html`<figure data-testid="editor-photo">
             ${src
-              ? html`<img
-                  src=${src}
-                  alt=${pictureAlt(item.name, index, shots.length)}
-                  loading="lazy"
-                  decoding="async"
-                />`
+              ? html`<button
+                  class="open"
+                  data-testid="editor-photo-open"
+                  aria-label=${`View ${pictureAlt(item.name, index, shots.length)}`}
+                  @click=${() => {
+                    this._lightbox = index;
+                  }}
+                >
+                  <img
+                    src=${src}
+                    alt=${pictureAlt(item.name, index, shots.length)}
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </button>`
               : html`<span class="placeholder" data-testid="editor-photo-placeholder"
                   >${icon('camera', 20)}</span
                 >`}
@@ -2617,6 +2638,18 @@ export class HVItemEditor extends LitElement {
           </div>
         </div>
       </div>
+
+      <hv-lightbox
+        data-testid="editor-lightbox-host"
+        .item=${this._current}
+        .media=${this.media}
+        .index=${this._lightbox}
+        .onOpenerGone=${() => this._refocus()}
+        @close=${(e: Event) => {
+          e.stopPropagation();
+          this._lightbox = null;
+        }}
+      ></hv-lightbox>
 
       <!-- Outside the form's own keydown scope, and their events stopped here:
            a host listens for the cancel event on this editor to close it, and a

--- a/cards/haventory-card/src/components/hv-lightbox.test.ts
+++ b/cards/haventory-card/src/components/hv-lightbox.test.ts
@@ -94,6 +94,10 @@ describe('hv-lightbox: opening and closing', () => {
     }
   });
 
+  // The URL is signed over the connection, so the update that opens this draws
+  // nothing at all; focus has to land once the photo is there. Waiting for one
+  // update only would compare a null panel against a null activeElement and
+  // pass while nothing was focused.
   it('takes focus so Escape reaches it, and hands it back on close', async () => {
     const opener = document.createElement('button');
     document.body.appendChild(opener);
@@ -101,11 +105,11 @@ describe('hv-lightbox: opening and closing', () => {
 
     const el = await mount({ id: 'i-1', attachments: shots(2) });
     el.index = 0;
-    await el.updateComplete;
+    await settle(el);
+    expect(panel(el)).not.toBe(null);
     expect(el.shadowRoot?.activeElement).toBe(panel(el));
 
-    el.index = null;
-    await el.updateComplete;
+    await press(el, 'Escape');
     expect(document.activeElement).toBe(opener);
     opener.remove();
   });
@@ -175,6 +179,25 @@ describe('hv-lightbox: navigation', () => {
 
     await tap(el, 'lightbox-next');
     expect(shown(el)).toBe('Drill — photo 1 of 3');
+  });
+
+  // The next photo's URL is signed over the connection, so there is an update
+  // with nothing to draw. Standing the surface down for it would flash the page
+  // underneath and drop focus on <body>, which takes Escape with it.
+  it('stays up, and keeps focus, while the next photo is still being signed', async () => {
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(3) }, 0);
+    const before = panel(el);
+
+    (q(el, '[data-testid="lightbox-next"]') as HTMLButtonElement).click();
+    await el.updateComplete; // the signature has not come back yet
+
+    expect(panel(el)).toBe(before);
+    expect(el.shadowRoot?.activeElement).toBe(before);
+    expect(q(el, 'img')).toBe(null);
+
+    await settle(el);
+    expect(shown(el)).toBe('Drill — photo 2 of 3');
+    expect(panel(el)).toBe(before);
   });
 
   it('does not close when a nav button is pressed', async () => {

--- a/cards/haventory-card/src/components/hv-lightbox.test.ts
+++ b/cards/haventory-card/src/components/hv-lightbox.test.ts
@@ -1,0 +1,247 @@
+import './hv-lightbox';
+import { makeAttachment, makeItem, makeMediaBindings } from '../test.utils';
+import type { HVLightbox } from './hv-lightbox';
+import type { Item } from '../store/types';
+
+const shots = (n: number) => Array.from({ length: n }, (_, i) => makeAttachment({ id: `att-${i + 1}` }));
+
+async function mount(item: Partial<Item>, index: number | null = null) {
+  const el = document.createElement('hv-lightbox') as HVLightbox;
+  el.item = makeItem(item);
+  el.media = makeMediaBindings();
+  el.index = index;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await el.updateComplete;
+  return el;
+}
+
+const q = (el: HVLightbox, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
+const panel = (el: HVLightbox) => q(el, '[data-testid="lightbox"]');
+const shown = (el: HVLightbox) => (q(el, 'img') as HTMLImageElement | null)?.getAttribute('alt');
+const counter = (el: HVLightbox) => q(el, '[data-testid="lightbox-counter"]')?.textContent?.trim();
+
+/**
+ * Two passes: the URL for a photo this component has not shown yet is signed
+ * asynchronously, so the first render after a move has no `src` to draw with.
+ */
+const settle = async (el: HVLightbox) => {
+  await el.updateComplete;
+  await el.updateComplete;
+};
+
+const press = async (el: HVLightbox, key: string) => {
+  panel(el)?.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  await settle(el);
+};
+
+const tap = async (el: HVLightbox, testid: string) => {
+  (q(el, `[data-testid="${testid}"]`) as HTMLButtonElement).click();
+  await settle(el);
+};
+
+const lightboxCss = () => {
+  const styles = (customElements.get('hv-lightbox') as typeof HVLightbox).styles;
+  return (Array.isArray(styles) ? styles : [styles])
+    .map((s) => String(s.cssText))
+    .join('\n')
+    .replace(/\s+/g, ' ');
+};
+
+/** Photos at full size, shared by the phone sheet and the edit form's strip. */
+describe('hv-lightbox: opening and closing', () => {
+  it('draws nothing until a host names a photo', async () => {
+    const el = await mount({ id: 'i-1', attachments: shots(2) });
+    expect(panel(el)).toBe(null);
+  });
+
+  it('opens on the photo it was given', async () => {
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(3) }, 1);
+    expect(panel(el)?.getAttribute('aria-label')).toBe('Drill — photo 2 of 3');
+    expect(shown(el)).toBe('Drill — photo 2 of 3');
+  });
+
+  it.each(['close button', 'backdrop', 'escape'] as const)('reports a close from the %s', async (how) => {
+    const el = await mount({ id: 'i-1', attachments: shots(2) }, 0);
+    let closes = 0;
+    el.addEventListener('close', () => {
+      closes += 1;
+    });
+
+    if (how === 'close button') q(el, '[data-testid="lightbox-close"]')?.click();
+    else if (how === 'backdrop') panel(el)?.click();
+    else await press(el, 'Escape');
+    await el.updateComplete;
+
+    expect(closes).toBe(1);
+    expect(panel(el)).toBe(null);
+  });
+
+  // The surface under it closes on Escape too; without stopping the event the
+  // photo and the whole item would go at once.
+  it('keeps the closing Escape to itself', async () => {
+    const el = await mount({ id: 'i-1', attachments: shots(2) }, 0);
+    let escaped = 0;
+    const count = () => {
+      escaped += 1;
+    };
+    document.addEventListener('keydown', count);
+    try {
+      await press(el, 'Escape');
+      expect(escaped).toBe(0);
+    } finally {
+      document.removeEventListener('keydown', count);
+    }
+  });
+
+  it('takes focus so Escape reaches it, and hands it back on close', async () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const el = await mount({ id: 'i-1', attachments: shots(2) });
+    el.index = 0;
+    await el.updateComplete;
+    expect(el.shadowRoot?.activeElement).toBe(panel(el));
+
+    el.index = null;
+    await el.updateComplete;
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  // Focus was on the panel that has just gone, so the browser drops it on
+  // <body> — outside whatever surface is still on screen, and out of reach of
+  // its Escape. Only the host knows where it belongs instead.
+  it('asks the host where focus goes when the opener went with the photo', async () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(1) }, 0);
+    let rescued = 0;
+    el.onOpenerGone = () => {
+      rescued += 1;
+    };
+
+    // The photo and the thumbnail that opened it go together.
+    opener.remove();
+    el.item = makeItem({ id: 'i-1', name: 'Drill', attachments: [] });
+    await settle(el);
+
+    expect(panel(el)).toBe(null);
+    expect(rescued).toBe(1);
+  });
+
+  // Setting a cover or removing another photo re-broadcasts the same item; the
+  // photo on screen has no reason to go with it.
+  it('survives a same-item refresh, and falls back when the strip shrinks', async () => {
+    const el = await mount({ id: 'i-1', name: 'Drill', version: 3, attachments: shots(2) }, 1);
+
+    el.item = makeItem({ id: 'i-1', name: 'Drill', version: 4, attachments: shots(2) });
+    await settle(el);
+    expect(shown(el)).toBe('Drill — photo 2 of 2');
+
+    el.item = makeItem({ id: 'i-1', name: 'Drill', version: 5, attachments: shots(1) });
+    await settle(el);
+    expect(shown(el)).toBe('Photo of Drill');
+  });
+});
+
+describe('hv-lightbox: navigation', () => {
+  it('counts the photo out of the strip it belongs to', async () => {
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(3) }, 1);
+    expect(counter(el)).toBe('2 of 3');
+    // Announced rather than only drawn: the dialog's label changes with the
+    // photo, and a changed label is not re-read.
+    expect(q(el, '[data-testid="lightbox-counter"]')?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('steps forward and back from the tap-edge buttons', async () => {
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(3) }, 0);
+
+    await tap(el, 'lightbox-next');
+    expect(shown(el)).toBe('Drill — photo 2 of 3');
+
+    await tap(el, 'lightbox-prev');
+    expect(shown(el)).toBe('Drill — photo 1 of 3');
+  });
+
+  it('wraps at both ends rather than stopping', async () => {
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(3) }, 0);
+
+    await tap(el, 'lightbox-prev');
+    expect(shown(el)).toBe('Drill — photo 3 of 3');
+
+    await tap(el, 'lightbox-next');
+    expect(shown(el)).toBe('Drill — photo 1 of 3');
+  });
+
+  it('does not close when a nav button is pressed', async () => {
+    const el = await mount({ id: 'i-1', attachments: shots(3) }, 0);
+    let closes = 0;
+    el.addEventListener('close', () => {
+      closes += 1;
+    });
+
+    await tap(el, 'lightbox-next');
+
+    expect(panel(el)).toBeTruthy();
+    expect(closes).toBe(0);
+  });
+
+  it('moves with the arrow keys', async () => {
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(3) }, 0);
+
+    await press(el, 'ArrowRight');
+    expect(shown(el)).toBe('Drill — photo 2 of 3');
+    await press(el, 'ArrowLeft');
+    expect(shown(el)).toBe('Drill — photo 1 of 3');
+  });
+
+  it('offers no navigation for a single photo', async () => {
+    const el = await mount({ id: 'i-1', attachments: shots(1) }, 0);
+    expect(q(el, '[data-testid="lightbox-prev"]')).toBe(null);
+    expect(q(el, '[data-testid="lightbox-next"]')).toBe(null);
+    expect(q(el, '[data-testid="lightbox-counter"]')).toBe(null);
+  });
+
+  it('still closes on Escape with the navigation on screen', async () => {
+    const el = await mount({ id: 'i-1', attachments: shots(3) }, 1);
+    await press(el, 'Escape');
+    expect(panel(el)).toBe(null);
+  });
+});
+
+// The chrome floats on the photo, so a white frame is the worst case its scrim
+// has to survive: the counter is 13px text and wants 4.5:1 against whatever it
+// lands on, which the chevrons beside it do not.
+describe('hv-lightbox: chrome over any photo', () => {
+  it('keeps the controls readable over a white photo', () => {
+    const alpha = Number(/--hv-lightbox-scrim: rgba\(0, 0, 0, ([\d.]+)\)/.exec(lightboxCss())?.[1]);
+    expect(alpha).toBeGreaterThan(0);
+
+    const channel = (c: number) => {
+      const s = c / 255;
+      return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    };
+    // The scrim over a pure white frame, which is what the white ink sits on.
+    const backing = channel(255 * (1 - alpha));
+    expect(1.05 / (backing + 0.05)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('backs every control with that one scrim', () => {
+    const css = lightboxCss();
+    for (const selector of ['\\.lightbox \\.close', '\\.lightbox \\.nav', '\\.lightbox \\.counter']) {
+      const rule = new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
+      expect(rule).toContain('background: var(--hv-lightbox-scrim)');
+    }
+  });
+
+  // Fixed to the viewport from inside whatever opened it — a bottom sheet, an
+  // expanded view — so it has to stack above that rather than inside it.
+  it('takes a stacking layer of its own when it opens', async () => {
+    const el = await mount({ id: 'i-1', attachments: shots(1) }, 0);
+    expect(Number(panel(el)?.style.zIndex)).toBeGreaterThan(0);
+  });
+});

--- a/cards/haventory-card/src/components/hv-lightbox.ts
+++ b/cards/haventory-card/src/components/hv-lightbox.ts
@@ -166,8 +166,12 @@ export class HVLightbox extends LitElement {
     const shots = pictures(item.attachments);
     const shot = shots[index];
     if (!shot) return null;
+    // A URL that is not signed yet leaves the frame empty for a moment; it does
+    // not take the surface down. Every arrow press moves to a photo this
+    // component has not shown before, and an overlay that unmounted while the
+    // signature was in flight would flash the page underneath, drop focus on
+    // `<body>` — taking Escape with it — and come back a stranger.
     const src = this._urls.get(item.id, shot.id, attachmentNameToken(shot));
-    if (!src) return null;
 
     const many = shots.length > 1;
     const nav = (delta: number) => (e: Event) => {
@@ -202,7 +206,7 @@ export class HVLightbox extends LitElement {
       }}
       @click=${this._close}
     >
-      <img src=${src} alt=${pictureAlt(item.name, index, shots.length)} />
+      ${src ? html`<img src=${src} alt=${pictureAlt(item.name, index, shots.length)} />` : null}
       <button class="close" data-testid="lightbox-close" aria-label="Close photo" @click=${this._close}>
         ${icon('close', 22)}
       </button>

--- a/cards/haventory-card/src/components/hv-lightbox.ts
+++ b/cards/haventory-card/src/components/hv-lightbox.ts
@@ -1,0 +1,230 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { tokens, base } from '../ui/tokens';
+import { icon } from '../ui/icons';
+import { DialogFocus } from '../ui/dialog-focus';
+import { MediaUrls, attachmentNameToken, pictureAlt, pictures } from '../ui/media';
+import type { MediaBindings } from '../ui/media';
+import type { Item } from '../store/types';
+import { nextZBase } from '../utils/zindex';
+
+/**
+ * An item's photos at full size, with the arrows, the counter and Escape.
+ *
+ * The only way to see a photo at a useful size, so every surface that shows a
+ * thumbnail can open it: the phone's detail sheet and the edit form on each of
+ * its three hosts.
+ *
+ * The host says which photo to open at and nulls that back on `close`; where
+ * the index goes after that is this component's own business. Focus returns to
+ * whatever opened it, and `onOpenerGone` is the host's answer for the case where
+ * that control has been taken out of the document — which is exactly what a
+ * photo removed from under the lightbox does.
+ */
+@customElement('hv-lightbox')
+export class HVLightbox extends LitElement {
+  static styles = [
+    tokens,
+    base,
+    css`
+      :host {
+        display: contents;
+      }
+      .lightbox {
+        position: fixed;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        /* Opaque rather than a scrim: a photo is what the surface is for, and
+           whatever is behind it competes at any transparency. */
+        background: #000;
+        /* Every control here floats on the photo, so its own backing is the
+           only contrast it is guaranteed. The worst case is a white frame,
+           where this resolves to #6B6B6B — 5.3:1 under the white ink, enough
+           for the counter, which is 13px text and therefore wants 4.5:1 rather
+           than the 3:1 the chevrons would settle for. One value for all three,
+           set by the strictest thing sitting on it. */
+        --hv-lightbox-scrim: rgba(0, 0, 0, 0.58);
+      }
+      .lightbox img {
+        max-width: 100vw;
+        max-height: 100vh;
+        object-fit: contain;
+      }
+      .lightbox .close {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        min-width: 44px;
+        min-height: 44px;
+        display: inline-grid;
+        place-items: center;
+        border: none;
+        border-radius: 50%;
+        background: var(--hv-lightbox-scrim);
+        color: #fff;
+      }
+      /* Both controls sit on the photo, which is any colour at all — hence the
+         scrim behind them rather than bare white glyphs. */
+      .lightbox .nav {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        min-width: 44px;
+        min-height: 44px;
+        display: inline-grid;
+        place-items: center;
+        border: none;
+        border-radius: 50%;
+        background: var(--hv-lightbox-scrim);
+        color: #fff;
+      }
+      .lightbox .nav.prev {
+        left: 8px;
+      }
+      .lightbox .nav.next {
+        right: 8px;
+      }
+      .lightbox .counter {
+        position: absolute;
+        bottom: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 4px 12px;
+        border-radius: var(--hv-radius-chip);
+        background: var(--hv-lightbox-scrim);
+        color: #fff;
+        font: 500 13px var(--hv-font);
+      }
+    `,
+  ];
+
+  /** The item whose pictures these are. */
+  @property({ attribute: false }) item: Item | null = null;
+  /** Signing, for the attachment URLs. */
+  @property({ attribute: false }) media: MediaBindings | null = null;
+  /**
+   * Which picture to open at, or null for closed. Set it to open; the `close`
+   * event is the host's cue to set it back to null.
+   */
+  @property({ type: Number }) index: number | null = null;
+  /**
+   * Where focus belongs when the control that opened this is no longer in the
+   * document. Only the host knows what is still on screen around it.
+   */
+  @property({ attribute: false }) onOpenerGone: (() => void) | null = null;
+
+  /** The picture actually shown, which the arrows move and `index` seeds. */
+  @state() private _at: number | null = null;
+  @state() private _zBase: number | null = null;
+
+  private readonly _urls = new MediaUrls(this);
+  private readonly _focus = new DialogFocus();
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    this._urls.configure(this.media?.sign ?? null);
+    if (changed.has('index')) {
+      if (this.index !== null && this._at === null) this._zBase = nextZBase();
+      this._at = this.index;
+    }
+    if (this._at === null) return;
+    // The strip survives a same-item refresh, and one of those refreshes is a
+    // photo being removed from under this. An index past the end renders
+    // nothing while still counting as open, which strands focus on a panel that
+    // is no longer there.
+    const count = pictures(this.item?.attachments).length;
+    this._at = count === 0 ? null : Math.min(this._at, count - 1);
+  }
+
+  protected updated() {
+    const open = this._at !== null;
+    this._focus.sync(
+      open,
+      () => this.renderRoot.querySelector<HTMLElement>('[data-testid="lightbox"]'),
+      () => this.onOpenerGone?.(),
+    );
+    // One place announces the close, whether the user asked for it or the last
+    // photo went away underneath.
+    if (!open && this.index !== null) {
+      this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    }
+  }
+
+  private _close = () => {
+    this._at = null;
+  };
+
+  private _step(delta: number, count: number) {
+    if (this._at === null) return;
+    this._at = (this._at + delta + count) % count;
+  }
+
+  render() {
+    const item = this.item;
+    const index = this._at;
+    if (!item || index === null) return null;
+    const shots = pictures(item.attachments);
+    const shot = shots[index];
+    if (!shot) return null;
+    const src = this._urls.get(item.id, shot.id, attachmentNameToken(shot));
+    if (!src) return null;
+
+    const many = shots.length > 1;
+    const nav = (delta: number) => (e: Event) => {
+      // The backdrop closes on click and these sit on top of it.
+      e.stopPropagation();
+      this._step(delta, shots.length);
+    };
+
+    return html`<div
+      class="lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-label=${pictureAlt(item.name, index, shots.length)}
+      data-testid="lightbox"
+      tabindex="-1"
+      style="z-index: ${this._zBase ?? 9998};"
+      @keydown=${(e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          // Stopped here, or the surface under it takes the same Escape and
+          // closes the whole item rather than the photo on top of it.
+          e.preventDefault();
+          e.stopPropagation();
+          this._close();
+          return;
+        }
+        if (!many) return;
+        if (e.key === 'ArrowLeft') this._step(-1, shots.length);
+        else if (e.key === 'ArrowRight') this._step(1, shots.length);
+        else return;
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      @click=${this._close}
+    >
+      <img src=${src} alt=${pictureAlt(item.name, index, shots.length)} />
+      <button class="close" data-testid="lightbox-close" aria-label="Close photo" @click=${this._close}>
+        ${icon('close', 22)}
+      </button>
+      ${many
+        ? html`<button class="nav prev" data-testid="lightbox-prev" aria-label="Previous photo" @click=${nav(-1)}>
+              ${icon('chevronLeft', 26)}
+            </button>
+            <button class="nav next" data-testid="lightbox-next" aria-label="Next photo" @click=${nav(1)}>
+              ${icon('chevronRight', 26)}
+            </button>
+            <!-- Announced rather than only drawn: the dialog's own label
+                 changes with the photo, and a changed label is not re-read. -->
+            <span class="counter" data-testid="lightbox-counter" aria-live="polite"
+              >${index + 1} of ${shots.length}</span
+            >`
+        : null}
+    </div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'hv-lightbox': HVLightbox;
+  }
+}

--- a/cards/haventory-card/src/ui/dialog-focus.test.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.test.ts
@@ -85,6 +85,47 @@ describe('DialogFocus', () => {
     expect(() => f.sync(false, () => null)).not.toThrow();
   });
 
+  // A surface whose content arrives over the connection draws nothing on the
+  // update that opened it — the lightbox has no image URL until the signature
+  // comes back. Focus has to land when the panel appears, not be given up on.
+  it('waits for a surface that appears an update later', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const f = new DialogFocus();
+    let p: HTMLElement | null = null;
+    f.sync(true, () => p);
+    expect(document.activeElement).toBe(trigger);
+
+    p = panel();
+    f.sync(true, () => p);
+    expect(document.activeElement).toBe(p);
+
+    f.sync(false, () => p);
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  // The opener is read on the first "open", so one that never drew must not
+  // leave it behind for whatever opens next.
+  it('forgets the opener of a surface that closed before it drew', () => {
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+    document.body.append(first, second);
+
+    const f = new DialogFocus();
+    first.focus();
+    f.sync(true, () => null);
+    f.sync(false, () => null);
+
+    second.focus();
+    const p = panel();
+    f.sync(true, () => p);
+    expect(document.activeElement).toBe(p);
+    f.sync(false, () => p);
+    expect(document.activeElement).toBe(second);
+  });
+
   it('does nothing while the surface stays closed', () => {
     const btn = document.createElement('button');
     document.body.appendChild(btn);

--- a/cards/haventory-card/src/ui/dialog-focus.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.ts
@@ -111,29 +111,40 @@ export class DialogFocus {
     panel: () => HTMLElement | null | undefined,
     onOpenerGone?: () => void,
   ): void {
-    if (open && !this._active) {
-      this._active = true;
-      this._returnTo = deepActiveElement();
+    if (open) {
+      if (this._active) return;
+      // Where focus came from is read the moment the host says "open", because
+      // focus has not moved yet — but the panel may need another update to
+      // exist. The lightbox signs its image URL over the connection and draws
+      // nothing until that resolves, so its first update has no panel to focus.
+      // Staying inactive is what makes the next update try again; treating the
+      // surface as focused before it is there leaves it deaf to the Escape
+      // bound to its panel, with nowhere to hand focus back to.
+      this._returnTo ??= deepActiveElement();
       const el = panel();
-      if (el) {
-        if (!el.hasAttribute('tabindex')) el.setAttribute('tabindex', '-1');
-        el.focus({ preventScroll: true });
-      }
+      if (!el) return;
+      this._active = true;
+      if (!el.hasAttribute('tabindex')) el.setAttribute('tabindex', '-1');
+      el.focus({ preventScroll: true });
       return;
     }
-    if (!open && this._active) {
-      this._active = false;
-      const back = this._returnTo;
+    if (!this._active) {
+      // Closed before it ever drew: forget the opener rather than returning to
+      // a stale one the next time something opens.
       this._returnTo = null;
-      if (back?.isConnected) {
-        back.focus({ preventScroll: true });
-        return;
-      }
-      // Nothing to return to. Rescue focus only if it really was stranded:
-      // a close that happened while the user was already somewhere else must
-      // not have focus yanked out from under them.
-      const stranded = deepActiveElement();
-      if (!stranded || stranded === document.body || !stranded.isConnected) onOpenerGone?.();
+      return;
     }
+    this._active = false;
+    const back = this._returnTo;
+    this._returnTo = null;
+    if (back?.isConnected) {
+      back.focus({ preventScroll: true });
+      return;
+    }
+    // Nothing to return to. Rescue focus only if it really was stranded: a
+    // close that happened while the user was already somewhere else must not
+    // have focus yanked out from under them.
+    const stranded = deepActiveElement();
+    if (!stranded || stranded === document.body || !stranded.isConnected) onOpenerGone?.();
   }
 }

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -82,11 +82,13 @@ haventory-card                     Lovelace element; store owner
     │                              document pickers, cover/reorder controls,
     │                              per-document title field, per-file retry
     │       ├── hv-chip-input      tag chips with suggestions
+    │       ├── hv-lightbox        the photo strip opens full-size here too
     │       └── hv-location-tree
-    ├── hv-detail-sheet            mobile: read view + edit view in one sheet;
-    │   │                          photo gallery strip, a navigable full-size
-    │   │                          lightbox and the Documents list
+    ├── hv-detail-sheet            the narrow read view, on the card and the full
+    │   │                          view alike: read + edit in one sheet, photo
+    │   │                          gallery strip and the Documents list
     │   ├── hv-item-editor
+    │   ├── hv-lightbox            photos full-size, with arrows and a counter
     │   └── hv-checkout-popover    inline due-date step
     ├── hv-checkout-popover        desktop: anchored due-date step
     ├── hv-organize-dialog         Locations / Categories / Tags / Statuses
@@ -102,6 +104,8 @@ haventory-card                     Lovelace element; store owner
         ├── hv-item-editor         inline above the table (the same one edit form)
         ├── hv-data-table          sortable table + selection column; rows carry the
         │                          same ⋮ actions the card's rows do
+        ├── hv-detail-sheet        the read view at phone width, the same one the
+        │                          card opens
         ├── hv-checkout-popover    the row menu's due-date step
         └── hv-bulk-bar            bulk actions, progress, per-operation results
 ```


### PR DESCRIPTION
## Summary

P10 of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`), and the last of Session C.

**Stacked PR — merge in order: #345 → #346 → this.** Base is #346 (P9), which is based on #345 (P8). After #346 squash-merges, this branch is rebased onto `main` (`git rebase --onto origin/main claude/session-c-frontend-packages-ea1f9o-p9`) before it merges; the local verification session does that rebase as part of its pass.

Fixes **F14** and **F15** from the register in `dev/v040_frontend_completeness_plan.md`. Neither is filed as an issue, so there is no `Closes` line.

### F15 — a photo was only viewable on a phone

The lightbox lived inside `hv-detail-sheet` and nothing else could reach it, so the edit form's 72px thumbnails were inert `<img>`s — on the card, in the expanded view and on the sidebar page. Documents already opened; photos did not.

It is `hv-lightbox` now, with the arrows, the counter, the Escape handling and the focus return moving with it, and the form's thumbnails are buttons that open it. The component takes the photo to open at and reports `close`; where the index goes after that is its own business, so a host holds one number and nothing else. It stacks with `nextZBase()` rather than a z-index scoped to one host's shadow root, because it is fixed to the viewport from inside whatever opened it — a bottom sheet, an expanded view.

`onOpenerGone` stays a host callback: focus was on the panel that has just gone, the browser drops it on `<body>`, and only the host knows what is still on screen to catch it. The sheet answers "my own panel", as it did before.

### F14 — the sidebar page at phone width had no read view

Tapping a row landed straight in the edit form. The table that would have been the read view is off the side of a phone, and the card answers that same tap with a sheet. At the narrow breakpoint `hv-full-view` opens `hv-detail-sheet` too, with Edit one tap deeper inside it; on a screen wide enough for the table, the table is the read surface and a row click opens the form as before. One method decides, so the row click, the pencil and the row menu's Edit cannot disagree.

The sheet stops being shell-only, so its host contract — the store slices it reads, the events it emits, and the fact that it answers for the form inside it (P8's rule; a host cannot see into its shadow root) — is stated in its own JSDoc rather than left to be read off one host's bindings.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1607 passed), `npm run build`

New coverage. `hv-lightbox` gets a suite of its own: closed until a host names a photo; opening on the one it was given; close from the button, the backdrop and Escape, each reported once; Escape kept off the surface underneath; focus taken and handed back, with `onOpenerGone` for the case where the opener went with the photo; surviving a same-item refresh and falling back when the strip shrinks; the arrows, the wrap at both ends, the counter and its `aria-live`, the single-photo case; the scrim contrast pins and a stacking layer of its own. The editor gets the thumbnail path: the clicked photo opens, each thumbnail is named for what it opens, closing leaves the form standing without reading as a cancel, and no opener is drawn where the URL has not arrived. The full view gets the narrow read view: a row tap opens the sheet and not the form, Edit is inside it, a save through the sheet lands in the store, a deleted item takes the sheet down, and a desktop viewport still opens the inline form.

The detail sheet's own lightbox tests were retargeted through the nested component rather than dropped, and the two scrim-contrast pins moved to the new component's suite because the rules moved with it. The sheet's tests also gained a `settle` that awaits the child's update — a host's `updateComplete` does not carry its children's.

Docs: the README's attachments bullet says a thumbnail opens full-size everywhere, and the full-view bullet describes the narrow read view; `docs/frontend_architecture.md`'s component map places `hv-lightbox` under both hosts and `hv-detail-sheet` under the full view.

### Delegated to the local verification session

Checklist P10 in the plan's §Verification: panel at 390px — tap a row, get the detail sheet with photos, documents, facts and check-out; Edit opens the form; save lands back on fresh data. Desktop full view: a row click opens the inline form as before. Lightbox: open a photo from the editor on the card, the expanded view and the panel — arrows navigate, the counter counts, Escape returns focus to the thumbnail. Card behaviour byte-identical to before.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`README.md`, `docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

Deferred to the local verification session — this cloud session has no browser.

## Follow-ups

- A clean save from inside the sheet leaves it on the edit form rather than returning to the read view. That is how the card has always behaved, so it is unchanged here rather than fixed on one surface only.
- Adding an item from the narrow full view still opens the inline form; the card uses a sheet for that. Out of scope for F14, which is about opening an existing item.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Stzf72H6aEA8vk1NFMQpr)_