### PR TITLE
fix(card): the detail sheet writes custom-field keys for reading

### DIFF
--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -193,6 +193,43 @@ describe('hv-detail-sheet: read view', () => {
     expect(facts.checked).toContain('Feb 1, 2019');
   });
 
+  // The facts list mixes these with "Due" and "Next inspection", where a raw
+  // "purchase_price" read as debug output rather than as a fact about the item.
+  it('writes a custom field key for reading and keeps the key on the row', async () => {
+    const el = await mount({ custom_fields: { purchase_price: 64.57, serial_number: 'SN-363905' } });
+    const fact = (key: string) =>
+      all(el, '[data-testid="sheet-fact"]').find((f) => f.dataset.key === key);
+
+    expect(fact('purchase_price')?.textContent?.replace(/\s+/g, ' ')).toContain('Purchase price');
+    expect(fact('purchase_price')?.textContent).not.toContain('purchase_price');
+    expect(fact('serial_number')?.textContent?.replace(/\s+/g, ' ')).toContain('Serial number');
+
+    // The key is the stored identity, so it stays addressable on the row.
+    expect(fact('purchase_price')).toBeTruthy();
+    expect(fact('serial_number')).toBeTruthy();
+  });
+
+  // Display formatting is the read surface's business alone: the editor writes
+  // the key back, so a label there would rename the field on save.
+  it('leaves the editor showing the key exactly as it is stored', async () => {
+    const el = await mount({ custom_fields: { purchase_price: 64.57 } });
+    (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const editor = el.shadowRoot?.querySelector('hv-item-editor') as HTMLElement & {
+      updateComplete: Promise<unknown>;
+    };
+    // On a phone the custom fields sit behind the editor's "More" disclosure.
+    (editor.shadowRoot?.querySelector('[data-testid="editor-more-toggle"]') as HTMLButtonElement).click();
+    await editor.updateComplete;
+
+    const keys = [...(editor.shadowRoot?.querySelectorAll('[data-testid="editor-cf-key"]') ?? [])].map(
+      (i) => (i as HTMLInputElement).value,
+    );
+    expect(keys).toContain('purchase_price');
+    expect(keys).not.toContain('Purchase price');
+  });
+
   it('says "Not set" rather than hiding an empty date', async () => {
     const el = await mount({ due_date: null, inspection_date: null });
     const facts = all(el, '[data-testid="sheet-fact"]');

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -4,6 +4,7 @@ import { tokens, base } from '../ui/tokens';
 import { chip, renderTagChip } from '../ui/chip';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue, relativeTime } from '../ui/relative-time';
+import { customFieldLabel } from '../ui/field-label';
 import { inferType } from '../ui/item-form';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
 import { isLowStock } from './hv-list-row';
@@ -492,19 +493,27 @@ export class HVDetailSheet extends LitElement {
     else this._close();
   }
 
+  /**
+   * One custom field, as a fact rather than as a stored pair.
+   *
+   * The label is written for reading; `data-key` still carries the key itself,
+   * which is what the editor shows and what an export document and an
+   * automation name.
+   */
   private _renderCustomFact(key: string, value: ScalarValue) {
     const type = inferType(value);
+    const label = customFieldLabel(key);
     if (type === 'boolean') {
       const on = value === true;
       return html`<div class="fact" data-testid="sheet-fact" data-key=${key}>
-        <span>${key}</span>
+        <span>${label}</span>
         <span class="value ${on ? 'yes' : 'unset'}">
           ${on ? html`${icon('check', 15)} Yes` : 'No'}
         </span>
       </div>`;
     }
     return html`<div class="fact" data-testid="sheet-fact" data-key=${key}>
-      <span>${key}</span>
+      <span>${label}</span>
       <span class="value">${type === 'date' ? formatDate(String(value)) : String(value)}</span>
     </div>`;
   }

--- a/cards/haventory-card/src/ui/field-label.test.ts
+++ b/cards/haventory-card/src/ui/field-label.test.ts
@@ -1,0 +1,26 @@
+import { customFieldLabel } from './field-label';
+
+describe('customFieldLabel', () => {
+  it('writes a snake_case key as a sentence', () => {
+    expect(customFieldLabel('purchase_price')).toBe('Purchase price');
+    expect(customFieldLabel('serial_number')).toBe('Serial number');
+  });
+
+  it('takes dashes and runs of separators too', () => {
+    expect(customFieldLabel('warranty-until')).toBe('Warranty until');
+    expect(customFieldLabel('bought__from')).toBe('Bought from');
+    expect(customFieldLabel('_notes_')).toBe('Notes');
+  });
+
+  // The household wrote the key; only the first letter is ours to raise.
+  it('leaves the capitals the household chose alone', () => {
+    expect(customFieldLabel('SKU')).toBe('SKU');
+    expect(customFieldLabel('model_EAN')).toBe('Model EAN');
+    expect(customFieldLabel('Purchase price')).toBe('Purchase price');
+  });
+
+  it('keeps a key it cannot make a label out of', () => {
+    expect(customFieldLabel('___')).toBe('___');
+    expect(customFieldLabel('')).toBe('');
+  });
+});

--- a/cards/haventory-card/src/ui/field-label.ts
+++ b/cards/haventory-card/src/ui/field-label.ts
@@ -1,0 +1,20 @@
+/**
+ * A custom field's key, written for reading.
+ *
+ * The key is the identity: it is what the item stores, what an export document
+ * carries and what an automation names, so every surface that *edits* a field
+ * shows it exactly as typed. A surface that only *reads* one is under no such
+ * obligation, and "purchase_price 64.57" in a list beside "Due" and "Next
+ * inspection" reads as debug output rather than as a fact about the item.
+ *
+ * Separators become spaces and the first letter is raised; nothing else is
+ * touched. Lower-casing the rest would rewrite an initialism the household
+ * chose — "SKU" is not "Sku" — and splitting runs of capitals would guess at
+ * where the words are. A key with no letters left after the separators go
+ * (`"___"`) keeps its raw form, because a blank label names nothing.
+ */
+export function customFieldLabel(key: string): string {
+  const words = key.replace(/[_-]+/g, ' ').trim().replace(/\s+/g, ' ');
+  if (!words) return key;
+  return words[0].toUpperCase() + words.slice(1);
+}


### PR DESCRIPTION
The last of the v0.4.1 milestone that could be landed. **#389 is not in here** —
see the note at the bottom.

## Closes #383 — raw custom-field keys in the detail sheet

The facts list mixed proper labels ("Due", "Next inspection") with keys printed
verbatim ("purchase_price 64.57", "serial_number SN-363905").

Display and edit are now separate, which is what the issue asks for:

- **Read** (`hv-detail-sheet`) formats the key through a new
  `customFieldLabel()` — separators become spaces, the first letter is raised,
  **nothing else is touched**. Lower-casing the rest would rewrite an initialism
  the household chose ("SKU" is not "Sku"), and splitting runs of capitals would
  guess at where the words are. A key with no letters left after the separators
  go (`"___"`) keeps its raw form rather than rendering as a blank label.
- **Edit** (`hv-item-editor`) is untouched: the key is the stored identity, it is
  what the editor writes back, and it is what an export document and an
  automation name. `data-key` still carries the raw key on the read row too, so
  nothing addressable was lost.

## Verification

- Backend gate: 752 passed / 22 skipped; ruff check, ruff format --check, mypy clean.
- Frontend gate: eslint clean, tsc clean, **1711 passed across 62 files** (up from 1705), build clean.
- Deployed and checked on the dev instance against `QA-Gate Camera Kit`
  (`purchase_price` / `brand` / `serial_number`):
  - the sheet reads **Purchase price 499.99 · Brand Canon · Serial number SN-424242**, level with "Due" and "Next inspection";
  - the editor behind "Edit details → More" still shows `purchase_price` and `brand` exactly as stored.
- `log_sweep.py`: BLOCKING 0, verdict PASS.

## Not in this PR: #389

The agreed fix for #389 was to flip the row ⋮ popup above its trigger when there
is no room below. **Measured on the dev instance, that does not work**, so the
issue is left open with the numbers rather than closed with a fix that is not
one — [full comment here](https://github.com/chrreiter/HAventory/issues/389#issuecomment-5253810806).

Short version: the clip is not the card, it is `div.scroller` inside `hv-list`
(`overflow-y: auto`), which is **58px tall** when the list holds one row. The menu
needs 137px. Opening down leaves 6px visible; flipping it up leaves 6px visible.
Neither direction fits inside a clipper smaller than the menu, and a one-row list
is exactly the repro. Fixing it means taking the popup out of that overflow
context (`position: fixed` with measured coordinates, as the component already
does below 700px), which is the "overlay layer" half of the issue's own proposal
and a real piece of work.

## Follow-up noted, not filed

#383's report also mentions that "numbers get no formatting". The agreed fix is
scoped to keys, and locale/currency formatting of custom values is a separate
decision (a `purchase_price` is not necessarily money, and the type system here
only knows `number`), so values still render as stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
