### PR TITLE
fix(card): the editor's check-out box lines up and matches Next inspection

### DIFF
--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -228,7 +228,7 @@ describe('hv-item-editor: field parity', () => {
   // `title` explaining it never reaches a phone.
   it('greys the due date out, and says why, while the item is not checked out', async () => {
     const el = await mount(makeItem({ id: '1', checked_out: false }));
-    expect(q(el, '[data-testid="editor-due-date"]')?.closest('.cell')?.classList).toContain('muted');
+    expect(q(el, '.due-label')?.classList).toContain('muted');
     expect(q(el, '[data-testid="editor-due-hint"]')?.textContent?.trim()).toBe(
       'A due date applies while the item is checked out.',
     );
@@ -237,7 +237,7 @@ describe('hv-item-editor: field parity', () => {
     );
 
     await checkOut(el);
-    expect(q(el, '[data-testid="editor-due-date"]')?.closest('.cell')?.classList).not.toContain('muted');
+    expect(q(el, '.due-label')?.classList).not.toContain('muted');
     expect(q(el, '[data-testid="editor-due-hint"]')).toBe(null);
 
     const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
@@ -362,6 +362,47 @@ describe('hv-item-editor: field parity', () => {
     expect(css).toMatch(/\.checkout-body \{[^}]*grid-template-columns: 1fr 1fr/);
     expect(css).toMatch(/:host\(\[mobile\]\) \.checkout-body \{[^}]*grid-template-columns: 1fr;/);
     expect(css).toMatch(/:host\(\[mobile\]\) \.state \{[^}]*grid-template-columns: 1fr;/);
+    // Stacked, the button leads and the label stays with its own field.
+    expect(css).toMatch(
+      /:host\(\[mobile\]\) \.checkout-body \{[^}]*grid-template-areas: 'action' 'label' 'field' 'hint'/,
+    );
+  });
+
+  /*
+   * The check-out box holds two controls side by side and one of them has no
+   * label, which is what put them on different lines: packed to the top of
+   * their own cells, the button landed level with the *label* opposite it and
+   * the date input a label's height lower, with dead air under the button.
+   *
+   * jsdom lays out nothing, so what can be pinned here is the structure the
+   * alignment rests on — one grid, four children, named rows — rather than the
+   * two edges lining up. The measurement is in the PR body.
+   */
+  it('puts the button and the due date in one grid rather than two stacks', async () => {
+    const el = await mount(makeItem({ id: '1', checked_out: false }));
+    const body = q(el, '.checkout-body') as HTMLElement;
+    const children = [...body.children].map((c) => c.className.split(' ').filter(Boolean));
+
+    expect(children).toEqual([
+      ['field-button', 'checkout-action'],
+      ['hv-label', 'due-label', 'muted'],
+      ['hv-input', 'due-input'],
+      ['group-hint'],
+    ]);
+    // No per-half wrapper left to pack its own contents to the top.
+    expect(body.querySelector('.cell')).toBe(null);
+  });
+
+  // Checked out, the note goes and the grid is three children — the hint area
+  // collapses rather than leaving a row behind.
+  it('drops the note once the item is checked out', async () => {
+    const el = await mount(makeItem({ id: '1', checked_out: true, due_date: '2099-01-01' }));
+    const body = q(el, '.checkout-body') as HTMLElement;
+    expect([...body.children].map((c) => c.getAttribute('data-testid'))).toEqual([
+      'editor-checked-out',
+      null,
+      'editor-due-date',
+    ]);
   });
 });
 

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -204,7 +204,8 @@ export class HVItemEditor extends LitElement {
          textarea — and its two auto rows split the difference between them.
          That is why the status select came out taller than an input and shorter
          than the textarea beside it: exactly the midpoint. The same hazard is
-         guarded one level down on the state row; this closes it at the top. */
+         guarded inside the boxes on the state row, which are stretched on
+         purpose; this closes it at the top. */
       .cell {
         display: grid;
         align-content: start;
@@ -213,7 +214,12 @@ export class HVItemEditor extends LitElement {
       }
       /* Checked out and Due date are two halves of one fact; Next inspection is
          unrelated to both. The boxes below carry that split visually, so the
-         three fields are never read as three peer settings of the same kind. */
+         three fields are never read as three peer settings of the same kind.
+
+         Both boxes take the height of the taller one. Left to size themselves
+         they never agreed — one carries a note, the other three offset chips —
+         and a row of two boxes of different heights reads as four stacked
+         pieces rather than two. */
       .state {
         display: grid;
         /* Even halves. At 2fr/1fr the inspection box was narrow enough that its
@@ -221,13 +227,18 @@ export class HVItemEditor extends LitElement {
            with room to spare. */
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         gap: 12px;
-        align-items: start;
       }
       :host([mobile]) .state {
         grid-template-columns: 1fr;
       }
+      /* Packed to the top, because the row above stretches these boxes to the
+         taller of the two: auto rows in a stretched grid share the surplus out
+         between the caption and the controls instead of leaving it below them,
+         which would make the date field in the shorter box taller than the one
+         beside it. */
       .group {
         display: grid;
+        align-content: start;
         gap: 9px;
         min-width: 0;
         border: 1px solid var(--hv-divider);
@@ -251,13 +262,45 @@ export class HVItemEditor extends LitElement {
         gap: 12px;
         min-width: 0;
       }
-      /* Not bottom-aligned: the button carries no label, so lining its bottom
-         edge up with the dated field beside it put the dead air above it,
-         between the box's caption and its first control. The cell's own
-         align-content: start now lands it directly under the caption, level
-         with the label opposite, and the surplus falls below both. */
+      /* Shut, the popover renders nothing but still takes a row of the box and
+         the gap above it — nine invisible pixels that decided how tall the row
+         beside it had to stretch. */
+      hv-checkout-popover:not([open]) {
+        display: none;
+      }
+      /*
+       * The button and the due date share a row by construction, not by
+       * matching heights: three named rows, and column 1 of the label row is
+       * simply empty because the button carries no label of its own. Aligning
+       * the two halves by hand instead only moved the dead air — top-aligned
+       * put the button level with the *label* opposite it, bottom-aligned put
+       * the gap between the caption and the first control.
+       *
+       * The note spans the box: it says what state both controls are in, not
+       * just the field above it.
+       */
       .checkout-body {
         grid-template-columns: 1fr 1fr;
+        grid-template-areas:
+          '. label'
+          'action field'
+          'hint hint';
+        gap: 4px 12px;
+      }
+      .checkout-action {
+        grid-area: action;
+      }
+      .due-label {
+        grid-area: label;
+      }
+      .due-input {
+        grid-area: field;
+      }
+      .checkout-body .group-hint {
+        grid-area: hint;
+      }
+      .hv-label.muted {
+        color: var(--hv-text-tertiary);
       }
       /* Checking out is something you do, not a setting you hold — the same
          button the detail sheet has offered all along, in the same words. */
@@ -333,9 +376,22 @@ export class HVItemEditor extends LitElement {
         font-size: var(--hv-input-font, 14.5px);
       }
       /* A native date input clips its own placeholder much below ~140px, and
-         half of a 375px screen minus the box padding is under that. */
+         half of a 375px screen minus the box padding is under that. Stacked,
+         the alignment question above does not arise: the areas are re-mapped
+         rather than dropped, so the order is written down here too. */
       :host([mobile]) .checkout-body {
         grid-template-columns: 1fr;
+        grid-template-areas:
+          'action'
+          'label'
+          'field'
+          'hint';
+      }
+      /* The row gap is the one between a label and its own control. Stacked,
+         the button is not a caption for the field below it, so it keeps the
+         distance the two halves have side by side. */
+      :host([mobile]) .checkout-action {
+        margin-bottom: 8px;
       }
       label.hv-label {
         display: block;
@@ -365,9 +421,6 @@ export class HVItemEditor extends LitElement {
         color: var(--hv-text-tertiary);
         -webkit-text-fill-color: var(--hv-text-tertiary);
         cursor: not-allowed;
-      }
-      .cell.muted .hv-label {
-        color: var(--hv-text-tertiary);
       }
       textarea.hv-input {
         min-height: 44px;
@@ -1664,32 +1717,30 @@ export class HVItemEditor extends LitElement {
             ${icon('account', 14)} Check out
           </span>
           <div class="group-body checkout-body">
-            <div class="cell">
-              <button
-                class="field-button checkout-action"
-                data-testid="editor-checked-out"
-                @click=${this._onCheckoutPressed}
-              >
-                ${icon(model.checkedOut ? 'check' : 'account', 16)}
-                <span>${model.checkedOut ? 'Check in' : 'Check out…'}</span>
-              </button>
-            </div>
-            <div class="cell ${model.checkedOut ? '' : 'muted'}">
-              <label class="hv-label" for="editor-due">Due date</label>
-              <input
-                id="editor-due"
-                class="hv-input"
-                type="date"
-                data-testid="editor-due-date"
-                ?disabled=${!model.checkedOut}
-                title=${model.checkedOut ? '' : DUE_DATE_HINT}
-                .value=${model.dueDate}
-                @input=${(e: Event) => this._patch({ dueDate: (e.target as HTMLInputElement).value })}
-              />
-              ${model.checkedOut
-                ? null
-                : html`<span class="group-hint" data-testid="editor-due-hint">${DUE_DATE_HINT}</span>`}
-            </div>
+            <button
+              class="field-button checkout-action"
+              data-testid="editor-checked-out"
+              @click=${this._onCheckoutPressed}
+            >
+              ${icon(model.checkedOut ? 'check' : 'account', 16)}
+              <span>${model.checkedOut ? 'Check in' : 'Check out…'}</span>
+            </button>
+            <label class="hv-label due-label ${model.checkedOut ? '' : 'muted'}" for="editor-due">
+              Due date
+            </label>
+            <input
+              id="editor-due"
+              class="hv-input due-input"
+              type="date"
+              data-testid="editor-due-date"
+              ?disabled=${!model.checkedOut}
+              title=${model.checkedOut ? '' : DUE_DATE_HINT}
+              .value=${model.dueDate}
+              @input=${(e: Event) => this._patch({ dueDate: (e.target as HTMLInputElement).value })}
+            />
+            ${model.checkedOut
+              ? null
+              : html`<span class="group-hint" data-testid="editor-due-hint">${DUE_DATE_HINT}</span>`}
           </div>
           <hv-checkout-popover
             data-testid="editor-checkout"


### PR DESCRIPTION
## Summary

The item editor's "Check out" box holds two controls side by side and one of them carries no
label. Each half was a `.cell` packed to the top of itself, so the button landed level with the
*label* opposite it and the date input a label's height plus the cell gap lower — with dead air
under the button. The box also came out a different height from "Next inspection" beside it, so
the pair read as four stacked pieces rather than two boxes.

**The two controls now share a row of one grid** rather than being two stacks aligned by hand:
`.checkout-body` is three named rows —

```
'.      label'
'action field'
'hint   hint'
```

— and column 1 of the label row is simply empty, because the button has no label. Nothing has to
match a height for the two edges to line up. The comment that recorded the old choice (bottom-
aligning put the gap *above* the button instead) is replaced by one describing this.

**The two boxes take the height of the taller one.** `.state` drops `align-items: start`. Two
things follow, both of them in the diff:

- `.group` packs its contents to the top. Auto rows in a stretched grid share the surplus out
  between the caption and the controls, which would have made the date field in the shorter box
  taller than the one beside it.
- A closed `hv-checkout-popover` stops taking a row of its box. It renders nothing but is
  `display: block`, so it was contributing a grid row plus the 9px gap above it — nine invisible
  pixels that decided how far the box beside it had to stretch.

The note under the field spans the box now. It says what state both controls are in, not just the
field above it, and one line across the box instead of two lines under half of it is what keeps
the box the size it is.

**The phone layout is unchanged.** The areas are re-mapped rather than dropped, so the single
column is written down in the stylesheet too, and a native date input still gets the full width it
needs to render its own placeholder. The one number that had to be restored by hand is the 12px
between the button and the label under it — the grid's row gap is the label-to-its-own-control
gap, and stacked, the button is not a caption for the field below it.

Backend untouched; nothing inside `custom_components/haventory/` is deleted or renamed, so no
`RETIRED_PATHS` entry is needed.

Closes #359

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

Both gates green on this branch.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 752 passed, 22 skipped ·
      `uv run ruff check .` → All checks passed · `uv run ruff format --check .` → 115 files already
      formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean ·
      `npx vitest run` → **1653 passed / 59 files** · `npm run build` → 580 kB bundle

Tests:

- New: the check-out box is one grid with four children in a fixed order — button, label, input,
  note — and no `.cell` wrapper left to pack its own contents to the top. That is the structure the
  alignment rests on; jsdom lays out nothing, so the two edges lining up is measured below instead.
- New (edge): checked out, the note goes and the box is three children — the hint area collapses
  rather than leaving a row behind.
- Updated: the "greys the due date out" test now reads `muted` off the label itself. The class used
  to sit on the `.cell` wrapper that no longer exists, and it only ever styled the label.
- Extended: the existing phone-layout pin also checks the stacked area order
  (`'action' 'label' 'field' 'hint'`) — same test, same subject, one more line. No new
  regex-over-stylesheet test was added (#353).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — none needed; layout only.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

Measured in the Docker dev HA in a real browser — jsdom computes no layout, so these are
`getBoundingClientRect` values from the running editor. PNGs are in the gitignored
`.claude/skills/run-haventory/` (`before-pr2-editor.png`, `after-pr2-editor.png`,
`after-pr2-popover.png`, `after-pr2-390.png`, plus a 42-surface `visual_pass.mjs` sweep in
`after-pr2/`).

**Desktop, wide view at 1440px — new item, not checked out**

| | before | after |
|---|---|---|
| "Check out…" button | y 657.5 → 693.5 (h 36) | y 681.5 → 719.5 (h 38) |
| Due date input | y 681.5 → 719.5 (h 38) | y 681.5 → 719.5 (h 38) |
| shared edges? | no — 24px apart at the top, 26px at the bottom | **yes — same top, same bottom** |
| "Due date" label | y 657.5 (h 20) | y 657.5 (h 20) — unmoved |
| Check out box | 142.8px | **133.8px** |
| Next inspection box | 131.0px | **133.8px** |
| the two boxes | 11.8px apart | **equal** |

Opening the popover from the button still anchors under it and still writes the date back into the
field (`after-pr2-popover.png`).

**Phone, 390×844 touch — same box, single column**

| gap | before | after |
|---|---|---|
| button → "Due date" label | 12px | **12px** |
| label → input | 4px | **4px** |
| input → note | 4px | **4px** |

Controls keep their 48px phone height and the 16px input font. The two boxes stack and size
themselves independently, as they did.

`visual_pass.mjs` after the change: 42/42 surfaces captured, no console errors — desktop and phone
widths on the card, and both widths on `/haventory`.

## Follow-ups

None from this change. The `hv-checkout-popover:not([open])` rule is written on the editor's side
rather than in the popover, because the popover's own `:host { display: block }` is correct for
every other host it has; if a third host grows the same phantom row, that is the point to move it
into the component.
