### PR TITLE
fix(card): v0.4.2 table and overflow-menu residuals from the v0.4.1 pass

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -239,6 +239,36 @@ describe('hv-card-shell: overflow menu', () => {
     expect(metaOf('organize')).toBe('Locations · Tags · Categories · Statuses');
   });
 
+  // The segment lists above were capitalized while the Data entries stayed
+  // sentence-style — "All 31 items · all locations" under "Items · Locations ·
+  // Stats" — which is two conventions in the same menu. One rule now covers
+  // every hint line the menu draws, `meta` and `sub` alike.
+  it('opens every segment of every hint line with a capital', async () => {
+    const { el, store, sr } = await mountShell({
+      items: [makeItem({ id: '1', category: 'Tools' })],
+    });
+    // A filter is what brings "Export current view" out, so both Data lines
+    // are on screen to be checked together.
+    store.setFilters({ category: 'Tools' });
+    await settle(el);
+    const menu = sr.querySelector('[data-testid="card-overflow"]') as HTMLElement;
+    (menu.shadowRoot?.querySelector('[data-testid="overflow-trigger"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const lines = [...(menu.shadowRoot?.querySelectorAll('.meta, .sub') ?? [])].map((n) =>
+      (n.textContent ?? '').trim(),
+    );
+    expect(lines).toContain('All 1 item · All locations');
+    expect(lines).toContain('1 filtered item · Keeps location paths');
+    for (const line of lines) {
+      for (const segment of line.split('·')) {
+        // A count opens a line as a numeral, which is the same sentence-free
+        // shape as a capital and reads as one beside it.
+        expect(segment.trim(), line).toMatch(/^[\p{Lu}\d]/u);
+      }
+    }
+  });
+
   // Column choices only drive the full view's table — the card list draws a
   // fixed compact row — so the entry belongs where it does something.
   it('offers Columns in the full view but not on the card itself', async () => {

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -56,6 +56,50 @@ describe('hv-data-table: area', () => {
     expect(q(el, '[data-testid="cell-location"]')?.textContent?.trim()).toBe('—');
   });
 
+  // An area "Kitchen" over a root location "Kitchen" — the way a household
+  // names both — put the same word twice in the cell, "Kitchen Kitchen", where
+  // the card's own rows had already stopped doing it. One rule, both surfaces.
+  it('drops the area mark when the path already opens with that name', async () => {
+    const rooted = (display_path: string) => ({
+      id_path: [],
+      name_path: [],
+      display_path,
+      sort_key: '',
+    });
+    for (const path of ['Kitchen', 'Kitchen / Pantry']) {
+      const el = await mount(
+        [{ id: '1', effective_area_id: 'area-kitchen', location_path: rooted(path) }],
+        { columns: ['location'], areas: AREAS },
+      );
+      const cell = q(el, '[data-testid="cell-location"]');
+
+      expect(cell?.querySelector('[data-testid="area-chip"]'), path).toBe(null);
+      expect(cell?.textContent?.replace(/\s+/g, ' ').trim(), path).toBe(path.replace(' / ', ' › '));
+      // The pairing is still readable in full where the cell keeps it.
+      expect(cell?.getAttribute('title'), path).toBe(
+        `Area: Kitchen · ${path.replace(' / ', ' › ')}`,
+      );
+      el.remove();
+    }
+  });
+
+  // A deeper segment of the same name is a different place inside the area, so
+  // the mark still has something to say.
+  it('keeps the mark when the area only reappears further down the path', async () => {
+    const el = await mount(
+      [
+        {
+          id: '1',
+          effective_area_id: 'area-kitchen',
+          location_path: { id_path: [], name_path: [], display_path: 'Cellar / Kitchen', sort_key: '' },
+        },
+      ],
+      { columns: ['location'], areas: AREAS },
+    );
+    expect(
+      q(el, '[data-testid="cell-location"]')?.querySelector('.hv-area-chip')?.textContent,
+    ).toContain('Kitchen');
+  });
 });
 
 describe('hv-data-table: a path too long for its column', () => {

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -55,6 +55,7 @@ describe('hv-data-table: area', () => {
     const el = await mount([{ id: '1' }], { columns: ['location'], areas: AREAS });
     expect(q(el, '[data-testid="cell-location"]')?.textContent?.trim()).toBe('—');
   });
+
 });
 
 describe('hv-data-table: a path too long for its column', () => {
@@ -146,7 +147,7 @@ describe('hv-data-table: a path too long for its column', () => {
 });
 
 describe('hv-data-table: narrow screens', () => {
-  // The template has a hard ~1354px minimum, and a grid whose tracks do not fit
+  // The template has a hard ~1366px minimum, and a grid whose tracks do not fit
   // overflows its box rather than shrinking. With overflow visible the spill
   // was clipped by the shell: rows measured clientWidth 634 / scrollWidth 854
   // at 375px, and three columns could not be reached by any gesture.
@@ -370,11 +371,11 @@ describe('hv-data-table: columns', () => {
   });
 });
 
-// Both chips are unshrinkable, so on a row carrying both they took 138px of the
-// 220px name track and left 82px of name — about eleven characters, measured on
-// a real instance at the table's floor width and again at 390px, where the same
-// cell is pinned. Dropping one is what buys the name back; which one to drop is
-// the choice the phone row already makes on its single line.
+// Both chips are unshrinkable, so on a row carrying both they take 138px of the
+// 250px name track and leave 112px of name — about sixteen characters, measured
+// on a real instance at the table's floor width and again at 390px, where the
+// same cell is pinned. Dropping one is what buys the name back; which one to
+// drop is the choice the phone row already makes on its single line.
 describe('hv-data-table: the name cell picks one chip', () => {
   const bothWays = { quantity: 1, low_stock_threshold: 5 };
 

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -48,7 +48,7 @@ export class HVDataTable extends LitElement {
         /* The one scroll container on this surface, in both axes.
 
            Sideways because the column template has a hard minimum — about
-           1354px for the default set, 1402px with the selection column — and a
+           1366px for the default set, 1414px with the selection column — and a
            grid whose tracks do not fit overflows its own box rather than
            shrinking. With overflow visible that spilled content was simply
            clipped by the shell: at 375px the rows measured clientWidth 634
@@ -163,7 +163,7 @@ export class HVDataTable extends LitElement {
       }
       /*
        * A phone shows about a quarter of this table — the template's floor is
-       * around 1354px — so the identity column holds while the rest scrolls
+       * around 1366px — so the identity column holds while the rest scrolls
        * under it, and the right edge says there is more to reach.
        *
        * The offsets are the row's own metrics, so nothing shifts as the swipe
@@ -559,7 +559,7 @@ export class HVDataTable extends LitElement {
     const statusColumn = columns.includes('status');
     // Low stands down for Checked out in the same cell, the way a phone row's
     // one line already picks the most interrupting thing it has to say: both
-    // chips are unshrinkable, and together they take 138px of a 220px track,
+    // chips are unshrinkable, and together they take 138px of a 250px track,
     // which leaves the name too short to tell two items apart. Who has the item
     // outranks how many are left, and the Qty column still draws a low count in
     // amber.

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -17,7 +17,13 @@ import type { ColumnKey } from '../store/columns';
 import { isLowStock, rowMenuEntries } from './hv-list-row';
 import './hv-overflow-menu';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
-import { itemPathParts, pathTitle, renderAreaChip, renderPathSegments } from '../ui/location-path';
+import {
+  areaMarkName,
+  itemPathParts,
+  pathTitle,
+  renderAreaChip,
+  renderPathSegments,
+} from '../ui/location-path';
 import type { Item, Sort, SortField } from '../store/types';
 
 /**
@@ -523,7 +529,7 @@ export class HVDataTable extends LitElement {
           role="cell"
           data-testid="cell-location"
           title=${pathTitle(parts)}
-          >${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
+          >${renderAreaChip(areaMarkName(parts.areaName, parts.path))}<span class="hv-chip-line-text"
             >${parts.path ? renderPathSegments(parts.path) : '—'}</span
           ></span
         >`;

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -1,7 +1,7 @@
 import './hv-list-row';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
-import { areaMarkName, elideMobilePath, elidePath, isLowStock, rowMenuEntries } from './hv-list-row';
+import { elideMobilePath, elidePath, isLowStock, rowMenuEntries } from './hv-list-row';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVListRow } from './hv-list-row';
 import type { Item } from '../store/types';
@@ -31,27 +31,6 @@ describe('isLowStock', () => {
   it('is low at or below the threshold', () => {
     expect(isLowStock(makeItem({ quantity: 3, low_stock_threshold: 3 }))).toBe(true);
     expect(isLowStock(makeItem({ quantity: 4, low_stock_threshold: 3 }))).toBe(false);
-  });
-});
-
-describe('areaMarkName', () => {
-  it('keeps an area the path does not already name', () => {
-    expect(areaMarkName('Garage', 'Workshop › Drawer A')).toBe('Garage');
-  });
-
-  it('drops an area the path opens with', () => {
-    expect(areaMarkName('Küche', 'Küche')).toBe(null);
-    expect(areaMarkName('Küche', 'Küche › Oberstes Fach')).toBe(null);
-  });
-
-  // Only the first segment counts: a deeper segment of the same name is a
-  // different place inside the area, and the mark still says which area.
-  it('only compares the first segment', () => {
-    expect(areaMarkName('Küche', 'Keller › Küche')).toBe('Küche');
-  });
-
-  it('has nothing to drop when there is no area', () => {
-    expect(areaMarkName(null, 'Küche')).toBe(null);
   });
 });
 

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
-import { itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
+import { areaMarkName, itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { formatDate, isOverdue } from '../ui/relative-time';
 import { itemStatus, renderStatusChip, statusLabel } from '../ui/status';
@@ -65,21 +65,6 @@ export function elidePath(path: string, maxSegments = 2): string {
   const segments = path.split(' › ');
   if (segments.length <= maxSegments) return path;
   return `${segments[0]} › … › ${segments[segments.length - 1]}`;
-}
-
-/**
- * The area worth marking beside a path, or nothing.
- *
- * Naming a root location after the area it stands in is the most natural thing
- * a household does — an area "Kitchen" holding a location "Kitchen" — and the
- * row then prints the same word twice in a row with only a separator between
- * them. When the path's first segment already is the area, the path has said
- * it, and the mark is dropped. The full pairing survives in the row's `title`,
- * which is where the unelided truth lives either way.
- */
-export function areaMarkName(areaName: string | null, path: string): string | null {
-  if (!areaName) return null;
-  return path.split(' › ')[0].trim() === areaName.trim() ? null : areaName;
 }
 
 /**

--- a/cards/haventory-card/src/components/hv-overflow-menu.test.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.test.ts
@@ -35,7 +35,7 @@ describe('hv-overflow-menu', () => {
   it('stacks a long hint under its label instead of beside it', async () => {
     const el = await mount([
       { id: 'organize', label: 'Organize…', meta: 'Locations · Tags · Categories' },
-      { id: 'export', label: 'Export backup', sub: 'All 556 items · all locations' },
+      { id: 'export', label: 'Export backup', sub: 'All 556 items · All locations' },
     ]);
 
     const labels = item(el, 'organize').querySelector('.labels') as HTMLElement;

--- a/cards/haventory-card/src/components/hv-overflow-menu.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.ts
@@ -11,9 +11,9 @@ export interface OverflowMenuItem {
   id: string;
   label: string;
   glyph?: IconName;
-  /** Right-aligned muted text, e.g. "Locations · Tags · Categories". */
+  /** Muted hint line, e.g. "Locations · Tags · Categories". */
   meta?: string;
-  /** Second line under the label, e.g. "38 filtered items · keeps location paths". */
+  /** Second line under the label, e.g. "38 filtered items · Keeps location paths". */
   sub?: string;
   /** Right-aligned pill, e.g. "2 issues". Only shown when there is something to say. */
   badge?: string;

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -206,6 +206,11 @@ export class HostSurfaces {
   /**
    * The full view's ⋮ menu. Both hosts serve this same list, so the card's
    * expanded view and the sidebar panel cannot drift apart on what it offers.
+   *
+   * Every hint line under an entry — `meta` and `sub` alike — is a list of
+   * `·`-separated segments, and each segment opens with a capital. A line that
+   * reads as a sentence beside one that reads as a list makes the two look like
+   * different kinds of thing when they are the same kind.
    */
   menuEntries(): OverflowMenuEntry[] {
     const st = this.getStore()?.state.value ?? null;
@@ -231,7 +236,7 @@ export class HostSurfaces {
         id: 'export-all',
         label: 'Export backup',
         glyph: 'download',
-        sub: total === null ? 'Everything' : `All ${counted(total, 'item')} · all locations`,
+        sub: total === null ? 'Everything' : `All ${counted(total, 'item')} · All locations`,
       },
       // Only while a filter is on. Unfiltered, "the current view" is the whole
       // inventory that Export backup above already offers, and the entry could
@@ -244,8 +249,8 @@ export class HostSurfaces {
               glyph: 'download' as const,
               sub:
                 filtered === null
-                  ? 'Active filter · keeps location paths'
-                  : `${filtered} filtered ${plural(filtered, 'item')} · keeps location paths`,
+                  ? 'Active filter · Keeps location paths'
+                  : `${filtered} filtered ${plural(filtered, 'item')} · Keeps location paths`,
             },
           ]
         : []),

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -192,20 +192,41 @@ function widthOf(contentWidth: number, key: ColumnKey): number {
   return widths[1 + columns.indexOf(key)];
 }
 
+/** The resolved width of the name column of the default table. */
+function nameWidthOf(contentWidth: number): number {
+  return resolveTracks(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }), contentWidth)[0];
+}
+
+/**
+ * What the sidebar panel at 1920 leaves the table's grid, measured on a real
+ * instance: HA's docked sidebar takes 256px and the full view's locations rail
+ * another 264, which puts the table's box at 1400 and its content box — inside
+ * the row's own 20px padding either side — here.
+ */
+const PANEL_GRID_AT_1920 = 1360;
+
+/**
+ * An ordinary name, in pixels. Measured in the row's own 13.5px/500 text: a
+ * 32-character name draws 223px and a 28-character one 189px, so ~7px a
+ * character, and the ~35 characters an ordinary household item needs come to
+ * about this.
+ */
+const ORDINARY_NAME_WIDTH = 245;
+
 describe('table column widths', () => {
   // Pinned as a number so that adding a column, or widening one, shows up here
   // as a deliberate change rather than as another phone-width overflow.
   it('cannot lay the default table out narrower than a phone', () => {
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1242);
-    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1282);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false }))).toBe(1254);
+    expect(minWidthOf(tableTemplateFor([...DEFAULT_COLUMNS], { selectable: true }))).toBe(1294);
   });
 
   it('only fits a phone when almost every column is turned off', () => {
-    // Name (220) + Qty (70) + the actions gutter (140). That overflows a 375px
+    // Name (250) + Qty (70) + the actions gutter (140). That overflows a 375px
     // screen on its own — so trimming columns was never a reliable answer, and
     // it would have discarded a choice the user made. The table scrolls
     // sideways instead, and pins the name column while it does.
-    expect(minWidthOf(tableTemplateFor(['quantity'], { selectable: false }))).toBe(430);
+    expect(minWidthOf(tableTemplateFor(['quantity'], { selectable: false }))).toBe(460);
   });
 
   // With every column on, the flexible tracks all sit at their floor and the
