### PR TITLE
fix(card): the v0.4.3 residuals — the full view's row check-out popover and the sheet's path crumb

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -897,9 +897,12 @@ describe('hv-data-table: row menu', () => {
     expect(menu(el, 0).entries).toEqual(rowMenuEntries(makeItem({ id: '1', name: 'In' })));
   });
 
-  it('reports the picked action, the row it came from, and where to anchor', async () => {
+  // No anchor travels with it: everything the menu opens on this surface is
+  // centred, because the ⋮ it would hang from sits in a column the table scrolls
+  // sideways out of view.
+  it('reports the picked action and the row it came from, and nothing else', async () => {
     const el = await mount([{ id: '1', name: 'Drill' }]);
-    const seen: { itemId: string; action: string; anchor?: DOMRect }[] = [];
+    const seen: Record<string, unknown>[] = [];
     el.addEventListener('row-action', (e) => seen.push((e as CustomEvent).detail));
 
     for (const id of ['check-out', 'edit', 'delete']) {
@@ -908,7 +911,11 @@ describe('hv-data-table: row menu', () => {
 
     expect(seen.map((d) => d.action)).toEqual(['check-out', 'edit', 'delete']);
     expect(seen.every((d) => d.itemId === '1')).toBe(true);
-    expect(seen[0].anchor).toBeTruthy();
+    expect(seen.map((d) => Object.keys(d).sort())).toEqual([
+      ['action', 'itemId'],
+      ['action', 'itemId'],
+      ['action', 'itemId'],
+    ]);
   });
 
   // The row's own click opens the item; a click on the menu is not that.

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -695,9 +695,7 @@ export class HVDataTable extends LitElement {
                       @select=${(e: CustomEvent) => {
                         e.stopPropagation();
                         const { id } = e.detail as { id: string };
-                        // The check-out flow needs somewhere to anchor its popover.
-                        const anchor = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                        this._emit('row-action', { itemId: item.id, action: id, anchor });
+                        this._emit('row-action', { itemId: item.id, action: id });
                       }}
                     ></hv-overflow-menu>
                   </span>

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -76,6 +76,46 @@ describe('hv-detail-sheet: area', () => {
     expect(crumb?.textContent?.trim()).toBe('No location');
     expect(crumb?.querySelector('.hv-area-chip')).toBe(null);
   });
+
+  // Naming a root location after the room it stands in is the ordinary thing to
+  // do, and it put "Kitchen Kitchen" on the crumb. The card's rows and the
+  // table's Location cell answer this the same way; the crumb is a clipped
+  // one-line chip like both of them, and the pairing it drops stays readable in
+  // full in its title.
+  const KITCHEN = [{ id: 'area-kitchen', name: 'Kitchen' }];
+  const rooted = (display_path: string) => ({
+    id_path: [],
+    name_path: [],
+    display_path,
+    sort_key: '',
+  });
+
+  it('drops the area mark when the path already opens with that name', async () => {
+    for (const path of ['Kitchen', 'Kitchen / Pantry']) {
+      const el = await mount(
+        { effective_area_id: 'area-kitchen', location_path: rooted(path) },
+        { areas: KITCHEN },
+      );
+      const crumb = q(el, '[data-testid="sheet-path"]');
+
+      expect(crumb?.querySelector('[data-testid="area-chip"]'), path).toBe(null);
+      expect(crumb?.textContent?.replace(/\s+/g, ' ').trim(), path).toBe(path.replace(' / ', ' › '));
+      expect(crumb?.getAttribute('title'), path).toBe(`Area: Kitchen · ${path.replace(' / ', ' › ')}`);
+      el.remove();
+    }
+  });
+
+  // A segment deeper down that happens to share the area's name is a different
+  // place inside it, so the mark still has something to say.
+  it('keeps the mark when the area only reappears further down the path', async () => {
+    const el = await mount(
+      { effective_area_id: 'area-kitchen', location_path: rooted('Cellar / Kitchen') },
+      { areas: KITCHEN },
+    );
+    const crumb = q(el, '[data-testid="sheet-path"]');
+    expect(crumb?.querySelector('.hv-area-chip')?.textContent).toContain('Kitchen');
+    expect(crumb?.textContent).toContain('Cellar › Kitchen');
+  });
 });
 
 describe('hv-detail-sheet: read view', () => {

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -8,7 +8,7 @@ import { customFieldLabel } from '../ui/field-label';
 import { inferType } from '../ui/item-form';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
 import { isLowStock } from './hv-list-row';
-import { itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
+import { areaMarkName, itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import {
   MediaUrls,
   attachmentNameToken,
@@ -629,7 +629,7 @@ export class HVDetailSheet extends LitElement {
           ${icon('close', 22)}
         </button>
         <span class="crumb hv-chip-line" data-testid="sheet-path" title=${pathTitle(parts)}
-          >${renderAreaChip(parts.areaName)}<span class="hv-chip-line-text"
+          >${renderAreaChip(areaMarkName(parts.areaName, parts.path))}<span class="hv-chip-line-text"
             >${parts.path || 'No location'}</span
           ></span
         >

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -2218,6 +2218,42 @@ describe('hv-full-view: table row actions', () => {
     expect(store.state.value.items.find((i) => i.id === '1')?.checked_out).toBe(true);
   });
 
+  // The popover's phone presentation is an inline step, a static card meant to
+  // sit inside the body of the surface that opened it — and this call site is a
+  // sibling at the end of the shell with no body around it, so the step landed
+  // stranded and unscrimmed at the foot of the page. The anchored presentation
+  // is no better here: the ⋮ it would hang from sits in a column the table
+  // scrolls sideways out of view. It presents the way the bulk popover does.
+  it('presents the single-row check-out centred and scrimmed at every width', async () => {
+    for (const narrow of [false, true]) {
+      const restore = stubViewport(narrow);
+      try {
+        const { el, sr } = await mount({ items: [makeItem({ id: '1', name: 'Drill' })] });
+        pick(sr, 'check-out');
+        await settle(el);
+
+        const popover = q(sr, '[data-testid="full-checkout"]') as HTMLElement & {
+          open: boolean;
+          mobile: boolean;
+          anchor: DOMRect | null;
+        };
+        const where = `narrow=${narrow}`;
+        expect(popover.open, where).toBe(true);
+        expect(popover.mobile, where).toBe(false);
+        expect(popover.anchor, where).toBe(null);
+
+        const scrim = popover.shadowRoot?.querySelector('.scrim');
+        expect(scrim?.classList.contains('dim'), where).toBe(true);
+        const card = popover.shadowRoot?.querySelector('[data-testid="checkout-popover"]');
+        expect(card?.getAttribute('style'), where).toContain('left: 50%');
+
+        el.remove();
+      } finally {
+        restore();
+      }
+    }
+  });
+
   it('sets a due date on an item already out', async () => {
     const { el, sr } = await mount({
       items: [makeItem({ id: '1', name: 'Drill', checked_out: true })],

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -824,11 +824,10 @@ export class HVFullView extends LitElement {
   @state() private _pendingDelete = false;
   /** The whole selection's check-out is waiting on one due date. */
   @state() private _pendingBulkCheckout = false;
-  /** The row whose check-out / due-date step is open, and where to anchor it. */
+  /** The row whose check-out / due-date step is open. */
   @state() private _checkout: {
     itemId: string;
     mode: 'check-out' | 'set-due-date';
-    anchor: DOMRect | null;
   } | null = null;
   /**
    * Where the surface goes once a discard is confirmed, or null while nothing
@@ -1088,13 +1087,13 @@ export class HVFullView extends LitElement {
    * host, which owns the confirmation and the store call; the Delete key on a
    * row already went the same way.
    */
-  private _onRowAction(detail: { itemId?: string; action?: string; anchor?: DOMRect }) {
+  private _onRowAction(detail: { itemId?: string; action?: string }) {
     const item = this.st?.items.find((i) => i.id === detail.itemId);
     if (!item) return;
     switch (detail.action) {
       case 'check-out':
       case 'set-due-date':
-        this._checkout = { itemId: item.id, mode: detail.action, anchor: detail.anchor ?? null };
+        this._checkout = { itemId: item.id, mode: detail.action };
         break;
       case 'check-in':
         void this.store?.markCheckedIn(item.id, item.version);
@@ -2059,7 +2058,7 @@ export class HVFullView extends LitElement {
               @edit=${(e: CustomEvent) => this._onRowEvent('edit', e.detail)}
               @open-item=${(e: CustomEvent) => this._onRowEvent('open-item', e.detail)}
               @row-action=${(e: CustomEvent) =>
-                this._onRowAction(e.detail as { itemId?: string; action?: string; anchor?: DOMRect })}
+                this._onRowAction(e.detail as { itemId?: string; action?: string })}
               @toggle-select=${(e: CustomEvent) =>
                 this.store?.toggleSelected((e.detail as { itemId: string }).itemId)}
               @select-all-loaded=${() => this.store?.selectAllLoaded()}
@@ -2167,12 +2166,16 @@ export class HVFullView extends LitElement {
             ></hv-detail-sheet>`
           : null}
 
+        <!-- Centred and scrimmed at every width, like the bulk popover below.
+             Neither of the other two presentations fits this call site: the
+             mobile one draws an inline step that has to sit inside the body of
+             the surface that opened it, and this is a sibling at the end of the
+             shell with no body around it; the anchored one hangs off the row ⋮,
+             which sits in a column the table scrolls sideways out of view. -->
         <hv-checkout-popover
           data-testid="full-checkout"
           ?open=${this._checkout !== null}
-          ?mobile=${this._narrow}
           .mode=${this._checkout?.mode ?? 'check-out'}
-          .anchor=${this._checkout?.anchor ?? null}
           .item=${this._checkout ? (st?.items.find((i) => i.id === this._checkout!.itemId) ?? null) : null}
           @check-out=${(e: CustomEvent) => {
             const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };


### PR DESCRIPTION
## Summary

Milestone V0.4.3: the three card findings the v0.4.x PRs noted rather than filed. Two
were real and are fixed here; the third turned out to have nothing wrong with it and is
closed on the issue instead of in a diff.

**#402 — the full view's single-row check-out popover stops landing at the foot of the
shell.** `hv-checkout-popover`'s mobile presentation is an inline step: a static,
unscrimmed card meant to sit inside the body of the surface that opened it, which is how
`hv-detail-sheet` mounts it. The full view's copy is a sibling at the end of the template,
after the table and the sheet, so at 390px a row's *Check out…* / *Set due date…* drew
that card below "Showing 50 of 1078 items", running to the bottom edge of the screen —
measured at `position: static`, `y = 409.8 → 844` in an 844px viewport, no scrim. It now
presents the way the bulk popover beside it does: centred at 20dvh with a dimmed scrim, at
every width (`y = 168.8 → 507.0` at 390px, `x = 570` at 1440px). Anchoring was the other
candidate and is worse here — the ⋮ it would hang from sits in the actions column, which
the table scrolls sideways out of view, and it would add a second placement path of the
kind #389/#395 already had to clamp against the viewport. With no caller left reading it,
the anchor comes out of the table's `row-action` detail and the full view's `_checkout`
state; the card's list rows keep theirs, since `hv-card-shell` still anchors that popover
to the ⋮ it hangs from.

**#403 — the detail sheet's path crumb stops repeating the area name.** A root location
named after the room it stands in is the ordinary thing a household does, and the sheet
answered it with "Kitchen  Kitchen" — the string `areaMarkName()` already drops for the
card's rows and the table's Location cell (#377, #398). The sheet now calls it too. The
counter-argument was that the sheet is the surface whose job is the unelided truth, but its
crumb is a clipped one-line chip like the other two: at 390px what fits is
"Kitchen › Pantry › Top Shelf", and the full pairing stays in the crumb's `title`,
"Area: Kitchen · Kitchen › Pantry › Top Shelf", where the row and the cell keep theirs.

**#401 — closed as not planned, no change.** `pm-05-row-editor` does not fail on `main`
@ 17dc662: 4/4 green (one full `--only panel-mobile` run at 8/8, plus three consecutive
`--surfaces 05-row-editor` runs). The issue's leading hypothesis was already dead — the
harness is in this repo, `.claude/skills/run-haventory/visual_pass.mjs`, and its step has
gone row → detail sheet → *Edit details* → editor since 5ab5750 (#347), which merged before
the #351 pass that recorded the failure. Driven at 375px on the dev instance, the panel
does what #347 designed: a row tap opens the read sheet, *Edit details* opens the form, and
the row pencil goes the same way as the row. What the reproduction added, and what is now
[recorded on the issue](https://github.com/chrreiter/HAventory/issues/401#issuecomment-5258126904),
is why an empty store produces exactly the reported shape — `05-row-editor` is the only
panel-mobile surface that needs a row to exist — and that the row's hover-only actions cell
sits ~900px off the side of a 1366px-wide table at that width, with everything it offers
also in the sheet the row tap opens.

Closes #402
Closes #403

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `752 passed, 22 skipped`; `ruff check` clean; `ruff format --check` clean;
      `mypy` clean (no backend change — the gate is the gate).
- [x] Frontend (`cards/haventory-card`): `eslint` clean, `typecheck` clean,
      `vitest run` **1739 passed / 62 files**, `npm run build` OK, `npm audit` 0
      vulnerabilities.

One test per fix, at the level the fix lives at:

- `hv-full-view.test.ts` — the single-row popover, opened from the row ⋮ at both widths:
  no `mobile`, no `anchor`, a `.scrim.dim` behind it and the centred position on the card.
  Looping over narrow and wide is the point — the presentation is the same at both.
- `hv-data-table.test.ts` — `row-action` now carries the action and the row and nothing
  else, so the removed anchor cannot come back unnoticed.
- `hv-detail-sheet.test.ts` — the crumb drops the mark for "Kitchen" and "Kitchen / Pantry",
  keeps it for "Cellar / Kitchen", and keeps the full pairing in its `title`. Mirrors the
  table's, which mirrors the row's.

Real instance (HA 2026.6.0, dev container), deployed and driven at each step:

- **#402 before**, panel at 390px: `mobile` set, `position: static`, card at
  `y 409.8 → 844.0` (the viewport's own bottom edge), `scrim: null`. Screenshot shows it
  under the table's "Showing 50 of 1078 items" footer.
- **#402 after**, panel at 390px: `mobile` unset, `position: fixed`, card at
  `x 45, y 168.8 → 507.0`, scrim `rgba(0,0,0,0.35)`. At 1440px: `x 570, y 180 → 492.3`,
  same scrim — the presentation the bulk popover and both confirms already use.
- **#403 before**, detail sheet crumb for "Spice Jar #0818" (area Kitchen, path
  `Kitchen / Pantry / Top Shelf`): `"Area: KitchenKitchen › Pantry › Top Shelf"` — on the
  panel at 390px *and* in the card in a dashboard column at 1440px.
- **#403 after**, same two surfaces: `"Kitchen › Pantry › Top Shelf"`, no area chip, title
  still `"Area: Kitchen · Kitchen › Pantry › Top Shelf"`. The control case — "Ceramic Fuse
  Assortment", area Living Room under a "QA House" root — keeps its chip on both, before
  and after.
- **#401**: `visual_pass.mjs --only panel-mobile` 8/8, then `--surfaces 05-row-editor` three
  more times, all green. Captures show the read sheet on a row tap and the edit form one tap
  deeper.
- `visual_pass.mjs` over all four passes on the built branch: **42/42**, no console errors
  and no missing card assets. The `d-`/`m-` layout assertions confirm each card pass
  photographed the branch it asked for.

## Follow-ups

None of these is in this diff. The first two are filed and staged for V0.5.0.

- **#405** — the area mark repeats on two more surfaces the sweep did not name:
  `hv-item-editor.ts:1413` (the Location field's button) and `hv-full-view.ts:1666` (the
  context breadcrumb over the table). Whether the rule belongs on a picker and on a
  browsing crumb is a decision rather than a copy of this one, and neither carries the
  pairing in a `title` the way the three eliding surfaces do.
- **#406** — `hv-checkout-popover`'s `mobile` attribute ties thumb-sized controls
  (40–50px) to the inline-step presentation, so a caller that cannot use the step cannot
  get the sizes either. Both of the full view's popovers are now in that position: at 390px
  they draw 29px offset chips and a 31px confirm where the narrow shell sets
  `--hv-tap-min: 44px`. The bulk one has always been that size; the single-row one is now.
  The sizing cannot simply move behind a viewport query — `hv-card-shell` mounts the sheet,
  and with it the inline step, whenever the *card* measures under 600px, which happens in a
  dashboard column in a 1440px window.
- `hv-card-shell.ts:1138` passes `?mobile` to its own check-out popover from the same kind
  of sibling position, but the narrow card hides `hv-list-row`'s hover actions outright, so
  nothing on that branch can open it. Below the bar for an issue; noted here in case that
  branch ever grows a route to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
