### PR TITLE
fix(card): the expanded view stops taking the card's touch sizing; sidebar rows match

### DIFF
--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -174,6 +174,14 @@ describe('hv-full-view: phone-width app bar', () => {
     // context bar are on this surface too and need the same sizing.
     expect(narrow()).toMatch(/\.shell \{[^}]*--hv-tap-min: 44px/);
     expect(narrow()).toMatch(/\.shell \{[^}]*--hv-input-font: 16px/);
+    // And outside the query, where the card's own idea of narrow used to reach
+    // in: an overlay renders inside hv-card-shell's tree, which declares both
+    // of these for a card measured at 600px or under — an ordinary dashboard
+    // column on a desktop. The guaranteed-invalid value rather than a number,
+    // so each consumer keeps the size it was written with.
+    const shell = /\.shell \{([^}]*)\}/.exec(fullCss())?.[1] ?? '';
+    expect(shell).toMatch(/--hv-tap-min: initial/);
+    expect(shell).toMatch(/--hv-input-font: initial/);
   });
 
   // Selection mode reuses the same bar. `.subcount` was the only shrinkable

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -572,6 +572,31 @@ describe('hv-full-view: sidebar facets', () => {
   const rows = (sr: ShadowRoot, section: string) =>
     [...sr.querySelectorAll(`[data-testid="sidebar-${section}-row"]`)] as HTMLElement[];
 
+  // A facet row and a location row are the same control in two shadow roots,
+  // one list under the other in the same column, and they had drifted apart on
+  // both height and label inset. The row that carries the shared class is what
+  // makes them one; the slot is what holds the inset, so it is reserved on a
+  // row with nothing to put in it rather than left out.
+  it('draws a facet row as the shared browse row, slot and all', async () => {
+    const { el, sr } = await mount({ items: faceted, locations: [loc('garage', 'Garage')] });
+    const all = [...rows(sr, 'categories'), ...rows(sr, 'tags')];
+
+    for (const row of all) {
+      expect(row.classList, row.dataset.value).toContain('hv-browse-row');
+      const lead = row.querySelector('.hv-browse-row-lead');
+      expect(lead, row.dataset.value).toBeTruthy();
+      expect(lead?.classList.contains('placeholder'), row.dataset.value).toBe(true);
+      expect(row.querySelector('.hv-browse-row-label')?.textContent).toBe(row.dataset.value);
+    }
+
+    rows(sr, 'categories').find((r) => r.dataset.value === 'Tools')?.click();
+    await settle(el);
+    const picked = rows(sr, 'categories').find((r) => r.dataset.value === 'Tools')!;
+    // Picked, the same slot holds the check — the label does not move sideways.
+    expect(picked.querySelector('.hv-browse-row-lead')?.classList.contains('placeholder')).toBe(false);
+    expect(picked.querySelector('.hv-browse-row-lead svg')).toBeTruthy();
+  });
+
   it('lists categories and tags with their counts, locations still first', async () => {
     const { sr } = await mount({ items: faceted, locations: [loc('garage', 'Garage')] });
 
@@ -603,7 +628,9 @@ describe('hv-full-view: sidebar facets', () => {
     rows(sr, 'categories').find((r) => r.dataset.value === 'Tools')?.click();
     await settle(el);
     expect(store.state.value.filters.category).toBe('Tools');
-    expect(rows(sr, 'categories').find((r) => r.dataset.value === 'Tools')?.classList).toContain('on');
+    expect(rows(sr, 'categories').find((r) => r.dataset.value === 'Tools')?.classList).toContain(
+      'selected',
+    );
 
     rows(sr, 'categories').find((r) => r.dataset.value === 'Tools')?.click();
     await settle(el);
@@ -821,7 +848,7 @@ describe('hv-full-view: sidebar status', () => {
     missing()?.click();
     await settle(el);
     expect(store.state.value.filters.status).toBe('missing');
-    expect(missing()?.classList).toContain('on');
+    expect(missing()?.classList).toContain('selected');
 
     missing()?.click();
     await settle(el);
@@ -839,9 +866,11 @@ describe('hv-full-view: sidebar status', () => {
     await settle(el);
 
     expect(store.state.value.filters.status).toBe('needs_repair');
-    expect(rows(sr).filter((r) => r.classList.contains('on')).map((r) => r.dataset.value)).toEqual([
-      'needs_repair',
-    ]);
+    expect(
+      rows(sr)
+        .filter((r) => r.classList.contains('selected'))
+        .map((r) => r.dataset.value),
+    ).toEqual(['needs_repair']);
   });
 
   // A backend too old to send the map still prices the two flagged built-ins in

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -95,6 +95,24 @@ export class HVFullView extends LitElement {
         grid-template-rows: auto 1fr;
         background: var(--hv-surface);
         color: var(--hv-text);
+        /*
+         * This surface covers the viewport, so how wide the card that opened it
+         * happens to be says nothing about it. As an overlay it renders inside
+         * the card's shadow tree, and hv-card-shell declares both of these on
+         * :host([mobile]) — a card measured at 600px or under, which an
+         * ordinary dashboard column is on a desktop. Every field and every
+         * pressable row in here took phone sizing from that.
+         *
+         * Set to the guaranteed-invalid value rather than to a number: each
+         * consumer then falls back to the size it was written with — 36px for
+         * an app-bar button, 34px for the tally slot, 13.5px for the search
+         * box — instead of one value flattening all of them. The media query
+         * below raises both to touch sizing on a narrow *viewport*, which is
+         * the only signal that means anything here, and it does so in the
+         * panel and in the overlay alike.
+         */
+        --hv-tap-min: initial;
+        --hv-input-font: initial;
         /* The app bar does not compress below 778px — close, the title, the
            search box's own minimum, three count pills, Add item and the ⋮ —
            and the grid column takes that minimum whatever the screen is. On a
@@ -314,10 +332,10 @@ export class HVFullView extends LitElement {
            with no horizontal scroll, which put Add item (532..636), the badges
            and the ⋮ (648..682) permanently off-screen — you could not add an
            item or open the menu at all. */
-        /* This surface fills the screen even when the card that opened it is
-           narrow, so it sets its own touch sizing rather than inheriting the
-           card's. Declared on the shell so the table, its sort headers and the
-           context bar are covered too, not just the app bar. */
+        /* Touch sizing on a narrow viewport, which is the one measurement that
+           describes this surface — the base rule above holds the card's own
+           idea of narrow off it. Declared on the shell so the table, its sort
+           headers and the context bar are covered too, not just the app bar. */
         .shell {
           --hv-tap-min: 44px;
           --hv-input-font: 16px;

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
+import { browseRow } from '../ui/browse-row';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import { counted, plural, showingCount } from '../ui/plural';
@@ -78,6 +79,7 @@ export class HVFullView extends LitElement {
     tokens,
     base,
     chip,
+    browseRow,
     bannerStack,
     css`
       :host {
@@ -495,45 +497,13 @@ export class HVFullView extends LitElement {
         justify-content: flex-end;
         width: var(--hv-tap-min, 34px);
       }
-      /*
-       * A category or tag row. Deliberately the same shape as a location row in
-       * hv-location-tree — it is the same act, filtering the table down to one
-       * facet — but that tree is another shadow root, so the rule cannot be
-       * shared. Indented to where the tree's names start, past its twisty.
-       */
-      .value-row {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        width: 100%;
-        box-sizing: border-box;
-        min-height: var(--hv-tap-min, auto);
-        border: none;
-        background: none;
-        text-align: left;
-        font: 400 13.5px var(--hv-font);
-        color: var(--hv-text);
-        padding: 7px 12px 7px 34px;
-        border-radius: var(--hv-radius-input);
-      }
-      .value-row:hover {
-        background: var(--hv-hover-overlay);
-      }
-      .value-row.on {
-        background: var(--hv-primary-tint);
-        color: var(--hv-on-primary-tint);
-        font-weight: 500;
-        box-shadow: inset -3px 0 0 0 var(--hv-primary);
-      }
-      .value-row .label {
-        flex: 1;
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
+      /* A status, category or tag row is the same control as a location row in
+         the tree under the heading above it, and the two lists are read as one
+         column — so both take their shape from ui/browse-row and neither
+         declares it. All that is left here is where the empty note sits, which
+         is under a row's name, past the slot the check occupies. */
       .section-empty {
-        padding: 2px 16px 8px 34px;
+        padding: 2px 16px 8px 38px;
         font-size: 12.5px;
         color: var(--hv-text-tertiary);
       }
@@ -1413,14 +1383,14 @@ export class HVFullView extends LitElement {
               const on = filters.status === s;
               const tally = statusCount(counts, s);
               return html`<button
-                class="value-row ${on ? 'on' : ''}"
+                class="value-row hv-browse-row ${on ? 'selected' : ''}"
                 data-testid="sidebar-status-row"
                 data-value=${s}
                 aria-pressed=${String(on)}
                 @click=${() => this._setFilters({ status: on ? null : s })}
               >
-                ${on ? icon('check', 15) : null}
-                <span class="label">${statusLabel(s, this.st?.statuses)}</span>
+                <span class="hv-browse-row-lead ${on ? '' : 'placeholder'}">${icon('check', 15)}</span>
+                <span class="label hv-browse-row-label">${statusLabel(s, this.st?.statuses)}</span>
                 ${tally === null ? null : html`<span class="hv-tally">${tally}</span>`}
               </button>`;
             })
@@ -1481,17 +1451,19 @@ export class HVFullView extends LitElement {
           ? values.length
             ? values.map(
                 (v) => html`<button
-                  class="value-row ${isOn(v.value) ? 'on' : ''}"
+                  class="value-row hv-browse-row ${isOn(v.value) ? 'selected' : ''}"
                   data-testid=${`sidebar-${section}-row`}
                   data-value=${v.value}
                   aria-pressed=${String(isOn(v.value))}
                   @click=${() => onPick(v.value)}
                 >
-                  ${isOn(v.value) ? icon('check', 15) : null}
+                  <span class="hv-browse-row-lead ${isOn(v.value) ? '' : 'placeholder'}"
+                    >${icon('check', 15)}</span
+                  >
                   <!-- These clip with an ellipsis, and a clipped value the user
                        typed is otherwise unreadable — there is nowhere else in
                        the sidebar it appears in full. -->
-                  <span class="label" title=${v.value}>${v.value}</span>
+                  <span class="label hv-browse-row-label" title=${v.value}>${v.value}</span>
                   <span class="hv-tally">${v.count}</span>
                 </button>`,
               )

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -1,6 +1,7 @@
 import './hv-location-tree';
 import type { HVLocationTree } from './hv-location-tree';
 import { chip } from '../ui/chip';
+import { browseRow } from '../ui/browse-row';
 import type { LocationTreeNode } from '../store/types';
 
 function node(
@@ -85,6 +86,36 @@ describe('hv-location-tree: hierarchy', () => {
     await el.updateComplete;
     const shelfRow = rows(el).find((r) => r.dataset.id === 'shelf-a')!;
     expect(shelfRow.querySelector('.twisty.placeholder')).toBeTruthy();
+  });
+});
+
+// The sidebar draws its status, category and tag rows from the same fragment,
+// one list under the other in the same column — so the shape has to come from
+// there rather than from a rule here that only looked like it.
+describe('hv-location-tree: the shared browse row', () => {
+  it('puts every row on it, with the twisty in the shared slot', async () => {
+    const el = await mount({ showAll: true, showOrphans: true });
+    const every = [
+      ...(el.shadowRoot?.querySelectorAll('[data-testid="tree-row"], [data-testid="tree-all"], [data-testid="tree-orphans"]') ?? []),
+    ] as HTMLElement[];
+
+    expect(every.length).toBeGreaterThan(2);
+    for (const row of every) {
+      expect(row.classList, row.textContent ?? '').toContain('hv-browse-row');
+      expect(row.querySelector('.hv-browse-row-lead'), row.textContent ?? '').toBeTruthy();
+      expect(row.querySelector('.hv-browse-row-label'), row.textContent ?? '').toBeTruthy();
+    }
+  });
+
+  // A leaf has nothing to expand, and the All-items and No-location rows have
+  // no twisty at all — but a name that started further left on those rows would
+  // put three insets in one column.
+  it('holds the slot open on a row with no twisty to put in it', async () => {
+    const el = await mount({ nodes: [{ ...tree[0], children: [] }], showAll: true });
+    const leadless = [...(el.shadowRoot?.querySelectorAll('.hv-browse-row') ?? [])].filter(
+      (r) => !r.querySelector('.hv-browse-row-lead.placeholder') && !r.querySelector('button.twisty'),
+    );
+    expect(leadless).toEqual([]);
   });
 });
 
@@ -396,10 +427,12 @@ describe('hv-location-tree: area grouping', () => {
     const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
     const sheets = Array.isArray(styles) ? styles : [styles];
     const own = String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
-    // Tracks whatever `.row` is set to rather than restating a number beside it,
-    // and both bands are named by one rule so neither can drift from the other.
+    // Tracks whatever a browse row is set to rather than restating a number
+    // beside it, and both bands are named by one rule so neither can drift.
     expect(own).toMatch(/\.area-name \.hv-area-chip, \.area-none \{ font-size: inherit/);
-    expect(own).toMatch(/\.row \{[^}]*font: 400 [\d.]+px/);
+    expect(String(browseRow.cssText).replace(/\s+/g, ' ')).toMatch(
+      /\.hv-browse-row \{[^}]*font: 400 [\d.]+px/,
+    );
     // The other surfaces put this chip beside a path it qualifies, where it is
     // an annotation and stays smaller than the line carrying it.
     expect(String(chip.cssText).replace(/\s+/g, ' ')).toMatch(
@@ -628,7 +661,7 @@ describe('hv-location-tree: manage mode', () => {
       .join('\n')
       .replace(/\s+/g, ' ');
 
-    expect(css).toMatch(/\.row \{[^}]*padding: var\(--hv-organize-row-pad, 7px\) 12px/);
+    expect(css).toMatch(/\.hv-browse-row \{[^}]*padding: var\(--hv-organize-row-pad, 7px\) 12px/);
     // Nothing here declares it — a tree that declared its own would answer for
     // every host at once.
     expect(css).not.toContain('--hv-organize-row-pad:');

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -4,6 +4,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import type { TemplateResult } from 'lit';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
+import { browseRow } from '../ui/browse-row';
 import { icon } from '../ui/icons';
 import type { IconName } from '../ui/icons';
 import { groupRootsByArea, locationMatches } from '../store/location-tree';
@@ -56,42 +57,19 @@ export class HVLocationTree extends LitElement {
     tokens,
     base,
     chip,
+    browseRow,
     css`
       :host {
         display: block;
       }
+      /* Shape, spacing and the picked state come from ui/browse-row, shared with
+         the sidebar's facet rows so the two lists sit in one column. */
       .row {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        width: 100%;
-        box-sizing: border-box;
-        border: none;
-        background: none;
-        text-align: left;
-        font: 400 13.5px var(--hv-font);
-        color: var(--hv-text);
-        /* The organize dialog declares this property, so the tree it hosts
-           keeps the same vertical rhythm as the value rows on its other three
-           tabs. Nothing else declares it, so every other host — the sidebar,
-           the filter panel, the editor's location field — takes the fallback
-           and is unaffected. */
-        padding: var(--hv-organize-row-pad, 7px) 12px;
-        border-radius: var(--hv-radius-input);
         /* The whole row picks the location it names. The All-items and
            No-location rows below are real buttons and get this for free; a node
            row cannot be one, because it holds the twisty and the manage actions
            and a button may not contain a button. */
         cursor: pointer;
-      }
-      .row:hover {
-        background: var(--hv-hover-overlay);
-      }
-      .row.selected {
-        background: var(--hv-primary-tint);
-        color: var(--hv-on-primary-tint);
-        font-weight: 500;
-        box-shadow: inset -3px 0 0 0 var(--hv-primary);
       }
       .row.orphans {
         color: var(--hv-warn);
@@ -100,12 +78,9 @@ export class HVLocationTree extends LitElement {
         opacity: 0.4;
         cursor: default;
       }
+      /* The row's leading slot, as a control: the box comes from the shared
+         hv-browse-row-lead, the round hover from here. */
       .twisty {
-        flex: none;
-        display: inline-grid;
-        place-items: center;
-        width: 20px;
-        height: 20px;
         border: none;
         background: none;
         border-radius: 50%;
@@ -114,17 +89,6 @@ export class HVLocationTree extends LitElement {
       }
       .twisty:hover {
         background: var(--hv-hover-overlay);
-      }
-      .twisty.placeholder {
-        visibility: hidden;
-      }
-      .name {
-        flex: 1;
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        text-align: left;
       }
       .count {
         flex: none;
@@ -487,7 +451,7 @@ export class HVLocationTree extends LitElement {
     return html`
       <div>
         <div
-          class="row ${selected ? 'selected' : ''} ${this.manage ? 'manage' : ''} ${this.mobile
+          class="row hv-browse-row ${selected ? 'selected' : ''} ${this.manage ? 'manage' : ''} ${this.mobile
             ? 'touch'
             : ''}"
           role="treeitem"
@@ -514,7 +478,7 @@ export class HVLocationTree extends LitElement {
         >
           ${hasChildren
             ? html`<button
-                class="twisty"
+                class="twisty hv-browse-row-lead"
                 data-testid="tree-twisty"
                 aria-label=${open ? `Collapse ${node.name}` : `Expand ${node.name}`}
                 @click=${(e: Event) => {
@@ -524,8 +488,8 @@ export class HVLocationTree extends LitElement {
               >
                 ${icon(open ? 'chevronDown' : 'chevronRight', 17)}
               </button>`
-            : html`<span class="twisty placeholder">${icon('chevronRight', 17)}</span>`}
-          <span class="name">${node.name}</span>
+            : html`<span class="twisty hv-browse-row-lead placeholder">${icon('chevronRight', 17)}</span>`}
+          <span class="name hv-browse-row-label">${node.name}</span>
           ${this.showCounts ? this._renderCount(node, isExcluded) : null}
           ${this.manage && this.mobile
             ? html`<span class="actions">
@@ -638,7 +602,7 @@ export class HVLocationTree extends LitElement {
       : html`<span class="hv-area-chip quiet area-none">No area</span>`;
 
     return html`<div
-      class="row area-head ${selected ? 'selected' : ''} ${pickable ? 'selectable' : ''}"
+      class="row hv-browse-row area-head ${selected ? 'selected' : ''} ${pickable ? 'selectable' : ''}"
       role="treeitem"
       aria-selected=${String(selected)}
       aria-expanded=${ifDefined(empty ? undefined : String(open))}
@@ -648,9 +612,9 @@ export class HVLocationTree extends LitElement {
       data-area=${group?.id ?? NO_AREA_KEY}
     >
       ${empty
-        ? html`<span class="twisty placeholder">${icon('chevronRight', 17)}</span>`
+        ? html`<span class="twisty hv-browse-row-lead placeholder">${icon('chevronRight', 17)}</span>`
         : html`<button
-            class="twisty"
+            class="twisty hv-browse-row-lead"
             data-testid="tree-area-twisty"
             data-area=${group?.id ?? NO_AREA_KEY}
             aria-label=${open
@@ -791,13 +755,13 @@ export class HVLocationTree extends LitElement {
       <div role="tree" aria-label="Locations">
         ${this.showAll
           ? html`<button
-              class="row ${!this.orphansSelected && this.selectedId === null ? 'selected' : ''}"
+              class="row hv-browse-row ${!this.orphansSelected && this.selectedId === null ? 'selected' : ''}"
               data-testid="tree-all"
               @click=${() => this._emit('select', { locationId: null, node: null })}
             >
-              <span class="twisty placeholder">${icon('chevronRight', 17)}</span>
+              <span class="twisty hv-browse-row-lead placeholder">${icon('chevronRight', 17)}</span>
               ${icon(this.allIcon, 18)}
-              <span class="name">${this.allLabel}</span>
+              <span class="name hv-browse-row-label">${this.allLabel}</span>
               ${this.showCounts && this.totalCount !== null
                 ? this._pairedCount(this.totalCount, this.matchingTotalCount)
                 : null}
@@ -815,13 +779,13 @@ export class HVLocationTree extends LitElement {
           ? html`
               <div class="divider"></div>
               <button
-                class="row orphans ${this.orphansSelected ? 'selected' : ''}"
+                class="row hv-browse-row orphans ${this.orphansSelected ? 'selected' : ''}"
                 data-testid="tree-orphans"
                 @click=${() => this._emit('select-orphans', {})}
               >
-                <span class="twisty placeholder">${icon('chevronRight', 17)}</span>
+                <span class="twisty hv-browse-row-lead placeholder">${icon('chevronRight', 17)}</span>
                 ${icon('alert', 18)}
-                <span class="name">No location</span>
+                <span class="name hv-browse-row-label">No location</span>
                 ${this.showCounts && this.orphanCount !== null
                   ? this._pairedCount(this.orphanCount, this._matchingOrphanCount)
                   : null}

--- a/cards/haventory-card/src/ui/browse-row.test.ts
+++ b/cards/haventory-card/src/ui/browse-row.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { CSSResult } from 'lit';
+import { browseRow } from './browse-row';
+
+import '../components/hv-full-view';
+import '../components/hv-location-tree';
+
+/**
+ * The two shadow roots that draw a row you browse by. They render one under the
+ * other in the sidebar's single column, so the metrics have to come from the
+ * one fragment rather than being written out on each side — which is how they
+ * drifted 4px of height and 22px of label inset apart.
+ */
+const BROWSERS = ['hv-full-view', 'hv-location-tree'];
+
+function sheetsOf(tag: string): CSSResult[] {
+  const ctor = customElements.get(tag) as { styles?: CSSResult | CSSResult[] } | undefined;
+  if (!ctor?.styles) throw new Error(`${tag} has no styles`);
+  return Array.isArray(ctor.styles) ? ctor.styles : [ctor.styles];
+}
+
+/** A component's own block — the last fragment, after the shared ones. */
+function ownCss(tag: string): string {
+  const sheets = sheetsOf(tag);
+  return String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+}
+
+describe('ui/browse-row: one row in two shadow roots', () => {
+  it('reaches both roots that draw one', () => {
+    for (const tag of BROWSERS) expect(sheetsOf(tag), tag).toContain(browseRow);
+  });
+
+  it('leaves neither of them restating the shape it provides', () => {
+    for (const tag of BROWSERS) {
+      const css = ownCss(tag);
+      // The two rules that used to hold these, in the shapes that disagreed.
+      for (const selector of ['\\.value-row', '\\.row']) {
+        const rule = new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
+        expect(rule, `${tag}: ${selector} { ${rule} }`).not.toMatch(
+          /padding|font:|min-height|border-radius|display: flex/,
+        );
+      }
+    }
+  });
+});

--- a/cards/haventory-card/src/ui/browse-row.ts
+++ b/cards/haventory-card/src/ui/browse-row.ts
@@ -1,0 +1,78 @@
+import { css } from 'lit';
+
+/**
+ * A row you browse by: one location in `hv-location-tree`, one status,
+ * category or tag in the full view's sidebar.
+ *
+ * Pressing either narrows the table to that value, and the two lists sit one
+ * under the other in the same column — so they are one control drawn in two
+ * shadow roots, which cannot share a rule and had drifted 4px of height and
+ * 22px of label inset apart. The metrics live here instead of being written
+ * out on each side.
+ *
+ * The leading slot is what holds the inset together. The tree puts its twisty
+ * in it and reserves it on a leaf; a facet row puts its check in it and
+ * reserves it while nothing is picked. A name therefore starts at the same x
+ * whatever the row can do and whichever state it is in: 12px of padding, a
+ * 20px slot and the 6px gap — where the tree's own top-level entries (All
+ * items, No location, an area band) have always started. A nested location
+ * indents from there, which is the one difference that means something.
+ *
+ * That slot is also the row's height, so there is no number here to keep in
+ * step with it.
+ *
+ * Usage: `static styles = [tokens, base, browseRow, css\`...\`]`, with
+ * `hv-browse-row` on the row, `hv-browse-row-lead` on its first child and
+ * `hv-browse-row-label` on the name.
+ */
+export const browseRow = css`
+  .hv-browse-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    box-sizing: border-box;
+    border: none;
+    background: none;
+    text-align: left;
+    font: 400 13.5px var(--hv-font);
+    color: var(--hv-text);
+    /* The organize dialog declares this property, so the tree it hosts keeps
+       the same vertical rhythm as the value rows on its other three tabs.
+       Nothing else declares it, so every other host takes the fallback. */
+    padding: var(--hv-organize-row-pad, 7px) 12px;
+    border-radius: var(--hv-radius-input);
+  }
+  .hv-browse-row:hover {
+    background: var(--hv-hover-overlay);
+  }
+  /* Picked. The rail on the closing edge is what still reads when a user theme
+     repaints the tint out from under the fill. */
+  .hv-browse-row.selected {
+    background: var(--hv-primary-tint);
+    color: var(--hv-on-primary-tint);
+    font-weight: 500;
+    box-shadow: inset -3px 0 0 0 var(--hv-primary);
+  }
+  .hv-browse-row-lead {
+    flex: none;
+    display: inline-grid;
+    place-items: center;
+    width: 20px;
+    height: 20px;
+  }
+  /* Held open rather than removed: a row with nothing to put in the slot still
+     starts its name where the rows around it do. */
+  .hv-browse-row-lead.placeholder {
+    visibility: hidden;
+  }
+  /* One line each, elided. A value long enough to wrap would break the run of
+     rows the column is read down. */
+  .hv-browse-row-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;


### PR DESCRIPTION
## Summary

Two halves, one commit each.

**(a) The expanded view stops taking the card's touch sizing.** `hv-card-shell` declares
`--hv-tap-min: 44px` and `--hv-input-font: 16px` on `:host([mobile])`, which is the card element's
own measured width at or under 600px — an ordinary dashboard column, on a desktop as much as on a
phone. The overlay renders inside that shadow tree, so both properties inherited straight into a
surface that covers the whole viewport.

**Taken differently from what the issue sketches, and this is the reason.** The issue proposes
declaring desktop numbers on `.shell`. But the consumers deliberately fall back to four different
sizes — `auto` for the section heading and the Any/All control, `30px` for the count pills, `34px`
for the tally slot, `36px` for an app-bar button — and one number on `.shell` flattens all of them,
including in the panel, which the issue says needs no change. So the shell sets both to the
**guaranteed-invalid value** instead:

```css
.shell {
  --hv-tap-min: initial;
  --hv-input-font: initial;
}
```

Every `var(--hv-tap-min, X)` then resolves to its own `X`. The panel behaves exactly as it did —
it never had the properties declared above it — and the overlay now matches it, by construction
rather than by a table of numbers kept in step. The media query still raises both to 44px/16px on
a narrow *viewport*, in both modes. The comment claiming the surface already did this is replaced
by one describing what it does.

**(b) The sidebar's facet rows and the location rows become one row.** A status, category or tag
row and a location row are the same control — press either and the table narrows to that value —
rendered one list under the other in the same column, in two shadow roots that cannot share a
rule. New `src/ui/browse-row.ts` declares the shape once; both components take it.

The leading slot is what holds the inset together: the tree puts its twisty in it and reserves it
on a leaf, a facet row puts its check in it and reserves it while nothing is picked. So a name
starts at the same x whatever the row can do and whichever state it is in — and a facet row no
longer shifts sideways by 21px the moment it is selected, which it did.

**The inset is 38px**, decided once and written once: 12px of padding, the 20px slot, the 6px gap.
That is where the tree's own top-level entries — All items, No location, an area band — have
always started, and a nested location indents from there, which is the one difference between
these rows that means something. The alternative in the issue (56px, matching a depth-1 name) lines
the facets up with *nested* entries and leaves a quarter of a 264px column empty in front of every
one of them.

Half (a) alone does not close the issue: it leaves the panel's own 30px-vs-34px mismatch in both
modes. (b) is what removes it.

Backend untouched; nothing inside `custom_components/haventory/` is deleted or renamed, so no
`RETIRED_PATHS` entry is needed.

Closes #363

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

Both gates green, run before each commit.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 752 passed, 22 skipped ·
      `uv run ruff check .` → All checks passed · `uv run ruff format --check .` → 115 files already
      formatted · `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean ·
      `npx vitest run` → **1656 passed / 60 files** · `npm run build` → 580 kB bundle

Tests:

- New `src/ui/browse-row.test.ts`: the fragment reaches both roots that draw one of these rows
  (object identity, not a string match), and neither `.row` nor `.value-row` restates the shape it
  provides — which is the guard against the two drifting apart again.
- New in `hv-full-view`: every facet row carries the shared class, holds its slot open with a
  placeholder while nothing is picked, and puts the check in that same slot once something is —
  the label does not move. Its name carries the shared label class.
- New in `hv-location-tree`: every row — node, All items, No location — carries the class, the slot
  and the label; and a row with no twisty to put in the slot still holds it open (the edge case
  that decides whether one inset or three end up in the column).
- Updated: three `hv-full-view` tests read the picked state off `selected` rather than `on`, the
  two class names the two roots used for one thing.
- Extended: `hv-full-view`'s "sizes its own touch targets rather than inheriting the card its
  opener had" — the test whose title was already the claim — now also checks the base `.shell`
  resets both properties. `hv-location-tree`'s two stylesheet pins follow the declarations into the
  shared fragment.

No new regex-over-stylesheet test was written (#353); the two that changed are existing ones whose
subject moved.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — none needed; no user-facing behaviour or API changed.
      `docs/frontend_architecture.md` names components, not shared style fragments.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

Measured in the Docker dev HA (1075 items, 79 locations) in a real browser. jsdom computes no
layout, so every number is `getBoundingClientRect` / `getComputedStyle` from the running surface.
PNGs in the gitignored `.claude/skills/run-haventory/` (`before-pr3-fullview.png`,
`before-pr3-panel.png`, `after-pr3-fullview.png`, `after-pr3-panel.png`, plus a 42-surface
`visual_pass.mjs` sweep in `after-pr3/`).

**Expanded view opened from a 500px dashboard column, 1440px window**

| | before | after |
|---|---|---|
| `--hv-tap-min` seen inside the view | `44px` | unset — each consumer falls back |
| `--hv-input-font` seen inside the view | `16px` | unset — each consumer falls back |
| status / category / tag row | **44px** tall, label at x 34 | **34px** tall, label at x **38** |
| location row (depth 1) | 34px, name at x 56 | 34px, name at x 56 |
| tree "All items" row | 34px, name at x 38 | 34px, name at x 38 |
| area band | 38.9px | 38.9px |
| `.appbar .tap` | 44 × 44 | **36 × 36** |
| `.head-action` slot | 44 wide | **34** |
| `.section-toggle` | 44 tall | **18** (auto) |
| app-bar search input | **16px** type | **13.5px** |
| editor fields hosted in the view | 16px | 13.5px |

**Sidebar panel `/haventory`, 1440px** — every number identical to the expanded view above, offset
only by HA's own 256px sidebar: facet row 34px with its label at 256+38 = 294, location name at
256+56 = 312, `.appbar .tap` 36×36, `.head-action` 34. The panel's facet rows were 30px with the
label at 34 before, so (b) moved them into line with the tree they sit under; nothing else in the
panel changed.

**Both surfaces at 375×812 (touch)** — `--hv-tap-min: 44px`, `--hv-input-font: 16px`, app-bar
buttons 44×44, sidebar `display: none`. The media query still wins, in both modes.

**Organize dialog** — it hosts the same tree and tightens it through `--hv-organize-row-pad: 8px`.
That still resolves through the shared fragment: rows 42px, names at the same +56 indent.

`visual_pass.mjs` after the change: 42/42 surfaces captured, no console errors, at desktop and
phone widths on the card and on `/haventory`.

## Follow-ups

- The padding hook the shared fragment reads is still called `--hv-organize-row-pad`. It now
  governs a row in two components rather than one, so the name is narrower than the thing; renaming
  it would touch `hv-organize-dialog` and its pins for no behaviour change, so it is left as it is
  with the fragment's comment explaining who declares it.
- The area band is 38.9px against the 34px of the rows under it, because the area chip inside it is
  taller than the 20px slot. It is a band rather than an entry, so it is not part of the run these
  rows form — noted rather than filed.
