### PR TITLE
fix(card): v0.4.1 list-row fixes for areas and checked-out items

### DIFF
--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -138,11 +138,46 @@ describe('hv-list-row: content', () => {
     expect(q(el, '[data-testid="row-qty"]')?.classList.contains('low')).toBe(true);
   });
 
-  it('marks a checked-out item and disables its stepper', async () => {
-    const el = await mount({ checked_out: true });
+  // The stepper used to sit there greyed and check-in was reachable only through
+  // the ⋮ menu, which a wide row hides until the row is hovered.
+  it('gives a checked-out row the check-in button in the stepper place, at any width', async () => {
+    for (const mobile of [false, true]) {
+      const el = await mount({ checked_out: true }, { mobile });
+      const where = `mobile=${mobile}`;
+
+      expect(q(el, '[data-testid="row-stepper"]'), where).toBe(null);
+      const button = q(el, '[data-testid="row-check-in"]');
+      expect(button?.textContent?.trim(), where).toBe('Check in');
+
+      const emitted: string[] = [];
+      el.addEventListener('check-in', () => emitted.push('check-in'));
+      (button as HTMLButtonElement).click();
+      expect(emitted, where).toEqual(['check-in']);
+
+      el.remove();
+    }
+
+    // Still a secondary path, so a user who reaches for the menu keeps it.
+    expect(
+      rowMenuEntries(makeItem({ checked_out: true })).some((e) => 'id' in e && e.id === 'check-in'),
+    ).toBe(true);
+  });
+
+  it('marks a checked-out item on the wide row and keeps its location beside it', async () => {
+    const el = await mount({
+      checked_out: true,
+      category: 'Tools',
+      location_path: {
+        id_path: [],
+        name_path: [],
+        display_path: 'Workshop / Drawer A',
+        sort_key: '',
+      },
+    });
     expect(q(el, '[data-testid="row-checked-out"]')?.textContent).toContain('Checked out');
-    expect((q(el, '[data-testid="row-increment"]') as HTMLButtonElement).disabled).toBe(true);
-    expect((q(el, '[data-testid="row-decrement"]') as HTMLButtonElement).disabled).toBe(true);
+    const secondary = q(el, '[data-testid="row-secondary"]')?.textContent;
+    expect(secondary).toContain('Drawer A');
+    expect(secondary).toContain('Tools');
   });
 
   it('calls out an overdue check-out in error colour', async () => {
@@ -442,14 +477,20 @@ describe('hv-list-row: mobile affordances', () => {
     );
   });
 
-  it('leaves a checked-out phone row saying what it always said', async () => {
+  // Being out used to take the line rather than lead it, so the one row you most
+  // want the shelf of — the borrowed one — was the row that stopped naming it.
+  it('leads a checked-out phone row with the checkout and keeps the location behind it', async () => {
     const el = await mount(
       { checked_out: true, due_date: '2099-07-31', effective_area_id: 'area-workshop', location_path: deepPath },
       { mobile: true, areas: [{ id: 'area-workshop', name: 'Garage' }] },
     );
     const secondary = q(el, '[data-testid="row-secondary"]');
-    expect(secondary?.textContent).toContain('Checked out');
-    expect(secondary?.textContent).not.toContain('Garage');
+    const text = secondary?.textContent?.replace(/\s+/g, ' ') ?? '';
+
+    expect(text).toContain('Checked out · due');
+    expect(secondary?.querySelector('[data-testid="area-chip"]')?.textContent).toContain('Garage');
+    expect(text).toContain('… › Small Bin');
+    expect(text.indexOf('Checked out')).toBeLessThan(text.indexOf('Small Bin'));
   });
 
   // Both lines clip with an ellipsis, and the phone row drops the middle of the

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -1,7 +1,7 @@
 import './hv-list-row';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
-import { elideMobilePath, elidePath, isLowStock } from './hv-list-row';
+import { areaMarkName, elideMobilePath, elidePath, isLowStock, rowMenuEntries } from './hv-list-row';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVListRow } from './hv-list-row';
 import type { Item } from '../store/types';
@@ -31,6 +31,27 @@ describe('isLowStock', () => {
   it('is low at or below the threshold', () => {
     expect(isLowStock(makeItem({ quantity: 3, low_stock_threshold: 3 }))).toBe(true);
     expect(isLowStock(makeItem({ quantity: 4, low_stock_threshold: 3 }))).toBe(false);
+  });
+});
+
+describe('areaMarkName', () => {
+  it('keeps an area the path does not already name', () => {
+    expect(areaMarkName('Garage', 'Workshop › Drawer A')).toBe('Garage');
+  });
+
+  it('drops an area the path opens with', () => {
+    expect(areaMarkName('Küche', 'Küche')).toBe(null);
+    expect(areaMarkName('Küche', 'Küche › Oberstes Fach')).toBe(null);
+  });
+
+  // Only the first segment counts: a deeper segment of the same name is a
+  // different place inside the area, and the mark still says which area.
+  it('only compares the first segment', () => {
+    expect(areaMarkName('Küche', 'Keller › Küche')).toBe('Küche');
+  });
+
+  it('has nothing to drop when there is no area', () => {
+    expect(areaMarkName(null, 'Küche')).toBe(null);
   });
 });
 
@@ -332,28 +353,54 @@ describe('hv-list-row: mobile affordances', () => {
   });
 
   it('spends the phone row on the room, and marks it as a room', async () => {
-    // No chip fits this line, so the area goes in as the leading segment — the
-    // half elidePath keeps — with the home mark saying it is Home Assistant's
-    // area rather than the top of our own tree.
+    // The area travels through the elision as the leading segment — the half
+    // elidePath keeps — and comes back out of it as the pill the wide row hangs
+    // beside a path. As plain text it was only a space away from the path.
     const el = await mount(
       { category: null, effective_area_id: 'area-workshop', location_path: deepPath },
       { mobile: true, areas: [{ id: 'area-workshop', name: 'Garage' }] },
     );
     const secondary = q(el, '[data-testid="row-secondary"]');
-    const mark = secondary?.querySelector('[data-testid="row-area-mark"]');
+    const mark = secondary?.querySelector('[data-testid="area-chip"]');
+    expect(mark?.classList.contains('hv-area-chip')).toBe(true);
     expect(mark?.textContent).toContain('Garage');
     expect(mark?.querySelector('svg')).toBeTruthy();
     expect(secondary?.textContent).toContain('… › Small Bin');
-    // The mark is the separator now.
+    // The pill is the separator now.
     expect(secondary?.textContent).not.toContain('Garage › ');
-    // Still the phone line, not the chip the desktop row gets.
-    expect(secondary?.querySelector('.hv-area-chip')).toBe(null);
+  });
+
+  // An area "Küche" over a root location "Küche" — the way a household names
+  // both — printed "Küche Küche", two identical words a single space apart.
+  it('drops the area mark when the path already opens with that name', async () => {
+    const kitchen = {
+      id_path: [],
+      name_path: [],
+      display_path: 'Küche / Oberstes Fach',
+      sort_key: '',
+    };
+    for (const mobile of [false, true]) {
+      const el = await mount(
+        { category: null, effective_area_id: 'area-kitchen', location_path: kitchen },
+        { mobile, areas: [{ id: 'area-kitchen', name: 'Küche' }] },
+      );
+      const secondary = q(el, '[data-testid="row-secondary"]');
+      const where = `mobile=${mobile}`;
+
+      expect(secondary?.querySelector('[data-testid="area-chip"]'), where).toBe(null);
+      expect(secondary?.textContent?.replace(/\s+/g, ' ').trim(), where).toBe(
+        'Küche › Oberstes Fach',
+      );
+      // The pairing is still readable in full where the row keeps it.
+      expect(secondary?.getAttribute('title'), where).toBe('Area: Küche · Küche › Oberstes Fach');
+      el.remove();
+    }
   });
 
   it('renders no mark at all on a phone row with no area', async () => {
     const el = await mount({ category: null, location_path: deepPath }, { mobile: true });
     const secondary = q(el, '[data-testid="row-secondary"]');
-    expect(secondary?.querySelector('[data-testid="row-area-mark"]')).toBe(null);
+    expect(secondary?.querySelector('[data-testid="area-chip"]')).toBe(null);
     expect(secondary?.textContent?.trim()).toBe('Workshop › … › Small Bin');
   });
 
@@ -369,9 +416,7 @@ describe('hv-list-row: mobile affordances', () => {
     );
     const secondary = q(el, '[data-testid="row-secondary"]');
     expect(secondary?.textContent).toContain('Needs repair');
-    expect(secondary?.querySelector('[data-testid="row-area-mark"]')?.textContent).toContain(
-      'Garage',
-    );
+    expect(secondary?.querySelector('[data-testid="area-chip"]')?.textContent).toContain('Garage');
     expect(secondary?.textContent).toContain('… › Small Bin');
   });
 
@@ -389,9 +434,9 @@ describe('hv-list-row: mobile affordances', () => {
       { mobile: true, areas: [{ id: 'area-workshop', name: 'Garage' }] },
     );
     const secondary = q(el, '[data-testid="row-secondary"]');
-    expect(
-      secondary?.querySelector('[data-testid="row-area-mark"] .hv-sr-only')?.textContent,
-    ).toBe('Area: ');
+    expect(secondary?.querySelector('[data-testid="area-chip"] .hv-sr-only')?.textContent).toBe(
+      'Area: ',
+    );
     expect(secondary?.getAttribute('title')).toBe(
       'Area: Garage · Workshop › Parts Cabinet › Drawer A › Small Bin',
     );

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -308,9 +308,6 @@ export class HVListRow extends LitElement {
         border: 1px solid var(--hv-divider);
         border-radius: var(--hv-radius-chip);
       }
-      .stepper.disabled {
-        opacity: 0.45;
-      }
       .stepper button {
         display: inline-grid;
         place-items: center;
@@ -340,15 +337,27 @@ export class HVListRow extends LitElement {
       .qty.low {
         color: var(--hv-warn);
       }
+      /* Takes the stepper's place at both widths, so it is sized against the
+         stepper it replaces — 30px is that control's height with its border. */
       .check-in {
         flex: none;
         border: 1px solid var(--hv-primary-tint-border);
         background: none;
         color: var(--hv-primary-darker);
         border-radius: var(--hv-radius-chip);
+        min-height: 30px;
+        padding: 0 12px;
+        font: 500 13px var(--hv-font);
+      }
+      .check-in:hover {
+        background: var(--hv-hover-overlay);
+      }
+      /* A finger needs the platform minimum, and the phone row has the width for
+         the padding to go with it. */
+      :host([mobile]) .check-in {
         min-height: var(--hv-tap-min, 40px);
         padding: 0 18px;
-        font: 500 13.5px var(--hv-font);
+        font-size: 13.5px;
       }
       .box {
         flex: none;
@@ -453,12 +462,20 @@ export class HVListRow extends LitElement {
     }
   };
 
+  /**
+   * The row's trailing control: the quantity stepper, or the way to take the
+   * item back.
+   *
+   * A checked-out item's quantity is not the thing to adjust, and that holds at
+   * any width — so the stepper gives its place to "Check in" rather than sitting
+   * there greyed. The ⋮ menu still offers the same action, and on a wide row it
+   * only appears on hover: a user who never hovers had no visible way to check
+   * anything in from the list at all.
+   */
   private _renderStepper() {
     const item = this.item;
     const low = isLowStock(item);
-    // A checked-out item's quantity is not the thing to adjust.
-    const disabled = item.checked_out;
-    if (this.mobile && item.checked_out) {
+    if (item.checked_out) {
       return html`<button
         class="check-in"
         data-testid="row-check-in"
@@ -471,11 +488,10 @@ export class HVListRow extends LitElement {
       </button>`;
     }
     return html`
-      <span class="stepper ${disabled ? 'disabled' : ''}" data-testid="row-stepper">
+      <span class="stepper" data-testid="row-stepper">
         <button
           data-testid="row-decrement"
           aria-label="Decrease quantity"
-          ?disabled=${disabled}
           @click=${(e: Event) => {
             e.stopPropagation();
             this._emit('decrement');
@@ -487,7 +503,6 @@ export class HVListRow extends LitElement {
         <button
           data-testid="row-increment"
           aria-label="Increase quantity"
-          ?disabled=${disabled}
           @click=${(e: Event) => {
             e.stopPropagation();
             this._emit('increment');
@@ -508,6 +523,7 @@ export class HVListRow extends LitElement {
     // already behind us means it is waiting to be done.
     const inspectionDue = isOverdue(item.inspection_date);
     const parts = itemPathParts(item, this.areas);
+    const areaMark = areaMarkName(parts.areaName, parts.path);
     // The desktop row has room for the whole path and the area chip beside it.
     const secondary = [parts.path, item.category].filter(Boolean).join(' · ');
     // A phone line has no room for the whole path, so the area travels through
@@ -519,15 +535,16 @@ export class HVListRow extends LitElement {
     const mobileTail = [mobileLead.rest, item.category].filter(Boolean).join(' · ');
     const hasMobileSecondary = Boolean(mobileLead.area || mobileTail);
     const mobileSecondary = html`${renderAreaChip(mobileLead.area)}${mobileTail}`;
-    const areaMark = areaMarkName(parts.areaName, parts.path);
     // The tooltip carries the *unelided* path: on a phone the middle of it is
     // dropped on purpose, and this is where the whole thing can still be read.
     const secondaryFull = [pathTitle(parts), item.category].filter(Boolean).join(' · ');
     // A phone row has one line for all of this and no room for the chips the
-    // wide row hangs on the right, so the line says the most interrupting
+    // wide row hangs on the right, so the line leads with the most interrupting
     // thing it has: who has the item, then what state it is flagged with, then
-    // what it is waiting for, then where it lives. The path is a tap away in
-    // the detail sheet either way.
+    // what it is waiting for. Being out and being flagged put the location
+    // behind them rather than in place of them — the wide row shows both, and a
+    // borrowed item is exactly the one whose shelf you want to read. What runs
+    // past the edge elides, so the width decides how much of it survives.
     const status = itemStatus(item);
     const flagged = status !== 'ok';
     const mobileState = item.checked_out ? 'out' : flagged || inspectionDue ? 'inspect' : '';
@@ -589,7 +606,7 @@ export class HVListRow extends LitElement {
             ${this.mobile && item.checked_out
               ? html`${overdue ? 'Overdue' : 'Checked out'}${item.due_date
                   ? ` · due ${formatDate(item.due_date)}`
-                  : ''}`
+                  : ''}${hasMobileSecondary ? html` · ${mobileSecondary}` : ''}`
               : this.mobile && flagged
                 ? html`<span data-testid="row-status">${statusLabel(status, this.statuses)}</span>${hasMobileSecondary
                     ? html` · ${mobileSecondary}`

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -68,6 +68,21 @@ export function elidePath(path: string, maxSegments = 2): string {
 }
 
 /**
+ * The area worth marking beside a path, or nothing.
+ *
+ * Naming a root location after the area it stands in is the most natural thing
+ * a household does — an area "Kitchen" holding a location "Kitchen" — and the
+ * row then prints the same word twice in a row with only a separator between
+ * them. When the path's first segment already is the area, the path has said
+ * it, and the mark is dropped. The full pairing survives in the row's `title`,
+ * which is where the unelided truth lives either way.
+ */
+export function areaMarkName(areaName: string | null, path: string): string | null {
+  if (!areaName) return null;
+  return path.split(' › ')[0].trim() === areaName.trim() ? null : areaName;
+}
+
+/**
  * The phone row's location line, with the area separated back out of the front
  * of it.
  *
@@ -216,23 +231,17 @@ export class HVListRow extends LitElement {
       .secondary.hv-chip-line {
         display: flex;
       }
-      /* The same home mark the area chip carries, marking the leading segment
-         of a phone row's path as Home Assistant's area rather than the top of
-         our own tree. Not a chip: this line has room for neither the fill nor
-         the spelled-out word, which is why the area is a text segment here at
-         all. Colour and weight stay inherited, so the mark travels with
-         whichever state variant the line is in. */
-      .area-lead {
-        display: inline-flex;
-        align-items: center;
-        /* Tighter than the chip's own 4px: this sits inside a text run with no
-           fill around it, and every pixel here comes off the elided tail. */
-        gap: 2px;
-        margin-right: 4px;
-        /* An inline-flex box whose first child is an svg has no baseline of its
-           own and would otherwise sit a couple of pixels low against the path
-           beside it. */
-        vertical-align: middle;
+      /* The wide row's area pill, inside a line that is a text run rather than a
+         row of chips. The fill is what separates the area from the path after
+         it: as plain text in the same colour and weight, a root location named
+         after its own area printed the word twice with a single space between
+         them and nothing to say which was which.
+
+         The margin is the gap the wide line gets from its flex layout. The line
+         itself stays a block with inline content, because text-overflow does not
+         apply to a flex container and the path tail has to keep its ellipsis. */
+      :host([mobile]) .secondary .hv-area-chip {
+        margin-right: 6px;
       }
       /* The path elides; the chip ahead of it does not. */
       .secondary.hv-chip-line > .hv-chip-line-text {
@@ -501,19 +510,16 @@ export class HVListRow extends LitElement {
     const parts = itemPathParts(item, this.areas);
     // The desktop row has room for the whole path and the area chip beside it.
     const secondary = [parts.path, item.category].filter(Boolean).join(' · ');
-    // A phone line fits neither, so the area goes in as the leading segment —
-    // the half elidePath keeps — and the room survives a path deep enough to
-    // lose its middle. The home mark is what says the segment is an area and
-    // not the top of our own tree; it replaces the separator after it, so it
-    // costs the line about what that separator cost.
-    const mobileLead = elideMobilePath(parts.areaName, parts.path);
+    // A phone line has no room for the whole path, so the area travels through
+    // the elision as the leading segment — the half elidePath keeps — and comes
+    // back out of it as the same pill the wide row hangs beside a path. The
+    // pill's fill is what marks the boundary: as plain text in the path's own
+    // colour and weight, a root named after its area read as one word twice.
+    const mobileLead = elideMobilePath(areaMark, parts.path);
     const mobileTail = [mobileLead.rest, item.category].filter(Boolean).join(' · ');
     const hasMobileSecondary = Boolean(mobileLead.area || mobileTail);
-    const mobileSecondary = html`${mobileLead.area
-      ? html`<span class="area-lead" data-testid="row-area-mark"
-          >${icon('home', 11)}<span class="hv-sr-only">Area: </span>${mobileLead.area}</span
-        >`
-      : null}${mobileTail}`;
+    const mobileSecondary = html`${renderAreaChip(mobileLead.area)}${mobileTail}`;
+    const areaMark = areaMarkName(parts.areaName, parts.path);
     // The tooltip carries the *unelided* path: on a phone the middle of it is
     // dropped on purpose, and this is where the whole thing can still be read.
     const secondaryFull = [pathTitle(parts), item.category].filter(Boolean).join(' · ');
@@ -594,7 +600,7 @@ export class HVListRow extends LitElement {
                     ? hasMobileSecondary
                       ? mobileSecondary
                       : 'No location'
-                    : html`${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
+                    : html`${renderAreaChip(areaMark)}<span class="hv-chip-line-text"
                         >${secondary || 'No location'}</span
                       >`}
           </span>


### PR DESCRIPTION
Both findings live in `hv-list-row`, and both are about the two layout branches
having drifted apart. One commit each.

## Closes #377 — area and path blur into one text run on phone rows

The narrow branch wrote the area as plain text (`.area-lead`) in the path's own
colour and weight, one space ahead of the path. With the standing dev repro — HA
area **Küche**, root location **Küche** — that rendered `Küche Küche`.

Phone rows now hang the same `renderAreaChip` pill the wide branch does. The
`.area-lead` rule is gone; the pill gets the 6px the wide line gets from its flex
gap, and the line stays `display: block` so the path tail keeps its ellipsis
(text-overflow does not apply to a flex container).

**Second half, from the issue comment:** a new `areaMarkName(areaName, path)`
drops the mark entirely when the path's first segment *is* the area — the path
has already said it. **Applied to both branches**, not only the phone one: it is
the same redundancy at either width, and hiding it on a phone while the desktop
kept showing it would be a fresh inconsistency. `pathTitle` is untouched, so the
row's `title` still carries `Area: Küche · Küche › …` in full.

## Closes #379 — one check-in affordance across layouts

Decision as agreed in the issue: **"Check in" takes the stepper's place at both
widths.** A checked-out item's quantity is not the thing to adjust, and that
reasoning does not depend on width; the disabled stepper occupied exactly the
spot the button could take. The ⋮ entry stays as the secondary path. `.check-in`
is now sized against the stepper it replaces (30px) and keeps the platform tap
minimum under `:host([mobile])`.

**Second line, made consistent:** the narrow row used to replace the whole line
with `Checked out · due …`, dropping the location. It now leads with the checkout
and keeps the location behind it — the same shape the `flagged` branch already
used, and what the wide row shows (location on the line, checkout as a chip).
What runs past the edge elides, so the width decides how much survives.

## Verification

- Backend gate: 752 passed / 22 skipped; ruff check, ruff format --check, mypy clean.
- Frontend gate: eslint clean, tsc clean, **1705 passed across 61 files** (up from 1699), build clean.
- Deployed and checked against the Küche repro on the dev instance:
  - phone row for `Kaffeefilter Größe 4` reads **`Küche`** — no more `🏠 Küche Küche`;
  - phone row for `Gewürzsammlung international` reads `Küche › … › Oberstes Fach links neben d…`, one mark, no stutter;
  - phone row for `QA-07 Stand Mixer` (area *Living Room*, root *QA House* — the case where the mark is kept) renders the pill: `[🏠 Living Room] … › QA Kit…`;
  - checked-out phone row reads `Checked out · due Sep 17 · Garage…`;
  - checked-out **wide** row shows `Garage · Tools` on line two, the `Checked out` chip, and a visible `Check in` button in the stepper column.
- `log_sweep.py`: BLOCKING 0, verdict PASS.

## Follow-ups (not fixed here)

- The narrow row's **inspection-due** branch still replaces the line rather than
  leading it (`Inspection due · <date>`, no location). #379 is scoped to
  checked-out rows, so it is left as-is; it is the last branch that displaces the
  location instead of preceding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
