### PR TITLE
build(deps): stop Dependabot bumping the pins that hold the HA floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,17 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
+    ignore:
+      # Not dependencies to keep current. `requirements-integration.txt` pins the
+      # Home Assistant core to the floor `hacs.json` declares, so the in-process
+      # suite runs the integration *at* the minimum it claims to support rather
+      # than at whatever is newest, and the frontend wheel is whatever that
+      # release's own `frontend` manifest asks for. Two tests hold them there —
+      # tests/test_min_ha_version.py and tests/integration/test_frontend.py — so
+      # a bump arrives as a red pull request that reopens every week. Both move
+      # together, by hand, when the declared floor moves.
+      - dependency-name: "homeassistant"
+      - dependency-name: "home-assistant-frontend"
     groups:
       python-dev:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

The `uv` entry in `.github/dependabot.yml` had no `ignore` list, so Dependabot keeps
proposing the two pins in `requirements-integration.txt` that exist precisely *not* to be
current:

- **`homeassistant`** is the floor `hacs.json` declares. The in-process suite runs the
  integration **at** the minimum it claims to support, which is the whole reason that pin
  is hand-maintained — the file's own header says so. `tests/test_min_ha_version.py` holds
  it to `hacs.json`.
- **`home-assistant-frontend`** is whatever that HA release's own `frontend` manifest asks
  for. A real Home Assistant installs component requirements at startup; this harness does
  not, so the wheel is hand-carried.
  `tests/integration/test_frontend.py::test_the_frontend_wheel_matches_what_this_ha_release_asks_for`
  compares the two.

The two move **together, by hand**, when the declared floor moves. Until then every
proposal is a red pull request, and closing one only buys a week.

This closes out #358's four dispositions; the rest of the sweep is below.

Closes #358

## The sweep

