### PR TITLE
fix(ci): guard the Python floor's copies

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -34,10 +34,11 @@ esac
 # `uv sync` is the documented bootstrap (CLAUDE.md) and the only one that
 # reproduces the locked set: requirements-dev.txt carries its own header saying
 # it is a generated pip fallback for environments without uv, not a second source
-# of truth. The fallback searches 3.14 first because requires-python is >=3.14 and
-# the source uses PEP 758 unparenthesized `except A, B:`, which does not parse on
-# 3.13 — an older interpreter yields an environment that cannot import the
-# integration at all, which is worse than no environment.
+# of truth. The fallback searches for Python 3.14 first because that is the floor
+# `requires-python` declares, and the source uses PEP 758 unparenthesized
+# `except A, B:`, which does not parse on 3.13 — an older interpreter yields an
+# environment that cannot import the integration at all, which is worse than no
+# environment.
 if [ "$POSIX_VENV_HOST" -eq 0 ]; then
   log "Windows shell detected; skipping the Python bootstrap (develop through WSL2, see CLAUDE.md)"
 elif command -v uv >/dev/null 2>&1; then
@@ -84,8 +85,8 @@ fi
 # requirements-integration.txt). It uses a DEDICATED env (.venv-integration) so
 # the offline `.venv` above stays Home-Assistant-free.
 #
-# This is heavy and needs a 3.14 interpreter plus network for the HA core, so it
-# is strictly best-effort: it must NEVER fail session bootstrap (e.g. in
+# This is heavy and needs a Python 3.14 interpreter plus network for the HA core,
+# so it is strictly best-effort: it must NEVER fail session bootstrap (e.g. in
 # restricted-egress sandboxes that can't fetch Python 3.14). The offline suite is
 # unaffected either way. Run the suite with: scripts/test_integration.sh
 INT_VENV=".venv-integration"

--- a/.claude/skills/test-haventory/SKILL.md
+++ b/.claude/skills/test-haventory/SKILL.md
@@ -105,7 +105,7 @@ export PYTHONIOENCODING=utf-8   # [Windows/Git Bash] only; a Linux terminal is U
 S=".claude/skills/test-haventory/stress.py"
 RUN="uv run --no-project --with aiohttp python $S"
 
-$RUN baseline      # health + version — proves the deployed code imported (PEP 758 needs 3.14)
+$RUN baseline      # health + version — proves the deployed code imported (needs Python 3.14)
 $RUN fuzz          # malformed single-mutation inputs; asserts dataset untouched
 $RUN bulkfuzz      # adversarial haventory/items/bulk
 $RUN subteardown   # HA-core unsubscribe_events teardown (the card's path)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Reproducible HAventory dev container: Debian base + uv (Python) + Node (via a
-# devcontainer feature). uv provisions the Python interpreter (the declared
+# devcontainer feature). uv provisions the interpreter (the declared Python
 # 3.14 HA runtime) from pyproject.toml / uv.lock.
 FROM mcr.microsoft.com/devcontainers/base:bookworm
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,9 +30,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The extractor resolves imports and the stdlib against whatever `python3`
+      # is on PATH — its log shows it skipping built-ins out of this
+      # interpreter's lib directory — so the pin decides which Python CodeQL
+      # models the source against.
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - uses: actions/setup-node@v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,14 @@ Three floors constrain everything, none of them written down here:
   egress must preinstall it or allow the python-build-standalone download, otherwise the
   offline suite cannot run there.
 - **Node** — `engines` in `cards/haventory-card/package.json`; CI runs a matrix across the
-  supported majors.
+  supported majors, and every `node-version:` a workflow pins has to be one of them.
+
+`tests/test_toolchain_pins.py` holds the Python and Node floors the way
+`tests/test_min_ha_version.py` holds HA's: it enumerates the copies, fails when one drifts,
+and sweeps the tree so a copy in a file it does not list fails too. Add a new copy to that
+test or don't write it. It also ties the pins that are written twice — ruff and actionlint
+in `pyproject.toml`/`.github/workflows/ci.yml` against `.pre-commit-config.yaml` — so a
+hook can no longer run a different version than CI.
 
 When raising the HA floor, three constraints stack and the binding one is not always the
 same: the HA APIs the integration touches, the Python floor those releases carry, and
