### PR TITLE
fix(card): mark the area on a phone row instead of spelling it as a path segment

### DIFF
--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -1,7 +1,7 @@
 import './hv-list-row';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
-import { elidePath, isLowStock } from './hv-list-row';
+import { elideMobilePath, elidePath, isLowStock } from './hv-list-row';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVListRow } from './hv-list-row';
 import type { Item } from '../store/types';
@@ -58,6 +58,40 @@ describe('elidePath', () => {
 
   it('handles an item with no location at all', () => {
     expect(elidePath('')).toBe('');
+  });
+});
+
+describe('elideMobilePath', () => {
+  // The area still has to travel through the elision as the leading segment, or
+  // a deep path would drop it; what comes back is the same line with the area
+  // separated out for the row to mark instead of punctuate.
+  it('keeps the room and the bin, and hands the room back on its own', () => {
+    expect(elideMobilePath('Garage', 'Workshop › Parts Cabinet › Drawer A › Small Bin')).toEqual({
+      area: 'Garage',
+      rest: '… › Small Bin',
+    });
+  });
+
+  it('leaves a path that fits alone, area and all', () => {
+    expect(elideMobilePath('Garage', 'Shelf A')).toEqual({ area: 'Garage', rest: 'Shelf A' });
+  });
+
+  it('gives back exactly what elidePath does when there is no area', () => {
+    const path = 'Workshop › Parts Cabinet › Drawer A › Small Bin';
+    expect(elideMobilePath(null, path)).toEqual({ area: null, rest: elidePath(path) });
+  });
+
+  // An area name carrying the separator lands as two segments, so the elided
+  // string no longer starts with it and there is nothing safe to mark. The line
+  // then reads as it always did — the wrong words marked would be worse.
+  it('marks nothing when the area name is itself split by the separator', () => {
+    const result = elideMobilePath('Kitchen › Pantry', 'Shelf A › Box 2');
+    expect(result.area).toBe(null);
+    expect(result.rest).toBe(elidePath('Kitchen › Pantry › Shelf A › Box 2'));
+  });
+
+  it('marks an area that has no path under it', () => {
+    expect(elideMobilePath('Garage', '')).toEqual({ area: 'Garage', rest: '' });
   });
 });
 
@@ -297,16 +331,70 @@ describe('hv-list-row: mobile affordances', () => {
     );
   });
 
-  it('spends the phone row on the room, which the elision keeps', async () => {
+  it('spends the phone row on the room, and marks it as a room', async () => {
     // No chip fits this line, so the area goes in as the leading segment — the
-    // half elidePath keeps.
+    // half elidePath keeps — with the home mark saying it is Home Assistant's
+    // area rather than the top of our own tree.
     const el = await mount(
       { category: null, effective_area_id: 'area-workshop', location_path: deepPath },
       { mobile: true, areas: [{ id: 'area-workshop', name: 'Garage' }] },
     );
     const secondary = q(el, '[data-testid="row-secondary"]');
-    expect(secondary?.textContent).toContain('Garage › … › Small Bin');
+    const mark = secondary?.querySelector('[data-testid="row-area-mark"]');
+    expect(mark?.textContent).toContain('Garage');
+    expect(mark?.querySelector('svg')).toBeTruthy();
+    expect(secondary?.textContent).toContain('… › Small Bin');
+    // The mark is the separator now.
+    expect(secondary?.textContent).not.toContain('Garage › ');
+    // Still the phone line, not the chip the desktop row gets.
     expect(secondary?.querySelector('.hv-area-chip')).toBe(null);
+  });
+
+  it('renders no mark at all on a phone row with no area', async () => {
+    const el = await mount({ category: null, location_path: deepPath }, { mobile: true });
+    const secondary = q(el, '[data-testid="row-secondary"]');
+    expect(secondary?.querySelector('[data-testid="row-area-mark"]')).toBe(null);
+    expect(secondary?.textContent?.trim()).toBe('Workshop › … › Small Bin');
+  });
+
+  it('puts the mark after the status a flagged phone row leads with', async () => {
+    const el = await mount(
+      {
+        category: null,
+        status: 'needs_repair',
+        effective_area_id: 'area-workshop',
+        location_path: deepPath,
+      },
+      { mobile: true, areas: [{ id: 'area-workshop', name: 'Garage' }] },
+    );
+    const secondary = q(el, '[data-testid="row-secondary"]');
+    expect(secondary?.textContent).toContain('Needs repair');
+    expect(secondary?.querySelector('[data-testid="row-area-mark"]')?.textContent).toContain(
+      'Garage',
+    );
+    expect(secondary?.textContent).toContain('… › Small Bin');
+  });
+
+  it('still says "No location" when there is neither a path nor a category', async () => {
+    const el = await mount({ category: null, location_path: undefined }, { mobile: true });
+    expect(q(el, '[data-testid="row-secondary"]')?.textContent?.trim()).toBe('No location');
+  });
+
+  // The mark is decorative, so the word has to be there for a reader who cannot
+  // see it — and the row's own title already spells the area out, which is the
+  // one place it must not be doubled.
+  it('names the area for a screen reader without repeating it in the title', async () => {
+    const el = await mount(
+      { category: null, effective_area_id: 'area-workshop', location_path: deepPath },
+      { mobile: true, areas: [{ id: 'area-workshop', name: 'Garage' }] },
+    );
+    const secondary = q(el, '[data-testid="row-secondary"]');
+    expect(
+      secondary?.querySelector('[data-testid="row-area-mark"] .hv-sr-only')?.textContent,
+    ).toBe('Area: ');
+    expect(secondary?.getAttribute('title')).toBe(
+      'Area: Garage · Workshop › Parts Cabinet › Drawer A › Small Bin',
+    );
   });
 
   it('leaves a checked-out phone row saying what it always said', async () => {

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -68,6 +68,33 @@ export function elidePath(path: string, maxSegments = 2): string {
 }
 
 /**
+ * The phone row's location line, with the area separated back out of the front
+ * of it.
+ *
+ * The area has to travel through `elidePath` as the leading segment — that is
+ * the half the elision keeps — but it is Home Assistant's, not one of our
+ * locations, and the `›` after it reads as though it were one. So the line is
+ * composed and elided exactly as it is shown, then the leading segment is taken
+ * back off for the caller to mark instead of punctuate.
+ *
+ * An area name that itself contains ` › ` lands as two segments and the elided
+ * string no longer starts with it. Then there is nothing safe to mark and the
+ * whole string comes back as `rest`, which renders as the line always did
+ * rather than putting the mark on the wrong words.
+ */
+export function elideMobilePath(
+  areaName: string | null,
+  path: string,
+): { area: string | null; rest: string } {
+  const composed = elidePath([areaName, path].filter(Boolean).join(' › '));
+  if (!areaName) return { area: null, rest: composed };
+  if (composed === areaName) return { area: areaName, rest: '' };
+  const prefix = `${areaName} › `;
+  if (!composed.startsWith(prefix)) return { area: null, rest: composed };
+  return { area: areaName, rest: composed.slice(prefix.length) };
+}
+
+/**
  * One row of the standard card list.
  *
  * Desktop reveals edit and row-menu actions on hover; touch has no hover, so the
@@ -188,6 +215,24 @@ export class HVListRow extends LitElement {
          shared fragment and would otherwise keep the row inline. */
       .secondary.hv-chip-line {
         display: flex;
+      }
+      /* The same home mark the area chip carries, marking the leading segment
+         of a phone row's path as Home Assistant's area rather than the top of
+         our own tree. Not a chip: this line has room for neither the fill nor
+         the spelled-out word, which is why the area is a text segment here at
+         all. Colour and weight stay inherited, so the mark travels with
+         whichever state variant the line is in. */
+      .area-lead {
+        display: inline-flex;
+        align-items: center;
+        /* Tighter than the chip's own 4px: this sits inside a text run with no
+           fill around it, and every pixel here comes off the elided tail. */
+        gap: 2px;
+        margin-right: 4px;
+        /* An inline-flex box whose first child is an svg has no baseline of its
+           own and would otherwise sit a couple of pixels low against the path
+           beside it. */
+        vertical-align: middle;
       }
       /* The path elides; the chip ahead of it does not. */
       .secondary.hv-chip-line > .hv-chip-line-text {
@@ -456,11 +501,19 @@ export class HVListRow extends LitElement {
     const parts = itemPathParts(item, this.areas);
     // The desktop row has room for the whole path and the area chip beside it.
     const secondary = [parts.path, item.category].filter(Boolean).join(' · ');
-    // A phone line fits neither, so the area goes in as the leading text
-    // segment — the half elidePath keeps — and the room survives a path deep
-    // enough to lose its middle.
-    const mobilePath = elidePath([parts.areaName, parts.path].filter(Boolean).join(' › '));
-    const mobileSecondary = [mobilePath, item.category].filter(Boolean).join(' · ');
+    // A phone line fits neither, so the area goes in as the leading segment —
+    // the half elidePath keeps — and the room survives a path deep enough to
+    // lose its middle. The home mark is what says the segment is an area and
+    // not the top of our own tree; it replaces the separator after it, so it
+    // costs the line about what that separator cost.
+    const mobileLead = elideMobilePath(parts.areaName, parts.path);
+    const mobileTail = [mobileLead.rest, item.category].filter(Boolean).join(' · ');
+    const hasMobileSecondary = Boolean(mobileLead.area || mobileTail);
+    const mobileSecondary = html`${mobileLead.area
+      ? html`<span class="area-lead" data-testid="row-area-mark"
+          >${icon('home', 11)}<span class="hv-sr-only">Area: </span>${mobileLead.area}</span
+        >`
+      : null}${mobileTail}`;
     // The tooltip carries the *unelided* path: on a phone the middle of it is
     // dropped on purpose, and this is where the whole thing can still be read.
     const secondaryFull = [pathTitle(parts), item.category].filter(Boolean).join(' · ');
@@ -532,13 +585,15 @@ export class HVListRow extends LitElement {
                   ? ` · due ${formatDate(item.due_date)}`
                   : ''}`
               : this.mobile && flagged
-                ? html`<span data-testid="row-status">${statusLabel(status, this.statuses)}</span>${mobileSecondary
-                    ? ` · ${mobileSecondary}`
+                ? html`<span data-testid="row-status">${statusLabel(status, this.statuses)}</span>${hasMobileSecondary
+                    ? html` · ${mobileSecondary}`
                     : ''}`
                 : this.mobile && inspectionDue
                   ? html`<span data-testid="row-inspection-due">Inspection due</span> · ${formatDate(item.inspection_date)}`
                   : this.mobile
-                    ? mobileSecondary || 'No location'
+                    ? hasMobileSecondary
+                      ? mobileSecondary
+                      : 'No location'
                     : html`${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
                         >${secondary || 'No location'}</span
                       >`}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -233,8 +233,8 @@ on the wire; no command changed.
 `ui/location-path.ts` composes the result. `itemPathParts` and `locationPathParts` split
 "where" into `{ areaName, path }`, `pathTitle` writes both as one string
 (`Area: Kitchen · Garage › Shelf A`) for a `title` attribute, and `renderAreaChip` is the
-single visual treatment — a home glyph and the name, styled by `.hv-area-chip` in `tokens`'
-`base` so every shadow root draws it identically. That chip is how an area is told apart
+single visual treatment — a home glyph and the name, styled by `.hv-area-chip` in the `chip`
+fragment (`ui/chip.ts`) so every shadow root draws it identically. That chip is how an area is told apart
 from a path segment: an area is never printed as one. It renders nothing when there is no
 area, so callers embed it unguarded and a location outside every area reads exactly as it
 did before areas were shown at all.
@@ -244,7 +244,12 @@ Two surfaces spell the area out in words instead — `hv-filter-chips`' location
 within a chip is noise, so they print `pathTitle`'s text form, which is also the wording
 the area *filter*'s own chip has always used. `hv-list-row` does the same on a phone for a
 different reason: with no room for a chip the area goes in as the leading text segment,
-where `elidePath` keeps it.
+where `elidePath` keeps it. It is still marked as an area there — `elideMobilePath` composes
+and elides the line exactly as it is shown and then takes the leading segment back off, so
+the row can put the chip's own home glyph in front of it and drop the `›` that followed. The
+mark is the separator, and it costs the line about what that separator cost. An area name
+that itself contains ` › ` splits into two segments and comes back unmarked, which reads as
+the line always did rather than marking the wrong words.
 
 Threading is by property, outward from the two containers that hold `areasCache`.
 `hv-card-shell` and `hv-full-view` pass `.areas` to `hv-list` (which forwards to


### PR DESCRIPTION
## Summary

A phone row joins the area to the location path with the same `›` that divides the path's own
segments, so `Living Room › … › QA Office` reads as though Living Room were one of our
locations. It is Home Assistant's, and every other surface in the card says so with a chip —
this line was the one exception.

The line still has room for neither a chip nor the spelled-out `Area:`, and the area still has
to travel through `elidePath` as the leading segment or a deep path drops it. So:

- **New pure helper `elideMobilePath(areaName, path)`** beside `elidePath`. It composes and
  elides the line exactly as it is shown, then takes the `${areaName} › ` prefix back off, and
  returns `{ area, rest }`. Pure, so the elision rules are unit-tested without a component.
- **`render()` puts the chip's own home glyph in front of `rest`** with an sr-only `Area: `,
  and the `›` after the area goes — the mark is the separator now.
- **`.area-lead`** is an inline-flex run beside `.secondary`. Colour and weight stay inherited,
  so the mark travels with whichever state variant the line is in (`out`, `overdue`, `inspect`).
  Its gap and margin are tighter than the chip's own 4px, because every pixel here comes off
  the elided tail.
- **An area name that itself contains ` › `** lands as two segments, so the elided string no
  longer starts with the prefix. Then `area` is `null` and `rest` is the whole string — the
  line reads exactly as it does today rather than putting the mark on the wrong words.
- `mobileSecondary` becomes a `TemplateResult`, so the two branches that consume it take a
  `hasMobileSecondary` boolean for the `|| 'No location'` fallback and the `· ` join. The
  checked-out branch names no location and the inspection-due branch prints no path; both are
  untouched.

**The issue's second bullet — the "No area" band label — already shipped with #245, and this
was checked rather than assumed.** `hv-location-tree.ts` sets `font-size: inherit` on both
`.area-name .hv-area-chip` and `.area-none`, and the no-area band renders as
`.hv-area-chip quiet`, saying its difference with an outline instead of a smaller uppercase
label. Confirmed live on `/haventory` (`after-203-bands.png`): the four area bands and the
"No area" band are the same size and shape. Nothing to do there, so the issue closes on the
phone marker alone.

Desktop, table, sheet, breadcrumb and both chip surfaces are unchanged. The row's `title` is
unchanged — `pathTitle` already spelled `Area: Living Room · …`.

`docs/frontend_architecture.md` gains the mark in the paragraph that described the phone row's
text segment. While that paragraph was open, its attribution of `.hv-area-chip` to `tokens`'
`base` is corrected: the rule lives in the `chip` fragment (`ui/chip.ts`).

No `custom_components/` change; nothing deleted or renamed inside the integration package, so
no `RETIRED_PATHS` entry.

Closes #203

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green before the commit.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → `752 passed, 22 skipped` ·
      `uv run ruff check .` → `All checks passed!` · `uv run ruff format --check .` →
      `115 files already formatted` · `uv run mypy` → `no issues found in 15 source files`
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean ·
      `npx vitest run` → **1678 passed / 60 files** (1669 before) · `npm run build` → 584 kB

Tests, in `hv-list-row.test.ts`:

- New `elideMobilePath` block — the room and the bin both survive a four-segment path and the
  room comes back on its own; a path that already fits is left alone; with no area the result
  is `elidePath`'s own output, asserted against the function rather than a literal; an area
  name split by the separator comes back unmarked; an area with no path under it still marks.
- Rewritten "spends the phone row on the room, **and marks it as a room**" — the mark holds the
  area name and an `svg`, the row still reads `… › Small Bin`, and no longer contains
  `Garage › `.
- New: a phone row with no area renders no mark and reads exactly as before; a flagged row puts
  the mark after the status label; a row with neither path nor category still says
  `No location`; the mark carries the sr-only `Area: ` and the row's `title` is unchanged.
- Kept as the regression pin: the checked-out phone row still names no area at all.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md`. No `README.md`
      change: the row's wording is unchanged, only its punctuation.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

Measured in the Docker dev HA at 390×844 (touch), in both themes, against real HA areas
assigned to two location roots. The **before** column is `origin/main`'s bundle deployed into
the same container against the same data, not a recollection. PNGs in the gitignored
`.claude/skills/run-haventory/`: `before-203-390.png`, `after-203-390.png`,
`before-203-long.png`, `after-203-long.png`, `after-203-dark.png`, `after-203-flagged.png`,
`after-203-bands.png`.

**A realistic area name ("Living Room"), path `QA House › QA Upstairs › QA Office`, category `Office`**

| | before | after |
|---|---|---|
| what the line reads | `Living Room › … › QA Office · Office` | `⌂ Living Room  … › QA Office · Office` |
| secondary line width | 216 | 216 |
| **line overflow** | **0** | **0** — the mark costs the line nothing here |
| mark box | — | 79 wide (11px icon + 2px gap + 62px of area text), 4px margin after |
| icon centre vs line centre | — | 409.4 vs 409.0 — **0.4px off** |
| mark colour / weight (light) | — | `rgb(94,94,94)` / 400 — identical to the line, i.e. inherited |
| mark colour / weight (dark) | — | `rgb(155,155,155)` / 400 — identical to the line |
| row `title` | `Area: Living Room · QA House › QA Upstairs › QA Office · Office` | unchanged |

**Worst case — a 25-character area name ("Ground Floor Utility Room"), which overflowed the
line before the change too**

| | before | after |
|---|---|---|
| line overflow | 41 | **48** |
| what survives | `Ground Floor Utility Room › … › Storage…` | `⌂ Ground Floor Utility Room … › Storag…` |

The mark costs 7px more than the `›` it replaces, which on an area name this long is about one
character off a tail that was already being cut. Both spacing values were tightened for exactly
this reason (`gap: 2px`, `margin-right: 4px`); the leaf segment survives in both.

**State variants** — a flagged row (`.secondary.inspect`): mark and icon measure
`rgb(122,77,0)` at weight 500, identical to the line they sit on, and the mark renders after
the status label. The checked-out and inspection-due branches print no path and are untouched.

**The "No area" band** (`after-203-bands.png`, `/haventory` at 1280): `⌂ Bedroom`,
`⌂ Ground Floor Utility Room`, `⌂ Kitchen`, `⌂ Living Room` and `No area` all draw at the same
size and shape, the last one outlined rather than filled.

## Follow-ups

- **A screen-reader pass is still owed.** The DOM is verified — the mark carries the sr-only
  `Area: ` and the row `title` is unchanged, structurally identical to the desktop row's
  `renderAreaChip`, which already ships that pairing — but this session had no assistive
  technology to run it through. Not filed: it is a check on an existing shipped pattern rather
  than a defect.
- The dev instance now carries an HA area named "Ground Floor Utility Room" and two roots
  (`PR351 Test Home`, `QA House`) with areas assigned, created to get the phone row into a
  state where the mark renders at all. Test data on a disposable instance; nothing in the repo.
