### PR TITLE
feat(ws): filter subscriptions by area

### DIFF
--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -634,4 +634,33 @@ describe('Store', () => {
     expect(store.state.value.distinctValuesCache?.tags).toEqual([]);
   });
 
+  it('scopes the items subscription to the active area and re-opens it when the area changes', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1' })] });
+    const store = new Store(hass);
+    await store.init();
+
+    const itemsSubscribe = () => {
+      const sent = hass.__subscribeMessages.filter((m) => m.topic === 'items');
+      return sent[sent.length - 1];
+    };
+
+    // Unfiltered, the subscription asks for every area.
+    expect(itemsSubscribe().area_id).toBe(null);
+    const roundOne = hass.__subscribeCalls.length;
+
+    store.setFilters({ areaId: 'kitchen' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // A fresh round of all four topics, and the items one now names the area —
+    // without it the card would keep receiving every other area's events.
+    expect(hass.__subscribeCalls.length).toBe(roundOne * 2);
+    expect(itemsSubscribe().area_id).toBe('kitchen');
+
+    // A filter the backend applies to the page rather than to the subscription
+    // leaves the sockets alone.
+    store.setFilters({ category: 'Tools' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(hass.__subscribeCalls.length).toBe(roundOne * 2);
+  });
+
 });

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -558,6 +558,7 @@ export class Store {
     if (this.itemsUnsub) this.itemsUnsub();
     this.itemsUnsub = this.ws.subscribe('items', onEvent((evt) => this.onItemsEvent(evt)), {
       location_id: this.state.value.filters.locationId ?? undefined,
+      area_id: this.state.value.filters.areaId ?? undefined,
       include_subtree: true, // Always include sublocations
       onError,
       onOpen,
@@ -1110,7 +1111,9 @@ export class Store {
   // ---------- Filters ----------
   setFilters(patch: Partial<StoreFilters>) {
     const next = { ...this.state.value.filters, ...patch };
-    const locationChanged = next.locationId !== this.state.value.filters.locationId;
+    const scopeChanged =
+      next.locationId !== this.state.value.filters.locationId ||
+      next.areaId !== this.state.value.filters.areaId;
     // The rows already loaded stay on screen until the refetch lands, marked as
     // loading. Blanking them is what tore the scroller down mid-edit and took an
     // open editor with it; `listItems(true)` replaces the array wholesale anyway,
@@ -1122,9 +1125,9 @@ export class Store {
       // A row that is no longer listed cannot stay selected.
       selection: new Set<string>(),
     });
-    // The items subscription is scoped by location, so only a location change
-    // needs the sockets torn down and rebuilt.
-    if (locationChanged) this.subscribeTopics();
+    // The items subscription is scoped by location and area, so those two are
+    // the only filters that need the sockets torn down and rebuilt.
+    if (scopeChanged) this.subscribeTopics();
     void this.listItems(true);
     // Per-location counts are measured against the filter, so they move with it.
     // Coalesced: a filter panel can patch several keys in a row. Re-ordering

--- a/cards/haventory-card/src/store/ws.test.ts
+++ b/cards/haventory-card/src/store/ws.test.ts
@@ -229,6 +229,30 @@ describe('WSClient.subscribe when Home Assistant returns a promise', () => {
     expect(sent[0]).toMatchObject({ topic: 'items', location_id: 'l1', include_subtree: true });
     expect(sent[1]).not.toHaveProperty('location_id');
   });
+
+  it('scopes an items subscription by area only when asked', () => {
+    const sent: Record<string, unknown>[] = [];
+    const hass = {
+      callWS: () => Promise.resolve(undefined),
+      connection: {
+        subscribeMessage(_cb: unknown, msg: Record<string, unknown>) {
+          sent.push(msg);
+          return () => undefined;
+        },
+      },
+    } as unknown as HassLike;
+    const ws = new WSClient(hass);
+
+    ws.subscribe('items', () => undefined, { area_id: 'kitchen' });
+    // An undefined area is "every area": the backend reads a null as no filter,
+    // so the key going over the wire is not the same as the filter being on.
+    ws.subscribe('items', () => undefined, { area_id: undefined });
+    ws.subscribe('stats', () => undefined);
+
+    expect(sent[0]).toMatchObject({ topic: 'items', area_id: 'kitchen' });
+    expect(sent[1]).toMatchObject({ topic: 'items', area_id: null });
+    expect(sent[2]).not.toHaveProperty('area_id');
+  });
 });
 
 describe('WSClient attachments', () => {

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -426,6 +426,7 @@ export class WSClient {
     cb: (payload: AnyEventPayload) => void,
     opts?: {
       location_id?: string | null;
+      area_id?: string | null;
       include_subtree?: boolean;
       /**
        * Called when the backend rejects the subscribe — most importantly with
@@ -447,6 +448,7 @@ export class WSClient {
       topic,
     };
     if (opts && 'location_id' in opts) msg.location_id = opts.location_id ?? null;
+    if (opts && 'area_id' in opts) msg.area_id = opts.area_id ?? null;
     if (opts && 'include_subtree' in opts) msg.include_subtree = !!opts.include_subtree;
 
     const unsubOrPromise = this.hass.connection.subscribeMessage((event) => {

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -56,6 +56,8 @@ export interface MockHass extends HassLike {
   __messages: Record<string, unknown>[];
   /** Every subscribed topic seen so far, in order — refused attempts included. */
   __subscribeCalls: string[];
+  /** Every `haventory/subscribe` message in full, for assertions about its filters. */
+  __subscribeMessages: Record<string, unknown>[];
   /** Deliver a Home Assistant core event to whoever subscribed to it. */
   __emitHaEvent(eventType: string, data?: Record<string, unknown>): void;
   /** Open core-event subscriptions for `eventType` — 0 once a store disposes. */
@@ -104,6 +106,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
   const calls: string[] = [];
   const messages: Record<string, unknown>[] = [];
   const subscribeCalls: string[] = [];
+  const subscribeMessages: Record<string, unknown>[] = [];
 
   const findItem = (msg: Record<string, unknown>): Item => {
     const itemId = String((msg as any).item_id);
@@ -122,6 +125,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
     __calls: calls,
     __messages: messages,
     __subscribeCalls: subscribeCalls,
+    __subscribeMessages: subscribeMessages,
     async callWS<T>(msg: Record<string, unknown>): Promise<T> {
       const type = String(msg.type || '');
       calls.push(type);
@@ -629,6 +633,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
         }
         const topic = String((msg as any).topic || '');
         subscribeCalls.push(topic);
+        subscribeMessages.push({ ...msg });
         if (subscribeFailRemaining > 0) {
           // Real HA rejects the subscribe promise; the client must not treat the
           // topic as live.

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -454,6 +454,7 @@ def _execute_item_op(
 class _Subscription(TypedDict, total=False):
     topic: str
     location_id: str | None
+    area_id: str | None
     include_subtree: bool
     inspection_overdue_only: bool
 
@@ -620,6 +621,13 @@ def _payload_inspection_is_overdue(item: dict[str, Any]) -> bool:
 
 def _item_matches_filter(item: dict[str, Any], sub: _Subscription) -> bool:
     if sub.get("inspection_overdue_only") and not _payload_inspection_is_overdue(item):
+        return False
+    # Read the area off the payload rather than resolving it from the repository:
+    # the matcher runs once per subscription per event, and `_serialize_item` has
+    # already walked the location ancestry to compute the same value. An item with
+    # no location carries `effective_area_id: None`, which matches no area filter.
+    area_filter = sub.get("area_id")
+    if area_filter and item.get("effective_area_id") != area_filter:
         return False
     loc_filter = sub.get("location_id")
     if not loc_filter:
@@ -1064,6 +1072,9 @@ async def ws_health(
         vol.Required("type"): "haventory/subscribe",
         vol.Required("topic"): str,
         vol.Optional("location_id"): object,
+        # `object` rather than `str`, matching `location_id`: an explicit null
+        # clears the filter instead of being refused by HA core's schema.
+        vol.Optional("area_id"): object,
         vol.Optional("include_subtree"): bool,
         vol.Optional("inspection_overdue_only"): bool,
     }
@@ -1081,6 +1092,8 @@ async def ws_subscribe(
     }
     if "location_id" in msg:
         sub["location_id"] = msg.get("location_id")
+    if "area_id" in msg:
+        sub["area_id"] = msg.get("area_id")
     if "include_subtree" in msg:
         sub["include_subtree"] = bool(msg.get("include_subtree"))
     if "inspection_overdue_only" in msg:

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -1,0 +1,66 @@
+# V0.5.0 — handovers to a local session
+
+Cloud sessions have no Home Assistant. Each section below is one thing a cloud session
+finished but could not verify, written for a local session driving the dev Docker instance
+(`run-haventory` / `test-haventory`). Sections are appended in session order; the protocol
+is `dev/V0_5_0_implementation.md` §5.
+
+Delete this file with the plan when the milestone closes.
+
+---
+
+## H3 — #194 an area-filtered subscription only hears about its own area
+
+**Branch / PR**: `claude/v0-5-0-w1b-subscribe-area` / #TBD
+**Why this needs a real HA**: offline tests drive the matcher directly and the in-process
+suite drives one connection. What neither shows is two live dashboards on one Home
+Assistant, each holding its own `haventory/subscribe` round, and a mutation reaching only
+one of them — the fan-out across connections, over a real socket, with real areas from the
+area registry.
+
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+
+Seed two areas in HA (Settings → Areas, or reuse two that exist), then build a tree with a
+root anchored in each and one item per root:
+
+    uv run python scripts/ws_init_haventory.py     # if the instance is empty
+    uv run python scripts/ws_probe.py              # for ad-hoc location/create + item/create calls
+
+The shape that matters: `Kitchen` (area = the first area) → `Drawer`, `Garage` (area = the
+second area), one item in `Drawer`, one item in `Garage`, and one item with **no** location.
+
+### Steps
+
+1. Open two browser tabs on the HAventory panel.
+2. In tab A, filter to the kitchen area (area chip in the filter panel). Leave tab B unfiltered.
+3. In tab B, edit the item that lives in `Garage` — rename it.
+4. Watch tab A: the row count and the list must not flicker, and no toast or row change may
+   appear for the garage item.
+5. In tab B, edit the item in `Drawer`. Tab A must show the new name without a manual refresh.
+6. In tab B, edit the item with no location. Tab A must not react.
+7. With tab A still filtered to the kitchen, move `Drawer` under `Garage` (drag in the
+   location tree, or `location/move_subtree`). Tab A is expected to re-list — it does that
+   on the `locations` `moved` event — and the item must then be gone from its list. This is
+   the documented behaviour, not a bug: no per-item departure event is emitted.
+8. Optional, the same case the other way: reassign `Kitchen`'s own area in the location
+   editor. Today that emits no `locations` event at all, so tab A keeps showing the items
+   until something else makes it re-list. Note what you see; it is the follow-up below.
+
+### What "pass" looks like
+
+- Steps 3, 4 and 6: nothing moves in tab A. In the browser devtools WS frames, tab A's
+  connection receives **no** `event` frame carrying the garage item or the location-less one.
+- Step 5: tab A updates live, no refresh.
+- Step 7: tab A re-lists once and the item disappears from it.
+- `home-assistant.log` carries no `websocket_api` ERROR and no `haventory` warning across
+  the whole run.
+
+### What to send back
+
+- The two tabs side by side after step 4 (screenshot), and the devtools WS frame list for
+  tab A across steps 3–6.
+- Whatever step 8 does, in one line — it decides whether the follow-up below is worth an issue.
+- Paste the result as a comment on #194 and reply on the PR thread.

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -111,8 +111,9 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 ### Subscriptions and events
 
 - Subscribe
-  - `haventory/subscribe` request: `{id, type, topic: "items"|"locations"|"stats"|"statuses", location_id?: string|null, include_subtree?: boolean, inspection_overdue_only?: boolean}`
+  - `haventory/subscribe` request: `{id, type, topic: "items"|"locations"|"stats"|"statuses", location_id?: string|null, area_id?: string|null, include_subtree?: boolean, inspection_overdue_only?: boolean}`
   - Result: `null` (result envelope with `result: null`)
+  - `area_id` narrows the `items` topic to items whose `effective_area_id` equals it — the same area `item/list`'s `area_id` filter selects by, read off the event's own item payload. A `null` (or an omitted key) means no area filter, not "items with no area"; an item with no location has `effective_area_id: null` and therefore reaches no area-filtered subscription. An `area_id` naming an area nothing resolves to is accepted and simply delivers nothing. Filters combine with AND: a subscription carrying both `area_id` and `location_id` requires both to match. The `locations` topic ignores `area_id`.
   - `inspection_overdue_only` narrows the `items` topic to items past their `inspection_date`, using the same rule as the `item/list` filter of that name. Like every subscription filter it is applied to the event's item payload as it stands *after* the mutation, so an item that leaves the filtered set (its inspection date rescheduled or cleared) produces no event for that subscription — a client that tracks a filtered set re-lists rather than relying on a departure event.
   - Subsequent events delivered as HA WS events to the same connection using this `id` as the subscription id.
 
@@ -136,6 +137,7 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - When `location_id` filter is provided on subscription:
     - Items: if `include_subtree` (default true) match any item whose `location_path.id_path` contains the filter id; otherwise only direct `location_id` matches.
     - Locations: if `include_subtree` match the location itself or descendants; otherwise only the exact location.
+  - Re-anchoring a location under a different root rewrites `effective_area_id` for its whole subtree and emits a single `locations` `moved` event; reassigning a location's own `area_id` through `location/update` emits no `locations` event at all. Neither emits item events, so an area-filtered items subscription sees no departure for the items that just left its area, and no arrival for those that joined it. A client tracking a filtered set re-lists on a `locations` event rather than waiting for one — the same rule `inspection_overdue_only` carries, and the reason there is no synthetic per-item event here.
 
 - **An event implies a durable write.** Every mutation command persists the change *before* it broadcasts and before it replies, so any event on any topic says the write behind it reached storage. When the write fails the caller receives `storage_error` and **no event is emitted at all** — subscribers are told nothing rather than told about a change that is not on disk. A client may therefore treat a received event as committed and never has to reconcile it against a `storage_error` another client saw for the same change.
   - The guarantee is about the wire, not about the running repository: a failed write leaves the mutation applied in memory (`import/execute` is the exception — it rolls the dataset back, because a wholesale swap has more to undo than one entity does). Nothing announces that divergence, and it ends at the next restart, which reads back whatever last reached disk.

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -362,6 +362,13 @@ Common envelope inside HA WS event wrapper:
 - Stats: `counts` with `{counts: <Counts>}`.
 - Every topic: `unavailable` (common fields only), sent once per open subscription when the config entry serving it tears down. The subscription is over at that point; see the API contract's "While no entry is loaded".
 
+Subscription filters (`haventory/subscribe`) are matched against the payload above, not
+against the repository:
+
+- `location_id` / `include_subtree` read the item's `location_path.id_path` (or the location's own `path.id_path`).
+- `area_id` reads the item's `effective_area_id`, so it selects the same area `ItemFilter.area_id` does. An item with no location carries `effective_area_id: null` and matches no area filter; a `null` or omitted `area_id` on the subscription means no area filter at all. `area_id` applies to the `items` topic only.
+- Filters combine with AND, and every one of them is applied to the payload as it stands *after* the mutation. An item that leaves a filtered set produces no event for that subscription, so a client tracking one re-lists rather than waiting for a departure event — including after a `locations` `moved` event, which is the only signal that a subtree's `effective_area_id` was rewritten.
+
 ### Validation notes
 
 - UUIDs must be version 4.

--- a/tests/integration/test_ws_items.py
+++ b/tests/integration/test_ws_items.py
@@ -126,6 +126,38 @@ async def test_ws_rename_keeps_item_versions_valid(hass: HomeAssistant, hass_ws_
     assert updated["result"]["version"] == held_version + 1
 
 
+async def test_ws_subscribe_accepts_area_id_and_refuses_unknown_keys(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """Real HA applies the subscribe schema; the offline stub stores it unapplied.
+
+    So the two halves of the schema change — ``area_id`` accepted, including as an
+    explicit null, and anything else still refused — are only genuinely asserted
+    against a real connection.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 1, "type": "haventory/subscribe", "topic": "items", "area_id": "kitchen"}
+    )
+    accepted = await client.receive_json()
+    assert accepted["success"] is True, accepted
+
+    await client.send_json(
+        {"id": 2, "type": "haventory/subscribe", "topic": "items", "area_id": None}
+    )
+    cleared = await client.receive_json()
+    assert cleared["success"] is True, cleared
+
+    await client.send_json(
+        {"id": 3, "type": "haventory/subscribe", "topic": "items", "area": "kitchen"}
+    )
+    refused = await client.receive_json()
+    assert refused["success"] is False, refused
+
+
 async def test_ws_item_get_unknown_returns_error(hass: HomeAssistant, hass_ws_client) -> None:
     """Fetching a missing item surfaces a structured error, not a crash."""
 

--- a/tests/test_ws_effective_area_offline.py
+++ b/tests/test_ws_effective_area_offline.py
@@ -4,6 +4,7 @@ Scenarios:
 - effective_area_id reflects first ancestor with area_id
 - effective_area_id is null when no ancestor has area_id
 - area-only changes update effective_area_id without bumping item.version
+- the subscription matcher and item/list agree on which area an item is in
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import pytest
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.ws import _item_matches_filter
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
@@ -114,3 +116,44 @@ async def test_effective_area_id_updates_on_area_change_without_version_bump() -
     ver_after = after["result"]["version"]
     assert after["result"].get("effective_area_id") == "kitchen"
     assert ver_after == ver_before
+
+
+@pytest.mark.asyncio
+async def test_subscription_matcher_agrees_with_item_list_on_area() -> None:
+    """The area a subscriber sees an item in is the one `item/list` filters by.
+
+    Both read the same `effective_area_id`, so a subscriber's view of an area
+    cannot drift from the page `item/list` returns for it.
+    """
+
+    hass = HomeAssistant()
+    repo = Repository()
+    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    kitchen = repo.create_location(name="Kitchen", area_id="kitchen")
+    drawer = repo.create_location(name="Drawer", parent_id=kitchen.id)
+    garage = repo.create_location(name="Garage", area_id="garage")
+
+    for name, loc in (("Whisk", drawer), ("Spanner", garage), ("Loose screw", None)):
+        await _send(
+            hass,
+            1,
+            "haventory/item/create",
+            name=name,
+            location_id=str(loc.id) if loc is not None else None,
+        )
+
+    listed = await _send(hass, 2, "haventory/item/list", filter={"area_id": "kitchen"})
+    by_list = {it["name"] for it in listed["result"]["items"]}
+
+    everything = await _send(hass, 3, "haventory/item/list")
+    by_matcher = {
+        it["name"]
+        for it in everything["result"]["items"]
+        if _item_matches_filter(it, {"topic": "items", "area_id": "kitchen"})
+    }
+
+    assert by_list == {"Whisk"}
+    assert by_matcher == by_list

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -7,6 +7,8 @@ Scenarios:
   payload-less items event reaches every subscription regardless, because it is
   a refetch signal rather than a per-item patch
 - inspection_overdue_only narrows item events the way item/list narrows a page
+- area_id narrows item events to the payload's own effective_area_id, and never
+  delivers an item that has no location
 """
 
 from __future__ import annotations
@@ -409,6 +411,162 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
     undated = await _send(hass, conn, 5, "haventory/item/create", name="Bucket")
     assert undated["success"] is True
     assert item_event_ids() == {SUB_ID_EVERYTHING}
+
+
+@pytest.mark.asyncio
+async def test_area_filter_constrains_delivered_events() -> None:
+    """`area_id` narrows item events to the area the item's location tree is anchored to."""
+
+    hass = HomeAssistant()
+    repo = Repository()
+    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    conn = _ConnStub()
+
+    # Kitchen(area=kitchen) -> Drawer, and a separate Garage(area=garage).
+    kitchen = repo.create_location(name="Kitchen", area_id="kitchen")
+    drawer = repo.create_location(name="Drawer", parent_id=kitchen.id)
+    garage = repo.create_location(name="Garage", area_id="garage")
+
+    SUB_ID_KITCHEN = 501
+    SUB_ID_EVERYTHING = 502
+    SUB_ID_NULL_AREA = 503
+    await _send(hass, conn, SUB_ID_KITCHEN, "haventory/subscribe", topic="items", area_id="kitchen")
+    await _send(hass, conn, SUB_ID_EVERYTHING, "haventory/subscribe", topic="items")
+    # An explicit null is "no area filter", not "items with no area".
+    await _send(hass, conn, SUB_ID_NULL_AREA, "haventory/subscribe", topic="items", area_id=None)
+
+    def item_event_ids() -> set[object]:
+        return {
+            m.get("id")
+            for m in conn.messages
+            if m.get("type") == "event" and m.get("event", {}).get("topic") == "items"
+        }
+
+    # An item deep under the kitchen inherits its area and reaches all three.
+    conn.messages.clear()
+    inside = await _send(
+        hass, conn, 1, "haventory/item/create", name="Whisk", location_id=str(drawer.id)
+    )
+    assert inside["success"] is True
+    assert item_event_ids() == {SUB_ID_KITCHEN, SUB_ID_EVERYTHING, SUB_ID_NULL_AREA}
+
+    # An item in another area does not.
+    conn.messages.clear()
+    outside = await _send(
+        hass, conn, 2, "haventory/item/create", name="Spanner", location_id=str(garage.id)
+    )
+    assert outside["success"] is True
+    assert item_event_ids() == {SUB_ID_EVERYTHING, SUB_ID_NULL_AREA}
+
+    # Neither does an item with no location: its effective_area_id is null, and a
+    # null resolves to no area rather than to every area.
+    conn.messages.clear()
+    orphan = await _send(hass, conn, 3, "haventory/item/create", name="Loose screw")
+    assert orphan["success"] is True
+    assert orphan["result"]["effective_area_id"] is None
+    assert item_event_ids() == {SUB_ID_EVERYTHING, SUB_ID_NULL_AREA}
+
+
+@pytest.mark.asyncio
+async def test_area_and_location_filters_are_conjunctive() -> None:
+    """`area_id` and `location_id` on one subscription both have to match."""
+
+    hass = HomeAssistant()
+    repo = Repository()
+    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    conn = _ConnStub()
+
+    kitchen = repo.create_location(name="Kitchen", area_id="kitchen")
+    drawer = repo.create_location(name="Drawer", parent_id=kitchen.id)
+    shelf = repo.create_location(name="Shelf", parent_id=kitchen.id)
+
+    SUB_ID_BOTH = 601
+    SUB_ID_UNUSED_AREA = 602
+    await _send(
+        hass,
+        conn,
+        SUB_ID_BOTH,
+        "haventory/subscribe",
+        topic="items",
+        area_id="kitchen",
+        location_id=str(drawer.id),
+    )
+    # An area no item resolves to simply never matches; it is not an error.
+    await _send(
+        hass, conn, SUB_ID_UNUSED_AREA, "haventory/subscribe", topic="items", area_id="attic"
+    )
+
+    def item_event_ids() -> set[object]:
+        return {
+            m.get("id")
+            for m in conn.messages
+            if m.get("type") == "event" and m.get("event", {}).get("topic") == "items"
+        }
+
+    conn.messages.clear()
+    await _send(hass, conn, 1, "haventory/item/create", name="Whisk", location_id=str(drawer.id))
+    assert item_event_ids() == {SUB_ID_BOTH}
+
+    # Right area, wrong location.
+    conn.messages.clear()
+    await _send(hass, conn, 2, "haventory/item/create", name="Jar", location_id=str(shelf.id))
+    assert item_event_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_location_area_change_emits_no_item_events() -> None:
+    """Re-anchoring a subtree rewrites effective_area_id without item events.
+
+    An area-filtered subscription therefore sees no departure when the items it
+    was watching leave the area — the same rule `inspection_overdue_only`
+    carries: filters are applied to the payload as it stands after a mutation,
+    and a client tracking a filtered set re-lists rather than waiting for a
+    departure event.
+    """
+
+    hass = HomeAssistant()
+    repo = Repository()
+    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+
+    conn = _ConnStub()
+
+    kitchen = repo.create_location(name="Kitchen", area_id="kitchen")
+    garage = repo.create_location(name="Garage", area_id="garage")
+    drawer = repo.create_location(name="Drawer", parent_id=kitchen.id)
+    await _send(hass, conn, 1, "haventory/item/create", name="Whisk", location_id=str(drawer.id))
+
+    SUB_ID_KITCHEN = 701
+    await _send(hass, conn, SUB_ID_KITCHEN, "haventory/subscribe", topic="items", area_id="kitchen")
+    await _send(hass, conn, 702, "haventory/subscribe", topic="locations")
+
+    conn.messages.clear()
+    moved = await _send(
+        hass,
+        conn,
+        2,
+        "haventory/location/move_subtree",
+        location_id=str(drawer.id),
+        new_parent_id=str(garage.id),
+    )
+    assert moved["success"] is True
+
+    assert [ev.get("action") for ev in _extract_events(conn, topic="locations")] == ["moved"]
+    assert _extract_events(conn, topic="items") == []
+
+    # The item is genuinely out of the kitchen now, and the next event about it
+    # goes only to subscriptions watching where it landed.
+    conn.messages.clear()
+    listed = await _send(hass, conn, 3, "haventory/item/list", filter={"area_id": "garage"})
+    assert [it["name"] for it in listed["result"]["items"]] == ["Whisk"]
+    assert _extract_events(conn, topic="items") == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`haventory/subscribe` gains an optional `area_id`, so a dashboard filtered to one area stops receiving every other area's item events and discarding them client-side. Purely additive, mirroring how `location_id` is already plumbed.

- `_Subscription` gains `area_id: str | None`; the schema takes `vol.Optional("area_id"): object` — `object` rather than `str`, matching `location_id`, so an explicit `null` clears the filter instead of being refused by HA core's schema. `ws_subscribe` copies it across with the same `if "area_id" in msg:` shape the other optional keys use, so an absent key stays absent from the stored subscription.
- The matcher resolves through the event payload's own `effective_area_id`, **not** through the repository. `_serialize_item` has already walked the location ancestry to compute that value, so the matcher stays a pure function of the payload exactly as its `location_id` branch is, and the delivery fan-out takes no per-subscriber tree walk. The area check sits with `inspection_overdue_only` at the top, ahead of the `location_id` branch, which returns.
- An item with no location carries `effective_area_id: null` and reaches no area-filtered subscription. A `null` or omitted `area_id` means "no area filter", not "items with no area". An `area_id` naming an area nothing resolves to is accepted and delivers nothing. Filters combine with AND.
- `_location_matches_filter` is untouched: filtering the `locations` topic by area is a separate question and nothing asks for it.

Card side ships here too, or the motivating case is unchanged: `WSClient.subscribe`'s opts take `area_id`, `Store.openSubscriptions` sends the active `areaId`, and `setFilters` treats an `areaId` change as a resubscribe trigger the way a `locationId` change already is.

### The location-move behaviour, documented rather than invented

Re-anchoring a location under a different root rewrites `effective_area_id` for its whole subtree and emits one `locations` `moved` event — no item events. So an area-filtered items subscription sees no departure for the items that just left it, and no arrival for those that joined. That is the same rule `inspection_overdue_only` already carries (filters are applied to the payload as it stands after the mutation) and the card already re-lists on `moved`, so no synthetic per-item event was added. Both contract docs now say so.

One thing the issue's notes did not anticipate, decided against the code: reassigning a location's *own* `area_id` through `haventory/location/update` emits **no** `locations` event at all today — `ws_location_update` broadcasts only on `new_parent_id` (`moved`) or `name` (`renamed`). The docs state that too rather than describing an event that is not sent. Now filed as #419.

Closes #194

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (780 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (clean)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1753 passed), `npm run build`

New tests:

- `tests/test_ws_subscriptions_offline.py` — an area-filtered subscription receives an item deep under that area's root and not one in another area; `area_id: null` is no filter; an item with no location is never delivered; `area_id` + `location_id` are conjunctive; an area nothing resolves to delivers nothing rather than erroring; a subtree move emits `locations/moved` and no item events.
- `tests/test_ws_effective_area_offline.py` — the matcher and `item/list` select the same items for the same area, so a subscriber's view of an area cannot drift from the page.
- `cards/haventory-card/src/store/ws.test.ts`, `store.test.ts` — the items subscribe carries the active area, an `areaId` change opens a fresh round and a page-level filter does not. `makeMockHass` grew a `__subscribeMessages` recorder so a test can assert on the subscribe frame, not just the topic.
- `tests/integration/test_ws_items.py` — `area_id` accepted (including an explicit null) and an unknown key still refused. Only real HA applies the command schema; the offline stub stores it unapplied.

**`scripts/test_integration.sh` in the cloud environment** (§4 asked the first session needing it to report): it works, but not as-is — the container's `uv` is 0.8.17, whose python-build-standalone index tops out at CPython 3.14.0rc2, and `homeassistant==2026.6.0` requires `>=3.14.2`, so provisioning fails on resolution. Installing a current `uv` from PyPI into a throwaway venv and running `uv python install 3.14.2` fixes it; the script then provisions and passes — **45 passed**, on Python 3.14.2. Nothing in the repo needs changing for that, and PyPI and the npm registry are both reachable. (CI's own `integration` leg is unaffected and green.)

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed — `docs/backend_api_contract.md` (the subscribe request line, the `area_id` semantics, the location-move caveat) and `docs/data_shapes.md` (how subscription filters are matched against the event payload). `README.md` needs nothing: the change is additive on the wire and only removes events the card was already discarding.
- [x] WebSocket API changes keep `ws.py` and both docs in sync.
- [x] Essential invariants preserved.

## Live verification — **done, passed**

Handover **H3** (`dev/v0_5_0_handover_prompts.md`) ran against the dev HA on this PR's build: two tabs, one WS connection each, tab A filtered to a real area through the filter panel, tab B unfiltered and editing through the row editor. Tab A's subscribe went out as `{"topic":"items","location_id":null,"area_id":"h3_kitchen","include_subtree":true}`.

| step | tab B did | items frames on tab A | tab A's list |
|---|---|---|---|
| 3–4 | renamed the garage item | 0 | unchanged |
| 5 | renamed the drawer item | 1 | live update, no refresh |
| 6 | renamed the location-less item | 0 | unchanged |
| 7 | moved `Drawer` under `Garage` | 0 (one `locations/moved`) | re-listed once, 1 → 0 |

Plus a control the handover did not ask for and the claim needs: the same garage rename watched on **both** connections — tab A 0 frames, tab B 1. The broadcast did happen; only the filtered connection was spared it, which is the fan-out claim rather than an absence of events. No `websocket_api` ERROR and no `haventory` warning in a 60-minute log sweep; both browser consoles clean. Full results are on #194.

## Follow-ups

- **Filed as #419** (V0.5.0), confirmed live by H3 step 8: reassigning a location's own `area_id` emits `stats` counts and no `locations` event, so a second viewer filtered to that area keeps showing an item that has left it until it re-lists. Real but thin — it needs a concurrent viewer during a re-home and self-heals on any re-list. Out of scope here: the fix is a new broadcast in `ws_location_update`, not a subscription filter. Note #419 is in the milestone but not in any session's work package in `dev/V0_5_0_implementation.md`.
- **Pre-existing, untouched by this PR**, and folded into #419's notes since it lives in the same handler: a pure rename from the card's editor broadcasts `items/moved` rather than `items/updated`, because the editor always sends `location_id` and the action is keyed on the key being present rather than on the value changing, while `docs/backend_api_contract.md` says "changed". Cosmetic and already on `main`.

## Screenshots (card / UI changes)

None — nothing visible changed. What changed is which events reach a filtered card, captured as devtools WS frames in the H3 results on #194.