### PR TITLE
fix(card): rows stop being sized by the parts that cannot shrink

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -261,8 +261,45 @@ describe('hv-data-table: columns', () => {
     ]);
     expect(q(el, '[data-testid="cell-quantity"]')?.classList.contains('low')).toBe(true);
     expect(q(el, '[data-testid="cell-due_date"]')?.classList.contains('overdue')).toBe(true);
-    expect(el.shadowRoot?.textContent).toContain('Low');
     expect(el.shadowRoot?.textContent).toContain('Checked out');
+  });
+});
+
+// Both chips are unshrinkable, so on a row carrying both they took 138px of the
+// 220px name track and left 82px of name — about eleven characters, measured on
+// a real instance at the table's floor width and again at 390px, where the same
+// cell is pinned. Dropping one is what buys the name back; which one to drop is
+// the choice the phone row already makes on its single line.
+describe('hv-data-table: the name cell picks one chip', () => {
+  const bothWays = { quantity: 1, low_stock_threshold: 5 };
+
+  it('marks a low row that nobody has taken', async () => {
+    const el = await mount([{ id: '1', ...bothWays }]);
+    expect(q(el, '[data-testid="table-low"]')?.textContent?.trim()).toBe('Low');
+  });
+
+  it('stands Low down for Checked out, which is the more interrupting of the two', async () => {
+    const el = await mount([{ id: '1', ...bothWays, checked_out: true }]);
+    expect(q(el, '[data-testid="table-low"]')).toBe(null);
+    expect(q(el, '.name-cell')?.textContent).toContain('Checked out');
+    // The fact is not lost with the chip: the quantity is still drawn as low.
+    expect(q(el, '[data-testid="cell-quantity"]')?.classList.contains('low')).toBe(true);
+  });
+
+  it('leaves the status chip alone — that one can shrink and elide its own label', async () => {
+    const el = await mount([{ id: '1', ...bothWays, checked_out: true, status: 'missing' }], {
+      columns: ['quantity'],
+    });
+    expect(q(el, '[data-testid="table-low"]')).toBe(null);
+    expect(q(el, '[data-testid="table-status"]')?.textContent?.trim()).toBe('Missing');
+    expect(q(el, '.name-cell')?.textContent).toContain('Checked out');
+  });
+
+  it('keeps the name itself the only part of the cell that gives way', () => {
+    const css = tableCss();
+    // The cell shares its shrink rule with the two other pinned cells.
+    expect(css).toMatch(/\.name-cell,[^{]*\{[^}]*min-width: 0/);
+    expect(/\.name \{([^}]*)\}/.exec(css)?.[1]).toContain('text-overflow: ellipsis');
   });
 });
 

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -520,6 +520,12 @@ export class HVDataTable extends LitElement {
     // Status column. With the column shown it would put the same word twice on
     // one row, so the column takes over and the chip stands down.
     const statusColumn = columns.includes('status');
+    // Low stands down for Checked out in the same cell, the way a phone row's
+    // one line already picks the most interrupting thing it has to say: both
+    // chips are unshrinkable, and together they take 138px of a 220px track,
+    // which leaves the name too short to tell two items apart. Who has the item
+    // outranks how many are left, and the Qty column still draws a low count in
+    // amber.
     const template = tableTemplateFor(columns, { selectable: this.selectable });
     const loadedIds = this.items.map((i) => i.id);
     const selectedCount = loadedIds.filter((id) => this.selection.has(id)).length;
@@ -588,8 +594,13 @@ export class HVDataTable extends LitElement {
                     : null}
                   <span class="name-cell" role="cell">
                     <span class="name" data-testid="table-name" title=${item.name}>${item.name}</span>
-                    ${isLowStock(item)
-                      ? html`<span class="hv-chip warning" aria-label="Low stock">Low</span>`
+                    ${isLowStock(item) && !item.checked_out
+                      ? html`<span
+                          class="hv-chip warning"
+                          data-testid="table-low"
+                          aria-label="Low stock"
+                          >Low</span
+                        >`
                       : null}
                     ${!statusColumn && itemStatus(item) !== DEFAULT_STATUS
                       ? renderStatusChip(itemStatus(item), this.statuses, {

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -1000,6 +1000,31 @@ describe('hv-detail-sheet: documents', () => {
     expect(all(el, '[data-testid="sheet-document-open"]')).toHaveLength(2);
   });
 
+  // jsdom computes no layout, so the widths these two rules produce are only
+  // observable on a real phone. What is pinned here is the pair of declarations
+  // that keeps a row inside the list: without them the single track sizes itself
+  // to the widest row, whose tail (the Open link, the "File missing" chip) does
+  // not shrink, and `overflow: hidden` clips exactly those two away.
+  it('sizes the documents track off the list rather than off its widest row', () => {
+    const css = sheetCss();
+    const rule = (selector: string) =>
+      new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
+
+    expect(rule('\\.documents ul')).toContain('grid-template-columns: minmax(0, 1fr)');
+    expect(rule('\\.documents li')).toContain('min-width: 0');
+  });
+
+  // The row shrinking into its track is only worth anything if the two elements
+  // it was cutting off are the ones that keep their size.
+  it('leaves the Open link and the missing-file chip unshrinkable', () => {
+    const css = sheetCss();
+    const rule = (selector: string) =>
+      new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
+
+    expect(rule('\\.documents \\.doc-open')).toContain('flex: none');
+    expect(rule('\\.documents \\.doc-text')).toContain('min-width: 0');
+  });
+
   it('shows the documents in stored order, not the order they were uploaded', async () => {
     serve(206);
     const el = await mount(

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -311,6 +311,12 @@ export class HVDetailSheet extends LitElement {
         margin: 0;
         padding: 0;
         display: grid;
+        /* One track the width of the list, not the width of its widest row. An
+           implicit track sizes itself from the rows, and a row's tail — the
+           Open link and the "File missing" chip — cannot shrink, so the track
+           runs past the list and the hidden overflow below cuts off exactly the
+           two elements the row exists to offer. */
+        grid-template-columns: minmax(0, 1fr);
         gap: 1px;
         background: var(--hv-row-divider);
         border-radius: 10px;
@@ -320,6 +326,9 @@ export class HVDetailSheet extends LitElement {
         display: flex;
         align-items: center;
         gap: 10px;
+        /* A grid item's automatic minimum is its own content, which would put
+           the row straight back outside the track above. */
+        min-width: 0;
         min-height: 52px;
         padding: 8px 12px;
         background: var(--hv-surface);

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -120,11 +120,13 @@ const COLUMN_TABLE_SIZE: Record<ColumnKey, string> = Object.fromEntries(
  * the name, the chosen columns, then room for the hover actions.
  *
  * The name track outweighs every flexible column beside it, in both halves of
- * its `minmax`: the name is the row's identity, and it also carries the inline
- * Low and Checked-out chips, which take their width before the name gets any.
- * With the full column set the flexible tracks all sit at their minimum
- * anyway — there the floor is the whole answer, and the growth factor decides
- * only what a wider window hands out.
+ * its `minmax`: the name is the row's identity, and it also carries an inline
+ * chip — Low, or Checked out, or the status when that column is off — which
+ * takes its width before the name gets any. At most one of Low and Checked out
+ * draws, so the floor holds a readable name rather than the tail of one; the
+ * table renders that choice. With the full column set the flexible tracks all
+ * sit at their minimum anyway — there the floor is the whole answer, and the
+ * growth factor decides only what a wider window hands out.
  */
 export const NAME_COLUMN_SIZE = 'minmax(220px, 3fr)';
 


### PR DESCRIPTION
## Summary

One failure mode in two surfaces: an inline element that cannot shrink sets a floor, and the
text-bearing element beside it pays for it. One commit each.

**(a) #326 — the detail sheet's Documents list.** At 390px every row laid out **548.4px wide
inside a 354px list**, and `.documents ul` hides its overflow, so the whole right-hand end of
each row was cut away. That end is where the two things a row exists to offer sit: the Open
link and the "File missing" chip. Not "sliced mid-glyph" — with a realistic filename both sat
at x 474–479 against a list ending at 372, i.e. **entirely off the surface**. A document whose
bytes are gone was readable only from the struck-through title.

The single implicit track sized itself to the widest row, and a row's tail is `flex: none`, so
the track grew instead of the row. Two declarations fix it:

```css
.documents ul { grid-template-columns: minmax(0, 1fr); }  /* track off the list, not the row */
.documents li { min-width: 0; }                           /* row shrinks into the track */
```

`.doc-text` keeps doing the eliding it was already dressed for.

**The editor's document rows (`hv-item-editor`) measured clean and are untouched** — see the
numbers below. They share the shape but not the outcome: the title there is an `<input>`, whose
intrinsic width follows its `size`, not the filename, and the unshrinkable tail sums to ~191px
against a 358px list. Nothing to fix, so nothing was changed.

**(b) #314 — the table's name cell.** Low and Checked out are both `flex: none`, so a row
carrying both spent **137.6px of the 220px name track** and left **82.4px of name** — about
eleven characters, the same number at the table's floor width and at 390px where the cell is
pinned.

**The decision: the cell says the more interrupting of the two.** Who has the item outranks how
many are left, so Low stands down when the row is checked out. Reasons, against the four options
in the issue:

- **It is the choice the card already makes.** `hv-list-row`'s phone line renders the low dot
  only `if (low && !item.checked_out)` — a row that is both already says "Checked out" and drops
  Low, on the card's tightest surface. Doing the same in the table means one rule, not two.
- **A template decision, not a rule at the `≤700px` breakpoint.** The name text measures 82.4px
  at *both* 1280px and 390px, because the track sits at its 220px floor in both. A rule scoped to
  the phone breakpoint would have left the case the issue actually measured exactly as it was.
- **Nothing is lost.** The Qty column draws a low count in amber and bolder (`.cell.qty.low`) —
  visible in the same row in both screenshots below — and the detail sheet spells out the
  threshold.
- **Not a glyph-only variant** (#367 just unified the chip vocabulary) and **not a capped,
  clipping chip run** (a half-drawn "Checked o…" is what the issue is avoiding).

The status chip is untouched: `.hv-status-chip` can shrink and elide its own label, so it was
never part of the floor. `NAME_COLUMN_SIZE`'s comment in `store/columns.ts` stops describing an
open question and describes the rule.

No `custom_components/` change; nothing deleted or renamed inside the integration package, so no
`RETIRED_PATHS` entry.

Closes #326
Closes #314

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green, run before each of the two commits.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → `752 passed, 22 skipped` ·
      `uv run ruff check .` → `All checks passed!` · `uv run ruff format --check .` →
      `115 files already formatted` · `uv run mypy` → `no issues found in 15 source files`
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean ·
      `npx vitest run` → **1675 passed / 60 files** (1669 before) · `npm run build` → 584.34 kB

Tests — jsdom computes no layout, so each pins the constraint that carries the fix and names in
its title what the pin is protecting:

- `hv-detail-sheet.test.ts`: the documents track is sized off the list (`minmax(0, 1fr)`) and the
  row can shrink into it (`min-width: 0`); and the pair only means something while the Open link
  stays `flex: none` and `.doc-text` stays the one thing that gives way, which is the second test.
- `hv-data-table.test.ts`, new block: a low row nobody has taken still shows Low; a row that is
  both shows Checked out, no Low, **and** a Qty cell still marked low; with the Status column off
  the status chip is still drawn beside Checked out; and the name is the only part of the cell
  that gives way.
- Updated: "marks low stock and overdue in the cells" mounts exactly the both-ways row, so it is
  now the pin for the new behaviour rather than the old.

`visual_pass.mjs` after the change: **42/42 surfaces captured**, every recipe PASS, at desktop and
phone widths on the card and on `/haventory`. The two 404s it reports are the attachment file the
test fixture deliberately deletes to produce the missing-file case.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — no user-facing wording or API changed;
      `docs/frontend_architecture.md` describes components, not these rules.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

Measured in the Docker dev HA in a real browser, on a seeded item carrying a **titled**, an
**untitled** and a **missing-file** document (the third one's bytes removed from the container's
`/config/haventory/attachments/…`). jsdom computes no layout, so every number below is
`getBoundingClientRect` from the running surface, read through the shadow roots. PNGs in the
gitignored `.claude/skills/run-haventory/`: `before-326-light.png`, `before-326-dark.png`,
`after-326-light.png`, `after-326-dark.png`, `after-326-light-editor.png`, `before-314-1280.png`,
`before-314-390.png`, `after-314-1280.png`, `after-314-390.png`, plus the 42-surface sweep in
`pr1-after/`.

**(a) Detail sheet, Documents list — 390×844, light and dark (identical numbers in both)**

| | before | after |
|---|---|---|
| list inner width | 354 | 354 |
| list hidden overflow | **194px** | **0** |
| every row's width | **548.4** (right edge 566.4) | **354** (right edge 372) |
| "Open" link | x 478.9 → 554.4 — **outside the list entirely** | x 284.5 → **360**, inside 372 |
| "Open" tap height | 40 | 40 (≥ 24 ✓) |
| "File missing" chip | x 474.5 → 554.4 — **outside the list entirely** | x 280.1 → **360**, 79.9 wide, whole |
| `.doc-title` / `.doc-meta` | 408.9 (never elided, just clipped) | 214.5, elides |

Row heights, the divider gaps and the missing row's strike-through are unchanged. Both themes were
captured; the boxes are identical and only the palette differs.

**Editor document rows, same item, same width — measured, unchanged, no fix needed**

| | before | after |
|---|---|---|
| list width | 358 | 358 |
| every row's width | 358 (right edge 374 = list right edge) | 358 |
| list overflow | 0 | 0 |
| title `<input>` | 217.3 / 217.3 / **167.4** on the missing row | same |
| "File missing" chip | x 256.1 → 336, whole | same |
| remove ✕ | x 344 → 374, inside | same |

**(b) Table name cell — the row carrying both Low and Checked out**

| | before | after |
|---|---|---|
| name track / cell | 220 (240 pinned at 390px) | unchanged |
| chips in the cell | Low 39.3 + Checked out 82.3 + gaps = **137.6** | Checked out 82.3 |
| **name text @ 1280px** (table at its floor) | **82.4** | **129.7** |
| **name text @ 390px** (cell pinned) | **82.4** | **129.7** |
| what a reader sees | `Kärcher K5 …` | `Kärcher K5 Premiu…` |
| Qty cell | `1` in amber | `1` in amber (unchanged) |

## Follow-ups

- The detail sheet's `.doc-meta` now ellipsizes a long filename that previously ran (invisibly)
  past the edge — e.g. `Bosch-GSR18V60FC-Bedienungsanleitu…`. That is the intended behaviour of the
  element and the row's title line still carries the document's name, so nothing is filed.
- A row that is low, checked out **and** carries a non-default status with the Status column off
  now draws two chips (status + Checked out) where it drew three. The status chip elides its own
  label, so the cell holds; measured, not filed.
