### PR TITLE
fix(card): the full view's table stops cutting Location and Tags mid-content

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -57,8 +57,96 @@ describe('hv-data-table: area', () => {
   });
 });
 
+describe('hv-data-table: a path too long for its column', () => {
+  const AREAS = [{ id: 'area-kitchen', name: 'Küche' }];
+  const DEEP = 'Küche / Hochschrank / Oberstes Fach / Vorratsbox / Backzutaten';
+  const deep = (display_path: string) => ({ id_path: [], name_path: [], display_path, sort_key: '' });
+
+  const mountPath = (display_path: string) =>
+    mount([{ id: '1', effective_area_id: 'area-kitchen', location_path: deep(display_path) }], {
+      columns: ['location'],
+      areas: AREAS,
+    });
+
+  const segments = (el: HVDataTable) =>
+    [...q(el, '[data-testid="cell-location"]')!.querySelectorAll('.hv-path-seg')].map(
+      (s) => s.textContent ?? '',
+    );
+
+  // Elided as one run of text the cell showed the area mark and "Küc…" — three
+  // letters of a five-segment path, naming nothing, with the leaf the reader is
+  // after nowhere on the row.
+  it('keeps every segment of a deep path whole', async () => {
+    const el = await mountPath(DEEP);
+    const names = segments(el).map((s) => s.replace(' › ', ''));
+
+    expect(names).toEqual([
+      'Küche',
+      'Hochschrank',
+      'Oberstes Fach',
+      'Vorratsbox',
+      'Backzutaten',
+    ]);
+  });
+
+  // The separator rides inside the segment ahead of it, so a wrap can never
+  // open a line with a lone "›" — and the path still reads as one string when
+  // it is copied or announced.
+  it('never leaves a separator to start a line on its own', async () => {
+    const el = await mountPath(DEEP);
+    const parts = segments(el);
+
+    for (const part of parts) expect(part.startsWith('›')).toBe(false);
+    expect(parts.slice(0, -1).every((p) => p.endsWith(' › '))).toBe(true);
+    expect(parts[parts.length - 1]).toBe('Backzutaten');
+    expect(q(el, '[data-testid="cell-location"]')?.textContent).toContain(
+      'Küche › Hochschrank › Oberstes Fach › Vorratsbox › Backzutaten',
+    );
+  });
+
+  // The reported cell was "🏠 Living Room (" — the mark, an opening bracket and
+  // nothing after it. Punctuation inside a location name travels with the word
+  // it belongs to and cannot be left holding a cell on its own.
+  it('never strands the punctuation inside a location name', async () => {
+    const el = await mountPath('Wohnzimmer (Nord) / Regal');
+    const parts = segments(el);
+
+    expect(parts.map((p) => p.replace(' › ', ''))).toEqual(['Wohnzimmer (Nord)', 'Regal']);
+    for (const part of parts) expect(/^[(){}[\]·,;:]+$/.test(part.trim())).toBe(false);
+  });
+
+  it('carries the whole path in the cell title, wrapped or not', async () => {
+    const el = await mountPath(DEEP);
+    expect(q(el, '[data-testid="cell-location"]')?.getAttribute('title')).toBe(
+      'Area: Küche · Küche › Hochschrank › Oberstes Fach › Vorratsbox › Backzutaten',
+    );
+  });
+
+  // jsdom computes no layout, so what is assertable is the contract the wrap
+  // rests on: the segments are the flex items of a wrapping box, each holds its
+  // own line, and the separator's spaces are protected — at the end of a flex
+  // item's only line, normal white-space processing drops them and the two
+  // segments either side run together.
+  it('wraps between segments rather than clipping at the cell edge', () => {
+    const css = tableCss();
+    expect(css).toMatch(/\.cell\.path \{[^}]*flex-wrap: wrap/);
+    expect(css).toMatch(/\.cell\.path > \.hv-chip-line-text \{[^}]*display: flex/);
+    expect(css).toMatch(/\.cell\.path > \.hv-chip-line-text \{[^}]*flex-wrap: wrap/);
+    expect(css).toMatch(/\.hv-path-seg \{[^}]*white-space: nowrap/);
+    expect(css).toMatch(/\.hv-path-sep \{ white-space: pre; \}/);
+  });
+
+  // The last resort, for one segment wider than the whole column: an ellipsis
+  // on the segment, never a hard cut — and the title above still has the truth.
+  it('elides a single segment only once there is no break left to take', () => {
+    expect(tableCss()).toMatch(
+      /\.hv-path-seg \{[^}]*min-width: 0;[^}]*overflow: hidden;[^}]*text-overflow: ellipsis/,
+    );
+  });
+});
+
 describe('hv-data-table: narrow screens', () => {
-  // The template has a hard ~786px minimum, and a grid whose tracks do not fit
+  // The template has a hard ~1354px minimum, and a grid whose tracks do not fit
   // overflows its box rather than shrinking. With overflow visible the spill
   // was clipped by the shell: rows measured clientWidth 634 / scrollWidth 854
   // at 375px, and three columns could not be reached by any gesture.
@@ -200,6 +288,23 @@ describe('hv-data-table: columns', () => {
     expect(tags.every((t) => t.classList.contains('tag'))).toBe(true);
     // The category cell is plain text in this column, not a chip at all.
     expect(q(el, '[data-testid="cell-category"]')?.querySelector('.hv-chip')).toBe(null);
+  });
+
+  // Cut at the cell's edge the column showed one chip of six and half of the
+  // next — "#re…", sometimes a bare "#" — with no count to say the rest
+  // existed. jsdom lays nothing out, so what is assertable is that nothing
+  // clips and the chips have somewhere to go.
+  it('wraps a long tag set onto more lines instead of cutting a chip', async () => {
+    const tags = ['essen', 'vorrat', 'trocken', 'reserve', 'küche', 'bio'];
+    const el = await mount([{ id: '1', tags }], { columns: ['tags'] });
+    const chips = [...q(el, '[data-testid="cell-tags"]')!.querySelectorAll('.hv-chip')];
+
+    // Every tag, whole: no cut-off set and no "+N" standing in for one.
+    expect(chips.map((c) => c.textContent?.trim())).toEqual(tags.map((t) => `#${t}`));
+
+    const css = tableCss();
+    expect(css).toMatch(/\.tags \{[^}]*flex-wrap: wrap/);
+    expect(css).not.toMatch(/\.tags \{[^}]*overflow: hidden/);
   });
 
   it('says so when an item carries no tags', async () => {

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -17,7 +17,7 @@ import type { ColumnKey } from '../store/columns';
 import { isLowStock, rowMenuEntries } from './hv-list-row';
 import './hv-overflow-menu';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
-import { itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
+import { itemPathParts, pathTitle, renderAreaChip, renderPathSegments } from '../ui/location-path';
 import type { Item, Sort, SortField } from '../store/types';
 
 /**
@@ -48,7 +48,7 @@ export class HVDataTable extends LitElement {
         /* The one scroll container on this surface, in both axes.
 
            Sideways because the column template has a hard minimum — about
-           1260px for the default set, 1308px with the selection column — and a
+           1354px for the default set, 1402px with the selection column — and a
            grid whose tracks do not fit overflows its own box rather than
            shrinking. With overflow visible that spilled content was simply
            clipped by the shell: at 375px the rows measured clientWidth 634
@@ -162,8 +162,8 @@ export class HVDataTable extends LitElement {
         white-space: nowrap;
       }
       /*
-       * A phone shows about a third of this table — the template's floor is
-       * around 1260px — so the identity column holds while the rest scrolls
+       * A phone shows about a quarter of this table — the template's floor is
+       * around 1354px — so the identity column holds while the rest scrolls
        * under it, and the right edge says there is more to reach.
        *
        * The offsets are the row's own metrics, so nothing shifts as the swipe
@@ -234,11 +234,43 @@ export class HVDataTable extends LitElement {
         white-space: nowrap;
         color: var(--hv-text-secondary);
       }
-      /* The path elides; the chip ahead of it does not. */
+      /*
+       * The path wraps between its segments and the row grows to hold it.
+       *
+       * Elided as one run of text it broke wherever the pixels ran out, which
+       * left a stub of a location name — "Küc…" of a five-segment path, with
+       * the leaf the reader is actually after nowhere on the row. Every segment
+       * survives instead, on as many lines as the column needs, and the cell's
+       * title still carries the whole path for the one case below that cannot.
+       *
+       * The chip and the path are the two items of the outer row, so a path too
+       * long to sit beside the chip takes the lines under it rather than
+       * squeezing into what the chip leaves.
+       */
+      .cell.path {
+        flex-wrap: wrap;
+        row-gap: 2px;
+      }
       .cell.path > .hv-chip-line-text {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        row-gap: 2px;
+      }
+      /* A segment holds its line, and elides only when one segment on its own
+         is wider than the whole column — the point past which there is no break
+         left to take. */
+      .hv-path-seg {
+        white-space: nowrap;
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
-        white-space: nowrap;
+      }
+      /* The separator's spaces sit at the end of a flex item's only line, where
+         normal white-space processing drops them and the segments either side
+         would run together. */
+      .hv-path-sep {
+        white-space: pre;
       }
       .cell.qty {
         color: var(--hv-text);
@@ -261,10 +293,15 @@ export class HVDataTable extends LitElement {
         font-size: 12.5px;
         color: var(--hv-text-tertiary);
       }
+      /* Chips wrap onto as many lines as the set needs and the row grows to
+         hold them. Cut at the cell's edge instead, the column showed one chip
+         of six and half of the next, with no count to say the rest existed —
+         and a half-drawn chip reports nothing at all. */
       .tags {
         display: flex;
-        gap: 5px;
-        overflow: hidden;
+        flex-wrap: wrap;
+        gap: 4px 5px;
+        min-width: 0;
       }
       .actions {
         display: flex;
@@ -487,7 +524,7 @@ export class HVDataTable extends LitElement {
           data-testid="cell-location"
           title=${pathTitle(parts)}
           >${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
-            >${parts.path || '—'}</span
+            >${parts.path ? renderPathSegments(parts.path) : '—'}</span
           ></span
         >`;
       }

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -146,12 +146,58 @@ function growthOf(template: string, index: number): number {
   return Number(/,\s*([\d.]+)fr\)$/.exec(track)?.[1] ?? 0);
 }
 
+/**
+ * The widths a grid would give these tracks inside a content box of
+ * `contentWidth`, so the distribution can be asserted as pixels rather than as
+ * a set of `fr` numbers whose outcome nobody can read off the template.
+ *
+ * jsdom lays nothing out, so this is the sizing algorithm itself: the leftover
+ * space after the fixed tracks and the gaps is shared out in proportion to the
+ * flex factors, and a flexible track whose share comes out under its floor is
+ * frozen at the floor and the rest shared again without it. That freezing is
+ * the whole mechanism here — it is why a growth factor alone says nothing about
+ * who actually ends up with the surplus.
+ *
+ * A box narrower than the template's minimum returns the floors, which is the
+ * overflow the table answers by scrolling sideways.
+ */
+function resolveTracks(template: string, contentWidth: number, gap = 8): number[] {
+  const tracks = template.split(/\s+(?![^(]*\))/).map((t) => {
+    const flexible = /^minmax\((\d+)px,\s*([\d.]+)fr\)$/.exec(t);
+    return flexible
+      ? { min: Number(flexible[1]), flex: Number(flexible[2]) }
+      : { min: Number(/^(\d+)px$/.exec(t)![1]), flex: 0 };
+  });
+  const space = contentWidth - gap * (tracks.length - 1);
+  const frozen = tracks.map((t) => t.flex === 0);
+  for (;;) {
+    const taken = tracks.reduce((sum, t, i) => sum + (frozen[i] ? t.min : 0), 0);
+    const flexSum = tracks.reduce((sum, t, i) => sum + (frozen[i] ? 0 : t.flex), 0);
+    if (flexSum === 0) return tracks.map((t) => t.min);
+    const fr = (space - taken) / flexSum;
+    const starved = tracks.findIndex((t, i) => !frozen[i] && t.min > t.flex * fr);
+    if (starved < 0) return tracks.map((t, i) => (frozen[i] ? t.min : t.flex * fr));
+    frozen[starved] = true;
+  }
+}
+
+/** The resolved width of one column of the default table. */
+function widthOf(contentWidth: number, key: ColumnKey): number {
+  const columns = [...DEFAULT_COLUMNS];
+  const widths = resolveTracks(
+    tableTemplateFor(columns, { selectable: false }),
+    contentWidth,
+  );
+  // 0 is the name; the chosen columns follow it in order, then the gutter.
+  return widths[1 + columns.indexOf(key)];
+}
+
 describe('table column widths', () => {
   // Pinned as a number so that adding a column, or widening one, shows up here
   // as a deliberate change rather than as another phone-width overflow.
   it('cannot lay the default table out narrower than a phone', () => {
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1178);
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1218);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1242);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1282);
   });
 
   it('only fits a phone when almost every column is turned off', () => {
@@ -179,13 +225,54 @@ describe('table column widths', () => {
     for (const min of flexible) expect(nameMin).toBeGreaterThan(min);
   });
 
-  // Free width goes to the name first: a row identified by its tags and not by
-  // its name cannot be scanned.
-  it('grows the name column faster than the tags column', () => {
+  // A name is one line of text with an end to it; a path and a tag set are not.
+  // So the name is served first through the floors and stops there, and the
+  // growth factors hand what is left to the two columns that can still use it.
+  it('grows the wrapping columns at least as fast as the name', () => {
     const template = tableTemplateFor(['category', 'location', 'tags'], { selectable: false });
-    // 0 is the name; the tags track is the last flexible one before the gutter.
-    expect(growthOf(template, 0)).toBeGreaterThan(growthOf(template, 3));
-    expect(growthOf(template, 3)).toBe(1);
+    // 0 is the name, then category, location and tags in order.
+    expect(growthOf(template, 2)).toBeGreaterThanOrEqual(growthOf(template, 0));
+    expect(growthOf(template, 3)).toBeGreaterThanOrEqual(growthOf(template, 0));
+    expect(growthOf(template, 1)).toBeLessThan(growthOf(template, 2));
+  });
+
+  // The measurement behind this: at 1920 with all eight columns on and room to
+  // spare, Location sat on a 110px floor showing an area mark and three letters
+  // of a five-segment path, and Tags showed one chip of six cut in half — while
+  // the name track, on 3fr against everyone else's 1fr, took the surplus it had
+  // no use for. Pixels rather than fr numbers, because which track a factor
+  // actually feeds depends on who freezes at their floor first.
+  it('hands a wide table its surplus width to wrap paths and tags with', () => {
+    // The sidebar panel at 1920, give or take the HA sidebar's own width.
+    expect(widthOf(1560, 'location')).toBeGreaterThan(230);
+    expect(widthOf(1560, 'tags')).toBeGreaterThan(230);
+    // A five-segment path and a six-chip tag set have a use for every one of
+    // those pixels; a name that is already whole does not.
+    expect(widthOf(1560, 'location')).toBeGreaterThan(widthOf(1560, 'category'));
+    expect(widthOf(1560, 'tags')).toBeGreaterThan(widthOf(1560, 'category'));
+  });
+
+  // Between the two the name is still served before either of them grows: it
+  // reaches its floor while they are still on theirs.
+  it('serves the name to its floor before the surplus moves on', () => {
+    const tracks = resolveTracks(
+      tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }),
+      1400,
+    );
+    expect(tracks[0]).toBeGreaterThanOrEqual(220);
+    expect(widthOf(1400, 'location')).toBeGreaterThan(170);
+    expect(widthOf(1400, 'tags')).toBeGreaterThan(170);
+  });
+
+  // Narrower than the template's own minimum every track sits on its floor and
+  // the table scrolls sideways — the same answer as before, with Location and
+  // Tags standing on floors that hold a segment and a chip rather than a stub
+  // of one.
+  it('puts every track on its floor once the table is scrolling', () => {
+    const template = tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false });
+    const tracks = resolveTracks(template, 1016);
+    expect(tracks).toEqual([220, 70, 112, 110, 140, 130, 100, 124, 96, 140]);
+    expect(tracks.reduce((a, b) => a + b, 0)).toBe(minWidthOf(template));
   });
 
   // The pinned name cell offsets itself by the checkbox track, and an offset

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -37,12 +37,15 @@ export const COLUMN_DEFS: readonly ColumnDef[] = [
   // Wide enough for the "Needs repair" chip on one line: a status that wrapped
   // or clipped would be unreadable in exactly the rows that matter most.
   { key: 'status', label: 'Status', tableSize: '112px' },
+  // One word, and the only flexible column that carries one: it takes the
+  // smallest floor and the smallest share of whatever is left over.
   { key: 'category', label: 'Category', tableSize: 'minmax(110px, 1fr)' },
-  { key: 'location', label: 'Location', tableSize: 'minmax(110px, 1fr)' },
-  // The narrowest of the flexible columns, and the only one that yields to the
-  // name: a row identified by its tags and not by its name cannot be scanned,
-  // and tags are the column a reader can most afford to see one of.
-  { key: 'tags', label: 'Tags', tableSize: 'minmax(96px, 1fr)' },
+  // The two columns whose content has no natural end — a path grows a segment
+  // per nesting level, a tag set a chip per tag — so they are where surplus
+  // width does the most: their cells wrap, and every pixel they get is a
+  // segment or a chip that does not need a second line.
+  { key: 'location', label: 'Location', tableSize: 'minmax(140px, 2fr)' },
+  { key: 'tags', label: 'Tags', tableSize: 'minmax(130px, 2fr)' },
   { key: 'due_date', label: 'Due', tableSize: '100px', sortField: 'due_date' },
   {
     key: 'inspection_date',
@@ -119,16 +122,21 @@ const COLUMN_TABLE_SIZE: Record<ColumnKey, string> = Object.fromEntries(
  * grid-template-columns for the full-view table: an optional selection column,
  * the name, the chosen columns, then room for the hover actions.
  *
- * The name track outweighs every flexible column beside it, in both halves of
- * its `minmax`: the name is the row's identity, and it also carries an inline
- * chip — Low, or Checked out, or the status when that column is off — which
- * takes its width before the name gets any. At most one of Low and Checked out
- * draws, so the floor holds a readable name rather than the tail of one; the
- * table renders that choice. With the full column set the flexible tracks all
- * sit at their minimum anyway — there the floor is the whole answer, and the
- * growth factor decides only what a wider window hands out.
+ * The name's *floor* outranks every flexible column beside it: the name is the
+ * row's identity, and it also carries an inline chip — Low, or Checked out, or
+ * the status when that column is off — which takes its width before the name
+ * gets any. At most one of Low and Checked out draws, so the floor holds a
+ * readable name rather than the tail of one.
+ *
+ * Its growth factor does not outrank them, and that is the point. A name is one
+ * line of text with an end to it; a path and a tag set are not. With the full
+ * column set the name lands on its floor and every pixel past it goes to
+ * Location and Tags, whose cells wrap — which is where a wider window can still
+ * change what the row says. Ahead of the flexible columns' floors the name is
+ * served first either way, so the two ends of the range answer different
+ * questions rather than the same one twice.
  */
-export const NAME_COLUMN_SIZE = 'minmax(220px, 3fr)';
+export const NAME_COLUMN_SIZE = 'minmax(220px, 2fr)';
 
 /**
  * The selection column's track. Exported because the table pins the name cell

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -138,11 +138,21 @@ describe('ui/chip: the shared fragment', () => {
   // text-overflow does nothing on a flex container, so a path left on the row
   // itself would hard-cut mid-character with no ellipsis to say so.
   it('moves the elision onto the text when the row becomes a flex box', () => {
-    for (const tag of ['hv-data-table', 'hv-detail-sheet', 'hv-list-row']) {
+    for (const tag of ['hv-detail-sheet', 'hv-list-row']) {
       expect(ownCss(tag), tag).toMatch(
         /\.hv-chip-line-text \{[^}]*text-overflow: ellipsis[^}]*\}/,
       );
     }
+  });
+
+  // The table is the surface that does not elide: its rows grow, so the path
+  // takes a second line instead of an ellipsis. It still keeps the chip on the
+  // row — that part is the same everywhere — and the text beside it is a flex
+  // box of its own, one item per segment, which is what it wraps between.
+  it('lets the one surface with room to grow wrap the text instead', () => {
+    const css = ownCss('hv-data-table');
+    expect(css).toMatch(/\.hv-chip-line-text \{[^}]*flex-wrap: wrap/);
+    expect(css).not.toMatch(/\.hv-chip-line-text \{[^}]*text-overflow/);
   });
 
   // An area is marked one way wherever the card marks one, and that mark is not

--- a/cards/haventory-card/src/ui/location-path.ts
+++ b/cards/haventory-card/src/ui/location-path.ts
@@ -12,8 +12,11 @@ import type { AreaRef, Item, Location } from '../store/types';
  * is the whole point — four components print location paths and the separator is
  * a presentation choice none of them owns.
  */
+/** What a path is written with once `prettyPath` has been over it. */
+export const PATH_SEPARATOR = ' › ';
+
 export function prettyPath(path: string): string {
-  return path.replace(/\s*\/\s*/g, ' › ');
+  return path.replace(/\s*\/\s*/g, PATH_SEPARATOR);
 }
 
 /**
@@ -73,6 +76,32 @@ export function locationPathParts(
  */
 export function pathTitle(parts: PathParts): string {
   return [parts.areaName ? `Area: ${parts.areaName}` : '', parts.path].filter(Boolean).join(' · ');
+}
+
+/**
+ * A path as one element per segment, for a surface that gives it more than one
+ * line rather than cutting it off at the edge of its box.
+ *
+ * A path elided as plain text breaks wherever the pixels run out, which leaves
+ * a stub of a location name — "Küc…" — that names nothing a reader can act on.
+ * One element per segment gives the surface a set of places it is allowed to
+ * break, and its own CSS decides whether they wrap or shrink.
+ *
+ * The separator travels *inside* the segment ahead of it, so a break can never
+ * open a line with a lone "›". It keeps its spaces so the path still reads as
+ * one string when copied or announced, and the surface styling `.hv-path-sep`
+ * has to protect those spaces where a break would otherwise drop them.
+ */
+export function renderPathSegments(path: string): TemplateResult[] {
+  const segments = path.split(PATH_SEPARATOR);
+  return segments.map(
+    (segment, i) =>
+      html`<span class="hv-path-seg"
+        >${segment}${i < segments.length - 1
+          ? html`<span class="hv-path-sep">${PATH_SEPARATOR}</span>`
+          : null}</span
+      >`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Two mechanisms, fixed in that order.

**1. Track weights.** The name track was `minmax(220px, 3fr)` against `1fr` on Category,
Location and Tags. In the sidebar panel at 1920 that left Location on its 110px floor while
the name took 319px — a name is one line of text with an end to it, so the surplus was going
to the one column that had no use for it. The name keeps the highest floor, so it is still
served before any flexible column grows, and its growth factor comes down to their rate
while Location and Tags take twice that. Their floors rise to hold a whole segment and a
whole chip at the widths where the table is already scrolling sideways.

Measured in the sidebar panel on the dev instance, against the repro item (three-segment
path, six tags). How much width the table gets depends on whether HA's own sidebar is
docked, so both are listed — the panel's own locations rail takes 264px either way:

| track | 1920, HA sidebar docked (table 1400px) | | 1920, HA sidebar hidden (table 1656px) | |
| --- | --- | --- | --- | --- |
| | before | after | before | after |
| Name | 319.5 | 220 | 451 | 258 |
| Category | 110 | 110 | 150 | 129 |
| Location | **110** (floor) | **158** | 150 | **258** |
| Tags | 106.5 | **158** | 150 | **258** |

Docked is HA's default, and it is the case that shows the pathology plainest: Location sat
on its 110px floor while the name held 319px of a name that had already ended.

At 1280 the table is narrower than the template's own minimum either way, so every track
sits on its floor and nothing is redistributed: Location 110 → 140, Tags 96 → 130, name
unchanged at 220. The template minimum goes 1290px → 1354px, which the table answers the
way it already did — by scrolling sideways.

**2. Cell overflow.** Both cells cut at the pixel edge. Location showed the area mark and
`Küc…`, three letters of the path, with the leaf the reader is after nowhere on the row;
with a bracket in a location name the cell ended on a stranded `(`. Tags showed one chip of
six and half of the next, with no count to say the rest existed — on the dev seed at 1920,
18 of the 50 loaded rows had a Tags cell cut that way, the repro row by 490px.

The rows grow instead — the agreed auto-expanding direction, no fallback needed (see
below). Tag chips wrap onto as many lines as the set needs. The path is rendered one
element per segment, so it wraps *between* segments and every name survives whole; the
separator travels inside the segment ahead of it, so a wrap can never open a line with a
lone `›`, and it keeps its spaces so the path still reads as one string when copied or
announced. A segment elides only once it is wider on its own than the whole column — the
point past which there is no break left to take — and the cell's `title` carries the full
path either way.

**Auto-height was checked before it was committed to.** Nothing in the table sizes a row
from the outside: no virtualization, no measured row height, paging is a scroll-ratio
event, and the sticky header plus the pinned name and checkbox cells all resolve against
the row's own box. So no `+N` fallback was needed. Measured on the instance: the checkbox
sits centred to the pixel on rows of 55, 69, 121 and 174px, and the header's tracks and
width still match the body's in every column configuration.

What it costs — a row is as tall as its content — measured over the 50 loaded rows:

| table width | row heights |
| --- | --- |
| 1656px (1920, HA sidebar hidden) | 48 × 55px, 1 × 87px, 1 × 95px |
| 1400px (1920, HA sidebar docked) | 41 × 55px, 7 × 69px, 1 × 95px, 1 × 174px |
| 1354px (1280 and phone, all floors) | 32 × 65px, 14 × 69px, 2 × 95px, 1 × 121px, 1 × 174px |

The 174px row is the worst case in a 1077-item seed and it is the deliberate repro: six
long German compound tags, each too wide to share a 130px line with another. Where the
table has room, the same row is 95px and nothing on the page changes but it.

Closes #378

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (752 passed, 22
      skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all
      clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` (1722 passed across 62 files, up from 1712), `npm run build`.

New tests, all offline:

- `store/columns.test.ts` — a track solver that is the grid sizing algorithm itself, since
  a growth factor on its own says nothing about who ends up with the surplus: which track
  freezes at its floor first is what decides that. Pins the wide-table distribution, the
  name being served to its floor first, and every track sitting on its floor once the
  table is scrolling. The template-minimum pin moves 1178 → 1242 (1218 → 1282 selectable).
- `hv-data-table.test.ts` — six chips all render with no `+N` and nothing clipping; a
  five-segment path keeps every segment whole; no segment starts with `›`; punctuation
  inside a location name (`Wohnzimmer (Nord)`) is never left holding a cell on its own;
  the title carries the whole path; and the CSS contract the wrap rests on.
- `ui/chip.test.ts` — the table is now the one chip-line surface that wraps rather than
  elides, recorded as its own expectation.

### Verified on the dev instance

Deployed with `reload_addon.sh` and driven in the real panel at `/haventory`. Before and
after were both measured against the same seed by rebuilding the three changed sources from
`main`, so every number above is one instance, one dataset, two bundles.

- Both gates green locally on the branch, at the counts above.
- `visual_pass --out after` — 42/42 surfaces captured, no console errors. The three changed
  files reach only the table: `columns.ts` sets the table template, `hv-data-table.ts` is
  the table, and `location-path.ts` only *adds* `renderPathSegments`, whose one consumer is
  the table. No other surface can move, and none did.
- Panel at 1280 and 1920, phone full view (iPhone 15), **light and dark** — dark carries no
  colour change, as the diff predicts, and the wrapped chips and paths read the same in
  both.
- No chip is cut anywhere, at any width, in any configuration. No letter-level stub, no
  stranded `(`, no stranded `›`.
- The reported punctuation case is refuted directly: a location named `Wohnzimmer (Nord)`
  renders whole at the 140px floor, on its own line, both brackets intact.
- One elision survives by design: the seed's 34-character leaf `Oberstes Fach links neben
  dem Herd` is wider on its own than a 140–158px column, so that one segment elides and the
  `title` carries the full path. At 1656px it fits whole.
- Columns dialog: hiding Due / Next inspection / Updated (leaving Tags last) and reordering
  Location to the end both behave, header and body tracks stay identical, and no clipping
  appears in whichever column lands last.
- Selection mode: checkbox centred on rows of 55, 69, 121 and 174px.
- The table scrolls sideways; the page never does — checked at every width above.
- `log_sweep.py --since 60m` — 265 records, **BLOCKING: 0**, verdict PASS.

**Repro data left in the seed**, so this stays reproducible: `Gewürzsammlung international`
(six tags, `Küche › Vorratsschrank › Oberstes Fach links neben dem Herd`) was already there,
and `Wohnzimmer (Nord)` plus `Ersatzgläser (klein)` were added under the Küche chain for the
bracket case, which nothing in the seed covered.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + edge cases: deep path, punctuation in a location
      name, six-chip tag set, table below its own minimum width).
- [x] Docs — card layout only; nothing in `README.md` or `docs/` describes these cells.
- [x] WebSocket API unchanged.
- [x] Essential invariants preserved — no backend change; `location_path` is still read
      exactly as the backend derives it, only rendered differently.

## Screenshots (card / UI changes)

Captured on the dev instance in `visual_pass --out after` (42 surfaces) plus the targeted
panel, phone and dark-theme frames described above. The measurements in this body are what
those frames were read for.
