### PR TITLE
fix(card): consistency sweep — cursors, buttons, copy, bulk check-out date

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,8 @@ throughout.
   something, always names a location.
 - **Check-out** invites an optional due date (+7 / +31 / +90 / +X day suggestions) rather
   than silently checking out with none — the date is what makes overdue highlighting mean
-  anything. "No due date" stays a first-class choice.
+  anything. "No due date" stays a first-class choice. Checking out a whole selection asks
+  the same question once and gives every item the answer.
 - **Mobile** — the card switches layout from its own width. Tapping a row opens one bottom
   sheet holding everything about the item; filters open as a staged sheet whose apply
   button shows the live matching count. Every surface honours the same 44px touch minimum

--- a/cards/haventory-card/src/components/hv-bulk-bar.test.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.test.ts
@@ -81,18 +81,23 @@ describe('hv-bulk-bar: actions', () => {
     expect(q(el, '[data-testid="bulk-picker"]')?.textContent).toContain('Move 1 item to');
   });
 
-  it('runs the immediate actions straight away', async () => {
+  it('leaves for the host without an inline step', async () => {
     const el = await mount();
     const seen = runs(el);
     (q(el, '[data-action="check-in"]') as HTMLButtonElement).click();
     (q(el, '[data-action="check-out"]') as HTMLButtonElement).click();
     (q(el, '[data-action="delete"]') as HTMLButtonElement).click();
 
-    expect(seen).toEqual([
-      { action: 'check-in' },
-      { action: 'check-out', dueDate: null },
-      { action: 'delete' },
-    ]);
+    // Check-out carries no due date: the host asks for one, and tells that
+    // apart from a deliberate "no due date" by the key being absent.
+    expect(seen).toEqual([{ action: 'check-in' }, { action: 'check-out' }, { action: 'delete' }]);
+  });
+
+  it('names check-out as the step it is', async () => {
+    const el = await mount();
+    const labels = all(el, '[data-testid="bulk-action"]').map((b) => b.textContent?.trim());
+    expect(labels).toContain('Check out…');
+    expect(labels).toContain('Check in');
   });
 });
 
@@ -108,7 +113,7 @@ describe('hv-bulk-bar: inline pickers', () => {
 
     const treeEl = el.shadowRoot?.querySelector('hv-location-tree') as HTMLElement;
     (
-      treeEl.shadowRoot?.querySelector('[data-testid="tree-select"][data-id="workshop"]') as HTMLButtonElement
+      treeEl.shadowRoot?.querySelector('[data-testid="tree-row"][data-id="workshop"]') as HTMLButtonElement
     ).click();
     expect(seen).toEqual([{ action: 'move', locationId: 'workshop' }]);
   });
