### PR TITLE
fix(ws): bound and type the WebSocket inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,11 @@ uniquely-named item and deletes it (best-effort cleanup even on failure).
 - Services via `hass.services.async_register` with `voluptuous` schemas; handlers re-raise
   validation/repository/storage errors so HA surfaces them.
 - Areas via `homeassistant.helpers.area_registry.async_get(hass)`; never auto-create areas.
+- Every free-text and collection field is capped on the way in — 4000 characters of
+  description, 50 tags, 50 custom fields, and so on beside the 120-character name limit —
+  because the store is one JSON document rewritten in full on every mutation. The same caps
+  apply to an imported document, so a restore cannot introduce an entity the API would refuse.
+  The full table is in [`docs/data_shapes.md`](docs/data_shapes.md) → "Input caps".
 - Case-insensitive search; denormalized `location_path` on items; item `version` for optimistic
   concurrency. `version` counts *item* mutations only — renaming or moving a location rewrites
   the derived `location_path` across its whole subtree without bumping `version` or restamping

--- a/cards/haventory-card/src/ui/item-form.test.ts
+++ b/cards/haventory-card/src/ui/item-form.test.ts
@@ -124,6 +124,54 @@ describe('validateForm', () => {
     const rows = [newCustomFieldRow({ key: '  ', type: 'number', value: '' })];
     expect(validateForm({ ...base(), name: 'A', customFields: rows })).toEqual([]);
   });