@@ -48,7 +55,7 @@ assuming the current floor is still the right one. `dependency-review` fails CI 
 Toolchain: **uv** (env + lockfile + dependency groups), ruff, mypy, ESLint (no separate
 formatter), TypeScript, Vite, Vitest. Pins live in `pyproject.toml` and
 `cards/haventory-card/package.json`; ruff's pin is duplicated in `.pre-commit-config.yaml`
-and the two must move together.
+and the two must move together, which `tests/test_toolchain_pins.py` now enforces.
 
 ## Architecture & key files
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ offline stubs, so the two modes never collide; the offline run never collects
 Store persistence round-trip, and `haventory/areas/list` against the real area registry.
 
 > Restricted-egress environments (e.g. sandboxes that can't fetch Python 3.14 or the HA
-> core) can't run this mode — CI provisions 3.14 and runs it in its own job.
+> core) can't run this mode — CI provisions Python 3.14 and runs it in its own job.
 
 #### Online smoke tests (opt-in)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "chrreiter" }]
 # Matches the declared HA runtime (min HA 2026.6.0 => Python 3.14). uv provisions
-# 3.14 automatically (`uv sync` / `uv python install 3.14`); dev environments
-# must allow the interpreter download or preinstall 3.14.
+# the interpreter automatically (`uv sync` / `uv python install 3.14`); dev
+# environments must allow that download or preinstall Python 3.14.
 requires-python = ">=3.14"
 
 [project.urls]
@@ -85,7 +85,7 @@ quote-style = "preserve"
 "scripts/**" = ["ASYNC240", "ASYNC250"]
 
 [tool.mypy]
-# python_version matches requires-python / ruff target (HA 2026.6.0 => 3.14).
+# python_version matches requires-python / ruff target (HA 2026.6.0 => Python 3.14).
 python_version = "3.14"
 files = ["custom_components/haventory"]
 namespace_packages = true