@@ -280,5 +285,52 @@ describe('describeFailure', () => {
 
   it('passes an unknown code through with its message', () => {
     expect(describeFailure(failure('a', 'something_new', 'odd'))).toBe('odd');
+  });
+});
+
+// The bar was the one surface that ignored the tokens: a hardcoded blue-grey
+// band and a hardcoded red for Delete, neither of which moved with the HA
+// theme — and a running batch's Cancel that was a bare native button on top of
+// it, unstyled where every sibling control was a pill.
+describe('hv-bulk-bar: the band belongs to the theme', () => {
+  const barCss = () => {
+    const styles = (customElements.get('hv-bulk-bar') as typeof HVBulkBar).styles;
+    return (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+  };
+
+  it('takes its fill and its ink from tokens rather than from hex', () => {
+    const css = barCss();
+    expect(css).toMatch(/\.bar, \.progress \{[^}]*background: var\(--hv-selection-bar\)/);
+    expect(css).toMatch(/\.bar, \.progress \{[^}]*color: var\(--hv-on-selection-bar\)/);
+    expect(css).toMatch(/\.band-button\.danger \{[^}]*color: var\(--hv-on-selection-bar-danger\)/);
+    // The rules that draw the band carry no literal colour of their own.
+    const band = css.slice(css.indexOf('.bar, .progress {'), css.indexOf('.result {'));
+    expect(band).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+    expect(band).not.toMatch(/rgba?\(/);
+  });
+
+  it('draws the running batch a real button', async () => {
+    const el = await mount({ progress: { done: 1, total: 4, failed: 0, label: 'Moving' } });
+    expect(q(el, '[data-testid="bulk-cancel"]')?.className).toContain('band-button');
+    // And it no longer positions itself with an inline style per failure state.
+    expect(q(el, '[data-testid="bulk-cancel"]')?.getAttribute('style')).toBe(null);
+  });
+
+  it('keeps the failure count and Cancel together at the trailing edge', async () => {
+    const el = await mount({ progress: { done: 3, total: 4, failed: 1, label: 'Moving' } });
+    expect(q(el, '[data-testid="bulk-progress-failed"]')?.className).toBe('failed');
+    expect(barCss()).toMatch(/\.progress \.spacer \{ margin-left: auto; \}/);
+  });
+});
+
+describe('hv-bulk-bar: close verbs', () => {
+  // A result panel is read and dismissed; "Close" is what every other surface
+  // that only dismisses says.
+  it('closes the result rather than dismissing it', async () => {
+    const el = await mount({ result: { label: 'Move', succeeded: 2, failed: [] } });
+    expect(q(el, '[data-testid="bulk-result-dismiss"]')?.textContent?.trim()).toBe('Close');
   });
 });

--- a/cards/haventory-card/src/components/hv-bulk-bar.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.ts
@@ -41,14 +41,20 @@ export interface BulkResultView {
   failed: BulkFailure[];
 }
 
-const ACTIONS: { id: BulkAction; label: string; glyph?: IconName; immediate?: boolean }[] = [
-  { id: 'move', label: 'Move to…', glyph: 'mapMarker' },
-  { id: 'add-tags', label: 'Add tags…' },
-  { id: 'remove-tags', label: 'Remove tags…' },
-  { id: 'set-category', label: 'Set category…' },
-  { id: 'adjust-qty', label: 'Adjust qty…' },
-  { id: 'check-out', label: 'Check out', immediate: true },
-  { id: 'check-in', label: 'Check in', immediate: true },
+/**
+ * `picker` opens the bar's own inline step and the batch starts when it is
+ * applied. Without it the action leaves the bar the moment it is pressed — for
+ * check-in straight into the batch, for check-out into the host's date popover,
+ * which is why its label carries the same ellipsis the inline steps do.
+ */
+const ACTIONS: { id: BulkAction; label: string; glyph?: IconName; picker?: boolean }[] = [
+  { id: 'move', label: 'Move to…', glyph: 'mapMarker', picker: true },
+  { id: 'add-tags', label: 'Add tags…', picker: true },
+  { id: 'remove-tags', label: 'Remove tags…', picker: true },
+  { id: 'set-category', label: 'Set category…', picker: true },
+  { id: 'adjust-qty', label: 'Adjust qty…', picker: true },
+  { id: 'check-out', label: 'Check out…' },
+  { id: 'check-in', label: 'Check in' },
 ];
 
 /**
@@ -60,7 +66,11 @@ const ACTIONS: { id: BulkAction; label: string; glyph?: IconName; immediate?: bo
  * and it can retry just the failures.
  *
  * Pickers open inline above the bar rather than as dialogs, so the bulk flow
- * never stacks a second dialog over the one the user is already in.
+ * never stacks a second dialog over the one the user is already in. The two
+ * questions the bar does not ask itself belong to the host: the delete
+ * confirmation, and check-out's due date — both are one answer applied to the
+ * whole selection, and the host already owns the surfaces that ask them for a
+ * single row.
  */
 @customElement('hv-bulk-bar')
 export class HVBulkBar extends LitElement {
@@ -101,47 +111,51 @@ export class HVBulkBar extends LitElement {
         overflow: auto;
         padding: 4px 0;
       }
+      .bar,
+      .progress {
+        background: var(--hv-selection-bar);
+        color: var(--hv-on-selection-bar);
+      }
       .bar {
         display: flex;
         align-items: center;
         gap: 8px;
         flex-wrap: wrap;
         padding: 12px 16px;
-        background: #263238;
-        color: #fff;
       }
       .bar .lead {
         font: 500 13px var(--hv-font);
         margin-right: 4px;
       }
-      .bar button {
+      /* Every control drawn on the band, wherever the band appears — the actions
+         and the running batch's Cancel alike. Mixed from the band's own ink so
+         one colour decision carries the whole strip. */
+      .band-button {
         display: inline-flex;
         align-items: center;
         gap: 5px;
         border: none;
         border-radius: var(--hv-radius-chip);
-        background: rgba(255, 255, 255, 0.14);
-        color: #fff;
+        background: color-mix(in srgb, var(--hv-on-selection-bar) 14%, transparent);
+        color: var(--hv-on-selection-bar);
         padding: 7px 14px;
         font: 400 12.5px var(--hv-font);
       }
-      .bar button:hover {
-        background: rgba(255, 255, 255, 0.24);
+      .band-button:hover {
+        background: color-mix(in srgb, var(--hv-on-selection-bar) 24%, transparent);
       }
-      .bar button.active {
-        background: rgba(255, 255, 255, 0.32);
+      .band-button.active {
+        background: color-mix(in srgb, var(--hv-on-selection-bar) 32%, transparent);
       }
-      .bar button.danger {
+      .band-button.danger {
         margin-left: auto;
         background: none;
-        border: 1px solid rgba(239, 83, 80, 0.7);
-        color: #ef9a9a;
+        border: 1px solid color-mix(in srgb, var(--hv-on-selection-bar-danger) 70%, transparent);
+        color: var(--hv-on-selection-bar-danger);
         font-weight: 500;
       }
       .progress {
         padding: 12px 16px;
-        background: #263238;
-        color: #fff;
         display: grid;
         gap: 8px;
       }
@@ -151,10 +165,16 @@ export class HVBulkBar extends LitElement {
         gap: 8px;
         font: 400 12.5px var(--hv-font);
       }
+      .progress .spacer {
+        margin-left: auto;
+      }
+      .progress .failed {
+        opacity: 0.8;
+      }
       .track {
         height: 6px;
         border-radius: 999px;
-        background: rgba(255, 255, 255, 0.2);
+        background: color-mix(in srgb, var(--hv-on-selection-bar) 20%, transparent);
         overflow: hidden;
       }
       .fill {
@@ -353,13 +373,12 @@ export class HVBulkBar extends LitElement {
     return html`<div class="progress" data-testid="bulk-progress">
       <div class="line">
         <span data-testid="bulk-progress-label">${progress.label} ${progress.done} of ${progress.total}</span>
+        <span class="spacer"></span>
         ${progress.failed > 0
-          ? html`<span style="margin-left:auto;opacity:.8" data-testid="bulk-progress-failed"
-              >${progress.failed} failed</span
-            >`
+          ? html`<span class="failed" data-testid="bulk-progress-failed">${progress.failed} failed</span>`
           : null}
         <button
-          style="margin-left:${progress.failed > 0 ? '8px' : 'auto'}"
+          class="band-button"
           data-testid="bulk-cancel"
           @click=${() => this.dispatchEvent(new CustomEvent('cancel-run', { bubbles: true, composed: true }))}
         >
@@ -410,7 +429,7 @@ export class HVBulkBar extends LitElement {
           data-testid="bulk-result-dismiss"
           @click=${() => this.dispatchEvent(new CustomEvent('dismiss-result', { bubbles: true, composed: true }))}
         >
-          Dismiss
+          Close
         </button>
         ${failedCount
           ? html`<button
@@ -441,25 +460,31 @@ export class HVBulkBar extends LitElement {
         <span class="lead" data-testid="bulk-lead">Apply to ${counted(this.selectedCount, 'item')}</span>
         ${ACTIONS.map(
           (action) => html`<button
-            class=${this._active === action.id ? 'active' : ''}
+            class="band-button ${this._active === action.id ? 'active' : ''}"
             data-testid="bulk-action"
             data-action=${action.id}
             @click=${() => {
-              if (action.immediate) {
-                // Check-out sends no due date, which the API allows; the date
-                // step is offered by the check-out popover on single rows.
-                this._run(action.id === 'check-out' ? { action: 'check-out', dueDate: null } : { action: action.id });
-              } else {
+              if (action.picker) {
                 this._active = this._active === action.id ? null : action.id;
                 this._tags = [];
                 this._draft = '';
+              } else {
+                // No due date on the detail: check-out carries one only once the
+                // host's popover has asked for it, and the host tells the two
+                // apart by its absence.
+                this._run({ action: action.id });
               }
             }}
           >
             ${action.glyph ? icon(action.glyph, 15) : null}${action.label}
           </button>`,
         )}
-        <button class="danger" data-testid="bulk-action" data-action="delete" @click=${() => this._run({ action: 'delete' })}>
+        <button
+          class="band-button danger"
+          data-testid="bulk-action"
+          data-action="delete"
+          @click=${() => this._run({ action: 'delete' })}
+        >
           ${icon('del', 15)}Delete
         </button>
       </div>

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -481,20 +481,26 @@ describe('hv-card-shell: list and footer', () => {
     expect(seen).toEqual([0.82]);
   });
 
-  it('counts loaded rows against the filtered total', async () => {
+  it('counts loaded rows against the filtered total, and names the noun', async () => {
     const items = Array.from({ length: 60 }, (_, i) => makeItem({ id: `i${i}` }));
     const { sr } = await mountShell({ items });
-    expect(sr.querySelector('[data-testid="showing-count"]')?.textContent).toContain('Showing 50 of 60');
+    expect(sr.querySelector('[data-testid="showing-count"]')?.textContent?.trim()).toBe(
+      'Showing 50 of 60 items',
+    );
   });
 
-  it('says "filtered" only when a filter is on', async () => {
+  it('says the total is the matching one only when a filter is on', async () => {
     const items = [makeItem({ id: '1', category: 'Tools' }), makeItem({ id: '2', category: 'Other' })];
     const { el, store, sr } = await mountShell({ items });
-    expect(sr.querySelector('[data-testid="showing-count"]')?.textContent).not.toContain('filtered');
+    expect(sr.querySelector('[data-testid="showing-count"]')?.textContent?.trim()).toBe(
+      'Showing 2 of 2 items',
+    );
 
     store.setFilters({ category: 'Tools' });
     await settle(el);
-    expect(sr.querySelector('[data-testid="showing-count"]')?.textContent).toContain('filtered');
+    expect(sr.querySelector('[data-testid="showing-count"]')?.textContent?.trim()).toBe(
+      'Showing 1 of 1 matching item',
+    );
   });
 
   it('adjusts quantity from the row stepper', async () => {

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
-import { counted, plural } from '../ui/plural';
+import { counted, plural, showingCount } from '../ui/plural';
 import { ResponsiveController } from '../ui/responsive';
 import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters } from '../store/store';
@@ -304,12 +304,6 @@ export class HVCardShell extends LitElement {
       }
       .sheet-footer .apply {
         flex: 1;
-        min-height: 46px;
-        border: none;
-        background: var(--hv-primary);
-        color: var(--hv-text-on-primary);
-        border-radius: var(--hv-radius-chip);
-        font: 500 14.5px var(--hv-font);
       }
       .sheet-head {
         display: flex;
@@ -323,6 +317,9 @@ export class HVCardShell extends LitElement {
         font-weight: 500;
         color: var(--hv-text);
       }
+      /* The footer's way into the expanded view. Sized to the footer it sits in
+         rather than to the card's other text buttons, which is why it is not
+         .hv-text-button: the line it shares with the item count is 12px. */
       .link {
         border: none;
         background: none;
@@ -332,12 +329,6 @@ export class HVCardShell extends LitElement {
         font: 500 12.5px var(--hv-font);
         color: var(--hv-primary-dark);
         padding: 0;
-      }
-      /* A text link in the filter sheet's header is still a control, so it gets
-         a tap-sized target. */
-      :host([mobile]) .link {
-        min-height: var(--hv-tap-min, auto);
-        padding: 0 6px;
       }
     `,
   ];
@@ -1016,11 +1007,7 @@ export class HVCardShell extends LitElement {
 
       ${loaded > 0
         ? html`<div class="footer">
-            <span data-testid="showing-count">
-              ${total !== null && total !== undefined
-                ? `Showing ${loaded} of ${total}${filterCount > 0 ? ' filtered' : ''}`
-                : `Showing ${loaded}`}
-            </span>
+            <span data-testid="showing-count">${showingCount(loaded, total, filterCount > 0)}</span>
             ${mobile
               ? null
               : html`<button
@@ -1068,7 +1055,7 @@ export class HVCardShell extends LitElement {
               <span class="heading">Filters</span>
               <span style="font-size:12.5px;color:var(--hv-text-secondary)">${stagedFilterCount} active</span>
               <button
-                class="link"
+                class="hv-text-button"
                 style="margin-left:auto"
                 data-testid="sheet-clear-all"
                 @click=${() => this._filterPanel?.clearAll()}
@@ -1090,7 +1077,7 @@ export class HVCardShell extends LitElement {
                 Cancel
               </button>
               <button
-                class="apply"
+                class="hv-pill large apply"
                 data-testid="sheet-apply"
                 @click=${() => this._filterPanel?.apply()}
               >

--- a/cards/haventory-card/src/components/hv-checkout-popover.test.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.test.ts
@@ -200,4 +200,18 @@ describe('hv-checkout-popover: placement', () => {
     expect(q(el, '.scrim')).toBe(null);
     expect(q(el, '[data-testid="checkout-popover"]')?.getAttribute('style')).toBe('');
   });
+
+  // Anchored it is a popover, and its scrim is only there to catch the click
+  // that dismisses. With nothing to anchor to it is a centred dialog instead,
+  // and a dialog that does not dim reads as a card floating over a live surface.
+  it('dims the page only when it has no control to hang from', async () => {
+    const anchored = await mount({}, { anchor: { left: 120, bottom: 240 } as DOMRect });
+    expect(q(anchored, '.scrim')?.classList.contains('dim')).toBe(false);
+
+    const centred = await mount({}, { anchor: null });
+    expect(q(centred, '.scrim')?.classList.contains('dim')).toBe(true);
+    expect(
+      (q(centred, '[data-testid="checkout-popover"]') as HTMLElement).getAttribute('style'),
+    ).toContain('left: 50%');
+  });
 });

--- a/cards/haventory-card/src/components/hv-checkout-popover.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.ts
@@ -40,6 +40,14 @@ export class HVCheckoutPopover extends LitElement {
         position: fixed;
         inset: 0;
       }
+      /* Anchored, this layer exists only to catch the click that dismisses, and
+         a popover hanging off the control that opened it dims nothing. With no
+         anchor it is a centred dialog instead — asked by a bar that has no
+         control to hang from, about a whole selection — so it dims like the
+         confirm it stands beside, at the same strength. */
+      .scrim.dim {
+        background: rgba(0, 0, 0, 0.35);
+      }
       .card {
         position: fixed;
         width: 300px;
@@ -384,7 +392,12 @@ export class HVCheckoutPopover extends LitElement {
 
     if (this.mobile) return card;
     return html`
-      <div class="scrim" role="presentation" style="z-index:${z}" @click=${this._cancel}></div>
+      <div
+        class="scrim ${this.anchor ? '' : 'dim'}"
+        role="presentation"
+        style="z-index:${z}"
+        @click=${this._cancel}
+      ></div>
       ${card}
     `;
   }

--- a/cards/haventory-card/src/components/hv-confirm.test.ts
+++ b/cards/haventory-card/src/components/hv-confirm.test.ts
@@ -40,7 +40,10 @@ describe('hv-confirm', () => {
 
     const accept = el.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement;
     expect(accept.textContent).toContain('Delete 42');
-    expect(accept.classList.contains('destructive')).toBe(true);
+    // The card's one committing shape, in its error fill — this dialog draws no
+    // primary of its own.
+    expect(accept.classList.contains('hv-pill')).toBe(true);
+    expect(accept.classList.contains('danger')).toBe(true);
     accept.click();
 
     expect(fired).toBe(1);

--- a/cards/haventory-card/src/components/hv-confirm.ts
+++ b/cards/haventory-card/src/components/hv-confirm.ts
@@ -70,20 +70,6 @@ export class HVConfirm extends LitElement {
         gap: 8px;
         padding: 0 14px 14px;
       }
-      .confirm {
-        background: var(--hv-primary);
-        color: var(--hv-text-on-primary);
-        border: none;
-        border-radius: var(--hv-radius-chip);
-        padding: 8px 18px;
-        font: 500 13px var(--hv-font);
-      }
-      .confirm.destructive {
-        background: var(--hv-error);
-      }
-      .confirm:hover {
-        opacity: 0.9;
-      }
     `,
     dialogSheet,
   ];
@@ -151,7 +137,7 @@ export class HVConfirm extends LitElement {
               ${this.cancelLabel}
             </button>
             <button
-              class="confirm ${this.destructive ? 'destructive' : ''}"
+              class="hv-pill ${this.destructive ? 'danger' : ''}"
               data-testid="confirm-accept"
               @click=${this._confirm}
             >

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -756,3 +756,10 @@ describe('hv-data-table: row menu', () => {
     expect(seen).toEqual(['key', 'delete']);
   });
 });
+
+describe('hv-data-table: the row is a target', () => {
+  it('shows the hand on a body row and not on the header', () => {
+    expect(tableCss()).toMatch(/\.row \{[^}]*cursor: pointer/);
+    expect(tableCss()).not.toMatch(/\.head \{[^}]*cursor: pointer/);
+  });
+});

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -133,6 +133,11 @@ export class HVDataTable extends LitElement {
         border-bottom: 1px solid var(--hv-row-divider);
         font-size: 13.5px;
         color: var(--hv-text);
+        /* Same as the card's list rows: the row is the target, but a role=row
+           div gets none of the hand the shared button rule gives every other
+           one. Body rows only — the header carries .head, and there it is the
+           sort buttons that are pressable, not the row. */
+        cursor: pointer;
       }
       .row:hover {
         background: var(--hv-row-hover);

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -253,18 +253,6 @@ export class HVDetailSheet extends LitElement {
         border-radius: var(--hv-radius-chip);
         font: 500 14.5px var(--hv-font);
       }
-      .actions .primary {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 8px;
-        min-height: 50px;
-        border: none;
-        background: var(--hv-primary);
-        color: var(--hv-text-on-primary);
-        border-radius: var(--hv-radius-chip);
-        font: 500 14.5px var(--hv-font);
-      }
       .actions .danger {
         min-height: 48px;
         border: none;
@@ -765,7 +753,7 @@ export class HVDetailSheet extends LitElement {
                 ${icon('account', 18)}Check out
               </button>`}
           <button
-            class="primary"
+            class="hv-pill large"
             data-testid="sheet-edit-details"
             @click=${() => {
               this._mode = 'edit';

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -241,12 +241,16 @@ export class HVDetailSheet extends LitElement {
         grid-template-columns: 1fr 1fr;
         gap: 10px;
       }
+      /* The pair's other half. It shares the row with an .hv-pill.large, and a
+         stretch grid gives both the taller one's height — so a private height
+         here would silently override the modifier that exists to keep every
+         thumb-sized action the same size. */
       .actions .outline {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         gap: 8px;
-        min-height: 50px;
+        min-height: 48px;
         border: 1px solid var(--hv-input-border);
         background: none;
         color: var(--hv-text);

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
@@ -175,6 +175,15 @@ describe('hv-diagnostics-panel: actions', () => {
     expect(el.report).toContain('subscriptions: items=true');
   });
 
+  // This panel writes nothing, so its way out must not wear the shape that
+  // means "commit" on every other surface of the card.
+  it('draws its close as an outline, not as the filled primary', async () => {
+    const el = await mount();
+    const close = q(el, '[data-testid="diagnostics-close"]') as HTMLElement;
+    expect(close.textContent?.trim()).toBe('Close');
+    expect(close.className.split(/\s+/)).toEqual(['hv-pill', 'outline']);
+  });
+
   it('closes from the button, the backdrop and Escape', async () => {
     for (const trigger of ['button', 'backdrop', 'escape'] as const) {
       const el = await mount();

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.ts
@@ -198,14 +198,6 @@ export class HVDiagnosticsPanel extends LitElement {
       .foot .spacer {
         margin-left: auto;
       }
-      .primary {
-        border: none;
-        border-radius: var(--hv-radius-chip);
-        background: var(--hv-primary);
-        color: var(--hv-text-on-primary);
-        padding: 9px 20px;
-        font: 500 13.5px var(--hv-font);
-      }
     `,
     dialogSheet,
   ];
@@ -398,7 +390,9 @@ export class HVDiagnosticsPanel extends LitElement {
             >
               ${this._copied ? 'Copied' : 'Copy report'}
             </button>
-            <button class="primary" data-testid="diagnostics-close" @click=${this._close}>Close</button>
+            <!-- This panel reports; it commits nothing. Its way out is drawn as
+                 an outline so the filled shape keeps meaning "this writes". -->
+            <button class="hv-pill outline" data-testid="diagnostics-close" @click=${this._close}>Close</button>
           </div>
         </div>
       </div>

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -162,16 +162,6 @@ export class HVFilterChips extends LitElement {
       .chip svg {
         opacity: 0.8;
       }
-      .clear-all {
-        border: none;
-        background: none;
-        font: 500 12px var(--hv-font);
-        color: var(--hv-text-secondary);
-        padding: 4px 6px;
-      }
-      .clear-all:hover {
-        color: var(--hv-primary-dark);
-      }
     `,
   ];
 
@@ -213,7 +203,7 @@ export class HVFilterChips extends LitElement {
           </button>`,
         )}
         <button
-          class="clear-all"
+          class="hv-text-button"
           data-testid="filter-chips-clear"
           @click=${() =>
             this.dispatchEvent(new CustomEvent('clear-filters', { bubbles: true, composed: true }))}

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -406,7 +406,7 @@ describe('hv-filter-panel: dates and location', () => {
     await el.updateComplete;
 
     const treeEl = el.shadowRoot?.querySelector('hv-location-tree') as HTMLElement;
-    (treeEl.shadowRoot?.querySelector('[data-testid="tree-select"][data-id="garage"]') as HTMLButtonElement).click();
+    (treeEl.shadowRoot?.querySelector('[data-testid="tree-row"][data-id="garage"]') as HTMLButtonElement).click();
     expect(seen[0]).toEqual({ locationId: 'garage' });
 
     await el.updateComplete;

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -308,13 +308,6 @@ export class HVFilterPanel extends LitElement {
         font-size: 12px;
         color: var(--hv-text-secondary);
       }
-      .link {
-        border: none;
-        background: none;
-        font: 500 12.5px var(--hv-font);
-        color: var(--hv-primary-dark);
-        padding: 0;
-      }
       .tree-holder {
         border: 1px solid var(--hv-divider);
         border-radius: var(--hv-radius-input);
@@ -873,7 +866,7 @@ export class HVFilterPanel extends LitElement {
                   ? ` · ${this.total} of ${this.grandTotal} match`
                   : ''}
               </span>
-              <button class="link" data-testid="filter-clear-all" @click=${() => this.clearAll()}>
+              <button class="hv-text-button" data-testid="filter-clear-all" @click=${() => this.clearAll()}>
                 Clear all
               </button>
             </div>`}

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -505,7 +505,7 @@ describe('hv-full-view: sidebar', () => {
     const { el, store, sr } = await mount({ items: [makeItem({ id: '1' })], locations });
     const tree = q(sr, '[data-testid="sidebar-tree"]') as HTMLElement;
 
-    (tree.shadowRoot?.querySelector('[data-testid="tree-select"][data-id="garage"]') as HTMLButtonElement).click();
+    (tree.shadowRoot?.querySelector('[data-testid="tree-row"][data-id="garage"]') as HTMLButtonElement).click();
     await settle(el);
     expect(store.state.value.filters.locationId).toBe('garage');
 
@@ -975,11 +975,19 @@ describe('hv-full-view: context bar and table', () => {
     }
   });
 
-  it('counts loaded rows against the filtered total', async () => {
+  // The same sentence the card's footer prints — the two used to phrase one
+  // fact two ways, and neither named what it was counting.
+  it('counts loaded rows against the filtered total, in the words the card uses', async () => {
     const items = Array.from({ length: 60 }, (_, i) => makeItem({ id: `i${i}` }));
-    const { sr } = await mount({ items });
-    expect(q(sr, '[data-testid="full-footer"]')?.textContent).toContain('Showing 50 of 60');
-    expect(q(sr, '[data-testid="full-footer"]')?.textContent).toContain('scroll to load more');
+    const { el, store, sr } = await mount({ items });
+    expect(q(sr, '[data-testid="full-footer"]')?.textContent?.replace(/\s+/g, ' ').trim()).toBe(
+      'Showing 50 of 60 items · scroll to load more',
+    );
+
+    store.setFilters({ q: 'i1' });
+    await settle(el);
+    await settle(el);
+    expect(q(sr, '[data-testid="full-footer"]')?.textContent).toContain('matching item');
   });
 });
 
@@ -1812,7 +1820,7 @@ describe('hv-full-view: selection and bulk actions', () => {
     (bar.shadowRoot?.querySelector('[data-testid="bulk-action"][data-action="move"]') as HTMLButtonElement).click();
     await settle(el);
     const tree = bar.shadowRoot?.querySelector('hv-location-tree') as HTMLElement;
-    (tree.shadowRoot?.querySelector('[data-testid="tree-select"][data-id="workshop"]') as HTMLButtonElement).click();
+    (tree.shadowRoot?.querySelector('[data-testid="tree-row"][data-id="workshop"]') as HTMLButtonElement).click();
     await settle(el);
     await settle(el);
 
@@ -1856,6 +1864,88 @@ describe('hv-full-view: selection and bulk actions', () => {
     );
     expect(bar.shadowRoot?.querySelector('[data-testid="bulk-failure"]')?.textContent).toContain('Stubborn');
     expect([...store.state.value.selection]).toEqual(['2']);
+  });
+
+  // Bulk check-out used to fire on the press with no due date at all, so a
+  // batch could never go overdue while a single row was always asked.
+  describe('bulk check-out asks for a due date, once', () => {
+    async function selectTwoAndCheckOut() {
+      const items = [makeItem({ id: '1' }), makeItem({ id: '2' })];
+      const mounted = await mount({ items });
+      const { el, sr } = mounted;
+      el.menuEntries = withSelectEntry.entries;
+      await settle(el);
+      await enterSelection(el, sr);
+
+      (table(sr).shadowRoot?.querySelector('[data-testid="table-select-all"]') as HTMLButtonElement).click();
+      await settle(el);
+      (bulkBar(sr).shadowRoot?.querySelector('[data-action="check-out"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      const popover = q(sr, '[data-testid="full-bulk-checkout"]') as HTMLElement & { open: boolean };
+      return { ...mounted, popover };
+    }
+
+    it('opens one popover for the whole selection and applies the date to every row', async () => {
+      const { el, store, popover } = await selectTwoAndCheckOut();
+      expect(popover.open).toBe(true);
+      // One question, named for what it covers.
+      expect(popover.shadowRoot?.querySelector('[data-testid="checkout-title"]')?.textContent).toContain(
+        'Check out 2 items',
+      );
+      // Nothing has run yet.
+      expect(store.state.value.items.some((i) => i.checked_out)).toBe(false);
+
+      const date = popover.shadowRoot?.querySelector(
+        '[data-testid="checkout-date"] input',
+      ) as HTMLInputElement;
+      date.value = '2031-04-05';
+      date.dispatchEvent(new Event('input', { bubbles: true }));
+      await settle(el);
+      (popover.shadowRoot?.querySelector('[data-testid="checkout-confirm"]') as HTMLButtonElement).click();
+      await settle(el);
+      await settle(el);
+
+      expect(store.state.value.items.map((i) => [i.checked_out, i.due_date])).toEqual([
+        [true, '2031-04-05'],
+        [true, '2031-04-05'],
+      ]);
+    });
+
+    it('honours the explicit no-date choice', async () => {
+      const { el, store, popover } = await selectTwoAndCheckOut();
+      (popover.shadowRoot?.querySelector('[data-testid="checkout-no-date"]') as HTMLButtonElement).click();
+      await settle(el);
+      await settle(el);
+
+      expect(store.state.value.items.every((i) => i.checked_out && i.due_date === null)).toBe(true);
+    });
+
+    it('checks nothing out when the question is cancelled', async () => {
+      const { el, store, popover } = await selectTwoAndCheckOut();
+      (popover.shadowRoot?.querySelector('[data-testid="checkout-cancel"]') as HTMLButtonElement).click();
+      await settle(el);
+      await settle(el);
+
+      expect(store.state.value.items.some((i) => i.checked_out)).toBe(false);
+    });
+
+    // Nothing to ask about, so nothing is asked.
+    it('leaves bulk check-in immediate', async () => {
+      const items = [makeItem({ id: '1', checked_out: true }), makeItem({ id: '2', checked_out: true })];
+      const { el, store, sr } = await mount({ items });
+      el.menuEntries = withSelectEntry.entries;
+      await settle(el);
+      await enterSelection(el, sr);
+
+      (table(sr).shadowRoot?.querySelector('[data-testid="table-select-all"]') as HTMLButtonElement).click();
+      await settle(el);
+      (bulkBar(sr).shadowRoot?.querySelector('[data-action="check-in"]') as HTMLButtonElement).click();
+      await settle(el);
+      await settle(el);
+
+      expect(store.state.value.items.every((i) => !i.checked_out)).toBe(true);
+    });
   });
 
   it('confirms a bulk delete and warns about checked-out items', async () => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -5,7 +5,7 @@ import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
-import { counted, plural } from '../ui/plural';
+import { counted, plural, showingCount } from '../ui/plural';
 import { nextZBase } from '../utils/zindex';
 import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters } from '../store/store';
@@ -834,6 +834,8 @@ export class HVFullView extends LitElement {
   @state() private _bulkProgress: BulkProgress | null = null;
   @state() private _bulkResult: BulkResultView | null = null;
   @state() private _pendingDelete = false;
+  /** The whole selection's check-out is waiting on one due date. */
+  @state() private _pendingBulkCheckout = false;
   /** The row whose check-out / due-date step is open, and where to anchor it. */
   @state() private _checkout: {
     itemId: string;
@@ -1162,6 +1164,7 @@ export class HVFullView extends LitElement {
     this._selecting = false;
     this._bulkResult = null;
     this._lastOps = null;
+    this._pendingBulkCheckout = false;
     this.store?.clearSelection();
   }
 
@@ -1230,6 +1233,13 @@ export class HVFullView extends LitElement {
     if (detail.action === 'delete') {
       // Destructive actions get a confirmation step of their own.
       this._pendingDelete = true;
+      return;
+    }
+    if (detail.action === 'check-out' && detail.dueDate === undefined) {
+      // A check-out with no due date is a check-out nothing can ever call
+      // overdue, so the batch asks the question a single row is asked — once,
+      // and the answer covers the selection.
+      this._pendingBulkCheckout = true;
       return;
     }
     void this._execute(this._opsFor(detail, this._selectedItems));
@@ -2092,9 +2102,9 @@ export class HVFullView extends LitElement {
               : null}
 
             <div class="footer" data-testid="full-footer">
-              ${st?.total !== null && st?.total !== undefined
-                ? `Showing ${loaded} of ${st.total}${st.cursor ? ' · scroll to load more' : ''}`
-                : `Showing ${loaded}`}
+              ${showingCount(loaded, st?.total, activeFilterCount(filters) > 0)}${st?.cursor
+                ? ' · scroll to load more'
+                : ''}
             </div>
           </div>
         </div>
@@ -2182,6 +2192,25 @@ export class HVFullView extends LitElement {
           }}
           @cancel=${() => {
             this._checkout = null;
+          }}
+        ></hv-checkout-popover>
+
+        <!-- Centred at every width rather than following _narrow: the mobile
+             presentation is an inline step drawn inside the surface that opened
+             it, and this one is opened by a bar at the foot of the table with no
+             body of its own to sit in. It anchors to nothing, so it takes the
+             same scrimmed middle-of-the-screen position the bulk confirm does. -->
+        <hv-checkout-popover
+          data-testid="full-bulk-checkout"
+          ?open=${this._pendingBulkCheckout}
+          .itemName=${counted(selection.size, 'item')}
+          @check-out=${(e: CustomEvent) => {
+            const { dueDate } = e.detail as { dueDate: string | null };
+            this._pendingBulkCheckout = false;
+            void this._execute(this._opsFor({ action: 'check-out', dueDate }, this._selectedItems));
+          }}
+          @cancel=${() => {
+            this._pendingBulkCheckout = false;
           }}
         ></hv-checkout-popover>
 

--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -170,6 +170,18 @@ describe('hv-import-sheet: preview', () => {
     expect(counts['locations-add']).toContain('+4');
   });
 
+  // The wire value is not what the user pressed, and the preview is quoting
+  // their choice back at them.
+  it('names the policy the way the card offered it', async () => {
+    const merge = await mount({ preview: preview() });
+    const sub = merge.shadowRoot?.querySelector('.head .sub')?.textContent?.replace(/\s+/g, ' ') ?? '';
+    expect(sub).toContain('policy Merge');
+    expect(sub).not.toContain('policy merge');
+
+    const skip = await mount({ preview: preview({ policy: 'skip' }) });
+    expect(skip.shadowRoot?.querySelector('.head .sub')?.textContent).toContain('Skip');
+  });
+
   it('explains what the chosen policy does with conflicts', async () => {
     const merge = await mount({ preview: preview({ items: { add: [], update: [], conflict: ['x'], unchanged: [] } }) });
     expect(q(merge, '[data-testid="import-conflicts"]')?.textContent).toContain("Merge keeps the file's values");

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -36,6 +36,14 @@ const POLICIES: { id: ImportPolicy; title: string; description: string }[] = [
 ];
 
 /**
+ * The name a policy was picked by. The preview quotes the choice back, and the
+ * wire value ("merge") is not what the user pressed ("Merge").
+ */
+function policyTitle(id: ImportPolicy): string {
+  return POLICIES.find((p) => p.id === id)?.title ?? id;
+}
+
+/**
  * Restore from a backup.
  *
  * The server-side dry run is mandatory and stays that way: nothing is written
@@ -97,6 +105,11 @@ export class HVImportSheet extends LitElement {
         font-size: 12.5px;
         color: var(--hv-text-secondary);
         margin-top: 3px;
+      }
+      /* The one thing in this line the user chose, lifted out of the secondary
+         ink the rest of it sits in. */
+      .head .sub .policy-name {
+        color: var(--hv-text);
       }
       .body {
         flex: 1;
@@ -279,17 +292,6 @@ export class HVImportSheet extends LitElement {
         color: var(--hv-text-tertiary);
         margin-right: auto;
       }
-      .primary {
-        border: none;
-        border-radius: var(--hv-radius-chip);
-        background: var(--hv-primary);
-        color: var(--hv-text-on-primary);
-        padding: 9px 20px;
-        font: 500 13.5px var(--hv-font);
-      }
-      .primary[disabled] {
-        opacity: 0.5;
-      }
       .reveal {
         position: absolute;
         width: 1px;
@@ -468,7 +470,7 @@ export class HVImportSheet extends LitElement {
         <span class="hint">Import applies for every connected client</span>
         <button class="hv-text-button" data-testid="import-cancel" @click=${this._close}>Cancel</button>
         <button
-          class="primary"
+          class="hv-pill"
           data-testid="import-preview"
           ?disabled=${!this._text.trim() || this.busy}
           @click=${() => this._emit('preview')}
@@ -525,7 +527,7 @@ export class HVImportSheet extends LitElement {
           ${this._copied ? 'Copied' : 'Copy errors'}
         </button>
         <button
-          class="primary"
+          class="hv-pill"
           data-testid="import-back"
           @click=${() =>
             this.dispatchEvent(new CustomEvent('invalidate-preview', { bubbles: true, composed: true }))}
@@ -547,7 +549,7 @@ export class HVImportSheet extends LitElement {
         <div class="row"><h2>Import backup · preview</h2></div>
         <div class="sub">
           Step 2 of 2 · validated on the server, nothing written yet · policy
-          <strong style="color:var(--hv-text)">${preview.policy}</strong>
+          <strong class="policy-name">${policyTitle(preview.policy)}</strong>
         </div>
       </div>
       <div class="body">
@@ -588,7 +590,7 @@ export class HVImportSheet extends LitElement {
         <span class="hint"></span>
         <button class="hv-text-button" data-testid="import-cancel" @click=${this._close}>Cancel</button>
         <button
-          class="primary"
+          class="hv-pill"
           data-testid="import-execute"
           ?disabled=${this.busy}
           @click=${() => this._emit('execute')}
@@ -629,7 +631,7 @@ export class HVImportSheet extends LitElement {
       </div>
       <div class="foot">
         <span class="hint"></span>
-        <button class="primary" data-testid="import-done" @click=${this._close}>Done</button>
+        <button class="hv-pill" data-testid="import-done" @click=${this._close}>Done</button>
       </div>
     `;
   }

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -550,7 +550,7 @@ describe('hv-item-editor: location and tags', () => {
 
     const treeEl = el.shadowRoot?.querySelector('hv-location-tree') as HTMLElement;
     (
-      treeEl.shadowRoot?.querySelector('[data-testid="tree-select"][data-id="garage"]') as HTMLButtonElement
+      treeEl.shadowRoot?.querySelector('[data-testid="tree-row"][data-id="garage"]') as HTMLButtonElement
     ).click();
     await el.updateComplete;
 

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -552,3 +552,16 @@ describe('hv-list-row: document marker', () => {
     expect(css).toMatch(/\.name \{[^}]*min-width: 0[^}]*text-overflow: ellipsis/);
   });
 });
+
+describe('hv-list-row: the row is a target', () => {
+  it('shows the hand a button would', () => {
+    const styles = (customElements.get('hv-list-row') as typeof HVListRow).styles;
+    const css = (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+    // The shared `button { cursor: pointer }` cannot reach a role=row div, and
+    // every chip, pill and menu beside the row already shows the hand.
+    expect(css).toMatch(/\.row \{[^}]*cursor: pointer/);
+  });
+});

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -98,6 +98,11 @@ export class HVListRow extends LitElement {
         text-align: left;
         color: inherit;
         font: inherit;
+        /* A row opens the item it names, but it is a role=row div rather than a
+           button — it has to hold the chips and controls a button cannot
+           legally contain — so the hand that the shared button rule gives every
+           other target has to be asked for here. */
+        cursor: pointer;
       }
       :host([mobile]) .row {
         padding: 11px 14px;

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -108,7 +108,7 @@ describe('hv-location-tree: counts and decorations', () => {
     const el = await mount();
     (q(el, '[data-testid="tree-twisty"]') as HTMLButtonElement).click();
     await el.updateComplete;
-    expect(q(el, '[data-testid="tree-select"][data-id="shelf-a"]')?.getAttribute('title')).toBe(
+    expect(q(el, '[data-testid="tree-row"][data-id="shelf-a"]')?.getAttribute('title')).toBe(
       'garage / Shelf A',
     );
   });
@@ -178,7 +178,7 @@ describe('hv-location-tree: selection', () => {
     el.addEventListener('select', (e) => {
       detail = (e as CustomEvent).detail;
     });
-    (q(el, '[data-testid="tree-select"][data-id="garage"]') as HTMLButtonElement).click();
+    (q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLButtonElement).click();
     expect(detail.locationId).toBe('garage');
   });
 
@@ -245,7 +245,7 @@ describe('hv-location-tree: filtering and cycle guard', () => {
     el.addEventListener('select', () => {
       fired += 1;
     });
-    (q(el, '[data-testid="tree-select"][data-id="garage"]') as HTMLButtonElement).click();
+    (q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLButtonElement).click();
     expect(fired).toBe(0);
   });
 });
@@ -723,5 +723,64 @@ describe('hv-location-tree: the first location', () => {
 
     expect(q(el, '[data-testid="tree-empty"]')?.textContent).toContain('No locations match');
     expect(q(el, '[data-testid="tree-create"]')).toBe(null);
+  });
+});
+
+// The row highlights across its full width, so the part of it that answers a
+// click is the whole of it — the way the facet rows beside it and this tree's
+// own All-items and No-location rows already work.
+describe('hv-location-tree: the whole row is the target', () => {
+  const selections = (el: HVLocationTree) => {
+    const seen: (string | null)[] = [];
+    el.addEventListener('select', (e) => seen.push((e as CustomEvent).detail.locationId));
+    return seen;
+  };
+
+  it('picks the location from anywhere on the row, count included', async () => {
+    const el = await mount({ showCounts: true });
+    const seen = selections(el);
+
+    (q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLElement).click();
+    (q(el, '[data-testid="tree-row"][data-id="garage"] [data-testid="tree-count"]') as HTMLElement).click();
+
+    expect(seen).toEqual(['garage', 'garage']);
+  });
+
+  it('carries the name as plain text rather than a button inside the row', async () => {
+    const el = await mount();
+    const name = q(el, '[data-testid="tree-row"][data-id="garage"] .name');
+    expect(name?.localName).toBe('span');
+    expect(q(el, '[data-testid="tree-row"][data-id="garage"]')?.getAttribute('role')).toBe('treeitem');
+  });
+
+  it('answers Enter and Space, which a div gets from nothing', async () => {
+    const el = await mount();
+    const seen = selections(el);
+    const row = q(el, '[data-testid="tree-row"][data-id="kitchen"]') as HTMLElement;
+
+    for (const key of ['Enter', ' ']) {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      row.dispatchEvent(event);
+      expect(event.defaultPrevented, key).toBe(true);
+    }
+    expect(seen).toEqual(['kitchen', 'kitchen']);
+  });
+
+  it('leaves the expander its own control', async () => {
+    const el = await mount();
+    const seen = selections(el);
+    (q(el, '[data-testid="tree-twisty"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(seen).toEqual([]);
+    expect(ids(el)).toContain('shelf-a');
+  });
+
+  it('keeps an excluded row out of the tab order', async () => {
+    const el = await mount({ excludeSubtreeOf: 'garage' });
+    const row = q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLElement;
+    expect(row.getAttribute('tabindex')).toBe('-1');
+    expect(row.getAttribute('aria-disabled')).toBe('true');
+    expect(q(el, '[data-testid="tree-row"][data-id="kitchen"]')?.getAttribute('tabindex')).toBe('0');
   });
 });

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -78,6 +78,11 @@ export class HVLocationTree extends LitElement {
            and is unaffected. */
         padding: var(--hv-organize-row-pad, 7px) 12px;
         border-radius: var(--hv-radius-input);
+        /* The whole row picks the location it names. The All-items and
+           No-location rows below are real buttons and get this for free; a node
+           row cannot be one, because it holds the twisty and the manage actions
+           and a button may not contain a button. */
+        cursor: pointer;
       }
       .row:hover {
         background: var(--hv-hover-overlay);
@@ -119,6 +124,7 @@ export class HVLocationTree extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        text-align: left;
       }
       .count {
         flex: none;
@@ -274,19 +280,8 @@ export class HVLocationTree extends LitElement {
         font: 500 12.5px var(--hv-font);
         cursor: pointer;
       }
-      .create-submit {
+      .create-row .hv-pill {
         flex: none;
-        min-height: var(--hv-tap-min, 30px);
-        border: none;
-        border-radius: var(--hv-radius-chip);
-        background: var(--hv-primary);
-        color: var(--hv-text-on-primary);
-        padding: 0 14px;
-        font: 500 12.5px var(--hv-font);
-        cursor: pointer;
-      }
-      .create-submit[disabled] {
-        opacity: 0.5;
       }
       .divider {
         height: 1px;
@@ -420,6 +415,12 @@ export class HVLocationTree extends LitElement {
     return null;
   }
 
+  /** Pick a node — from anywhere on its row, which is one target. */
+  private _select(node: LocationTreeNode, excluded: boolean) {
+    if (excluded) return;
+    this._emit('select', { locationId: node.id, node });
+  }
+
   private _toggle(id: string) {
     const next = new Set(this._expanded);
     if (next.has(id)) next.delete(id);
@@ -494,11 +495,22 @@ export class HVLocationTree extends LitElement {
           aria-expanded=${ifDefined(hasChildren ? String(open) : undefined)}
           aria-controls=${ifDefined(hasChildren ? nodeChildrenId(node.id) : undefined)}
           aria-level=${depth + 1}
+          aria-disabled=${ifDefined(isExcluded ? 'true' : undefined)}
+          title=${node.path?.display_path ?? node.name}
+          tabindex=${isExcluded ? -1 : 0}
           data-testid="tree-row"
           data-id=${node.id}
           data-depth=${depth}
           ?disabled=${isExcluded}
           style="padding-left: ${12 + depth * 18}px"
+          @click=${() => this._select(node, isExcluded)}
+          @keydown=${(e: KeyboardEvent) => {
+            // The row answers Enter and Space itself now that it is the target;
+            // as a div it inherits neither from the browser.
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            e.preventDefault();
+            this._select(node, isExcluded);
+          }}
         >
           ${hasChildren
             ? html`<button
@@ -513,20 +525,7 @@ export class HVLocationTree extends LitElement {
                 ${icon(open ? 'chevronDown' : 'chevronRight', 17)}
               </button>`
             : html`<span class="twisty placeholder">${icon('chevronRight', 17)}</span>`}
-          <button
-            class="name"
-            data-testid="tree-select"
-            data-id=${node.id}
-            title=${node.path?.display_path ?? node.name}
-            ?disabled=${isExcluded}
-            style="border:none;background:none;padding:0;font:inherit;color:inherit;text-align:left"
-            @click=${() => {
-              if (isExcluded) return;
-              this._emit('select', { locationId: node.id, node });
-            }}
-          >
-            ${node.name}
-          </button>
+          <span class="name">${node.name}</span>
           ${this.showCounts ? this._renderCount(node, isExcluded) : null}
           ${this.manage && this.mobile
             ? html`<span class="actions">
@@ -756,7 +755,7 @@ export class HVLocationTree extends LitElement {
           }}
         />
         <button
-          class="create-submit"
+          class="hv-pill"
           data-testid="tree-create-submit"
           ?disabled=${!name}
           @click=${() => this._submitCreate()}

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -458,7 +458,7 @@ describe('hv-organize-dialog: locations', () => {
 
     it('moves the subtree when a different parent is picked', async () => {
       const { el, sr, calls } = await editShelfA();
-      await pickParent(el, sr, '[data-testid="tree-select"][data-id="attic"]');
+      await pickParent(el, sr, '[data-testid="tree-row"][data-id="attic"]');
 
       (q(sr, '[data-testid="location-save"]') as HTMLButtonElement).click();
       await settle(el);
@@ -621,7 +621,7 @@ describe('hv-organize-dialog: locations', () => {
   // the way into the items.
   it('opens the items behind a location from its name or its count', async () => {
     const items = [makeItem({ id: '1', location_id: 'shelf-a' })];
-    for (const testid of ['tree-select', 'tree-count']) {
+    for (const testid of ['tree-row', 'tree-count']) {
       const { el, store, sr } = await mount({ items, locations });
       const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
       let browsed = 0;
@@ -691,7 +691,7 @@ describe('hv-organize-dialog: locations', () => {
     await settle(el);
     expect(disabled()).toEqual(expect.arrayContaining(['garage', 'shelf-a']));
 
-    (picker.shadowRoot?.querySelector('[data-testid="tree-select"][data-id="workshop"]') as HTMLButtonElement).click();
+    (picker.shadowRoot?.querySelector('[data-testid="tree-row"][data-id="workshop"]') as HTMLButtonElement).click();
     await settle(el);
     expect(q(sr, '[data-testid="merge-effect"]')?.textContent).toContain('2 items and 1 sub-location');
 
@@ -729,7 +729,7 @@ describe('hv-organize-dialog: locations', () => {
     (q(sr, '[data-testid="merge-target"]') as HTMLButtonElement).click();
     await settle(el);
     const picker = q(sr, '[data-testid="merge-target-tree"]') as HTMLElement;
-    (picker.shadowRoot?.querySelector('[data-testid="tree-select"][data-id="workshop"]') as HTMLButtonElement).click();
+    (picker.shadowRoot?.querySelector('[data-testid="tree-row"][data-id="workshop"]') as HTMLButtonElement).click();
     await settle(el);
     (q(sr, '[data-testid="merge-apply"]') as HTMLButtonElement).click();
     for (let i = 0; i < 4; i += 1) await settle(el);
@@ -1443,7 +1443,7 @@ describe('hv-organize-dialog: statuses', () => {
     const css = dialogCss();
     expect(css).toMatch(/:host \{[^}]*--hv-organize-row-pad: 8px/);
     expect(css).toMatch(/\.value-row \{[^}]*padding: var\(--hv-organize-row-pad\) 8px/);
-    // Nothing re-declares it per tab, or the tabs could drift again.
+    // Nothing redeclares it per tab, or the tabs could drift again.
     expect(css.match(/--hv-organize-row-pad:/g)).toHaveLength(1);
   });
 

--- a/cards/haventory-card/src/ui/button-recipes.test.ts
+++ b/cards/haventory-card/src/ui/button-recipes.test.ts
@@ -59,6 +59,14 @@ describe('shared button recipes', () => {
     expect(cssOf('hv-card-shell')).toContain('.sheet-footer .apply { flex: 1; }');
   });
 
+  // The detail sheet's two actions share a stretch grid, so the row takes the
+  // taller of them. A neighbour a couple of pixels above the modifier therefore
+  // sets the height of both and the modifier decides nothing — which is how the
+  // pair came to sit at 50px while the filter sheet's footer sat at 48px.
+  it('sizes the detail sheet action pair to the touch modifier, not past it', () => {
+    expect(cssOf('hv-detail-sheet')).toMatch(/\.actions \.outline \{[^}]*min-height: 48px/);
+  });
+
   it.each(CLEAR_ALL_HOSTS)('%s draws Clear all with the shared text button', (tag) => {
     const css = cssOf(tag);
     expect(css).not.toMatch(/\.clear-all \{/);

--- a/cards/haventory-card/src/ui/button-recipes.test.ts
+++ b/cards/haventory-card/src/ui/button-recipes.test.ts
@@ -1,0 +1,69 @@
+import '../components/hv-card-shell';
+import '../components/hv-confirm';
+import '../components/hv-detail-sheet';
+import '../components/hv-diagnostics-panel';
+import '../components/hv-filter-chips';
+import '../components/hv-filter-panel';
+import '../components/hv-import-sheet';
+import '../components/hv-location-tree';
+import { base } from './tokens';
+import type { CSSResult } from 'lit';
+
+/**
+ * One recipe per shape, across every surface that draws it.
+ *
+ * The dialog that commits had been hand-rolled in six components and the
+ * "Clear all" text button in three, each a few pixels and a shade off its
+ * siblings — two of the latter visible at once on a filtered card. These pins
+ * are what stops the next dialog from adding a seventh: the shared rules live
+ * in `base`, and a private copy of one is a regression, not a style.
+ */
+
+type StyledElement = { styles: CSSResult | CSSResult[] };
+
+function cssOf(tag: string): string {
+  const styles = (customElements.get(tag) as unknown as StyledElement).styles;
+  return (Array.isArray(styles) ? styles : [styles])
+    .map((s) => String(s.cssText))
+    .join('\n')
+    .replace(/\s+/g, ' ');
+}
+
+/** Each retired variant, by the selector it was written as. */
+const RETIRED_PRIMARIES: [tag: string, selector: string][] = [
+  ['hv-confirm', '.confirm {'],
+  ['hv-import-sheet', '.primary {'],
+  ['hv-diagnostics-panel', '.primary {'],
+  ['hv-detail-sheet', '.actions .primary {'],
+  ['hv-location-tree', '.create-submit {'],
+];
+
+const CLEAR_ALL_HOSTS = ['hv-card-shell', 'hv-filter-chips', 'hv-filter-panel'];
+
+describe('shared button recipes', () => {
+  it('declares the filled primary, its danger fill and its touch size once', () => {
+    const css = String(base.cssText).replace(/\s+/g, ' ');
+    expect(css).toMatch(/\.hv-pill \{[^}]*background: var\(--hv-primary\)/);
+    expect(css).toMatch(/\.hv-pill\.danger \{[^}]*background: var\(--hv-error\)/);
+    expect(css).toMatch(/\.hv-pill\.large \{[^}]*min-height: 48px/);
+  });
+
+  it.each(RETIRED_PRIMARIES)('%s no longer carries its own %s', (tag, selector) => {
+    expect(cssOf(tag)).not.toContain(selector);
+  });
+
+  // The one that survives as a selector keeps its layout only: the sheet footer
+  // stretches its committing action across the remaining width, and that is not
+  // something the shared recipe can know.
+  it('leaves the filter sheet footer nothing but the stretch', () => {
+    expect(cssOf('hv-card-shell')).toContain('.sheet-footer .apply { flex: 1; }');
+  });
+
+  it.each(CLEAR_ALL_HOSTS)('%s draws Clear all with the shared text button', (tag) => {
+    const css = cssOf(tag);
+    expect(css).not.toMatch(/\.clear-all \{/);
+    // The shell keeps a `.link` for the footer's way into the expanded view,
+    // which is sized to a 12px footer rather than to a control row.
+    if (tag !== 'hv-card-shell') expect(css).not.toMatch(/\.link \{/);
+  });
+});

--- a/cards/haventory-card/src/ui/plural.ts
+++ b/cards/haventory-card/src/ui/plural.ts
@@ -17,3 +17,18 @@ export function plural(count: number, singular: string, pluralForm = `${singular
 export function counted(count: number, singular: string, pluralForm = `${singular}s`): string {
   return `${count} ${plural(count, singular, pluralForm)}`;
 }
+
+/**
+ * The line under a list saying how much of the set is on screen.
+ *
+ * The card and the expanded view report the same fact about the same store, so
+ * they say it in the same words — and the words name what is being counted,
+ * which a bare "Showing 50 of 60" never did. `total` is what matches the active
+ * filters, so with any of them on the noun says so; null means the server has
+ * not priced the set yet. A surface may append its own suffix (the expanded
+ * view offers "scroll to load more"), but not rephrase this.
+ */
+export function showingCount(loaded: number, total: number | null | undefined, filtered = false): string {
+  if (total === null || total === undefined) return `Showing ${counted(loaded, 'item')}`;
+  return `Showing ${loaded} of ${counted(total, filtered ? 'matching item' : 'item')}`;
+}

--- a/cards/haventory-card/src/ui/tokens.ts
+++ b/cards/haventory-card/src/ui/tokens.ts
@@ -118,6 +118,26 @@ export const tokens = css`
     --hv-tone-red-strong-bg: #c62828;
     --hv-tone-red-strong-fg: #fff;
 
+    /*
+     * The band the bulk bar draws while a selection is being acted on. It is a
+     * mode the card is in rather than another panel, so it stays a dark strip
+     * in both themes instead of following --hv-surface — and because the fill
+     * is one hue per theme rather than a surface a user theme repaints, the ink
+     * on it is fixed, the same constraint --hv-on-amber is written for. The
+     * dark half sits under the surfaces around it; the light half is the
+     * blue-grey the bar has always drawn.
+     *
+     * Everything else the band needs — the wash under its buttons, the progress
+     * track — is mixed from --hv-on-selection-bar where it is used, so one ink
+     * decision covers the whole strip.
+     */
+    --hv-selection-bar: light-dark(#263238, #1b2429);
+    --hv-on-selection-bar: #fff;
+    /* Delete, on the band. The deep half of --hv-error is ink for a light
+       surface and disappears here, so this is the light red that reads on both
+       halves of the fill above. */
+    --hv-on-selection-bar-danger: #ef9a9a;
+
     /* Inputs */
     --hv-input-bg: var(--input-fill-color, light-dark(#f5f5f5, #2b2b2b));
     --hv-input-border: light-dark(#cfd8dc, #4a4a4a);
@@ -233,6 +253,21 @@ export const base = css`
   .hv-pill.outline:hover {
     background: var(--hv-hover-overlay);
     opacity: 1;
+  }
+
+  /* The one thing that removes data wears the error fill, filled like any other
+     committing action so it still reads as the button that ends the dialog. */
+  .hv-pill.danger {
+    background: var(--hv-error);
+  }
+
+  /* The size a phone's committing action takes: the sheet footers and the
+     detail sheet's action pair are thumb targets, not pointer targets, and one
+     modifier keeps them from each inventing their own height. */
+  .hv-pill.large {
+    min-height: 48px;
+    padding: 0 20px;
+    font-size: 14.5px;
   }
 
   .hv-text-button {

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -106,7 +106,7 @@ haventory-card                     Lovelace element; store owner
         │                          same ⋮ actions the card's rows do
         ├── hv-detail-sheet        the read view at phone width, the same one the
         │                          card opens
-        ├── hv-checkout-popover    the row menu's due-date step
+        ├── hv-checkout-popover    due-date step for a row and for a selection
         └── hv-bulk-bar            bulk actions, progress, per-operation results
 ```
 
@@ -496,6 +496,13 @@ Any other key in that record is ignored, so an older or newer payload never brea
 - **Bulk work is chunked**, so progress is determinate and cancel stops cleanly after the
   in-flight chunk. Nothing is rolled back — the endpoint is not transactional, and the UI
   says so.
+- **A batch asks whatever the single row is asked.** The bar owns the steps that only
+  concern a selection (which location, which tags); the two questions a single row already
+  has a surface for — the delete confirmation and check-out's due date — belong to the
+  host, which opens the same `hv-confirm` and `hv-checkout-popover` once and applies the
+  one answer to every selected item. A `check-out` run detail carrying no `dueDate` key at
+  all is how the bar says "ask"; `dueDate: null` is a user who chose no due date. Check-in
+  stays immediate: there is nothing to ask.
 - **Per-operation results.** `haventory/items/bulk` returns a result per operation and
   partial failure is normal, so the result panel names every failed row, translates its
   error, and offers a retry scoped to those. Retries rebuild their operations rather than


### PR DESCRIPTION
## Summary

**P11** of the v0.4.0 frontend campaign (`dev/v040_frontend_completeness_plan.md`), and the
last package in it. Nine small findings, each one a place where a single surface disagreed
with the rest of the card. It runs last on purpose: every edit is small and spread across
files the earlier packages owned.

Fixes **F4, F17, F21, F22, F23, F25, F26, F27, F28** from the register in
`dev/v040_frontend_completeness_plan.md`. None of them has been filed as an issue, so this
PR carries no `Closes` line.

| Finding | What changes |
|---|---|
| **F4** | Item rows show the hand. They are `role="row"` divs — the shared `button { cursor: pointer }` cannot reach them, while every chip, pill and menu beside them had it. Card list and table both. The sweep for other clickable non-buttons found only the tree row (F26); the dialog scrims are dismissal areas and keep the arrow. |
| **F26** | A location tree row is one target across its full width, like the facet rows beside it and the tree's own All-items / No-location rows. The name stops being a `<button>` inside a `treeitem`; the row itself answers click, Enter and Space, and the twisty, the count link and the manage actions stay their own controls. An excluded row stays out of the tab order and says `aria-disabled`. |
| **F17** | Bulk check-out asks for a due date once and applies it to every selected item, exactly as a single row is asked — decision 14. Without one, no batch could ever go overdue. The bar drops the action's `immediate` flag and hands the question to the host, which opens the same `hv-checkout-popover`; "No due date" stays a first-class answer. Bulk check-in stays immediate. |
| **F21** | One filled-primary recipe — decision 17. The six hand-rolled variants (`hv-confirm`, `hv-import-sheet`, `hv-diagnostics-panel`, `hv-detail-sheet`, `hv-card-shell`, `hv-location-tree`) are **deleted** for `.hv-pill`, plus a `danger` fill for the destructive confirm and one `large` size modifier for the two thumb-sized footers. |
| **F22** | One "Clear all". The chips row, the filter panel footer and the phone filter sheet converge on `.hv-text-button` — two of the three were visible at once on a filtered card. |
| **F23** | Diagnostics closes with an outline instead of the filled shape that means "commit" everywhere else; the bulk result says **Close**, not "Dismiss". The column picker keeps **Done** — its changes apply live (decision 15). |
| **F25** | The import preview names the policy the way the card offered it ("Merge"), not the wire value ("merge"). |
| **F27** | The bulk band's two hardcoded hexes become tokens (`--hv-selection-bar`, `--hv-on-selection-bar`, `--hv-on-selection-bar-danger`), with the washes and the progress track mixed from the band's own ink — so the one surface that ignored the HA theme stops ignoring it. A running batch's Cancel becomes a real button instead of a bare native one, and two inline styles leave the progress row. |
| **F28** | Both footers print one sentence from one helper (`showingCount` in `ui/plural.ts`), and it names what it counts: "Showing 50 of 60 items", "Showing 1 of 1 matching item" when a filter is on. The expanded view still appends its "scroll to load more". |

Backend untouched; nothing inside `custom_components/haventory/` is deleted or renamed, so
no `RETIRED_PATHS` entry is needed.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

Both gates green on this branch.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 752 passed, 22 skipped · `uv run ruff check .` → clean · `uv run ruff format --check .` → 115 files formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean · `npx vitest run` → **1649 passed / 59 files** · `npm run build` → 578 kB bundle

New and rewritten tests:

- `hv-list-row` / `hv-data-table`: the hand on a body row, and not on the table header.
- `hv-location-tree`: the whole row selects (count included), the name is a `<span>` inside a `treeitem`, Enter and Space are answered and `preventDefault`ed, the twisty selects nothing, an excluded row is `tabindex="-1"` + `aria-disabled`.
- `hv-full-view`: bulk check-out opens one popover titled "Check out 2 items", runs nothing until it is answered, applies the picked date to every row, honours the explicit no-date path, cancels cleanly — and bulk check-in stays immediate.
- `hv-bulk-bar`: rewritten run pin (`check-out` now carries no `dueDate` key at all), the "Check out…" label, the band's fill/ink read from tokens with no literal colour left in those rules, Cancel carries the band class and no inline style, the result closes rather than dismisses.
- `src/ui/button-recipes.test.ts` (new): the shared `.hv-pill` / `.hv-pill.danger` / `.hv-pill.large` rules exist once in `base`, each of the five retired primary selectors is gone, the filter sheet's footer keeps nothing but its stretch, and no surface carries a private "Clear all".
- `hv-confirm`: accept is `.hv-pill danger`, not a private `.confirm.destructive`.
- `hv-diagnostics-panel`: Close reads "Close" and is `hv-pill outline`.
- `hv-import-sheet`: the preview says "policy Merge", never "policy merge".
- `hv-card-shell` / `hv-full-view`: both footers pinned to the same sentence, with and without a filter.
- Every `[data-testid="tree-select"]` query across seven test files is repointed to `[data-testid="tree-row"]` — the row is the target now, so it is also what a test presses.

## Delegated to the local verification session

jsdom lays out no shadow DOM, so nothing here proves how any of it looks or feels. The
handover covers, against the Docker dev HA in a real browser:

- Hover an item row on the card and in the table — hand cursor, both views.
- Location tree rows respond across their full width, in the sidebar, the organize dialog,
  the editor's location picker and bulk move; the twisty still only expands.
- Select 3 items → bulk Check out: the popover asks once, all 3 carry the chosen date, and
  the explicit no-date path also works.
- Import preview reads "Merge".
- The bulk-run Cancel looks like a button and the band follows the theme in light and dark.
- Both footers read the same sentence.
- Primary buttons look alike in the confirm, import, diagnostics, detail sheet and tree —
  including at 390px, where the two `large` footers changed height by a couple of pixels.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated: `README.md` (bulk check-out asks once) and `docs/frontend_architecture.md` (the popover's two roles, and where a batch's questions live).
- [x] No WebSocket API change.
- [x] Essential invariants untouched — this package is card-only.

## Follow-ups

Not fixed here, and below the real-world-impact bar in `CLAUDE.md` for an issue of their own:

- `hv-detail-sheet`'s edit-bar Save (`.bar .save`, a 40px pill in a 56px bar) and the photo
  hero's `+` are filled with `--hv-primary` but are not among the six variants F21 names.
  They read as bar furniture rather than as a dialog's committing action; left alone
  deliberately.
- The full view's **single-row** check-out popover passes `?mobile` at narrow widths, which
  makes `hv-checkout-popover` render as a static inline card — and there it is mounted at
  the end of the shell rather than inside a body. Predates this package (the row menu that
  reaches it arrived in #346). The new bulk popover deliberately does not pass `mobile`, so
  it is centred and scrimmed at every width. Worth a look during the final gate at 390px.