+
+  it('mirrors the backend size caps so the editor refuses before the round trip', () => {
+    const over = [
+      { model: { description: 'd'.repeat(4001) }, field: 'description' },
+      { model: { category: 'c'.repeat(121) }, field: 'category' },
+      { model: { tags: ['t'.repeat(65)] }, field: 'tags' },
+      { model: { tags: Array.from({ length: 51 }, (_, i) => `t${i}`) }, field: 'tags' },
+      {
+        model: { customFields: [newCustomFieldRow({ key: 'k'.repeat(65), value: 'v' })] },
+        field: 'custom:',
+      },
+      {
+        model: { customFields: [newCustomFieldRow({ key: 'k', value: 'v'.repeat(1001) })] },
+        field: 'custom:',
+      },
+      {
+        model: {
+          customFields: Array.from({ length: 51 }, (_, i) =>
+            newCustomFieldRow({ key: `k${i}`, value: 'v' }),
+          ),
+        },
+        field: 'customFields',
+      },
+    ];
+    for (const { model, field } of over) {
+      const errors = validateForm({ ...base(), name: 'A', ...model });
+      expect(errors.length, JSON.stringify(field)).toBeGreaterThan(0);
+      expect(errors.some((e) => e.field.startsWith(field))).toBe(true);
+    }
+  });
+
+  it('accepts a form sitting exactly at every cap', () => {
+    const atCap = validateForm({
+      ...base(),
+      name: 'n'.repeat(120),
+      description: 'd'.repeat(4000),
+      category: 'c'.repeat(120),
+      tags: ['t'.repeat(64)],
+      customFields: [newCustomFieldRow({ key: 'k'.repeat(64), value: 'v'.repeat(1000) })],
+    });
+    expect(atCap).toEqual([]);
+  });
+
+  it('counts tags the way the backend counts them, after normalization', () => {
+    // Fifty-one entries, but two are the same tag under different casings.
+    const tags = ['Bolt', 'bolt', ...Array.from({ length: 49 }, (_, i) => `t${i}`)];
+    expect(validateForm({ ...base(), name: 'A', tags })).toEqual([]);
+  });
 });
 
 describe('customFieldsFrom', () => {

--- a/cards/haventory-card/src/ui/item-form.ts
+++ b/cards/haventory-card/src/ui/item-form.ts
@@ -43,6 +43,21 @@ export interface FieldError {
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * The backend's input caps, mirrored so the editor refuses before the round
+ * trip rather than showing a server error on save. These are the values in
+ * `models.py`; a value the editor accepts and the backend refuses is the
+ * failure mode to avoid, so they only ever move together.
+ */
+const NAME_MAX_LENGTH = 120;
+const DESCRIPTION_MAX_LENGTH = 4000;
+const CATEGORY_MAX_LENGTH = 120;
+const TAG_MAX_LENGTH = 64;
+const TAGS_MAX_COUNT = 50;
+const CUSTOM_FIELDS_MAX_KEYS = 50;
+const CUSTOM_FIELD_KEY_MAX_LENGTH = 64;
+const CUSTOM_FIELD_VALUE_MAX_LENGTH = 1000;
+
 let rowSeq = 0;
 
 export function newCustomFieldRow(partial: Partial<CustomFieldRow> = {}): CustomFieldRow {
@@ -88,14 +103,41 @@ export function validateForm(model: ItemFormModel): FieldError[] {
   const errors: FieldError[] = [];
   if (!model.name.trim()) {
     errors.push({ field: 'name', message: 'Name is required.' });
-  } else if (model.name.trim().length > 120) {
-    errors.push({ field: 'name', message: 'Name is limited to 120 characters.' });
+  } else if (model.name.trim().length > NAME_MAX_LENGTH) {
+    errors.push({
+      field: 'name',
+      message: `Name is limited to ${NAME_MAX_LENGTH} characters.`,
+    });
+  }
+  if (model.description.length > DESCRIPTION_MAX_LENGTH) {
+    errors.push({
+      field: 'description',
+      message: `Description is limited to ${DESCRIPTION_MAX_LENGTH} characters.`,
+    });
+  }
+  if (model.category.trim().length > CATEGORY_MAX_LENGTH) {
+    errors.push({
+      field: 'category',
+      message: `Category is limited to ${CATEGORY_MAX_LENGTH} characters.`,
+    });
   }
   if (!Number.isFinite(model.quantity) || !Number.isInteger(model.quantity) || model.quantity < 0) {
     errors.push({ field: 'quantity', message: "Quantity can't be negative." });
   }
   if (model.lowStock !== null && (!Number.isFinite(model.lowStock) || model.lowStock < 0)) {
     errors.push({ field: 'lowStock', message: 'Low-stock threshold must be 0 or more, or empty.' });
+  }
+  // Counted after normalization, the way the backend counts it: two casings of
+  // one tag are one tag on both sides.
+  const tags = normalizeTags(model.tags);
+  if (tags.length > TAGS_MAX_COUNT) {
+    errors.push({ field: 'tags', message: `An item can carry at most ${TAGS_MAX_COUNT} tags.` });
+  }
+  if (tags.some((tag) => tag.length > TAG_MAX_LENGTH)) {
+    errors.push({
+      field: 'tags',
+      message: `Each tag is limited to ${TAG_MAX_LENGTH} characters.`,
+    });
   }
   const seen = new Set<string>();
   for (const row of model.customFields) {
@@ -106,12 +148,30 @@ export function validateForm(model: ItemFormModel): FieldError[] {
       continue;
     }
     seen.add(key);
+    if (key.length > CUSTOM_FIELD_KEY_MAX_LENGTH) {
+      errors.push({
+        field: `custom:${row.id}`,
+        message: `Field names are limited to ${CUSTOM_FIELD_KEY_MAX_LENGTH} characters.`,
+      });
+    }
     if (row.type === 'number' && (row.value.trim() === '' || !Number.isFinite(Number(row.value)))) {
       errors.push({ field: `custom:${row.id}`, message: `"${key}" must be a number.` });
     }
     if (row.type === 'date' && row.value.trim() !== '' && !DATE_RE.test(row.value.trim())) {
       errors.push({ field: `custom:${row.id}`, message: `"${key}" must be a date.` });
     }
+    if (row.type === 'string' && row.value.length > CUSTOM_FIELD_VALUE_MAX_LENGTH) {
+      errors.push({
+        field: `custom:${row.id}`,
+        message: `"${key}" is limited to ${CUSTOM_FIELD_VALUE_MAX_LENGTH} characters.`,
+      });
+    }
+  }
+  if (seen.size > CUSTOM_FIELDS_MAX_KEYS) {
+    errors.push({
+      field: 'customFields',
+      message: `An item can carry at most ${CUSTOM_FIELDS_MAX_KEYS} custom fields.`,
+    });
   }
   return errors;
 }

--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -58,9 +58,17 @@ from typing import Any, Literal
 from .const import INTEGRATION_VERSION
 from .exceptions import ValidationError
 from .models import (
+    CATEGORY_MAX_LENGTH,
+    CUSTOM_FIELD_KEY_MAX_LENGTH,
+    CUSTOM_FIELD_VALUE_MAX_LENGTH,
+    CUSTOM_FIELDS_MAX_KEYS,
     DEFAULT_ITEM_STATUS,
+    DESCRIPTION_MAX_LENGTH,
     EMPTY_LOCATION_PATH,
     ITEM_STATUSES,
+    NAME_MAX_LENGTH,
+    TAG_MAX_LENGTH,
+    TAGS_MAX_COUNT,
     Item,
     Location,
     build_location_path_from_map,
@@ -72,6 +80,7 @@ from .models import (
     serialize_attachment_meta,
     serialize_status_definition,
     validate_attachment_meta,
+    validate_due_date_rules,
     validate_status_definition,
 )
 from .repository import Repository
@@ -335,6 +344,26 @@ def _validate_uuid4(value: Any, path: str, errors: list[dict[str, str]]) -> str 
     return value
 
 
+def _validate_capped_text(
+    value: Any, path: str, max_length: int, errors: list[dict[str, str]]
+) -> None:
+    """Report an optional free-text field that is not a string, or is too long.
+
+    Absence and an explicit null are both fine; every item field this guards is
+    nullable.
+    """
+
+    if value is None:
+        return
+    if not isinstance(value, str):
+        errors.append(_err(path, f"{path.rsplit('.', 1)[-1]} must be a string or null"))
+        return
+    if len(value) > max_length:
+        errors.append(
+            _err(path, f"{path.rsplit('.', 1)[-1]} must be at most {max_length} characters")
+        )
+
+
 def _validate_location_doc(
     idx: int, doc: dict[str, Any], errors: list[dict[str, str]]
 ) -> str | None:
@@ -343,6 +372,8 @@ def _validate_location_doc(
     name = doc.get("name")
     if not isinstance(name, str) or not name.strip():
         errors.append(_err(f"{base}.name", "name is required and must be a non-empty string"))
+    elif len(name.strip()) > NAME_MAX_LENGTH:
+        errors.append(_err(f"{base}.name", f"name must be at most {NAME_MAX_LENGTH} characters"))
     parent_id = doc.get("parent_id")
     if parent_id is not None:
         _validate_uuid4(parent_id, f"{base}.parent_id", errors)
@@ -385,6 +416,63 @@ def _validate_attachments_doc(base: str, doc: dict[str, Any], errors: list[dict[
             errors.append(_err(f"{base}.attachments[{idx}]", str(exc)))
 
 
+def _validate_tags_doc(base: str, doc: dict[str, Any], errors: list[dict[str, str]]) -> None:
+    """Hold an imported tag list to the caps a written one is held to.
+
+    The count is measured on the normalized list, the way the write path
+    measures it: a document repeating a tag under two casings carries one tag.
+    """
+
+    tags = doc.get("tags", [])
+    if not isinstance(tags, list) or any(not isinstance(t, str) for t in tags):
+        errors.append(_err(f"{base}.tags", "tags must be an array of strings"))
+        return
+    if len(normalize_tags(tags)) > TAGS_MAX_COUNT:
+        errors.append(_err(f"{base}.tags", f"tags must have at most {TAGS_MAX_COUNT} entries"))
+    if any(len(t) > TAG_MAX_LENGTH for t in tags):
+        errors.append(_err(f"{base}.tags", f"each tag must be at most {TAG_MAX_LENGTH} characters"))
+
+
+def _validate_custom_fields_doc(
+    base: str, doc: dict[str, Any], errors: list[dict[str, str]]
+) -> None:
+    """Hold an imported custom-field map to the caps a written one is held to."""
+
+    cf = doc.get("custom_fields", {})
+    if not isinstance(cf, dict):
+        errors.append(_err(f"{base}.custom_fields", "custom_fields must be an object"))
+        return
+    if len(cf) > CUSTOM_FIELDS_MAX_KEYS:
+        errors.append(
+            _err(
+                f"{base}.custom_fields",
+                f"custom_fields must have at most {CUSTOM_FIELDS_MAX_KEYS} keys",
+            )
+        )
+    for k, v in cf.items():
+        if not isinstance(k, str) or not k:
+            errors.append(
+                _err(f"{base}.custom_fields", "custom_fields keys must be non-empty strings")
+            )
+        elif len(k) > CUSTOM_FIELD_KEY_MAX_LENGTH:
+            errors.append(
+                _err(
+                    f"{base}.custom_fields",
+                    f"custom_fields keys must be at most {CUSTOM_FIELD_KEY_MAX_LENGTH} characters",
+                )
+            )
+        elif not isinstance(v, str | int | float | bool):
+            errors.append(_err(f"{base}.custom_fields.{k}", "custom_fields values must be scalar"))
+        elif isinstance(v, str) and len(v) > CUSTOM_FIELD_VALUE_MAX_LENGTH:
+            errors.append(
+                _err(
+                    f"{base}.custom_fields.{k}",
+                    "custom_fields values must be at most "
+                    f"{CUSTOM_FIELD_VALUE_MAX_LENGTH} characters",
+                )
+            )
+
+
 def _validate_item_doc(
     idx: int, doc: dict[str, Any], errors: list[dict[str, str]], known_statuses: Collection[str]
 ) -> str | None:
@@ -393,6 +481,12 @@ def _validate_item_doc(
     name = doc.get("name")
     if not isinstance(name, str) or not name.strip():
         errors.append(_err(f"{base}.name", "name is required and must be a non-empty string"))
+    elif len(name.strip()) > NAME_MAX_LENGTH:
+        errors.append(_err(f"{base}.name", f"name must be at most {NAME_MAX_LENGTH} characters"))
+    _validate_capped_text(
+        doc.get("description"), f"{base}.description", DESCRIPTION_MAX_LENGTH, errors
+    )
+    _validate_capped_text(doc.get("category"), f"{base}.category", CATEGORY_MAX_LENGTH, errors)
     qty = doc.get("quantity", 1)
     if not isinstance(qty, int) or isinstance(qty, bool) or qty < 0:
         errors.append(_err(f"{base}.quantity", "quantity must be an integer >= 0"))
@@ -409,24 +503,10 @@ def _validate_item_doc(
     loc_id = doc.get("location_id")
     if loc_id is not None:
         _validate_uuid4(loc_id, f"{base}.location_id", errors)
-    tags = doc.get("tags", [])
-    if not isinstance(tags, list) or any(not isinstance(t, str) for t in tags):
-        errors.append(_err(f"{base}.tags", "tags must be an array of strings"))
-    cf = doc.get("custom_fields", {})
-    if not isinstance(cf, dict):
-        errors.append(_err(f"{base}.custom_fields", "custom_fields must be an object"))
-    else:
-        for k, v in cf.items():
-            if not isinstance(k, str) or not k:
-                errors.append(
-                    _err(f"{base}.custom_fields", "custom_fields keys must be non-empty strings")
-                )
-            elif not isinstance(v, str | int | float | bool):
-                errors.append(
-                    _err(f"{base}.custom_fields.{k}", "custom_fields values must be scalar")
-                )
-    # Canonical fixed-width timestamps are a load-bearing invariant: sorting
-    # and range filters compare them lexicographically. A field that is PRESENT
+    _validate_tags_doc(base, doc, errors)
+    _validate_custom_fields_doc(base, doc, errors)
+    # Canonical fixed-width timestamps are an invariant sorting and range
+    # filters depend on: they compare lexicographically. A field that is PRESENT
     # must be canonical (an explicit null / non-canonical string is rejected so
     # it cannot be stored as "None"/garbage); an omitted field is allowed and
     # backfilled with a canonical value on load.
@@ -438,7 +518,25 @@ def _validate_item_doc(
                     f"{ts_field} must be an ISO-8601 UTC timestamp (YYYY-MM-DDTHH:MM:SSZ)",
                 )
             )
+    _validate_due_date_doc(base, doc, errors)
     return iid
+
+
+def _validate_due_date_doc(base: str, doc: dict[str, Any], errors: list[dict[str, str]]) -> None:
+    """Hold an imported item to the same due-date invariant a write is held to.
+
+    A due date only exists while an item is checked out, and every WS and
+    service path enforces that. A document is the one way an item could arrive
+    carrying a date nothing will ever clear.
+    """
+
+    due_date = doc.get("due_date")
+    if due_date is None:
+        return
+    try:
+        validate_due_date_rules(checked_out=bool(doc.get("checked_out", False)), due_date=due_date)
+    except ValidationError as exc:
+        errors.append(_err(f"{base}.due_date", str(exc)))
 
 
 def _canonical_item(doc: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -78,6 +78,18 @@ LOCATION_GUARD_MAX_STEPS = 10_000
 # model SMS4HVI31E)".
 ATTACHMENT_TITLE_MAX_LENGTH = 200
 
+# Input bounds for the free-text and collection fields, anchored on the 120-char
+# name cap above. The store is one JSON document rewritten in full on every
+# mutation, so an unbounded field is a cost every later write pays; these are set
+# where a household's real entry still fits comfortably.
+DESCRIPTION_MAX_LENGTH = 4_000
+CATEGORY_MAX_LENGTH = 120
+TAG_MAX_LENGTH = 64
+TAGS_MAX_COUNT = 50
+CUSTOM_FIELDS_MAX_KEYS = 50
+CUSTOM_FIELD_KEY_MAX_LENGTH = 64
+CUSTOM_FIELD_VALUE_MAX_LENGTH = 1_000
+
 
 @dataclass
 class Location:
@@ -366,13 +378,99 @@ def validate_custom_fields(values: dict[str, ScalarValue]) -> None:
 
     if not isinstance(values, dict):
         raise ValidationError("custom_fields must be a mapping of string keys to scalars")
+    if len(values) > CUSTOM_FIELDS_MAX_KEYS:
+        raise ValidationError(f"custom_fields must have at most {CUSTOM_FIELDS_MAX_KEYS} keys")
     for key, value in values.items():
         if not isinstance(key, str) or not key:
             raise ValidationError("custom_fields keys must be non-empty strings")
+        if len(key) > CUSTOM_FIELD_KEY_MAX_LENGTH:
+            raise ValidationError(
+                f"custom_fields keys must be at most {CUSTOM_FIELD_KEY_MAX_LENGTH} characters"
+            )
         if not isinstance(value, str | int | float | bool):
             raise ValidationError(
                 "custom_fields values must be scalar (string, number, or boolean)"
             )
+        if isinstance(value, str) and len(value) > CUSTOM_FIELD_VALUE_MAX_LENGTH:
+            raise ValidationError(
+                f"custom_fields values must be at most {CUSTOM_FIELD_VALUE_MAX_LENGTH} characters"
+            )
+
+
+def validate_tags(tags: list[str] | None, *, previous: Collection[str] = ()) -> list[str]:
+    """Normalize an *item's* tag list and enforce the item-side tag caps.
+
+    Separate from :func:`normalize_tags`, which also normalizes *filter* values:
+    a filter naming sixty tags is a query, not an item, and is not over any
+    limit.
+
+    ``previous`` is the item's current tag list, and the caps are enforced
+    against what the edit *adds*. An item that predates the caps can therefore
+    still be edited — including by the edit that removes the excess, which an
+    absolute check would refuse along with everything else.
+    """
+
+    normalized = normalize_tags(tags)
+    previous_tags = set(previous)
+    for tag in normalized:
+        if tag not in previous_tags and len(tag) > TAG_MAX_LENGTH:
+            raise ValidationError(f"each tag must be at most {TAG_MAX_LENGTH} characters")
+    if len(normalized) > TAGS_MAX_COUNT and len(normalized) > len(previous_tags):
+        raise ValidationError(f"tags must have at most {TAGS_MAX_COUNT} entries")
+    return normalized
+
+
+#: Every key an :class:`ItemFilter` accepts. Derived from the TypedDict so a new
+#: filter key is accepted the moment it is declared there, with no second list
+#: to keep in step.
+ITEM_FILTER_KEYS: Final[frozenset[str]] = frozenset(ItemFilter.__annotations__)
+
+#: The fields :func:`sort_items` can order by, and the two orders it accepts.
+SORT_FIELDS: Final[frozenset[str]] = frozenset(
+    {"updated_at", "created_at", "name", "quantity", "due_date", "inspection_date"}
+)
+SORT_ORDERS: Final[frozenset[str]] = frozenset({"asc", "desc"})
+#: The keys a sort object carries. Anything else is a client typo.
+SORT_KEYS: Final[frozenset[str]] = frozenset({"field", "order"})
+
+
+def validate_item_filter(flt: object) -> None:
+    """Reject a filter object carrying keys no filter understands.
+
+    An unknown key is silently dropped by :func:`filter_items`, so a typo'd
+    ``search`` or ``query`` in place of ``q`` returns the *whole* inventory
+    labelled as a filtered result. Naming the offending key is the only way a
+    caller finds that out.
+    """
+
+    if flt is None:
+        return
+    if not isinstance(flt, dict):
+        raise ValidationError("filter must be an object")
+    unknown = sorted(str(key) for key in flt if key not in ITEM_FILTER_KEYS)
+    if unknown:
+        raise ValidationError(f"unknown filter key(s): {', '.join(unknown)}")
+
+
+def validate_sort(sort: object) -> None:
+    """Reject a sort object carrying unknown keys, fields or orders.
+
+    Same footgun as :func:`validate_item_filter`: an unknown key leaves the
+    ordering at its default, which reads as "the sort did nothing".
+    """
+
+    if sort is None:
+        return
+    if not isinstance(sort, dict):
+        raise ValidationError("sort must be an object")
+    unknown = sorted(str(key) for key in sort if key not in SORT_KEYS)
+    if unknown:
+        raise ValidationError(f"unknown sort key(s): {', '.join(unknown)}")
+    field_value = sort.get("field")
+    if field_value not in SORT_FIELDS:
+        raise ValidationError(f"sort.field must be one of: {', '.join(sorted(SORT_FIELDS))}")
+    if sort.get("order") not in SORT_ORDERS:
+        raise ValidationError("sort.order must be 'asc' or 'desc'")
 
 
 def validate_due_date_rules(*, checked_out: bool, due_date: str | None) -> str | None:
@@ -646,14 +744,20 @@ def _is_int_not_bool(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def _validate_optional_text(value: object, field_name: str) -> None:
-    """Ensure an optional free-text field is a string or None.
+def _validate_optional_text(
+    value: object, field_name: str, *, max_length: int | None = None
+) -> None:
+    """Ensure an optional free-text field is a string or None, within its cap.
 
     Non-text values (list/dict/number) would otherwise reach the search-index
     build and crash mid-way, leaving a partially-indexed item.
     """
-    if value is not None and not isinstance(value, str):
+    if value is None:
+        return
+    if not isinstance(value, str):
         raise ValidationError(f"{field_name} must be a string or null")
+    if max_length is not None and len(value) > max_length:
+        raise ValidationError(f"{field_name} must be at most {max_length} characters")
 
 
 def _validate_item_core_fields(name: str, quantity: int, low_stock_threshold: int | None) -> None:
@@ -687,14 +791,23 @@ def create_item_from_create(
         A fully-populated Item instance with defaults applied.
     """
 
-    name = payload.get("name")
-    if name is None:
+    raw_name = payload.get("name")
+    if raw_name is None:
         raise ValidationError("name is required")
+    # Type before shape: the command schema types `name` as `object` so a wrong
+    # type answers `validation_error` rather than an HA-core schema rejection,
+    # and `.strip()` on a non-string would reach that route as `unknown_error`.
+    if not isinstance(raw_name, str):
+        raise ValidationError("name is required and must be a non-empty string")
     # Trim whitespace before validation and persistence
-    name = name.strip()
+    name = raw_name.strip()
     description = payload.get("description")
+    # Type before conversion, for the same reason `name` is checked before
+    # `.strip()`: the command schema types `quantity` as `object`, and `int()`
+    # over a non-numeric string raises `ValueError`, which routes to
+    # `unknown_error` instead of naming the field.
     raw_quantity = payload.get("quantity", 1)
-    if isinstance(raw_quantity, bool):
+    if not _is_int_not_bool(raw_quantity):
         raise ValidationError("quantity must be an integer >= 0")
     quantity = int(raw_quantity)
     status = validate_item_status(
@@ -704,13 +817,13 @@ def create_item_from_create(
     due_date = payload.get("due_date")
     inspection_date = payload.get("inspection_date")
     location_id_raw = payload.get("location_id")
-    tags = normalize_tags(payload.get("tags"))
+    tags = validate_tags(payload.get("tags"))
     category = payload.get("category")
     low_stock_threshold = payload.get("low_stock_threshold")
     custom_fields = payload.get("custom_fields", {})
 
-    _validate_optional_text(description, "description")
-    _validate_optional_text(category, "category")
+    _validate_optional_text(description, "description", max_length=DESCRIPTION_MAX_LENGTH)
+    _validate_optional_text(category, "category", max_length=CATEGORY_MAX_LENGTH)
     _validate_item_core_fields(name, quantity, low_stock_threshold)
     validate_custom_fields(custom_fields)
     normalized_due_date = validate_due_date_rules(checked_out=checked_out, due_date=due_date)
@@ -762,7 +875,9 @@ def _update_name_and_description(new_item: Item, update: ItemUpdate) -> None:
             raise ValidationError("name must be at most 120 characters")
         new_item.name = trimmed
     if "description" in update:
-        _validate_optional_text(update["description"], "description")
+        _validate_optional_text(
+            update["description"], "description", max_length=DESCRIPTION_MAX_LENGTH
+        )
         new_item.description = update["description"]
 
 
@@ -819,9 +934,9 @@ def _update_location_and_path(
 
 def _update_tags_category_threshold(new_item: Item, update: ItemUpdate) -> None:
     if "tags" in update:
-        new_item.tags = normalize_tags(update.get("tags") or [])
+        new_item.tags = validate_tags(update.get("tags") or [], previous=new_item.tags)
     if "category" in update:
-        _validate_optional_text(update["category"], "category")
+        _validate_optional_text(update["category"], "category", max_length=CATEGORY_MAX_LENGTH)
         new_item.category = update["category"]
     if "low_stock_threshold" in update:
         thr = update["low_stock_threshold"]
@@ -833,6 +948,7 @@ def _update_tags_category_threshold(new_item: Item, update: ItemUpdate) -> None:
 def _update_custom_fields(new_item: Item, update: ItemUpdate) -> None:
     to_set = update.get("custom_fields_set", {})
     to_unset = update.get("custom_fields_unset", [])
+    before = len(new_item.custom_fields)
     if to_set:
         validate_custom_fields(to_set)
         new_item.custom_fields = {**new_item.custom_fields, **to_set}
@@ -840,6 +956,13 @@ def _update_custom_fields(new_item: Item, update: ItemUpdate) -> None:
         new_item.custom_fields = {
             k: v for k, v in new_item.custom_fields.items() if k not in set(to_unset)
         }
+    # The key cap bounds the item, not the patch: a two-key patch onto an item
+    # already at the limit is what would otherwise walk past it. Judged on the
+    # result of the whole call, and only when the call grew the map — so an item
+    # that predates the cap can still be edited down.
+    after = len(new_item.custom_fields)
+    if after > CUSTOM_FIELDS_MAX_KEYS and after > before:
+        raise ValidationError(f"custom_fields must have at most {CUSTOM_FIELDS_MAX_KEYS} keys")
 
 
 def apply_item_update(
@@ -1197,13 +1320,9 @@ def sort_items(items: Iterable[Item], sort: Sort | None = None) -> list[Item]:
 
     field = sort.get("field")
     order = sort.get("order")
-    allowed_fields = {"updated_at", "created_at", "name", "quantity", "due_date", "inspection_date"}
-    if field not in allowed_fields:
-        raise ValidationError(
-            "sort.field must be one of: updated_at, created_at, name, quantity, "
-            "due_date, inspection_date"
-        )
-    if order not in {"asc", "desc"}:
+    if field not in SORT_FIELDS:
+        raise ValidationError(f"sort.field must be one of: {', '.join(sorted(SORT_FIELDS))}")
+    if order not in SORT_ORDERS:
         raise ValidationError("sort.order must be 'asc' or 'desc'")
 
     reverse = order == "desc"

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -109,6 +109,11 @@ UNSET: object = object()
 TRIGRAM_MIN_LEN = 3
 PREFIX_MIN_LEN = 2
 
+#: Longest pagination cursor this build will even attempt to decode. A cursor is
+#: base64 of a small JSON object this repository minted itself, so anything
+#: appreciably longer did not come from here.
+CURSOR_MAX_LENGTH = 2_048
+
 #: Rows of one kind logged individually before ``load_state`` switches to a total.
 #:
 #: A drop is per-row, so a wholesale corruption would otherwise emit one ERROR
@@ -2002,13 +2007,17 @@ class Repository:
         return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
 
     def _decode_cursor(self, cursor: str) -> dict[str, Any] | None:
+        # Bounded before decoding: base64 expands to bytes this method then
+        # parses as JSON, so an unbounded cursor is unbounded work per frame.
+        if len(cursor) > CURSOR_MAX_LENGTH:
+            return None
         try:
             raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
             obj = json.loads(raw)
             if not isinstance(obj, dict):
                 return None
             return obj
-        except ValueError, binascii.Error:  # pragma: no cover - defensive
+        except ValueError, binascii.Error:
             return None
 
     def _primary_sort_value(self, item: Item, sort: Sort) -> str | int:
@@ -2050,31 +2059,45 @@ class Repository:
     ) -> tuple[list[Item], str | None]:
         start_index = 0
         order = sort.get("order", "desc")
-        cursor_info = self._decode_cursor(cursor) if cursor else None
 
-        if cursor_info is not None:
+        if cursor:
+            # Every way a cursor can be wrong is an error, never a silent
+            # restart: answering an unreadable cursor with page one returns the
+            # whole first page dressed as "the next page", and a caller paging
+            # through an inventory would loop over it forever without ever
+            # being told.
+            cursor_info = self._decode_cursor(cursor)
+            if cursor_info is None:
+                raise ValidationError("cursor is not a valid pagination cursor")
             cur_sort = (
                 cursor_info.get("sort") if isinstance(cursor_info.get("sort"), dict) else None
             )
-            # If sort differs, ignore the cursor to avoid inconsistency
             if (
-                cur_sort
-                and cur_sort.get("field") == sort.get("field")
-                and cur_sort.get("order") == sort.get("order")
+                not cur_sort
+                or cur_sort.get("field") != sort.get("field")
+                or cur_sort.get("order") != sort.get("order")
             ):
-                last_key = cursor_info.get("last_sort_key")
-                last_id = cursor_info.get("last_id")
-                if isinstance(last_id, str) and isinstance(last_key, str | int):
-                    # Find first item strictly after the cursor tuple. When
-                    # nothing compares after it (e.g. the tail was deleted
-                    # between pages), the page is empty — not page one again.
-                    needle: tuple[str | int, str] = (last_key, last_id)
-                    start_index = len(items_sorted)
-                    for idx, it in enumerate(items_sorted):
-                        tup = (self._primary_sort_value(it, sort), str(it.id))
-                        if self._tuple_cmp(tup, needle, order) > 0:
-                            start_index = idx
-                            break
+                raise ValidationError(
+                    "cursor was issued for a different sort; restart pagination without it"
+                )
+            last_key = cursor_info.get("last_sort_key")
+            last_id = cursor_info.get("last_id")
+            if (
+                not isinstance(last_id, str)
+                or isinstance(last_key, bool)
+                or not isinstance(last_key, str | int)
+            ):
+                raise ValidationError("cursor is not a valid pagination cursor")
+            # Find first item strictly after the cursor tuple. When nothing
+            # compares after it (e.g. the tail was deleted between pages), the
+            # page is empty — not page one again.
+            needle: tuple[str | int, str] = (last_key, last_id)
+            start_index = len(items_sorted)
+            for idx, it in enumerate(items_sorted):
+                tup = (self._primary_sort_value(it, sort), str(it.id))
+                if self._tuple_cmp(tup, needle, order) > 0:
+                    start_index = idx
+                    break
 
         end_index = min(len(items_sorted), start_index + max(0, limit))
         page = items_sorted[start_index:end_index]

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -61,6 +61,8 @@ from .models import (
     serialize_status_definition,
     today_utc_date,
     validate_attachment_meta,
+    validate_item_filter,
+    validate_sort,
 )
 from .rate_limit import RateLimiter
 from .repository import UNSET, InternalIndexes, Repository
@@ -254,9 +256,13 @@ def ws_guard(
 
 
 def _validate_bulk_ops(operations: Any) -> list[dict[str, Any]]:
+    # The command schema types `operations` as `object` so a wrong type answers
+    # `validation_error` here instead of an HA-core schema rejection that never
+    # reaches `ws_guard` — which makes this check the only one there is.
     if not isinstance(operations, list):
         raise ValidationError("operations must be a list")
     validated: list[dict[str, Any]] = []
+    seen_op_ids: set[str] = set()
     for _idx, op in enumerate(operations):
         if not isinstance(op, dict):
             raise ValidationError("each operation must be an object")
@@ -265,6 +271,14 @@ def _validate_bulk_ops(operations: Any) -> list[dict[str, Any]]:
         op_id = op.get("op_id")
         if not isinstance(op_id, str | int):
             raise ValidationError("op_id must be a string or integer")
+        # Results are keyed by op_id, so a repeat would leave the caller holding
+        # one verdict for two operations with no way to tell which it belongs
+        # to. Compared after `str()`, the same normalization the result map uses
+        # — so `1` and `"1"` are one id, not two.
+        normalized_op_id = str(op_id)
+        if normalized_op_id in seen_op_ids:
+            raise ValidationError(f"duplicate op_id in operations: {normalized_op_id}")
+        seen_op_ids.add(normalized_op_id)
         kind = op.get("kind")
         # Do not reject unknown kinds at schema-level; allow mixed results.
         if not isinstance(kind, str):
@@ -274,7 +288,7 @@ def _validate_bulk_ops(operations: Any) -> list[dict[str, Any]]:
             payload = {}
         if not isinstance(payload, dict):
             raise ValidationError("operation.payload must be an object")
-        validated.append({"op_id": str(op_id), "kind": str(kind), "payload": payload})
+        validated.append({"op_id": normalized_op_id, "kind": str(kind), "payload": payload})
     return validated
 
 
@@ -1150,9 +1164,9 @@ async def ws_unsubscribe(
     {
         vol.Required("type"): "haventory/item/create",
         # ItemCreate fields (name required; others optional)
-        vol.Required("name"): str,
+        vol.Required("name"): object,
         vol.Optional("description"): object,
-        vol.Optional("quantity"): int,
+        vol.Optional("quantity"): object,
         # Widened to object so the model layer rejects bad values as a typed
         # validation_error instead of HA core logging a schema ERROR.
         vol.Optional("status"): object,
@@ -1200,7 +1214,7 @@ async def ws_item_get(
         # ItemUpdate fields (all optional)
         vol.Optional("name"): object,
         vol.Optional("description"): object,
-        vol.Optional("quantity"): int,
+        vol.Optional("quantity"): object,
         vol.Optional("status"): object,
         vol.Optional("checked_out"): bool,
         vol.Optional("due_date"): vol.Any(str, None),
@@ -1271,7 +1285,7 @@ async def ws_item_delete(
     {
         vol.Required("type"): "haventory/item/adjust_quantity",
         vol.Required("item_id"): object,
-        vol.Required("delta"): int,
+        vol.Required("delta"): object,
         vol.Optional("expected_version"): int,
     }
 )
@@ -1280,8 +1294,10 @@ async def ws_item_delete(
 async def ws_item_adjust_quantity(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
+    # The schema types `delta` as `object`, so the integer check lives here and
+    # answers `validation_error` rather than an HA-core schema rejection.
     item = _repo(hass).adjust_quantity(
-        msg["item_id"], msg["delta"], expected_version=msg.get("expected_version")
+        msg["item_id"], _payload_int(msg, "delta"), expected_version=msg.get("expected_version")
     )
     serialized = _serialize_item(hass, item)
     await _persist_repo(hass)
@@ -1294,7 +1310,7 @@ async def ws_item_adjust_quantity(
     {
         vol.Required("type"): "haventory/item/set_quantity",
         vol.Required("item_id"): object,
-        vol.Required("quantity"): int,
+        vol.Required("quantity"): object,
         vol.Optional("expected_version"): int,
     }
 )
@@ -1303,9 +1319,12 @@ async def ws_item_adjust_quantity(
 async def ws_item_set_quantity(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    qty = msg.get("quantity")
-    # Validate upfront so schema errors surface as validation_error even when id is bad
-    if not isinstance(qty, int) or qty < 0:
+    # Validated here, not in the schema: `quantity` is typed `object` so a wrong
+    # type answers `validation_error` instead of an HA-core schema rejection,
+    # and validating upfront keeps the answer about the quantity even when the
+    # item id is also bad.
+    qty = _payload_int(msg, "quantity")
+    if qty < 0:
         raise ValidationError("quantity must be an integer >= 0")
     item = _repo(hass).set_quantity(
         msg["item_id"], qty, expected_version=msg.get("expected_version")
@@ -1698,7 +1717,7 @@ async def ws_item_move(
 
 
 @websocket_api.websocket_command(
-    {vol.Required("type"): "haventory/items/bulk", vol.Required("operations"): list}
+    {vol.Required("type"): "haventory/items/bulk", vol.Required("operations"): object}
 )
 @websocket_api.async_response
 @ws_guard("items_bulk", ())
@@ -1817,10 +1836,10 @@ async def ws_items_bulk(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "haventory/item/list",
-        vol.Optional("filter"): dict,
-        vol.Optional("sort"): dict,
-        vol.Optional("limit"): int,
-        vol.Optional("cursor"): str,
+        vol.Optional("filter"): object,
+        vol.Optional("sort"): object,
+        vol.Optional("limit"): object,
+        vol.Optional("cursor"): object,
     }
 )
 @websocket_api.async_response
@@ -1828,11 +1847,18 @@ async def ws_items_bulk(
 async def ws_item_list(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    # Accept filter/sort/limit/cursor passthrough
     flt = msg.get("filter")
     sort = msg.get("sort")
     limit = msg.get("limit")
     cursor = msg.get("cursor")
+    validate_item_filter(flt)
+    validate_sort(sort)
+    if limit is not None and (isinstance(limit, bool) or not isinstance(limit, int)):
+        raise ValidationError("limit must be an integer")
+    if cursor is not None and (not isinstance(cursor, str) or not cursor):
+        # An empty cursor is a client bug rather than "start from the
+        # beginning" — omitting the key is how a caller asks for page one.
+        raise ValidationError("cursor must be a non-empty string")
     page = _repo(hass).list_items(flt=flt, sort=sort, limit=limit, cursor=cursor)
     result = {
         "items": [_serialize_item(hass, it) for it in page["items"]],
@@ -1850,7 +1876,7 @@ async def ws_item_list(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "haventory/location/create",
-        vol.Required("name"): str,
+        vol.Required("name"): object,
         vol.Optional("parent_id"): object,
         vol.Optional("area_id"): object,
     }
@@ -1893,7 +1919,7 @@ async def ws_location_get(
         vol.Required("type"): "haventory/location/update",
         vol.Required("location_id"): object,
         vol.Optional("new_parent_id"): object,
-        vol.Optional("name"): str,
+        vol.Optional("name"): object,
         vol.Optional("area_id"): object,
     }
 )
@@ -1965,7 +1991,7 @@ async def ws_location_list(
 
 
 @websocket_api.websocket_command(
-    {vol.Required("type"): "haventory/location/tree", vol.Optional("filter"): dict}
+    {vol.Required("type"): "haventory/location/tree", vol.Optional("filter"): object}
 )
 @websocket_api.async_response
 @ws_guard("location_tree", ())
@@ -1982,6 +2008,7 @@ async def ws_location_tree(
     # a sidebar can read "4 / 37" instead of a total that never moves. Counted
     # once here and rolled up, rather than one query per location.
     item_filter = msg.get("filter")
+    validate_item_filter(item_filter)
     matching_direct = (
         repo.count_matching_by_location(item_filter) if item_filter is not None else None
     )
@@ -2245,16 +2272,15 @@ async def ws_areas_list(
 
 
 @websocket_api.websocket_command(
-    {vol.Required("type"): "haventory/export", vol.Optional("filter"): dict}
+    {vol.Required("type"): "haventory/export", vol.Optional("filter"): object}
 )
 @websocket_api.async_response
 @ws_guard("export", ())
 async def ws_export(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    if "filter" in msg and not isinstance(msg.get("filter"), dict):
-        raise ValidationError("filter must be an object")
     item_filter = msg.get("filter") if "filter" in msg else None
+    validate_item_filter(item_filter)
     document = import_export.build_export_document(
         _repo(hass),
         item_filter=item_filter,

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -11,7 +11,7 @@ when the milestone closes.
 
 ## H1 — #197 the widened frames stop HA core logging the client payload at ERROR
 
-**Branch / PR**: `claude/v0-5-0-w1a-input-hardening` / #TBD
+**Branch / PR**: `claude/v0-5-0-w1a-input-hardening` / #415
 **Why this needs a real HA**: the log line comes from Home Assistant core, not from this
 integration. `homeassistant.components.websocket_api.http.connection` logs a schema
 rejection at ERROR *with the client's payload in the message* — the whole point of typing

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -1,0 +1,60 @@
+# V0.5.0 — handovers to a local session
+
+Cloud sessions have no Home Assistant. Each section below is one thing a V0.5.0 PR could
+not verify offline, written to be run in front of the dev Docker instance the
+`run-haventory` and `test-haventory` skills drive.
+
+Appended in session order, per `dev/V0_5_0_implementation.md` §5. Deleted with that plan
+when the milestone closes.
+
+---
+
+## H1 — #197 the widened frames stop HA core logging the client payload at ERROR
+
+**Branch / PR**: `claude/v0-5-0-w1a-input-hardening` / #TBD
+**Why this needs a real HA**: the log line comes from Home Assistant core, not from this
+integration. `homeassistant.components.websocket_api.http.connection` logs a schema
+rejection at ERROR *with the client's payload in the message* — the whole point of typing
+`name` / `quantity` / `delta` / `operations` / `filter` / `sort` / `limit` / `cursor` as
+`object` is that they no longer take that path. The in-process suite proves the frames now
+answer `validation_error`; only a running instance shows what its log does about it.
+
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+
+Seed one item so the batch case has something to address:
+
+    uv run python scripts/create_test_items.py --count 1
+
+### Steps
+
+1. Start following the log: `docker logs -f home-assistant 2>&1 | grep -i websocket_api`.
+2. Send each of these over the WebSocket (`uv run python scripts/ws_probe.py` drives it):
+   - `{"type": "haventory/item/create", "name": "Hammer", "quantity": 1.5}`
+   - `{"type": "haventory/item/create", "name": 42}`
+   - `{"type": "haventory/item/adjust_quantity", "item_id": "<id>", "delta": "two"}`
+   - `{"type": "haventory/items/bulk", "operations": "oops"}`
+   - `{"type": "haventory/item/list", "filter": {"query": "hammer"}}`
+   - `{"type": "haventory/item/list", "limit": 2, "cursor": ""}`
+3. For contrast, send one frame that is *still* schema-typed and must still be refused by
+   core: `{"type": "haventory/item/create", "name": "Hammer", "tags": "chisel"}`.
+
+### What "pass" looks like
+
+- Every frame in step 2 answers `{"success": false, "error": {"code": "validation_error"}}`,
+  and the message names the field.
+- **No `ERROR` line from `homeassistant.components.websocket_api.http.connection`** for any
+  of them. Each appears once at WARNING from `custom_components.haventory.ws`, with no
+  traceback and with the payload absent from the message.
+- The frame in step 3 still answers `invalid_format` and still logs at ERROR from core —
+  that contrast is what shows the widening is what changed the behaviour, rather than a
+  logging config difference.
+- The inventory is unchanged afterwards: `haventory/stats` reports the same `items_total`
+  it did before step 2.
+
+### What to send back
+
+- The grepped log excerpt covering steps 2 and 3, and the six error envelopes.
+- Paste the result as a comment on #197 and reply on the PR thread.

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -38,6 +38,8 @@ Guarantees (every `haventory/*` command is wrapped by the same guard):
 
 Transport-level errors produced by Home Assistant itself (before a handler runs) are outside this taxonomy and can also be observed by clients: `invalid_format` (request failed the command's voluptuous schema) and `unknown_command` (integration not loaded or unknown `type`).
 
+Several fields are deliberately typed `object` in their command schema rather than concretely, so that a wrong type is answered by the handler as `validation_error` instead of by Home Assistant as `invalid_format`. The difference matters to an operator: core refuses the frame before the guard runs and logs the client's payload at ERROR, while the guard names the field at WARNING with no traceback. The fields treated this way are the ones a client most plausibly gets wrong: `name` (`item/create`, `location/create`, `location/update`), `quantity` (`item/create`, `item/update`, `item/set_quantity`), `delta` (`item/adjust_quantity`), `operations` (`items/bulk`), and `filter` / `sort` / `limit` / `cursor` (`item/list`, `location/tree`, `export`). Every other field keeps its concrete schema type, and a wrong type there is still `invalid_format`.
+
 ### Logging
 
 Every rejection the API boundary answers is also logged once, with the same structured context the envelope carries. The level says who is expected to act on it, not how unusual it is:
@@ -243,11 +245,14 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - Supported `kind` values: `item_update`, `item_delete`, `item_move`, `item_adjust_quantity`, `item_set_quantity`, `item_check_out`, `item_check_in`, `item_add_tags`, `item_remove_tags`, `item_update_custom_fields`, `item_set_low_stock_threshold`.
   - Result: `{results: { [op_id: string]: {success: true, result: <Item>} | {success: false, error: {code, message, context}} }}`; if any success, a single `stats/counts` event is emitted.
   - A failed op fails only itself; the batch continues and reports it under its `op_id`. A failed *write*, by contrast, fails the whole command with `storage_error` and returns no `results` map at all — the batch is one write.
+  - **`op_id`s must be unique within one batch**, and are compared as strings — `1` and `"1"` are the same id. A repeat rejects the whole command with `validation_error` and runs nothing, because the results map is keyed by `op_id` and could only report one verdict for the two operations.
 
 - `haventory/item/list`
   - Payload: `{filter?: <ItemFilter>, sort?: <Sort>, limit?: number, cursor?: string}`
   - Result: `{items: <Item[]>, next_cursor: string|null, total: number}`
   - `total` is the number of items matching the filter across **all** pages (not the page size), recomputed per request — so "Showing N of `total`" is renderable on every page.
+  - **Unknown `filter` and `sort` keys are refused** with `validation_error` naming the offending key, rather than dropped. A dropped key returns the whole inventory labelled as a filtered result, which no caller can tell from a filter that legitimately matched everything. The accepted key set is exactly `<ItemFilter>`'s; `sort` accepts `field` and `order` only.
+  - **A `cursor` that cannot be honoured is an error, never a silent restart.** `validation_error` is answered for a cursor that is empty, undecodable, longer than 2048 characters, missing its `last_id` / `last_sort_key`, or minted under a different `sort` than the request carries. Answering any of those with page one makes a caller paging through the inventory loop over the first page indefinitely without being told. To restart pagination, omit `cursor` — do not send `""`.
 
 ### Locations
 
@@ -320,7 +325,7 @@ except `status/delete` with a reassign target.
   - Result: `<Location[]>` (flat list)
 
 - `haventory/location/tree`
-  - Payload: `{filter?: <ItemFilter>}`
+  - Payload: `{filter?: <ItemFilter>}` (a non-object `filter`, or one carrying an unknown key, → `validation_error`).
   - Result: Array of tree nodes: `{id, name, parent_id, path: <LocationPath>, direct_item_count, subtree_item_count, children: <Node[]>}`
   - `direct_item_count` counts items whose `location_id` is exactly that node; `subtree_item_count` counts items in the node or any descendant (`subtree_item_count >= direct_item_count`). Counts change on item create/delete/move — clients showing them should refresh the tree on item events (or on `stats/counts`), not only on location events.
   - With a `filter`, each node additionally carries `matching_direct_count` and `matching_subtree_count` — the same two counts restricted to items the filter keeps — so a location sidebar can show "4 / 37" rather than a total that ignores the active filter. The unfiltered counts are still returned unchanged. Both keys are absent when no `filter` is sent. A filter that names `location_id` is honoured like any other, so a sidebar wanting per-location counts should leave the location dimension out of the filter it sends.
@@ -341,7 +346,7 @@ and locations; a round-trip (export → import into an empty instance) reproduce
 data. See `data_shapes.md` for the full document, preview, and summary shapes.
 
 - `haventory/export`
-  - Payload: `{filter?: <ItemFilter>}` (a non-object `filter` → `validation_error`).
+  - Payload: `{filter?: <ItemFilter>}` (a non-object `filter`, or one carrying an unknown key, → `validation_error`).
   - Result: `<ExportDocument>`. With no filter this is a full backup; with a filter,
     only matching items are exported together with the locations on each item's
     ancestry (so the document stays referentially self-consistent).

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -231,11 +231,25 @@ counts items at the node or any descendant (so it is always >= the direct count)
   - `{ field: "updated_at"|"created_at"|"name"|"quantity"|"due_date"|"inspection_date", order: "asc"|"desc" }`
   - `due_date` / `inspection_date`: items without a date sort last in both orders; ties break by id asc.
 
+**Unknown keys are rejected**, in a filter and in a sort alike: the reply is `validation_error`
+naming the offending key. A dropped key is worse than a refused one — a filter that lost its
+only predicate returns the whole inventory, and nothing in the reply says the filter did not
+apply. `sort` accepts `field` and `order` and nothing else. The accepted filter key set is
+exactly the list above, and it is read off the filter type itself, so a filter key added later
+is accepted the moment it is declared.
+
 ### Pagination
 
 - `item/list` returns `{items: <Item[]>, next_cursor: string|null, total: number}`.
 - `total` is the count of items matching the filter across all pages, independent of `limit`/`cursor`.
 - `cursor` is an opaque base64url-encoded JSON with last tuple and sort metadata; pass it back unchanged.
+- A cursor that cannot be honoured is `validation_error`, never a silent restart at page one:
+  empty, undecodable, longer than 2048 characters, missing `last_id` / `last_sort_key`, or
+  minted under a different `sort` than the request carries. Restart pagination by omitting
+  `cursor` — sending `""` is refused, because a caller who meant page one had no reason to
+  send the key at all.
+- Changing the sort means dropping the cursor. A cursor addresses a position in one specific
+  ordering, and honouring it against another would silently return a page from neither.
 
 ### Stats
 
@@ -368,3 +382,31 @@ Common envelope inside HA WS event wrapper:
 - Dates use `YYYY-MM-DD` and are validated for real calendar dates.
 - `name` trimmed; max length 120 for items and locations.
 - `custom_fields` keys must be non-empty strings; values must be scalars.
+
+#### Input caps
+
+Every free-text and collection field is bounded. The store is one JSON document rewritten in
+full on every mutation, so an unbounded field is a cost every later write keeps paying. Over
+a cap is `validation_error`, at a cap is accepted:
+
+| Field | Cap |
+|---|---|
+| `name` (item and location) | 120 characters |
+| `description` | 4000 characters |
+| `category` | 120 characters |
+| each entry of `tags` | 64 characters |
+| `tags` | 50 entries, counted after normalization |
+| `custom_fields` | 50 keys |
+| each `custom_fields` key | 64 characters |
+| each string `custom_fields` value | 1000 characters |
+
+The caps refuse *growth*, not every edit: an item that predates them — one loaded from a
+store written by an earlier release — can still be edited, including by the edit that removes
+the excess. What it cannot do is add to a collection already over its cap.
+
+The same caps, the 120-character name limit and the `due_date` ⇔ `checked_out` invariant are
+applied to `import/preview` as well, so a document cannot introduce an entity the WebSocket
+API would refuse. They are reported per field in `report.errors`, as a refused import rather
+than as dropped rows. `Repository.load_state` deliberately does **not** re-validate: a store
+written before the caps existed is legal data this integration itself wrote, and refusing it
+would turn an upgrade into a backend that will not start.

--- a/tests/integration/test_ws_items.py
+++ b/tests/integration/test_ws_items.py
@@ -136,3 +136,107 @@ async def test_ws_item_get_unknown_returns_error(hass: HomeAssistant, hass_ws_cl
     resp = await client.receive_json()
     assert resp["success"] is False, resp
     assert "error" in resp
+
+
+async def test_widened_frames_answer_validation_error(hass: HomeAssistant, hass_ws_client) -> None:
+    """The fields typed ``object`` reach the handler and answer through the guard.
+
+    Home Assistant refuses a schema mismatch before ``ws_guard`` runs, so a
+    frame the schema rejects can only ever answer ``invalid_format``. This is
+    the mode that applies the real voluptuous schemas, so it is the one that can
+    tell the two answers apart.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    frames = [
+        {"type": "haventory/item/create", "name": "Hammer", "quantity": 1.5},
+        {"type": "haventory/item/create", "name": 42},
+        {"type": "haventory/items/bulk", "operations": "oops"},
+    ]
+    for msg_id, frame in enumerate(frames, start=1):
+        await client.send_json({"id": msg_id, **frame})
+        resp = await client.receive_json()
+        assert resp["success"] is False, resp
+        assert resp["error"]["code"] == "validation_error", resp
+
+    # Nothing was created along the way.
+    await client.send_json({"id": len(frames) + 1, "type": "haventory/item/list"})
+    listed = await client.receive_json()
+    assert listed["result"]["items"] == []
+
+
+async def test_item_list_input_hardening_over_the_real_schema(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """Unknown filter keys, unknown sort fields and bad cursors are refused."""
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})
+    assert (await client.receive_json())["success"] is True
+
+    refused = [
+        {"type": "haventory/item/list", "filter": {"query": "Hammer"}},
+        {"type": "haventory/item/list", "sort": {"field": "colour", "order": "asc"}},
+        {"type": "haventory/item/list", "limit": 1, "cursor": ""},
+        {"type": "haventory/item/list", "limit": 1, "cursor": "garbage"},
+    ]
+    for msg_id, frame in enumerate(refused, start=2):
+        await client.send_json({"id": msg_id, **frame})
+        resp = await client.receive_json()
+        assert resp["success"] is False, resp
+        assert resp["error"]["code"] == "validation_error", resp
+
+    # A known filter and a real cursor still page.
+    await client.send_json(
+        {
+            "id": 100,
+            "type": "haventory/item/list",
+            "filter": {"q": "Hammer"},
+            "sort": {"field": "name", "order": "asc"},
+            "limit": 1,
+        }
+    )
+    listed = await client.receive_json()
+    assert listed["success"] is True, listed
+    assert [i["name"] for i in listed["result"]["items"]] == ["Hammer"]
+
+
+async def test_duplicate_op_ids_reject_the_batch(hass: HomeAssistant, hass_ws_client) -> None:
+    """Results are keyed by op_id, so a repeat has to fail the whole command."""
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})
+    created = await client.receive_json()
+    item_id = created["result"]["id"]
+
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "haventory/items/bulk",
+            "operations": [
+                {
+                    "op_id": "dup",
+                    "kind": "item_set_quantity",
+                    "payload": {"item_id": item_id, "quantity": 2},
+                },
+                {
+                    "op_id": "dup",
+                    "kind": "item_set_quantity",
+                    "payload": {"item_id": item_id, "quantity": 3},
+                },
+            ],
+        }
+    )
+    resp = await client.receive_json()
+    assert resp["success"] is False, resp
+    assert resp["error"]["code"] == "validation_error", resp
+
+    await client.send_json({"id": 3, "type": "haventory/item/get", "item_id": item_id})
+    fetched = await client.receive_json()
+    assert fetched["result"]["quantity"] == 1

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -22,7 +22,17 @@ from custom_components.haventory import import_export as ie
 from custom_components.haventory import media
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import StorageError, ValidationError
-from custom_components.haventory.models import validate_attachment_meta
+from custom_components.haventory.models import (
+    CATEGORY_MAX_LENGTH,
+    CUSTOM_FIELD_KEY_MAX_LENGTH,
+    CUSTOM_FIELD_VALUE_MAX_LENGTH,
+    CUSTOM_FIELDS_MAX_KEYS,
+    DESCRIPTION_MAX_LENGTH,
+    NAME_MAX_LENGTH,
+    TAG_MAX_LENGTH,
+    TAGS_MAX_COUNT,
+    validate_attachment_meta,
+)
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
 from custom_components.haventory.ws import setup as ws_setup
@@ -125,17 +135,29 @@ async def test_ws_export_returns_document() -> None:
 
 @pytest.mark.asyncio
 async def test_ws_export_invalid_filter_field() -> None:
-    """Invalid-field case: a non-object filter never reaches the handler.
+    """Invalid-field case: a non-object filter is the handler's to refuse.
 
-    ``haventory/export`` declares ``filter`` as a dict, so Home Assistant
-    refuses the frame with the transport-level ``invalid_format`` before
-    dispatch — not with the handler's own ``validation_error``.
+    ``haventory/export`` declares ``filter`` as ``object`` so the frame reaches
+    the handler and answers ``validation_error``, rather than being refused by
+    Home Assistant with a transport-level ``invalid_format`` that never passes
+    through the guard.
     """
 
     hass = _new_hass()
     res = await _send(hass, 1, "haventory/export", filter="not-an-object")
     assert res["success"] is False, res
-    assert res["error"]["code"] == "invalid_format"
+    assert res["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_ws_export_unknown_filter_key_is_named() -> None:
+    """A typo'd filter key is refused rather than dropped, and named."""
+
+    hass = _new_hass()
+    res = await _send(hass, 1, "haventory/export", filter={"search": "hammer"})
+    assert res["success"] is False, res
+    assert res["error"]["code"] == "validation_error"
+    assert "search" in res["error"]["message"]
 
 
 # -----------------------------
@@ -641,3 +663,149 @@ async def test_import_merge_keeps_a_file_the_document_does_not_mention() -> None
     assert res["success"] is True, res
     assert [str(a.id) for a in repo.get_item(item.id).attachments] == [str(meta.id)]
     assert path.is_file()
+
+
+# -----------------------------
+# Import-side parity with the write path
+# -----------------------------
+
+
+def _item_doc(**overrides: object) -> dict:
+    doc = {
+        "id": "22222222-2222-4222-8222-222222222222",
+        "name": "Ghost",
+        "quantity": 1,
+        "tags": [],
+        "custom_fields": {},
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _envelope(item: dict) -> dict:
+    return {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [item],
+        "locations": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("overrides", "path"),
+    [
+        ({"name": "n" * (NAME_MAX_LENGTH + 1)}, "items[0].name"),
+        ({"description": "d" * (DESCRIPTION_MAX_LENGTH + 1)}, "items[0].description"),
+        ({"category": "c" * (CATEGORY_MAX_LENGTH + 1)}, "items[0].category"),
+        ({"tags": ["t" * (TAG_MAX_LENGTH + 1)]}, "items[0].tags"),
+        ({"tags": [f"t{i}" for i in range(TAGS_MAX_COUNT + 1)]}, "items[0].tags"),
+        (
+            {"custom_fields": {f"k{i}": i for i in range(CUSTOM_FIELDS_MAX_KEYS + 1)}},
+            "items[0].custom_fields",
+        ),
+        ({"custom_fields": {"k" * (CUSTOM_FIELD_KEY_MAX_LENGTH + 1): 1}}, "items[0].custom_fields"),
+        (
+            {"custom_fields": {"k": "v" * (CUSTOM_FIELD_VALUE_MAX_LENGTH + 1)}},
+            "items[0].custom_fields.k",
+        ),
+        ({"due_date": "2026-01-01"}, "items[0].due_date"),
+    ],
+)
+def test_preview_holds_an_imported_item_to_the_write_path_rules(overrides: dict, path: str) -> None:
+    """A document is the one way an entity the WS API would refuse could arrive.
+
+    Reported per field rather than dropped, because ``plan_import`` reports to
+    the caller — a refused import, not lost rows.
+    """
+
+    repo = Repository()
+    report, target = ie.plan_import(
+        repo, _envelope(_item_doc(**overrides)), current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    assert report["valid"] is False
+    assert target is None
+    assert path in {e["path"] for e in report["errors"]}
+
+
+def test_preview_reports_a_long_location_name() -> None:
+    repo = Repository()
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [],
+        "locations": [
+            {
+                "id": "33333333-3333-4333-8333-333333333333",
+                "name": "l" * (NAME_MAX_LENGTH + 1),
+                "parent_id": None,
+            }
+        ],
+    }
+    report, target = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert report["valid"] is False
+    assert target is None
+    assert "locations[0].name" in {e["path"] for e in report["errors"]}
+
+
+def test_preview_accepts_a_due_date_on_a_checked_out_item() -> None:
+    """The invariant is due_date ⇔ checked_out, not "no due dates"."""
+
+    repo = Repository()
+    report, target = ie.plan_import(
+        repo,
+        _envelope(_item_doc(due_date="2026-01-01", checked_out=True)),
+        current_schema_version=CURRENT_SCHEMA_VERSION,
+    )
+
+    assert report["valid"] is True, report["errors"]
+    assert target is not None
+
+
+def test_preview_accepts_an_item_at_every_cap() -> None:
+    """The regression that matters: nothing legitimate got refused."""
+
+    repo = Repository()
+    report, target = ie.plan_import(
+        repo,
+        _envelope(
+            _item_doc(
+                name="n" * NAME_MAX_LENGTH,
+                description="d" * DESCRIPTION_MAX_LENGTH,
+                category="c" * CATEGORY_MAX_LENGTH,
+                tags=["t" * TAG_MAX_LENGTH],
+                custom_fields={
+                    "k" * CUSTOM_FIELD_KEY_MAX_LENGTH: "v" * CUSTOM_FIELD_VALUE_MAX_LENGTH
+                },
+            )
+        ),
+        current_schema_version=CURRENT_SCHEMA_VERSION,
+    )
+
+    assert report["valid"] is True, report["errors"]
+    assert target is not None
+
+
+def test_a_clean_round_trip_still_imports() -> None:
+    """An export of a real inventory passes every new import-side check."""
+
+    repo = Repository()
+    loc = repo.create_location(name="Garage")
+    repo.create_item(
+        {
+            "name": "Hammer",
+            "description": "Claw hammer",
+            "category": "tools",
+            "tags": ["heavy", "metal"],
+            "custom_fields": {"weight": "1.2kg"},
+            "location_id": str(loc.id),
+        }
+    )
+
+    report, target = ie.plan_import(
+        repo, _doc_from(repo), current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    assert report["valid"] is True, report["errors"]
+    assert target is not None

--- a/tests/test_item_input_validation_offline.py
+++ b/tests/test_item_input_validation_offline.py
@@ -15,7 +15,17 @@ from typing import Any
 import pytest
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import ValidationError
-from custom_components.haventory.models import ItemCreate, ItemUpdate
+from custom_components.haventory.models import (
+    CATEGORY_MAX_LENGTH,
+    CUSTOM_FIELD_KEY_MAX_LENGTH,
+    CUSTOM_FIELD_VALUE_MAX_LENGTH,
+    CUSTOM_FIELDS_MAX_KEYS,
+    DESCRIPTION_MAX_LENGTH,
+    TAG_MAX_LENGTH,
+    TAGS_MAX_COUNT,
+    ItemCreate,
+    ItemUpdate,
+)
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
@@ -143,3 +153,115 @@ async def test_ws_set_quantity_bool_is_validation_error() -> None:
     got = await _send(hass, 4, "haventory/item/get", item_id=item_id)
     assert got["result"]["quantity"] == 1
     assert got["result"]["quantity"] is not True
+
+
+# -----------------------------
+# Size caps (one case at each boundary, one over)
+# -----------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "at_cap", "over_cap"),
+    [
+        (
+            "description",
+            {"description": "d" * DESCRIPTION_MAX_LENGTH},
+            {"description": "d" * (DESCRIPTION_MAX_LENGTH + 1)},
+        ),
+        (
+            "category",
+            {"category": "c" * CATEGORY_MAX_LENGTH},
+            {"category": "c" * (CATEGORY_MAX_LENGTH + 1)},
+        ),
+        (
+            "tag length",
+            {"tags": ["t" * TAG_MAX_LENGTH]},
+            {"tags": ["t" * (TAG_MAX_LENGTH + 1)]},
+        ),
+        (
+            "tag count",
+            {"tags": [f"t{i}" for i in range(TAGS_MAX_COUNT)]},
+            {"tags": [f"t{i}" for i in range(TAGS_MAX_COUNT + 1)]},
+        ),
+        (
+            "custom field count",
+            {"custom_fields": {f"k{i}": i for i in range(CUSTOM_FIELDS_MAX_KEYS)}},
+            {"custom_fields": {f"k{i}": i for i in range(CUSTOM_FIELDS_MAX_KEYS + 1)}},
+        ),
+        (
+            "custom field key length",
+            {"custom_fields": {"k" * CUSTOM_FIELD_KEY_MAX_LENGTH: 1}},
+            {"custom_fields": {"k" * (CUSTOM_FIELD_KEY_MAX_LENGTH + 1): 1}},
+        ),
+        (
+            "custom field value length",
+            {"custom_fields": {"k": "v" * CUSTOM_FIELD_VALUE_MAX_LENGTH}},
+            {"custom_fields": {"k": "v" * (CUSTOM_FIELD_VALUE_MAX_LENGTH + 1)}},
+        ),
+    ],
+)
+def test_create_accepts_at_the_cap_and_refuses_over_it(
+    field: str, at_cap: dict[str, Any], over_cap: dict[str, Any]
+) -> None:
+    repo = Repository()
+    repo.create_item(ItemCreate(name="Widget", **at_cap))  # type: ignore[typeddict-item]
+    assert repo.get_counts()["items_total"] == 1, field
+
+    with pytest.raises(ValidationError):
+        repo.create_item(ItemCreate(name="Widget", **over_cap))  # type: ignore[typeddict-item]
+    # No phantom left behind: the item at the cap is still the only one.
+    assert repo.get_counts()["items_total"] == 1, field
+
+
+@pytest.mark.asyncio
+async def test_ws_create_over_a_cap_is_validation_error_no_phantom() -> None:
+    hass = _make_hass()
+    res = await _send(
+        hass,
+        1,
+        "haventory/item/create",
+        name="Widget",
+        description="d" * (DESCRIPTION_MAX_LENGTH + 1),
+    )
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    listed = await _send(hass, 2, "haventory/item/list")
+    assert listed["result"]["items"] == []
+
+
+def test_an_item_over_a_cap_can_still_be_edited_down() -> None:
+    """The caps refuse growth, not every edit on an item that predates them.
+
+    An item written before the caps existed reaches the repository through
+    ``load_state``, which does not re-validate. The edit that removes the excess
+    must not be refused along with the edit that would add to it.
+    """
+
+    repo = Repository()
+    item = repo.create_item(ItemCreate(name="Widget"))
+    # Reach past the write path the way a pre-cap store would have.
+    stored = repo._items_by_id[str(item.id)]
+    stored.tags = [f"t{i}" for i in range(TAGS_MAX_COUNT + 10)]
+    stored.custom_fields = {f"k{i}": i for i in range(CUSTOM_FIELDS_MAX_KEYS + 10)}
+
+    kept_tags = 5
+    unset_keys = 20
+
+    trimmed = repo.update_item(item.id, ItemUpdate(tags=stored.tags[:kept_tags]))
+    assert len(trimmed.tags) == kept_tags
+
+    unset = repo.update_item(
+        item.id, ItemUpdate(custom_fields_unset=[f"k{i}" for i in range(unset_keys)])
+    )
+    assert len(unset.custom_fields) == CUSTOM_FIELDS_MAX_KEYS + 10 - unset_keys
+
+
+def test_an_item_over_the_custom_field_cap_may_not_grow_further() -> None:
+    repo = Repository()
+    item = repo.create_item(ItemCreate(name="Widget"))
+    repo._items_by_id[str(item.id)].custom_fields = {
+        f"k{i}": i for i in range(CUSTOM_FIELDS_MAX_KEYS + 1)
+    }
+
+    with pytest.raises(ValidationError):
+        repo.update_item(item.id, ItemUpdate(custom_fields_set={"one_more": 1}))

--- a/tests/test_models_filter_sort_offline.py
+++ b/tests/test_models_filter_sort_offline.py
@@ -9,6 +9,7 @@ import pytest
 from custom_components.haventory.exceptions import ValidationError
 from custom_components.haventory.models import (
     EMPTY_LOCATION_PATH,
+    SORT_FIELDS,
     ItemFilter,
     Location,
     Sort,
@@ -17,6 +18,8 @@ from custom_components.haventory.models import (
     filter_items,
     new_uuid4_str,
     sort_items,
+    validate_item_filter,
+    validate_sort,
 )
 
 
@@ -456,3 +459,72 @@ async def test_filter_then_sort_pipeline() -> None:
     filt = ItemFilter(tags_any=["x"])
     out = sort_items(filter_items([a, b, c], filt), Sort(field="name", order="asc"))
     assert [x.name for x in out] == ["B", "C"]
+
+
+# -----------------------------
+# Unknown filter and sort keys
+# -----------------------------
+
+
+def test_validate_item_filter_accepts_every_declared_key() -> None:
+    """Keyed off the TypedDict, so a new filter key needs no second list.
+
+    Asserted explicitly because that coupling is what lets a later filter key be
+    added without touching the validator — incidental agreement would not.
+    """
+
+    every_key: dict[str, object] = dict.fromkeys(ItemFilter.__annotations__, None)
+    validate_item_filter(every_key)
+
+
+@pytest.mark.parametrize("typo", ["search", "query", "location", "tags"])
+def test_validate_item_filter_names_the_unknown_key(typo: str) -> None:
+    with pytest.raises(ValidationError, match=typo):
+        validate_item_filter({typo: "hammer"})
+
+
+def test_validate_item_filter_reports_every_unknown_key() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        validate_item_filter({"search": "x", "sort_by": "name", "q": "ok"})
+    message = str(excinfo.value)
+    assert "search" in message
+    assert "sort_by" in message
+    assert "q" not in message
+
+
+@pytest.mark.parametrize("bad", ["not-an-object", 5, ["q"]])
+def test_validate_item_filter_rejects_a_non_object(bad: object) -> None:
+    with pytest.raises(ValidationError, match=r"filter must be an object"):
+        validate_item_filter(bad)
+
+
+def test_validate_item_filter_passes_none_through() -> None:
+    validate_item_filter(None)
+
+
+def test_validate_sort_accepts_the_vocabulary_and_rejects_the_rest() -> None:
+    for field_name in SORT_FIELDS:
+        validate_sort({"field": field_name, "order": "asc"})
+        validate_sort({"field": field_name, "order": "desc"})
+
+    with pytest.raises(ValidationError, match=r"sort\.field"):
+        validate_sort({"field": "colour", "order": "asc"})
+    with pytest.raises(ValidationError, match=r"sort\.order"):
+        validate_sort({"field": "name", "order": "sideways"})
+    with pytest.raises(ValidationError, match="by"):
+        validate_sort({"by": "name", "order": "asc"})
+    with pytest.raises(ValidationError, match=r"sort must be an object"):
+        validate_sort("name")
+
+
+def test_validate_sort_agrees_with_sort_items() -> None:
+    """The two must not drift: both read the same allowed-field set."""
+
+    for field_name in SORT_FIELDS:
+        sort_items([], Sort(field=field_name, order="asc"))  # type: ignore[typeddict-item]
+
+    with pytest.raises(ValidationError):
+        sort_items(
+            [create_item_from_create({"name": "Widget"})],
+            {"field": "colour", "order": "asc"},  # type: ignore[typeddict-item]
+        )

--- a/tests/test_repository_items_offline.py
+++ b/tests/test_repository_items_offline.py
@@ -6,13 +6,14 @@ and derived counts (checked_out and low_stock).
 
 from __future__ import annotations
 
+import base64
 import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from custom_components.haventory.exceptions import ConflictError, NotFoundError
+from custom_components.haventory.exceptions import ConflictError, NotFoundError, ValidationError
 from custom_components.haventory.models import ItemCreate, ItemFilter, ItemUpdate, Sort
-from custom_components.haventory.repository import Repository
+from custom_components.haventory.repository import CURSOR_MAX_LENGTH, Repository
 
 TOTAL_ITEMS = 3
 INITIAL_LOW_STOCK_COUNT = 1
@@ -503,3 +504,68 @@ async def test_list_items_total_counts_all_matches() -> None:
     none = repo.list_items(flt=ItemFilter(q="zzz-not-there"))
     assert none["total"] == 0
     assert none["items"] == []
+
+
+# -----------------------------
+# Malformed cursors
+# -----------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_cursor",
+    [
+        "garbage",
+        base64.urlsafe_b64encode(b"not json at all").decode("ascii"),
+        base64.urlsafe_b64encode(b'["a list", "not an object"]').decode("ascii"),
+        base64.urlsafe_b64encode(b'{"sort": {"field": "name", "order": "asc"}}').decode("ascii"),
+        "A" * (CURSOR_MAX_LENGTH + 1),
+    ],
+)
+def test_a_malformed_cursor_raises_rather_than_returning_page_one(bad_cursor: str) -> None:
+    """The footgun this closes: an unreadable cursor answered with a full page.
+
+    A caller paging through the inventory would loop over page one forever and
+    never be told the cursor stopped being understood.
+    """
+
+    repo = Repository()
+    for i in range(5):
+        repo.create_item(ItemCreate(name=f"Item {i}"))
+
+    with pytest.raises(ValidationError):
+        repo.list_items(limit=2, cursor=bad_cursor)
+
+
+def test_a_cursor_minted_under_another_sort_raises() -> None:
+    repo = Repository()
+    for i in range(5):
+        repo.create_item(ItemCreate(name=f"Item {i}"))
+
+    page1 = repo.list_items(sort=Sort(field="name", order="asc"), limit=2)
+    assert isinstance(page1["next_cursor"], str)
+
+    with pytest.raises(ValidationError):
+        repo.list_items(
+            sort=Sort(field="quantity", order="asc"), limit=2, cursor=page1["next_cursor"]
+        )
+
+
+def test_a_valid_cursor_still_pages_to_the_end() -> None:
+    """The regression that matters: hardening did not break the round trip."""
+
+    repo = Repository()
+    for i in range(5):
+        repo.create_item(ItemCreate(name=f"Item {i}"))
+
+    sort = Sort(field="name", order="asc")
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(5):
+        page = repo.list_items(sort=sort, limit=2, cursor=cursor)
+        seen.extend(it.name for it in page["items"])
+        cursor = page["next_cursor"]
+        if cursor is None:
+            break
+
+    assert seen == [f"Item {i}" for i in range(5)]
+    assert cursor is None

--- a/tests/test_ws_bulk_offline.py
+++ b/tests/test_ws_bulk_offline.py
@@ -79,7 +79,7 @@ async def test_bulk_mixed_results_and_single_persist(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) -> None:
-    """Bulk: empty returns empty results; invalid type rejected; dup op_id last wins."""
+    """Bulk: empty returns empty results; invalid type rejected; dup op_id rejects."""
 
     hass = HomeAssistant()
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
@@ -99,20 +99,20 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
     assert res["success"] is True and res["result"]["results"] == {}
     assert calls["count"] == 0  # nothing to persist
 
-    # Invalid operations type: the command declares `operations` as a list, so
-    # Home Assistant refuses the frame before the handler runs.
+    # Invalid operations type: the command declares `operations` as `object`, so
+    # the frame reaches the handler and is answered through the guard.
     res = await _send(hass, 2, "haventory/items/bulk", operations="oops")
-    assert res["success"] is False and res["error"]["code"] == "invalid_format"
+    assert res["success"] is False and res["error"]["code"] == "validation_error"
 
-    # The shape of each entry is the handler's to check — the schema only knows
-    # `operations` is a list.
+    # The shape of each entry is the handler's to check too.
     res = await _send(hass, 3, "haventory/items/bulk", operations=["oops"])
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
-    # Duplicate op_id: last result should be in the map
+    # Duplicate op_id: the batch is refused whole, because results are keyed by
+    # op_id and a repeat would leave the caller one verdict for two operations.
     created = await _send(hass, 4, "haventory/item/create", name="X", quantity=1)
     iid = created["result"]["id"]
-    FINAL_QTY = 3
+    START_QTY = 1
     ops = [
         {
             "op_id": "dup",
@@ -122,10 +122,30 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
         {
             "op_id": "dup",
             "kind": "item_set_quantity",
-            "payload": {"item_id": iid, "quantity": FINAL_QTY},
+            "payload": {"item_id": iid, "quantity": 3},
         },
     ]
     res = await _send(hass, 5, "haventory/items/bulk", operations=ops)
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    assert "dup" in res["error"]["message"]
+    # Nothing ran: the quantity is still what item/create left it at.
+    got = await _send(hass, 6, "haventory/item/get", item_id=iid)
+    assert got["result"]["quantity"] == START_QTY
+
+    # `1` and `"1"` are one id, not two — the result map normalizes with str().
+    ops_mixed = [
+        {"op_id": 1, "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 2}},
+        {"op_id": "1", "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 3}},
+    ]
+    res = await _send(hass, 7, "haventory/items/bulk", operations=ops_mixed)
+    assert res["success"] is False and res["error"]["code"] == "validation_error"
+
+    # Distinct ids still return one result each.
+    ops_ok = [
+        {"op_id": "a", "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 2}},
+        {"op_id": "b", "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 3}},
+    ]
+    res = await _send(hass, 8, "haventory/items/bulk", operations=ops_ok)
     assert res["success"] is True
-    assert res["result"]["results"]["dup"]["success"] is True
-    assert res["result"]["results"]["dup"]["result"]["quantity"] == FINAL_QTY
+    assert set(res["result"]["results"]) == {"a", "b"}

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -855,3 +855,104 @@ async def test_attachment_reorder_refuses_a_partial_list(upload) -> None:
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
+
+
+# -----------------------------
+# item/list input hardening
+# -----------------------------
+
+
+def _hass_with_items(count: int = 3) -> HomeAssistant:
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    ws_setup(hass)
+    repo = _repo_of(hass)
+    for i in range(count):
+        repo.create_item({"name": f"Item {i}"})
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_item_list_refuses_an_unknown_filter_key_by_name() -> None:
+    """A typo'd key used to be dropped, and the reply was the whole inventory."""
+
+    hass = _hass_with_items()
+
+    res = await _send(hass, 1, "haventory/item/list", filter={"query": "Item 0"})
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    assert "query" in res["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_item_list_refuses_an_unknown_sort_field() -> None:
+    hass = _hass_with_items()
+
+    res = await _send(hass, 1, "haventory/item/list", sort={"field": "colour", "order": "asc"})
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_item_list_refuses_an_empty_cursor() -> None:
+    """Omitting the key is how a caller asks for page one; "" is a client bug."""
+
+    hass = _hass_with_items()
+
+    res = await _send(hass, 1, "haventory/item/list", limit=2, cursor="")
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_item_list_refuses_an_undecodable_cursor() -> None:
+    hass = _hass_with_items()
+
+    res = await _send(hass, 1, "haventory/item/list", limit=2, cursor="garbage")
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_item_list_refuses_a_non_integer_limit() -> None:
+    hass = _hass_with_items()
+
+    res = await _send(hass, 1, "haventory/item/list", limit="two")
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_item_list_still_serves_a_full_known_filter_and_pages() -> None:
+    """The regression that matters: nothing legitimate got refused."""
+
+    hass = _hass_with_items()
+
+    listed = await _send(
+        hass,
+        1,
+        "haventory/item/list",
+        filter={"q": "Item", "include_subtree": True, "low_stock_first": False},
+        sort={"field": "name", "order": "asc"},
+        limit=2,
+    )
+    assert listed["success"] is True, listed
+    assert [i["name"] for i in listed["result"]["items"]] == ["Item 0", "Item 1"]
+
+    page2 = await _send(
+        hass,
+        2,
+        "haventory/item/list",
+        filter={"q": "Item", "include_subtree": True, "low_stock_first": False},
+        sort={"field": "name", "order": "asc"},
+        limit=2,
+        cursor=listed["result"]["next_cursor"],
+    )
+    assert page2["success"] is True, page2
+    assert [i["name"] for i in page2["result"]["items"]] == ["Item 2"]

--- a/tests/test_ws_schema_validation_offline.py
+++ b/tests/test_ws_schema_validation_offline.py
@@ -243,15 +243,46 @@ async def test_a_refusal_is_answered_on_the_connection() -> None:
 
 @pytest.mark.asyncio
 async def test_a_real_command_refuses_a_wrong_typed_field_and_mutates_nothing() -> None:
-    """The same guard over a shipped command, end to end."""
+    """The same guard over a shipped command, end to end.
+
+    ``tags`` is one of the fields ``item/create`` still types concretely. The
+    fields whose wrong type is a plausible client bug — ``name``, ``quantity``
+    — are typed ``object`` on purpose so they answer ``validation_error``
+    through the guard instead; the test below covers those.
+    """
 
     hass = _fresh_hass()
     repo = hass.data[DOMAIN]["repository"]
 
-    res = await _send(hass, 1, "haventory/item/create", name="Hammer", quantity="many")
+    res = await _send(hass, 1, "haventory/item/create", name="Hammer", tags="chisel")
 
     assert res["success"] is False
     assert res["error"]["code"] == INVALID_FORMAT
+    assert repo.get_counts()["items_total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_the_widened_fields_answer_validation_error_and_mutate_nothing() -> None:
+    """A field typed ``object`` is refused by the handler, through the guard.
+
+    Home Assistant refuses a schema mismatch before ``ws_guard`` runs and logs
+    the client's payload at ERROR while doing it. The fields a client most
+    plausibly gets wrong are typed ``object`` so the answer comes from the model
+    layer instead, naming the field at WARNING.
+    """
+
+    hass = _fresh_hass()
+    repo = hass.data[DOMAIN]["repository"]
+
+    for payload in (
+        {"name": "Hammer", "quantity": "many"},
+        {"name": 42},
+        {"name": "Hammer", "quantity": 1.5},
+    ):
+        res = await _send(hass, 1, "haventory/item/create", **payload)
+        assert res["success"] is False, payload
+        assert res["error"]["code"] == "validation_error", payload
+
     assert repo.get_counts()["items_total"] == 0
 
 


### PR DESCRIPTION
## Summary

Five validation gaps the WebSocket API had in common — input the schema accepts and the code then mis-serves. #293 rides along because its two guards are exactly the two this pass rewrites; fixing it separately would mean writing a guard decision this PR then deletes.

**Size caps** (`models.py`, beside `NAME_MAX_LENGTH`): description 4000, category 120, tag 64 × 50 entries, custom fields 50 keys × 64-char keys × 1000-char string values. One validator covers WS, `services.py` and `import_export.py`, which all funnel through the model layer. A separate `validate_tags` rather than a check inside `normalize_tags`, because that helper also normalizes *filter* values and a filter is not an item.

**Malformed cursors**: `_paginate` returned index 0 for an undecodable cursor — a full first page dressed as "the next page", which a caller paging through an inventory loops over forever without being told. Now `validation_error` for an undecodable cursor, a missing `last_id`/`last_sort_key`, a cursor over the 2048-char bound applied *before* base64-decoding, an empty cursor (refused at the WS layer), and the previously silent "sort differs → ignore the cursor" branch.

**Duplicate `op_id`**: rejected rather than documented as last-wins. Compared after `str()`, the same normalization the results map uses, so `1` and `"1"` are one id.

**Unknown filter/sort keys**: `validate_item_filter` keyed off `ItemFilter.__annotations__`, `validate_sort` sharing `sort_items`' allowed-field set. Both name the offending key; called from `ws_item_list`, `ws_location_tree` and `ws_export`.

**Type-loose frames**: `name`, `quantity`, `delta`, `operations` and `item/list`'s `filter`/`sort`/`limit`/`cursor` are typed `object`, so a wrong type answers `validation_error` through `ws_guard` instead of being refused by HA core — which logs the client's payload at ERROR *before* the guard runs. `create_item_from_create`'s `name.strip()` and `int(quantity)` both moved behind their type checks; either would have routed to `unknown_error`.

**Import parity**: `plan_import` applies the same caps, the name limit and the `due_date` ⇔ `checked_out` invariant, reported per field.

Card side: `validateForm` in `ui/item-form.ts` mirrors the caps so the editor refuses before the round trip.

Closes #197
Closes #293

## Decisions recorded here rather than in the issues

**The `load_state` parity half is deliberately not taken.** #197's ordering comment gates it on #228, and #228 is closed — so it is unblocked, and I am still declining it. The argument that unblocked it has been replaced by a stronger one pointing the other way. #228 changed the failure mode from "rows silently dropped at DEBUG" to "setup refuses rather than load a partial dataset". That is the right behaviour for a corrupt store, and exactly the wrong behaviour here: **the caps are new in this release**, so any store written by an earlier HAventory can legitimately carry a 1 MB description or sixty custom fields — values the WS API accepted until this PR. Tightening `load_state` would turn a routine HACS upgrade into a backend that will not start, fixable only by hand-editing JSON. The boundary worth hardening is where foreign input arrives: `plan_import` (a document from elsewhere, which reports errors to the caller) is in this PR; `load_state` reads a file this integration itself wrote and is left alone. Recorded in `docs/data_shapes.md` so it reads as a decision rather than an omission.

**`filter`, `sort`, `limit` and `cursor` were widened too**, beyond the four fields #197's notes name. This is what makes #293's answer coherent: its acceptance is "no unreachable type guard behind a strict schema, and each survivor carries a comment". Keeping `filter: dict` while `validate_item_filter` re-checks `isinstance(dict)` would have left exactly the dead guard #293 is about. Widening makes both guards live and gives `item/list`'s whole input surface the same treatment.

**`#293`'s two guards are kept, not deleted.** `operations must be a list` in `_validate_bulk_ops` is now the only type check there is, since the schema types `operations` as `object`; `ws_export`'s `filter must be an object` is replaced by `validate_item_filter`, which subsumes it. Both carry a comment saying what they defend. The sweep for the same shape found no other survivor: every remaining `isinstance` in `ws.py` is either against a bulk *op payload* (which carries no schema at all) or a membership check on a value, not a type check.

## Where the issues have drifted from the code

- `#293`'s `ws.py:1890` is now `ws.py:2261` (`ws_export`); its `ws.py:234` is now `ws.py:257` (`_validate_bulk_ops`). Both matched by message string.
- `#197`'s `repository.py:1773` (`load_state`) is now `repository.py:2203` — moot, given the decision above.
- **`#197`'s notes and §6.2 both say the frame-typing half "is verified in phacc mode or nowhere", because "the offline stub stores `_ws_schema` without applying it".** That is no longer true: #282 / PR #292 made the offline stub apply each command's schema before dispatch — which is *why* #293 exists. Half 5 is therefore observable offline as well, and `tests/test_ws_schema_validation_offline.py` now asserts it directly. The phacc run was done anyway and is the stronger evidence; see below.
- `test_a_real_command_refuses_a_wrong_typed_field_and_mutates_nothing` used `quantity` as its wrong-typed field, which this PR widens. Repointed at `tags`, which `item/create` still types concretely, so the test keeps proving what it was written to prove.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

Three wire-visible behaviour changes, all documented: a duplicate `op_id` now rejects the batch instead of collapsing; a malformed cursor now errors instead of returning page one; unknown filter/sort keys are now refused instead of dropped. The card sends none of these — `toWireFilter` emits exactly the `ItemFilter` key set, and `Store.setFilters` clears the cursor whenever the sort changes.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **826 passed, 22 skipped**; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` → **1754 passed (62 files)**, `npm run build` clean.
- [x] In-process HA (phacc): **37 passed, 10 skipped**, including three new cases in `tests/integration/test_ws_items.py` for the widened frames, `item/list` hardening and duplicate `op_id`s over the real voluptuous schemas.

New coverage: caps at and over each boundary plus the edit-down case (`test_item_input_validation_offline.py`); five malformed-cursor shapes, a cross-sort cursor and the intact round trip (`test_repository_items_offline.py`); unknown filter key, unknown sort field, empty and undecodable cursor, non-integer limit, and a full known filter still paging (`test_ws_items_offline.py`); duplicate and `1`/`"1"` `op_id`s rejecting with nothing mutated (`test_ws_bulk_offline.py`); every `ItemFilter` key accepted and the TypedDict coupling asserted explicitly (`test_models_filter_sort_offline.py`); nine per-field import refusals plus an item at every cap and a clean round trip still importing (`test_import_export_offline.py`); the cap mirror in `item-form.test.ts`.

### `scripts/test_integration.sh` — first session to need it, result recorded per §4

**It does not provision as shipped in this environment**, and the cause is not this PR:

```
Because the current Python version (3.14rc2) does not satisfy Python>=3.14.2
and homeassistant==2026.6.0 depends on Python>=3.14.2, we can conclude that
homeassistant==2026.6.0 cannot be used.
```

`requires-python = ">=3.14"` and the script's `PY_VERSION` default of `3.14` let the pinned uv (0.8.17) resolve **3.14.0rc2**, whose python-build-standalone index predates 3.14.2 — so `uv python install 3.14.2` fails outright on that uv. The suite ran green after provisioning `.venv-integration` on **3.14.3** with a newer uv (0.12.3); nothing in the repository was changed to do it, and the environment is not modified for anyone else.

Two follow-ups fall out of this, neither fixed here (see below).

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Live verification

**H1** is written into `dev/v0_5_0_handover_prompts.md`. It covers the one thing neither suite can show: that the widened frames stop `homeassistant.components.websocket_api.http.connection` logging the client's payload at ERROR. That log line comes from HA core, so only a running instance shows it. The PR is complete-but-unverified on that point, and reviewable without it — the phacc run already proves the frames answer `validation_error`.

## Follow-ups

Not fixed here; both are real and both are about the toolchain rather than this diff.

1. **`scripts/test_integration.sh` cannot provision an interpreter HA will accept.** `requires-python = ">=3.14"` admits 3.14.0rc2, and `requirements-integration.txt` pins `homeassistant==2026.6.0`, which needs `>=3.14.2`. Anyone running the script on the pinned uv gets an unsatisfiable resolution with no hint that the interpreter is the problem. Worth an issue: either raise `requires-python` to the floor HA actually needs, or have the script pin a concrete patch version. `tests/test_toolchain_pins.py` is the natural place to defend whichever is chosen.
2. **The pinned uv (0.8.17) cannot reach any Python 3.14 past rc2.** Independent of the above, and it is what makes the first item hard to diagnose.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtikceikZrGxHZPiRmbFJS)_