### PR TITLE
fix: escape ancestor clips by viewport-fixing the overflow menu

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -77,27 +77,6 @@ export class HVCardShell extends LitElement {
         border-radius: var(--hv-radius-card);
         overflow: hidden;
       }
-      /* The ⋮ menu is an absolutely positioned dropdown inside this box, so the
-         overflow rule above — which is what keeps the list's rows inside the
-         rounded corners — clips it. A card holding few enough items to be shorter
-         than the open menu cuts it off at the bottom edge, and the entries it
-         loses are the last ones: Export and Import. An empty card is the worst
-         case at 269px against a 381px menu.
-
-         Reserving the height the menu needs is what keeps every entry reachable.
-         Measured from the card's top edge: 56px of header above the trigger, a
-         6px gap, then the menu itself; the remainder covers a second line under
-         "Export current view", which the sub-label takes when the filtered count
-         is long.
-
-         Only above 600px, matching hv-overflow-menu's own breakpoint: below it
-         the menu is a fixed bottom sheet anchored to the viewport, which nothing
-         here clips and which would not justify a 470px card on a phone. */
-      @media (min-width: 601px) {
-        :host {
-          min-height: 470px;
-        }
-      }
       /* Declared once here and inherited into every nested component's shadow
          DOM — the shared .hv-icon-button, the sheets, the row steppers and the
          editor all read it, so none of them needs its own copy of "is the card

--- a/cards/haventory-card/src/components/hv-overflow-menu.test.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.test.ts
@@ -1,4 +1,5 @@
 import './hv-overflow-menu';
+import { placeMenu } from './hv-overflow-menu';
 import type { HVOverflowMenu } from './hv-overflow-menu';
 import { NARROW_QUERY } from '../ui/responsive';
 
@@ -87,11 +88,12 @@ describe('hv-overflow-menu: narrow screens', () => {
     expect(narrow()).toContain('@media (max-width: 700px)');
   });
 
-  // A 250px anchored dropdown covered most of the list it was acting on, and
-  // "Export current view" wrapped onto two lines inside it.
+  // A 250px trigger-anchored dropdown covered most of the list it was acting
+  // on, and "Export current view" wrapped onto two lines inside it. The base
+  // rule already carries position: fixed; the sheet is the inset overriding
+  // the measured coordinates.
   it('becomes a bottom sheet instead of an anchored dropdown', () => {
     const css = narrow();
-    expect(css).toMatch(/\.menu \{[^}]*position: fixed/);
     expect(css).toMatch(/\.menu \{[^}]*inset: auto 0 0 0/);
     expect(css).toMatch(/\.menu \{[^}]*max-width: none/);
   });
@@ -178,5 +180,88 @@ describe('hv-overflow-menu: narrow screens', () => {
     await el.updateComplete;
 
     expect(el.shadowRoot?.activeElement).toBe(trigger);
+  });
+});
+
+// A list filtered down to a single row leaves hv-list's scroller shorter than
+// the open menu (#389). Anchoring the popup inside the row put it inside that
+// scroller's clip, where neither opening direction could fit — opening down and
+// flipping up both left a ~6px sliver. The menu is viewport-fixed instead, so
+// no ancestor's overflow can cut it.
+describe('hv-overflow-menu: escaping ancestor clips', () => {
+  // The first .menu block is the base rule; the sheet's overrides live in the
+  // narrow @media block after it.
+  const baseMenuRule = () => {
+    const styles = (customElements.get('hv-overflow-menu') as typeof HVOverflowMenu).styles;
+    const css = (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+    return /\.menu \{[^}]*\}/.exec(css)?.[0] ?? '';
+  };
+
+  it('draws the dropdown viewport-fixed, from measured coordinates', () => {
+    expect(baseMenuRule()).toContain('position: fixed');
+    expect(baseMenuRule()).toContain('top: var(--hv-menu-top');
+    expect(baseMenuRule()).toContain('left: var(--hv-menu-left');
+  });
+
+  it('carries live placement coordinates while open', async () => {
+    const el = await mount([{ id: 'refresh', label: 'Refresh data' }]);
+    // jsdom has no layout — every rect is zero — so both axes clamp to the
+    // 8px viewport margin; what matters is that the coordinates are set.
+    expect(el.style.getPropertyValue('--hv-menu-top')).toBe('8px');
+    expect(el.style.getPropertyValue('--hv-menu-left')).toBe('8px');
+  });
+
+  it('follows the trigger when a composed ancestor scrolls', async () => {
+    const el = await mount([{ id: 'refresh', label: 'Refresh data' }]);
+    const trigger = el.shadowRoot?.querySelector('[data-testid="overflow-trigger"]') as HTMLElement;
+    trigger.getBoundingClientRect = () => ({ top: 100, right: 600, bottom: 124 }) as DOMRect;
+
+    document.body.dispatchEvent(new Event('scroll'));
+
+    expect(el.style.getPropertyValue('--hv-menu-top')).toBe('130px');
+    expect(el.style.getPropertyValue('--hv-menu-left')).toBe('600px');
+  });
+
+  it('releases its reflow listeners when it closes', async () => {
+    const el = await mount([{ id: 'refresh', label: 'Refresh data' }]);
+    // The body is one of the composed ancestors the open menu listens on.
+    const removed = vi.spyOn(document.body, 'removeEventListener');
+    el.close();
+    expect(removed.mock.calls.some(([type]) => type === 'scroll')).toBe(true);
+  });
+});
+
+describe('placeMenu', () => {
+  const menu = { width: 250, height: 137 };
+  const viewport = { width: 1280, height: 900 };
+
+  it('hangs just under the trigger, right edges aligned, when there is room below', () => {
+    expect(placeMenu({ top: 210, right: 1200, bottom: 244 }, menu, viewport)).toEqual({
+      top: 250,
+      left: 950,
+    });
+  });
+
+  it('flips above the trigger when the room below runs out', () => {
+    expect(placeMenu({ top: 800, right: 1200, bottom: 834 }, menu, viewport)).toEqual({
+      top: 657,
+      left: 950,
+    });
+  });
+
+  it('pins to the viewport margin when neither side could hold it whole', () => {
+    // 120px of viewport against a 137px menu: below overflows, above is
+    // negative — the clamp keeps the top edge and the first entries on-screen.
+    expect(placeMenu({ top: 60, right: 400, bottom: 84 }, menu, { width: 1280, height: 120 })).toEqual({
+      top: 8,
+      left: 150,
+    });
+  });
+
+  it('keeps the menu inside the left viewport edge', () => {
+    expect(placeMenu({ top: 210, right: 200, bottom: 244 }, menu, viewport).left).toBe(8);
   });
 });

--- a/cards/haventory-card/src/components/hv-overflow-menu.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.ts
@@ -29,10 +29,42 @@ function isItem(entry: OverflowMenuEntry): entry is OverflowMenuItem {
   return 'id' in entry;
 }
 
+/** The sides of the trigger's rect that the placement reads. */
+export interface MenuAnchorRect {
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Viewport coordinates for the dropdown: right edge on the trigger's right
+ * edge, top just below the trigger — flipped to just above it when the room
+ * below the trigger runs out and the room above suffices. Both axes then
+ * clamp to an 8px viewport margin, so even when neither side could hold the
+ * menu whole its top entries stay on-screen and reachable.
+ */
+export function placeMenu(
+  trigger: MenuAnchorRect,
+  menu: { width: number; height: number },
+  viewport: { width: number; height: number },
+): { top: number; left: number } {
+  const gap = 6;
+  const margin = 8;
+  let top = trigger.bottom + gap;
+  if (top + menu.height > viewport.height - margin && trigger.top - gap - menu.height >= margin) {
+    top = trigger.top - gap - menu.height;
+  }
+  top = Math.max(margin, Math.min(top, viewport.height - margin - menu.height));
+  let left = trigger.right - menu.width;
+  left = Math.max(margin, Math.min(left, viewport.width - margin - menu.width));
+  return { top, left };
+}
+
 /**
  * The ⋮ menu for the card and full-view headers, and for each list row.
  *
- * Self-contained: it renders its own trigger and an anchored popover. HA's
+ * Self-contained: it renders its own trigger and a popover placed from the
+ * trigger's rect. HA's
  * `ha-button-menu`/`mwc-list-item` are not used because they only exist inside
  * the HA frontend — see the note in ui/icons.ts.
  */
@@ -44,7 +76,6 @@ export class HVOverflowMenu extends LitElement {
     css`
       :host {
         display: inline-block;
-        position: relative;
       }
       .trigger.on-primary {
         color: #fff;
@@ -56,10 +87,17 @@ export class HVOverflowMenu extends LitElement {
         background: var(--hv-primary-tint);
         color: var(--hv-on-primary-tint);
       }
+      /* Placed against the viewport, not the trigger's box: a popup anchored
+         inside the row is clipped by the nearest scrolling ancestor, and the
+         list's row scroller shrinks below this menu's height whenever few rows
+         match — with one row, neither opening direction can fit inside it.
+         Fixed positioning is outside every ancestor's clip; placeMenu()
+         supplies the coordinates from the trigger's rect, and they follow the
+         trigger while an ancestor scrolls or the window resizes. */
       .menu {
-        position: absolute;
-        top: calc(100% + 6px);
-        right: 0;
+        position: fixed;
+        top: var(--hv-menu-top, 0);
+        left: var(--hv-menu-left, 0);
         width: 250px;
         max-width: 80vw;
         background: var(--hv-surface);
@@ -130,16 +168,17 @@ export class HVOverflowMenu extends LitElement {
         color: var(--hv-text-tertiary);
       }
 
-      /* An anchored 250px dropdown is a desktop shape. At 375px it covered most
-         of the list it was supposed to be acting on and "Export current view"
-         wrapped onto two lines, while the rest of the card answers exactly this
-         need with a bottom sheet. The menu becomes one here.
+      /* A trigger-anchored 250px dropdown is a desktop shape. At 375px it
+         covered most of the list it was supposed to be acting on and "Export
+         current view" wrapped onto two lines, while the rest of the card
+         answers exactly this need with a bottom sheet. The menu becomes one
+         here — the inset overrides the measured coordinates.
 
-         A media query rather than the card's mobile flag: once the panel is
-         position: fixed it is placed against the viewport, so the viewport is
-         what decides whether there is room — and it keeps the component free
-         of a mobile property that all three of its callers would have to
-         thread through.
+         A media query rather than the card's mobile flag: the panel is
+         position: fixed, so it is placed against the viewport and the
+         viewport is what decides whether there is room — and it keeps the
+         component free of a mobile property that all three of its callers
+         would have to thread through.
 
          The width is NARROW_QUERY from ui/responsive.ts, which CSS cannot
          read; a test pins the two spellings together. Every overlay the card
@@ -151,7 +190,6 @@ export class HVOverflowMenu extends LitElement {
       }
       @media (max-width: 700px) {
         .menu {
-          position: fixed;
           inset: auto 0 0 0;
           width: auto;
           max-width: none;
@@ -224,7 +262,60 @@ export class HVOverflowMenu extends LitElement {
     this.close();
   };
 
+  /**
+   * Ancestors holding a scroll listener while the menu is open. A scroll moves
+   * the trigger while a fixed menu stays where it was painted, and scroll
+   * events are composed: false — a scroller inside another component's shadow
+   * root never reaches a window listener. Only an ancestor's scrolling can
+   * move the trigger, so listening on each composed ancestor directly covers
+   * every scroller that matters; ancestors that never scroll never fire.
+   */
+  private _reflowTargets: EventTarget[] = [];
+
+  private readonly _onReflow = () => this._place();
+
+  private _watchReflow() {
+    let node: Node | null = this.parentNode;
+    while (node) {
+      if (node instanceof ShadowRoot) {
+        node = node.host;
+        continue;
+      }
+      this._reflowTargets.push(node);
+      node = node.parentNode;
+    }
+    this._reflowTargets.push(window);
+    for (const target of this._reflowTargets) {
+      target.addEventListener('scroll', this._onReflow, { passive: true });
+    }
+    window.addEventListener('resize', this._onReflow, { passive: true });
+  }
+
+  private _unwatchReflow() {
+    for (const target of this._reflowTargets) {
+      target.removeEventListener('scroll', this._onReflow);
+    }
+    window.removeEventListener('resize', this._onReflow);
+    this._reflowTargets = [];
+  }
+
+  private _place() {
+    const trigger = this.renderRoot.querySelector<HTMLElement>('[data-testid="overflow-trigger"]');
+    const menu = this.renderRoot.querySelector<HTMLElement>('[data-testid="overflow-menu"]');
+    if (!trigger || !menu) return;
+    const { top, left } = placeMenu(
+      trigger.getBoundingClientRect(),
+      { width: menu.offsetWidth, height: menu.offsetHeight },
+      { width: window.innerWidth, height: window.innerHeight },
+    );
+    this.style.setProperty('--hv-menu-top', `${top}px`);
+    this.style.setProperty('--hv-menu-left', `${left}px`);
+  }
+
   protected updated() {
+    // Placement first: focusing an unplaced menu would let the browser scroll
+    // a (0, 0) box into view before the coordinates land.
+    if (this._open) this._place();
     this._dialogFocus.sync(this._open, () =>
       this.renderRoot.querySelector<HTMLElement>('[data-testid="overflow-menu"]'),
     );
@@ -233,12 +324,14 @@ export class HVOverflowMenu extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     document.removeEventListener('pointerdown', this._onDocPointerDown, true);
+    this._unwatchReflow();
   }
 
   close() {
     if (!this._open) return;
     this._open = false;
     document.removeEventListener('pointerdown', this._onDocPointerDown, true);
+    this._unwatchReflow();
   }
 
   private _toggle = () => {
@@ -249,6 +342,7 @@ export class HVOverflowMenu extends LitElement {
     this._zBase = nextZBase();
     this._open = true;
     document.addEventListener('pointerdown', this._onDocPointerDown, true);
+    this._watchReflow();
   };
 
   private _choose(item: OverflowMenuItem) {

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -75,11 +75,10 @@ export class HAventoryCard extends LitElement {
    * Sections-view sizing. `getCardSize` above still answers the masonry view,
    * which knows nothing about columns.
    *
-   * Full section width, and tall enough that the ⋮ menu opens inside the card:
-   * `hv-card-shell` reserves 470px for it above 601px, and a card shorter than
-   * that clips the menu's last entries. The minimums are what keep the card
-   * usable when a dashboard hand-shrinks it — below them the list has room for
-   * no rows at all.
+   * Full section width, and enough rows that the list opens with room for
+   * content rather than a sliver. The minimums are what keep the card usable
+   * when a dashboard hand-shrinks it — below them the list has room for no
+   * rows at all.
    */
   public getGridOptions(): {
     columns: number;

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -38,8 +38,8 @@ the count's call.
 `getStubConfig` and `getConfigElement` are **statics on the class**, not module exports:
 Home Assistant reads them off `customElements.get(type)` and never imports from the bundle,
 so an export is a spelling nothing looks at. `getGridOptions` sizes the card in a sections
-view — full section width, and tall enough that `hv-card-shell`'s reserved 470px for the
-open ⋮ menu is not squeezed — while `getCardSize` still answers the masonry view, which
+view — full section width, and enough default rows that the list opens with room for
+content — while `getCardSize` still answers the masonry view, which
 knows nothing about columns.
 
 It also publishes the active HA theme as `color-scheme` on the host, which every nested


### PR DESCRIPTION
## Summary

Fixes #389: when `hv-list` is filtered down to a single row, its scroller becomes shorter than the open ⋮ menu. An absolutely-positioned dropdown anchored inside the row gets clipped by that scroller's overflow, leaving neither opening direction with room to fit the menu whole.

The menu is now `position: fixed` against the viewport instead, with coordinates calculated from the trigger's bounding rect via a new `placeMenu()` function. The menu follows the trigger when composed ancestors scroll or the window resizes by listening on each ancestor directly (scroll events are `composed: false` and never bubble through shadow roots). This also removes the artificial 470px minimum height that `hv-card-shell` was reserving to keep the menu unclipped.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- Frontend: `npx eslint .`, `npm run typecheck`, `npx vitest run`, `npm run build` — all pass
- Added comprehensive unit tests for `placeMenu()` covering:
  - Normal placement below the trigger with right edges aligned
  - Flipping above when room below runs out
  - Clamping to viewport margins when neither side fits the menu whole
  - Keeping the menu inside the left viewport edge
- Added integration tests verifying:
  - The menu carries live placement coordinates while open
  - The menu follows the trigger when composed ancestors scroll
  - Reflow listeners are released when the menu closes

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated (unit tests for `placeMenu()` + integration tests for reflow behavior)
- [x] Docs updated (`frontend_architecture.md` and `index.ts` comments reflect removal of the 470px minimum)

## Technical details

**New `placeMenu()` function:**
- Takes trigger rect, menu dimensions, and viewport dimensions
- Places the menu 6px below the trigger with right edges aligned
- Flips to 6px above if room below runs out and room above suffices
- Clamps both axes to an 8px viewport margin so entries stay reachable even when neither side could hold the menu whole

**Reflow tracking:**
- `_watchReflow()` walks the composed ancestor chain (through shadow roots) and attaches scroll listeners to each ancestor plus the window
- `_onReflow` callback recalculates placement on any scroll or resize
- `_unwatchReflow()` cleans up all listeners when the menu closes or the component disconnects

**CSS changes:**
- `.menu` now uses `position: fixed` with `top` and `left` set via CSS custom properties
- Removed the `position: relative` from `:host` (no longer needed for absolute positioning)
- Removed the `position: fixed` override from the narrow media query (now in the base rule)
- Removed the 470px `min-height` reservation from `hv-card-shell`