### PR TITLE
feat(import): warn when an incoming name collides with another id

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,11 @@ What HAventory does *not* do today, stated up front so none of it is a surprise:
   all classify an incoming item or location by its id. Restoring a backup onto entities
   you rebuilt by hand — which carry fresh uuids — therefore duplicates them instead of
   merging, and the backup's items follow their stored `location_id` onto the duplicate.
-  Restore into an empty inventory, or onto one whose ids are still intact.
+  Restore into an empty inventory, or onto one whose ids are still intact. **The import
+  preview flags this before you write anything**: every incoming entry about to be added
+  under a name something here already answers to — under a different id — is listed as a
+  name clash in the preview sheet. It warns rather than gates, because resolving it would
+  mean matching by name, which is exactly what identity-by-id exists to avoid.
 - **A JSON export carries attachment *metadata*, not the files.** The export is one
   WebSocket result the card writes to a file, so it cannot carry binaries; photos and
   manuals live on disk under `<config>/haventory/attachments/`. Importing a document onto

--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -204,16 +204,17 @@ describe('hv-import-sheet: preview', () => {
           {
             code: 'name_collision',
             path: 'items[0]',
-            message: '"Hammer" will be added as a second entry: an existing item already goes by that name.',
+            message:
+              '"Hammer" would be added while an item here already goes by that name, under a different id.',
             name: 'Hammer',
-            existing_id: 'abc',
+            existing_ids: ['abc'],
           },
         ],
       }),
     });
     const block = q(el, '[data-testid="import-warnings"]');
     expect(block?.textContent).toContain('1 name clash');
-    expect(block?.textContent).toContain('"Hammer" will be added as a second entry');
+    expect(block?.textContent).toContain('"Hammer" would be added while an item here already goes by');
   });
 
   it('warns without gating: the import button stays enabled either way', async () => {

--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -197,6 +197,61 @@ describe('hv-import-sheet: preview', () => {
     expect(q(el, '[data-testid="import-conflicts"]')).toBe(null);
   });
 
+  it('flags an incoming name a different id already answers to', async () => {
+    const el = await mount({
+      preview: preview({
+        warnings: [
+          {
+            code: 'name_collision',
+            path: 'items[0]',
+            message: '"Hammer" will be added as a second entry: an existing item already goes by that name.',
+            name: 'Hammer',
+            existing_id: 'abc',
+          },
+        ],
+      }),
+    });
+    const block = q(el, '[data-testid="import-warnings"]');
+    expect(block?.textContent).toContain('1 name clash');
+    expect(block?.textContent).toContain('"Hammer" will be added as a second entry');
+  });
+
+  it('warns without gating: the import button stays enabled either way', async () => {
+    const withWarnings = await mount({
+      preview: preview({
+        warnings: [{ code: 'name_collision', path: 'items[0]', message: 'a clash' }],
+      }),
+    });
+    expect((q(withWarnings, '[data-testid="import-execute"]') as HTMLButtonElement).disabled).toBe(false);
+
+    const without = await mount({ preview: preview() });
+    expect((q(without, '[data-testid="import-execute"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('hides the warning block when there are none, and when the backend sends none', async () => {
+    const empty = await mount({ preview: preview({ warnings: [] }) });
+    expect(q(empty, '[data-testid="import-warnings"]')).toBe(null);
+
+    // A backend that predates warnings omits the key entirely.
+    const absent = await mount({ preview: preview() });
+    expect(absent.preview?.warnings).toBeUndefined();
+    expect(q(absent, '[data-testid="import-warnings"]')).toBe(null);
+  });
+
+  it('lists the first few clashes and counts the rest', async () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      code: 'name_collision',
+      path: `items[${i}]`,
+      message: `clash ${i}`,
+    }));
+    const el = await mount({ preview: preview({ warnings: many }) });
+    const text = el.shadowRoot?.textContent?.replace(/\s+/g, ' ') ?? '';
+    expect(text).toContain('8 name clashes');
+    expect(text).toContain('clash 4');
+    expect(text).not.toContain('clash 5');
+    expect(text).toContain('and 3 more');
+  });
+
   it('states the all-or-nothing behaviour and what it costs other clients', async () => {
     const el = await mount({ preview: preview() });
     const text = el.shadowRoot?.textContent?.replace(/\s+/g, ' ') ?? '';

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -17,6 +17,13 @@ import type { ImportBucketCounts, ImportPolicy, ImportPreview, ImportSummary } f
 // deletes anything — an item absent from the file is always left alone — so each
 // description says so too, because "Replace" on its own reads like a
 // whole-inventory swap.
+/**
+ * How many name clashes are listed individually before the block switches to a
+ * count. A restore onto a hand-rebuilt inventory can clash on hundreds of
+ * entries, and a list that long would push the import button off the sheet.
+ */
+const WARNING_LIST_LIMIT = 5;
+
 const POLICIES: { id: ImportPolicy; title: string; description: string }[] = [
   {
     id: 'merge',
@@ -254,6 +261,11 @@ export class HVImportSheet extends LitElement {
       .alert.ok {
         background: var(--hv-primary-tint);
         color: var(--hv-success);
+      }
+      .warn-list {
+        margin: 6px 0 0;
+        /* Room for the marker, which sits outside the text box by default. */
+        padding-inline-start: 18px;
       }
       .fine {
         font-size: 12px;
@@ -543,6 +555,8 @@ export class HVImportSheet extends LitElement {
     const locations = preview.counts.locations;
     const conflicts = preview.items.conflict.length + preview.locations.conflict.length;
     const willWrite = (items?.add ?? 0) + (items?.update ?? 0);
+    // Absent on a preview from a backend that predates warnings.
+    const warnings = preview.warnings ?? [];
 
     return html`
       <div class="head">
@@ -565,6 +579,24 @@ export class HVImportSheet extends LitElement {
                   : preview.policy === 'skip'
                     ? 'Skip leaves them as they are.'
                     : 'Replace overwrites them.'}
+              </span>
+            </div>`
+          : null}
+        ${warnings.length
+          ? html`<div class="alert warn" data-testid="import-warnings">
+              <span class="glyph">${icon('alert', 18)}</span>
+              <span>
+                ${counted(warnings.length, 'name clash', 'name clashes')} — the file would add
+                ${warnings.length === 1 ? 'an entry' : 'entries'} under a name something here already uses,
+                under a different id. Import matches on the id alone, so
+                ${warnings.length === 1 ? 'this becomes a duplicate' : 'these become duplicates'} rather than
+                an update.
+                <ul class="warn-list">
+                  ${warnings.slice(0, WARNING_LIST_LIMIT).map((w) => html`<li>${w.message}</li>`)}
+                </ul>
+                ${warnings.length > WARNING_LIST_LIMIT
+                  ? html`<span class="hint">…and ${warnings.length - WARNING_LIST_LIMIT} more.</span>`
+                  : null}
               </span>
             </div>`
           : null}

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -410,6 +410,23 @@ export interface ImportError {
   message: string;
 }
 
+/**
+ * A non-blocking finding about an otherwise valid import document.
+ *
+ * Warnings never affect `valid` and never reach `import/execute` — the preview
+ * tells, the entity id still decides. `code` discriminates the kind:
+ * `name_collision` is an incoming entity about to be created under a name a
+ * stored entity of a *different* id already answers to, which import duplicates
+ * rather than merges.
+ */
+export interface ImportWarning {
+  code: 'name_collision' | string;
+  path: string;
+  message: string;
+  name?: string;
+  existing_id?: string;
+}
+
 /** Per-type classification counts in an import preview. */
 export interface ImportBucketCounts {
   total: number;
@@ -431,6 +448,8 @@ export interface ImportBuckets {
 export interface ImportPreview {
   valid: boolean;
   errors: ImportError[];
+  /** Optional so a preview from a backend that predates warnings still type-checks. */
+  warnings?: ImportWarning[];
   policy: ImportPolicy;
   document: {
     haventory_export_version: number | null;

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -424,7 +424,12 @@ export interface ImportWarning {
   path: string;
   message: string;
   name?: string;
-  existing_id?: string;
+  /**
+   * Every stored entity the name collides with, not just one. A location tree
+   * repeats leaf names ("Shelf A", "Drawer 1"), so a hand-rebuilt tree collides
+   * several deep on the same name at once.
+   */
+  existing_ids?: string[];
 }
 
 /** Per-type classification counts in an import preview. */

--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -237,7 +237,7 @@ def _err(path: str, message: str) -> dict[str, str]:
     return {"path": path, "message": message}
 
 
-def _warn(code: str, path: str, message: str, **fields: str) -> dict[str, str]:
+def _warn(code: str, path: str, message: str, **fields: Any) -> dict[str, Any]:
     """One non-blocking finding about an otherwise valid document.
 
     Unlike an error, a warning carries a ``code``: every error means "this
@@ -688,15 +688,104 @@ def _recompute_paths(
     return {"items": out_items, "locations": out_locations}
 
 
+#: How many colliding stored entries a warning quotes by name before it counts
+#: the rest. The message renders as one line in the import sheet, and a repeated
+#: leaf name ("Drawer 1") can collide with a dozen stored entries at once.
+COLLISION_LABELS_SHOWN = 3
+
+
+def _quoted_path(entry: dict[str, Any], key: str) -> str:
+    """The display path an entity carries under ``key``, or "" when it has none."""
+
+    path = entry.get(key)
+    display = path.get("display_path") if isinstance(path, dict) else None
+    return display if isinstance(display, str) and display else ""
+
+
+def _join_phrases(phrases: list[str]) -> str:
+    if len(phrases) == 1:
+        return phrases[0]
+    return f"{', '.join(phrases[:-1])} and {phrases[-1]}"
+
+
+def _describe_incoming_item(doc: dict[str, Any], name: str) -> str:
+    """Name the incoming item, and where the document puts it.
+
+    Two incoming items of one name would otherwise render as two identical
+    lines, and the location is what separates them — the same job the stored
+    side's path does.
+    """
+
+    where = _quoted_path(doc, "location_path")
+    return f'"{name}" in "{where}"' if where else f'"{name}"'
+
+
+def _describe_incoming_location(doc: dict[str, Any], name: str) -> str:
+    return f'"{_quoted_path(doc, "path") or name}"'
+
+
+def _describe_stored_item(_stored: dict[str, Any]) -> str:
+    """An item has no path of its own — the count and the ids are the handle."""
+
+    return ""
+
+
+def _describe_stored_location(stored: dict[str, Any]) -> str:
+    """Name the stored location by its path.
+
+    Two legitimate "Shelf A"s under different parents are common, and the path
+    is what lets an operator tell one from the rebuilt duplicate at a glance.
+    The check itself deliberately does not scope by parent: an incoming
+    location's parent may itself be incoming, so resolving it would mean
+    planning the tree twice to answer what the path already answers.
+    """
+
+    return f'"{_quoted_path(stored, "path")}"' if _quoted_path(stored, "path") else ""
+
+
+def _collision_message(*, subject: str, kind: str, stored_labels: list[str]) -> str:
+    """One self-contained sentence naming both sides of a name collision.
+
+    Held to a single sentence on purpose: the import sheet renders one of these
+    per clash under a lead that already explains what a clash is, so a line that
+    repeats the explanation puts the same claim on screen six times.
+
+    ``stored_labels`` is one entry per colliding stored entity, empty-stringed
+    for a kind that has no path to quote. Every entity is counted; only the
+    quotable ones are named, and only the first few of those.
+    """
+
+    total = len(stored_labels)
+    plural = total > 1
+    ids_phrase = "under different ids" if plural else "under a different id"
+
+    quotable = [label for label in stored_labels if label]
+    if quotable:
+        shown = quotable[:COLLISION_LABELS_SHOWN]
+        rest = total - len(shown)
+        more = f", and {rest} more" if rest > 0 else ""
+        verb = "are" if plural else "is"
+        already = f"{_join_phrases(shown)}{more} {verb} already here"
+    else:
+        article = "an" if kind[0] in "aeiou" else "a"
+        counted_kind = f"{total} {kind}s" if plural else f"{article} {kind}"
+        verb = "go" if plural else "goes"
+        already = f"{counted_kind} here already {verb} by that name"
+
+    return f"{subject} would be added while {already}, {ids_phrase}."
+
+
 def _name_collision_warnings(  # noqa: PLR0913 - one document side, one stored side
     *,
     label: str,
+    kind: str,
     added_ids: list[str],
     incoming: list[dict[str, Any]],
     ids: list[str],
     existing: dict[str, Any],
-    describe,
-) -> list[dict[str, str]]:
+    describe_stored,
+    describe_incoming,
+) -> list[dict[str, Any]]:
     """Flag each incoming entity about to be created under a taken name.
 
     The hazard this catches is the one the contract already names: a document
@@ -717,68 +806,55 @@ def _name_collision_warnings(  # noqa: PLR0913 - one document side, one stored s
     Names are compared under ``normalize_text_for_sort`` — case-insensitive,
     accent-folded, whitespace-collapsed — which is how the repository itself
     compares names.
+
+    **Every** stored entity of a colliding name is reported, not the first one
+    found. Repeated leaf names are how location trees are shaped, so a
+    hand-rebuilt tree collides several deep on "Shelf A" or "Drawer 1" at once;
+    naming one arbitrary stored entity there would point the path quote at the
+    wrong counterpart, which is the one job that quote exists to do.
     """
 
     if not added_ids:
         return []
 
-    stored_by_name: dict[str, tuple[str, dict[str, Any]]] = {}
+    stored_by_name: dict[str, list[tuple[str, dict[str, Any]]]] = {}
     for stored_id, stored in existing.items():
         name = stored.get("name")
         if isinstance(name, str) and name.strip():
-            stored_by_name.setdefault(normalize_text_for_sort(name), (str(stored_id), stored))
+            stored_by_name.setdefault(normalize_text_for_sort(name), []).append(
+                (str(stored_id), stored)
+            )
 
     index_by_id = {eid: idx for idx, eid in enumerate(ids) if eid}
-    warnings: list[dict[str, str]] = []
+    warnings: list[dict[str, Any]] = []
     for eid in added_ids:
         idx = index_by_id.get(eid)
         if idx is None:  # pragma: no cover - every added id came from `ids`
             continue
-        name = incoming[idx].get("name")
+        doc = incoming[idx]
+        name = doc.get("name")
         if not isinstance(name, str) or not name.strip():
             continue
-        match = stored_by_name.get(normalize_text_for_sort(name))
-        if match is None:
+        matches = stored_by_name.get(normalize_text_for_sort(name))
+        if not matches:
             continue
-        existing_id, stored = match
+        # Ordered by what the message shows, so the same document reports the
+        # same thing whatever order the repository happens to hold its entities.
+        ordered = sorted(matches, key=lambda match: (describe_stored(match[1]), match[0]))
         warnings.append(
             _warn(
                 "name_collision",
                 f"{label}[{idx}]",
-                (
-                    f'"{name.strip()}" will be added as a second entry: '
-                    f"{describe(stored)} already goes by that name under a different id. "
-                    "Import matches on the id alone, so this creates a duplicate rather "
-                    "than updating what is here."
+                _collision_message(
+                    subject=describe_incoming(doc, name.strip()),
+                    kind=kind,
+                    stored_labels=[describe_stored(stored) for _, stored in ordered],
                 ),
                 name=name.strip(),
-                existing_id=existing_id,
+                existing_ids=[stored_id for stored_id, _ in ordered],
             )
         )
     return warnings
-
-
-def _describe_stored_item(_stored: dict[str, Any]) -> str:
-    """An item has no path to quote — the id in the warning entry is the handle."""
-
-    return "an existing item"
-
-
-def _describe_stored_location(stored: dict[str, Any]) -> str:
-    """Name the stored location by its path.
-
-    Two legitimate "Shelf A"s under different parents are common, and the path
-    is what lets an operator tell one from the rebuilt duplicate at a glance.
-    The check itself deliberately does not scope by parent: an incoming
-    location's parent may itself be incoming, so resolving it would mean
-    planning the tree twice to answer what the path already answers.
-    """
-
-    path = stored.get("path")
-    display = path.get("display_path") if isinstance(path, dict) else None
-    if isinstance(display, str) and display:
-        return f'the location at "{display}"'
-    return "an existing location"
 
 
 def _empty_bucket() -> dict[str, list[str]]:
@@ -822,7 +898,7 @@ def plan_import(
     if policy not in POLICIES:
         raise ValidationError(f"policy must be one of: {', '.join(POLICIES)}")
 
-    warnings: list[dict[str, str]] = []
+    warnings: list[dict[str, Any]] = []
     items_in, locations_in, errors = _parse_envelope(
         doc, current_schema_version=current_schema_version
     )
@@ -896,21 +972,25 @@ def plan_import(
     warnings.extend(
         _name_collision_warnings(
             label="locations",
+            kind="location",
             added_ids=report["locations"]["add"],
             incoming=locations_in,
             ids=loc_ids,
             existing=existing_locations,
-            describe=_describe_stored_location,
+            describe_stored=_describe_stored_location,
+            describe_incoming=_describe_incoming_location,
         )
     )
     warnings.extend(
         _name_collision_warnings(
             label="items",
+            kind="item",
             added_ids=report["items"]["add"],
             incoming=items_in,
             ids=item_ids,
             existing=existing_items,
-            describe=_describe_stored_item,
+            describe_stored=_describe_stored_item,
+            describe_incoming=_describe_incoming_item,
         )
     )
 

--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -75,6 +75,7 @@ from .models import (
     is_canonical_utc_timestamp,
     iso_utc_now,
     normalize_tags,
+    normalize_text_for_sort,
     parse_uuid4,
     seed_status_definitions,
     serialize_attachment_meta,
@@ -234,6 +235,17 @@ def _sorted_index_by_id(items: list[Item]) -> list[int]:
 
 def _err(path: str, message: str) -> dict[str, str]:
     return {"path": path, "message": message}
+
+
+def _warn(code: str, path: str, message: str, **fields: str) -> dict[str, str]:
+    """One non-blocking finding about an otherwise valid document.
+
+    Unlike an error, a warning carries a ``code``: every error means "this
+    document is unusable" and needs no discriminator, while warnings accumulate
+    kinds, and the code is what keeps a second kind from needing a second list.
+    """
+
+    return {"code": code, "path": path, "message": message, **fields}
 
 
 def _coerce_entity_list(value: Any) -> list[dict[str, Any]] | None:
@@ -676,6 +688,99 @@ def _recompute_paths(
     return {"items": out_items, "locations": out_locations}
 
 
+def _name_collision_warnings(  # noqa: PLR0913 - one document side, one stored side
+    *,
+    label: str,
+    added_ids: list[str],
+    incoming: list[dict[str, Any]],
+    ids: list[str],
+    existing: dict[str, Any],
+    describe,
+) -> list[dict[str, str]]:
+    """Flag each incoming entity about to be created under a taken name.
+
+    The hazard this catches is the one the contract already names: a document
+    imported onto entities that were deleted and rebuilt by hand duplicates
+    them rather than merging, because identity is the id and the rebuilt entity
+    has a new one. That is precisely an incoming entity about to be *created*
+    while a stored entity of a different id already answers to its name.
+
+    Restricted to the ``add`` bucket for the same reason. ``update`` and
+    ``unchanged`` are the same entity by id, so a name they share with some
+    third entity is an ordinary namesake — warning on it would fire on healthy
+    documents, and a check that fires on the normal case is worse than none.
+
+    Incoming-vs-incoming matches are out of scope: duplicate ids inside one
+    document are already an error, and two same-named entities in one document
+    are the exporting inventory's business, not a collision with this one.
+
+    Names are compared under ``normalize_text_for_sort`` — case-insensitive,
+    accent-folded, whitespace-collapsed — which is how the repository itself
+    compares names.
+    """
+
+    if not added_ids:
+        return []
+
+    stored_by_name: dict[str, tuple[str, dict[str, Any]]] = {}
+    for stored_id, stored in existing.items():
+        name = stored.get("name")
+        if isinstance(name, str) and name.strip():
+            stored_by_name.setdefault(normalize_text_for_sort(name), (str(stored_id), stored))
+
+    index_by_id = {eid: idx for idx, eid in enumerate(ids) if eid}
+    warnings: list[dict[str, str]] = []
+    for eid in added_ids:
+        idx = index_by_id.get(eid)
+        if idx is None:  # pragma: no cover - every added id came from `ids`
+            continue
+        name = incoming[idx].get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        match = stored_by_name.get(normalize_text_for_sort(name))
+        if match is None:
+            continue
+        existing_id, stored = match
+        warnings.append(
+            _warn(
+                "name_collision",
+                f"{label}[{idx}]",
+                (
+                    f'"{name.strip()}" will be added as a second entry: '
+                    f"{describe(stored)} already goes by that name under a different id. "
+                    "Import matches on the id alone, so this creates a duplicate rather "
+                    "than updating what is here."
+                ),
+                name=name.strip(),
+                existing_id=existing_id,
+            )
+        )
+    return warnings
+
+
+def _describe_stored_item(_stored: dict[str, Any]) -> str:
+    """An item has no path to quote — the id in the warning entry is the handle."""
+
+    return "an existing item"
+
+
+def _describe_stored_location(stored: dict[str, Any]) -> str:
+    """Name the stored location by its path.
+
+    Two legitimate "Shelf A"s under different parents are common, and the path
+    is what lets an operator tell one from the rebuilt duplicate at a glance.
+    The check itself deliberately does not scope by parent: an incoming
+    location's parent may itself be incoming, so resolving it would mean
+    planning the tree twice to answer what the path already answers.
+    """
+
+    path = stored.get("path")
+    display = path.get("display_path") if isinstance(path, dict) else None
+    if isinstance(display, str) and display:
+        return f'the location at "{display}"'
+    return "an existing location"
+
+
 def _empty_bucket() -> dict[str, list[str]]:
     return {"add": [], "update": [], "conflict": [], "unchanged": []}
 
@@ -717,6 +822,7 @@ def plan_import(
     if policy not in POLICIES:
         raise ValidationError(f"policy must be one of: {', '.join(POLICIES)}")
 
+    warnings: list[dict[str, str]] = []
     items_in, locations_in, errors = _parse_envelope(
         doc, current_schema_version=current_schema_version
     )
@@ -724,6 +830,9 @@ def plan_import(
     report: dict[str, Any] = {
         "valid": False,
         "errors": errors,
+        # Present from construction, so an invalid document returns the same
+        # shape as a valid one and the card has one thing to render.
+        "warnings": warnings,
         "policy": policy,
         "document": _document_meta(doc if isinstance(doc, dict) else {}),
         "items": _empty_bucket(),
@@ -778,6 +887,31 @@ def plan_import(
         policy=policy,
         canonical=_canonical_item,
         merge=_merge_item,
+    )
+
+    # After planning, because only planning says which entities land in `add` —
+    # and before path recomputation, because the stored paths a location warning
+    # quotes are the ones this inventory has now, not the ones the import would
+    # produce.
+    warnings.extend(
+        _name_collision_warnings(
+            label="locations",
+            added_ids=report["locations"]["add"],
+            incoming=locations_in,
+            ids=loc_ids,
+            existing=existing_locations,
+            describe=_describe_stored_location,
+        )
+    )
+    warnings.extend(
+        _name_collision_warnings(
+            label="items",
+            added_ids=report["items"]["add"],
+            incoming=items_in,
+            ids=item_ids,
+            existing=existing_items,
+            describe=_describe_stored_item,
+        )
     )
 
     payload = _recompute_paths(target_items, target_locations, errors)

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -222,3 +222,59 @@ second area), one item in `Drawer`, one item in `Garage`, and one item with **no
   tab A across steps 3–6.
 - Whatever step 8 does, in one line — it decides whether the follow-up below is worth an issue.
 - Paste the result as a comment on #194 and reply on the PR thread.
+
+---
+
+## H2 — #195 the name-clash block on a hand-rebuilt inventory
+
+**Branch / PR**: `claude/v0-5-0-w1a-import-name-collisions` / #TBD
+**Why this needs a real HA**: the offline and phacc suites both prove the warning is
+produced and survives the wire, but neither renders it. What is unverified is the block in
+the import sheet on a realistic document — whether the clash list is legible at the width
+the sheet actually has, whether five entries plus "…and N more" is the right cut, and
+whether the block reads as a caution rather than as a refusal while the Import button
+beside it stays enabled.
+
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+
+Then build the situation the warning exists for — an inventory whose locations were
+rebuilt by hand, so they carry fresh ids under the old names:
+
+1. Seed a small tree and some items:
+   `uv run python scripts/ws_init_haventory.py` (or the card's own UI).
+2. **Export a backup** from the card: ⋮ → Export backup. Keep the file.
+3. **Delete every location** and recreate them by hand with the same names — same
+   spelling, same nesting. This is what gives them new ids.
+4. Recreate two or three items by hand under the old names as well, so the item side of
+   the block has something to show.
+
+### Steps
+
+1. Card ⋮ → Import backup, paste or pick the file from step 2, choose **Merge**, Preview.
+2. Read the preview sheet. Repeat with **Replace** and with **Skip**.
+3. Then the negative case, which is the one that matters most: export a *fresh* backup of
+   the inventory as it now stands and immediately preview that file back onto it, under all
+   three policies.
+
+### What "pass" looks like
+
+- Step 2: a `data-testid="import-warnings"` block appears above the fine print, listing the
+  clashes. Each location line quotes the stored location's path (`the location at "Garage /
+  Shelf A"`), which is what tells one legitimate "Shelf A" from the rebuilt duplicate. With
+  more than five, exactly five are listed and the rest are counted.
+- The **Import button stays enabled** in every case, and the preview still reports
+  `valid: true` — this warns, it does not gate.
+- Step 3 produces **no warning block at all**, under all three policies. A check that fires
+  on the ordinary round trip is worse than no check, so this is the failing case to watch
+  for.
+- Legible in both themes: the block uses the same `alert warn` treatment as the existing
+  conflict banner, so it should sit beside it without a second visual language.
+
+### What to send back
+
+- Screenshots of the preview sheet from step 2 (one with a handful of clashes, one with
+  more than five if you can make it) and from step 3, in light and dark.
+- Paste the result as a comment on #195 and reply on the PR thread.

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -227,7 +227,7 @@ second area), one item in `Drawer`, one item in `Garage`, and one item with **no
 
 ## H2 — #195 the name-clash block on a hand-rebuilt inventory
 
-**Branch / PR**: `claude/v0-5-0-w1a-import-name-collisions` / #TBD
+**Branch / PR**: `claude/v0-5-0-w1a-import-name-collisions` / #417
 **Why this needs a real HA**: the offline and phacc suites both prove the warning is
 produced and survives the wire, but neither renders it. What is unverified is the block in
 the import sheet on a realistic document — whether the clash list is legible at the width

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -364,6 +364,17 @@ data. See `data_shapes.md` for the full document, preview, and summary shapes.
     (id present, identical), `update` (id present, differs, resolved by the policy), or
     `conflict` (id present, differs, left untouched by `skip`). Invalid documents return
     `{valid: false, errors: [{path, message}]}` rather than throwing.
+  - **Every preview carries `warnings: <ImportWarning[]>`**, present whether or not it is
+    empty and whether or not the document is valid, so a client has one shape to render.
+    A warning **never affects `valid`** and **never reaches `import/execute`**: the preview
+    tells, the entity id still decides. One code exists today, `name_collision` — an incoming
+    entity classified `add` whose name matches, case- and accent-insensitively, that of a
+    stored entity of the same kind carrying a *different* id. That is exactly the
+    duplicate-on-rebuilt-ids hazard described under `import/execute` below, caught before
+    the write. Only the `add` bucket is checked: `update` and `unchanged` are the same entity
+    by id, so a name they share with some third entity is an ordinary namesake and warning on
+    it would fire on healthy documents. A clean round trip (export → import onto the same
+    instance) therefore produces no warnings under any policy.
   - A valid preview additionally carries `attachments: {referenced: number, missing: number}` —
     how many attachment references the resulting dataset would hold, and how many of them
     name a file this install does not have. The export carries metadata and not bytes, so
@@ -389,7 +400,10 @@ data. See `data_shapes.md` for the full document, preview, and summary shapes.
     `add`, and every incoming item follows its own `location_id` onto the incoming location,
     leaving the hand-rebuilt one holding nothing. `import/preview` shows this before the
     write — entities you expect to already exist appear under `unchanged`/`update`, never
-    under `add`.
+    under `add`, and the preview additionally flags each incoming name a different id already
+    answers to as a `name_collision` warning. It flags the case rather than resolving it:
+    resolving would mean matching by name, which is what identity-by-id exists to avoid.
+    `import/execute` is unchanged by this and applies the document either way.
   - Conflict policies (for ids already present): `skip` keeps the existing entity;
     `replace` overwrites it with the incoming one; `merge` overlays incoming onto
     existing (scalar fields from incoming; item `tags` unioned; item `attachments`

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -365,10 +365,10 @@ Result of `distinct_values`, used by category/tag autocomplete, the browser view
 ```json
 {
   "code": "name_collision",
-  "path": "items[3]",
-  "message": "\"Shelf A\" will be added as a second entry: …",
+  "path": "locations[3]",
+  "message": "\"Garage / Shelf A\" would be added while \"Cellar / Shelf A\" is already here, under a different id.",
   "name": "Shelf A",
-  "existing_id": "uuid-v4"
+  "existing_ids": [ "uuid-v4", ... ]
 }
 ```
 
@@ -379,9 +379,17 @@ Result of `distinct_values`, used by category/tag autocomplete, the browser view
 - `name_collision` is raised for an incoming entity classified `add` whose name matches that
   of a stored entity **of the same kind carrying a different id**. Names are compared
   case-insensitively, accent-folded and whitespace-collapsed — the same comparison the
-  repository uses for names. `existing_id` is the stored entity; for a location the message
-  also quotes its `display_path`, because two legitimate "Shelf A"s under different parents
-  are common and the path is what tells them apart.
+  repository uses for names.
+- `existing_ids` lists **every** stored entity of that name, not one of them. Location trees
+  repeat leaf names ("Shelf A", "Drawer 1"), so a hand-rebuilt tree collides several deep on
+  one name at once, and naming a single arbitrary stored entity would point the path quote at
+  the wrong counterpart.
+- `message` is one self-contained sentence, because a client renders one per clash under a
+  lead that already explains what a clash is. It names the incoming entity by its own
+  `display_path` where it has one — two incoming "Shelf A"s are otherwise indistinguishable
+  on screen — then quotes the colliding stored locations' paths, or counts the colliding
+  stored items, which have no path of their own. At most three stored paths are quoted and
+  the rest are counted; `existing_ids` stays complete either way.
 - Only the `add` bucket is checked. `update` and `unchanged` are the same entity by id, so a
   shared name there is an ordinary namesake, and a clean round trip produces **zero**
   warnings under every policy. Incoming-vs-incoming name matches are out of scope: duplicate

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -333,6 +333,7 @@ Result of `distinct_values`, used by category/tag autocomplete, the browser view
 {
   "valid": true,
   "errors": [ { "path": "items[2].id", "message": "must be a UUID v4 string" } ],
+  "warnings": [ <ImportWarning>, ... ],
   "policy": "merge",
   "document": {
     "haventory_export_version": 1, "schema_version": 4,
@@ -355,6 +356,37 @@ Result of `distinct_values`, used by category/tag autocomplete, the browser view
   empty. Envelope problems (bad/missing versions, malformed `items`/`locations`, a
   `schema_version` newer than supported), invalid entities, duplicate ids, and broken
   references (e.g. an item's `location_id` with no matching location) all surface here.
+  Every import-side rule the WebSocket API enforces on a write is enforced here too — the
+  input caps, the 120-character name limit and the `due_date` ⇔ `checked_out` invariant — so
+  a document cannot introduce an entity the API would refuse.
+- `warnings` is present on every preview, empty or not, valid or not: one shape to render.
+
+`ImportWarning` — a non-blocking finding about an otherwise usable document:
+```json
+{
+  "code": "name_collision",
+  "path": "items[3]",
+  "message": "\"Shelf A\" will be added as a second entry: …",
+  "name": "Shelf A",
+  "existing_id": "uuid-v4"
+}
+```
+
+- A warning **never** affects `valid` and **never** reaches `import/execute`. The preview
+  tells; the id still decides.
+- `code` discriminates the kind — `errors` needs none, because every error means "this
+  document is unusable", while warnings accumulate kinds.
+- `name_collision` is raised for an incoming entity classified `add` whose name matches that
+  of a stored entity **of the same kind carrying a different id**. Names are compared
+  case-insensitively, accent-folded and whitespace-collapsed — the same comparison the
+  repository uses for names. `existing_id` is the stored entity; for a location the message
+  also quotes its `display_path`, because two legitimate "Shelf A"s under different parents
+  are common and the path is what tells them apart.
+- Only the `add` bucket is checked. `update` and `unchanged` are the same entity by id, so a
+  shared name there is an ordinary namesake, and a clean round trip produces **zero**
+  warnings under every policy. Incoming-vs-incoming name matches are out of scope: duplicate
+  ids inside one document are already an error, and two same-named entities in one document
+  are the exporting inventory's business.
 
 `ImportSummary` — result of a successful `haventory/import/execute`:
 ```json

--- a/tests/integration/test_import_export.py
+++ b/tests/integration/test_import_export.py
@@ -120,3 +120,59 @@ async def test_import_preview_reports_errors_without_mutating(
     await client.send_json({"id": 3, "type": "haventory/stats"})
     stats = await client.receive_json()
     assert stats["result"]["items_total"] == 0
+
+
+async def test_import_preview_name_collision_survives_the_wire(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """The warning entry serializes through the real result envelope.
+
+    ``ws_import_preview`` passes the report to ``websocket_api.result_message``
+    unmodified, so only the real command layer proves the payload survives it.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})
+    created = await client.receive_json()
+    stored_id = created["result"]["id"]
+
+    document = {
+        "haventory_export_version": 1,
+        "schema_version": 4,
+        # A hand-rebuilt "Hammer": the same name under an id this install has
+        # never seen, which import adds rather than merges.
+        "items": [
+            {
+                "id": "44444444-4444-4444-8444-444444444444",
+                "name": "Hammer",
+                "quantity": 1,
+                "tags": [],
+                "custom_fields": {},
+            }
+        ],
+        "locations": [],
+    }
+
+    await client.send_json({"id": 2, "type": "haventory/import/preview", "document": document})
+    preview = await client.receive_json()
+
+    assert preview["success"] is True, preview
+    # A warning tells; it does not gate.
+    assert preview["result"]["valid"] is True
+    warnings = preview["result"]["warnings"]
+    assert [w["code"] for w in warnings] == ["name_collision"]
+    assert warnings[0]["existing_id"] == stored_id
+    assert warnings[0]["name"] == "Hammer"
+
+    # And a document with nothing to flag reports the key as an empty list.
+    await client.send_json(
+        {
+            "id": 3,
+            "type": "haventory/import/preview",
+            "document": {**document, "items": []},
+        }
+    )
+    clean = await client.receive_json()
+    assert clean["result"]["warnings"] == []

--- a/tests/integration/test_import_export.py
+++ b/tests/integration/test_import_export.py
@@ -163,7 +163,7 @@ async def test_import_preview_name_collision_survives_the_wire(
     assert preview["result"]["valid"] is True
     warnings = preview["result"]["warnings"]
     assert [w["code"] for w in warnings] == ["name_collision"]
-    assert warnings[0]["existing_id"] == stored_id
+    assert warnings[0]["existing_ids"] == [stored_id]
     assert warnings[0]["name"] == "Hammer"
 
     # And a document with nothing to flag reports the key as an empty list.

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -809,3 +809,183 @@ def test_a_clean_round_trip_still_imports() -> None:
 
     assert report["valid"] is True, report["errors"]
     assert target is not None
+
+
+# -----------------------------
+# Name-collision warnings
+# -----------------------------
+
+
+def _rebuilt_item_doc(name: str, item_id: str = "44444444-4444-4444-8444-444444444444") -> dict:
+    """An item doc whose id is absent here, standing for a hand-rebuilt entity."""
+
+    return _item_doc(id=item_id, name=name)
+
+
+def test_an_incoming_name_taken_by_another_id_is_warned_about() -> None:
+    """The hazard the docs describe: rebuilt ids duplicate rather than merge."""
+
+    repo = Repository()
+    stored = repo.create_item({"name": "Hammer"})
+
+    report, target = ie.plan_import(
+        repo, _envelope(_rebuilt_item_doc("Hammer")), current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    # A warning tells; the id still decides.
+    assert report["valid"] is True, report["errors"]
+    assert target is not None
+    assert len(report["warnings"]) == 1
+    warning = report["warnings"][0]
+    assert warning["code"] == "name_collision"
+    assert warning["path"] == "items[0]"
+    assert warning["name"] == "Hammer"
+    assert warning["existing_id"] == str(stored.id)
+    # Classification is untouched: the entity is still an add.
+    assert report["items"]["add"] == ["44444444-4444-4444-8444-444444444444"]
+
+
+def test_a_location_collision_names_the_stored_path() -> None:
+    """Two legitimate "Shelf A"s under different parents are common."""
+
+    repo = Repository()
+    garage = repo.create_location(name="Garage")
+    shelf = repo.create_location(name="Shelf A", parent_id=str(garage.id))
+
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [],
+        "locations": [
+            {"id": "55555555-5555-4555-8555-555555555555", "name": "Shelf A", "parent_id": None}
+        ],
+    }
+    report, target = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert report["valid"] is True, report["errors"]
+    assert target is not None
+    warning = report["warnings"][0]
+    assert warning["code"] == "name_collision"
+    assert warning["path"] == "locations[0]"
+    assert warning["existing_id"] == str(shelf.id)
+    assert "Garage / Shelf A" in warning["message"]
+
+
+@pytest.mark.parametrize("policy", ["merge", "replace", "skip"])
+def test_a_clean_round_trip_warns_about_nothing(policy: str) -> None:
+    """The regression that matters most.
+
+    Every entity of a re-imported export classifies `unchanged` or `update`, so
+    a check that fired here would fire on every healthy document — which is
+    worse than no check at all.
+    """
+
+    repo = Repository()
+    _seed(repo)
+    # Two entities deliberately sharing a name with a third, to prove a
+    # legitimate namesake is not what this warns about.
+    repo.create_item({"name": "Hammer"})
+    repo.create_location(name="Hammer")
+
+    report, target = ie.plan_import(
+        repo, _doc_from(repo), policy=policy, current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    assert report["valid"] is True, report["errors"]
+    assert target is not None
+    assert report["warnings"] == []
+
+
+@pytest.mark.parametrize("policy", ["merge", "replace", "skip"])
+def test_a_round_trip_onto_a_changed_inventory_still_warns_about_nothing(policy: str) -> None:
+    """`update` and `conflict` are the same entity by id — not a collision."""
+
+    repo = Repository()
+    ids = _seed(repo)
+    doc = _doc_from(repo)
+    # Change one stored item so the document classifies it update/conflict
+    # rather than unchanged, depending on the policy.
+    repo.update_item(ids["hammer"], {"quantity": 99})
+
+    report, _ = ie.plan_import(
+        repo, doc, policy=policy, current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    assert report["warnings"] == []
+
+
+@pytest.mark.parametrize("incoming_name", ["hammer", "HAMMER", "  Hammer  ", "Hämmer"])
+def test_names_differing_only_by_case_spacing_or_accent_still_collide(incoming_name: str) -> None:
+    """Compared the way the repository compares names, not byte for byte."""
+
+    repo = Repository()
+    repo.create_item({"name": "Hammer"})
+
+    report, _ = ie.plan_import(
+        repo,
+        _envelope(_rebuilt_item_doc(incoming_name)),
+        current_schema_version=CURRENT_SCHEMA_VERSION,
+    )
+
+    assert [w["code"] for w in report["warnings"]] == ["name_collision"]
+
+
+def test_no_warning_when_the_colliding_stored_entity_is_the_same_id() -> None:
+    """Same id means the same entity — an update, not a duplicate."""
+
+    repo = Repository()
+    stored = repo.create_item({"name": "Hammer"})
+
+    report, _ = ie.plan_import(
+        repo,
+        _envelope(_item_doc(id=str(stored.id), name="Hammer", quantity=7)),
+        current_schema_version=CURRENT_SCHEMA_VERSION,
+    )
+
+    assert report["items"]["update"] == [str(stored.id)]
+    assert report["warnings"] == []
+
+
+def test_an_invalid_document_returns_warnings_as_an_empty_list() -> None:
+    """One shape for the card to render, valid or not — never a missing key."""
+
+    repo = Repository()
+    bad = {"haventory_export_version": 1, "schema_version": CURRENT_SCHEMA_VERSION, "items": 3}
+
+    report, target = ie.plan_import(repo, bad, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert report["valid"] is False
+    assert target is None
+    assert report["warnings"] == []
+
+
+def test_warnings_do_not_reach_import_execute() -> None:
+    """The preview tells; the id still decides. Execute is unchanged."""
+
+    repo = Repository()
+    repo.create_item({"name": "Hammer"})
+
+    report, target = ie.plan_import(
+        repo, _envelope(_rebuilt_item_doc("Hammer")), current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+    assert report["warnings"]
+    assert target is not None
+
+    repo.load_state(target)
+    # Both survive: the warning flagged the duplicate, it did not prevent it.
+    names = sorted(item.name for item in repo._items_by_id.values())
+    assert names == ["Hammer", "Hammer"]
+
+
+@pytest.mark.asyncio
+async def test_ws_import_preview_carries_the_warnings() -> None:
+    hass = _new_hass()
+    hass.data[DOMAIN]["repository"].create_item({"name": "Hammer"})
+
+    res = await _send(
+        hass, 1, "haventory/import/preview", document=_envelope(_rebuilt_item_doc("Hammer"))
+    )
+
+    assert res["success"] is True, res
+    assert res["result"]["valid"] is True
+    assert [w["code"] for w in res["result"]["warnings"]] == ["name_collision"]

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -840,7 +840,7 @@ def test_an_incoming_name_taken_by_another_id_is_warned_about() -> None:
     assert warning["code"] == "name_collision"
     assert warning["path"] == "items[0]"
     assert warning["name"] == "Hammer"
-    assert warning["existing_id"] == str(stored.id)
+    assert warning["existing_ids"] == [str(stored.id)]
     # Classification is untouched: the entity is still an add.
     assert report["items"]["add"] == ["44444444-4444-4444-8444-444444444444"]
 
@@ -867,7 +867,7 @@ def test_a_location_collision_names_the_stored_path() -> None:
     warning = report["warnings"][0]
     assert warning["code"] == "name_collision"
     assert warning["path"] == "locations[0]"
-    assert warning["existing_id"] == str(shelf.id)
+    assert warning["existing_ids"] == [str(shelf.id)]
     assert "Garage / Shelf A" in warning["message"]
 
 
@@ -989,3 +989,156 @@ async def test_ws_import_preview_carries_the_warnings() -> None:
     assert res["success"] is True, res
     assert res["result"]["valid"] is True
     assert [w["code"] for w in res["result"]["warnings"]] == ["name_collision"]
+
+
+def test_every_stored_entity_of_a_colliding_name_is_reported() -> None:
+    """Repeated leaf names are how location trees are shaped.
+
+    A hand-rebuilt tree collides several deep on "Shelf A" at once, and naming
+    one arbitrary stored location would point the path quote at the wrong
+    counterpart — the one job that quote exists to do.
+    """
+
+    repo = Repository()
+    garage = repo.create_location(name="Garage")
+    cellar = repo.create_location(name="Cellar")
+    garage_shelf = repo.create_location(name="Shelf A", parent_id=str(garage.id))
+    cellar_shelf = repo.create_location(name="Shelf A", parent_id=str(cellar.id))
+
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [],
+        "locations": [
+            {
+                "id": "55555555-5555-4555-8555-555555555555",
+                "name": "Shelf A",
+                "parent_id": None,
+                "path": {"display_path": "Garage / Shelf A"},
+            }
+        ],
+    }
+    report, _ = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert report["valid"] is True, report["errors"]
+    warning = report["warnings"][0]
+    assert sorted(warning["existing_ids"]) == sorted([str(garage_shelf.id), str(cellar_shelf.id)])
+    # Both stored paths are named, so neither line claims a counterpart it does
+    # not have.
+    assert '"Cellar / Shelf A"' in warning["message"]
+    assert '"Garage / Shelf A"' in warning["message"]
+
+
+def test_two_incoming_entries_of_one_name_do_not_render_identically() -> None:
+    """Each line has to say which incoming entry it is about.
+
+    Naming the subject by bare name alone leaves two hand-rebuilt "Shelf A"s as
+    two byte-identical bullets in the import sheet.
+    """
+
+    repo = Repository()
+    repo.create_location(name="Shelf A")
+
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [],
+        "locations": [
+            {
+                "id": "55555555-5555-4555-8555-555555555555",
+                "name": "Shelf A",
+                "parent_id": None,
+                "path": {"display_path": "Garage / Shelf A"},
+            },
+            {
+                "id": "66666666-6666-4666-8666-666666666666",
+                "name": "Shelf A",
+                "parent_id": None,
+                "path": {"display_path": "Cellar / Shelf A"},
+            },
+        ],
+    }
+    report, _ = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    incoming_entries = 2
+    messages = [w["message"] for w in report["warnings"]]
+    assert len(messages) == incoming_entries
+    assert len(set(messages)) == incoming_entries
+    assert any('"Garage / Shelf A" would be added' in m for m in messages)
+    assert any('"Cellar / Shelf A" would be added' in m for m in messages)
+
+
+def test_an_item_collision_counts_the_stored_namesakes_and_places_the_incoming() -> None:
+    """An item has no path of its own, so the count and its location carry it."""
+
+    repo = Repository()
+    first = repo.create_item({"name": "Hammer"})
+    second = repo.create_item({"name": "hammer"})
+
+    report, _ = ie.plan_import(
+        repo,
+        _envelope(
+            _item_doc(
+                id="44444444-4444-4444-8444-444444444444",
+                name="Hammer",
+                location_path={"display_path": "Garage / Shelf A"},
+            )
+        ),
+        current_schema_version=CURRENT_SCHEMA_VERSION,
+    )
+
+    warning = report["warnings"][0]
+    assert sorted(warning["existing_ids"]) == sorted([str(first.id), str(second.id)])
+    assert '"Hammer" in "Garage / Shelf A" would be added' in warning["message"]
+    assert "2 items here already go by that name" in warning["message"]
+
+
+def test_a_collision_message_stays_one_line_however_many_entries_collide() -> None:
+    """A repeated leaf name can collide a dozen deep; the message still fits."""
+
+    colliding = 12
+    repo = Repository()
+    for i in range(colliding):
+        parent = repo.create_location(name=f"Room {i}")
+        repo.create_location(name="Drawer 1", parent_id=str(parent.id))
+
+    doc = {
+        "haventory_export_version": 1,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": [],
+        "locations": [
+            {
+                "id": "55555555-5555-4555-8555-555555555555",
+                "name": "Drawer 1",
+                "parent_id": None,
+                "path": {"display_path": "Room 0 / Drawer 1"},
+            }
+        ],
+    }
+    report, _ = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    warning = report["warnings"][0]
+    # Every colliding id is reported; only the first few are named.
+    assert len(warning["existing_ids"]) == colliding
+    # The subject plus the quoted stored paths, and no more.
+    assert warning["message"].count("Drawer 1") == ie.COLLISION_LABELS_SHOWN + 1
+    assert f"and {colliding - ie.COLLISION_LABELS_SHOWN} more" in warning["message"]
+
+
+def test_a_collision_message_does_not_repeat_the_sheet_lead() -> None:
+    """The sheet renders one of these per clash under a lead that explains it.
+
+    A line that restates the explanation puts the same claim on screen once per
+    entry, which is what turns the block into a wall.
+    """
+
+    repo = Repository()
+    repo.create_item({"name": "Hammer"})
+
+    report, _ = ie.plan_import(
+        repo, _envelope(_rebuilt_item_doc("Hammer")), current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    message = report["warnings"][0]["message"]
+    assert "Import matches on the id alone" not in message
+    assert message.count(".") == 1


### PR DESCRIPTION
## Summary

> **Stacked on #415.** Based on `claude/v0-5-0-w1a-input-hardening` so the diff shown here is only this change — both PRs edit `import_export.py` and `tests/test_import_export_offline.py` in overlapping places. GitHub retargets this to `main` automatically when #415 merges. Review #415 first.

Import identity is the entity id and only the id, which is what keeps two genuinely different "Shelf A"s from being fused. The corollary — already stated in `docs/backend_api_contract.md` — is that a backup restored onto entities somebody deleted and rebuilt by hand duplicates them rather than merging, because the rebuilt entities carry fresh uuids and the document's copies classify as `add`. The preview is the only surface that could catch that before the write, since it already holds both sides in hand.

`plan_import` now returns `warnings` beside `errors`, present whether or not it is empty and whether or not the document is valid, so the card has one shape to render rather than an optional key. **Warnings never touch `report["valid"]` and never reach `import/execute`**: the preview tells, the id still decides. That is the whole reason the check lives here rather than in `_plan_entities`, which resolves the write.

One code today, `name_collision`: an incoming entity classified `add` whose name matches — under `normalize_text_for_sort`, the repository's own name comparison, so case, accents and spacing all fold — that of a stored entity of the same kind carrying a *different* id.

```json
{"code": "name_collision", "path": "items[3]", "name": "Shelf A",
 "existing_id": "<uuid>", "message": "…"}
```

`errors` needs no code (every error means "this document is unusable"); warnings will accumulate kinds, and the code is what keeps a second kind from needing a second list.

Card side: `_renderPreview` grows a warning block beside the existing conflict alert, same `alert warn` treatment, listing the first five clashes and counting the rest. It sits above the fine print and **leaves the execute button enabled** — this warns, it does not gate.

Closes #195

## The two choices that carry the design

**Only the `add` bucket is checked.** `update` and `unchanged` are the same entity by id, so a name they share with some third entity is an ordinary namesake — warning on it would fire on healthy documents. The hazard being caught is precisely an incoming entity about to be *created* while a stored entity of a different id already answers to its name, and `add` is that set exactly, so the check has no false-positive class to tune away. **The regression that matters is that a clean round trip produces zero warnings under every policy**, and it is asserted three ways: a plain export→import (parametrized over `merge`/`replace`/`skip`), the same onto an inventory changed since the export so entities classify `update`/`conflict` rather than `unchanged`, and a seeded inventory deliberately containing two entities that share a name with a third, to prove a legitimate namesake is not what this flags.

**Locations are not scoped by parent.** An incoming location's parent may itself be incoming, so resolving it would mean planning the tree twice to answer a question the path already answers. Instead the message quotes the stored location's `display_path` — `the location at "Garage / Shelf A"` — because two legitimate "Shelf A"s under different parents are common, and the path is what lets an operator tell one from the rebuilt duplicate at a glance.

Incoming-vs-incoming name matches are out of scope: duplicate ids in one document are already rejected by `_check_duplicate_ids`, and two same-named entities inside one document are the exporting inventory's business, not a collision with this one.

One implementation note worth a reviewer's eye: the warnings are computed **after** `_plan_entities` (only planning says which entities land in `add`) but **before** `_recompute_paths`, so the paths a location warning quotes are the ones this inventory has now, not the ones the import would produce.

## Where the issue has drifted from the code

Nothing material. The notes' file list, warning shape, sequencing and test list all still describe the code as it stands, and I followed them. Two small departures, both additive:

- The card block **lists the individual clashes** (capped at five, with the rest counted) rather than only announcing that some exist. On the motivating case — a restore onto a hand-rebuilt tree — a bare count says nothing an operator can act on, and the per-entry message is where the location path lives. The cap exists because that same case can clash on hundreds of entries, and an uncapped list would push the import button off the sheet.
- The notes name `README.md`'s "import/restore description" as the place to mention this. I put it on the **"Import identity is the id, never the name"** bullet instead, which is where the duplicate-on-rebuilt-ids hazard is actually explained — the preview flagging it belongs in the same breath as the hazard, not two sections away.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

Additive on the wire: `warnings` is a new key on `<ImportPreview>`, typed optional on the card so a preview from an older backend still type-checks. `import/execute` is untouched.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **842 passed, 22 skipped**; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` → **1758 passed (62 files)**, `npm run build` clean.
- [x] In-process HA (phacc): **48 passed**, including a new case in `tests/integration/test_import_export.py` — `ws_import_preview` hands the report to `websocket_api.result_message` unmodified, so only the real command layer proves the warning entry serializes through the envelope.

New offline coverage in `tests/test_import_export_offline.py`: an item collision naming both sides with the entity still in `add` and `valid` still true; a location collision quoting the stored display path; the clean round trip under all three policies; the changed-inventory round trip under all three policies; names differing only by case, casing, spacing or accent still colliding; no warning when the colliding stored entity is the *same* id; an invalid document returning `warnings: []` rather than omitting the key; and that applying the target payload still produces the duplicate — the warning flagged it, it did not prevent it. Card: the block renders with warnings and is absent without them or when the key is missing entirely, the execute button stays enabled in both, and the five-plus-count cut is asserted.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Live verification

**H2** is written into `dev/v0_5_0_handover_prompts.md`, with the setup for building a hand-rebuilt inventory to import onto. Both suites prove the warning is produced and survives the wire; neither renders it. What is open is whether the block is legible at the sheet's real width, whether five-plus-a-count is the right cut, and whether it reads as a caution rather than a refusal with the Import button live beside it. Screenshots in both themes are what comes back.

## Screenshots (card / UI changes)

Deferred to H2 — this session has no Home Assistant to render the sheet against.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtikceikZrGxHZPiRmbFJS)_