### PR TITLE
feat(config): offer the quick-filter pills in the options flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,9 @@ changed name on its next refresh or reload; the change is not pushed live.
 
 `quick_filters` says which pills are *allowed*; a pill still only shows when it has
 something to count, so `low_stock` draws nothing while nothing is low. An explicit empty
-list is a choice and offers none.
+list is a choice and offers none. `total` is narrower than the other four: only the card
+draws it as a pill, and only at full width — the full view and the sidebar page print the
+total in their header instead, whichever way it is set.
 
 Omitting the key hands the decision to **Quick-filter pills** under Settings → Devices &
 services → HAventory → **Configure**, which is the one place that reaches every surface:

--- a/README.md
+++ b/README.md
@@ -483,7 +483,9 @@ throughout.
 - **Standard card** — one Add button and a single ⋮ menu (Select items, Organize, Refresh,
   Diagnostics, Export backup / Export current view, Import); Columns is offered in the full
   view, which is the only surface it changes. Live stat badges — items, low stock, overdue,
-  due for inspection, checked out — are click-to-filter. Rows carry a quantity stepper, a
+  due for inspection, checked out — are click-to-filter, and which of them a household
+  offers is set under Settings → Devices & services → HAventory → **Configure**, or per
+  dashboard with the card's `quick_filters:`. Rows carry a quantity stepper, a
   LOW badge, an overdue check-out chip, an "Inspection due" chip, an amber status chip
   when an item is flagged Missing / Needs repair, and hover actions.
 - **Filters** — a collapsible panel exposing the whole backend filter object: location
@@ -622,7 +624,7 @@ quick_filters:  # optional; which quick-filter pills this card offers
 | Key | Type | Default | What it does |
 |---|---|---|---|
 | `title` | string | the integration-wide card title | Names this card, for this dashboard only. |
-| `quick_filters` | list | every pill | Which quick-filter pills the card and its full view offer: `total`, `low_stock`, `overdue`, `inspection_due`, `checked_out`. |
+| `quick_filters` | list | the integration-wide choice, or every pill | Which quick-filter pills the card and its full view offer: `total`, `low_stock`, `overdue`, `inspection_due`, `checked_out`. |
 
 Those two are the only options the card reads. Any other key is ignored rather than
 rejected, so a stale dashboard config never breaks the card — and the same holds inside
@@ -631,10 +633,10 @@ the key being absent.
 
 Adding the card from the card picker opens a **visual editor** for `title`; the YAML above
 stays equivalent, and switching to it shows the same config. The editor covers `title`
-only — `quick_filters` is set in YAML, because the pill choice that reaches every surface
-(the sidebar panel included) belongs to the integration's options, not to one dashboard's
-card. Editing a card that carries `quick_filters` through the visual editor leaves that key
-exactly as it was.
+only — the pill choice that reaches every surface (the sidebar panel included) belongs to
+the integration's options rather than one dashboard's card, and `quick_filters` above is
+the per-dashboard exception to it, set in YAML. Editing a card that carries
+`quick_filters` through the visual editor leaves that key exactly as it was.
 
 Without `title`, the card uses the name set under Settings → Devices & services →
 HAventory → **Configure** (asked for at setup too, and defaulting to "HAventory"), so one
@@ -643,10 +645,14 @@ dashboards should name the same inventory differently. An open dashboard picks u
 changed name on its next refresh or reload; the change is not pushed live.
 
 `quick_filters` says which pills are *allowed*; a pill still only shows when it has
-something to count, so `low_stock` draws nothing while nothing is low. Omitting the key
-offers all of them, which is what every dashboard written before this option gets. An
-explicit empty list is a choice and offers none. The sidebar panel has no dashboard config
-of its own, so it always offers all of them.
+something to count, so `low_stock` draws nothing while nothing is low. An explicit empty
+list is a choice and offers none.
+
+Omitting the key hands the decision to **Quick-filter pills** under Settings → Devices &
+services → HAventory → **Configure**, which is the one place that reaches every surface:
+the sidebar panel has no dashboard config of its own, so that setting is all it reads.
+Leave both unset — a fresh install, or any dashboard written before either option existed
+— and all five pills are offered.
 
 ### CI/CD & Ops
 

--- a/cards/haventory-card/src/haventory-card.test.ts
+++ b/cards/haventory-card/src/haventory-card.test.ts
@@ -7,13 +7,21 @@ type Card = HAventoryCard & { updateComplete: Promise<unknown>; hass?: unknown }
 
 async function mountCard(
   config: unknown = {},
-  opts: { items?: ReturnType<typeof makeItem>[]; cardTitle?: string } = {},
+  opts: {
+    items?: ReturnType<typeof makeItem>[];
+    cardTitle?: string;
+    quickFilters?: string[] | null;
+  } = {},
 ) {
   const el = document.createElement('haventory-card') as Card;
   document.body.appendChild(el);
   await customElements.whenDefined('haventory-card');
   el.setConfig(config);
-  el.hass = makeMockHass({ items: opts.items ?? [], cardTitle: opts.cardTitle });
+  el.hass = makeMockHass({
+    items: opts.items ?? [],
+    cardTitle: opts.cardTitle,
+    quickFilters: opts.quickFilters,
+  });
   await el.updateComplete;
   return { el, sr: el.shadowRoot as ShadowRoot };
 }
@@ -126,6 +134,38 @@ describe('haventory-card: the Lovelace element', () => {
 
     it('honours an explicit empty list', async () => {
       const { sr } = await mountCard({ quick_filters: [] });
+      expect(shellOf(sr).quickFilters).toEqual([]);
+    });
+
+    // Same precedence the heading has: this dashboard, then the integration,
+    // then the built-in default.
+    it('takes the pills from the integration when the dashboard names none', async () => {
+      const { el, sr } = await mountCard({}, { quickFilters: ['low_stock'] });
+      await settle(el);
+      expect(shellOf(sr).quickFilters).toEqual(['low_stock']);
+    });
+
+    it('lets this dashboard override the integration-wide choice', async () => {
+      const { el, sr } = await mountCard({ quick_filters: ['overdue'] }, { quickFilters: ['low_stock'] });
+      await settle(el);
+      expect(shellOf(sr).quickFilters).toEqual(['overdue']);
+    });
+
+    it('lets a dashboard that wants no pills say so over the integration', async () => {
+      const { el, sr } = await mountCard({ quick_filters: [] }, { quickFilters: ['low_stock'] });
+      await settle(el);
+      expect(shellOf(sr).quickFilters).toEqual([]);
+    });
+
+    it('offers every pill when the integration has no opinion either', async () => {
+      const { el, sr } = await mountCard({}, { quickFilters: null });
+      await settle(el);
+      expect(shellOf(sr).quickFilters).toBe(null);
+    });
+
+    it('honours an integration that wants no pills anywhere', async () => {
+      const { el, sr } = await mountCard({}, { quickFilters: [] });
+      await settle(el);
       expect(shellOf(sr).quickFilters).toEqual([]);
     });
   });

--- a/cards/haventory-card/src/haventory-panel.test.ts
+++ b/cards/haventory-card/src/haventory-panel.test.ts
@@ -8,6 +8,7 @@ type FullView = HTMLElement & {
   store?: unknown;
   heading: string;
   columns: string[];
+  quickFilters: string[] | null;
   embedded: boolean;
   open: boolean;
   narrow: boolean;
@@ -20,6 +21,7 @@ async function mountPanel(
     config?: Record<string, unknown> | null;
     narrow?: boolean;
     withHass?: boolean;
+    quickFilters?: string[] | null;
   } = {},
 ) {
   const el = document.createElement('haventory-panel') as Panel;
@@ -28,7 +30,11 @@ async function mountPanel(
   if (opts.config !== undefined) el.panel = { config: opts.config };
   if (opts.narrow) el.narrow = true;
   if (opts.withHass !== false) {
-    el.hass = makeMockHass({ items: opts.items ?? [], cardTitle: opts.cardTitle });
+    el.hass = makeMockHass({
+      items: opts.items ?? [],
+      cardTitle: opts.cardTitle,
+      quickFilters: opts.quickFilters,
+    });
   }
   await el.updateComplete;
   const sr = el.shadowRoot as ShadowRoot;
@@ -64,6 +70,34 @@ describe('haventory-panel: the surface', () => {
   it('leaves narrow off by default', async () => {
     const { view } = await mountPanel();
     expect(view().narrow).toBe(false);
+  });
+});
+
+// A panel has no Lovelace config, so the options flow is the only thing that
+// can narrow its pills — the reason the setting exists on the integration at
+// all rather than only in card YAML.
+describe('haventory-panel: quick-filter pills', () => {
+  it('offers every pill while the integration has no opinion', async () => {
+    const { el, view } = await mountPanel({ quickFilters: null });
+    await settle(el);
+    expect(view().quickFilters).toBe(null);
+  });
+
+  it('narrows to the pills the integration chose', async () => {
+    const { el, view } = await mountPanel({ quickFilters: ['low_stock', 'overdue'] });
+    await settle(el);
+    expect(view().quickFilters).toEqual(['low_stock', 'overdue']);
+  });
+
+  it('honours an integration that wants no pills at all', async () => {
+    const { el, view } = await mountPanel({ quickFilters: [] });
+    await settle(el);
+    expect(view().quickFilters).toEqual([]);
+  });
+
+  it('offers every pill before the store has answered', async () => {
+    const { view } = await mountPanel({ withHass: false });
+    expect(view().quickFilters).toBe(null);
   });
 });
 

--- a/cards/haventory-card/src/haventory-panel.ts
+++ b/cards/haventory-card/src/haventory-panel.ts
@@ -4,6 +4,7 @@ import type { HassLike } from './store/types';
 import { Store } from './store/store';
 import { resolveColorScheme } from './ui/theme';
 import { DEFAULT_CARD_TITLE } from './ui/card-title';
+import type { QuickFilterKey } from './ui/quick-filters';
 import { defineCardElement } from './register';
 import { HostSurfaces } from './host-surfaces';
 import type { OrganizeTab } from './components/hv-organize-dialog';
@@ -131,6 +132,7 @@ export class HAventoryPanel extends LitElement {
         ?narrow=${this.narrow}
         .store=${this.store}
         .heading=${this._heading()}
+        .quickFilters=${this._quickFilters()}
         .columns=${this.surfaces.columns}
         .menuEntries=${this.surfaces.menuEntries()}
         @menu-action=${this._onMenuAction}
@@ -140,6 +142,17 @@ export class HAventoryPanel extends LitElement {
 
       ${this.surfaces.renderSurfaces()}
     `;
+  }
+
+  /**
+   * Which pills the panel offers.
+   *
+   * One source only: a panel has no Lovelace config to carry a per-dashboard
+   * `quick_filters:`, so the integration's options flow decides, and `null` —
+   * no choice made, or the store has not answered yet — means every pill.
+   */
+  private _quickFilters(): QuickFilterKey[] | null {
+    return this.store?.state.value.quickFilters ?? null;
   }
 
   /**

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -155,9 +155,23 @@ export class HAventoryCard extends LitElement {
         data-testid="card-shell"
         .store=${this.store}
         .heading=${this._heading()}
-        .quickFilters=${this.config?.quickFilters ?? null}
+        .quickFilters=${this._quickFilters()}
       ></hv-card-shell>
     `;
+  }
+
+  /**
+   * Which pills this card offers, most specific source first: this dashboard's
+   * `quick_filters:`, then the choice made in the integration's options flow,
+   * then `null` — every pill, which is what a dashboard written before either
+   * setting existed still gets.
+   *
+   * An explicit empty list is a choice at both levels and stops the search, the
+   * way an empty `title:` would not: `[]` means no pills, not "ask the next
+   * source".
+   */
+  private _quickFilters(): QuickFilterKey[] | null {
+    return this.config?.quickFilters ?? this.store?.state.value.quickFilters ?? null;
   }
 
   /**

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -1432,6 +1432,41 @@ describe('Store: location tree and diagnostics data', () => {
     expect(store.state.value.cardTitle).toBe('Pantry');
   });
 
+  it('reads the quick-filter pills configured in the integration', async () => {
+    const hass = makeMockHass({ items: [], quickFilters: ['low_stock', 'overdue'] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    expect(store.state.value.quickFilters).toEqual(['low_stock', 'overdue']);
+  });
+
+  // `null` and `[]` are different answers, and the store is where the two
+  // could most easily collapse into one falsy value.
+  it('keeps an explicit "no pills" apart from "no choice made"', async () => {
+    const none = new Store(makeMockHass({ items: [], quickFilters: [] }), fast);
+    await none.init();
+    expect(none.state.value.quickFilters).toEqual([]);
+
+    const unset = new Store(makeMockHass({ items: [], quickFilters: null }), fast);
+    await unset.init();
+    expect(unset.state.value.quickFilters).toBeNull();
+  });
+
+  it('drops a pill name this bundle does not know', async () => {
+    const hass = makeMockHass({ items: [], quickFilters: ['low_stock', 'sideways'] });
+    const store = new Store(hass, fast);
+    await store.init();
+
+    expect(store.state.value.quickFilters).toEqual(['low_stock']);
+  });
+
+  it('leaves the pills unset against a backend that does not report them', async () => {
+    const store = new Store(makeMockHass({ items: [] }), fast);
+    await store.init();
+
+    expect(store.state.value.quickFilters).toBeNull();
+  });
+
   // The card bundle is served by the integration, so this only happens with a
   // stale cached bundle — and a missing heading must not cost the user their
   // items, which init loads after this call.

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -32,6 +32,7 @@ import type {
 } from './types';
 import { WSClient } from './ws';
 import { DEFAULT_SORT } from './sort';
+import { normalizeQuickFilters } from '../ui/quick-filters';
 import { sortLocationTree } from './location-tree';
 
 /** Page size for the main list. */
@@ -372,6 +373,7 @@ export class Store {
       healthCache: null,
       versionInfo: null,
       cardTitle: null,
+      quickFilters: null,
       mediaConfig: null,
       statuses: null,
       distinctValuesCache: null,
@@ -906,23 +908,31 @@ export class Store {
     this.stateObs.set({ versionInfo: info });
   }
 
-  /**
-   * Card heading configured in the integration's options flow.
-   *
-   * Cosmetic, so a backend that does not answer the command — an integration
-   * older than this bundle — leaves the card on its built-in heading instead
-   * of failing the whole init.
-   */
   /** Re-read the status vocabulary after another client changed it. */
   async refreshStatuses() {
     const statuses = await this.run(() => this.ws.listStatuses()).catch(() => null);
     if (statuses) this.stateObs.set({ statuses });
   }
 
+  /**
+   * What the integration decided: card heading, quick-filter pills, the status
+   * vocabulary, the attachment caps.
+   *
+   * All of it cosmetic, so a backend that does not answer the command — an
+   * integration older than this bundle — leaves every one of them at its
+   * built-in default instead of failing the whole init.
+   */
   async refreshConfig() {
     const config = await this.run(() => this.ws.config()).catch(() => null);
     const title = config?.card_title;
     if (typeof title === 'string' && title) this.stateObs.set({ cardTitle: title });
+    // `undefined` is a backend too old to answer and leaves the state alone;
+    // `null` is one that answered "no opinion". Both read as every pill, but
+    // only the second is a report, and an explicit `[]` is a third answer the
+    // normalizer keeps whole.
+    if (config && 'quick_filters' in config) {
+      this.stateObs.set({ quickFilters: normalizeQuickFilters(config.quick_filters) });
+    }
     if (config?.media) this.stateObs.set({ mediaConfig: config.media });
     if (config?.statuses?.length) this.stateObs.set({ statuses: config.statuses });
   }

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -4,6 +4,8 @@
  * These mirror the backend WebSocket contract in custom_components/haventory/ws.py.
  */
 
+import type { QuickFilterKey } from '../ui/quick-filters';
+
 export type ScalarValue = string | number | boolean;
 
 /**
@@ -285,6 +287,13 @@ export interface MediaConfig {
 export interface IntegrationConfig {
   /** Heading set in the integration's options flow. */
   card_title: string;
+  /**
+   * Which quick-filter pills the integration offers, or `null` when it has no
+   * opinion — which is also what an older backend's silence reads as. `null`
+   * and `[]` are different answers: no opinion leaves the choice to the
+   * dashboard's own `quick_filters:`, an empty list is a choice of no pills.
+   */
+  quick_filters?: string[] | null;
   /** The status vocabulary. Optional: an older backend does not send it. */
   statuses?: StatusDefinition[];
   /** Attachment caps and the media route. Optional for the same reason. */
@@ -621,6 +630,13 @@ export interface StoreState {
   versionInfo: VersionInfo | null;
   /** Heading configured in the integration, or null until it has been read. */
   cardTitle: string | null;
+  /**
+   * Quick-filter pills chosen in the integration's options flow, or null when
+   * it has none — the state a fresh install, an older backend and a store that
+   * has not answered yet all share. A dashboard's own `quick_filters:` outranks
+   * it; the sidebar panel has no dashboard config, so this is all it reads.
+   */
+  quickFilters: QuickFilterKey[] | null;
   /**
    * Attachment caps and the media route, or null until `haventory/config` has
    * answered — or permanently, against a backend too old to report them.

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -23,6 +23,12 @@ interface MockConfig {
   conflictOnUpdate?: boolean;
   /** What `haventory/config` reports as the configured card heading. */
   cardTitle?: string;
+  /**
+   * What `haventory/config` reports as the integration-wide pill choice.
+   * Omitted means the key is absent from the response, as an older backend
+   * leaves it; `null` is a backend saying it has no opinion.
+   */
+  quickFilters?: string[] | null;
   /** What `haventory/areas/list` reports — the HA area registry, read-only. */
   areas?: AreaRef[];
   /** The status vocabulary; defaults to the built-in three the backend seeds. */
@@ -82,6 +88,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
   let locations: Location[] = initial?.locations ? [...initial.locations] : [];
   let conflictOnUpdate = !!initial?.conflictOnUpdate;
   const cardTitle = initial?.cardTitle ?? 'HAventory';
+  const quickFilters = initial?.quickFilters;
   let areas: AreaRef[] = initial?.areas ? [...initial.areas] : [];
   // The three the backend seeds, so a test that says nothing about statuses
   // still sees what a real install carries.
@@ -229,7 +236,11 @@ export function makeMockHass(initial?: MockConfig): MockHass {
           return { integration_version: '0.0.1', schema_version: 4 } as unknown as T;
         }
         case 'haventory/config': {
-          return { card_title: cardTitle, statuses: [...statuses] } as unknown as T;
+          return {
+            card_title: cardTitle,
+            statuses: [...statuses],
+            ...(quickFilters === undefined ? {} : { quick_filters: quickFilters }),
+          } as unknown as T;
         }
         case 'haventory/areas/list': {
           return { areas } as unknown as T;

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -53,6 +53,7 @@ from . import stale_files
 from . import ws as ws_mod
 from .const import (
     CONF_CARD_TITLE,
+    CONF_QUICK_FILTERS,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
     DEFAULT_SIDEBAR_PANEL_ENABLED,
@@ -60,6 +61,7 @@ from .const import (
     PANEL_ELEMENT_NAME,
     PANEL_ICON,
     PANEL_URL_PATH,
+    QUICK_FILTER_KEYS,
 )
 from .exceptions import CorruptSchemaVersionError, SchemaDowngradeError, StorageError
 from .rate_limit import RateLimitConfig, RateLimiter
@@ -207,8 +209,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _register_media_view(hass)
     await _async_sweep_orphaned_media(hass, repository)
 
-    # Heading served to the card by `haventory/config`.
+    # Heading and pill choice served to the card by `haventory/config`.
     hass.data[DOMAIN]["card_title"] = _resolve_card_title(entry)
+    hass.data[DOMAIN]["quick_filters"] = _resolve_quick_filters(entry)
 
     # WebSocket rate limiting (off by default; configured via the options flow)
     hass.data[DOMAIN]["rate_limiter"] = RateLimiter(
@@ -305,10 +308,29 @@ def _resolve_card_title(entry: ConfigEntry) -> str:
     return DEFAULT_CARD_TITLE
 
 
+def _resolve_quick_filters(entry: ConfigEntry) -> list[str] | None:
+    """Read the configured quick-filter pills, or `None` when none was chosen.
+
+    `None` and `[]` are different answers and stay that way: an entry that never
+    chose leaves the decision to the dashboard's own `quick_filters:`, and after
+    that to the card's "every pill" default, while an empty list is a household
+    saying it wants no pills anywhere. Names this build does not know are
+    dropped rather than passed on — the card would drop them too, and dropping
+    them here keeps the wire payload to the vocabulary both sides share.
+    """
+    options = getattr(entry, "options", None) or {}
+    chosen = options.get(CONF_QUICK_FILTERS)
+    if not isinstance(chosen, list):
+        return None
+    known = {entry_name for entry_name in chosen if isinstance(entry_name, str)}
+    return [key for key in QUICK_FILTER_KEYS if key in known]
+
+
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Apply changed options: card title, sidebar panel, rebuilt WS rate limiter."""
+    """Apply changed options: card title, pills, sidebar panel, WS rate limiter."""
     bucket = hass.data.setdefault(DOMAIN, {})
     bucket["card_title"] = _resolve_card_title(entry)
+    bucket["quick_filters"] = _resolve_quick_filters(entry)
     bucket["rate_limiter"] = RateLimiter(
         RateLimitConfig.from_options(getattr(entry, "options", None))
     )

--- a/custom_components/haventory/config_flow.py
+++ b/custom_components/haventory/config_flow.py
@@ -7,9 +7,15 @@ from typing import TYPE_CHECKING, Any
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import section
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .const import (
     CONF_CARD_TITLE,
+    CONF_QUICK_FILTERS,
     CONF_RATE_LIMIT_COMMANDS_BURST,
     CONF_RATE_LIMIT_COMMANDS_PER_SECOND,
     CONF_RATE_LIMIT_ENABLED,
@@ -21,6 +27,7 @@ from .const import (
     CONF_RATE_LIMIT_GLOBAL_EVENTS_PER_SECOND,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
+    DEFAULT_QUICK_FILTERS,
     DEFAULT_RATE_LIMIT_COMMANDS_BURST,
     DEFAULT_RATE_LIMIT_COMMANDS_PER_SECOND,
     DEFAULT_RATE_LIMIT_ENABLED,
@@ -32,6 +39,7 @@ from .const import (
     DEFAULT_RATE_LIMIT_GLOBAL_EVENTS_PER_SECOND,
     DEFAULT_SIDEBAR_PANEL_ENABLED,
     DOMAIN,
+    QUICK_FILTER_KEYS,
 )
 
 if TYPE_CHECKING:
@@ -71,6 +79,38 @@ def clean_card_title(value: Any) -> str:
     if not isinstance(value, str):
         return DEFAULT_CARD_TITLE
     return value.strip() or DEFAULT_CARD_TITLE
+
+
+def clean_quick_filters(value: Any) -> list[str]:
+    """Normalize a submitted pill list to the names this build knows.
+
+    Canonical order rather than click order, so the stored list reads the same
+    however it was assembled. An empty result is kept as it is: a household that
+    unticks everything is choosing no pills, which is not the same as never
+    having chosen. Anything that is not a list at all — which the selector
+    itself already refuses — reads as the form's prefill.
+    """
+    if not isinstance(value, list):
+        return list(DEFAULT_QUICK_FILTERS)
+    chosen = {entry for entry in value if isinstance(entry, str)}
+    return [key for key in QUICK_FILTER_KEYS if key in chosen]
+
+
+def _quick_filters_selector() -> SelectSelector:
+    """Build the pill picker: the five names, as a checkbox list.
+
+    `LIST` rather than a dropdown because the vocabulary is fixed and short, and
+    a household deciding which pills it wants should see all of them at once.
+    The labels come from the translation key, so the wire names never surface.
+    """
+    return SelectSelector(
+        SelectSelectorConfig(
+            options=list(QUICK_FILTER_KEYS),
+            multiple=True,
+            mode=SelectSelectorMode.LIST,
+            translation_key=CONF_QUICK_FILTERS,
+        )
+    )
 
 
 def _user_schema() -> vol.Schema:
@@ -131,6 +171,17 @@ def _options_schema(current: dict[str, Any]) -> vol.Schema:
                     current.get(CONF_SIDEBAR_PANEL_ENABLED, DEFAULT_SIDEBAR_PANEL_ENABLED)
                 ),
             ): bool,
+            # Prefilled with every pill when the entry has never chosen, so
+            # saving this form for one of the fields above cannot quietly mean
+            # "no pills". Once saved, the choice is explicit for good — the
+            # unset state is not reachable from the form, only from an entry
+            # that predates the option.
+            vol.Required(
+                CONF_QUICK_FILTERS,
+                default=clean_quick_filters(
+                    current.get(CONF_QUICK_FILTERS, list(DEFAULT_QUICK_FILTERS))
+                ),
+            ): _quick_filters_selector(),
             # Collapsed while the whole block is untouched, so the common case
             # is a form with one field; a customized limiter opens expanded
             # rather than hiding the values behind a header. No default on the
@@ -154,13 +205,18 @@ def _flatten_options(user_input: dict[str, Any]) -> dict[str, Any]:
 
 
 class HAventoryOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle HAventory options (card title, WebSocket rate limiting)."""
+    """Handle HAventory options (card title, sidebar, pills, WS rate limiting)."""
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
             options = _flatten_options(user_input)
             options[CONF_CARD_TITLE] = clean_card_title(options.get(CONF_CARD_TITLE))
+            # Only when the form carried the field: writing it unconditionally
+            # would turn "never chose" into an explicit list on any submission
+            # that skipped it, and the two are different answers downstream.
+            if CONF_QUICK_FILTERS in options:
+                options[CONF_QUICK_FILTERS] = clean_quick_filters(options[CONF_QUICK_FILTERS])
             return self.async_create_entry(title="", data=options)
 
         current = dict(getattr(self.config_entry, "options", None) or {})

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -24,6 +24,34 @@ CONF_CARD_TITLE: str = "card_title"
 DEFAULT_CARD_TITLE: str = "HAventory"
 
 # -----------------------------
+# Quick-filter pills (config-entry option)
+# -----------------------------
+# Which quick-filter pills the card and the sidebar panel offer. A dashboard's
+# own `quick_filters:` still wins for that one card; the panel has no dashboard
+# config at all, so this option is the only thing that reaches it.
+#
+# The vocabulary is the card's — `QUICK_FILTER_KEYS` in
+# `cards/haventory-card/src/ui/quick-filters.ts` — and the two spellings have to
+# agree, because a name only this side knows drops a pill silently instead of
+# failing. tests/test_frontend_registration.py holds them to each other.
+
+CONF_QUICK_FILTERS: str = "quick_filters"
+QUICK_FILTER_KEYS: tuple[str, ...] = (
+    "total",
+    "low_stock",
+    "overdue",
+    "inspection_due",
+    "checked_out",
+)
+
+# What the options form prefills when nothing is stored — every pill, so that
+# saving the form without touching this field changes nothing. It is not what
+# an unset option *means*: an entry with no value for it reports `None` over
+# `haventory/config`, which leaves the choice to the dashboard, and an empty
+# list is the household's explicit "no pills".
+DEFAULT_QUICK_FILTERS: tuple[str, ...] = QUICK_FILTER_KEYS
+
+# -----------------------------
 # Sidebar panel (config-entry option)
 # -----------------------------
 # HAventory as a page of its own, registered with `panel_custom` and rendered by

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -22,14 +22,16 @@
     "step": {
       "init": {
         "title": "HAventory Options",
-        "description": "Set the heading the card carries and whether HAventory has its own sidebar entry.",
+        "description": "Set the heading the card carries, whether HAventory has its own sidebar entry, and which quick-filter pills it offers.",
         "data": {
           "card_title": "Card title",
-          "sidebar_panel_enabled": "Show HAventory in the sidebar"
+          "sidebar_panel_enabled": "Show HAventory in the sidebar",
+          "quick_filters": "Quick-filter pills"
         },
         "data_description": {
           "card_title": "Heading shown on the HAventory card. A dashboard card with its own title: option keeps that one. Reload the dashboard to see a change.",
-          "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. This applies to everyone using this Home Assistant; each user can still hide the entry through the sidebar's own Edit sidebar mode. The entry appears and disappears as you save this form — no restart. On the Overview page, Edit then Add shortcut can also pin HAventory as a tile."
+          "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. This applies to everyone using this Home Assistant; each user can still hide the entry through the sidebar's own Edit sidebar mode. The entry appears and disappears as you save this form — no restart. On the Overview page, Edit then Add shortcut can also pin HAventory as a tile.",
+          "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
         },
         "sections": {
           "rate_limit": {
@@ -59,6 +61,17 @@
             }
           }
         }
+      }
+    }
+  },
+  "selector": {
+    "quick_filters": {
+      "options": {
+        "total": "Item total",
+        "low_stock": "Low stock",
+        "overdue": "Overdue",
+        "inspection_due": "Due for inspection",
+        "checked_out": "Checked out"
       }
     }
   },

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -31,7 +31,7 @@
         "data_description": {
           "card_title": "Heading shown on the HAventory card. A dashboard card with its own title: option keeps that one. Reload the dashboard to see a change.",
           "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. This applies to everyone using this Home Assistant; each user can still hide the entry through the sidebar's own Edit sidebar mode. The entry appears and disappears as you save this form — no restart. On the Overview page, Edit then Add shortcut can also pin HAventory as a tile.",
-          "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
+          "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. Item total is the exception in a second way: only the card draws it as a pill, and only at full width — the sidebar page and the full view print the total in their header instead, whether or not it is ticked here. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
         },
         "sections": {
           "rate_limit": {

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -22,14 +22,16 @@
     "step": {
       "init": {
         "title": "HAventory Options",
-        "description": "Set the heading the card carries and whether HAventory has its own sidebar entry.",
+        "description": "Set the heading the card carries, whether HAventory has its own sidebar entry, and which quick-filter pills it offers.",
         "data": {
           "card_title": "Card title",
-          "sidebar_panel_enabled": "Show HAventory in the sidebar"
+          "sidebar_panel_enabled": "Show HAventory in the sidebar",
+          "quick_filters": "Quick-filter pills"
         },
         "data_description": {
           "card_title": "Heading shown on the HAventory card. A dashboard card with its own title: option keeps that one. Reload the dashboard to see a change.",
-          "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. This applies to everyone using this Home Assistant; each user can still hide the entry through the sidebar's own Edit sidebar mode. The entry appears and disappears as you save this form — no restart. On the Overview page, Edit then Add shortcut can also pin HAventory as a tile."
+          "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. This applies to everyone using this Home Assistant; each user can still hide the entry through the sidebar's own Edit sidebar mode. The entry appears and disappears as you save this form — no restart. On the Overview page, Edit then Add shortcut can also pin HAventory as a tile.",
+          "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
         },
         "sections": {
           "rate_limit": {
@@ -59,6 +61,17 @@
             }
           }
         }
+      }
+    }
+  },
+  "selector": {
+    "quick_filters": {
+      "options": {
+        "total": "Item total",
+        "low_stock": "Low stock",
+        "overdue": "Overdue",
+        "inspection_due": "Due for inspection",
+        "checked_out": "Checked out"
       }
     }
   },

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -31,7 +31,7 @@
         "data_description": {
           "card_title": "Heading shown on the HAventory card. A dashboard card with its own title: option keeps that one. Reload the dashboard to see a change.",
           "sidebar_panel_enabled": "Gives HAventory a page of its own, named after the card title above. This applies to everyone using this Home Assistant; each user can still hide the entry through the sidebar's own Edit sidebar mode. The entry appears and disappears as you save this form — no restart. On the Overview page, Edit then Add shortcut can also pin HAventory as a tile.",
-          "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
+          "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. Item total is the exception in a second way: only the card draws it as a pill, and only at full width — the sidebar page and the full view print the total in their header instead, whether or not it is ticked here. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
         },
         "sections": {
           "rate_limit": {

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -838,15 +838,21 @@ async def ws_config(
     """Return the settings the frontend renders, not the whole options set.
 
     Rate-limit tunables stay server-side. What is here is what the card cannot
-    know on its own: the configured heading, the status vocabulary items are
-    labelled with, and the attachment caps — reported so the picker can refuse
-    an oversized file before it is sent, never so the backend can trust that it
-    did.
+    know on its own: the configured heading, which quick-filter pills to offer,
+    the status vocabulary items are labelled with, and the attachment caps —
+    reported so the picker can refuse an oversized file before it is sent, never
+    so the backend can trust that it did.
     """
     bucket = hass.data.get(DOMAIN) or {}
     title = bucket.get("card_title")
+    pills = bucket.get("quick_filters")
     result = {
         "card_title": title if isinstance(title, str) and title else DEFAULT_CARD_TITLE,
+        # `null` is a value here, not an omission: it says the integration has
+        # no opinion, which leaves a dashboard's own `quick_filters:` — and
+        # then the card's every-pill default — to decide. An empty list is the
+        # opposite, an explicit choice of no pills, so the two never collapse.
+        "quick_filters": list(pills) if isinstance(pills, list) else None,
         "statuses": [serialize_status_definition(d) for d in _repo(hass).list_statuses()],
         # The route itself is not here: it is a constant on both sides, pinned
         # across the language boundary by tests/test_frontend_registration.py.

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -1,0 +1,61 @@
+# V0.5.0 — handovers to a local session
+
+Cloud sessions have no Home Assistant. Each section below is one thing a cloud session
+finished but could not watch run, written so a session in front of the dev Docker instance
+(the `run-haventory` and `test-haventory` skills) can pick it up without reading the PR
+first.
+
+Appended in session order, per §5 of `dev/V0_5_0_implementation.md`. Delete this file with
+that plan when the milestone closes.
+
+---
+
+## H6 — #365 quick-filter pills in the options flow
+
+**Branch / PR**: `claude/v0-5-0-w1c-quick-filter-pills` / #NNN
+**Why this needs a real HA**: the offline suite validates the schema, never the form. What
+it cannot show is how Home Assistant *draws* a `SelectSelector(multiple=True,
+mode=LIST)` inside an options flow — whether the five pills come up as a checkbox list
+with their translated labels or as a dropdown of raw wire names — and whether the sidebar
+panel, which has no Lovelace config at all, picks the stored choice up.
+
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+    # Seed enough inventory that every pill has something to count, or the card
+    # draws none of them and the test says nothing:
+    uv run python scripts/create_test_items.py     # then, in the UI, mark one item
+    # low-stock, one overdue, one due for inspection, and check one out.
+
+### Steps
+
+1. Settings → Devices & services → HAventory → **Configure**. Read the new
+   **Quick-filter pills** field: how it renders, and what the five entries are called.
+2. Untick everything except **Low stock** and **Overdue**, save.
+3. Open the HAventory sidebar page. Then open a dashboard carrying a plain
+   `type: custom:haventory-card` with no `quick_filters:` key.
+4. Add a second card to the same dashboard with `quick_filters: [checked_out]`.
+5. Back in **Configure**, tick every pill again, save, reload the page.
+6. Untick all five, save, reload.
+
+### What "pass" looks like
+
+- Step 1: five labelled checkboxes — *Item total, Low stock, Overdue, Due for inspection,
+  Checked out* — not a dropdown of `low_stock`-style wire names, and not a free-text field.
+- Steps 2–3: after a page reload, both the sidebar page and the plain card show only the
+  low-stock and overdue pills. The panel is the half that could not be reached before, so
+  it is the one worth screenshotting.
+- Step 4: the second card shows only its checked-out pill — a dashboard's own key still
+  wins over the integration-wide choice.
+- Step 5: all five are back (subject to each having a non-zero count).
+- Step 6: no pills anywhere, on the panel and on the plain card alike — an empty choice is
+  a choice, not a reset to "all".
+- Nothing in the HA log at WARNING or above from `haventory` or `config_entries` across
+  any of it.
+
+### What to send back
+
+- A screenshot of the options form (step 1) and one of the sidebar page at step 3.
+- The pill row from step 4's second card, showing the two cards disagreeing on purpose.
+- Paste the result as a comment on #365 and reply on the PR thread.

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -12,7 +12,7 @@ that plan when the milestone closes.
 
 ## H6 — #365 quick-filter pills in the options flow
 
-**Branch / PR**: `claude/v0-5-0-w1c-quick-filter-pills` / #NNN
+**Branch / PR**: `claude/v0-5-0-w1c-quick-filter-pills` / #416
 **Why this needs a real HA**: the offline suite validates the schema, never the form. What
 it cannot show is how Home Assistant *draws* a `SelectSelector(multiple=True,
 mode=LIST)` inside an options flow — whether the five pills come up as a checkbox list

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -85,8 +85,9 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 
 - `haventory/config`
   - Request: `{id, type: "haventory/config"}` (no payload)
-  - Result: `{card_title: string, statuses: StatusDefinition[], media: MediaConfig}`
+  - Result: `{card_title: string, quick_filters: string[] | null, statuses: StatusDefinition[], media: MediaConfig}`
   - `card_title` is the heading set in the integration's options flow (Settings → Devices & services → HAventory → **Configure**), defaulting to `"HAventory"`. Only display settings appear here — rate-limit tunables stay server-side.
+  - `quick_filters` is which quick-filter pills the integration offers, out of `total`, `low_stock`, `overdue`, `inspection_due`, `checked_out`, set in the same options flow. `null` means no choice was made and leaves it to the client — a dashboard's own `quick_filters:` first, every pill otherwise — while `[]` is an explicit choice of no pills; the two are never interchangeable. Names the backend does not know are dropped before sending.
   - `statuses` is the status vocabulary in display order (see data shapes). Items store only a slug, so this is where a surface gets the label to render one with.
   - `media` is `{picture_mime_types: string[], max_pictures_per_item: number, manual_mime_types: string[], max_manuals_per_item: number, max_attachment_bytes: number}` — the attachment limits, reported so a picker can refuse a doomed file before uploading it. **Advisory only**: every one of them is re-derived server-side from the file's own bytes. The media *route* is deliberately not here; it is a constant on both sides of the language boundary (`/api/haventory/media/{item_id}/{attachment_id}`), pinned by a test.
   - Read at card init and on refresh, not pushed: changing the option emits no event, so an open dashboard shows the new heading after a refresh or reload.

--- a/stubs/homeassistant/helpers/selector.pyi
+++ b/stubs/homeassistant/helpers/selector.pyi
@@ -1,0 +1,27 @@
+from enum import StrEnum
+from typing import Any, Required, TypedDict
+
+class SelectSelectorMode(StrEnum):
+    LIST = "list"
+    DROPDOWN = "dropdown"
+
+class SelectOptionDict(TypedDict):
+    value: str
+    label: str
+
+class SelectSelectorConfig(TypedDict, total=False):
+    options: Required[list[str] | list[SelectOptionDict]]
+    multiple: bool
+    custom_value: bool
+    mode: SelectSelectorMode
+    translation_key: str
+    sort: bool
+
+# A voluptuous validator: it rejects anything outside `options`, and with
+# `multiple` set it takes and returns a list.
+class SelectSelector:
+    config: SelectSelectorConfig
+    def __init__(self, config: SelectSelectorConfig) -> None: ...
+    def __call__(self, data: Any) -> Any: ...
+
+def __getattr__(name: str) -> Any: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ import os
 import sys
 import tempfile
 import types
+from enum import StrEnum
 from pathlib import Path
 
 import voluptuous as vol
@@ -274,6 +275,43 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
     # below validates every frame's `id` with it.
     ha_helpers_cv.positive_int = vol.All(vol.Coerce(int), vol.Range(min=0))
     sys.modules["homeassistant.helpers.config_validation"] = ha_helpers_cv
+
+    # homeassistant.helpers.selector — only the select selector, which the
+    # options flow uses for the quick-filter pills. Validation mirrors HA's:
+    # nothing outside the offered options gets through, and a `multiple`
+    # selector takes and returns a list.
+    ha_helpers_selector = types.ModuleType("homeassistant.helpers.selector")
+
+    class SelectSelectorMode(StrEnum):  # type: ignore[override]
+        LIST = "list"
+        DROPDOWN = "dropdown"
+
+    # A TypedDict in HA, so it is called by name like a class.
+    def SelectSelectorConfig(**kwargs):  # type: ignore[override]
+        return dict(kwargs)
+
+    class SelectSelector:  # type: ignore[override]
+        def __init__(self, config) -> None:  # type: ignore[no-untyped-def]
+            self.config = dict(config)
+
+        def __call__(self, value):  # type: ignore[no-untyped-def]
+            offered = [
+                entry["value"] if isinstance(entry, dict) else entry
+                for entry in self.config.get("options") or ()
+            ]
+            values = value if self.config.get("multiple") else [value]
+            if not isinstance(values, list):
+                raise vol.Invalid("expected a list")
+            for entry in values:
+                if entry not in offered:
+                    raise vol.Invalid(f"{entry!r} is not one of {offered}")
+            return list(values) if self.config.get("multiple") else value
+
+    ha_helpers_selector.SelectSelector = SelectSelector
+    ha_helpers_selector.SelectSelectorConfig = SelectSelectorConfig
+    ha_helpers_selector.SelectSelectorMode = SelectSelectorMode
+    ha_helpers.selector = ha_helpers_selector
+    sys.modules["homeassistant.helpers.selector"] = ha_helpers_selector
 
     ha_helpers_storage = types.ModuleType("homeassistant.helpers.storage")
 

--- a/tests/integration/test_config_entry.py
+++ b/tests/integration/test_config_entry.py
@@ -15,10 +15,17 @@ cannot reproduce.
 
 from __future__ import annotations
 
-from custom_components.haventory.const import DOMAIN
+import pytest
+from custom_components.haventory.const import (
+    CONF_CARD_TITLE,
+    CONF_QUICK_FILTERS,
+    CONF_SIDEBAR_PANEL_ENABLED,
+    DOMAIN,
+)
 from custom_components.haventory.repository import Repository
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
@@ -233,3 +240,65 @@ async def test_re_adding_a_removed_entry_restores_the_inventory(
     listed = await client.receive_json()
     assert listed["success"] is True, listed
     assert [item["name"] for item in listed["result"]["items"]] == ["Screwdriver"]
+
+
+async def test_the_options_flow_stores_a_pill_choice_the_card_then_reads(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """The pill picker is a real selector, and only real HA applies it.
+
+    Offline the selector is a stand-in, so the shape of its config — the option
+    list, `multiple`, the mode — is asserted nowhere else. This walks the whole
+    path instead: the form Home Assistant builds, a submission through it, and
+    what `haventory/config` then reports to the card.
+    """
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/config"})
+    before = await client.receive_json()
+    assert before["success"] is True, before
+    # Nothing chosen yet: null, not an empty list — the card keeps every pill.
+    assert before["result"]["quick_filters"] is None
+
+    flow = await hass.config_entries.options.async_init(entry.entry_id)
+    assert flow["type"] is FlowResultType.FORM
+    result = await hass.config_entries.options.async_configure(
+        flow["flow_id"],
+        {
+            CONF_CARD_TITLE: "HAventory",
+            CONF_SIDEBAR_PANEL_ENABLED: True,
+            CONF_QUICK_FILTERS: ["overdue", "low_stock"],
+            "rate_limit": {},
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY, result
+    await hass.async_block_till_done()
+
+    assert entry.options[CONF_QUICK_FILTERS] == ["low_stock", "overdue"]
+
+    await client.send_json({"id": 2, "type": "haventory/config"})
+    after = await client.receive_json()
+    assert after["success"] is True, after
+    assert after["result"]["quick_filters"] == ["low_stock", "overdue"]
+
+
+async def test_the_options_flow_refuses_a_pill_it_does_not_offer(hass: HomeAssistant) -> None:
+    """A name outside the five is rejected by the form, not stored and dropped later."""
+
+    entry = await _setup(hass)
+
+    flow = await hass.config_entries.options.async_init(entry.entry_id)
+    with pytest.raises(InvalidData):
+        await hass.config_entries.options.async_configure(
+            flow["flow_id"],
+            {
+                CONF_CARD_TITLE: "HAventory",
+                CONF_SIDEBAR_PANEL_ENABLED: True,
+                CONF_QUICK_FILTERS: ["sideways"],
+                "rate_limit": {},
+            },
+        )
+
+    assert CONF_QUICK_FILTERS not in entry.options

--- a/tests/test_config_flow_offline.py
+++ b/tests/test_config_flow_offline.py
@@ -14,6 +14,7 @@ import json
 from pathlib import Path
 
 import pytest
+import voluptuous as vol
 from custom_components.haventory.config_flow import (
     RATE_LIMIT_DOCS_URL,
     HAventoryConfigFlow,
@@ -21,9 +22,11 @@ from custom_components.haventory.config_flow import (
 )
 from custom_components.haventory.const import (
     CONF_CARD_TITLE,
+    CONF_QUICK_FILTERS,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
     DEFAULT_SIDEBAR_PANEL_ENABLED,
+    QUICK_FILTER_KEYS,
 )
 from homeassistant.config_entries import ConfigEntry
 
@@ -209,6 +212,111 @@ async def test_sidebar_toggle_sits_outside_the_rate_limit_section() -> None:
 
     form = await flow.async_step_init(user_input=None)
     assert CONF_SIDEBAR_PANEL_ENABLED in _schema_keys(form["data_schema"])
+
+
+@pytest.mark.asyncio
+async def test_quick_filters_prefill_every_pill_for_an_entry_that_predates_them() -> None:
+    """An untouched entry opens the form with all five ticked.
+
+    The stored value is still absent at that point, and absent means "no
+    opinion" — so the prefill has to match what the card does without one, or
+    saving the form for the title alone would quietly take pills away.
+    """
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({CONF_CARD_TITLE: "Pantry"})
+
+    form = await flow.async_step_init(user_input=None)
+    assert _schema_default(form["data_schema"], CONF_QUICK_FILTERS) == list(QUICK_FILTER_KEYS)
+
+
+@pytest.mark.asyncio
+async def test_quick_filters_offer_and_store_a_narrowed_set() -> None:
+    """A chosen subset survives the round trip, in the card's own order."""
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({CONF_QUICK_FILTERS: ["low_stock", "total"]})
+
+    form = await flow.async_step_init(user_input=None)
+    assert _schema_default(form["data_schema"], CONF_QUICK_FILTERS) == ["total", "low_stock"]
+
+    result = await flow.async_step_init(
+        user_input={CONF_CARD_TITLE: "Pantry", CONF_QUICK_FILTERS: ["checked_out", "overdue"]}
+    )
+    assert result["data"][CONF_QUICK_FILTERS] == ["overdue", "checked_out"]
+
+
+@pytest.mark.asyncio
+async def test_quick_filters_keep_an_empty_choice_empty() -> None:
+    """Unticking everything means no pills, not "back to the default".
+
+    `[]` and an absent value are different answers all the way to the card, and
+    the form is the only place the empty one can be made.
+    """
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({CONF_QUICK_FILTERS: []})
+
+    form = await flow.async_step_init(user_input=None)
+    assert _schema_default(form["data_schema"], CONF_QUICK_FILTERS) == []
+
+    result = await flow.async_step_init(
+        user_input={CONF_CARD_TITLE: "Pantry", CONF_QUICK_FILTERS: []}
+    )
+    assert result["data"][CONF_QUICK_FILTERS] == []
+
+
+@pytest.mark.asyncio
+async def test_quick_filters_drop_a_name_this_build_does_not_know() -> None:
+    """A stored pill from another version is dropped rather than offered back.
+
+    The selector refuses anything outside the options it lists, so a prefill
+    carrying an unknown name would make the form unsubmittable until the user
+    noticed which invisible value was at fault.
+    """
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({CONF_QUICK_FILTERS: ["low_stock", "sideways"]})
+
+    form = await flow.async_step_init(user_input=None)
+    assert _schema_default(form["data_schema"], CONF_QUICK_FILTERS) == ["low_stock"]
+
+
+@pytest.mark.asyncio
+async def test_the_options_form_refuses_a_pill_that_is_not_offered() -> None:
+    """The selector is the guard: only the five names it lists validate."""
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({})
+
+    form = await flow.async_step_init(user_input=None)
+    with pytest.raises(vol.Invalid):
+        form["data_schema"](
+            {
+                CONF_CARD_TITLE: "Pantry",
+                CONF_SIDEBAR_PANEL_ENABLED: True,
+                CONF_QUICK_FILTERS: ["sideways"],
+                "rate_limit": {},
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_setup_does_not_ask_which_pills(monkeypatch) -> None:
+    """Setup stays two questions; the pills have a default worth keeping.
+
+    Every pill is the right answer until a household says otherwise, and the
+    field means nothing before there is an inventory to filter.
+    """
+
+    flow = HAventoryConfigFlow()
+    monkeypatch.setattr(flow, "_async_current_entries", lambda: [], raising=False)
+
+    form = await flow.async_step_user(user_input=None)
+    assert CONF_QUICK_FILTERS not in _schema_keys(form["data_schema"])
+
+    result = await flow.async_step_user(user_input={CONF_CARD_TITLE: "Pantry"})
+    assert CONF_QUICK_FILTERS not in result["options"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -36,6 +36,7 @@ from custom_components.haventory.const import (
     PANEL_ELEMENT_NAME,
     PANEL_ICON,
     PANEL_URL_PATH,
+    QUICK_FILTER_KEYS,
     STATUS_COLORS,
     STATUS_ICONS,
 )
@@ -835,6 +836,38 @@ def test_the_card_offers_exactly_the_vocabularies_the_backend_accepts() -> None:
 
     assert declared("STATUS_COLORS") == list(STATUS_COLORS)
     assert declared("STATUS_ICONS") == list(STATUS_ICONS)
+
+
+def test_the_options_flow_offers_exactly_the_pills_the_card_draws() -> None:
+    """The pill vocabulary is spelled out in both languages and must agree.
+
+    Neither side can check the other: the options flow stores names the card
+    looks up, and a name only one of them knows is dropped in silence — the
+    household ticks a pill that never appears, or loses one it never untucked.
+    """
+    source = (REPO_ROOT / "cards" / "haventory-card" / "src" / "ui" / "quick-filters.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"export const QUICK_FILTER_KEYS = \[(.*?)\] as const;", source, re.S)
+    assert match is not None, "QUICK_FILTER_KEYS is no longer declared in quick-filters.ts"
+    declared = re.findall(r"'([^']+)'", match.group(1))
+
+    assert declared == list(QUICK_FILTER_KEYS)
+
+
+def test_every_pill_the_options_flow_offers_carries_a_label() -> None:
+    """A selector option with no translation renders its raw wire name.
+
+    Home Assistant looks the labels up under `selector.<key>.options.<value>`,
+    so a pill added on the Python side alone reaches the form as `low_stock`.
+    """
+    strings = json.loads(
+        (REPO_ROOT / "custom_components" / "haventory" / "strings.json").read_text(encoding="utf-8")
+    )
+    labels = strings["selector"]["quick_filters"]["options"]
+
+    assert sorted(labels) == sorted(QUICK_FILTER_KEYS)
+    assert all(isinstance(text, str) and text for text in labels.values())
 
 
 def test_every_status_colour_has_a_rule_in_the_chip_stylesheet() -> None:

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -7,7 +7,11 @@ from copy import deepcopy
 
 import custom_components.haventory as haven_init
 import pytest
-from custom_components.haventory.const import CONF_CARD_TITLE, DEFAULT_CARD_TITLE
+from custom_components.haventory.const import (
+    CONF_CARD_TITLE,
+    CONF_QUICK_FILTERS,
+    DEFAULT_CARD_TITLE,
+)
 from custom_components.haventory.exceptions import (
     CorruptSchemaVersionError,
     SchemaDowngradeError,
@@ -193,6 +197,47 @@ async def test_setup_entry_publishes_card_title(monkeypatch) -> None:
     entry.options[CONF_CARD_TITLE] = "Garage"
     await haven_init._async_options_updated(hass, entry)
     assert hass.data[haven_init.DOMAIN]["card_title"] == "Garage"
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_publishes_the_quick_filter_choice(monkeypatch) -> None:
+    """The pill option reaches hass.data, and an edit to it lands there too."""
+
+    hass = HomeAssistant()
+    entry = ConfigEntry(options={CONF_QUICK_FILTERS: ["low_stock", "total"]})
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+    # Canonical order, not the order the checkboxes were ticked in.
+    assert hass.data[haven_init.DOMAIN]["quick_filters"] == ["total", "low_stock"]
+
+    entry.options[CONF_QUICK_FILTERS] = []
+    await haven_init._async_options_updated(hass, entry)
+    assert hass.data[haven_init.DOMAIN]["quick_filters"] == []
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_leaves_the_quick_filter_choice_unset(monkeypatch) -> None:
+    """No stored choice is `None`, which is not the same as an empty list.
+
+    `None` leaves a dashboard's own `quick_filters:` to decide and the card to
+    offer every pill; `[]` is a household asking for none.
+    """
+
+    hass = HomeAssistant()
+    entry = ConfigEntry()
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+    assert hass.data[haven_init.DOMAIN]["quick_filters"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_utils_offline.py
+++ b/tests/test_ws_utils_offline.py
@@ -107,6 +107,49 @@ async def test_config_falls_back_to_default_card_title() -> None:
 
 
 @pytest.mark.asyncio
+async def test_config_reports_the_configured_quick_filter_pills() -> None:
+    """haventory/config hands the card the pill choice made in the options flow."""
+
+    hass = HomeAssistant()
+    bucket = hass.data.setdefault(DOMAIN, {})
+    bucket["repository"] = Repository()
+    bucket["quick_filters"] = ["total", "low_stock"]
+    ws_setup(hass)
+
+    res = await _send(hass, 7, "haventory/config")
+    assert res["success"] is True
+    assert res["result"]["quick_filters"] == ["total", "low_stock"]
+
+
+@pytest.mark.asyncio
+async def test_config_reports_an_empty_pill_choice_as_empty() -> None:
+    """No pills is a choice, and has to arrive as one rather than as "unset"."""
+
+    hass = HomeAssistant()
+    bucket = hass.data.setdefault(DOMAIN, {})
+    bucket["repository"] = Repository()
+    bucket["quick_filters"] = []
+    ws_setup(hass)
+
+    res = await _send(hass, 8, "haventory/config")
+    assert res["success"] is True
+    assert res["result"]["quick_filters"] == []
+
+
+@pytest.mark.asyncio
+async def test_config_reports_no_pill_choice_as_null() -> None:
+    """An entry that never chose leaves the decision to the dashboard."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    ws_setup(hass)
+
+    res = await _send(hass, 9, "haventory/config")
+    assert res["success"] is True
+    assert res["result"]["quick_filters"] is None
+
+
+@pytest.mark.asyncio
 async def test_config_reports_the_status_vocabulary() -> None:
     """The card labels a stored slug from here, not from a constant of its own."""
 


### PR DESCRIPTION
## Summary

The quick-filter pills shipped as a card YAML key, which leaves the feature reachable only from the raw YAML editor and unreachable on the sidebar panel by construction — a panel has no Lovelace config, so `haventory-panel.ts` never set `.quickFilters` and the page always offered all five. The options flow is the one surface that reaches both, so the pill choice becomes an integration-wide setting with the card key kept as the per-dashboard override, exactly the shape `title` already has.

Precedence, copied from `index.ts:_heading()`:

```
card:   this.config?.quickFilters ?? store.quickFilters ?? null   // null = all pills
panel:  store.quickFilters ?? null
```

**`null` and `[]` stay different answers end to end.** The config entry stores no key until a household chooses; `haventory/config` reports `quick_filters: null` for that state and a list for every other; the store keeps `null` apart from `[]`; the card falls through `null` to the dashboard key and then to every pill, and stops at `[]`. What makes this safe in the form: the field prefills with *every* pill when nothing is stored, so saving the options form to change the title cannot quietly mean "no pills". Once saved, the choice is explicit — the unset state is not reachable from the form, only from an entry that predates the option, which is the state every install upgrading into this release is in.

**Setup does not ask.** `card_title` does, but setup is deliberately two questions and this one has a default worth keeping — the field also means little before there is an inventory to filter. Options flow only, as recommended in the plan; a test pins it so the decision does not drift.

**The cross-language pin.** The five names now exist in Python (`QUICK_FILTER_KEYS` in `const.py`) as well as TypeScript (`ui/quick-filters.ts`), and a mismatch drops a pill in silence rather than failing. `tests/test_frontend_registration.py` holds the two lists to each other the way it holds `PANEL_ICON` to the bundle's icon set, plus a second test that every offered pill has a translated label — without one, HA renders the raw wire name in the form.

The backend hands over a list and does not re-decide what is valid: the value lands in the existing `normalizeQuickFilters`, and the only filtering on the Python side is dropping names this build does not know, so an unknown entry never reaches a form that would then refuse to submit.

**UI.** The field is a `SelectSelector(multiple=True, mode=LIST)` — five labelled checkboxes rather than a dropdown of wire names — with the labels in `strings.json` / `translations/en.json` under `selector.quick_filters.options`.

Closes #365

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (789 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1764 passed), `npm run build` — all green.
- [x] In-process HA suite (phacc): `.venv-integration/bin/python -m pytest -o asyncio_mode=auto tests/integration` — 44 passed before this change, 46 with the two new options-flow tests.

New coverage: the options form's prefill for an unset entry (all five) and for a stored one; an empty choice surviving the round trip; an unknown stored name dropped from the prefill; the schema refusing a pill it does not offer; the setup step *not* asking; `hass.data` carrying the resolved list and `None` for an entry that never chose; `haventory/config` reporting list / `[]` / `null`; the store keeping the three apart and dropping unknown names; card precedence in all five combinations; and the panel taking its pills from the store alone.

**On the phacc mode**, which the plan asked the first session needing it to report: `scripts/test_integration.sh` **fails as written in this cloud environment**, and not for a network reason. `requirements-integration.txt` pins `homeassistant==2026.6.0`, which requires Python `>=3.14.2`; the `uv` on the image (0.8.17) knows no 3.14 build newer than `3.14.0rc2`, so `uv python install 3.14` provisions rc2 and the resolve fails with *"the current Python version (3.14rc2) does not satisfy Python>=3.14.2"*. Installing `uv==0.12.3` from PyPI (reachable) and running `uv python install 3.14.2` fixes it, after which the suite provisions and runs normally. This is the environment's uv, not the script — but a one-line floor in `scripts/test_integration.sh` (require a uv new enough to fetch the interpreter HA's floor needs, or pin `3.14.2` rather than `3.14`) would turn a confusing resolver error into a clear one. Noted under Follow-ups rather than fixed here.

The two new phacc tests are the only place the selector is genuinely applied — offline it is a stand-in — so the shape of its config (`options`, `multiple`, `mode`) and real HA's refusal of an unoffered name are asserted there.

## Live verification

H6 in `dev/v0_5_0_handover_prompts.md`: how HA actually draws the multi-pick selector inside the options flow, and that the sidebar panel honours the stored value. Everything offline can show is green; the handover confirms the rendering and the panel, so this PR is complete-but-unverified rather than incomplete.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`).
- [x] WebSocket API changes keep `ws.py` and `docs/backend_api_contract.md` in sync (`docs/data_shapes.md` carries no config shape, so it is unchanged).
- [x] Essential invariants preserved — this touches no item or location data path.

## Screenshots (card / UI changes)

None from here: the change is an options-flow field plus a value passed through to pills that already render. Screenshots of the form and the panel are what H6 asks the local session to send back.

## Follow-ups

- `scripts/test_integration.sh` provisions `3.14` and gets whatever build the local uv knows. Against an old uv that is `3.14.0rc2`, below HA's own `>=3.14.2` floor, and the failure reads as a dependency conflict rather than "your uv is too old". Worth a floor check or a `3.14.2` pin; it can matter on any developer machine with a stale uv, so it may be worth an issue.
- `tests/conftest.py` now stubs `homeassistant.helpers.selector` for the offline suite. It models only what the options flow uses (a `multiple` select validating against its option list); anything more elaborate belongs in the phacc mode instead, where the real one runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156xD2ghUcqn6RWTcveyanx)_