### PR TITLE
docs: record buttons as the card's reordering idiom

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -556,7 +556,9 @@ Things jsdom cannot do, and how the tests handle it:
 - **No real drag and drop** — jsdom builds a `DragEvent` with no `DataTransfer` behind it,
   so the editor's file-drop tests carry a plain-object `dataTransfer` and assert the
   routing (which kind each dropped file becomes) rather than the browser's drag machinery.
-  Dragging items onto tree nodes (an optional item in the handoff) is not implemented.
+  Dropping a file onto the editor is the only drag the card handles: an item's location
+  changes through the item editor or the bulk bar's Move action, never by dragging the row
+  onto a node of the sidebar tree.
 
 Run:
 
@@ -585,11 +587,22 @@ round trip is not free; the UI stays responsive and rolls back on failure.
 themes keep working. Accents with no HA equivalent (tints, hover washes, warning surfaces)
 track `prefers-color-scheme`.
 
+**Buttons are the card's reordering idiom** — the organize dialog's status rows and the item
+editor's photo strip both move an entry with a pair of arrow buttons, and both send the whole
+new order to the backend. Pointer drag has no keyboard equivalent, so it could only ever
+arrive *beside* the buttons and never in place of them; and whichever list grew it first
+would settle the gesture for the others, the unbuilt column order among them. It is not
+built. The buttons already carry the capability on every ordered list the card has, so
+nothing waits on it, and whether the gesture is worth implementing across three surfaces at
+once is a question about how the card gets used — which takes people using it to answer.
+
 ---
 
 ## Known gaps
 
-- Drag-and-drop of items onto sidebar tree nodes (optional in the handoff) is not built.
+- Nothing in the card moves by pointer drag. An item cannot be dragged onto a location in
+  the sidebar tree — its location changes through the item editor or the bulk bar's Move
+  action — and the ordered lists reorder with buttons, per the decision above.
 - Large lists rely on paging; no row virtualization.
 - The backend cannot sort by category, location or tags, filter by due date, or bulk-create
   items — the UI is shaped around those limits rather than hiding them.


### PR DESCRIPTION
## Summary

Records the decision #297 exists to make: **buttons stay the card's single reordering idiom,
and pointer drag is not built now.** No code changes — the capability already ships on both
ordered lists.

The reasoning, written into `docs/frontend_architecture.md` under **Key design decisions**:

- Drag has no keyboard equivalent, so it could only ever arrive *beside* the buttons, never
  in place of them.
- Whichever ordered list grew drag first would settle the gesture for the others — the
  organize dialog's status rows, the item editor's photo strip, and the unbuilt column order
  (#242). Not building it on one surface in isolation is what keeps that constraint intact.
- The buttons already carry the capability on every ordered list the card has, and both send
  the whole new order to the backend, so nothing is waiting on drag.
- Whether the gesture earns an implementation across three surfaces at once is a question
  about how the card gets used, and there is no real user feedback yet. #297's own triage
  says the same.

Two nearby lines pointed at a design handoff no reader of this repository can open
(`docs/frontend_architecture.md`, the jsdom-limits bullet and the Known gaps entry). Both now
say what is actually missing: an item's location changes through the item editor or the bulk
bar's Move action, never by dragging the row onto a node of the sidebar tree. The rest of the
file's stale references are left to #216 / #231.

**Known gaps** stays honest — it now says plainly that nothing in the card moves by pointer
drag, and points at the decision above.

The same decision is posted as a comment on #297 so it is on the issue independently of this
PR. The issue stays open; `Closes #297` below closes it on merge.

Closes #297

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Documentation only — no code, no test change. Both gates run anyway, per the per-commit rule.

- [x] Backend:
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → `752 passed, 22 skipped in 9.07s`
  - `uv run ruff check .` → `All checks passed!`
  - `uv run ruff format --check .` → `115 files already formatted`
  - `uv run mypy` → `Success: no issues found in 15 source files`
- [x] Frontend (`cards/haventory-card`):
  - `npx eslint .` → clean
  - `npm run typecheck` → clean
  - `npx vitest run` → `Test Files 60 passed (60) / Tests 1669 passed (1669)`
  - `npm run build` → `built in 203ms`, `haventory-card.js 583.59 kB │ gzip: 140.07 kB`

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case). — n/a, no behavior change
- [x] Docs updated where behavior changed — this PR *is* the doc change; the WS contract and data shapes are untouched
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync. — n/a
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None — nothing visible changes.

## Follow-ups

- `hv-organize-dialog.ts:248` calls the status-row arrows "the card's first reordering
  control". That is development history rather than a constraint, and it stopped being the
  only one when the photo strip grew the same pair. Left alone here to keep this PR to
  documentation; not filed as an issue — it clears no real-world bar, and #216 / #231 already
  sweep comment wording.