@@ -252,6 +273,28 @@ describe('table column widths', () => {
     expect(widthOf(1560, 'tags')).toBeGreaterThan(widthOf(1560, 'category'));
   });
 
+  // The panel is where the full column set is actually read, and there the
+  // fixed columns take enough that every flexible track sits on its floor —
+  // the growth factors never get a say. So the name's floor is the whole
+  // answer to whether a name ends or elides: at 220 a 32-character one needed
+  // 223px and lost its last three characters to an ellipsis, beside a Due and
+  // an Updated column holding nothing but "—".
+  it('renders an ordinary name whole at the width the sidebar panel gets', () => {
+    expect(nameWidthOf(PANEL_GRID_AT_1920)).toBeGreaterThanOrEqual(ORDINARY_NAME_WIDTH);
+  });
+
+  // The name is fed from Category, the flexible column carrying one word, and
+  // not from the two whose content has no natural end: at the same width they
+  // stay above their floors, so a path still breaks between segments and a tag
+  // set still wraps whole chips.
+  it('leaves Location and Tags growing while the name takes its floor', () => {
+    expect(widthOf(PANEL_GRID_AT_1920, 'location')).toBeGreaterThan(150);
+    expect(widthOf(PANEL_GRID_AT_1920, 'tags')).toBeGreaterThan(150);
+    expect(widthOf(PANEL_GRID_AT_1920, 'category')).toBeLessThan(
+      widthOf(PANEL_GRID_AT_1920, 'location'),
+    );
+  });
+
   // Between the two the name is still served before either of them grows: it
   // reaches its floor while they are still on theirs.
   it('serves the name to its floor before the surplus moves on', () => {
@@ -271,7 +314,7 @@ describe('table column widths', () => {
   it('puts every track on its floor once the table is scrolling', () => {
     const template = tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false });
     const tracks = resolveTracks(template, 1016);
-    expect(tracks).toEqual([220, 70, 112, 110, 140, 130, 100, 124, 96, 140]);
+    expect(tracks).toEqual([250, 70, 112, 92, 140, 130, 100, 124, 96, 140]);
     expect(tracks.reduce((a, b) => a + b, 0)).toBe(minWidthOf(template));
   });
 

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -38,8 +38,11 @@ export const COLUMN_DEFS: readonly ColumnDef[] = [
   // or clipped would be unreadable in exactly the rows that matter most.
   { key: 'status', label: 'Status', tableSize: '112px' },
   // One word, and the only flexible column that carries one: it takes the
-  // smallest floor and the smallest share of whatever is left over.
-  { key: 'category', label: 'Category', tableSize: 'minmax(110px, 1fr)' },
+  // smallest floor and the smallest share of whatever is left over. The floor
+  // holds its own header and a one-word value and stops there — with the full
+  // column set every flexible track freezes on its floor, so what this one does
+  // not claim is what the name beside it gets to finish a word on.
+  { key: 'category', label: 'Category', tableSize: 'minmax(92px, 1fr)' },
   // The two columns whose content has no natural end — a path grows a segment
   // per nesting level, a tag set a chip per tag — so they are where surplus
   // width does the most: their cells wrap, and every pixel they get is a
@@ -128,15 +131,19 @@ const COLUMN_TABLE_SIZE: Record<ColumnKey, string> = Object.fromEntries(
  * gets any. At most one of Low and Checked out draws, so the floor holds a
  * readable name rather than the tail of one.
  *
- * Its growth factor does not outrank them, and that is the point. A name is one
- * line of text with an end to it; a path and a tag set are not. With the full
- * column set the name lands on its floor and every pixel past it goes to
- * Location and Tags, whose cells wrap — which is where a wider window can still
- * change what the row says. Ahead of the flexible columns' floors the name is
- * served first either way, so the two ends of the range answer different
- * questions rather than the same one twice.
+ * That floor is what the name actually gets on the surface it is read on. With
+ * the full column set the fixed columns take enough that every flexible track
+ * freezes on its minimum, so the floor — not the growth factor — decides
+ * whether a name ends or elides: it holds an ordinary one of about 35
+ * characters, which is 245px at the row's 13.5px text.
+ *
+ * The growth factor does not outrank the others, and that is the point. A name
+ * is one line of text with an end to it; a path and a tag set are not. Past the
+ * floors every extra pixel goes to Location and Tags, whose cells wrap — which
+ * is where a wider window can still change what the row says. So the two ends
+ * of the range answer different questions rather than the same one twice.
  */
-export const NAME_COLUMN_SIZE = 'minmax(220px, 2fr)';
+export const NAME_COLUMN_SIZE = 'minmax(250px, 2fr)';
 
 /**
  * The selection column's track. Exported because the table pins the name cell

--- a/cards/haventory-card/src/ui/location-path.test.ts
+++ b/cards/haventory-card/src/ui/location-path.test.ts
@@ -1,5 +1,6 @@
 import { render } from 'lit';
 import {
+  areaMarkName,
   itemPathParts,
   locationLabel,
   locationPathParts,
@@ -111,6 +112,33 @@ describe('pathTitle', () => {
 
   it('is empty when there is neither', () => {
     expect(pathTitle({ areaName: null, path: '' })).toBe('');
+  });
+});
+
+describe('areaMarkName', () => {
+  it('keeps an area the path does not already name', () => {
+    expect(areaMarkName('Garage', 'Workshop › Drawer A')).toBe('Garage');
+  });
+
+  it('drops an area the path opens with', () => {
+    expect(areaMarkName('Küche', 'Küche')).toBe(null);
+    expect(areaMarkName('Küche', 'Küche › Oberstes Fach')).toBe(null);
+  });
+
+  // Only the first segment counts: a deeper segment of the same name is a
+  // different place inside the area, and the mark still says which area.
+  it('only compares the first segment', () => {
+    expect(areaMarkName('Küche', 'Keller › Küche')).toBe('Küche');
+  });
+
+  it('has nothing to drop when there is no area', () => {
+    expect(areaMarkName(null, 'Küche')).toBe(null);
+  });
+
+  // The rule reads the path as the surfaces write it, so it has to split on the
+  // separator `prettyPath` produces rather than on the stored one.
+  it('compares against the path as it is written for display', () => {
+    expect(areaMarkName('Küche', prettyPath('Küche / Oberstes Fach'))).toBe(null);
   });
 });
 

--- a/cards/haventory-card/src/ui/location-path.ts
+++ b/cards/haventory-card/src/ui/location-path.ts
@@ -105,6 +105,24 @@ export function renderPathSegments(path: string): TemplateResult[] {
 }
 
 /**
+ * The area worth marking beside a path, or nothing.
+ *
+ * Naming a root location after the area it stands in is the most natural thing
+ * a household does — an area "Kitchen" holding a location "Kitchen" — and the
+ * surface then prints the same word twice with only a chip's edge between them.
+ * When the path's first segment already is the area, the path has said it, and
+ * the mark is dropped. The full pairing survives in the `title`, which is where
+ * the unelided truth lives either way.
+ *
+ * Every surface that hangs an area chip beside a path goes through this, so the
+ * mark says the same thing on a card row as in the full view's table.
+ */
+export function areaMarkName(areaName: string | null, path: string): string | null {
+  if (!areaName) return null;
+  return path.split(PATH_SEPARATOR)[0].trim() === areaName.trim() ? null : areaName;
+}
+
+/**
  * The area beside a path, rendered so it cannot be mistaken for one of the
  * path's own segments. Renders nothing when there is no area, so a caller can
  * embed it unguarded.


### PR DESCRIPTION
## Summary

The three residual findings from the v0.4.1 verification pass, all in the card, all
next to the fixes that just shipped.

**#397 — the name column gets a whole name back.** In the sidebar panel at 1920 the
table's grid gets 1360px; the fixed columns take 642 of it, so every flexible track
freezes on its floor and the growth factors never get a say. The name's floor was
220px, and a 32-character name needing 223px lost its last characters to an ellipsis
beside a Due and an Updated column holding nothing but an em dash. The floor now holds
an ordinary ~35-character name (250px at the row's 13.5px text); the pixels come from
Category, the one flexible column carrying a single word, whose floor drops to what its
own header and a one-word value need (110 → 92). #378's guarantees stand: Location and
Tags keep their floors and their growth factor, paths still break at segment boundaries,
tag sets still wrap whole chips. Measured on the real instance, the resolved template at
1920 goes `220 70 112 110 158 158 …` → `250 70 112 92 152 152 …` — Location and Tags
give back 6px each. The template's minimum moves 1354 → 1366, so the table starts
scrolling sideways 12px earlier.

**#398 — the table's Location cell stops repeating the area.** The card's list rows
already drop the area mark when the path's first segment *is* the area name (#377); the
table did not, so an item in area Kitchen under a "Kitchen" root read "Kitchen Kitchen".
The rule moves out of `hv-list-row` into `ui/location-path`, beside the chip it decides
about, and both surfaces call it. The cell's `title` still carries the full pairing.

**#399 — one convention for the ⋮ menu's hint lines.** Every `·`-separated segment of
every meta/sub line opens with a capital, Data lines included: "All 1078 items · All
locations", "1 filtered item · Keeps location paths".

Closes #397
Closes #398
Closes #399

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `752 passed, 22 skipped`; `ruff check` clean; `ruff format --check` clean;
      `mypy` clean (no backend change — the gate is the gate).
- [x] Frontend (`cards/haventory-card`): `eslint` clean, `typecheck` clean,
      `vitest run` **1736 passed / 62 files**, `npm run build` OK.

One test per fix, all three at the level the fix lives at:

- `store/columns.test.ts` — the track distribution resolved at the panel's real grid
  width (1360px, measured), asserting the name column holds an ordinary name and that
  Location and Tags keep growing past their floors there. The pinned minimum widths and
  the floor-resolution vector move with it.
- `hv-data-table.test.ts` — the Location cell drops the mark for "Kitchen" and
  "Kitchen / Pantry", keeps it for "Cellar / Kitchen", and keeps the full pairing in the
  cell title. Mirrors the existing list-row test.
- `hv-card-shell.test.ts` — every `·`-separated segment of every hint line in the open
  menu opens with a capital (or a numeral), with both Data lines on screen. Holds the
  rule rather than the wording.

Real instance (HA 2026.6.0, dev container), deployed and driven:

- `visual_pass.mjs --out before` / `--out after`, 42/42 both times. 24 surfaces differ:
  the table surfaces and the two overflow menus (intended), plus small "N m ago" cells
  where the relative time drifted between the runs. Everything else is byte-identical.
- Panel at 1280 and 1920, light and dark. At 1920 the 32-character name renders whole;
  a temporary 35-character item confirmed the target case (210px drawn in a 250px track)
  and was deleted afterwards. At 1280 the table scrolls sideways as before, every track
  on its floor, nothing truncated.
- Open ⋮ menu at 1920, light and dark, filtered and unfiltered — one capitalization
  convention across all four hint lines.
- `log_sweep.py --since 60m`: **PASS, blocking=0.**

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs: no behavior a doc describes changed; comments naming the old track numbers
      (`hv-data-table`, its test) were corrected in the same commit.
- [x] No WebSocket API change.
- [x] Essential invariants untouched.

## Notes

- The dev instance had no item long enough to reproduce #397, so it now carries
  "Ceramic Fuse Assortment (20x5mm)" — 32 characters, six tags, the four-segment path
  `QA House › QA Ground Floor › QA Garage › QA Tool Wall` — mirroring the QA instance's
  reference case. Left in place as the standing repro, next to the Küche seed for #398.

### Follow-ups

- The detail sheet renders the area chip beside the path unconditionally, the way the
  table did. It is the surface whose job is the unelided truth (the same reason both row
  and cell keep the full pairing in their `title`), so it is left alone — noted here
  rather than filed.
