### PR TITLE
fix(card): the area mark and the check-out popover's thumb sizes

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -1132,10 +1132,14 @@ export class HVCardShell extends LitElement {
           ></hv-detail-sheet>`
         : null}
 
+      <!-- Never inline: that presentation is a step drawn inside the body of the
+           surface that opened it, and this is a sibling at the end of the shell
+           with no body around it. The narrow branch reaches its check-out
+           through the detail sheet, which mounts its own. -->
       <hv-checkout-popover
         data-testid="card-checkout"
         ?open=${this._checkout !== null}
-        ?mobile=${mobile}
+        ?touch=${mobile}
         .mode=${this._checkout?.mode ?? 'check-out'}
         .anchor=${this._checkout?.anchor ?? null}
         .item=${this._checkout ? (this._itemById(this._checkout.itemId) ?? null) : null}

--- a/cards/haventory-card/src/components/hv-checkout-popover.test.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.test.ts
@@ -200,8 +200,8 @@ describe('hv-checkout-popover: placement', () => {
     expect(left).toBeGreaterThanOrEqual(8);
   });
 
-  it('drops the scrim and fills the width on mobile, where it is an inline step', async () => {
-    const el = await mount({}, { mobile: true });
+  it('drops the scrim and fills the width when it is an inline step', async () => {
+    const el = await mount({}, { inline: true });
     expect(q(el, '.scrim')).toBe(null);
     expect(q(el, '[data-testid="checkout-popover"]')?.getAttribute('style')).toBe('');
   });
@@ -218,5 +218,43 @@ describe('hv-checkout-popover: placement', () => {
     expect(
       (q(centred, '[data-testid="checkout-popover"]') as HTMLElement).getAttribute('style'),
     ).toContain('left: 50%');
+  });
+});
+
+describe('hv-checkout-popover: where it draws and how big it is are separate asks', () => {
+  /** jsdom lays out no shadow DOM, so the sizes are asserted on the stylesheet. */
+  const popoverCss = () => {
+    const styles = (customElements.get('hv-checkout-popover') as typeof HVCheckoutPopover).styles;
+    return (Array.isArray(styles) ? styles : [styles])
+      .map((s) => String(s.cssText))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+  };
+
+  // As one flag, a caller that could not draw the inline step could not ask for
+  // finger-sized controls either — and the surfaces that open this as a centred
+  // dialog on a phone are exactly that caller.
+  it('hangs every thumb size on touch, and only the step itself on inline', () => {
+    const css = popoverCss();
+    for (const sel of ['.offset', '.custom input', '.date', '.actions', '.confirm', '.none-button']) {
+      expect(css, sel).toContain(`:host([touch]) ${sel} {`);
+    }
+    expect(css).toMatch(/:host\(\[inline\]\) \.card \{[^}]*position: static/);
+    expect(css.match(/:host\(\[inline\]\)/g)?.length).toBe(1);
+  });
+
+  it('keeps the scrim and its own placement when only the sizes grow', async () => {
+    const el = await mount({}, { touch: true });
+    expect(q(el, '.scrim')?.classList.contains('dim')).toBe(true);
+    expect(q(el, '[data-testid="checkout-popover"]')?.getAttribute('style')).toContain('left: 50%');
+  });
+
+  // The row of actions becomes a stack of full-width buttons, so the spacer that
+  // pushes the pair right in the flex row has to go with it — left in, it is an
+  // empty grid row with a gap on both sides of it.
+  it('stacks the actions and drops the spacer with the sizes, not with the step', async () => {
+    const el = await mount({}, { touch: true });
+    expect(q(el, '.actions .spacer')).toBe(null);
+    expect(q(await mount({}, { inline: true }), '.actions .spacer')).not.toBe(null);
   });
 });

--- a/cards/haventory-card/src/components/hv-checkout-popover.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.ts
@@ -24,8 +24,16 @@ const DEFAULT_OFFSET = 7;
  * instead of demanding it, and keeps "No due date" as a first-class path rather
  * than a cancel.
  *
- * Desktop anchors to the control that opened it; mobile fills the width as an
- * inline step.
+ * Where it draws and how big its controls are are two separate questions, and a
+ * caller answers them independently. `inline` makes it a step inside the body of
+ * the surface that opened it — no scrim, no placement of its own — which only a
+ * surface that has a body to hold it can ask for. `touch` grows the controls to
+ * thumb size, which any caller on a narrow surface needs, including the ones
+ * that draw it as a centred dialog. Left as one flag, the second was only
+ * available to callers that could take the first.
+ *
+ * With neither, it anchors to the control that opened it; with `touch` alone it
+ * is a centred dialog with finger-sized controls.
  */
 @customElement('hv-checkout-popover')
 export class HVCheckoutPopover extends LitElement {
@@ -59,7 +67,7 @@ export class HVCheckoutPopover extends LitElement {
         box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24);
         overflow: hidden;
       }
-      :host([mobile]) .card {
+      :host([inline]) .card {
         position: static;
         width: auto;
         border: 1px solid var(--hv-primary);
@@ -97,7 +105,7 @@ export class HVCheckoutPopover extends LitElement {
         padding: 6px 13px;
         font: 400 12.5px var(--hv-font);
       }
-      :host([mobile]) .offset {
+      :host([touch]) .offset {
         min-height: 40px;
         padding: 0 15px;
         font-size: 13.5px;
@@ -128,7 +136,7 @@ export class HVCheckoutPopover extends LitElement {
         padding: 5px 8px;
         font: 400 13.5px var(--hv-font);
       }
-      :host([mobile]) .custom input {
+      :host([touch]) .custom input {
         min-height: 44px;
         width: 88px;
         font-size: var(--hv-input-font, 14.5px);
@@ -142,7 +150,7 @@ export class HVCheckoutPopover extends LitElement {
         border-radius: var(--hv-radius-input);
         font-size: 13.5px;
       }
-      :host([mobile]) .date {
+      :host([touch]) .date {
         min-height: 48px;
         font-size: var(--hv-input-font, 13.5px);
       }
@@ -173,10 +181,10 @@ export class HVCheckoutPopover extends LitElement {
       .actions .none-button {
         flex-basis: 100%;
       }
-      :host(:not([mobile])) .actions .none-button {
+      :host(:not([touch])) .actions .none-button {
         text-align: left;
       }
-      :host([mobile]) .actions {
+      :host([touch]) .actions {
         display: grid;
         gap: 9px;
         padding: 0 12px 14px;
@@ -192,11 +200,11 @@ export class HVCheckoutPopover extends LitElement {
         padding: 8px 16px;
         font: 500 13px var(--hv-font);
       }
-      :host([mobile]) .confirm {
+      :host([touch]) .confirm {
         min-height: 50px;
         font-size: 15px;
       }
-      :host([mobile]) .none-button {
+      :host([touch]) .none-button {
         min-height: 48px;
         border: 1px solid var(--hv-input-border);
         background: none;
@@ -209,8 +217,11 @@ export class HVCheckoutPopover extends LitElement {
 
   @property({ attribute: false }) item: Item | null = null;
   @property({ type: Boolean, reflect: true }) open = false;
-  @property({ type: Boolean, reflect: true }) mobile = false;
-  /** Rectangle of the control that opened it; desktop anchors to this. */
+  /** Draw as a step inside the caller's body instead of placing itself. */
+  @property({ type: Boolean, reflect: true }) inline = false;
+  /** Size the controls for a finger. */
+  @property({ type: Boolean, reflect: true }) touch = false;
+  /** Rectangle of the control that opened it; anchors to this when given one. */
   @property({ attribute: false }) anchor: DOMRect | null = null;
   /**
    * `check-out` starts a new check-out; `set-due-date` only changes the date on
@@ -266,7 +277,7 @@ export class HVCheckoutPopover extends LitElement {
   };
 
   private get _position(): string {
-    if (this.mobile || !this.anchor) return 'top: 20dvh; left: 50%; transform: translateX(-50%);';
+    if (!this.anchor) return 'top: 20dvh; left: 50%; transform: translateX(-50%);';
     const width = 300;
     const gap = 6;
     const viewportWidth = typeof window === 'undefined' ? width : window.innerWidth;
@@ -299,7 +310,7 @@ export class HVCheckoutPopover extends LitElement {
         aria-modal="true"
         aria-label=${settingOnly ? 'Set due date' : `Check out ${subject}`}
         data-testid="checkout-popover"
-        style=${this.mobile ? '' : `z-index:${z + 1}; ${this._position}`}
+        style=${this.inline ? '' : `z-index:${z + 1}; ${this._position}`}
         @keydown=${onEscape(() => this._cancel())}
       >
         <div class="head">
@@ -376,7 +387,7 @@ export class HVCheckoutPopover extends LitElement {
           >
             ${settingOnly ? 'Clear due date' : 'Check out with no due date'}
           </button>
-          ${this.mobile ? null : html`<span class="spacer"></span>`}
+          ${this.touch ? null : html`<span class="spacer"></span>`}
           <button class="hv-text-button" data-testid="checkout-cancel" @click=${this._cancel}>Cancel</button>
           <button
             class="confirm"
@@ -390,7 +401,7 @@ export class HVCheckoutPopover extends LitElement {
       </div>
     `;
 
-    if (this.mobile) return card;
+    if (this.inline) return card;
     return html`
       <div
         class="scrim ${this.anchor ? '' : 'dim'}"

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -733,7 +733,8 @@ export class HVDetailSheet extends LitElement {
       ${this._checkoutOpen
         ? html`<div style="padding: 0 14px 14px">
             <hv-checkout-popover
-              mobile
+              inline
+              touch
               open
               data-testid="sheet-checkout"
               .item=${item}

--- a/cards/haventory-card/src/components/hv-filter-chips.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.test.ts
@@ -94,6 +94,20 @@ describe('chipsFor', () => {
     expect(chipsFor(filters, { locations: nested(null), areas: [] })[0].label).toBe('Garage › Shelf A');
   });
 
+  // Browsing a root named after its own room wrote the room twice on one chip:
+  // "Area: Garage · Garage › Shelf A + sub". The area drops out when the path
+  // has already said it, the way the chip beside a path does.
+  it('drops the area from the chip when the path opens with that name', () => {
+    for (const [subtree, label] of [
+      [false, 'Garage › Shelf A'],
+      [true, 'Garage › Shelf A + sub'],
+    ] as const) {
+      const filters = { ...defaultFilters(), locationId: 'shelf', includeSubtree: subtree };
+      const [chip] = chipsFor(filters, { locations: nested('a1'), areas: [{ id: 'a1', name: 'Garage' }] });
+      expect(chip.label, `subtree=${subtree}`).toBe(label);
+    }
+  });
+
   it('names an area the registry has dropped by its id, so the chip never reads as arealess', () => {
     const filters = { ...defaultFilters(), locationId: 'shelf', includeSubtree: false };
     expect(chipsFor(filters, { locations: nested('a-gone'), areas: [] })[0].label).toBe(

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { TAG_MARK, chip } from '../ui/chip';
-import { locationPathParts, pathTitle } from '../ui/location-path';
+import { locationPathParts, pathLabel } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { formatDate } from '../ui/relative-time';
 import { statusLabel, statusToneClass } from '../ui/status';
@@ -60,8 +60,9 @@ export function chipsFor(
     const loc = locations.find((l) => l.id === filters.locationId);
     // A chip is already the smallest thing on this row, so the area is named in
     // words rather than nested in a chip of its own — the same "Area: X" the
-    // area filter's own chip prints two lines down.
-    const path = pathTitle(locationPathParts(loc, locations, ctx.areas ?? [], 'Location'));
+    // area filter's own chip prints two lines down. It drops out when the path
+    // opens with it, as the chip beside a path does.
+    const path = pathLabel(locationPathParts(loc, locations, ctx.areas ?? [], 'Location'));
     chips.push({
       key: 'locationId',
       label: filters.includeSubtree ? `${path} + sub` : path,

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -505,8 +505,19 @@ describe('hv-filter-panel: dates and location', () => {
   });
 
   it('names the area the picked location inherits, matching the chip row wording', async () => {
+    const el = await mount(
+      { locationId: 'shelf-a' },
+      { locations: nestedLocations('area-kitchen'), areas: [{ id: 'area-kitchen', name: 'Kitchen' }] },
+    );
+    expect(label(el, 'filter-location')).toContain('Area: Kitchen · Garage › Shelf A');
+  });
+
+  // A root named after its own room made the field read "Area: Garage · Garage
+  // › Shelf A". The same elision the chip beside a path takes.
+  it('drops the area when the picked path opens with that name', async () => {
     const el = await mount({ locationId: 'shelf-a' }, { locations: nestedLocations('area-garage') });
-    expect(label(el, 'filter-location')).toContain('Area: Garage · Garage › Shelf A');
+    expect(label(el, 'filter-location')).toContain('Garage › Shelf A');
+    expect(label(el, 'filter-location')).not.toContain('Area:');
   });
 
   it('leaves a location in no area labelled exactly as before', async () => {

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip, tagLabel } from '../ui/chip';
-import { locationPathParts, pathTitle } from '../ui/location-path';
+import { locationPathParts, pathLabel } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
 import { activeFilterCount, defaultFilters } from '../store/store';
@@ -462,7 +462,7 @@ export class HVFilterPanel extends LitElement {
     const loc = locations.find((l) => l.id === f.locationId);
     // Named in words, not in a nested chip: this label lives inside a chip, and
     // it has to read the same as the chip row the applied filter turns into.
-    const label = pathTitle(locationPathParts(loc, locations, this.areas, 'Any location'));
+    const label = pathLabel(locationPathParts(loc, locations, this.areas, 'Any location'));
     return html`
       <div class="group">
         <span class="hv-label">Where</span>

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1972,9 +1972,36 @@ describe('hv-full-view: selection and bulk actions', () => {
       (bulkBar(sr).shadowRoot?.querySelector('[data-action="check-out"]') as HTMLButtonElement).click();
       await settle(el);
 
-      const popover = q(sr, '[data-testid="full-bulk-checkout"]') as HTMLElement & { open: boolean };
+      const popover = q(sr, '[data-testid="full-bulk-checkout"]') as HTMLElement & {
+        open: boolean;
+        inline: boolean;
+        touch: boolean;
+      };
       return { ...mounted, popover };
     }
+
+    // Opened by a bar at the foot of the table, so it has no body to be a step
+    // inside of and stays a centred dialog. That says nothing about how big its
+    // controls should be: on the narrow branch a finger has to hit them.
+    it('takes finger-sized controls on the narrow branch and stays a centred dialog', async () => {
+      for (const narrow of [false, true]) {
+        const restore = stubViewport(narrow);
+        try {
+          const { el, popover } = await selectTwoAndCheckOut();
+          const where = `narrow=${narrow}`;
+          expect(popover.open, where).toBe(true);
+          expect(popover.inline, where).toBe(false);
+          expect(popover.touch, where).toBe(narrow);
+          expect(
+            popover.shadowRoot?.querySelector('.scrim')?.classList.contains('dim'),
+            where,
+          ).toBe(true);
+          el.remove();
+        } finally {
+          restore();
+        }
+      }
+    });
 
     it('opens one popover for the whole selection and applies the date to every row', async () => {
       const { el, store, popover } = await selectTwoAndCheckOut();
@@ -2252,12 +2279,13 @@ describe('hv-full-view: table row actions', () => {
     expect(store.state.value.items.find((i) => i.id === '1')?.checked_out).toBe(true);
   });
 
-  // The popover's phone presentation is an inline step, a static card meant to
-  // sit inside the body of the surface that opened it — and this call site is a
-  // sibling at the end of the shell with no body around it, so the step landed
-  // stranded and unscrimmed at the foot of the page. The anchored presentation
-  // is no better here: the ⋮ it would hang from sits in a column the table
-  // scrolls sideways out of view. It presents the way the bulk popover does.
+  // The popover's inline step is a static card meant to sit inside the body of
+  // the surface that opened it — and this call site is a sibling at the end of
+  // the shell with no body around it, so the step landed stranded and unscrimmed
+  // at the foot of the page. Anchoring is no better here: the ⋮ it would hang
+  // from sits in a column the table scrolls sideways out of view. It presents
+  // the way the bulk popover does. How big its controls are is a separate ask,
+  // which is why `touch` follows the narrow branch while the placement does not.
   it('presents the single-row check-out centred and scrimmed at every width', async () => {
     for (const narrow of [false, true]) {
       const restore = stubViewport(narrow);
@@ -2268,12 +2296,14 @@ describe('hv-full-view: table row actions', () => {
 
         const popover = q(sr, '[data-testid="full-checkout"]') as HTMLElement & {
           open: boolean;
-          mobile: boolean;
+          inline: boolean;
+          touch: boolean;
           anchor: DOMRect | null;
         };
         const where = `narrow=${narrow}`;
         expect(popover.open, where).toBe(true);
-        expect(popover.mobile, where).toBe(false);
+        expect(popover.inline, where).toBe(false);
+        expect(popover.touch, where).toBe(narrow);
         expect(popover.anchor, where).toBe(null);
 
         const scrim = popover.shadowRoot?.querySelector('.scrim');

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -960,6 +960,40 @@ describe('hv-full-view: context bar and table', () => {
     expect(crumb?.textContent?.replace(/\s+/g, ' ')).toContain('garage › Shelf A');
   });
 
+  // Browsing into a root named after its own room used to write the room twice:
+  // "Kitchen  Kitchen › Pantry". The crumb elides like every other surface that
+  // marks an area, and the pairing stays in the title.
+  it('drops the area mark when the crumb already opens with the area name', async () => {
+    const kitchen = { ...loc('kitchen', 'Kitchen'), area_id: 'area-kitchen' };
+    const pantry: Location = {
+      ...loc('pantry', 'Pantry', 'kitchen'),
+      path: {
+        id_path: ['kitchen', 'pantry'],
+        name_path: ['Kitchen', 'Pantry'],
+        display_path: 'Kitchen / Pantry',
+        sort_key: '',
+      },
+    };
+    for (const [id, path] of [
+      ['kitchen', 'Kitchen'],
+      ['pantry', 'Kitchen › Pantry'],
+    ]) {
+      const { el, store, sr } = await mount({
+        items: [makeItem({ id: '1', location_id: id })],
+        locations: [kitchen, pantry],
+        areas: [{ id: 'area-kitchen', name: 'Kitchen' }],
+      });
+      store.setFilters({ locationId: id });
+      await settle(el);
+
+      const crumb = q(sr, '[data-testid="full-breadcrumb"]');
+      expect(crumb?.querySelector('.hv-area-chip'), path).toBe(null);
+      expect(crumb?.textContent?.replace(/\s+/g, ' ').trim(), path).toContain(path);
+      expect(crumb?.getAttribute('title'), path).toBe(`Area: Kitchen · ${path}`);
+      el.remove();
+    }
+  });
+
   it('leaves the crumb of an arealess tree exactly as it was', async () => {
     const locations = [loc('garage', 'Garage'), loc('shelf-a', 'Shelf A', 'garage')];
     const { el, store, sr } = await mount({

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -2173,14 +2173,16 @@ export class HVFullView extends LitElement {
           : null}
 
         <!-- Centred and scrimmed at every width, like the bulk popover below.
-             Neither of the other two presentations fits this call site: the
-             mobile one draws an inline step that has to sit inside the body of
-             the surface that opened it, and this is a sibling at the end of the
-             shell with no body around it; the anchored one hangs off the row ⋮,
-             which sits in a column the table scrolls sideways out of view. -->
+             Neither of the other two placements fits this call site: an inline
+             step has to sit inside the body of the surface that opened it, and
+             this is a sibling at the end of the shell with no body around it;
+             an anchored one hangs off the row ⋮, which sits in a column the
+             table scrolls sideways out of view. Finger-sized controls are a
+             separate question and follow the narrow branch on their own. -->
         <hv-checkout-popover
           data-testid="full-checkout"
           ?open=${this._checkout !== null}
+          ?touch=${this._narrow}
           .mode=${this._checkout?.mode ?? 'check-out'}
           .item=${this._checkout ? (st?.items.find((i) => i.id === this._checkout!.itemId) ?? null) : null}
           @check-out=${(e: CustomEvent) => {
@@ -2201,14 +2203,14 @@ export class HVFullView extends LitElement {
           }}
         ></hv-checkout-popover>
 
-        <!-- Centred at every width rather than following _narrow: the mobile
-             presentation is an inline step drawn inside the surface that opened
-             it, and this one is opened by a bar at the foot of the table with no
-             body of its own to sit in. It anchors to nothing, so it takes the
-             same scrimmed middle-of-the-screen position the bulk confirm does. -->
+        <!-- Centred at every width for the same reason as the one above: it is
+             opened by a bar at the foot of the table with no body of its own to
+             sit in. It anchors to nothing, so it takes the same scrimmed
+             middle-of-the-screen position the bulk confirm does. -->
         <hv-checkout-popover
           data-testid="full-bulk-checkout"
           ?open=${this._pendingBulkCheckout}
+          ?touch=${this._narrow}
           .itemName=${counted(selection.size, 'item')}
           @check-out=${(e: CustomEvent) => {
             const { dueDate } = e.detail as { dueDate: string | null };

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -13,8 +13,13 @@ import { activeFilterCount, defaultFilters } from '../store/store';
 import { countLocations } from '../store/location-tree';
 import { emptyKindFor, renderEmptyState } from '../ui/empty-state';
 import { deepFocusables } from '../ui/dialog-focus';
-import { areaNameById, effectiveAreaIdForLocation } from '../ui/area';
-import { renderAreaChip } from '../ui/location-path';
+import {
+  PATH_SEPARATOR,
+  areaMarkName,
+  locationPathParts,
+  pathTitle,
+  renderAreaChip,
+} from '../ui/location-path';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
@@ -1651,19 +1656,20 @@ export class HVFullView extends LitElement {
     const st = this.st;
     const filters = st?.filters ?? defaultFilters();
     const locations = st?.locationsFlatCache ?? [];
-    const loc = locations.find((l) => l.id === filters.locationId);
-    const segments = loc ? (loc.path?.display_path ?? loc.name).split('/').map((s) => s.trim()) : [];
-    // The crumb prints each path segment as its own span, so the area needs the
-    // chip to stay out of that sequence rather than reading as a first segment.
-    const areaName = loc
-      ? areaNameById(st?.areasCache?.areas ?? [], effectiveAreaIdForLocation(locations, loc.id))
-      : null;
+    // "Items with no location" is its own answer to where the table is pointed,
+    // so the crumb says that instead of a path and there is none to mark.
+    const loc = filters.orphansOnly ? undefined : locations.find((l) => l.id === filters.locationId);
+    const parts = locationPathParts(loc, locations, st?.areasCache?.areas ?? [], '');
+    const segments = parts.path ? parts.path.split(PATH_SEPARATOR) : [];
     const filterCount = activeFilterCount(filters);
 
     return html`
       <div class="context">
-        <span class="crumb hv-chip-line" data-testid="full-breadcrumb">
-          ${filters.orphansOnly || !segments.length ? null : renderAreaChip(areaName)}
+        <!-- The chip sits on the row rather than inside the text, because the
+             text below prints one span per path segment and an area folded into
+             that sequence would read as the path's first segment. -->
+        <span class="crumb hv-chip-line" data-testid="full-breadcrumb" title=${pathTitle(parts)}>
+          ${renderAreaChip(areaMarkName(parts.areaName, parts.path))}
           <span class="hv-chip-line-text">
             ${filters.orphansOnly
               ? html`<span class="current">No location</span>`

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -677,6 +677,54 @@ describe('hv-item-editor: location and tags', () => {
     expect(field?.querySelector('.value')?.textContent).toBe('Garage');
   });
 
+  // Naming a root after the room it stands in is the ordinary thing a household
+  // does, and the field then printed the same word twice with a chip's edge
+  // between them. Same rule as the rows, the table cell and the sheet's crumb —
+  // the picker elides too, and the pairing survives in the button's title.
+  it('drops the area mark when the chosen path already opens with that name', async () => {
+    const kitchen = { id: 'kitchen', name: 'Kitchen', parent_id: null, area_id: 'area-kitchen' };
+    for (const path of ['Kitchen', 'Kitchen / Pantry']) {
+      const el = await mount(makeItem({ id: '1', name: 'A', location_id: 'kitchen' }), {
+        locations: [
+          {
+            ...kitchen,
+            path: { id_path: ['kitchen'], name_path: [], display_path: path, sort_key: '' },
+          },
+        ],
+        areas: [{ id: 'area-kitchen', name: 'Kitchen' }],
+      });
+      const field = q(el, '[data-testid="editor-location"]');
+      const pretty = path.replace(' / ', ' › ');
+      expect(field?.querySelector('.hv-area-chip'), path).toBe(null);
+      expect(field?.querySelector('.value')?.textContent, path).toBe(pretty);
+      expect(field?.getAttribute('title'), path).toBe(`Area: Kitchen · ${pretty}`);
+      el.remove();
+    }
+  });
+
+  it('keeps the mark when the area only reappears further down the path', async () => {
+    const el = await mount(makeItem({ id: '1', name: 'A', location_id: 'kitchen' }), {
+      locations: [
+        {
+          id: 'kitchen',
+          name: 'Kitchen',
+          parent_id: null,
+          area_id: 'area-kitchen',
+          path: {
+            id_path: ['kitchen'],
+            name_path: [],
+            display_path: 'Cellar / Kitchen',
+            sort_key: '',
+          },
+        },
+      ],
+      areas: [{ id: 'area-kitchen', name: 'Kitchen' }],
+    });
+    const field = q(el, '[data-testid="editor-location"]');
+    expect(field?.querySelector('.hv-area-chip')?.textContent).toContain('Kitchen');
+    expect(field?.querySelector('.value')?.textContent).toBe('Cellar › Kitchen');
+  });
+
   it('shows no area chip for a location in no area', async () => {
     const el = await mount(makeItem({ id: '1', name: 'A', location_id: 'garage' }), {
       areas: [{ id: 'area-kitchen', name: 'Kitchen' }],

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
-import { locationPathParts, renderAreaChip } from '../ui/location-path';
+import { areaMarkName, locationPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import { icon } from '../ui/icons';
 import {
   DEFAULT_CUSTOM_DAYS,
@@ -1404,13 +1404,16 @@ export class HVItemEditor extends LitElement {
       <button
         class="field-button ${this._model.locationId ? '' : 'empty'}"
         data-testid="editor-location"
+        title=${pathTitle(parts)}
         aria-expanded=${String(this._locationOpen)}
         aria-controls=${LOCATION_TREE_ID}
         @click=${() => {
           this._locationOpen = !this._locationOpen;
         }}
       >
-        ${icon('mapMarker', 15)}${renderAreaChip(parts.areaName)}<span class="value">${parts.path}</span
+        ${icon('mapMarker', 15)}${renderAreaChip(areaMarkName(parts.areaName, parts.path))}<span
+          class="value"
+          >${parts.path}</span
         >${icon('chevronDown', 15)}
       </button>
       <div class="tree-holder" id=${LOCATION_TREE_ID} ?hidden=${!this._locationOpen}>

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -1751,7 +1751,8 @@ export class HVItemEditor extends LitElement {
             .item=${this.item}
             .itemName=${model.name.trim() || 'this item'}
             .anchor=${this._checkoutAnchor}
-            ?mobile=${this.mobile}
+            ?inline=${this.mobile}
+            ?touch=${this.mobile}
             ?open=${this._checkoutOpen}
             @check-out=${(e: CustomEvent) => {
               // Purely a form event: nothing outside this editor should act on

--- a/cards/haventory-card/src/ui/location-path.test.ts
+++ b/cards/haventory-card/src/ui/location-path.test.ts
@@ -4,6 +4,7 @@ import {
   itemPathParts,
   locationLabel,
   locationPathParts,
+  pathLabel,
   pathTitle,
   prettyPath,
   renderAreaChip,
@@ -112,6 +113,26 @@ describe('pathTitle', () => {
 
   it('is empty when there is neither', () => {
     expect(pathTitle({ areaName: null, path: '' })).toBe('');
+  });
+});
+
+// The pair a surface picks between: the title keeps the pairing whole because
+// it is the fallback for everything the label elides, and the label drops the
+// area once the path has opened with it.
+describe('pathLabel', () => {
+  it('drops an area the path opens with, where the title keeps it', () => {
+    const parts = { areaName: 'Kitchen', path: 'Kitchen › Pantry' };
+    expect(pathLabel(parts)).toBe('Kitchen › Pantry');
+    expect(pathTitle(parts)).toBe('Area: Kitchen · Kitchen › Pantry');
+  });
+
+  it('reads exactly as the title when the two names differ', () => {
+    const parts = { areaName: 'Kitchen', path: 'Fridge › Top Shelf' };
+    expect(pathLabel(parts)).toBe(pathTitle(parts));
+  });
+
+  it('is just the path when there is no area', () => {
+    expect(pathLabel({ areaName: null, path: 'Fridge' })).toBe('Fridge');
   });
 });
 

--- a/cards/haventory-card/src/ui/location-path.ts
+++ b/cards/haventory-card/src/ui/location-path.ts
@@ -79,6 +79,18 @@ export function pathTitle(parts: PathParts): string {
 }
 
 /**
+ * The same two parts for a label the reader sees, where the area is dropped once
+ * the path has already said it — the rule `areaMarkName` applies to the chip,
+ * applied to the surfaces that name the area in words instead of a chip.
+ *
+ * The two are a pair and differ in exactly that: a `title` is where the unelided
+ * pairing lives, so it never elides, and a label beside it does.
+ */
+export function pathLabel(parts: PathParts): string {
+  return pathTitle({ ...parts, areaName: areaMarkName(parts.areaName, parts.path) });
+}
+
+/**
  * A path as one element per segment, for a surface that gives it more than one
  * line rather than cutting it off at the edge of its box.
  *


### PR DESCRIPTION
## Summary

The two follow-ups #407 raised, pulled into V0.4.3 rather than deferred: one of
them is a regression that PR introduced, and the other is the same defect it
fixed, on the surfaces it did not reach. The milestone ends at zero either way.

**#405 — the area mark stops repeating on every surface that shows one.** A root
location named after the room it stands in is the ordinary thing a household
does, and #377/#398/#403 taught the card's rows, the table's Location cell and
the detail sheet's crumb to drop the mark the path had already said. Five
surfaces were still printing it twice:

| surface | before | after |
|---|---|---|
| editor's Location field | `🏠Kitchen  Kitchen › Pantry › Top Shelf` | `Kitchen › Pantry › Top Shelf` |
| full view's context crumb | `🏠Kitchen  Kitchen · 159 items` | `Kitchen · 159 items` |
| applied-filter chip | `Area: Kitchen · Kitchen + sub` | `Kitchen + sub` |
| filter panel's Where field | `Area: Garage · Garage › Shelf A` | `Garage › Shelf A` |

The first two hang a chip beside a path and now call `areaMarkName()` like the
three that already did. A picker and a browsing crumb are not an item's own
path, which is why the earlier passes left them out — but the repetition reads
the same wherever it happens, and neither surface names the area anywhere else.
Neither carried the pairing at all, so dropping the mark alone would have lost
it rather than moved it: both gain the `title` the three eliding surfaces have,
from the same `pathTitle()`.

The last two name the area in words instead of a chip, and built that label out
of `pathTitle()` — which never elides, because a title is the fallback for
everything a label drops. `pathLabel()` is the other half of that pair, the same
two parts with the mark rule over them. The two take it together: each already
carried a comment saying it has to read like the other.

Two sites keep their area name and are not this bug. The location tree's group
header names the band of roots hanging under an area — that is the grouping, not
a mark beside a path — and the organize dialog spells the area into a sentence
("Assigns 🏠Kitchen to the whole Kitchen tree, 3 locations") that loses its
subject without it.

**#406 — the check-out popover's thumb sizes stop riding on its inline step.**
`mobile` answered two questions at once: draw as a step inside the caller's body,
and size every control for a finger. A caller that could not take the first could
not have the second — and the full view is exactly that caller, since both of its
popovers are siblings at the end of the shell with no body to sit in. At 390px
they drew a 31px confirm and 29px offset chips inside a surface that sets
`--hv-tap-min: 44px` for everything else on it. The single-row one got there
through #402 in the last PR; the bulk one had always been that size.

Split into `inline` (the step: static card, no scrim, no placement of its own)
and `touch` (the sizes, plus the stacked action grid and the flex spacer that
goes with it). No size changes — the same rules, moved onto the flag that means
what they are about. Each host now asks for what it can use: the detail sheet
takes both, the item editor takes both on its narrow branch, the full view takes
`touch` and never the step, and the card shell takes `touch` only — its popover
has the same sibling shape, and its narrow branch reaches check-out through the
detail sheet, which mounts one of its own.

Closes #405
Closes #406

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `752 passed, 22 skipped`; `ruff check`, `ruff format --check` and
      `mypy` clean (no backend change — the gate is the gate).
- [x] Frontend (`cards/haventory-card`): `eslint` clean, `typecheck` clean,
      `vitest run` **1751 passed / 62 files**, `npm run build` OK, `npm audit`
      0 vulnerabilities.

Tests at the level each fix lives at:

- `location-path.test.ts` — `pathLabel` drops what `pathTitle` keeps, and the
  two read identically when the names differ.
- `hv-item-editor.test.ts` / `hv-full-view.test.ts` — each surface loses the chip
  for `Kitchen` and `Kitchen / Pantry`, keeps it for `Cellar / Kitchen`, and
  keeps the full pairing in its `title`.
- `hv-filter-chips.test.ts` / `hv-filter-panel.test.ts` — the same rule on the
  chip (with and without `+ sub`) and on the Where field. The panel's existing
  test asserted the repeat outright: its fixture area is "Garage" over a path
  opening `Garage`, so it now asserts the elision and a second case covers a
  distinct name.
- `hv-checkout-popover.test.ts` — every thumb size hangs on `[touch]` and only
  the step itself on `[inline]`; `touch` alone keeps the scrim and the centred
  placement; the spacer goes with the sizes, not the step.
- `hv-full-view.test.ts` — both popovers, at both widths: never `inline`,
  `touch` exactly on the narrow branch.

Real instance (HA 2026.6.0, dev container), deployed and driven at each step.
Panel at 1440px, browsing into root "Kitchen" in area "Kitchen", with root
"QA House" in area "Living Room" as the control:

- crumb `"Kitchen · 159 items"`, no chip, `title="Area: Kitchen · Kitchen"`;
  control `"🏠Area: Living Room QA House · 13 items"`, chip kept.
- editor's Location field `"Kitchen › Pantry › Top Shelf"`, no chip,
  `title="Area: Kitchen · Kitchen › Pantry › Top Shelf"`.
- applied-filter chip `"Kitchen + sub"`; control `"Area: Living Room · QA House + sub"`.
- filter panel's Where field `"Kitchen"`.

Panel at 390px (iPhone 15, touch):

- editor's Location field, repeat case `"Kitchen › Pantry › Top Shelf"` with the
  title intact; control case (an item under "QA House") keeps `🏠Area: Living Room`.
- **#406 after**, single-row popover: `inline` unset, `touch` set,
  `position: fixed`, card `x 47, y 132 → 582`, scrim `rgba(0,0,0,0.35)`, actions
  `display: grid` — confirm **50px**, no-date **48px**, cancel **44px**, date row
  **70px**, offset chips **40/40/40**. Before, as measured in #407: 31px confirm,
  29px offsets.
- **#406 after**, bulk popover: the same numbers, from the same flags.

`visual_pass.mjs` over all four passes on the built branch: **42/42**, no console
errors and no missing card assets.

## Follow-ups

None in this diff.

- The `hv-card-shell` note from #407 is now moot: that popover no longer asks for
  a presentation it cannot draw. Its narrow branch still has no route to open it
  at all, which stays true and stays below the bar for an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
