### PR TITLE
fix(card): Home Assistant reads the card's picker statics off the class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,9 @@ repos:
           # hook `afterAll`, which the tracker names. "socio-economic" is the
           # Contributor Covenant's spelling, and CODE_OF_CONDUCT.md quotes that
           # document verbatim so it stays checkable against the original.
-          - --ignore-words-list=hass,batery,afterall,socio-economic
+          # "statics" is the plural of a class's `static` members, which is what
+          # Home Assistant reads a card's picker interface off.
+          - --ignore-words-list=hass,batery,afterall,socio-economic,statics
         exclude: |
           (?x)^(
             custom_components/haventory/www/|

--- a/README.md
+++ b/README.md
@@ -629,6 +629,13 @@ rejected, so a stale dashboard config never breaks the card — and the same hol
 `quick_filters`: an unknown pill name is dropped, and a value that is not a list reads as
 the key being absent.
 
+Adding the card from the card picker opens a **visual editor** for `title`; the YAML above
+stays equivalent, and switching to it shows the same config. The editor covers `title`
+only — `quick_filters` is set in YAML, because the pill choice that reaches every surface
+(the sidebar panel included) belongs to the integration's options, not to one dashboard's
+card. Editing a card that carries `quick_filters` through the visual editor leaves that key
+exactly as it was.
+
 Without `title`, the card uses the name set under Settings → Devices & services →
 HAventory → **Configure** (asked for at setup too, and defaulting to "HAventory"), so one
 setting renames every card. Per-dashboard `title:` wins over it — use that when two

--- a/cards/haventory-card/src/haventory-card-editor.test.ts
+++ b/cards/haventory-card/src/haventory-card-editor.test.ts
@@ -1,0 +1,110 @@
+import './haventory-card-editor';
+import type { HAventoryCardEditor, HAventoryCardConfig } from './haventory-card-editor';
+
+// jsdom does not define `ha-form` — Home Assistant does, at runtime — so the
+// node stays an unknown element. That is exactly the seam worth testing: what
+// Lit sets on it going in, and what this element makes of the event HA's own
+// control dispatches coming back.
+type Form = HTMLElement & {
+  schema?: { name: string }[];
+  data?: HAventoryCardConfig;
+  computeLabel?: () => string;
+};
+
+async function mount(config: HAventoryCardConfig) {
+  const el = document.createElement('haventory-card-editor') as HAventoryCardEditor & {
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  document.body.appendChild(el);
+  await customElements.whenDefined('haventory-card-editor');
+  el.setConfig(config);
+  await el.updateComplete;
+  return el;
+}
+
+const formOf = (el: { shadowRoot: ShadowRoot }) =>
+  el.shadowRoot.querySelector('[data-testid="card-editor-form"]') as Form;
+
+/** What HA's own `ha-form` raises when a field is edited. */
+const edit = (form: Form, value: Record<string, unknown>) =>
+  form.dispatchEvent(
+    new CustomEvent('value-changed', { detail: { value }, bubbles: true, composed: true }),
+  );
+
+function captured(el: HTMLElement) {
+  const seen: HAventoryCardConfig[] = [];
+  el.addEventListener('config-changed', (e) => {
+    seen.push((e as CustomEvent<{ config: HAventoryCardConfig }>).detail.config);
+  });
+  return seen;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('haventory-card-editor', () => {
+  it('puts the title into the form HA renders', async () => {
+    const el = await mount({ type: 'custom:haventory-card', title: 'Pantry' });
+    const form = formOf(el);
+    expect(form.schema?.map((f) => f.name)).toEqual(['title']);
+    expect(form.data?.title).toBe('Pantry');
+    expect(form.computeLabel?.()).toBe('Title');
+  });
+
+  it('raises exactly one config-changed, keeping the card type', async () => {
+    const el = await mount({ type: 'custom:haventory-card', title: 'Pantry' });
+    const seen = captured(el);
+
+    edit(formOf(el), { title: 'Garage shelf' });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual({ type: 'custom:haventory-card', title: 'Garage shelf' });
+  });
+
+  // `setConfig` on the card ignores unknown keys rather than rejecting them, so
+  // a dashboard's `quick_filters` — or a key from a version this build has never
+  // seen — has to survive a trip through this form untouched.
+  it('carries keys the card does not read straight through an edit', async () => {
+    const el = await mount({
+      type: 'custom:haventory-card',
+      title: 'Pantry',
+      quick_filters: ['low_stock'],
+      something_from_the_future: 42,
+    });
+    const seen = captured(el);
+
+    edit(formOf(el), { title: 'Garage shelf' });
+
+    expect(seen[0]).toEqual({
+      type: 'custom:haventory-card',
+      title: 'Garage shelf',
+      quick_filters: ['low_stock'],
+      something_from_the_future: 42,
+    });
+  });
+
+  // An empty title is the absent key, not an empty heading: that is what hands
+  // the heading back to the integration-wide option.
+  it('drops an emptied title from the config rather than writing ""', async () => {
+    const el = await mount({ type: 'custom:haventory-card', title: 'Pantry' });
+    const seen = captured(el);
+
+    edit(formOf(el), { title: '   ' });
+
+    expect(seen[0]).toEqual({ type: 'custom:haventory-card' });
+    expect('title' in seen[0]).toBe(false);
+  });
+
+  it('does not let the form event escape as well as the config change', async () => {
+    const el = await mount({ type: 'custom:haventory-card' });
+    const escaped: Event[] = [];
+    document.addEventListener('value-changed', (e) => escaped.push(e));
+
+    edit(formOf(el), { title: 'Garage shelf' });
+
+    expect(escaped).toHaveLength(0);
+    document.removeEventListener('value-changed', (e) => escaped.push(e));
+  });
+});

--- a/cards/haventory-card/src/haventory-card-editor.ts
+++ b/cards/haventory-card/src/haventory-card-editor.ts
@@ -1,0 +1,95 @@
+import { LitElement, css, html } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { tokens, base } from './ui/tokens';
+import { defineCardElement } from './register';
+import type { HassLike } from './store/types';
+
+/** What the card reads plus whatever else the dashboard wrote. */
+export interface HAventoryCardConfig {
+  type: string;
+  title?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * One field. `setConfig` on the card reads `title` and `quick_filters`, and the
+ * pill choice belongs to the integration's options flow instead — the sidebar
+ * panel has no dashboard config at all, so a card editor could never reach it.
+ */
+const SCHEMA = [{ name: 'title', selector: { text: {} } }];
+
+/**
+ * The visual editor Home Assistant opens from the card picker.
+ *
+ * `ha-form` rather than a local input: it is the frontend's own control, so it
+ * takes the dashboard's theming and its layout without this card re-deriving
+ * either. The element is not defined here — HA defines it — so nothing in this
+ * module may depend on it existing.
+ *
+ * Registered through `defineCardElement` rather than the decorator the `hv-*`
+ * components use, because HA instantiates this element by tag name after the
+ * frontend has swapped `window.customElements`. See `register.ts`.
+ */
+export class HAventoryCardEditor extends LitElement {
+  static styles = [
+    tokens,
+    base,
+    css`
+      :host {
+        display: block;
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) hass?: HassLike;
+
+  @state() private _config: HAventoryCardConfig = { type: 'custom:haventory-card' };
+
+  /** Lovelace hands the whole card config in, including keys the card ignores. */
+  public setConfig(config: HAventoryCardConfig): void {
+    this._config = { ...config };
+  }
+
+  render() {
+    return html`<ha-form
+      data-testid="card-editor-form"
+      .hass=${this.hass}
+      .data=${this._config}
+      .schema=${SCHEMA}
+      .computeLabel=${this._label}
+      @value-changed=${this._onValueChanged}
+    ></ha-form>`;
+  }
+
+  private _label(): string {
+    return 'Title';
+  }
+
+  /**
+   * Spread the existing config rather than rebuilding it: the card ignores
+   * unknown keys instead of rejecting them, so a dashboard's `quick_filters` —
+   * or a key from a version this build has never seen — has to survive a trip
+   * through this form untouched.
+   *
+   * An emptied title is dropped rather than written as "", which is what hands
+   * the heading back to the integration-wide option.
+   */
+  private _onValueChanged(event: CustomEvent<{ value?: { title?: unknown } }>): void {
+    event.stopPropagation();
+    const title = event.detail?.value?.title;
+    const config: HAventoryCardConfig = { ...this._config };
+    if (typeof title === 'string' && title.trim() !== '') config.title = title;
+    else delete config.title;
+
+    this._config = config;
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+}
+
+defineCardElement('haventory-card-editor', HAventoryCardEditor);

--- a/cards/haventory-card/src/haventory-card.test.ts
+++ b/cards/haventory-card/src/haventory-card.test.ts
@@ -1,5 +1,4 @@
 import './index';
-import { getStubConfig } from './index';
 import { makeMockHass, makeItem } from './test.utils';
 import { COLUMN_PREFS_STORAGE_KEY, DEFAULT_COLUMNS } from './store/columns';
 import type { HAventoryCard } from './index';
@@ -136,13 +135,48 @@ describe('haventory-card: the Lovelace element', () => {
     expect(el.getCardSize()).toBeGreaterThan(0);
   });
 
-  it('offers a stub config and registers itself with the card picker', async () => {
-    expect(getStubConfig().type).toBe('custom:haventory-card');
+  // Home Assistant reads these off `customElements.get(type)` and never imports
+  // from the bundle, so the class is the only surface worth asserting: a module
+  // export can be perfectly correct and still never be looked at.
+  describe('the picker statics, on the surface HA reads', () => {
+    type CardClass = CustomElementConstructor & {
+      getStubConfig?: () => { type: string; title: string };
+      getConfigElement?: () => HTMLElement;
+    };
+    const registered = () => customElements.get('haventory-card') as CardClass;
 
-    const before = window.customCards ? [...window.customCards] : [];
-    await import('./index');
-    expect((window.customCards ?? []).some((c) => c?.type === 'haventory-card')).toBe(true);
-    window.customCards = before;
+    it('offers a stub config', () => {
+      expect(registered().getStubConfig?.().type).toBe('custom:haventory-card');
+    });
+
+    it('answers with the visual editor rather than leaving HA on the YAML fallback', () => {
+      expect(registered().getConfigElement?.().tagName).toBe('HAVENTORY-CARD-EDITOR');
+    });
+
+    it('feeds its own stub config back in without complaint', async () => {
+      const stub = registered().getStubConfig!();
+      const { sr } = await mountCard(stub);
+      const shell = sr.querySelector('[data-testid="card-shell"]') as HTMLElement & { heading: string };
+      expect(shell.heading).toBe('HAventory');
+    });
+
+    it('sizes itself for a sections view, with minimums under the defaults', async () => {
+      const { el } = await mountCard();
+      const grid = (el as unknown as { getGridOptions(): Record<string, number> }).getGridOptions();
+      expect(grid.columns).toBeGreaterThan(0);
+      expect(grid.rows).toBeGreaterThan(0);
+      expect(grid.min_columns).toBeLessThan(grid.columns);
+      expect(grid.min_rows).toBeLessThan(grid.rows);
+    });
+
+    it('registers with the card picker, documentation link and all', async () => {
+      const before = window.customCards ? [...window.customCards] : [];
+      await import('./index');
+      const entry = (window.customCards ?? []).find((c) => c?.type === 'haventory-card');
+      expect(entry).toBeTruthy();
+      expect(entry?.documentationURL).toMatch(/^https:\/\//);
+      window.customCards = before;
+    });
   });
 });
 

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -8,9 +8,10 @@ import type { QuickFilterKey } from './ui/quick-filters';
 import { registerBrandIcon } from './ui/brand-icon';
 import { defineCardElement } from './register';
 import './components/hv-card-shell';
-// The sidebar panel is a second element out of this one bundle, so importing it
-// here is what puts it in the build.
+// The sidebar panel and the config editor are the bundle's other two HA-facing
+// elements, so importing them here is what puts them in the build.
 import './haventory-panel';
+import './haventory-card-editor';
 
 export class HAventoryCard extends LitElement {
   static styles = css`
@@ -27,6 +28,24 @@ export class HAventoryCard extends LitElement {
   private store?: Store;
   private _storeUnsub?: () => void;
   private _hass?: HassLike;
+
+  /**
+   * What the card picker writes into a new dashboard entry.
+   *
+   * A static on the class, not a module export: Home Assistant reads these off
+   * `customElements.get(type)`, and never imports from the bundle.
+   */
+  public static getStubConfig(): { type: string; title: string } {
+    return {
+      type: 'custom:haventory-card',
+      title: 'HAventory',
+    };
+  }
+
+  /** The visual editor the picker opens, created by tag so HA owns its lifecycle. */
+  public static getConfigElement(): HTMLElement {
+    return document.createElement('haventory-card-editor');
+  }
 
   // Lovelace interface: called by HA when the card is created/configured
   public setConfig(cfg: unknown): void {
@@ -50,6 +69,25 @@ export class HAventoryCard extends LitElement {
   public getCardSize(): number {
     // Approximate: header + search + list viewport
     return 6;
+  }
+
+  /**
+   * Sections-view sizing. `getCardSize` above still answers the masonry view,
+   * which knows nothing about columns.
+   *
+   * Full section width, and tall enough that the ⋮ menu opens inside the card:
+   * `hv-card-shell` reserves 470px for it above 601px, and a card shorter than
+   * that clips the menu's last entries. The minimums are what keep the card
+   * usable when a dashboard hand-shrinks it — below them the list has room for
+   * no rows at all.
+   */
+  public getGridOptions(): {
+    columns: number;
+    rows: number;
+    min_columns: number;
+    min_rows: number;
+  } {
+    return { columns: 12, rows: 8, min_columns: 6, min_rows: 4 };
   }
 
   get hass(): HassLike | undefined {
@@ -139,20 +177,14 @@ defineCardElement('haventory-card', HAventoryCard);
 // page — including the ones no card is on.
 registerBrandIcon();
 
-// Lovelace card picker metadata
-export function getStubConfig() {
-  return {
-    type: 'custom:haventory-card',
-    title: 'HAventory',
-  };
-}
-
 // Auto-register with Lovelace card picker when loaded via /local
 interface CustomCardMeta {
   type: string;
   name: string;
   description: string;
   preview?: boolean;
+  /** The picker entry's "documentation" link. */
+  documentationURL?: string;
 }
 
 declare global {
@@ -170,6 +202,7 @@ if (typeof window !== 'undefined') {
       name: 'HAventory',
       description: 'HAventory inventory card',
       preview: true,
+      documentationURL: 'https://github.com/chrreiter/HAventory#readme',
     });
   }
 }

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -19,8 +19,8 @@ It provides the full inventory UI, updating live over the HAventory WebSocket AP
 
 `src/index.ts` defines `haventory-card` — the element Home Assistant knows about. It owns
 the `Store` (created on the first `hass` assignment), the Lovelace interface
-(`setConfig`, `getCardSize`, `getStubConfig`, `window.customCards`), and nothing else of
-substance:
+(`setConfig`, `getCardSize`, `getGridOptions`, the statics `getStubConfig` and
+`getConfigElement`, and `window.customCards`), and nothing else of substance:
 
 ```ts
 setConfig(cfg) → { title?: string; quickFilters?: QuickFilterKey[] | null }
@@ -35,12 +35,30 @@ full view's pills offer one vocabulary; the sidebar panel, which has no dashboar
 takes the default. It decides what is *allowed*: whether an allowed pill draws is still
 the count's call.
 
+`getStubConfig` and `getConfigElement` are **statics on the class**, not module exports:
+Home Assistant reads them off `customElements.get(type)` and never imports from the bundle,
+so an export is a spelling nothing looks at. `getGridOptions` sizes the card in a sections
+view — full section width, and tall enough that `hv-card-shell`'s reserved 470px for the
+open ⋮ menu is not squeezed — while `getCardSize` still answers the masonry view, which
+knows nothing about columns.
+
 It also publishes the active HA theme as `color-scheme` on the host, which every nested
 component inherits.
 
 `src/haventory-panel.ts` defines `haventory-panel` — the same bundle's second element,
 which HA's custom-panel loader instantiates for the sidebar page. It mirrors the card's
 store lifecycle and renders `<hv-full-view embedded open>`.
+
+`src/haventory-card-editor.ts` defines `haventory-card-editor` — the bundle's third
+HA-facing element, which `getConfigElement` creates by tag. It renders one `ha-form` field
+for `title`, HA's own control rather than a local input, and turns the form's
+`value-changed` into a `config-changed` carrying `{ ...config, title }`. The spread is the
+point: the card ignores unknown keys instead of rejecting them, so `quick_filters` and
+anything a future version writes survive an edit untouched. An emptied title is dropped
+from the config rather than written as `""`, which hands the heading back to the
+integration-wide option. All three elements register through `defineCardElement`
+(`src/register.ts`), because HA creates each of them by tag after the frontend has swapped
+`window.customElements`.
 
 The integration registers that panel at `/haventory` through `panel_custom`, handing it
 the *same* module URL both card loaders get (`__init__.py`, `_async_apply_sidebar_panel`),


### PR DESCRIPTION
## Summary

`getStubConfig` was a module-level export, and Home Assistant reads a card's statics off
`customElements.get(type)` — it never imports from the bundle. So the picker had no stub
config to write, and the unit test asserting the export was verifying a surface nothing looks
at. Two more pieces of the HA card idiom were missing beside it.

- **`static getStubConfig()` on the class**, module export deleted rather than left as a
  second spelling. The test now asks `customElements.get('haventory-card')`.
- **`static getConfigElement()`** returning a fresh `haventory-card-editor`, so the picker
  opens a **visual editor** instead of the YAML fallback.
- **New `src/haventory-card-editor.ts`** — one `ha-form` field for `title`. HA's own control
  rather than a local input, so it takes the dashboard's theming and layout without this card
  re-deriving either. The emitted config is `{ ...this._config, title }`: `quick_filters`, and
  any key a future version writes, survive an edit untouched. An emptied title is *dropped*
  rather than written as `""`, which is what hands the heading back to the integration-wide
  option.
- **`getGridOptions()`** — `{ columns: 12, rows: 8, min_columns: 6, min_rows: 4 }`. Full
  section width; the row count leaves room for the 470px `hv-card-shell` reserves above 601px
  so the open ⋮ menu is not clipped; the minimums are what keep a hand-shrunk card usable.
  `getCardSize()` stays for the masonry view, which knows nothing about columns.
- **`documentationURL`** on the `window.customCards` entry, pointing at the repository README.
- The editor registers through **`defineCardElement`** (`src/register.ts`), not the
  `@customElement` decorator the `hv-*` components use: HA creates it by tag *after* the
  frontend has swapped `window.customElements`, which is the hazard that module exists for.
  `index.ts` imports it beside `./haventory-panel`, so the single Vite entry carries it.

**`quick_filters` is deliberately not in the editor** — decided in #222 against #365. The
sidebar panel has no Lovelace config at all, so a card editor cannot reach it and it would go
on offering all five pills regardless; the pill choice belongs to the options flow. This PR
keeps the key readable from card YAML and proves, in a test and live, that an edit does not
drop it.

**`getEntitySuggestion` stays out**, per the first comment on the issue: the API name is
unverified and there is nothing to suggest the card *for* until #218.

`.pre-commit-config.yaml` gains `statics` to the codespell ignore list (codespell reads it as
"statistics"), with a one-line note in the same style as the entries already there.

No `custom_components/` change. Nothing deleted or renamed inside the integration package —
the built bundle keeps its filename — so no `RETIRED_PATHS` entry.

Closes #222

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

The card gains an editor element, but what it fixes is a broken contract: the picker statics
HA looks for were not where HA looks. Filed and titled as a fix on that basis.

## How was this tested?

Both gates green before the commit.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → `752 passed, 22 skipped` ·
      `uv run ruff check .` → `All checks passed!` · `uv run ruff format --check .` →
      `115 files already formatted` · `uv run mypy` → `no issues found in 15 source files`
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean · `npm run typecheck` → clean ·
      `npx vitest run` → **1678 passed / 61 files** (1669 / 60 before) · `npm run build` →
      584.93 kB

Tests:

- `haventory-card.test.ts` — the module-export case is replaced by a block that asks the
  registry: the stub config's type, `getConfigElement()` answering with an element whose
  `tagName` is `HAVENTORY-CARD-EDITOR`, the stub config feeding back into `setConfig` and
  yielding the stub's heading (a picker writes it verbatim), `getGridOptions()` with minimums
  below the defaults, and the `customCards` entry carrying a `documentationURL`.
- New `haventory-card-editor.test.ts` — jsdom does not define `ha-form`, which is the point:
  the spec asserts what Lit sets on that node (`schema`, `data`, `computeLabel`) and dispatches
  at it exactly what HA's control does. Happy path: an edit raises exactly one `config-changed`
  keeping `type`. Edges: a config carrying `quick_filters` **and** an unknown key survives
  unchanged; an emptied title leaves no `title` key at all; the form's own `value-changed` does
  not escape alongside the config change.

`visual_pass.mjs` after the change: **42/42 surfaces captured**, every recipe PASS, at desktop
and phone widths on the card and on `/haventory`.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md` (the Lovelace
      interface list, why the statics are on the class, and the editor as the bundle's third
      element) and `README.md` "Card configuration".
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

Driven against the real Home Assistant frontend on the Docker dev instance, on a scratch
dashboard view holding one card with `title: Before edit` and
`quick_filters: [low_stock, overdue]`. Every line below is a live check, not a unit test.
PNGs in the gitignored `.claude/skills/run-haventory/`: `pr3-chromium-picker.png`,
`pr3-chromium-picker-editor.png`, `pr3-chromium-editor.png`, `pr3-chromium-editor-typed.png`,
`pr3-chromium-sections.png`, `pr3-min-size.png`, plus the 42-surface sweep in `pr3-after/`.

| check | result |
|---|---|
| all three elements resolve in the live registry (`haventory-card`, `haventory-panel`, `haventory-card-editor`) | PASS — Chromium and **Firefox**, each also after a **cold reload** |
| `window.customCards` entry | PASS — `{type, name, description, preview: true, documentationURL}` |
| the card picker lists HAventory | PASS — with a live preview of the real card, `preview: true` working |
| picking it opens the **visual** editor | PASS — `haventory-card-editor` present, `ha-code-editor` count 0 |
| an existing card's edit dialog lands on the visual editor too | PASS — same counts |
| the dialog links out to the documentation URL | PASS — `https://github.com/chrreiter/HAventory#readme` |
| typing a title reaches HA | PASS — the dialog's Save enables, and the live preview's heading follows |
| **the round trip keeps `quick_filters`** | PASS — read back over WS after saving: `{"type": "custom:haventory-card", "title": "After edit", "quick_filters": ["low_stock", "overdue"]}` |
| `getGridOptions()` on the rendered element | PASS — `{columns: 12, rows: 8, min_columns: 6, min_rows: 4}` |
| default size in a **sections** view | card box 500 × 641, filling its grid item exactly |
| dragged down to `min_columns` / `min_rows` (`grid_options: {columns: 6, rows: 4}`) | usable at ~245px wide: header, all four quick-filter pills, search, rows with steppers, footer count. Names elide hard, which is what a 6-column card is |

The Firefox run is the one that matters for `defineCardElement`: Chromium wins the
registry-swap race on its own, Firefox does not, and all three elements resolved there on a
cold load.

## Follow-ups

- **The picker and edit-dialog steps could not be driven in Firefox** — the edit-mode click
  affordances behave differently there and the probe's selectors do not reach them. The
  registry check, which is the Firefox-specific one, did run and passed; the dialog checks are
  Chromium-only. A harness limit, not a card defect, so not filed.
- The editor covers `title` only, by decision. If a pill picker is ever wanted there, #365
  keeps `quick_filters` readable from card YAML so it can be added without changing the config
  shape.
