### PR TITLE
fix(card): one chip vocabulary — tags blue everywhere, tag chips at chip size

### DIFF
--- a/cards/haventory-card/src/components/hv-chip-input.test.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.test.ts
@@ -34,6 +34,25 @@ describe('hv-chip-input', () => {
     expect(all(el, '[data-testid="chip-remove"]')).toHaveLength(2);
   });
 
+  // The editor's tokens are tags, so they wear the tag chip — the same one the
+  // table's Tags column and the detail sheet draw.
+  it('draws a value as the card draws a tag anywhere else', async () => {
+    const el = await mount({ values: ['battery'] });
+    const token = q(el, '[data-testid="chip"]')!;
+
+    expect([...token.classList].sort()).toEqual(['chip', 'hv-chip', 'tag']);
+    expect(token.querySelector('.hv-tag-mark')?.getAttribute('aria-hidden')).toBe('true');
+    // The remove button is named for the value, not for what is printed on the chip.
+    expect(q(el, '[data-testid="chip-remove"]')?.getAttribute('aria-label')).toBe('Remove battery');
+  });
+
+  // A tag someone writes with a # of their own would otherwise read as ##ok.
+  it('marks a value once, whatever the value looks like', async () => {
+    const el = await mount({ values: ['#ok'] });
+    expect(all(el, '.hv-tag-mark')).toHaveLength(1);
+    expect(q(el, '[data-testid="chip"]')?.textContent?.trim()).toBe('##ok');
+  });
+
   it('lowercases and trims on commit, matching how the backend stores tags', async () => {
     const el = await mount();
     const seen = changes(el);

--- a/cards/haventory-card/src/components/hv-chip-input.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.ts
@@ -38,15 +38,6 @@ export class HVChipInput extends LitElement {
       .field:focus-within {
         border-color: var(--hv-primary);
       }
-      /* A value already entered, not a fact about something else: it takes the
-         chip's shape and the state fill so it reads as one of the card's chips,
-         and owns the rest — a remove affordance, and enough height to be a
-         touch target, which no informational chip needs. */
-      .chip {
-        gap: 3px;
-        min-height: var(--hv-tap-min, auto);
-        padding: 3px 9px;
-      }
       .chip svg {
         opacity: 0.75;
       }
@@ -55,7 +46,13 @@ export class HVChipInput extends LitElement {
          well into the chip beside it and remove the wrong tag. 24px is the
          widest it can grow while still belonging to its own chip, which meets
          WCAG 2.5.8 even though it misses the 2.5.5 target the rest of the
-         mobile controls now hit. */
+         mobile controls now hit.
+
+         The pill around it is not a target at all, which is why it takes the
+         shared chip metrics untouched: the hit area below is set by this
+         ::after and a taller pill would not grow it by a pixel — it would only
+         make a tag in this field bigger than the same tag in the table. The
+         field still reaches a full tap height, from the input beside them. */
       .chip-remove {
         position: relative;
         width: 14px;

--- a/cards/haventory-card/src/components/hv-chip-input.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
-import { chip } from '../ui/chip';
+import { chip, tagLabel } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { normalizeTags } from '../ui/item-form';
 
@@ -135,8 +135,8 @@ export class HVChipInput extends LitElement {
     return html`
       <div class="field" data-testid="chip-field">
         ${this.values.map(
-          (tag) => html`<span class="hv-chip state chip" data-testid="chip" data-value=${tag}>
-            ${tag}
+          (tag) => html`<span class="hv-chip tag chip" data-testid="chip" data-value=${tag}>
+            ${tagLabel(tag)}
             <button
               class="hv-icon-button chip-remove"
               data-testid="chip-remove"

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -190,6 +190,25 @@ describe('hv-data-table: columns', () => {
     expect(q(el, '[data-testid="cell-tags"]')?.textContent).toContain('m4');
   });
 
+  // The Tags column and the Category column sit side by side, so a tag has to
+  // read as one here the same way it does in the detail sheet.
+  it('chips a tag the way every other surface chips one', async () => {
+    const el = await mount([{ id: '1', category: 'Hardware', tags: ['m4', 'metric'] }]);
+    const tags = [...q(el, '[data-testid="cell-tags"]')!.querySelectorAll('.hv-chip')];
+
+    expect(tags.map((t) => t.textContent?.trim())).toEqual(['#m4', '#metric']);
+    expect(tags.every((t) => t.classList.contains('tag'))).toBe(true);
+    // The category cell is plain text in this column, not a chip at all.
+    expect(q(el, '[data-testid="cell-category"]')?.querySelector('.hv-chip')).toBe(null);
+  });
+
+  it('says so when an item carries no tags', async () => {
+    const el = await mount([{ id: '1', tags: [] }]);
+    const cell = q(el, '[data-testid="cell-tags"]')!;
+    expect(cell.textContent?.trim()).toBe('—');
+    expect(cell.querySelector('.hv-tag-mark')).toBe(null);
+  });
+
   it('follows the column selection', async () => {
     const el = await mount([{ id: '1' }], { columns: ['quantity'] });
     expect(q(el, '[data-testid="cell-quantity"]')).toBeTruthy();

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { tokens, base } from '../ui/tokens';
-import { chip } from '../ui/chip';
+import { chip, renderTagChip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue, relativeTime } from '../ui/relative-time';
 import {
@@ -493,7 +493,7 @@ export class HVDataTable extends LitElement {
       }
       case 'tags':
         return html`<span class="tags" role="cell" data-testid="cell-tags">
-          ${item.tags.length ? item.tags.map((t) => html`<span class="hv-chip">${t}</span>`) : html`<span class="cell">—</span>`}
+          ${item.tags.length ? item.tags.map((t) => renderTagChip(t)) : html`<span class="cell">—</span>`}
         </span>`;
       case 'due_date':
         return html`<span

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -95,9 +95,37 @@ describe('hv-detail-sheet: read view', () => {
     expect(q(el, '[data-testid="sheet-out"]')?.textContent).toContain('Checked out · due Jul 31');
     expect(q(el, '[data-testid="sheet-category"]')?.textContent).toContain('Tools');
     expect(all(el, '[data-testid="sheet-tag"]').map((t) => t.textContent?.trim())).toEqual([
-      'electric',
-      'meter',
+      '#electric',
+      '#meter',
     ]);
+  });
+
+  // Same row, same size, same shape: without a marker on the chip itself,
+  // "Tools" and "electric" are one control wearing one fill and only a
+  // household that already knows its own vocabulary can tell which is which.
+  it('tells a category chip from a tag chip without reading either label', async () => {
+    const el = await mount({ category: 'Tools', tags: ['electric'] });
+    const category = q(el, '[data-testid="sheet-category"]')!;
+    const tag = q(el, '[data-testid="sheet-tag"]')!;
+
+    expect(tag.classList.contains('tag')).toBe(true);
+    expect(category.classList.contains('tag')).toBe(false);
+    // The mark carries the distinction in greyscale; the hue is the second signal.
+    expect(tag.querySelector('.hv-tag-mark')?.textContent).toBe('#');
+    expect(category.querySelector('.hv-tag-mark')).toBe(null);
+    // Decoration, not part of the value: a reader is told "electric", not "hash electric".
+    expect(tag.querySelector('.hv-tag-mark')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  // The "Checked out" chip takes the same blue, so the two must not collapse
+  // into one another in the row they share.
+  it('keeps the checked-out chip out of the tag vocabulary', async () => {
+    const el = await mount({ checked_out: true, tags: ['electric'] });
+    const out = q(el, '[data-testid="sheet-out"]')!;
+
+    expect(out.classList.contains('state')).toBe(true);
+    expect(out.classList.contains('tag')).toBe(false);
+    expect(out.querySelector('.hv-tag-mark')).toBe(null);
   });
 
   it('marks an overdue check-out and low stock', async () => {

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
-import { chip } from '../ui/chip';
+import { chip, renderTagChip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue, relativeTime } from '../ui/relative-time';
 import { inferType } from '../ui/item-form';
@@ -653,7 +653,7 @@ export class HVDetailSheet extends LitElement {
               </span>`
             : null}
           ${item.category ? html`<span class="hv-chip" data-testid="sheet-category">${item.category}</span>` : null}
-          ${item.tags.map((t) => html`<span class="hv-chip" data-testid="sheet-tag">${t}</span>`)}
+          ${item.tags.map((t) => renderTagChip(t, 'sheet-tag'))}
         </div>
       </div>
 

--- a/cards/haventory-card/src/components/hv-filter-chips.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.test.ts
@@ -110,8 +110,23 @@ describe('chipsFor', () => {
   it('says which way multiple tags combine', () => {
     const any = { ...defaultFilters(), tags: ['a', 'b'], tagsMode: 'any' as const };
     const all = { ...defaultFilters(), tags: ['a', 'b'], tagsMode: 'all' as const };
-    expect(chipsFor(any)[0].label).toBe('any of: a, b');
-    expect(chipsFor(all)[0].label).toBe('all of: a, b');
+    expect(chipsFor(any)[0].label).toBe('any of: #a, #b');
+    expect(chipsFor(all)[0].label).toBe('all of: #a, #b');
+  });
+
+  // Nothing above this row says which filter a chip clears, so a bare value
+  // could be the category, the location or the search box. Every facet that
+  // would otherwise print one names itself.
+  it('names the facet on a chip that would otherwise be a bare value', () => {
+    const filters = { ...defaultFilters(), category: 'Hardware', tags: ['metric'] };
+    expect(chipsFor(filters).map((c) => c.label)).toEqual(['Category: Hardware', 'any of: #metric']);
+  });
+
+  // The mark is the same one the tag chips wear, so the two surfaces read as
+  // one vocabulary rather than two spellings of it.
+  it('marks a single tag the way a tag chip is marked', () => {
+    const filters = { ...defaultFilters(), tags: ['metric'] };
+    expect(chipsFor(filters)[0].label).toBe('any of: #metric');
   });
 
   it('keeps low-stock-only and low-stock-first as separate chips', () => {

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
-import { chip } from '../ui/chip';
+import { TAG_MARK, chip } from '../ui/chip';
 import { locationPathParts, pathTitle } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { formatDate } from '../ui/relative-time';
@@ -72,9 +72,15 @@ export function chipsFor(
     const area = (ctx.areas ?? []).find((a) => a.id === filters.areaId);
     chips.push({ key: 'areaId', label: `Area: ${area?.name ?? filters.areaId}`, tone: 'primary' });
   }
-  if (filters.category) chips.push({ key: 'category', label: filters.category, tone: 'primary' });
+  // This row has no headings above it, so every chip on it has to name its own
+  // facet: a bare "Hardware" could be a category, a location or the search
+  // text. The facets that read as a bare value say so in words, the way Area
+  // and Status already do; tags carry the same mark they wear as chips, so the
+  // two vocabularies agree.
+  if (filters.category)
+    chips.push({ key: 'category', label: `Category: ${filters.category}`, tone: 'primary' });
   if (filters.tags.length) {
-    const joined = filters.tags.join(', ');
+    const joined = filters.tags.map((t) => `${TAG_MARK}${t}`).join(', ');
     chips.push({
       key: 'tags',
       label: filters.tagsMode === 'all' ? `all of: ${joined}` : `any of: ${joined}`,

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -111,6 +111,37 @@ describe('hv-filter-panel: category', () => {
     expect(all(el, '[data-testid="filter-category"]')).toHaveLength(5);
   });
 
+  // The group headings are the only thing separating the two runs of chips, and
+  // a value used as both a category and a tag appears in each of them.
+  it('tells a category chip from a tag chip without the group heading', async () => {
+    const el = await mount();
+    const category = q(el, '[data-testid="filter-category"]');
+    const tag = q(el, '[data-testid="filter-tag"]');
+
+    expect(tag.classList.contains('tag')).toBe(true);
+    expect(category.classList.contains('tag')).toBe(false);
+    expect(tag.querySelector('.hv-tag-mark')?.textContent).toBe('#');
+    expect(category.querySelector('.hv-tag-mark')).toBe(null);
+    // Pressable chips read as an outline until they are applied, so the mark is
+    // the whole distinction here — the fill says "picked", not "tag".
+    expect(tag.classList.contains('toggle')).toBe(true);
+  });
+
+  // A chip carries both marks once it is applied, and the check has to stay the
+  // leading one: it reports the state, the # only names the facet.
+  it('keeps the applied check ahead of the tag mark', async () => {
+    const el = await mount();
+    el.filters = { ...el.filters, tags: ['metric'] };
+    await el.updateComplete;
+    const tag = q(el, '[data-testid="filter-tag"][data-value="metric"]');
+
+    expect(tag.getAttribute('aria-pressed')).toBe('true');
+    expect(tag.querySelector('svg')).toBeTruthy();
+    expect(tag.textContent?.replace(/\s+/g, ' ').trim()).toBe('#metric 61');
+    const marks = [...tag.querySelectorAll('svg, .hv-tag-mark')].map((n) => n.tagName.toLowerCase());
+    expect(marks[0]).toBe('svg');
+  });
+
   it('is single-select and toggles off when picked again', async () => {
     const el = await mount();
     const seen = changes(el);

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
-import { chip } from '../ui/chip';
+import { chip, tagLabel } from '../ui/chip';
 import { locationPathParts, pathTitle } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
@@ -589,25 +589,25 @@ export class HVFilterPanel extends LitElement {
         <div class="chips">
           ${all.map(
             (t) => html`<button
-              class="hv-chip toggle chip ${selected.has(t.value) ? 'on' : ''}"
+              class="hv-chip toggle tag chip ${selected.has(t.value) ? 'on' : ''}"
               data-testid="filter-tag"
               data-value=${t.value}
               aria-pressed=${String(selected.has(t.value))}
               @click=${() => this._toggleTag(t.value)}
             >
-              ${selected.has(t.value) ? icon('check', 12) : null}${t.value}
+              ${selected.has(t.value) ? icon('check', 12) : null}${tagLabel(t.value)}
               <span class="hv-tally">${t.count}</span>
             </button>`,
           )}
           ${extras.map(
             (t) => html`<button
-              class="hv-chip toggle chip on"
+              class="hv-chip toggle tag chip on"
               data-testid="filter-tag"
               data-value=${t}
               aria-pressed="true"
               @click=${() => this._toggleTag(t)}
             >
-              ${icon('check', 12)}${t}
+              ${icon('check', 12)}${tagLabel(t)}
             </button>`,
           )}
           <label class="field" data-testid="filter-tag-add">

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -759,6 +759,20 @@ describe('hv-organize-dialog: tags and categories', () => {
     expect(el.open).toBe(false);
   });
 
+  // Two tabs of the same shape, so the chip has to say which facet is on
+  // screen — the tab strip is at the top of the dialog, the rows are not.
+  it('chips a tag as a tag and a category as a category', async () => {
+    const tags = await mount({ items, tab: 'tags' });
+    const tagChip = q(tags.sr, '[data-testid="value-row"] .hv-chip')!;
+    expect(tagChip.classList.contains('tag')).toBe(true);
+    expect(tagChip.textContent?.trim()).toBe('#aa');
+
+    const categories = await mount({ items, tab: 'categories' });
+    const categoryChip = q(categories.sr, '[data-testid="value-row"] .hv-chip')!;
+    expect(categoryChip.classList.contains('tag')).toBe(false);
+    expect(categoryChip.textContent?.trim()).toBe('Consumables');
+  });
+
   async function create(el: HVOrganizeDialog, sr: ShadowRoot, name: string) {
     (q(sr, '[data-testid="organize-new-value"]') as HTMLButtonElement).click();
     await settle(el);

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
-import { chip } from '../ui/chip';
+import { chip, tagLabel } from '../ui/chip';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
@@ -1012,6 +1012,18 @@ export class HVOrganizeDialog extends LitElement {
     return this.tab === 'tags' ? 'tag' : 'category';
   }
 
+  /**
+   * One value of whichever facet the open tab manages, chipped the way the rest
+   * of the card chips it: a tag blue and marked, a category neutral.
+   */
+  private _valueChip(value: string, opts: { style?: string; testid?: string } = {}) {
+    const style = opts.style ?? '';
+    const testid = opts.testid ?? '';
+    return this.tab === 'tags'
+      ? html`<span class="hv-chip tag" style=${style} data-testid=${testid}>${tagLabel(value)}</span>`
+      : html`<span class="hv-chip" style=${style} data-testid=${testid}>${value}</span>`;
+  }
+
   /** True while the value exists only on the card, with no item carrying it. */
   private _isDraft(value: string): boolean {
     return this.store?.isDraftValue(this._kind, value) ?? false;
@@ -1546,7 +1558,7 @@ export class HVOrganizeDialog extends LitElement {
 
     return html`<div class="expander" data-testid="value-editor" data-mode=${editing.mode}>
       <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap">
-        <span class="hv-chip" style=${merging ? 'text-decoration: line-through' : ''}>${value}</span>
+        ${this._valueChip(value, { style: merging ? 'text-decoration: line-through' : undefined })}
         <span style="font-size:12.5px;color:var(--hv-text-secondary)">${counted(count, 'item')}</span>
         ${merging ? icon('arrowRight', 18) : null}
         <label style="display:flex;align-items:center;gap:8px;flex:1;min-width:180px">
@@ -2041,7 +2053,7 @@ export class HVOrganizeDialog extends LitElement {
           ? values.map(
               (v) => html`
                 <div class="value-row" data-testid="value-row" data-value=${v.value}>
-                  <span class="hv-chip">${v.value}</span>
+                  ${this._valueChip(v.value)}
                   ${this._isDraft(v.value)
                     ? html`<span class="draft-note" data-testid="value-draft">
                         new · not saved until an item uses it
@@ -2136,9 +2148,10 @@ export class HVOrganizeDialog extends LitElement {
         <button data-testid="sheet-merge" @click=${() => this._startValueEdit(value, 'merge')}>
           ${icon('callMerge', 20)}Merge into…
           ${suggestion
-            ? html`<span class="hv-chip" style="margin-left:auto" data-testid="sheet-merge-suggestion"
-                >${suggestion}</span
-              >`
+            ? this._valueChip(suggestion, {
+                style: 'margin-left:auto',
+                testid: 'sheet-merge-suggestion',
+              })
             : null}
         </button>
         <button

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -109,9 +109,14 @@ describe('ui/chip: the shared fragment', () => {
     expect(ownCss('hv-location-tree')).toMatch(
       /\.area-name \.hv-area-chip, \.area-none \{ font-size: inherit/,
     );
-    // Every other surface takes the shared size untouched.
+    // Every other surface takes the shared size untouched — height and padding
+    // as well as type. Nothing inside an informational chip is a target that a
+    // touch height would grow, so one that sets its own only comes out bigger
+    // than the same value chipped a surface over.
     for (const tag of CHIPPED.filter((t) => t !== 'hv-filter-panel' && t !== 'hv-location-tree')) {
-      expect(ownCss(tag), tag).not.toMatch(/\.(hv-)?chip[^{]*\{[^}]*font-size/);
+      expect(ownCss(tag), tag).not.toMatch(
+        /\.(hv-)?chip(?![\w-])[^{]*\{[^}]*(font-size|min-height|padding:)/,
+      );
     }
   });
 

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -58,9 +58,13 @@ describe('ui/chip: the shared fragment', () => {
     expect(String(tokens.cssText)).toMatch(/--hv-chip-padding: /);
   });
 
-  it('carries the four fills the card marks things with, and a pressable variant', () => {
+  it('carries the five fills the card marks things with, and a pressable variant', () => {
     const css = String(chip.cssText).replace(/\s+/g, ' ');
     expect(css).toMatch(/\.hv-chip\.state \{[^}]*var\(--hv-primary-tint\)/);
+    // A tag takes the same blue as a state, and the # is what tells them apart
+    // — held off the pressable variant, where a pre-filled group of tags would
+    // read as already applied.
+    expect(css).toMatch(/\.hv-chip\.tag:not\(\.toggle\) \{[^}]*var\(--hv-primary-tint\)/);
     expect(css).toMatch(/\.hv-chip\.warning \{[^}]*var\(--hv-warn-bg\)/);
     expect(css).toMatch(/\.hv-chip\.error \{[^}]*var\(--hv-error-bg\)/);
     // No fill of its own, so its label is read against the page — which is why
@@ -76,7 +80,11 @@ describe('ui/chip: the shared fragment', () => {
   // for it; tone-contrast.test.ts checks the ratio the token resolves to.
   it('inks every tint-backed fill with the ink minted for that tint', () => {
     const css = String(chip.cssText).replace(/\s+/g, ' ');
-    for (const selector of ['\\.hv-chip\\.state', '\\.hv-chip\\.toggle\\.on']) {
+    for (const selector of [
+      '\\.hv-chip\\.state',
+      '\\.hv-chip\\.tag:not\\(\\.toggle\\)',
+      '\\.hv-chip\\.toggle\\.on',
+    ]) {
       expect(css, selector).toMatch(
         new RegExp(`${selector} \\{[^}]*background: var\\(--hv-primary-tint\\)[^}]*color: var\\(--hv-on-primary-tint\\)`),
       );
@@ -137,7 +145,7 @@ describe('ui/chip: the shared fragment', () => {
   it('shares the metrics with the area chip without folding it in', () => {
     const css = String(chip.cssText).replace(/\s+/g, ' ');
     expect(css).toMatch(/\.hv-chip, \.hv-area-chip, \.hv-status-chip \{/);
-    expect(css).not.toMatch(/\.hv-area-chip\.(state|warning|error)/);
+    expect(css).not.toMatch(/\.hv-area-chip\.(state|tag|warning|error)/);
   });
 
   // A status carries a colour the household picked, so it must not reach for the
@@ -145,7 +153,7 @@ describe('ui/chip: the shared fragment', () => {
   // "Low stock" would read as two points on one scale.
   it('keeps the status chip out of the semantic hue vocabulary', () => {
     const css = String(chip.cssText).replace(/\s+/g, ' ');
-    expect(css).not.toMatch(/\.hv-status-chip\.(state|warning|error|quiet)/);
+    expect(css).not.toMatch(/\.hv-status-chip\.(state|tag|warning|error|quiet)/);
     for (const hue of ['neutral', 'green', 'blue', 'amber', 'red']) {
       expect(css, hue).toMatch(new RegExp(`\\.hv-status-chip\\.tone-${hue} \\{`));
       expect(css, hue).toMatch(new RegExp(`\\.hv-status-chip\\.tone-${hue}-strong \\{`));

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -1,4 +1,5 @@
-import { css } from 'lit';
+import { css, html, type TemplateResult } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 /**
  * The card's chip vocabulary: the small pill that reports one fact beside the
@@ -15,7 +16,8 @@ import { css } from 'lit';
  * - `.hv-pill` in `tokens` is an action — a button shaped like a pill. A chip
  *   reports; a pill does something.
  * - `hv-chip-input`'s tokens are editable input values with a remove
- *   affordance. They take these metrics and own their own interaction.
+ *   affordance. They are tag chips like any other and take these metrics
+ *   unchanged; only the remove button is theirs.
  * - `.hv-area-chip` marks the HA area beside a location path. It shares the
  *   metrics so it sits level with the chips around it, and keeps its own glyph
  *   and spelled-out label, because an area is not one of the facts above.
@@ -74,11 +76,16 @@ export const chip = css`
     background: var(--hv-hover-overlay);
   }
 
-  /* What the hue means is fixed card-wide: blue for a state the item is in,
-     amber for a chore on something still on the shelf (low stock, an inspection
-     that has come due), red for an item that is out and late back. Keeping
-     amber and red apart is what lets both sit in one row without reading as a
-     single alarm.
+  /* What the hue means is fixed card-wide: blue for something the item itself
+     carries — the state it is in, the tags on it — amber for a chore on
+     something still on the shelf (low stock, an inspection that has come due),
+     red for an item that is out and late back. Keeping amber and red apart is
+     what lets both sit in one row without reading as a single alarm.
+
+     Blue covers two of those, so the fill is not what tells them apart: a tag
+     carries a leading # and a state chip carries none. Category is the third
+     thing that shares those rows and takes no hue at all, which is what a
+     neutral chip means here — a value with nothing to report about it.
 
      .hv-status-chip at the foot of this file is the one exception, taking its
      colour from the status definition instead. That is why it is a separate
@@ -88,6 +95,24 @@ export const chip = css`
     background: var(--hv-primary-tint);
     color: var(--hv-on-primary-tint);
     border-color: transparent;
+  }
+  /* A tag reads the same on every surface that prints one. Held off the
+     pressable variant because the filter panel offers tags as choices rather
+     than reporting them, and a group of them pre-filled blue would read as
+     already applied — there the # is the whole distinction from the category
+     chips beside it. */
+  .hv-chip.tag:not(.toggle) {
+    background: var(--hv-primary-tint);
+    color: var(--hv-on-primary-tint);
+    border-color: transparent;
+  }
+  /* The mark that names the facet without colour, so the distinction survives
+     greyscale and a colourblind reader. Pulled back over the chip's own 4px
+     gap: it belongs to the word, not beside it. Hidden from the accessible
+     name, where it would be read out as part of the tag. */
+  .hv-tag-mark {
+    margin-inline-end: -4px;
+    opacity: 0.65;
   }
   .hv-chip.warning {
     background: var(--hv-warn-bg);
@@ -245,3 +270,26 @@ export const chip = css`
     min-width: 0;
   }
 `;
+
+/**
+ * The glyph a tag is written with, here and in the applied-filters row, where
+ * a chip's label is a plain string and cannot carry the element below.
+ */
+export const TAG_MARK = '#';
+
+/**
+ * A tag's name with its mark, for a chip that carries more than the name —
+ * the editor's removable token, the filter panel's pressable chip.
+ */
+export function tagLabel(value: string): TemplateResult {
+  return html`<span class="hv-tag-mark" aria-hidden="true">${TAG_MARK}</span>${value}`;
+}
+
+/**
+ * A tag, reported. Every surface that prints one calls this, so a tag cannot
+ * come out grey on one of them and blue on the next — the same reason
+ * `renderAreaChip` and `renderStatusChip` exist.
+ */
+export function renderTagChip(value: string, testid?: string): TemplateResult {
+  return html`<span class="hv-chip tag" data-testid=${ifDefined(testid)}>${tagLabel(value)}</span>`;
+}

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -107,12 +107,11 @@ export const chip = css`
     border-color: transparent;
   }
   /* The mark that names the facet without colour, so the distinction survives
-     greyscale and a colourblind reader. Pulled back over the chip's own 4px
-     gap: it belongs to the word, not beside it. Hidden from the accessible
-     name, where it would be read out as part of the tag. */
+     greyscale and a colourblind reader. A shade back, because the value is
+     what is being read; not far enough back to stop carrying the distinction
+     on its own. */
   .hv-tag-mark {
-    margin-inline-end: -4px;
-    opacity: 0.65;
+    opacity: 0.75;
   }
   .hv-chip.warning {
     background: var(--hv-warn-bg);
@@ -280,9 +279,14 @@ export const TAG_MARK = '#';
 /**
  * A tag's name with its mark, for a chip that carries more than the name —
  * the editor's removable token, the filter panel's pressable chip.
+ *
+ * The two sit in one inline box because a chip is a flex row with a gap
+ * between its items, and the gap differs by surface: as separate items they
+ * would read "# spare" here and "#  spare" in the filter panel. The mark is
+ * out of the accessible name, where it would be read as part of the tag.
  */
 export function tagLabel(value: string): TemplateResult {
-  return html`<span class="hv-tag-mark" aria-hidden="true">${TAG_MARK}</span>${value}`;
+  return html`<span><span class="hv-tag-mark" aria-hidden="true">${TAG_MARK}</span>${value}</span>`;
 }
 
 /**


### PR DESCRIPTION
## Summary

One chip vocabulary, in one PR, so the surfaces cannot drift apart again halfway through the
series. Three commits, one per issue.

**Blue means "something the item carries"** — the state it is in, the tags on it. Amber and red
keep their meanings. A category takes no hue at all, which is what a neutral chip means here: a
value with nothing to report about it.

**A tag also carries a leading `#`**, because hue on its own does not reach a colourblind reader
and the filter panel's pressable chips have no hue to read. The mark is `aria-hidden` — the value
is the name, and "hash spare" is not it.

| Issue | What changes |
|---|---|
| **#361** | `ui/chip.ts` gains `.hv-chip.tag`, `.hv-tag-mark` and `renderTagChip` / `tagLabel`, so a surface cannot draw a tag its own way — the same reason `renderAreaChip` and `renderStatusChip` exist. The detail sheet, the table's Tags column, the editor's tokens and the organize dialog's value rows all go through it. The hue comment is rewritten to say what the fills now mean. |
| **#360** | `hv-chip-input` stops overriding the shared chip metrics: `padding: 3px 9px`, `gap: 3px` and `min-height: var(--hv-tap-min)` are gone, so an editor token is the pill the rest of the card draws. |
| **#364** | Tag chips in the filter panel carry the mark; the applied-filters row names the category ("Category: Hardware", the way Area and Status already do) and marks each tag value. |

Three decisions worth naming:

- **The touch height on the editor's tag pill is dropped, not moved behind a phone check.** The
  pill is not a target — only the remove button inside it is, and that button's hit area is set by
  `.chip-remove::after` at 24px and deliberately capped there so a target in a wrapped row cannot
  reach into the chip beside it. Growing the pill never grew the button by a pixel. The field still
  reaches a full tap height on a phone, from the input beside the chips (measured below).
- **A pressable tag chip keeps the outline.** `.hv-chip.tag` is held off `.toggle`, because a
  filter group pre-filled blue reads as already applied. There the `#` is the whole distinction
  from the category chips, and it is the one that survives greyscale.
- **The mark sits in one inline box with the value**, not as a sibling flex item: the chip's gap is
  4px in the detail sheet and 5px in the filter panel, and it must not open between the `#` and the
  word.

`hv-full-view.ts` is deliberately untouched — the sidebar's facet rows are rows under standing
headings, not chips, and that file belongs to the #363 PR in this series.

Backend untouched; nothing inside `custom_components/haventory/` is deleted or renamed, so no
`RETIRED_PATHS` entry is needed.

Closes #361
Closes #360
Closes #364

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

Both gates green on this branch, run before each of the three commits.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 752 passed, 22 skipped ·
      `uv run ruff check .` → All checks passed · `uv run ruff format --check .` → 115 files already
      formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean ·
      `npx vitest run` → **1662 passed / 59 files** · `npm run build` → 580 kB bundle

New tests, all of them over rendered markup rather than `cssText` (#353 is open to delete the
regex-over-stylesheet tests that already exist; this PR adds none):

- `hv-detail-sheet`: a category chip and a tag chip are told apart without reading either label —
  the tag carries `.tag` and an `aria-hidden` `.hv-tag-mark`, the category carries neither; and the
  "Checked out" chip, which takes the same blue, carries `.state` and no mark.
- `hv-data-table`: the Tags column chips carry the mark and the class; an item with no tags renders
  the em dash and no mark.
- `hv-chip-input`: a token's class list is exactly `hv-chip tag chip`, the remove button is still
  named `Remove battery`, and a value that already starts with `#` is marked once, not twice.
- `hv-filter-panel`: a category chip and a tag chip differ in the DOM while both keep the pressable
  outline; an applied tag draws the check *ahead* of the mark and reads `#metric 61`.
- `hv-filter-chips`: `chipsFor` labels — `Category: Hardware`, `any of: #metric`, `all of: #a, #b`.
- `hv-organize-dialog`: the value chip is a tag chip on the Tags tab and a plain one on Categories.

Two existing tests in `ui/chip.test.ts` are extended rather than added to: the fill inventory now
covers `.hv-chip.tag:not(.toggle)`, and the "no component restates the chip metrics" guard now
rejects `min-height` and `padding` as well as `font-size` — which is the regression test for #360
(it fails on `main`).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — none needed; no user-facing behaviour or API changed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

Verified against the Docker dev HA (1075 items, 79 locations) in a real browser — jsdom computes
no layout, so every number below is `getBoundingClientRect` / `getComputedStyle` from the running
card. PNGs are in the gitignored `.claude/skills/run-haventory/` (`before-pr1-*.png`,
`after-pr1-*.png`, and a full 42-surface `visual_pass.mjs` sweep in `after-pr1/`).

**#361 — detail sheet, card in a dashboard column (500px card, 1440px window)**

| chip | before | after |
|---|---|---|
| category "Hardware" | 22.1px, fill `rgb(231,231,231)` | 22.1px, fill `rgb(231,231,231)` |
| tag "spare" | 22.1px, fill `rgb(231,231,231)` — *the same chip* | 22.1px, fill `rgb(227,244,253)`, label `#spare` |

`rgb(227,244,253)` is `--hv-primary-tint`. The "Checked out" chip in the same row keeps that fill
without a mark, so the two stay apart.

**#360 — editor tag token, same card, mobile layout (`--hv-tap-min` resolves to 44px)**

| | before | after |
|---|---|---|
| tag token height | **44.0px** (`min-height: 44px`, padding-left 9px) | **22.1px** (padding-left 8px) |
| detail-sheet tag chip beside it | 22.1px | 22.1px — now identical |
| remove button | 14×14 with `::after` inset −5px → **24px** hit area | 14×14, `::after` inset −5px → **24px**, unchanged |
| tags field height | 62px | 62px — the input still carries the tap height |

Same numbers at a 390×844 touch viewport: token 22.1px, remove hit area 24px, field 62px.

**#364 — filter panel and applied-filters row, wide view at 1440px**

Applied one category and one tag:

| | before | after |
|---|---|---|
| category chip | `Automotive` | `Category: Automotive` |
| tags chip | `any of: spare` | `any of: #spare` |
| panel category chips | `Appliances 1` | `Appliances 1` — unchanged |
| panel tag chips | `spare 98` | `#spare 98` |
| applied tag chip in panel | `✓ spare 98` | `✓ #spare 98` — check still leads |

Both panel groups keep the 29.5px outline chip; nothing in the panel changed size.

**#362 is untouched.** The card shell's quick-filter badges keep their 44px touch height —
`:host([mobile]) .badge` is not in this diff, and the badges measure 44px in the after sweep.

`visual_pass.mjs` after the change: 42/42 surfaces captured, no console errors, at desktop and
phone widths on the card and on `/haventory`.

## Follow-ups

- The full view's sidebar prints category and tag values as rows rather than chips, so they take no
  mark here. They sit under standing group headings, which chips in a row do not — but the two
  vocabularies could still converge. Not filed: it clears no real-world bar on its own.
- `hv-filter-panel` is the one surface still allowed to restate chip metrics (12.5px/5px 12px, and a
  touch height on a phone), because its chips read at the size of the selects and date fields beside
  them. The guard test carves it out by name.
