### PR TITLE
fix(card): tell the truth about a lost connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,9 @@ throughout.
   payload-free reload an import broadcasts. Because subscription events carry no sequence
   number, a dropped one is undetectable — so the card says the list may be stale and
   offers an explicit Refresh. The banners are on **every** surface: the card, the expanded
-  view and the sidebar page, with the same wording and the same recovery actions.
+  view and the sidebar page, with the same wording and the same recovery actions. A view
+  left open when Home Assistant goes away says so on its own, without waiting for you to
+  try something first.
 - Deletes use an in-app confirmation, not `window.confirm`.
 - Card auto-registered as a Lovelace resource on integration setup.
 - **Note:** after first install, a browser refresh (F5 / Ctrl+Shift+R) is required for the

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -1187,6 +1187,31 @@ describe('Store: an idle surface going offline', () => {
     }
   });
 
+  it('sits out a reconnect that lands on the three-second retry rung', async () => {
+    // Home Assistant's client retries on a ladder — at once, then +1 s, +3 s,
+    // +6 s — so a socket dropped while the network is briefly away misses the
+    // first two rungs and returns on the third. That is an ordinary Wi-Fi roam
+    // and the grace period exists to sit it out; a shorter one would put a
+    // banner up and take it down again a second later.
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      const store = new Store(hass, backoff);
+      await store.init();
+
+      hass.__disconnect();
+      await vi.advanceTimersByTimeAsync(3_100);
+      expect(store.state.value.degraded.connectionLost).toBe(false);
+
+      hass.__connectionReady();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(store.state.value.degraded.connectionLost).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('takes the banner back down when the socket returns', async () => {
     vi.useFakeTimers();
     try {
@@ -1219,6 +1244,96 @@ describe('Store: an idle surface going offline', () => {
       await vi.advanceTimersByTimeAsync(5000);
 
       expect(store.state.value.degraded.connectionLost).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('Store: a card built while the backend cannot answer', () => {
+  const backoff = { retryBaseMs: 10 };
+  // Home Assistant rebuilds the Lovelace view when its socket reconnects, and a
+  // restarting instance serves that rebuild before the integration is set up
+  // again. Every command the fresh card makes is refused, so its first load
+  // fails outright — the one case where the routes back into the data must
+  // still be opened.
+  const REFUSED = { code: 'unknown_command', message: 'Unknown command.' };
+
+  it('still watches the socket after a first load that failed', async () => {
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      hass.__failNext(50, REFUSED);
+      const store = new Store(hass, backoff);
+      await store.init().catch(() => undefined);
+
+      // Driving the watch is the only honest proof it was attached.
+      hass.__disconnect();
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      expect(store.state.value.degraded.connectionLost).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still opens the subscriptions after a first load that failed', async () => {
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      hass.__failNext(50, REFUSED);
+      const store = new Store(hass, backoff);
+      await store.init().catch(() => undefined);
+
+      expect(hass.__subscribeCalls).toContain('items');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waits out a subscribe refused because the command is not registered yet', async () => {
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      hass.__failSubscribeNext(4, REFUSED);
+      const store = new Store(hass, backoff);
+      await store.init();
+
+      // Retrying, not paused: an unregistered command says the backend is early,
+      // and pausing would ask the user to act on something that fixes itself.
+      expect(store.state.value.degraded.liveUpdates).toBe('retrying');
+      expect(store.state.value.degraded.liveUpdatesReason).toBe('unavailable');
+      expect(store.state.value.errorQueue).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(store.state.value.degraded.liveUpdates).toBe('live');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reads the inventory once the backend starts answering', async () => {
+    // Nothing the user does is involved: the refused subscribe retries on its
+    // own backoff, and landing it re-reads everything the failed load missed.
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      // Exactly the loads `init` starts in parallel, so the refusal window
+      // closes with it and the recovery that follows is answered normally. The
+      // empty-list assertion below is what catches this count going stale.
+      hass.__failNext(8, REFUSED);
+      // The subscribe is refused the same way the commands were: a restarting
+      // instance has no `haventory/subscribe` registered yet either.
+      hass.__failSubscribeNext(4, REFUSED);
+      const store = new Store(hass, backoff);
+      await store.init().catch(() => undefined);
+      expect(store.state.value.items).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(store.state.value.items.map((i) => i.id)).toEqual(['1']);
+      expect(store.state.value.degraded.liveUpdates).toBe('live');
     } finally {
       vi.useRealTimers();
     }

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -735,19 +735,63 @@ describe('subscribeRetryDelayMs', () => {
     expect(store.state.value.degraded.rateLimited).toBe(false);
   });
 
-  it('counts unknown_error toward an outage even though it is a taxonomy code', async () => {
-    // `unknown_error` is in DOMAIN_ERROR_CODES so it renders as a real message,
-    // but it is deliberately excluded from the "socket is fine" reset: it is the
-    // backend's catch-all and says nothing about the transport.
+  it('does not count the taxonomy catch-all toward an outage', async () => {
+    // `unknown_error` is the backend's own answer to a command it could not
+    // carry out. It travelled the socket to get here, so it proves the transport
+    // works — reporting it as an outage would blame the connection for a fault
+    // that is entirely server-side.
     const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
     const store = new Store(hass, fast);
     await store.init();
 
-    hass.__failNext(2, { code: 'unknown_error', message: 'boom' });
+    hass.__failNext(3, { code: 'unknown_error', message: 'boom' });
+    await store.adjustQuantity('1', 1);
     await store.adjustQuantity('1', 1);
     await store.adjustQuantity('1', 1);
 
+    expect(store.state.value.degraded.connectionLost).toBe(false);
+    expect(store.state.value.errorQueue.map((e) => e.message)).toEqual(['boom', 'boom', 'boom']);
+  });
+
+  it('names a transport failure rather than borrowing the catch-all', async () => {
+    // Home Assistant rejects a call the socket never carried with a wrapper of
+    // its own: no top-level code, no message a person could read. Reported
+    // verbatim it says "Unknown error", which reads as a fault in what the user
+    // just did rather than in the connection.
+    const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    hass.__failNext(1, { type: 'result', success: false, error: { code: 3, message: 'Connection lost' } });
+    await store.adjustQuantity('1', 1);
+
+    expect(store.state.value.errorQueue).toHaveLength(1);
+    expect(store.state.value.errorQueue[0].code).toBe('connection_lost');
+    expect(store.state.value.errorQueue[0].message).toContain('Could not reach Home Assistant');
+  });
+
+  it('queues one entry for an outage however many calls fail', async () => {
+    // An outage fails everything in flight and everything tried next. Stacking
+    // one banner per call buries the rest of the queue under copies of a
+    // sentence the user has already read.
+    const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    hass.__failNext(4, new Error('socket closed'));
+    await store.adjustQuantity('1', 1);
+    await store.adjustQuantity('1', 1);
+    await store.refreshStats().catch(() => undefined);
+    await store.refreshHealth().catch(() => undefined);
+
+    expect(store.state.value.errorQueue.map((e) => e.code)).toEqual(['connection_lost']);
     expect(store.state.value.degraded.connectionLost).toBe(true);
+
+    // Dismissing it is not a permanent silence: the next failure says so again.
+    store.dismissError(store.state.value.errorQueue[0].id);
+    hass.__failNext(1, new Error('socket closed'));
+    await store.adjustQuantity('1', 1);
+    expect(store.state.value.errorQueue.map((e) => e.code)).toEqual(['connection_lost']);
   });
 
   it('counts the queued retries and schedules the next one', async () => {
@@ -1090,6 +1134,91 @@ describe('Store: HA area registry watch', () => {
 
       expect(refusing.attempts()).toBe(1);
       expect(hass.__haEventSubscriberCount(AREA_EVENT)).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('Store: an idle surface going offline', () => {
+  const backoff = { retryBaseMs: 10 };
+
+  it('says the connection is lost when the socket closes and stays closed', async () => {
+    // Nobody is touching this surface, so no call can report the outage. Without
+    // the socket's own event the list would sit there showing pre-outage data
+    // until someone tried something and got a failure.
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      const store = new Store(hass, backoff);
+      await store.init();
+
+      hass.__disconnect();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(store.state.value.degraded.connectionLost).toBe(true);
+      // The degraded stack carries this one; nothing was refused, so nothing
+      // belongs in the queue of refused operations.
+      expect(store.state.value.errorQueue).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sits out a reconnect that lands inside the grace period', async () => {
+    // Home Assistant reconnects by itself and a blip is over before anyone could
+    // act on it. Announcing it at once would flash a banner and withdraw it.
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      const store = new Store(hass, backoff);
+      await store.init();
+
+      hass.__disconnect();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(store.state.value.degraded.connectionLost).toBe(false);
+
+      hass.__connectionReady();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(store.state.value.degraded.connectionLost).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('takes the banner back down when the socket returns', async () => {
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      const store = new Store(hass, backoff);
+      await store.init();
+
+      hass.__disconnect();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(store.state.value.degraded.connectionLost).toBe(true);
+
+      hass.__connectionReady();
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(store.state.value.degraded.connectionLost).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops watching the socket once the store is disposed', async () => {
+    vi.useFakeTimers();
+    try {
+      const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+      const store = new Store(hass, backoff);
+      await store.init();
+
+      store.dispose();
+      hass.__disconnect();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(store.state.value.degraded.connectionLost).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -47,18 +47,34 @@ const PAGE_LIMIT = 50;
  */
 export const BULK_CHUNK_SIZE = 25;
 
-/** Error codes the backend's taxonomy defines; anything else looks like transport trouble. */
-const DOMAIN_ERROR_CODES = new Set([
-  'validation_error',
-  'not_found',
-  'conflict',
-  'storage_error',
-  'rate_limited',
-  'unknown_error',
-]);
+/**
+ * Code for a failure that never came back from the backend at all.
+ *
+ * Home Assistant rejects a command with the server's own `{code, message}`
+ * envelope when the socket carried it, and with a wrapper of its own — numeric
+ * code, no top-level message — when the socket did not. Only the first kind
+ * says anything about the request, so the second is named for what it is
+ * instead of borrowing the taxonomy's `unknown_error` catch-all and reading, to
+ * the person in front of it, as a fault in the thing they just did.
+ */
+const TRANSPORT_ERROR_CODE = 'connection_lost';
+
+/** What a transport failure says out loud; the rejection carries no usable text. */
+const TRANSPORT_ERROR_MESSAGE = 'Could not reach Home Assistant — the last action did not go through.';
 
 /** Consecutive transport failures before the card declares the connection lost. */
 const CONNECTION_LOST_THRESHOLD = 2;
+
+/**
+ * How long a closed socket may stay closed before the card says so.
+ *
+ * Home Assistant reconnects on its own, and a blip — a suspended tab waking, a
+ * proxy recycling — is over before anyone could act on it, so announcing it at
+ * once would flash a banner that answers nothing. Long enough to sit out an
+ * ordinary reconnect, short enough that a real outage shows up while the user
+ * is still looking at the surface that went stale.
+ */
+const CONNECTION_LOST_GRACE_MS = 2_000;
 
 /** Attempts (including the first) for a command rejected with `rate_limited`. */
 const RATE_LIMIT_ATTEMPTS = 4;
@@ -125,8 +141,16 @@ const NO_DEGRADATION: DegradedState = {
   nextLiveRetryAt: null,
 };
 
+/**
+ * The code a failure travelled home with.
+ *
+ * A string code means a server answered — the backend's taxonomy, or one of
+ * Home Assistant's own refusals. Anything else (a numeric transport code, a
+ * thrown `Error`, nothing at all) never reached one.
+ */
 function errorCode(err: unknown): string {
-  return String((err as { code?: unknown } | undefined)?.code ?? 'unknown_error');
+  const code = (err as { code?: unknown } | undefined)?.code;
+  return typeof code === 'string' && code ? code : TRANSPORT_ERROR_CODE;
 }
 
 function nonNegativeNumber(value: unknown): number | null {
@@ -309,8 +333,11 @@ export class Store {
   private areaRegistryRetryHandle: ReturnType<typeof setTimeout> | null = null;
   /** Identifies the newest area-registry watch, so a superseded one stops reporting. */
   private areaRegistryGeneration = 0;
-  /** Detaches the connection-lifecycle listener; null while none is attached. */
+  /** Detaches the connection-lifecycle listeners; null while none is attached. */
   private connectionReadyUnsub: Unsubscribe | null = null;
+  private connectionLostUnsub: Unsubscribe | null = null;
+  /** Counts down the grace period on a closed socket; null while it is open. */
+  private connectionLostHandle: ReturnType<typeof setTimeout> | null = null;
   /** Last untouched `distinct_values` result, so drafts can be re-merged. */
   private serverDistinct: DistinctValues | null = null;
   /** Values named in the organize dialog that no item carries yet. */
@@ -369,18 +396,43 @@ export class Store {
   }
 
   /**
-   * Re-read the areas whenever the connection comes back from a drop.
+   * Follow the socket itself, in both directions.
    *
-   * A dropped socket is the gap the registry watch cannot see: Home Assistant
+   * Coming back is the gap the registry watch cannot see: Home Assistant
    * re-issues the subscriptions it held before it reports `ready`, so the
    * subscribe neither fails nor re-opens and `watchAreaRegistry`'s catch-up
    * never runs — yet an area renamed while the socket was down fired its event
-   * into a closed connection. Only a refetch closes that, so it is driven off
-   * the connection's own lifecycle rather than off the watch.
+   * into a closed connection. Only a refetch closes that.
+   *
+   * Going down is what a surface nobody is touching has no other way to learn.
+   * Every other outage signal the card has comes from a call it made, so a list
+   * left open across a restart would go on showing pre-outage data, silently,
+   * until someone tried something.
    */
   private watchConnectionGaps() {
     this.connectionReadyUnsub?.();
-    this.connectionReadyUnsub = this.ws.onConnectionReady(() => this.scheduleAreasRefresh());
+    this.connectionLostUnsub?.();
+    this.connectionReadyUnsub = this.ws.onConnectionReady(() => {
+      this.cancelConnectionLostGrace();
+      this.noteSuccess();
+      this.scheduleAreasRefresh();
+    });
+    this.connectionLostUnsub = this.ws.onConnectionLost(() => this.startConnectionLostGrace());
+  }
+
+  /** Declare the connection lost unless it comes back inside the grace period. */
+  private startConnectionLostGrace() {
+    if (this.connectionLostHandle !== null) return;
+    this.connectionLostHandle = setTimeout(() => {
+      this.connectionLostHandle = null;
+      this.setDegraded({ connectionLost: true });
+    }, CONNECTION_LOST_GRACE_MS);
+  }
+
+  private cancelConnectionLostGrace() {
+    if (this.connectionLostHandle === null) return;
+    clearTimeout(this.connectionLostHandle);
+    this.connectionLostHandle = null;
   }
 
   /**
@@ -623,9 +675,12 @@ export class Store {
     // dashboard — a listener left behind would refetch for a disposed store on
     // every reconnect, for as long as the page is open.
     this.connectionReadyUnsub?.();
+    this.connectionLostUnsub?.();
+    this.cancelConnectionLostGrace();
     this.itemsUnsub = this.statsUnsub = this.locationsUnsub = this.statusesUnsub = null;
     this.areaRegistryUnsub = null;
     this.connectionReadyUnsub = null;
+    this.connectionLostUnsub = null;
     // Nothing is listening after this, so a queued re-subscribe must not fire.
     this.subscribeRound += 1;
     this.areaRegistryGeneration += 1;
@@ -1108,10 +1163,12 @@ export class Store {
   }
 
   /**
-   * Classify a failure. A code from the backend's taxonomy means the socket is
-   * fine and the command was refused; anything else is transport trouble, and a
-   * run of those is the only "connection lost" signal a card can observe — HA's
-   * WS client reconnects transparently and exposes no disconnect event.
+   * Classify a failure. A refusal that came back over the socket — including
+   * the taxonomy's `unknown_error` catch-all — proves the transport works and
+   * says only that the command was rejected. A run of failures that carry no
+   * such answer is the second "connection lost" signal, alongside the socket's
+   * own `disconnected` event: it catches the outages that close no socket, such
+   * as a server that accepts the connection and stops answering on it.
    */
   private noteFailure(err: unknown) {
     const code = errorCode(err);
@@ -1119,7 +1176,7 @@ export class Store {
       this.setDegraded({ rateLimited: true });
       return;
     }
-    if (DOMAIN_ERROR_CODES.has(code) && code !== 'unknown_error') {
+    if (code !== TRANSPORT_ERROR_CODE) {
       this.consecutiveTransportFailures = 0;
       return;
     }
@@ -1185,6 +1242,8 @@ export class Store {
    */
   async refreshAll(): Promise<void> {
     this.consecutiveTransportFailures = 0;
+    // The calls below re-answer the question the grace period was waiting on.
+    this.cancelConnectionLostGrace();
     this.setDegraded({ ...NO_DEGRADATION });
     await this.reloadAll();
     // Re-establish subscriptions in case one of them was refused earlier.
@@ -1526,8 +1585,15 @@ export class Store {
   private pushError(err: unknown, details?: { itemId?: string; changes?: ItemUpdate }) {
     // Home Assistant callWS returns an error envelope with {code, message, context}
     const anyErr = err as { code?: unknown; message?: unknown; context?: unknown; data?: unknown } | undefined;
-    const code = String(anyErr?.code ?? 'unknown_error');
-    const message = String(anyErr?.message ?? 'Unknown error');
+    const code = errorCode(err);
+    const transport = code === TRANSPORT_ERROR_CODE;
+    // An outage fails every call in flight and every one the user tries next,
+    // each of them with the same sentence. One entry stands for all of them —
+    // the degraded stack above is what tracks the connection itself.
+    if (transport && this.state.value.errorQueue.some((e) => e.code === TRANSPORT_ERROR_CODE)) return;
+    // A transport rejection carries either nothing or a socket-level string; in
+    // both cases the card's own wording is the only one worth showing.
+    const message = transport ? TRANSPORT_ERROR_MESSAGE : String(anyErr?.message ?? 'Unknown error');
     const context = (anyErr?.context ?? anyErr?.data ?? null) as Record<string, unknown> | null;
     const entry = {
       id: `${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -73,8 +73,16 @@ const CONNECTION_LOST_THRESHOLD = 2;
  * once would flash a banner that answers nothing. Long enough to sit out an
  * ordinary reconnect, short enough that a real outage shows up while the user
  * is still looking at the surface that went stale.
+ *
+ * Home Assistant's client retries on a fixed ladder — immediately, then one
+ * second later, then three, then six — so a reconnect does not take an
+ * arbitrary amount of time, it lands on a rung. A socket that drops while the
+ * network is briefly away misses the first two rungs and comes back on the
+ * three-second one, which is an ordinary Wi-Fi roam and must stay silent. This
+ * sits between that rung and the six-second one: past six, the network has been
+ * gone long enough that the outage is worth saying out loud.
  */
-const CONNECTION_LOST_GRACE_MS = 2_000;
+const CONNECTION_LOST_GRACE_MS = 4_500;
 
 /** Attempts (including the first) for a command rejected with `rate_limited`. */
 const RATE_LIMIT_ATTEMPTS = 4;
@@ -378,21 +386,39 @@ export class Store {
   }
 
   // ---------- Initialization and subscriptions ----------
+  /**
+   * Load everything, then start watching for the ways it can go stale.
+   *
+   * The watches are wired in a `finally` because a card is not always built
+   * against a backend that can answer. Home Assistant rebuilds the Lovelace
+   * view when its socket reconnects, and it does so before a restarting
+   * instance has finished setting the integration up — so the first load of
+   * that fresh card is refused, wholesale. Wiring the watches only on the happy
+   * path left such a card with no subscriptions, no connection listeners and
+   * nothing but the loading skeleton, permanently: every route back into the
+   * data is opened here, so failing to reach them is failing for good. Opened
+   * anyway, the refused subscribe retries on its own backoff and re-reads the
+   * inventory once it lands, which is the same path a disabled config entry
+   * already recovers through.
+   */
   async init() {
-    await Promise.all([
-      this.refreshStats(),
-      this.refreshHealth(),
-      this.refreshAreas(),
-      this.refreshLocationTree(),
-      this.refreshLocationsFlat(),
-      this.refreshDistinctValues(),
-      this.refreshVersion(),
-      this.refreshConfig(),
-    ]);
-    await this.listItems(true);
-    this.subscribeTopics();
-    this.watchAreaRegistry();
-    this.watchConnectionGaps();
+    try {
+      await Promise.all([
+        this.refreshStats(),
+        this.refreshHealth(),
+        this.refreshAreas(),
+        this.refreshLocationTree(),
+        this.refreshLocationsFlat(),
+        this.refreshDistinctValues(),
+        this.refreshVersion(),
+        this.refreshConfig(),
+      ]);
+      await this.listItems(true);
+    } finally {
+      this.subscribeTopics();
+      this.watchAreaRegistry();
+      this.watchConnectionGaps();
+    }
   }
 
   /**
@@ -601,20 +627,29 @@ export class Store {
    * A refused subscribe means live updates are gone, silently — no event will
    * ever arrive to hint at it.
    *
-   * Two refusals are worth waiting out. `rate_limited` is the expected one and
+   * Three refusals are worth waiting out. `rate_limited` is the expected one and
    * the contract's guidance is to retry later; `storage_error` is what a backend
-   * with no config entry answers, which a reload clears on its own. Either way
-   * the card backs off and says it is retrying instead of dropping an error on a
-   * user who has done nothing wrong. Once the budget is spent it stops, reports
-   * the refusal and leaves the manual refresh as the way back. Any other refusal
-   * is an outage and is reported at once.
+   * with no config entry answers, which a reload clears on its own; and
+   * `unknown_command` is Home Assistant's own answer for a command type nobody
+   * has registered, which for `haventory/subscribe` means the integration has
+   * not been set up yet. A restarting instance serves the frontend — and the
+   * Lovelace view it rebuilds on reconnect — before it gets that far, so a card
+   * refused this way is early rather than broken. All three back off and say the
+   * card is retrying instead of dropping an error on a user who has done nothing
+   * wrong. Once the budget is spent it stops, reports the refusal and leaves the
+   * manual refresh as the way back. Any other refusal is an outage and is
+   * reported at once.
    */
   private onSubscribeRefused(err: unknown) {
     this.stateObs.set({ connected: { items: false, stats: false } });
 
     const code = errorCode(err);
     const reason: LiveUpdatePause | null =
-      code === 'rate_limited' ? 'rate_limited' : code === 'storage_error' ? 'unavailable' : null;
+      code === 'rate_limited'
+        ? 'rate_limited'
+        : code === 'storage_error' || code === 'unknown_command'
+          ? 'unavailable'
+          : null;
     if (reason === null) {
       this.setDegraded({
         connectionLost: true,

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -507,10 +507,11 @@ export interface HassLike {
       cb: (event: AnyEventPayload) => void,
       msg: Record<string, unknown>,
     ): Unsubscribe | Promise<Unsubscribe>;
-    // Connection lifecycle. `ready` fires once the socket is back and Home
-    // Assistant has re-issued the subscriptions it was holding, so a listener
-    // runs with the watches already live again. Optional because the interface
-    // is structural: a caller may pass a connection that only sends messages.
+    // Connection lifecycle. `disconnected` fires when the socket closes, before
+    // Home Assistant starts reconnecting; `ready` fires once it is back and HA
+    // has re-issued the subscriptions it was holding, so a listener runs with
+    // the watches already live again. Optional because the interface is
+    // structural: a caller may pass a connection that only sends messages.
     addEventListener?(event: 'ready' | 'disconnected', cb: () => void): void;
     removeEventListener?(event: 'ready' | 'disconnected', cb: () => void): void;
   };
@@ -559,7 +560,7 @@ export interface StoreFilters {
 export interface DegradedState {
   /** A command or a subscribe came back `rate_limited`. */
   rateLimited: boolean;
-  /** Consecutive transport-level failures — best-effort, lags a real outage by one call. */
+  /** The socket closed and stayed closed, or calls keep failing before they reach a server. */
   connectionLost: boolean;
   /** Commands currently waiting on an automatic retry. */
   retrying: number;

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -502,19 +502,37 @@ export class WSClient {
    * `subscribeAreaRegistry` call — the watch simply resumes, and anything the
    * registry did meanwhile went to nobody. This event is the only notice the
    * card gets that such a gap happened at all.
+   */
+  onConnectionReady(cb: () => void): Unsubscribe {
+    return this.onConnectionEvent('ready', cb);
+  }
+
+  /**
+   * Call back when the socket closes, before Home Assistant reconnects.
+   *
+   * Without it a surface nobody is touching cannot tell that it went stale:
+   * every other signal the card has comes from a call it made, so an idle list
+   * would keep showing data from before the outage with nothing to say so.
+   */
+  onConnectionLost(cb: () => void): Unsubscribe {
+    return this.onConnectionEvent('disconnected', cb);
+  }
+
+  /**
+   * Attach one connection-lifecycle listener.
    *
    * Returns a no-op unsubscribe when the connection does not expose the
    * lifecycle, so a caller never has to branch on it.
    */
-  onConnectionReady(cb: () => void): Unsubscribe {
+  private onConnectionEvent(event: 'ready' | 'disconnected', cb: () => void): Unsubscribe {
     const connection = this.hass.connection;
     const { addEventListener, removeEventListener } = connection;
     if (typeof addEventListener !== 'function' || typeof removeEventListener !== 'function') {
       return () => undefined;
     }
     const handler = () => cb();
-    addEventListener.call(connection, 'ready', handler);
-    return () => removeEventListener.call(connection, 'ready', handler);
+    addEventListener.call(connection, event, handler);
+    return () => removeEventListener.call(connection, event, handler);
   }
 
   /**

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -71,6 +71,10 @@ export interface MockHass extends HassLike {
    * simply gone. Subscribers stay registered; nothing is replayed.
    */
   __reconnect(): void;
+  /** Close the socket and leave it closed, the way a stopped server does. */
+  __disconnect(): void;
+  /** Report the socket back up, with the watches already re-issued. */
+  __connectionReady(): void;
 }
 
 export function makeMockHass(initial?: MockConfig): MockHass {
@@ -660,7 +664,13 @@ export function makeMockHass(initial?: MockConfig): MockHass {
     },
     __setAreas(next: AreaRef[]) { areas = [...next]; },
     __reconnect() {
+      hass.__disconnect();
+      hass.__connectionReady();
+    },
+    __disconnect() {
       (lifecycleListeners.disconnected || []).forEach((cb) => cb());
+    },
+    __connectionReady() {
       (lifecycleListeners.ready || []).forEach((cb) => cb());
     },
     __setConflict(on: boolean) { conflictOnUpdate = on; },

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -400,7 +400,8 @@ than declaring the outage at once; `ready` inside that window cancels it, and `r
 it takes the banner back down.
 
 A *rejected subscribe* kills live updates outright — no event will ever arrive to hint at
-it — so it is handled separately. The three topics are opened as one **round**, because the
+it — so it is handled separately. The four topics — items, stats, locations and statuses —
+are opened as one **round**, because the
 limiter bills each subscribe separately and can admit `items` while refusing `stats`; live
 updates only count as restored once every subscribe in the newest round is accepted, which
 `WSClient.subscribe`'s `onOpen` reports. A round refused with `rate_limited` is re-opened

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -382,9 +382,22 @@ what the list is showing. `include_subtree` is always sent explicitly, because t
 filter defaults it to `false` server-side while subscriptions default it to `true`.
 
 **Rate limiting and degraded state.** Every WS call goes through `run()`, which retries a
-`rate_limited` rejection with backoff before surfacing it, and classifies failures: a code
-from the backend's taxonomy means the socket is fine, anything else counts toward
-`degraded.connectionLost`.
+`rate_limited` rejection with backoff before surfacing it, and classifies failures: a
+*string* error code means a server answered and the command was refused — including the
+taxonomy's `unknown_error` catch-all, which is a server-side fault, not a transport one.
+Anything else (Home Assistant's numeric transport codes, a thrown `Error`, no code at all)
+never reached a server; those are reported under the card's own `connection_lost` code with
+wording that names the connection, and count toward `degraded.connectionLost`. An outage
+fails every call in flight, so the error queue holds at most one such entry at a time.
+
+`degraded.connectionLost` has two sources. Repeated transport failures are one, and they
+catch an outage that closes no socket — a server that accepts the connection and stops
+answering on it. The socket's own `disconnected` event is the other, and it is what an
+**idle** surface depends on: every other signal comes from a call the card made, so a list
+left open across a restart would otherwise go on showing pre-outage data with nothing to say
+so. Home Assistant reconnects by itself, so the event starts a short grace period rather
+than declaring the outage at once; `ready` inside that window cancels it, and `ready` after
+it takes the banner back down.
 
 A *rejected subscribe* kills live updates outright — no event will ever arrive to hint at
 it — so it is handled separately. The three topics are opened as one **round**, because the

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -409,9 +409,21 @@ automatically up to four times, waiting the envelope's retry-after hint when it 
 and clamped to 30 s) and otherwise backing off exponentially. `degraded.liveUpdates` tracks
 this as `'live' | 'retrying' | 'paused'`, with `degraded.nextLiveRetryAt` for the scheduled
 attempt; every surface renders it as a non-blocking banner that clears itself when a retry
-gets back in. Once the budget is spent the state goes `'paused'`, the refusal reaches the error
-queue once, and the banner's Refresh (i.e. `refreshAll()`) is the way back. Any other
-refusal is an outage: reported immediately, never retried.
+gets back in. A round refused with `storage_error` or `unknown_command` is re-opened on the
+same backoff but a larger budget, because both say the backend is not there *yet* rather
+than broken: the first is what a config entry mid-reload answers, the second is Home
+Assistant's answer for a command type nobody has registered, which is what a restarting
+instance serves until the integration finishes setting up. Landing one of those re-reads the
+inventory, since every event in the gap went to a subscription that no longer existed. Once
+the budget is spent the state goes `'paused'`, the refusal reaches the error queue once, and
+the banner's Refresh (i.e. `refreshAll()`) is the way back. Any other refusal is an outage:
+reported immediately, never retried.
+
+`Store.init()` opens the subscriptions and the watches in a `finally`, so a card whose first
+load was refused outright still has them. Home Assistant rebuilds the Lovelace view when its
+socket reconnects and does so before a restarting instance has set the integration up, so
+that card is the common case rather than the odd one — and without the watches it would keep
+its loading skeleton for as long as the page stayed open.
 
 **Why the card offers a manual Refresh.** Subscription events carry no sequence number or
 generation, and the rate limiter can drop them silently, so a client cannot detect a gap.


### PR DESCRIPTION
## Summary

Two findings from the local verification pass on the v0.4.0 frontend campaign, both about
what the card says when Home Assistant is not there — plus two things the local pass on
*this* branch turned up, which are fixed here because the first of them is a hole this PR
itself opened. Nothing here was introduced by #345/#346/#347; those moved where the banners
render, not how the condition is detected.

Closes #349, closes #350.

**An idle surface never learned it went offline.** `degraded.connectionLost` had one
source: a run of failed calls, counted in `Store.noteFailure`. A surface nobody is touching
makes no calls, so a list left open across a restart went on showing pre-outage data with
nothing to say so — verified with HA down for 150 s and the view silent throughout. The
store now also follows the socket's own `disconnected` event, which `WSClient` already
exposed for the `ready` side. Home Assistant reconnects by itself, so the event opens a
grace period rather than declaring the outage at once. `ready` inside the window cancels
it, `ready` after it takes the banner back down, and `dispose()` detaches both listeners —
the connection outlives the card. The transport-failure counter stays, and now carries a
case the socket event cannot see: a server that accepts the connection and stops answering
on it.

**A lost connection stacked "Unknown error" banners beside "Connection lost".** `errorCode`
defaulted a missing code to `unknown_error`, which is also a real code in the backend's
taxonomy, so the two were indistinguishable. Home Assistant rejects a call the socket never
carried with a wrapper of its own — numeric code, no top-level message — so every such
failure read as "Unknown error", wording that blames whatever the user just did, once per
failed call. Now a *string* code means a server answered and the command was refused;
anything else never reached one, gets the card's own `connection_lost` code and wording
that names the connection, and holds at most one entry in the queue at a time (dismissing
it is not a permanent silence — the next failure says so again). The reverse conflation
goes with it: a genuine backend `unknown_error` travelled the socket to get here, so it
proves the transport works and no longer counts toward an outage.

**A card built while the backend is still coming up never came back.** Found by driving
this branch against a real instance. Home Assistant rebuilds the Lovelace view when its
socket reconnects, and a restarting instance serves that rebuild before it has set the
integration up again — so the fresh card's whole first load is refused with
`unknown_command`, `init` rejects, and the three statements after the load never run. That
card had no subscriptions, no connection listeners and no data, and kept its loading
skeleton for as long as the page stayed open. `main` hides this behind the exact
misclassification this PR removes: a refusal carrying a string code used to count as
transport trouble, so the same dead card at least showed the connection banner and its
Reconnect. Classifying it honestly took the last way out with it, so the way out is now
real: the watches are wired in a `finally`, and a subscribe refused with `unknown_command`
joins `storage_error` on the retry ladder — it says the backend is early, not broken. Such
a card now reports live updates paused, waits, and re-reads the inventory itself once the
subscribe lands.

**An ordinary reconnect overran the grace period.** HA's client retries on a fixed ladder —
at once, then +1 s, +3 s, +6 s — so a reconnect lands on a rung rather than taking an
arbitrary time. Measured against the dev instance: a socket dropped for ~1 s comes back at
1.02–1.06 s when it catches the one-second rung and at 3.04–3.07 s when it misses, and
anything from 1–3 s away always takes the three-second rung. At a 2 s grace that put the
banner up and withdrew it about a second later, on a blip nobody could act on.
`CONNECTION_LOST_GRACE_MS` is now 4 500 ms, between the three-second rung and the six-second
one: an ordinary Wi-Fi roam stays silent, an outage past six seconds is still said out loud.
Re-measured after the change — 1000/1500/2500 ms offline windows all silent, including a
repeat that took the three-second rung.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `752 passed, 22 skipped`; `ruff check` and `ruff format --check` clean; mypy
  `no issues found in 15 source files`. (Untouched by this change; run as the gate requires.)
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
  `npx vitest run` **1621 passed** across 58 files, `npm run build` → 575.64 kB.

Thirteen tests, all in `store.revamp.test.ts`: an idle store declares the connection lost
when the socket closes and stays closed (and queues no error entry — nothing was refused);
a reconnect inside the grace period says nothing; `ready` after it takes the banner down; a
disposed store stops watching; a transport-shaped rejection is named `connection_lost`, not
`unknown_error`; an outage across four failing calls queues one entry, and re-reports after
a dismiss; the backend's `unknown_error` no longer counts toward an outage (this pin
previously asserted the opposite — rewritten to the new rule, with the reasoning in the
test); and six covering the early-backend case — a refused first load still wires the
watches, `unknown_command` pauses rather than reporting an outage, and the retry re-reads
the inventory.

The existing "declares the connection lost after consecutive transport failures" and
"clears the degraded flags on an explicit refresh" pins are unchanged and still pass, so
the counter path is untouched. `works against a connection that exposes no lifecycle
events` covers the new `onConnectionLost` too.

### Verified against the dev Home Assistant

All seven handover checks run on a real instance, on the card, the expanded view and the
sidebar panel. Idle detection with no click: 4542 / 4566 / 4589 ms from the socket closing.
Five failed writes → exactly one banner, one id, no "Unknown error" anywhere. A disabled
config entry reads as "Live updates paused · HAventory is not available" with the server's
own message per action, and never as a lost connection. Conflict banners unchanged. CRUD
smoke green, visual pass 41/42 surfaces, lightbox verified at both widths.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed — `README.md` (a view left open says so on its
  own) and `docs/frontend_architecture.md` (the classification rule, both sources of
  `connectionLost`, the reconnect ladder the grace period is set against, and the
  `unknown_command` rung). The round description there also said "three topics" where
  `SUBSCRIBE_TOPIC_COUNT` is 4; corrected in passing.
- [x] No WebSocket API change — this is card-side classification of failures the backend
  never sent.
- [x] Essential invariants untouched.

## Screenshots (card / UI changes)

No new surface. The change is which banner appears and when: "Connection lost" now shows on
an idle view within ~4.5 s of the socket closing, the "Unknown error" entries that used to
pile up beside it are replaced by a single "Could not reach Home Assistant — the last action
did not go through.", and a card built into a restarting instance shows the paused-live-
updates banner and then fills itself in instead of sitting on skeletons.

## Follow-ups

- `pm-05-row-editor`: the panel's row editor does not open at 375 px. Pre-existing — it
  fails identically on `main` — and not characterised well enough yet to file; needs a repro
  against the current narrow read view before it becomes an issue.
- Not addressed here: the `hv-full-view` / `HostSurfaces` `matchMedia(NARROW_QUERY)`
  subscriptions that could fold into `ViewportNarrow` (carried from #345), and draft
  autosave (#334).