| PR | State | Disposition |
|---|---|---|
| [#321](https://github.com/chrreiter/HAventory/pull/321) actions group ×8 | all green | **ready — yours to merge** |
| [#259](https://github.com/chrreiter/HAventory/pull/259) aiohttp 3.14.3 | all green | **ready — yours to merge**, but see the note below |
| [#320](https://github.com/chrreiter/HAventory/pull/320) python-dev ×8 | was red on `backend (3.14)` + `integration` | **fixed on Dependabot's branch**, awaiting its CI |
| [#155](https://github.com/chrreiter/HAventory/pull/155) home-assistant-frontend | red on `integration` | **closed as not-planned**, with this rule as the reason |

**#259 is superseded by #320.** #320 raises the `aiohttp` constraint to `>=3.14.3` and
carries the same lockfile move, so merging #320 first leaves #259 with an empty diff.
Either order works — this is a note, not a blocker.

### What #320 needed

Pushed to `dependabot/uv/python-dev-a326c1644b` (main merged in first, so it is no longer
20 commits behind):

- **`RUF036` ×4** in `repository.py` — `None` ahead of the `UNSET` sentinel's `object` in
  a union. `ruff check --fix` handled all four; union order carries no meaning.
- **`PLR0917`** on `tests/conftest.py`'s `panel_custom` stub. The existing `# noqa`
  covered `PLR0913` only, and the two are separate rules. Extended rather than reshaped:
  the stub mirrors what HA takes positionally, so the argument count *is* the point.
- **`.pre-commit-config.yaml`'s ruff `rev`** → `v0.16.1`. Dependabot's `uv` ecosystem
  cannot see it, so the hook would have gone on formatting with 0.15.22 against a CI
  checking with 0.16.1. The lint command in `.claude/skills/test-haventory/SKILL.md` names
  a third copy and moved with it. ([#409](https://github.com/chrreiter/HAventory/pull/409)
  adds the test that would have caught this.)
- **`requirements-integration.txt` back to `homeassistant==2026.6.0`.**

### The `integration` failure on #320, confirmed

§6.1 asked which assertion fails there before calling it mergeable. It is the one the plan
suspected — read off the job log for run 31421924079:

```
FAILED tests/integration/test_frontend.py::test_the_frontend_wheel_matches_what_this_ha_release_asks_for
  At index 0 diff: 'home-assistant-frontend==20260527.4' != 'home-assistant-frontend==20260624.6'
1 failed, 43 passed in 3.66s
```

So **yes — #320 carried part of #155's problem, arriving from the other side.** #320 left
the frontend wheel alone and bumped `homeassistant` to 2026.7.4 instead; HA 2026.7.4's
`frontend` manifest asks for `20260624.6`, which is the very wheel #155 wanted. The test
is doing its job in both directions. Rather than taking the frontend pin out of the group,
the fix is the one this PR lands: both names ignored, so neither half of the pair can move
without the other.

A second, quieter consequence: the bump also put `requirements-integration.txt` out of
step with `hacs.json`, which `tests/test_min_ha_version.py` fails on. `backend (3.14)`
never got that far — ruff fails the job first — so it was latent behind the lint errors.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

This PR itself changes one config file; both gates were run on it regardless:

- [x] Backend: `752 passed, 22 skipped`; ruff check/format clean; mypy clean.
- [x] Frontend: eslint clean, tsc clean, `1739 passed (62 files)`, build OK.
- [x] `.github/dependabot.yml` parses and the `uv` entry carries both names.

On **#320's branch**, under ruff 0.16.1:

- [x] Backend: `752 passed, 22 skipped`; `ruff check` **All checks passed!**;
      `ruff format --check` clean (135 files); mypy clean.
- [x] Frontend: eslint clean, tsc clean, `1739 passed (62 files)`, build OK.
- [x] **In-process HA suite: `44 passed`** on `72f12f7` — the previously failing assertion
      included. That was 43 passed / 1 failed before.

### The phacc mode in the cloud environment (§4)

This was the first session to need it, so — recording the result as §4 asks: **it works,
with one snag worth knowing.**

`scripts/test_integration.sh` fails out of the box here:

```
Because the current Python version (3.14rc2) does not satisfy Python>=3.14.2
and homeassistant==2026.6.0 depends on Python>=3.14.2, we can conclude that
homeassistant==2026.6.0 cannot be used.
```

The image ships **uv 0.8.17**, whose python-build-standalone manifest knows no 3.14 build
newer than `3.14.0rc2` — `uv python list --all-versions` offers nothing else, so
`uv python install 3.14` resolves to the release candidate, and HA 2026.6.0 requires
≥3.14.2. Not a network limit and nothing in the repository: PyPI and the interpreter
downloads are both reachable. Dropping a current uv on PATH fixes it outright:

```bash
curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.3/uv-x86_64-unknown-linux-gnu.tar.gz \
  | tar xz && export PATH="$PWD/uv-x86_64-unknown-linux-gnu:$PATH"
bash scripts/test_integration.sh    # provisions 3.14.7, then: 44 passed
```

CI is unaffected — `astral-sh/setup-uv` installs the latest (0.12.3 on the run I read) and
provisions 3.14.7. No change is proposed here; it is a note for the sessions behind this
one, which will hit the same wall.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — none needed here; the two tests this rule protects
      (`test_min_ha_version.py`, `test_frontend.py`) already exist and are what made the
      Dependabot PRs red in the first place.
- [x] Docs updated where behavior changed (the rule is commented in place).
- [x] WebSocket API unchanged.
- [x] Essential invariants preserved (no runtime code touched).

## Follow-ups

- #210's Dependabot item is related and stays open — noted there rather than fixed here,
  per §6.1.
- Nothing stops a future `requirements-integration.txt` edit from raising the HA pin by
  hand without touching `hacs.json`; `tests/test_min_ha_version.py` catches exactly that,
  which is why no new check is proposed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UePS1PzUED69hxvsFhSMjw)_