### PR TITLE
fix(card): v0.4.1 copy fixes across the card's surfaces

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -326,11 +326,18 @@ describe('hv-card-shell: search and filters', () => {
     expect(store.state.value.filters.q).toBe('glue');
   });
 
-  it('puts the filtered total in the search placeholder', async () => {
+  // The full view and the panel word it this way, and the card searches the same
+  // store they do — "matching" claimed a filter that need not be there at all.
+  it('offers the whole inventory in the search placeholder, in the full view wording', async () => {
     const items = Array.from({ length: 3 }, (_, i) => makeItem({ id: `${i}` }));
-    const { sr } = await mountShell({ items });
+    const { el, store, sr } = await mountShell({ items });
     const input = sr.querySelector('[data-testid="search-input"]') as HTMLInputElement;
-    expect(input.placeholder).toBe('Search 3 matching items…');
+    expect(input.placeholder).toBe('Search all 3 items…');
+
+    // A filter narrowing the result does not renumber the offer.
+    store.setFilters({ q: 'nothing matches this' });
+    await settle(el);
+    expect(input.placeholder).toBe('Search all 3 items…');
   });
 
   it('marks the filter button when any filter is on, and toggles the panel', async () => {

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -226,6 +226,20 @@ describe('hv-card-shell: overflow menu', () => {
     ]);
   });
 
+  // Two meta lines sit one above the other in the same menu, so a lower-cased
+  // one reads as a different kind of thing rather than the same kind of list.
+  it('capitalizes every word of a meta line', async () => {
+    const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
+    const menu = sr.querySelector('[data-testid="card-overflow"]') as HTMLElement;
+    (menu.shadowRoot?.querySelector('[data-testid="overflow-trigger"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const metaOf = (id: string) =>
+      menu.shadowRoot?.querySelector(`[data-id="${id}"] .meta`)?.textContent?.trim();
+    expect(metaOf('refresh')).toBe('Items · Locations · Stats');
+    expect(metaOf('organize')).toBe('Locations · Tags · Categories · Statuses');
+  });
+
   // Column choices only drive the full view's table — the card list draws a
   // fixed compact row — so the entry belongs where it does something.
   it('offers Columns in the full view but not on the card itself', async () => {

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
-import { counted, plural, showingCount } from '../ui/plural';
+import { counted, showingCount } from '../ui/plural';
 import { ResponsiveController } from '../ui/responsive';
 import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters } from '../store/store';
@@ -887,6 +887,10 @@ export class HVCardShell extends LitElement {
     const stagedFilterCount = activeFilterCount(this._stagedFilters ?? filters);
     const loaded = st?.items.length ?? 0;
     const total = st?.total;
+    // The placeholder counts the whole inventory, not the filtered result: it is
+    // the same sentence the full view and the panel show, so the search box does
+    // not describe the same store two ways depending on which surface opened it.
+    const searchTotal = st?.statsCounts?.items_total ?? null;
     const mobile = this.mobile;
     // The filter button reports the surface its own width uses. The desktop
     // panel's open state is remembered across sessions, so reading it on a
@@ -933,9 +937,7 @@ export class HVCardShell extends LitElement {
           <input
             type="search"
             data-testid="search-input"
-            placeholder=${total !== null && total !== undefined
-              ? `Search ${total} matching ${plural(total, 'item')}…`
-              : 'Search items…'}
+            placeholder=${searchTotal === null ? 'Search items…' : `Search all ${counted(searchTotal, 'item')}…`}
             .value=${this._searchDraft}
             @input=${(e: Event) => {
               this._searchDraft = (e.target as HTMLInputElement).value;

--- a/cards/haventory-card/src/components/hv-checkout-popover.test.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.test.ts
@@ -40,11 +40,16 @@ describe('hv-checkout-popover: check-out', () => {
     expect(q(el, '[data-testid="checkout-date-label"]')?.textContent).toBe(formatDate(addDays(7)));
   });
 
-  // A week, a month, a quarter. +1 day was shorter than most borrowings ever
-  // are, and +30 was a month that isn't one.
+  // A week, a month, a quarter — the round spans a household names, with +1 day
+  // left out as shorter than most borrowings ever are.
   it('offers the other offsets and switches between them', async () => {
     const el = await mount();
-    expect(all(el, '[data-testid="checkout-offset"]').map((b) => b.dataset.days)).toEqual(['7', '31', '90']);
+    expect(all(el, '[data-testid="checkout-offset"]').map((b) => b.dataset.days)).toEqual(['7', '30', '90']);
+    expect(all(el, '[data-testid="checkout-offset"]').map((b) => b.textContent?.trim())).toEqual([
+      '+7 days',
+      '+30 days',
+      '+90 days',
+    ]);
 
     (all(el, '[data-testid="checkout-offset"]')[2] as HTMLButtonElement).click();
     await el.updateComplete;

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -243,6 +243,19 @@ describe('hv-filter-panel: status', () => {
   });
 });
 
+// The panel is a household surface: a hint that names how the backend stores a
+// value, or where a count came from, tells a user nothing they can act on.
+describe('hv-filter-panel: hints', () => {
+  it('says what the control does, in words a household uses', async () => {
+    const el = await mount();
+    const hints = all(el, '.hint').map((h) => h.textContent?.trim());
+
+    expect(hints).toContain('Pick one category');
+    expect(hints).toContain('Tags are always lowercase');
+    expect(hints.join(' ')).not.toMatch(/distinct values|on commit|Stored lowercase/);
+  });
+});
+
 describe('hv-filter-panel: tags', () => {
   it('multi-selects tags and switches between any and all', async () => {
     const el = await mount();

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -550,7 +550,7 @@ export class HVFilterPanel extends LitElement {
               </button>`
             : null}
         </div>
-        <span class="hint">Single select · counts from distinct values</span>
+        <span class="hint">Pick one category</span>
       </div>
     `;
   }
@@ -630,7 +630,7 @@ export class HVFilterPanel extends LitElement {
             />
           </label>
         </div>
-        <span class="hint">Stored lowercase — input lowercases on commit</span>
+        <span class="hint">Tags are always lowercase</span>
       </div>
     `;
   }

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -2635,7 +2635,7 @@ describe('hv-item-editor: one label recipe, one note size', () => {
     const el = await mount(makeItem({ id: '1' }));
     expect(el.shadowRoot?.innerHTML).not.toContain('style="text-transform');
     const note = el.shadowRoot?.querySelector('.label-note');
-    expect(note?.textContent).toContain('stored lowercase');
+    expect(note?.textContent).toContain('always lowercase');
   });
 
   // The tag field sat a point smaller than every input beside it.

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -300,14 +300,17 @@ describe('hv-item-editor: field parity', () => {
     const el = await mount(makeItem({ id: '1', inspection_date: null }));
     expect(all(el, '[data-testid="editor-inspection-offset"]').map((b) => b.dataset.days)).toEqual([
       '7',
-      '31',
+      '30',
       '90',
     ]);
+    expect(all(el, '[data-testid="editor-inspection-offset"]').map((b) => b.textContent?.trim())).toEqual(
+      ['+7 days', '+30 days', '+90 days'],
+    );
 
     const dateInput = () => q(el, '[data-testid="editor-inspection-date"]') as HTMLInputElement;
     (all(el, '[data-testid="editor-inspection-offset"]')[1] as HTMLButtonElement).click();
     await el.updateComplete;
-    expect(dateInput().value).toBe(addDays(31));
+    expect(dateInput().value).toBe(addDays(30));
     expect(all(el, '[data-testid="editor-inspection-offset"]')[1].classList.contains('on')).toBe(true);
   });
 

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -2641,7 +2641,7 @@ export class HVItemEditor extends LitElement {
           ${this.mobile ? this._renderStatusField() : null}
           <div class="cell span3">
             <span class="hv-label"
-              >Tags <span class="label-note">· stored lowercase</span></span
+              >Tags <span class="label-note">· always lowercase</span></span
             >
             <hv-chip-input
               data-testid="editor-tags"

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1007,14 +1007,21 @@ describe('hv-organize-dialog: statuses', () => {
     expect(q(sr, '[data-testid="status-chip"]')?.classList.contains('tone-green')).toBe(true);
   });
 
-  it('shows the slug beside the label, because an automation has to name it', async () => {
-    const { sr } = await mount({ tab: 'statuses' });
+  // The chip already names each status in the household's own words; printing
+  // "needs_repair" beside "Needs repair" only said the same thing in code.
+  it('leaves the slug out of the list rows and keeps it in the editor', async () => {
+    const { el, sr } = await mount({ tab: 'statuses' });
 
-    expect(all(sr, '[data-testid="status-slug"]').map((s) => s.textContent?.trim())).toEqual([
-      'ok',
-      'missing',
-      'needs_repair',
-    ]);
+    expect(all(sr, '[data-testid="status-slug"]')).toEqual([]);
+
+    (
+      all(sr, '[data-testid="status-row"]')
+        .find((r) => r.dataset.value === 'needs_repair')
+        ?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement
+    ).click();
+    await settle(el);
+
+    expect(q(sr, '[data-testid="status-slug-preview"]')?.textContent?.trim()).toBe('needs_repair');
   });
 
   it('counts the items on each status', async () => {
@@ -1345,7 +1352,7 @@ describe('hv-organize-dialog: statuses', () => {
 
   // The preview exists for people writing automations, and it was eliding the
   // identifier it exists to show while the row still had free width.
-  it('shows the derived slug in full, and titles both places it appears', async () => {
+  it('shows the derived slug in full, and titles it', async () => {
     const { el, sr } = await mount({ tab: 'statuses' });
     (q(sr, '[data-testid="organize-new-status"]') as HTMLButtonElement).click();
     await settle(el);
@@ -1358,11 +1365,6 @@ describe('hv-organize-dialog: statuses', () => {
     const preview = q(sr, '[data-testid="status-slug-preview"]');
     expect(preview?.textContent?.trim()).toBe('lent_out_to_the_neighbours');
     expect(preview?.getAttribute('title')).toBe('lent_out_to_the_neighbours');
-
-    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'needs_repair');
-    expect(row?.querySelector('[data-testid="status-slug"]')?.getAttribute('title')).toBe(
-      'needs_repair',
-    );
   });
 
   it('lets the slug wrap under the name field rather than eliding beside it', () => {
@@ -1370,9 +1372,8 @@ describe('hv-organize-dialog: statuses', () => {
     expect(css).toMatch(/\.status-name \{[^}]*flex-wrap: wrap/);
     // Not shrinkable, so it wraps to a line of its own instead of being cut…
     expect(css).toMatch(/\.status-name \.status-slug \{[^}]*flex: 0 0 auto/);
-    // …while the list row keeps the elision that stops a long slug pushing the
-    // delete button off the dialog.
-    expect(css).toMatch(/\.status-slug \{[^}]*flex: 0 1 auto[^}]*text-overflow: ellipsis/);
+    // …and elides only when the slug alone outruns that line.
+    expect(css).toMatch(/\.status-slug \{[^}]*text-overflow: ellipsis/);
   });
 
   // Measured in the sidebar panel at 390px: the row needed 404px of a 362px
@@ -1383,9 +1384,6 @@ describe('hv-organize-dialog: statuses', () => {
     // The chip is flex:none everywhere else; in a status row it has to give way.
     expect(css).toMatch(/\.status-row \.hv-status-chip \{[^}]*flex: 0 1 auto/);
     expect(css).toMatch(/\.status-row \.hv-status-chip \{[^}]*min-width: 0/);
-    // The slug still empties first — a shrink factor of 1 would take from both
-    // in proportion to their widths and cut the label while the slug held on.
-    expect(css).toMatch(/\.status-row \.status-slug \{[^}]*flex-shrink: 20/);
   });
 
   // Five children on one row left the select ~44px wide, showing "O⌄" — the one

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -274,8 +274,8 @@ export class HVOrganizeDialog extends LitElement {
         line-height: 0;
       }
       /* A phone keeps them stacked: a horizontal pair at the platform's 44px
-         is 88px of row, which does not fit beside the chip, the slug, the count
-         and two 44px actions. */
+         is 88px of row, which does not fit beside the chip, the count and two
+         44px actions. */
       :host([mobile]) .move {
         flex-direction: column;
         gap: 1px;
@@ -291,35 +291,23 @@ export class HVOrganizeDialog extends LitElement {
         opacity: 0.3;
         cursor: default;
       }
-      /* The identity items store. Shown because services.yaml and an export
-         document carry it, muted because a household never needs to type it.
-
-         In a list row it is the one part that may be cut: at phone width a long
-         slug otherwise pushes the delete button past the dialog edge, where it
-         cannot be tapped at all. Both places carry it as a title attribute too,
-         because either can end up eliding it. */
+      /* The identity items store, shown in the editor only: services.yaml and an
+         export document carry it, and it is muted there because a household
+         never needs to type it. It carries a title attribute too, because a
+         slug long enough to outrun its line still elides. */
       .status-slug {
         font: 400 12px var(--hv-font);
         color: var(--hv-text-tertiary);
         white-space: nowrap;
-        flex: 0 1 auto;
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      /* Giving up its width before the chip does is what "the one part that may
-         be cut" means, and a plain shrink factor of 1 does not say it: flexbox
-         would take from both in proportion to their widths, eliding a label the
-         household wrote while the slug it never types still holds 60px. */
-      .status-row .status-slug {
-        flex-shrink: 20;
-      }
       /* A label is a household's own words and can be long enough that the row
          overruns on its own — the fixed parts beside it (a 44px reorder column,
-         the count, two 44px actions) leave a phone row barely 130px for it. The
-         chip elides too, once the slug has nothing left to give; unshrinkable,
-         it pushes the delete button past the dialog edge where no finger
-         reaches it. */
+         the count, two 44px actions) leave a phone row barely 130px for it.
+         Unshrinkable, the chip pushes the delete button past the dialog edge
+         where no finger reaches it. */
       .status-row .hv-status-chip {
         flex: 0 1 auto;
         min-width: 0;
@@ -1820,7 +1808,6 @@ export class HVOrganizeDialog extends LitElement {
                 </button>
               </span>
               ${renderStatusChip(d.slug, defs, { testid: 'status-chip' })}
-              <span class="status-slug" data-testid="status-slug" title=${d.slug}>${d.slug}</span>
               <button class="count-link" data-testid="status-count" @click=${() =>
                 this._showStatus(d.slug)}>
                 ${counted(count, 'item')}

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -217,7 +217,7 @@ export class HostSurfaces {
       { id: 'organize', label: 'Organize…', glyph: 'mapMarker', meta: 'Locations · Tags · Categories · Statuses' },
       { id: 'columns', label: 'Columns…', glyph: 'viewColumn' },
       { divider: true },
-      { id: 'refresh', label: 'Refresh data', glyph: 'refresh', meta: 'Items · locations · stats' },
+      { id: 'refresh', label: 'Refresh data', glyph: 'refresh', meta: 'Items · Locations · Stats' },
       {
         id: 'diagnostics',
         label: 'Diagnostics',

--- a/cards/haventory-card/src/ui/relative-time.ts
+++ b/cards/haventory-card/src/ui/relative-time.ts
@@ -76,16 +76,16 @@ export function addDays(days: number, from: number = Date.now()): string {
 
 /**
  * The quick offsets every forward-dating control offers: a week, a month, a
- * quarter. +31 rather than +30 so "a month" lands a month later, and nothing
- * shorter than a week — a single day is less than most borrowings ever run,
- * and less than any inspection interval worth recording.
+ * quarter — the round numbers a household names a span by. Nothing shorter
+ * than a week: a single day is less than most borrowings ever run, and less
+ * than any inspection interval worth recording.
  *
  * Shared so the check-out popover and the editor's inspection field cannot
  * drift into offering different jumps for the same gesture.
  */
 export const QUICK_DAY_OFFSETS: readonly { days: number; label: string }[] = [
   { days: 7, label: '+7 days' },
-  { days: 31, label: '+31 days' },
+  { days: 30, label: '+30 days' },
   { days: 90, label: '+90 days' },
 ];
 


### PR DESCRIPTION
Four copy findings from the v0.4.1 RC pass. Strings and the tests that pin them;
no behaviour changes, no version files touched.

## Closes #384 — search placeholder

The card wrote `Search 30 matching items…`, the full view and the panel wrote
`Search all 30 items…` over the same store. The card now says what they say.

Note on the number: the full-view wording counts the **inventory**
(`statsCounts.items_total`), not the filtered result the card used to count — so
"all" stays true when a filter is on. A test pins that a filter narrowing the
list does not renumber the offer.

## Closes #385 — quick date chips

`+31 days` → `+30 days`. One shared `QUICK_DAY_OFFSETS` drives both the check-out
popover and the editor's next-inspection field, so both move together; both are
pinned by label as well as by day count now.

## Closes #386 — overflow meta lines

`Items · locations · stats` → `Items · Locations · Stats`, so it matches the
`Locations · Tags · Categories · Statuses` line directly above it. Both come from
`host-surfaces.menuEntries()`, so the card and the panel cannot drift.

## Closes #382 — developer wording in filters and Organize

Per line, whichever left the surface clearer:

| was | now |
|---|---|
| `Single select · counts from distinct values` | `Pick one category` |
| `Stored lowercase — input lowercases on commit` (filter panel) | `Tags are always lowercase` |
| `· stored lowercase` (item editor) | `· always lowercase` |
| raw slug beside every Organize → Statuses chip | dropped |

**Judgment call worth flagging:** the status slug is dropped from the *list rows*
only. The status **editor** still shows it (`status-slug-preview`) — that is where
someone writing an automation goes looking for the identity, and the row already
names the status in the household's own words. The now-dead
`.status-row .status-slug` shrink rule and the comments describing it went with it.

## Verification

- Backend gate: 752 passed / 22 skipped; ruff check, ruff format --check, mypy all clean.
- Frontend gate: eslint clean, tsc clean, **1695 passed across 61 files** (up from 1691), build clean.
- Deployed to the dev HA and checked at the real surfaces: card search box reads
  `Search all 1076 items…`; the ⋮ menu reads `Items · Locations · Stats`; the filter
  panel reads `Pick one category`; the editor reads `TAGS · always lowercase` and
  offers `+7 / +30 / +90 / +X days`; Organize → Statuses shows chips and counts with
  no slugs.
- `visual_pass --only panel`: 10/10. `log_sweep.py --since 30m`: BLOCKING 0, verdict PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
