### PR TITLE
build(card): tsc stops laying out an output tree it never writes

### DIFF
--- a/cards/haventory-card/tsconfig.json
+++ b/cards/haventory-card/tsconfig.json
@@ -9,7 +9,7 @@
     "useDefineForClassFields": false,
     "jsx": "react-jsx",
     "skipLibCheck": true,
-    "outDir": "dist",
+    "noEmit": true,
     "types": ["vitest/globals"]
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary

The card's `tsconfig.json` set `outDir: "dist"` without a `rootDir`. TypeScript 6 reports that as **TS5011** — TypeScript 7 stops inferring the common source directory, so the output layout would change underneath the setting:

> The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.

Only the editor surfaced it. The `typecheck` script passes `--noEmit`, and TS5011 fires only with emit on, so CI stayed green while the language service flagged the file.

Nothing ever emitted through that setting:

- Vite builds the bundle, into `custom_components/haventory/www` (`vite.config.ts`).
- `tsc` is invoked only as `tsc --noEmit`.
- No script, workflow or ignore rule referenced a `dist/` under the card, and none exists.

So the fix declares what is already true — `noEmit: true` — rather than naming a `rootDir` for output that is never written. `tsc` now reports the same thing to the editor and to CI, and the config no longer points at a directory the build does not use.

The reasoning above lives here rather than as a comment in the file, so `tsconfig.json` stays plain JSON.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green on this branch. The editor's diagnostic was reproduced first by running `tsc` with emit on (`npx tsc` with no flags, which is what the language service does) — TS5011 before the change, clean after.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 752 passed, 22 skipped; `uv run ruff check .` → all checks passed; `uv run ruff format --check .` → 115 files already formatted; `uv run mypy` → no issues in 15 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean, `npx tsc` (emit on) clean, `npx vitest run` → 1693 passed in 60 files, `npm run build` → bundle written

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [ ] Tests added/updated (happy path + at least one edge/error case).
- [ ] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [ ] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

No test accompanies this one: the compiler is the check, and it is exercised on every CI run of `npm run typecheck`. Nothing about the shipped bundle changes — the build path was already Vite's.