--- a/tests/test_toolchain_pins.py
+++ b/tests/test_toolchain_pins.py
@@ -1,0 +1,368 @@
+"""The Python floor, the Node floor and the ruff pin must agree everywhere.
+
+Each of the three is declared in exactly one place — ``requires-python`` in
+``pyproject.toml``, ``engines.node`` in the card's ``package.json``, and the
+``ruff==`` entry in the ``dev`` dependency group — and each is then copied into
+files that read nothing back. A copy that goes stale stays stale: the CodeQL
+workflow analysed Python on 3.12 for as long as nothing looked at it.
+
+The Python side works in two passes. Registered files are checked by count and
+by value, so changing a copy without changing the declaration fails; the whole
+tree is then swept for the same spellings, so a copy in an unregistered file
+fails too. Adding a copy means registering it here or not writing it.
+
+Two Python copies are shaped so no interpreter-version pattern can see them, and
+neither is unguarded: ``.github/rulesets/main.json`` names the required check
+``backend (3.14)``, which ``tests/test_repo_hardening_offline.py`` ties to the
+job the ``ci.yml`` matrix actually produces, and ``hacs.json``'s Home Assistant
+floor implies the interpreter, which ``tests/test_min_ha_version.py`` holds to
+the 2026.3 split where HA itself moved to 3.14.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CARD_PACKAGE_JSON = REPO_ROOT / "cards" / "haventory-card" / "package.json"
+PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def read_toml(path: Path) -> dict[str, Any]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def collapse(text: str) -> str:
+    """Text with wrapping, comment leaders and Markdown emphasis flattened away.
+
+    ``Python **3.14**`` split across two lines of prose is the same copy as
+    ``python3.14`` in a shell script, and a version that wrapped onto the next
+    line of a ``#`` comment block is the same copy again. One pattern has to see
+    all three, so the shapes that only separate them are removed first.
+    """
+    return re.sub(r"\s+", " ", re.sub(r"(?m)^[ \t]*#+[ \t]?", "", text.replace("**", "")))
+
+
+# --------------------------------------------------------------------------
+# The Python floor
+# --------------------------------------------------------------------------
+
+_PY = r"3\.\d+"
+
+# Every spelling of an interpreter version this repository uses. Anchored on
+# "python" or on the "3.14-only" phrase so that release versions which merely
+# look alike (``aiohttp==3.14.2``) are not mistaken for the floor.
+PYTHON_VERSION_FORMS = re.compile(
+    "|".join(
+        (
+            rf"--python[ =]({_PY})",  # uv: `uv venv --python 3.14`
+            rf"python install ({_PY})",  # uv: `uv python install 3.14`
+            rf"PYTHON:-({_PY})",  # shell default: `${HA_PYTHON:-3.14}`
+            rf"python[-_]version[\"']? *[:=] *\[? *[\"']?({_PY})",  # setup-python, mypy
+            rf"requires-python *= *\">=({_PY})\"",  # the declaration
+            rf"[Cc]?[Pp]ython[ :]?({_PY})",  # prose, `python3.14`, image tags
+            rf"({_PY})-only",  # "the source is 3.14-only"
+        )
+    )
+)
+
+# ruff spells the same number without the dot.
+RUFF_TARGET_VERSION = re.compile(r"target-version *= *\"py3(\d\d)\"")
+
+# (path relative to the repository root, number of copies in it).
+PYTHON_FLOOR_SITES: tuple[tuple[str, int], ...] = (
+    ("pyproject.toml", 8),
+    (".github/workflows/ci.yml", 5),
+    (".github/workflows/codeql.yml", 1),
+    ("README.md", 10),
+    ("CONTRIBUTING.md", 1),
+    ("docs/backend_api_contract.md", 1),
+    ("requirements-integration.txt", 2),
+    ("scripts/test_integration.sh", 4),
+    (".devcontainer/Dockerfile", 1),
+    (".devcontainer/develop.sh", 2),
+    (".devcontainer/post-create.sh", 1),
+    (".claude/hooks/session-start.sh", 8),
+    (".claude/skills/run-haventory/SKILL.md", 2),
+    (".claude/skills/test-haventory/SKILL.md", 7),
+)
+
+# Directories the sweep does not enter. `dev/` holds design documents that quote
+# configuration verbatim to describe it — snapshots, not copies anyone keeps
+# true, and they are deleted with the work they plan.
+SWEPT_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        ".venv-integration",
+        "__pycache__",
+        "dev",
+        "node_modules",
+    }
+)
+
+# Generated or vendored trees that carry versions nobody here writes.
+SWEPT_SKIP_PATHS = frozenset(
+    {
+        "cards/haventory-card/coverage",
+        "cards/haventory-card/dist",
+        "custom_components/haventory/www",
+        "cards/haventory-card/package-lock.json",
+        "uv.lock",
+        # This file names the spellings it looks for; it is the register, not a copy.
+        "tests/test_toolchain_pins.py",
+    }
+)
+
+SWEPT_SUFFIXES = frozenset(
+    {
+        ".cfg",
+        ".ini",
+        ".js",
+        ".json",
+        ".md",
+        ".mjs",
+        ".py",
+        ".pyi",
+        ".sh",
+        ".toml",
+        ".ts",
+        ".txt",
+        ".yaml",
+        ".yml",
+    }
+)
+
+SWEPT_NAMES = frozenset({"Dockerfile"})
+
+
+def declared_python_floor() -> str:
+    """The interpreter version ``requires-python`` demands."""
+    return read_toml(PYPROJECT)["project"]["requires-python"].removeprefix(">=")
+
+
+def python_versions_in(text: str) -> list[str]:
+    """Every interpreter version a file states, in both spellings."""
+    collapsed = collapse(text)
+    dotted = [
+        next(group for group in match.groups() if group is not None)
+        for match in PYTHON_VERSION_FORMS.finditer(collapsed)
+    ]
+    compact = [f"3.{match.group(1)}" for match in RUFF_TARGET_VERSION.finditer(collapsed)]
+    return dotted + compact
+
+
+def swept_files() -> list[Path]:
+    """Every committed text file that could carry a copy of a version."""
+    found: list[Path] = []
+    stack = [REPO_ROOT]
+    while stack:
+        for entry in sorted(stack.pop().iterdir()):
+            relative = entry.relative_to(REPO_ROOT).as_posix()
+            if relative in SWEPT_SKIP_PATHS:
+                continue
+            if entry.is_dir():
+                if entry.name not in SWEPT_SKIP_DIRS:
+                    stack.append(entry)
+            elif entry.suffix in SWEPT_SUFFIXES or entry.name in SWEPT_NAMES:
+                found.append(entry)
+    return found
+
+
+def test_the_floor_cannot_drop_below_the_syntax_the_source_uses() -> None:
+    """3.14 is a hard bottom, not a preference.
+
+    The integration uses PEP 758 unparenthesized ``except A, B:``, which no
+    older interpreter parses — an environment below the floor cannot import the
+    package at all, so lowering the declaration would not merely widen support.
+    """
+    major, minor = (int(part) for part in declared_python_floor().split("."))
+    assert (major, minor) >= (3, 14)
+
+
+@pytest.mark.parametrize(("relative_path", "occurrences"), PYTHON_FLOOR_SITES)
+def test_python_floor_sites_match_pyproject(relative_path: str, occurrences: int) -> None:
+    """Every registered copy of the floor agrees with ``requires-python``."""
+    found = python_versions_in((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+
+    assert len(found) == occurrences, (
+        f"{relative_path}: expected {occurrences} interpreter version(s), found {len(found)} "
+        f"({found}) — register the new copy here or drop it"
+    )
+    assert set(found) == {declared_python_floor()}, (
+        f"{relative_path} states {sorted(set(found))}, "
+        f"pyproject.toml declares {declared_python_floor()!r}"
+    )
+
+
+def test_no_unregistered_file_states_an_interpreter_version() -> None:
+    """A copy in a file this test does not know about fails the same way."""
+    registered = {path for path, _ in PYTHON_FLOOR_SITES}
+    carrying = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in swept_files()
+        if python_versions_in(path.read_text(encoding="utf-8", errors="replace"))
+    }
+
+    assert carrying == registered, (
+        f"unregistered: {sorted(carrying - registered)}; "
+        f"registered but no longer carrying one: {sorted(registered - carrying)}"
+    )
+
+
+def test_version_numbers_that_are_not_the_interpreter_are_left_alone() -> None:
+    """Release pins that look like an interpreter version are not copies of it."""
+    assert python_versions_in("aiohttp==3.14.2\nhomeassistant==2026.6.0\nidna==3.18\n") == []
+    assert python_versions_in("does not parse on 3.13") == []
+
+
+def test_both_spellings_of_a_version_are_found() -> None:
+    """ruff's dotless target and a line-wrapped prose mention read the same."""
+    assert python_versions_in('target-version = "py315"') == ["3.15"]
+    assert python_versions_in("needs Python\n**3.15** to run") == ["3.15"]
+    assert python_versions_in("uv venv --python 3.15 .venv") == ["3.15"]
+
+
+# --------------------------------------------------------------------------
+# The Node floor
+# --------------------------------------------------------------------------
+
+# Prose states the floor as a major, or as the major and minor `engines` names.
+NODE_PROSE = re.compile(r"Node ?(\d+)(?:\.(\d+))?")
+
+NODE_PROSE_SITES: tuple[str, ...] = (
+    "README.md",
+    "CONTRIBUTING.md",
+    "scripts/setup.sh",
+    "scripts/test_frontend.sh",
+    ".claude/skills/run-haventory/SKILL.md",
+    ".claude/skills/test-haventory/SKILL.md",
+)
+
+
+def declared_node_range() -> str:
+    """The Node range the card's ``engines`` field demands."""
+    return json.loads(CARD_PACKAGE_JSON.read_text(encoding="utf-8"))["engines"]["node"]
+
+
+def node_majors() -> set[str]:
+    """The majors ``engines`` names — one per comparator in the range."""
+    named = re.findall(r"\d+(?:\.\d+)*", declared_node_range())
+    return {version.split(".")[0] for version in named}
+
+
+def node_floor() -> tuple[str, str]:
+    """The oldest supported major and minor, as ``engines`` states them."""
+    with_minor = re.findall(r"\d+\.\d+", declared_node_range())
+    major, minor = min(with_minor, key=lambda v: tuple(map(int, v.split(".")))).split(".")
+    return major, minor
+
+
+def workflows() -> dict[str, dict[str, Any]]:
+    return {
+        path.name: yaml.safe_load(path.read_text(encoding="utf-8"))
+        for path in sorted(WORKFLOWS_DIR.glob("*.yml"))
+    }
+
+
+def values_for_key(node: Any, key: str) -> list[Any]:
+    """Every value stored under ``key`` anywhere in a parsed workflow."""
+    if isinstance(node, dict):
+        return [
+            *(node[key] if key in node and isinstance(node[key], list) else []),
+            *([node[key]] if key in node and not isinstance(node[key], list) else []),
+            *(value for child in node.values() for value in values_for_key(child, key)),
+        ]
+    if isinstance(node, list):
+        return [value for child in node for value in values_for_key(child, key)]
+    return []
+
+
+def test_ci_frontend_matrix_is_exactly_the_majors_engines_names() -> None:
+    """The matrix tests every supported major and nothing `engines` rejects.
+
+    Dropping a major from ``engines`` while CI keeps testing it — or the
+    reverse — is the failure this catches; nothing else reads the two together.
+    """
+    matrix = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"]["frontend"]
+    tested = {str(version) for version in matrix["strategy"]["matrix"]["node-version"]}
+
+    assert tested == node_majors()
+
+
+def test_every_workflow_node_pin_is_a_supported_major() -> None:
+    """A job pinned to an unsupported major builds the card on it anyway."""
+    for name, workflow in workflows().items():
+        # A matrix reference is checked where the matrix is declared, not here.
+        pins = (str(value) for value in values_for_key(workflow, "node-version"))
+        pinned = {value for value in pins if "${{" not in value}
+        assert pinned <= node_majors(), f"{name} pins Node {sorted(pinned - node_majors())}"
+
+
+def test_prose_node_versions_agree_with_engines() -> None:
+    """Documented majors are supported, and a stated minor is the floor's."""
+    major, minor = node_floor()
+    for relative_path in NODE_PROSE_SITES:
+        text = collapse((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+        for stated_major, stated_minor in NODE_PROSE.findall(text):
+            assert stated_major in node_majors(), f"{relative_path} names Node {stated_major}"
+            if stated_minor:
+                assert (stated_major, stated_minor) == (major, minor), (
+                    f"{relative_path} states Node {stated_major}.{stated_minor}, "
+                    f"engines declares {declared_node_range()!r}"
+                )
+
+
+# --------------------------------------------------------------------------
+# Tool pins written twice
+# --------------------------------------------------------------------------
+
+
+def dev_dependency_pin(name: str) -> str:
+    """The version the ``dev`` dependency group pins a tool to."""
+    group = read_toml(PYPROJECT)["dependency-groups"]["dev"]
+    return next(entry for entry in group if entry.startswith(f"{name}==")).removeprefix(f"{name}==")
+
+
+def pre_commit_rev(repo_url: str) -> str:
+    """The revision ``.pre-commit-config.yaml`` checks a hook repository out at."""
+    config = yaml.safe_load(PRE_COMMIT_CONFIG.read_text(encoding="utf-8"))
+    rev = next(repo["rev"] for repo in config["repos"] if repo["repo"] == repo_url)
+    return str(rev).removeprefix("v")
+
+
+def test_pre_commit_runs_the_pinned_ruff() -> None:
+    """A pre-commit hook on another ruff reformats what CI then rejects."""
+    hook = pre_commit_rev("https://github.com/astral-sh/ruff-pre-commit")
+    assert hook == dev_dependency_pin("ruff")
+
+
+def test_the_documented_ruff_command_runs_the_pinned_ruff() -> None:
+    """The skill's lint command names its own ruff, so it can disagree with CI."""
+    text = (REPO_ROOT / ".claude/skills/test-haventory/SKILL.md").read_text(encoding="utf-8")
+    documented = set(re.findall(r"ruff==(\S+)", text))
+
+    assert documented == {dev_dependency_pin("ruff")}
+
+
+def test_pre_commit_runs_the_actionlint_ci_runs() -> None:
+    """Same split as ruff: the hook and the CI job are pinned independently."""
+    ci_image = re.search(
+        r"docker://rhysd/actionlint:(\S+)", CI_WORKFLOW.read_text(encoding="utf-8")
+    )
+    assert ci_image is not None
+    assert pre_commit_rev("https://github.com/rhysd/actionlint") == ci_image.group(1)


### PR DESCRIPTION
## Summary

`CLAUDE.md` describes the three platform floors symmetrically, but only the HA one was
defended. `requires-python` is declared once and copied into fourteen files that read
nothing back, so a stale copy stays stale — which is exactly what #355 is.

`tests/test_toolchain_pins.py` reads the declaration and checks the copies two ways:

- **by count and by value** for each registered file, so changing a copy without changing
  the declaration fails, and so does adding a copy to a file already listed;
- **by sweeping the tree** for the same spellings, so a copy in a file the test does not
  list fails too. That is what makes "add a new copy to this test or don't write it"
  mechanical rather than a convention.

The sweep looks for interpreter-version *spellings* (`Python 3.14`, `python3.14`,
`--python 3.14`, `python-version:`, `PYTHON:-3.14`, `requires-python`, ruff's `py314`,
and the `3.14-only` phrase this repository uses) rather than version-shaped tokens, so
`aiohttp==3.14.2` and "does not parse on ≤3.13" are not mistaken for the floor. Wrapping,
`#` comment leaders and Markdown emphasis are flattened first, because a copy that wrapped
onto the next line of a comment block is still a copy.

Two Python copies are shaped so no version pattern can see them, and neither is left
unguarded — the test's docstring says where each is checked instead:
`.github/rulesets/main.json`'s `backend (3.14)` required check is tied to the `ci.yml`
matrix by `tests/test_repo_hardening_offline.py`, and `hacs.json`'s HA floor is held to
the 2026.3 split by `tests/test_min_ha_version.py`.

### #355 — the CodeQL pin

**Raised to 3.14 rather than dropping `setup-python`.** The step is not inert: the job's
own log shows the extractor resolving the stdlib against the interpreter that step
installs —

```
[build-stdout] [INFO] [4] Skipped built-in file /opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/copy.py
```

— so with `setup-python` removed the extractor would model the source against whatever
`ubuntu-latest` happens to ship, which is the same failure with no declaration to read.
Pinning it states the intent, and the new guard keeps it from drifting again.

**Confirmed on this PR's own CodeQL run** (job 93923826916): `Successfully set up CPython
(3.14.6)`, and the only stdlib path the extractor touches is now under `lib/python3.14/`.
File coverage is unchanged at 99 of 115, as expected — the pin governs what the source is
resolved *against*, not what gets extracted.

### What the run actually reports (#355's open question)

Read off the CodeQL Python job on `5f5e926` (run 31533335992, job 93918410870) rather than
the status page, because the log carries the per-file record the status page summarises:

- **`CodeQL scanned 99 out of 115 Python files`.** The repository tracks exactly **99**
  `.py` files, and that log contains exactly **99** `Extracted file` lines. It also tracks
  exactly **16** `.pyi` files, all under `stubs/`, and the log mentions neither `.pyi` nor
  `stubs/` once. 99 + 16 = 115: **the 16 unscanned files are the local HA type stubs.**
  No shipped module under `custom_components/haventory/` is among them — so this stays a
  pin fix, and the issue does not need retitling.
- **The raw-diagnostic count is not a stable number, and I could not read the diagnostics
  themselves.** `5f5e926` reports 3; this PR's run reports 6, the same as the run #355
  quotes. The difference tracks extraction mode, not the pin — `5f5e926` extracted all 99
  files, while this run reused a cached overlay-base database and re-extracted one. Both
  runs end with `created 0 summary diagnostics for status page`, so neither raised
  anything worth surfacing as a coverage problem. The text lives only on the
  [status page](https://github.com/chrreiter/HAventory/security/code-scanning/tools/CodeQL/status/),
  which needs security-events read this session does not have — that is the one line of
  #355 I could not close from evidence. Given full extraction and zero promoted
  diagnostics they read as informational, but worth a glance next time you have the tab
  open.
- Extraction is not degraded by PEP 758: every file carrying `except A, B:` extracted
  cleanly even under the 3.12 pin. The pin's effect is the stdlib the source is resolved
  against, not whether it parses.

### The two siblings, folded in

- **Node.** `engines: "^22.13.0 || >=24"` versus the hardcoded `[ '22', '24' ]` frontend
  matrix — nothing tied them. Now: the matrix is exactly the majors `engines` names, every
  literal `node-version:` in every workflow is one of those majors (that also covers the
  integration job's `'22'`, CodeQL's `"24"` and release-please's `'22'`), and documented
  majors are checked against `engines`, including the floor's minor where prose states it.
- **ruff.** `pyproject.toml` pins it and `.pre-commit-config.yaml` repeats it; `CLAUDE.md`
  said the two must move together and nothing enforced it. #358 moves that pin next, which
  is when the gap costs something. The `.claude/skills/test-haventory/SKILL.md` lint
  command names a third copy and is checked with them.
- **actionlint, not asked for** — it is split the same way (`.pre-commit-config.yaml`'s
  `rev` versus `docker://rhysd/actionlint:` in `ci.yml`) and cost three lines next to the
  ruff check. Say the word and I'll drop it.

### Prose that no pattern could see

Eight copies of the floor were phrased so nothing could match them — "uv provisions 3.14
automatically", "CI provisions 3.14", "needs a 3.14 interpreter", "PEP 758 needs 3.14".
Each now names the version the way the rest of the repository does ("Python 3.14"), which
brings it under the guard. Deliberate mentions of *other* versions are untouched and stay
invisible to the sweep on purpose: "does not parse on ≤3.13" is a fact about the syntax,
not a copy of the floor.

`CLAUDE.md` carries the "add a new copy to that test or don't write it" rule across to the
Python and Node floors, next to the sentence that already states it for HA.

Closes #356
Closes #355

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `776 passed, 22 skipped`; `ruff check` clean; `ruff format --check` clean
      (116 files); `mypy` clean (15 source files).
- [x] Frontend (`cards/haventory-card`): `eslint` clean, `tsc --noEmit` clean,
      `vitest run` `1739 passed (62 files)`, `npm run build` OK.

Beyond the happy path, the guard was run against a hand-broken copy of each of the five
things it defends, and each failed on the intended assertion and nothing else:

| broken by hand | fails |
|---|---|
| `codeql.yml` pinned back to `"3.12"` | `test_python_floor_sites_match_pyproject[.github/workflows/codeql.yml-1]` |
| a new `# needs Python 3.14` line in an unregistered file | `test_no_unregistered_file_states_an_interpreter_version` |
| one extra mention added to `README.md` | `test_python_floor_sites_match_pyproject[README.md-10]` |
| `engines` narrowed to `">=24"` while CI still tests 22 | the three Node tests |
| `.pre-commit-config.yaml` ruff `rev` moved alone | `test_pre_commit_runs_the_pinned_ruff` |

The suite's own edge cases cover the scanner directly: release pins that look like an
interpreter version are ignored, and both spellings (`py315`, a line-wrapped
`Python **3.15**`) normalise to the same value.

**In-process HA suite**: not run against this branch — nothing here touches the
integration package or its HA-facing surface (a test, a workflow pin, and comments), and
CI's `integration` job is green on it either way.
[#410](https://github.com/chrreiter/HAventory/pull/410) records how the phacc mode
provisions in the cloud environment, per §4.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`CLAUDE.md`; `README.md` prose only).
- [x] WebSocket API unchanged.
- [x] Essential invariants preserved (no runtime code touched).

## Follow-ups

- `README.md:683` and `pyproject.toml`'s mypy-override comment still carry `WP4`/`WP5`
  work-package references, which `CLAUDE.md` rules out. Left alone here — they belong to
  the [#216](https://github.com/chrreiter/HAventory/issues/216) /
  [#231](https://github.com/chrreiter/HAventory/issues/231) sweep.
- `pyproject.toml`'s `requires-python` and `hacs.json`'s HA floor are related but checked
  by two tests that do not know about each other. Nothing enforces "the Python floor is
  the one that HA release actually carries" — it is asserted in prose in `CLAUDE.md`. Not
  worth a check today: both move together in one deliberate PR.