### PR TITLE
feat(ws): price category and tag facets against the active filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,9 +548,12 @@ throughout.
   inventory. Category and status each pick one value and
   tags accumulate, matching how the backend treats them. With a filter on, each location,
   category and tag row reads "4 / 37" — matches over total — so you can see where the
-  matches are rather than a total that never moves. Each list drops its own dimension from
-  what it measures against, since that list is how you pick one: the location counts ignore
-  the location filter, and the category and tag counts ignore the chosen category and tags.
+  matches are rather than a total that never moves. All three switch to the pair together,
+  as soon as anything is filtering. Each list drops its own dimension from what it measures
+  against, since that list is how you pick one: the location counts ignore the location
+  filter, and the category and tag counts ignore the chosen category and tags — so with a
+  category as the only filter its own list reads "43 / 43" while the locations beside it
+  narrow, rather than one column carrying two kinds of number.
   No row disappears for matching nothing — the same list is what the item editor offers as
   autocomplete. Each heading also offers a create action: Locations opens an inline
   name field, while Categories, Tags and Status open the organize dialog on their own tab —

--- a/README.md
+++ b/README.md
@@ -546,10 +546,13 @@ throughout.
   Locations stays at the top. Every status row is priced from the backend's own per-status
   counts, so a status nothing carries reads 0 rather than inheriting the rest of the
   inventory. Category and status each pick one value and
-  tags accumulate, matching how the backend treats them. With a filter on, each location
-  row reads "4 / 37" — matches over total — so you can see where the matches are rather
-  than a total that never moves. The counts ignore the *location* filter, since the sidebar
-  is how you pick one. Each heading also offers a create action: Locations opens an inline
+  tags accumulate, matching how the backend treats them. With a filter on, each location,
+  category and tag row reads "4 / 37" — matches over total — so you can see where the
+  matches are rather than a total that never moves. Each list drops its own dimension from
+  what it measures against, since that list is how you pick one: the location counts ignore
+  the location filter, and the category and tag counts ignore the chosen category and tags.
+  No row disappears for matching nothing — the same list is what the item editor offers as
+  autocomplete. Each heading also offers a create action: Locations opens an inline
   name field, while Categories, Tags and Status open the organize dialog on their own tab —
   a category exists through the items using it, so that is where making one is explained.
   The app bar carries an Organize button of its own, beside the ⋮ that also lists it.
@@ -712,7 +715,9 @@ the offline suite. To bring up a real Home Assistant with HACS against the worki
   Areas integration; real-time subscriptions (items, locations, stats); documented persistence.
 - `haventory/distinct_values` returns distinct categories and tags with usage counts
   (categories grouped case-insensitively) plus distinct custom-field keys — powers
-  category/tag autocomplete, the browser views, and custom-field key suggestions.
+  category/tag autocomplete, the browser views, and custom-field key suggestions. With an
+  optional filter each category and tag also reports how many of its items that filter
+  keeps, without dropping any value from the list.
 
 ### ✅ Phase 2: Frontend Lovelace Card (Complete — superseded by Phase 2.5)
 > Historical: this describes the proof-of-concept card. Phase 2.5 replaced its components;

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -634,6 +634,37 @@ describe('hv-full-view: sidebar facets', () => {
     ]);
   });
 
+  // One sidebar column, one meaning for the grey number: with a filter on, the
+  // location rows read "matches / total" and these two read whole-inventory
+  // counts that never moved.
+  it('reads matches over total once a filter is narrowing the list', async () => {
+    const checkedOut = [
+      makeItem({ id: '1', category: 'Tools', tags: ['metric'], checked_out: true }),
+      makeItem({ id: '2', category: 'Tools', tags: ['metric'] }),
+      makeItem({ id: '3', category: 'Cleaning', tags: [] }),
+    ];
+    const { el, store, sr } = await mount({ items: checkedOut });
+    const tally = (section: string, value: string) =>
+      rows(sr, section)
+        .find((r) => r.dataset.value === value)
+        ?.querySelector('.hv-tally')
+        ?.textContent?.trim();
+
+    // Unfiltered, a bare total.
+    expect(tally('categories', 'Tools')).toBe('2');
+
+    store.setFilters({ checkedOutOnly: true });
+    await vi.waitUntil(() => store.state.value.distinctValuesCache?.categories[0]?.matching_count !== undefined);
+    await settle(el);
+
+    expect(tally('categories', 'Tools')).toBe('1 / 2');
+    expect(tally('categories', 'Cleaning')).toBe('0 / 1');
+    expect(tally('tags', 'metric')).toBe('1 / 2');
+    // The heading still counts rows rather than matches — it says how many
+    // categories there are, and none of them went away.
+    expect(q(sr, '[data-testid="sidebar-categories-tally"]')?.textContent?.trim()).toBe('2');
+  });
+
   it('puts a clipped facet name in reach of a pointer', async () => {
     const { sr } = await mount({ items: faceted });
     const row = rows(sr, 'categories').find((r) => r.dataset.value === 'Cleaning');

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -32,7 +32,15 @@ import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
 import type { ColumnKey } from '../store/columns';
-import type { Item, Location, LocationTreeNode, Sort, StoreFilters, StoreState } from '../store/types';
+import type {
+  DistinctValue,
+  Item,
+  Location,
+  LocationTreeNode,
+  Sort,
+  StoreFilters,
+  StoreState,
+} from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import { makeBulkOp } from '../store/store';
 import type { BulkOperation, BulkOutcome } from '../store/types';
@@ -1413,7 +1421,7 @@ export class HVFullView extends LitElement {
   private _renderFacetSection(
     section: 'categories' | 'tags',
     label: string,
-    values: { value: string; count: number }[],
+    values: DistinctValue[],
     isOn: (value: string) => boolean,
     onPick: (value: string) => void,
     head?: unknown,
@@ -1468,7 +1476,14 @@ export class HVFullView extends LitElement {
                        typed is otherwise unreadable — there is nowhere else in
                        the sidebar it appears in full. -->
                   <span class="label hv-browse-row-label" title=${v.value}>${v.value}</span>
-                  <span class="hv-tally">${v.count}</span>
+                  <!-- With a filter on, matches over total — the pair the
+                       location rows already read. A total that never moves says
+                       nothing about where the matches are. -->
+                  <span class="hv-tally"
+                    >${v.matching_count === undefined
+                      ? v.count
+                      : `${v.matching_count} / ${v.count}`}</span
+                  >
                 </button>`,
               )
             : html`<div class="section-empty" data-testid=${`sidebar-${section}-empty`}>

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -678,6 +678,59 @@ describe('Store', () => {
     ]);
   });
 
+  // The commonest filter of all is a category or a tag on its own. Gating the
+  // pair on what survives `facetCountFilters` left exactly that case mixed:
+  // location rows reading "8 / 37" beside category rows reading "43".
+  it('prices every list when the only filter is one the facets drop', async () => {
+    const items = [
+      makeItem({ id: '1', category: 'Tools', tags: ['red'] }),
+      makeItem({ id: '2', category: 'Books', tags: ['blue'] }),
+    ];
+    const hass = makeMockHass({ items });
+    const store = new Store(hass);
+    await store.init();
+
+    store.setFilters({ category: 'Tools' });
+    await vi.waitUntil(
+      () => store.state.value.distinctValuesCache?.categories[0]?.matching_count !== undefined,
+    );
+
+    // Nothing else is narrowing, so every row prices at n / n — true, and the
+    // same shape the location rows are showing at that moment.
+    expect(store.state.value.distinctValuesCache?.categories).toEqual([
+      { value: 'Books', count: 1, matching_count: 1 },
+      { value: 'Tools', count: 1, matching_count: 1 },
+    ]);
+
+    const sent = hass.__messages.filter((m) => m.type === 'haventory/distinct_values');
+    expect(sent[sent.length - 1].filter).toBeDefined();
+  });
+
+  // The same asymmetry the other way round: a lone location filter used to
+  // leave the tree bare while the facet lists beside it carried a pair.
+  it('prices the tree when the only filter is the one it drops', async () => {
+    const hass = makeMockHass({
+      items: [makeItem({ id: '1', location_id: 'garage' })],
+      locations: [
+        {
+          id: 'garage',
+          name: 'Garage',
+          parent_id: null,
+          area_id: null,
+          path: { id_path: ['garage'], name_path: ['Garage'], display_path: 'Garage', sort_key: 'garage' },
+        },
+      ],
+    });
+    const store = new Store(hass);
+    await store.init();
+
+    store.setFilters({ locationId: 'garage' });
+    await vi.waitUntil(() => store.state.value.locationTreeCache?.[0]?.matching_subtree_count !== undefined);
+
+    expect(store.state.value.locationTreeCache?.[0].matching_subtree_count).toBe(1);
+    expect(store.state.value.locationMatchTotal).toBe(1);
+  });
+
   it('coalesces the facet refetch across a burst of filter patches', async () => {
     const hass = makeMockHass({ items: [makeItem({ id: '1', category: 'Tools' })] });
     const store = new Store(hass);

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Store } from './store';
 import { makeMockHass, makeItem } from '../test.utils';
 
@@ -632,6 +632,88 @@ describe('Store', () => {
     store.removeDraftValue('tag', 'seasonal');
 
     expect(store.state.value.distinctValuesCache?.tags).toEqual([]);
+  });
+
+  it('asks for unpriced facets while nothing is filtering', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1', category: 'Tools', tags: ['red'] })] });
+    const store = new Store(hass);
+    await store.init();
+
+    const sent = hass.__messages.filter((m) => m.type === 'haventory/distinct_values');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].filter).toBeUndefined();
+    // No key at all rather than a matching_count equal to count: the two say
+    // different things, and only one of them is a report.
+    expect(store.state.value.distinctValuesCache?.categories).toEqual([
+      { value: 'Tools', count: 1 },
+    ]);
+  });
+
+  it('prices the facets against the active filter, minus category and tags', async () => {
+    const items = [
+      makeItem({ id: '1', category: 'Tools', tags: ['red'], checked_out: true }),
+      makeItem({ id: '2', category: 'Tools', tags: ['red'] }),
+      makeItem({ id: '3', category: 'Books', tags: ['blue'] }),
+    ];
+    const hass = makeMockHass({ items });
+    const store = new Store(hass);
+    await store.init();
+
+    // A category and a tag are picked alongside the narrowing filter; neither
+    // may reach the wire, or every other row would be priced at zero.
+    store.setFilters({ checkedOutOnly: true, category: 'Tools', tags: ['red'] });
+    await vi.waitUntil(
+      () => hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length > 1,
+    );
+
+    const sent = hass.__messages.filter((m) => m.type === 'haventory/distinct_values');
+    const filter = sent[sent.length - 1].filter as Record<string, unknown>;
+    expect(filter.checked_out).toBe(true);
+    expect(filter.category).toBeUndefined();
+    expect(filter.tags_any).toBeUndefined();
+
+    expect(store.state.value.distinctValuesCache?.categories).toEqual([
+      { value: 'Books', count: 1, matching_count: 0 },
+      { value: 'Tools', count: 2, matching_count: 1 },
+    ]);
+  });
+
+  it('coalesces the facet refetch across a burst of filter patches', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1', category: 'Tools' })] });
+    const store = new Store(hass);
+    await store.init();
+    const before = hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length;
+
+    // What a filter panel does: several keys in a row, one answer wanted.
+    store.setFilters({ checkedOutOnly: true });
+    store.setFilters({ lowStockOnly: true });
+    store.setFilters({ q: 'drill' });
+    await vi.waitUntil(
+      () => hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length > before,
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const after = hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length;
+    expect(after).toBe(before + 1);
+  });
+
+  it('gives a draft the priced shape once the server priced the rest', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1', category: 'Tools', checked_out: true })] });
+    const store = new Store(hass);
+    await store.init();
+
+    store.setFilters({ checkedOutOnly: true });
+    await vi.waitUntil(
+      () => hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length > 1,
+    );
+    store.addDraftValue('category', 'Consumables');
+
+    // A draft has no items, so it matches nothing — said in the same shape the
+    // priced rows use, rather than reading as an unpriced row among them.
+    expect(store.state.value.distinctValuesCache?.categories).toEqual([
+      { value: 'Consumables', count: 0, matching_count: 0 },
+      { value: 'Tools', count: 1, matching_count: 1 },
+    ]);
   });
 
   it('scopes the items subscription to the active area and re-opens it when the area changes', async () => {

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -327,6 +327,7 @@ export class Store {
   private retryBaseMs: number;
   private consecutiveTransportFailures = 0;
   private treeRefreshHandle: ReturnType<typeof setTimeout> | null = null;
+  private facetRefreshHandle: ReturnType<typeof setTimeout> | null = null;
   private areasRefreshHandle: ReturnType<typeof setTimeout> | null = null;
   /** Identifies the newest subscribe round, so a superseded one stops reporting. */
   private subscribeRound = 0;
@@ -349,6 +350,8 @@ export class Store {
   private connectionLostHandle: ReturnType<typeof setTimeout> | null = null;
   /** Last untouched `distinct_values` result, so drafts can be re-merged. */
   private serverDistinct: DistinctValues | null = null;
+  /** Whether the last `distinct_values` answer was priced against a filter. */
+  private serverDistinctPriced = false;
   /** Values named in the organize dialog that no item carries yet. */
   private drafts: { categories: string[]; tags: string[] } = { categories: [], tags: [] };
 
@@ -728,6 +731,10 @@ export class Store {
       clearTimeout(this.treeRefreshHandle);
       this.treeRefreshHandle = null;
     }
+    if (this.facetRefreshHandle !== null) {
+      clearTimeout(this.facetRefreshHandle);
+      this.facetRefreshHandle = null;
+    }
     if (this.areasRefreshHandle !== null) {
       clearTimeout(this.areasRefreshHandle);
       this.areasRefreshHandle = null;
@@ -796,6 +803,19 @@ export class Store {
     }, delayMs);
   }
 
+  /**
+   * Coalesce facet refetches, for the reason the tree's are coalesced: a filter
+   * panel patches several keys in a row and each patch would otherwise price
+   * every category and tag again.
+   */
+  private scheduleFacetRefresh(delayMs = 250) {
+    if (this.facetRefreshHandle !== null) clearTimeout(this.facetRefreshHandle);
+    this.facetRefreshHandle = setTimeout(() => {
+      this.facetRefreshHandle = null;
+      void this.refreshDistinctValues().catch(() => undefined);
+    }, delayMs);
+  }
+
   private onStatsEvent(evt: AnyEventPayload) {
     if (evt.topic !== 'stats' || evt.action !== 'counts') return;
     this.stateObs.set({ statsCounts: (evt as unknown as { counts: StatsCounts }).counts });
@@ -834,10 +854,28 @@ export class Store {
     this.stateObs.set({ areasCache: areas as AreasListResult });
   }
 
+  /**
+   * The filter the category and tag tallies are measured against.
+   *
+   * Both dimensions drop out, for the reason `locationCountFilters` drops
+   * location: a facet fed its own selection zeroes every other row exactly when
+   * the user wants to see where else the matches are. One request prices both,
+   * so a chosen category does not narrow the tag tallies — the same trade the
+   * tree already makes for its own dimension.
+   */
+  private facetCountFilters(): StoreFilters {
+    return { ...this.state.value.filters, category: null, tags: [] };
+  }
+
   /** Refresh distinct categories/tags with counts (source for autocomplete). */
   async refreshDistinctValues() {
-    const distinct = (await this.run(() => this.ws.distinctValues())) as DistinctValues;
+    const counting = this.facetCountFilters();
+    const filtered = activeFilterCount(counting) > 0;
+    const distinct = (await this.run(() =>
+      this.ws.distinctValues(filtered ? toWireFilter(counting) : undefined),
+    )) as DistinctValues;
     this.serverDistinct = distinct;
+    this.serverDistinctPriced = filtered;
     // A draft the backend now knows about is no longer a draft.
     const known = (list: DistinctValue[], value: string) =>
       list.some((v) => v.value.toLowerCase() === value.toLowerCase());
@@ -888,9 +926,14 @@ export class Store {
   private publishDistinct() {
     const server = this.serverDistinct;
     if (!server) return;
+    // A draft carries no items, so it matches nothing — but it has to say so in
+    // the same shape the priced rows use, or one row in the list reads as
+    // unpriced while the rest read as "0 of N".
+    const draft = (value: string): DistinctValue =>
+      this.serverDistinctPriced ? { value, count: 0, matching_count: 0 } : { value, count: 0 };
     const merge = (list: DistinctValue[], drafts: string[]): DistinctValue[] =>
       drafts.length
-        ? [...list, ...drafts.map((value) => ({ value, count: 0 }))].sort((a, b) =>
+        ? [...list, ...drafts.map(draft)].sort((a, b) =>
             a.value.toLowerCase().localeCompare(b.value.toLowerCase()),
           )
         : list;
@@ -1139,11 +1182,14 @@ export class Store {
     // the only filters that need the sockets torn down and rebuilt.
     if (scopeChanged) this.subscribeTopics();
     void this.listItems(true);
-    // Per-location counts are measured against the filter, so they move with it.
-    // Coalesced: a filter panel can patch several keys in a row. Re-ordering
-    // changes no count, and a sortable table header would otherwise walk the
-    // whole tree on every click.
-    if (Object.keys(patch).some((key) => key !== 'sort')) this.scheduleTreeRefresh();
+    // Per-location, per-category and per-tag counts are all measured against the
+    // filter, so they move with it. Coalesced: a filter panel can patch several
+    // keys in a row. Re-ordering changes no count, and a sortable table header
+    // would otherwise walk the whole tree on every click.
+    if (Object.keys(patch).some((key) => key !== 'sort')) {
+      this.scheduleTreeRefresh();
+      this.scheduleFacetRefresh();
+    }
   }
 
   /** Drop every filter, keeping the current sort. */

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -870,7 +870,13 @@ export class Store {
   /** Refresh distinct categories/tags with counts (source for autocomplete). */
   async refreshDistinctValues() {
     const counting = this.facetCountFilters();
-    const filtered = activeFilterCount(counting) > 0;
+    // Priced whenever *anything* is narrowing the list, including a filter this
+    // measurement then drops. Gating on what survives the drop is what left a
+    // lone category filter reading "8 / 37" on the location rows beside a bare
+    // "43" on the category rows — the mixed column, one dimension narrower.
+    // With nothing else active every row prices at n / n, which is true and
+    // keeps one meaning for the number.
+    const filtered = activeFilterCount(this.state.value.filters) > 0;
     const distinct = (await this.run(() =>
       this.ws.distinctValues(filtered ? toWireFilter(counting) : undefined),
     )) as DistinctValues;
@@ -1065,7 +1071,10 @@ export class Store {
 
   async refreshLocationTree() {
     const counting = this.locationCountFilters();
-    const filtered = activeFilterCount(counting) > 0;
+    // Same rule as the facet tallies, and the same reason: a lone location
+    // filter would otherwise leave this list bare while the two beside it read
+    // a pair.
+    const filtered = activeFilterCount(this.state.value.filters) > 0;
     const tree = await this.run(() => this.ws.getLocationTree(filtered ? toWireFilter(counting) : undefined));
     // Sorted once here so every consumer — sidebar, pickers, organize dialog —
     // sees the same order; the API returns nodes in insertion order.

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -243,6 +243,12 @@ export interface AreasListResult {
 export interface DistinctValue {
   value: string;
   count: number;
+  /**
+   * How many of this value's items the request's filter keeps. Present only
+   * when the request carried a filter, so `undefined` means "unpriced" rather
+   * than "nothing matches" — a backend older than this never sends it.
+   */
+  matching_count?: number;
 }
 
 /** Result of haventory/distinct_values: distinct categories and tags with counts. */

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -58,8 +58,15 @@ export class WSClient {
     return this.hass.callWS<HealthResult>({ type: 'haventory/health' });
   }
 
-  distinctValues() {
-    return this.hass.callWS<DistinctValues>({ type: 'haventory/distinct_values' });
+  /**
+   * Distinct categories, tags and custom-field keys with usage counts. With a
+   * filter each category and tag also carries `matching_count`; the lists
+   * themselves never shrink, so autocomplete keeps its full vocabulary.
+   */
+  distinctValues(filter?: ItemFilter) {
+    const msg: Record<string, unknown> = { type: 'haventory/distinct_values' };
+    if (filter) msg.filter = filter;
+    return this.hass.callWS<DistinctValues>(msg);
   }
 
   // ---------- Items ----------

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -300,7 +300,16 @@ export function makeMockHass(initial?: MockConfig): MockHass {
         }
         case 'haventory/distinct_values': {
           // Mirror the backend: distinct categories (case-insensitive) and tags,
-          // each with a usage count, sorted case-insensitively by value.
+          // each with a usage count, sorted case-insensitively by value. With a
+          // filter each entry also carries `matching_count`, and no entry is
+          // dropped — the list is autocomplete's vocabulary, not a result set.
+          const facetFilter = (msg as any).filter as unknown;
+          const facetMatched = facetFilter ? applyMockFilter(items, facetFilter) : null;
+          const matchedIds = facetMatched && new Set(facetMatched.map((i) => i.id));
+          const priced = <T extends { count: number }>(entry: T, ids: Set<string>) =>
+            matchedIds
+              ? { ...entry, matching_count: [...ids].filter((id) => matchedIds.has(id)).length }
+              : entry;
           const catGroups = new Map<string, { display: string; ids: Set<string> }>();
           for (const it of items) {
             const raw = (it.category ?? '').trim();
@@ -311,7 +320,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
             catGroups.set(key, group);
           }
           const categories = Array.from(catGroups.values())
-            .map((g) => ({ value: g.display, count: g.ids.size }))
+            .map((g) => priced({ value: g.display, count: g.ids.size }, g.ids))
             .sort((a, b) => a.value.toLowerCase().localeCompare(b.value.toLowerCase()));
           const tagGroups = new Map<string, Set<string>>();
           for (const it of items) {
@@ -322,7 +331,7 @@ export function makeMockHass(initial?: MockConfig): MockHass {
             }
           }
           const tags = Array.from(tagGroups.entries())
-            .map(([value, ids]) => ({ value, count: ids.size }))
+            .map(([value, ids]) => priced({ value, count: ids.size }, ids))
             .sort((a, b) => a.value.toLowerCase().localeCompare(b.value.toLowerCase()));
           const customKeys = new Set<string>();
           for (const it of items) {

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -1734,7 +1734,31 @@ class Repository:
             "subtree": len(self._items_in_subtree.get(key, set())),
         }
 
-    def get_distinct_field_values(self) -> dict[str, object]:
+    def _count_facets_matching(self, flt: ItemFilter) -> tuple[dict[str, int], dict[str, int]]:
+        """Tally categories and tags over the items a filter keeps.
+
+        One pass prices both facets — the shape ``count_matching_by_location``
+        uses for its own dimension. Category keys are the casefolded form
+        ``_index_item`` writes, so they line up with ``_category_to_item_ids``;
+        tags are normalized at ingress and de-duplicated per item, so each item
+        contributes at most one to any tag.
+        """
+
+        candidates = self._get_filtered_candidates(flt)
+        source: Iterable[Item] = (
+            candidates if candidates is not None else self._items_by_id.values()
+        )
+        by_category: dict[str, int] = {}
+        by_tag: dict[str, int] = {}
+        for item in filter_items(source, flt, known_statuses=self.status_slugs()):
+            key = (item.category or "").strip().casefold()
+            if key:
+                by_category[key] = by_category.get(key, 0) + 1
+            for tag in item.tags:
+                by_tag[tag] = by_tag.get(tag, 0) + 1
+        return by_category, by_tag
+
+    def get_distinct_field_values(self, flt: ItemFilter | None = None) -> dict[str, object]:
         """Return distinct categories, tags, and custom-field keys.
 
         Categories are grouped case-insensitively (matching the case-insensitive
@@ -1746,7 +1770,20 @@ class Repository:
         used across all items' ``custom_fields`` (keys are case-sensitive; sorted
         case-insensitively). The two value lists are sorted case-insensitively by
         value.
+
+        With ``flt``, every category and tag entry also carries ``matching_count``
+        — how many of that value's items the filter keeps. ``count`` stays a
+        whole-inventory figure and no entry is dropped: the same payload feeds
+        autocomplete and the organize dialog, which a list that shrank with the
+        filter would starve. Which dimensions to leave out of ``flt`` is the
+        caller's call, the way it is for :meth:`count_matching_by_location`.
+        ``custom_field_keys`` is unfiltered either way — it is a key picker, not
+        a tally, and hiding keys would hide ones the user is about to type.
         """
+
+        matching_categories, matching_tags = (
+            self._count_facets_matching(flt) if flt is not None else (None, None)
+        )
 
         categories: list[dict[str, object]] = []
         for key, item_ids in self._category_to_item_ids.items():
@@ -1759,13 +1796,18 @@ class Repository:
                 if raw:
                     originals[raw] = originals.get(raw, 0) + 1
             display = max(sorted(originals), key=lambda o: originals[o]) if originals else key
-            categories.append({"value": display, "count": len(item_ids)})
+            entry: dict[str, object] = {"value": display, "count": len(item_ids)}
+            if matching_categories is not None:
+                entry["matching_count"] = matching_categories.get(key, 0)
+            categories.append(entry)
         categories.sort(key=lambda c: str(c["value"]).casefold())
 
-        tags = [
-            {"value": tag, "count": len(item_ids)}
-            for tag, item_ids in self._tags_to_item_ids.items()
-        ]
+        tags: list[dict[str, object]] = []
+        for tag, item_ids in self._tags_to_item_ids.items():
+            tag_entry: dict[str, object] = {"value": tag, "count": len(item_ids)}
+            if matching_tags is not None:
+                tag_entry["matching_count"] = matching_tags.get(tag, 0)
+            tags.append(tag_entry)
         tags.sort(key=lambda t: str(t["value"]).casefold())
 
         custom_keys: set[str] = set()

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -900,13 +900,21 @@ async def ws_stats(
     conn.send_message(websocket_api.result_message(msg.get("id", 0), counts))
 
 
-@websocket_api.websocket_command({"type": "haventory/distinct_values"})
+@websocket_api.websocket_command(
+    {vol.Required("type"): "haventory/distinct_values", vol.Optional("filter"): object}
+)
 @websocket_api.async_response
 @ws_guard("distinct_values", ())
 async def ws_distinct_values(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    result = _repo(hass).get_distinct_field_values()
+    # With a filter, every value also reports how much of it the filter keeps, so
+    # a sidebar can read "4 / 37" the way the location tree already does. The
+    # list itself never shrinks — the same payload feeds autocomplete and the
+    # organize dialog.
+    item_filter = msg.get("filter")
+    validate_item_filter(item_filter)
+    result = _repo(hass).get_distinct_field_values(item_filter)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), result))
 
 

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -285,7 +285,7 @@ which is the control a household actually uses.
 
 ## H4 — #193 Categories and Tags move with the filter the way Locations does
 
-**Branch / PR**: `claude/v0-5-0-w2-facet-counts` / #TBD
+**Branch / PR**: `claude/v0-5-0-w2-facet-counts` / #422
 **Why this needs a real HA**: the offline suite proves the tallies are computed and the
 component test proves the pair renders. What neither shows is the thing the issue was
 filed about — one sidebar column where the three lists finally agree, read at the width

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -10,23 +10,6 @@ that plan when the milestone closes.
 
 ---
 
-## H6 — #365 quick-filter pills in the options flow
-
-**Branch / PR**: `claude/v0-5-0-w1c-quick-filter-pills` / #416
-**Why this needs a real HA**: the offline suite validates the schema, never the form. What
-it cannot show is how Home Assistant *draws* a `SelectSelector(multiple=True,
-mode=LIST)` inside an options flow — whether the five pills come up as a checkbox list
-with their translated labels or as a dropdown of raw wire names — and whether the sidebar
-panel, which has no Lovelace config at all, picks the stored choice up.
-Cloud sessions have no Home Assistant. Each section below is one thing a V0.5.0 PR could
-not verify offline, written to be run in front of the dev Docker instance the
-`run-haventory` and `test-haventory` skills drive.
-
-Appended in session order, per `dev/V0_5_0_implementation.md` §5. Deleted with that plan
-when the milestone closes.
-
----
-
 ## H1 — #197 the widened frames stop HA core logging the client payload at ERROR
 
 **Branch / PR**: `claude/v0-5-0-w1a-input-hardening` / #415
@@ -36,23 +19,173 @@ rejection at ERROR *with the client's payload in the message* — the whole poin
 `name` / `quantity` / `delta` / `operations` / `filter` / `sort` / `limit` / `cursor` as
 `object` is that they no longer take that path. The in-process suite proves the frames now
 answer `validation_error`; only a running instance shows what its log does about it.
-Cloud sessions have no Home Assistant. Each section below is one thing a cloud session
-finished but could not verify, written for a local session driving the dev Docker instance
-(`run-haventory` / `test-haventory`). Sections are appended in session order; the protocol
-is `dev/V0_5_0_implementation.md` §5.
 
-Delete this file with the plan when the milestone closes.
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+
+Seed one item so the batch case has something to address:
+
+    uv run python scripts/create_test_items.py --count 1
+
+### Steps
+
+1. Start following the log: `docker logs -f home-assistant 2>&1 | grep -i websocket_api`.
+2. Send each of these over the WebSocket (`uv run python scripts/ws_probe.py` drives it):
+   - `{"type": "haventory/item/create", "name": "Hammer", "quantity": 1.5}`
+   - `{"type": "haventory/item/create", "name": 42}`
+   - `{"type": "haventory/item/adjust_quantity", "item_id": "<id>", "delta": "two"}`
+   - `{"type": "haventory/items/bulk", "operations": "oops"}`
+   - `{"type": "haventory/item/list", "filter": {"query": "hammer"}}`
+   - `{"type": "haventory/item/list", "limit": 2, "cursor": ""}`
+3. For contrast, send one frame that is *still* schema-typed and must still be refused by
+   core: `{"type": "haventory/item/create", "name": "Hammer", "tags": "chisel"}`.
+
+### What "pass" looks like
+
+- Every frame in step 2 answers `{"success": false, "error": {"code": "validation_error"}}`,
+  and the message names the field.
+- **No `ERROR` line from `homeassistant.components.websocket_api.http.connection`** for any
+  of them. Each appears once at WARNING from `custom_components.haventory.ws`, with no
+  traceback and with the payload absent from the message.
+- The frame in step 3 still answers `invalid_format` and still logs at ERROR from core —
+  that contrast is what shows the widening is what changed the behaviour, rather than a
+  logging config difference.
+- The inventory is unchanged afterwards: `haventory/stats` reports the same `items_total`
+  it did before step 2.
+
+### What to send back
+
+- The grepped log excerpt covering steps 2 and 3, and the six error envelopes.
+- Paste the result as a comment on #197 and reply on the PR thread.
+
+---
+
+## H2 — #195 the name-clash block on a hand-rebuilt inventory
+
+**Branch / PR**: `claude/v0-5-0-w1a-import-name-collisions` / #417
+**Why this needs a real HA**: the offline and phacc suites both prove the warning is
+produced and survives the wire, but neither renders it. What is unverified is the block in
+the import sheet on a realistic document — whether the clash list is legible at the width
+the sheet actually has, whether five entries plus "…and N more" is the right cut, and
+whether the block reads as a caution rather than as a refusal while the Import button
+beside it stays enabled.
+
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+
+Then build the situation the warning exists for — an inventory whose locations were
+rebuilt by hand, so they carry fresh ids under the old names:
+
+1. Seed a small tree and some items:
+   `uv run python scripts/ws_init_haventory.py` (or the card's own UI).
+2. **Export a backup** from the card: ⋮ → Export backup. Keep the file.
+3. **Delete every location** and recreate them by hand with the same names — same
+   spelling, same nesting. This is what gives them new ids.
+4. Recreate two or three items by hand under the old names as well, so the item side of
+   the block has something to show.
+
+### Steps
+
+1. Card ⋮ → Import backup, paste or pick the file from step 2, choose **Merge**, Preview.
+2. Read the preview sheet. Repeat with **Replace** and with **Skip**.
+3. Then the negative case, which is the one that matters most: export a *fresh* backup of
+   the inventory as it now stands and immediately preview that file back onto it, under all
+   three policies.
+
+### What "pass" looks like
+
+- Step 2: a `data-testid="import-warnings"` block appears above the fine print, listing the
+  clashes. Each location line quotes the stored location's path (`the location at "Garage /
+  Shelf A"`), which is what tells one legitimate "Shelf A" from the rebuilt duplicate. With
+  more than five, exactly five are listed and the rest are counted.
+- The **Import button stays enabled** in every case, and the preview still reports
+  `valid: true` — this warns, it does not gate.
+- Step 3 produces **no warning block at all**, under all three policies. A check that fires
+  on the ordinary round trip is worse than no check, so this is the failing case to watch
+  for.
+- Legible in both themes: the block uses the same `alert warn` treatment as the existing
+  conflict banner, so it should sit beside it without a second visual language.
+
+### What to send back
+
+- Screenshots of the preview sheet from step 2 (one with a handful of clashes, one with
+  more than five if you can make it) and from step 3, in light and dark.
+- Paste the result as a comment on #195 and reply on the PR thread.
 
 ---
 
 ## H3 — #194 an area-filtered subscription only hears about its own area
 
-**Branch / PR**: `claude/v0-5-0-w1b-subscribe-area` / #TBD
+**Branch / PR**: `claude/v0-5-0-w1b-subscribe-area` / #414
 **Why this needs a real HA**: offline tests drive the matcher directly and the in-process
 suite drives one connection. What neither shows is two live dashboards on one Home
 Assistant, each holding its own `haventory/subscribe` round, and a mutation reaching only
 one of them — the fan-out across connections, over a real socket, with real areas from the
 area registry.
+
+
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+
+Seed two areas in HA (Settings → Areas, or reuse two that exist), then build a tree with a
+root anchored in each and one item per root:
+
+    uv run python scripts/ws_init_haventory.py     # if the instance is empty
+    uv run python scripts/ws_probe.py              # for ad-hoc location/create + item/create calls
+
+The shape that matters: `Kitchen` (area = the first area) → `Drawer`, `Garage` (area = the
+second area), one item in `Drawer`, one item in `Garage`, and one item with **no** location.
+
+### Steps
+
+1. Open two browser tabs on the HAventory panel.
+2. In tab A, filter to the kitchen area (area chip in the filter panel). Leave tab B unfiltered.
+3. In tab B, edit the item that lives in `Garage` — rename it.
+4. Watch tab A: the row count and the list must not flicker, and no toast or row change may
+   appear for the garage item.
+5. In tab B, edit the item in `Drawer`. Tab A must show the new name without a manual refresh.
+6. In tab B, edit the item with no location. Tab A must not react.
+7. With tab A still filtered to the kitchen, move `Drawer` under `Garage` (drag in the
+   location tree, or `location/move_subtree`). Tab A is expected to re-list — it does that
+   on the `locations` `moved` event — and the item must then be gone from its list. This is
+   the documented behaviour, not a bug: no per-item departure event is emitted.
+8. Optional, the same case the other way: reassign `Kitchen`'s own area in the location
+   editor. Today that emits no `locations` event at all, so tab A keeps showing the items
+   until something else makes it re-list. Note what you see.
+
+### What "pass" looks like
+
+- Steps 3, 4 and 6: nothing moves in tab A. In the browser devtools WS frames, tab A's
+  connection receives **no** `event` frame carrying the garage item or the location-less one.
+- Step 5: tab A updates live, no refresh.
+- Step 7: tab A re-lists once and the item disappears from it.
+- `home-assistant.log` carries no `websocket_api` ERROR and no `haventory` warning across
+  the whole run.
+
+### What to send back
+
+- The two tabs side by side after step 4 (screenshot), and the devtools WS frame list for
+  tab A across steps 3–6.
+- Whatever step 8 does, in one line — it decides whether reassigning a location's own area
+  needs an event of its own, which would be a follow-up rather than part of #194.
+- Paste the result as a comment on #194 and reply on the PR thread.
+
+---
+
+## H6 — #365 quick-filter pills in the options flow
+
+**Branch / PR**: `claude/v0-5-0-w1c-quick-filter-pills` / #416
+**Why this needs a real HA**: the offline suite validates the schema, never the form. What
+it cannot show is how Home Assistant *draws* a `SelectSelector(multiple=True,
+mode=LIST)` inside an options flow — whether the five pills come up as a checkbox list
+with their translated labels or as a dropdown of raw wire names — and whether the sidebar
+panel, which has no Lovelace config at all, picks the stored choice up.
 
 ### Setup
 
@@ -147,134 +280,66 @@ which is the control a household actually uses.
   with all three hex statuses visible.
 - A screenshot of the status editor with the custom swatch selected and the hint showing.
 - Paste the result as a comment on #298 and reply on the PR thread.
-Seed one item so the batch case has something to address:
-
-    uv run python scripts/create_test_items.py --count 1
-
-### Steps
-
-1. Start following the log: `docker logs -f home-assistant 2>&1 | grep -i websocket_api`.
-2. Send each of these over the WebSocket (`uv run python scripts/ws_probe.py` drives it):
-   - `{"type": "haventory/item/create", "name": "Hammer", "quantity": 1.5}`
-   - `{"type": "haventory/item/create", "name": 42}`
-   - `{"type": "haventory/item/adjust_quantity", "item_id": "<id>", "delta": "two"}`
-   - `{"type": "haventory/items/bulk", "operations": "oops"}`
-   - `{"type": "haventory/item/list", "filter": {"query": "hammer"}}`
-   - `{"type": "haventory/item/list", "limit": 2, "cursor": ""}`
-3. For contrast, send one frame that is *still* schema-typed and must still be refused by
-   core: `{"type": "haventory/item/create", "name": "Hammer", "tags": "chisel"}`.
-
-### What "pass" looks like
-
-- Every frame in step 2 answers `{"success": false, "error": {"code": "validation_error"}}`,
-  and the message names the field.
-- **No `ERROR` line from `homeassistant.components.websocket_api.http.connection`** for any
-  of them. Each appears once at WARNING from `custom_components.haventory.ws`, with no
-  traceback and with the payload absent from the message.
-- The frame in step 3 still answers `invalid_format` and still logs at ERROR from core —
-  that contrast is what shows the widening is what changed the behaviour, rather than a
-  logging config difference.
-- The inventory is unchanged afterwards: `haventory/stats` reports the same `items_total`
-  it did before step 2.
-
-### What to send back
-
-- The grepped log excerpt covering steps 2 and 3, and the six error envelopes.
-- Paste the result as a comment on #197 and reply on the PR thread.
-Seed two areas in HA (Settings → Areas, or reuse two that exist), then build a tree with a
-root anchored in each and one item per root:
-
-    uv run python scripts/ws_init_haventory.py     # if the instance is empty
-    uv run python scripts/ws_probe.py              # for ad-hoc location/create + item/create calls
-
-The shape that matters: `Kitchen` (area = the first area) → `Drawer`, `Garage` (area = the
-second area), one item in `Drawer`, one item in `Garage`, and one item with **no** location.
-
-### Steps
-
-1. Open two browser tabs on the HAventory panel.
-2. In tab A, filter to the kitchen area (area chip in the filter panel). Leave tab B unfiltered.
-3. In tab B, edit the item that lives in `Garage` — rename it.
-4. Watch tab A: the row count and the list must not flicker, and no toast or row change may
-   appear for the garage item.
-5. In tab B, edit the item in `Drawer`. Tab A must show the new name without a manual refresh.
-6. In tab B, edit the item with no location. Tab A must not react.
-7. With tab A still filtered to the kitchen, move `Drawer` under `Garage` (drag in the
-   location tree, or `location/move_subtree`). Tab A is expected to re-list — it does that
-   on the `locations` `moved` event — and the item must then be gone from its list. This is
-   the documented behaviour, not a bug: no per-item departure event is emitted.
-8. Optional, the same case the other way: reassign `Kitchen`'s own area in the location
-   editor. Today that emits no `locations` event at all, so tab A keeps showing the items
-   until something else makes it re-list. Note what you see; it is the follow-up below.
-
-### What "pass" looks like
-
-- Steps 3, 4 and 6: nothing moves in tab A. In the browser devtools WS frames, tab A's
-  connection receives **no** `event` frame carrying the garage item or the location-less one.
-- Step 5: tab A updates live, no refresh.
-- Step 7: tab A re-lists once and the item disappears from it.
-- `home-assistant.log` carries no `websocket_api` ERROR and no `haventory` warning across
-  the whole run.
-
-### What to send back
-
-- The two tabs side by side after step 4 (screenshot), and the devtools WS frame list for
-  tab A across steps 3–6.
-- Whatever step 8 does, in one line — it decides whether the follow-up below is worth an issue.
-- Paste the result as a comment on #194 and reply on the PR thread.
 
 ---
 
-## H2 — #195 the name-clash block on a hand-rebuilt inventory
+## H4 — #193 Categories and Tags move with the filter the way Locations does
 
-**Branch / PR**: `claude/v0-5-0-w1a-import-name-collisions` / #417
-**Why this needs a real HA**: the offline and phacc suites both prove the warning is
-produced and survives the wire, but neither renders it. What is unverified is the block in
-the import sheet on a realistic document — whether the clash list is legible at the width
-the sheet actually has, whether five entries plus "…and N more" is the right cut, and
-whether the block reads as a caution rather than as a refusal while the Import button
-beside it stays enabled.
+**Branch / PR**: `claude/v0-5-0-w2-facet-counts` / #TBD
+**Why this needs a real HA**: the offline suite proves the tallies are computed and the
+component test proves the pair renders. What neither shows is the thing the issue was
+filed about — one sidebar column where the three lists finally agree, read at the width
+the sidebar actually has, in both themes. `8 / 37` beside `43` was the complaint; whether
+`8 / 37` beside `2 / 43` reads as one column or as three numbers fighting for the same
+40 px is a judgement only the running card supports.
 
 ### Setup
 
     set -a; . ./.env; set +a
     bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
 
-Then build the situation the warning exists for — an inventory whose locations were
-rebuilt by hand, so they carry fresh ids under the old names:
+Seed enough inventory that the tallies are worth reading — a few dozen items across
+several categories and tags, with a handful genuinely low on stock:
 
-1. Seed a small tree and some items:
-   `uv run python scripts/ws_init_haventory.py` (or the card's own UI).
-2. **Export a backup** from the card: ⋮ → Export backup. Keep the file.
-3. **Delete every location** and recreate them by hand with the same names — same
-   spelling, same nesting. This is what gives them new ids.
-4. Recreate two or three items by hand under the old names as well, so the item side of
-   the block has something to show.
+    uv run python scripts/create_test_items.py
+
+Then, in the UI, give two or three items a low-stock threshold they are under, so the
+low-stock pill has something to select.
 
 ### Steps
 
-1. Card ⋮ → Import backup, paste or pick the file from step 2, choose **Merge**, Preview.
-2. Read the preview sheet. Repeat with **Replace** and with **Skip**.
-3. Then the negative case, which is the one that matters most: export a *fresh* backup of
-   the inventory as it now stands and immediately preview that file back onto it, under all
-   three policies.
+1. Open the HAventory sidebar page and expand the full view's sidebar. Note what the
+   Locations, Categories and Tags rows read with no filter on.
+2. Turn on the **Low stock** quick-filter pill.
+3. Read all three sections again.
+4. Click a category row to select it, and watch the *tag* tallies.
+5. Click a tag row as well, and watch the *category* tallies.
+6. Clear the filter. Then type something in the search box that matches nothing at all.
+7. Open the item editor and start typing a category name, with the low-stock filter still on.
+8. Switch between light and dark.
 
 ### What "pass" looks like
 
-- Step 2: a `data-testid="import-warnings"` block appears above the fine print, listing the
-  clashes. Each location line quotes the stored location's path (`the location at "Garage /
-  Shelf A"`), which is what tells one legitimate "Shelf A" from the rebuilt duplicate. With
-  more than five, exactly five are listed and the rest are counted.
-- The **Import button stays enabled** in every case, and the preview still reports
-  `valid: true` — this warns, it does not gate.
-- Step 3 produces **no warning block at all**, under all three policies. A check that fires
-  on the ordinary round trip is worse than no check, so this is the failing case to watch
-  for.
-- Legible in both themes: the block uses the same `alert warn` treatment as the existing
-  conflict banner, so it should sit beside it without a second visual language.
+- Step 1: every row is a bare number — no `/` anywhere in the sidebar.
+- Step 3: every location, category and tag row reads `matches / total`, and the two
+  numbers are the same *kind* of number in all three sections. A category nothing
+  low-stock carries reads `0 / 7` rather than vanishing.
+- Steps 4 and 5: picking a category leaves the tag tallies where they are (and vice
+  versa) — each list drops its own dimension, so selecting in one does not zero the
+  other. The location tallies do move, since the category is not their dimension.
+- Step 6: with a query matching nothing, every row reads `0 / n` and **no list is empty**.
+  An empty Categories list here is the failure this whole change exists to avoid.
+- Step 7: autocomplete still offers every category, including ones with `0 /` in the
+  sidebar. It is a vocabulary, not a result set.
+- Step 8: the pair is legible in both themes and does not wrap to a second line at the
+  sidebar's own width. A long category name still clips with an ellipsis rather than
+  pushing the number out of view.
+- Nothing in the HA log at WARNING or above from `haventory` across any of it.
 
 ### What to send back
 
-- Screenshots of the preview sheet from step 2 (one with a handful of clashes, one with
-  more than five if you can make it) and from step 3, in light and dark.
-- Paste the result as a comment on #195 and reply on the PR thread.
+- A screenshot of the expanded sidebar with the low-stock filter on, showing Locations,
+  Categories and Tags together — light and dark.
+- One with a long category name, to show the clip still happens on the label and not the
+  tally.
+- Paste the result as a comment on #193 and reply on the PR thread.

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -103,9 +103,12 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - `status_counts` is the same figure for **every** defined slug, including `ok`. Additive to the two keys above rather than a replacement for them, so a client written against the earlier shape keeps working.
 
 - `haventory/distinct_values`
-  - Request: `{id, type: "haventory/distinct_values"}` (no payload; extra fields → `validation_error`)
+  - Request: `{id, type: "haventory/distinct_values", filter?: ItemFilter}` (any other field → `invalid_format`; an unknown key *inside* `filter` → `validation_error` naming it, as for `item/list`)
   - Result: `{categories: DistinctValue[], tags: DistinctValue[], custom_field_keys: string[]}` (see data shapes)
   - `categories` are grouped case-insensitively; each `value` is a representative display label (most frequent original casing, ties broken alphabetically) and `count` is the number of items using that category. `tags` are already normalized (lowercase); each maps to one entry. Both lists are sorted case-insensitively by `value`. `custom_field_keys` is the sorted, distinct set of keys used across all items' `custom_fields` (case-sensitive keys, sorted case-insensitively).
+  - With a `filter`, every `categories` and `tags` entry also carries `matching_count` — how many of that value's items the filter keeps — beside its whole-inventory `count`, the pair `location/tree` reports as `matching_direct_count`/`matching_subtree_count`. **The lists never shrink**: an entry the filter keeps nothing of is present at `matching_count: 0`. The same payload feeds category/tag autocomplete and the organize dialog, both of which a list that dropped non-matching rows would starve. Omitting `filter` (or sending `null`) leaves the key off every entry entirely, which is what an unpriced list looks like — distinct from "everything matches".
+  - `custom_field_keys` is never filtered: it is a key picker, not a tally, and narrowing it would hide keys the user is about to type.
+  - Which dimensions to leave out of `filter` is the caller's decision, as it is for `location/tree`. The card drops `category` and `tags_any`/`tags_all` before sending, for the reason it drops `location_id` from the tree's filter: a facet priced against its own selection reads 0 on every other row exactly when the user wants to see where else the matches are. One request prices both facets, so a chosen category does not narrow the tag tallies.
   - Read-only: emits no events and does not mutate state.
 
 - `haventory/health`

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -293,7 +293,17 @@ Result of `distinct_values`, used by category/tag autocomplete, the browser view
 }
 ```
 
-- `DistinctValue`: `{ value: string, count: number }` where `count` is the number of items using that value.
+With a filter on the request, each category and tag entry also carries `matching_count`:
+```json
+{
+  "categories": [ { "value": "Books", "count": 1, "matching_count": 0 }, { "value": "Tools", "count": 2, "matching_count": 1 } ],
+  "tags": [ { "value": "blue", "count": 2, "matching_count": 1 }, { "value": "red", "count": 2, "matching_count": 0 } ],
+  "custom_field_keys": [ "serial", "Voltage", "warranty_until" ]
+}
+```
+
+- `DistinctValue`: `{ value: string, count: number, matching_count?: number }` where `count` is the number of items using that value.
+- `matching_count` is how many of that value's items the request's filter keeps. Present on every `categories` and `tags` entry when the request carried a `filter`, absent from all of them when it did not — so `undefined` means "unpriced", never "nothing matches". No entry is dropped for matching nothing; `count` is unaffected by the filter, and `custom_field_keys` is never filtered.
 - Categories are grouped case-insensitively; `value` is a representative display label (most frequent original casing, ties broken alphabetically). Tags are already normalized (lowercase), so `value` is the tag itself.
 - Both value lists are sorted case-insensitively by `value`. Items with no category (or no tags) contribute nothing to the respective list.
 - `custom_field_keys` is the sorted, distinct set of keys used across all items' `custom_fields` (keys are case-sensitive; sorted case-insensitively). Empty when no item has custom fields.

--- a/tests/test_repository_items_offline.py
+++ b/tests/test_repository_items_offline.py
@@ -16,6 +16,7 @@ from custom_components.haventory.models import ItemCreate, ItemFilter, ItemUpdat
 from custom_components.haventory.repository import CURSOR_MAX_LENGTH, Repository
 
 TOTAL_ITEMS = 3
+BOOKS_TOTAL = 3
 INITIAL_LOW_STOCK_COUNT = 1
 LOW_STOCK_AFTER_ADJUST = 2
 LOADED_ITEM_COUNT = 2
@@ -569,3 +570,45 @@ def test_a_valid_cursor_still_pages_to_the_end() -> None:
 
     assert seen == [f"Item {i}" for i in range(5)]
     assert cursor is None
+
+
+def test_distinct_values_priced_against_a_filter_folds_case_variants() -> None:
+    """One entry per casefolded category, and its matching_count is that group's."""
+
+    repo = Repository()
+    repo.create_item(ItemCreate(name="A", category="Books", quantity=0, low_stock_threshold=1))
+    repo.create_item(ItemCreate(name="B", category="books", quantity=5))
+    repo.create_item(ItemCreate(name="C", category="Books", quantity=5))
+
+    result = repo.get_distinct_field_values(ItemFilter(low_stock_only=True))
+    categories = result["categories"]
+    assert isinstance(categories, list)
+
+    assert len(categories) == 1
+    entry = categories[0]
+    # The representative label is still the most frequent original casing.
+    assert entry["value"] == "Books"
+    assert entry["count"] == BOOKS_TOTAL
+    assert entry["matching_count"] == 1
+
+
+def test_distinct_values_counts_an_excluded_item_towards_count_only() -> None:
+    """An item whose value matches but which the filter drops moves only `count`."""
+
+    repo = Repository()
+    repo.create_item(ItemCreate(name="Kept", category="Tools", tags=["red"], checked_out=True))
+    repo.create_item(ItemCreate(name="Dropped", category="Tools", tags=["red"]))
+
+    result = repo.get_distinct_field_values(ItemFilter(checked_out=True))
+    categories = result["categories"]
+    tags = result["tags"]
+    assert isinstance(categories, list)
+    assert isinstance(tags, list)
+
+    assert categories == [{"value": "Tools", "count": 2, "matching_count": 1}]
+    assert tags == [{"value": "red", "count": 2, "matching_count": 1}]
+
+    # Without a filter the key is absent rather than equal to `count`, so a
+    # client can tell "unpriced" from "everything matches".
+    unfiltered = repo.get_distinct_field_values()
+    assert unfiltered["categories"] == [{"value": "Tools", "count": 2}]

--- a/tests/test_ws_distinct_values_offline.py
+++ b/tests/test_ws_distinct_values_offline.py
@@ -4,8 +4,10 @@ Scenarios:
 - distinct_values returns distinct categories and tags with usage counts
 - categories are grouped case-insensitively with a representative display label
 - an empty repository yields empty lists
-- unknown/extra request fields are refused before the handler runs, as real
-  Home Assistant refuses them
+- a filtered request prices both facets without shrinking either list
+- an unfiltered request carries no matching_count key at all
+- unknown filter keys are refused by name; unknown/extra request fields are
+  refused before the handler runs, as real Home Assistant refuses them
 """
 
 from __future__ import annotations
@@ -129,16 +131,124 @@ async def test_distinct_values_returns_custom_field_keys() -> None:
 async def test_distinct_values_rejects_unknown_field() -> None:
     """Unknown request fields are refused before the handler runs.
 
-    ``haventory/distinct_values`` declares nothing but its type, which Home
-    Assistant compiles to the ``False`` schema: `id` and `type` are the only
-    keys such a frame may carry.
+    ``haventory/distinct_values`` declares ``type`` and an optional ``filter``,
+    and Home Assistant's default ``PREVENT_EXTRA`` refuses everything else.
     """
 
     hass = _fresh_hass()
-    assert ws_distinct_values._ws_schema is False
+    assert set(ws_distinct_values._ws_schema.schema) == {"id", "type", "filter"}
 
     assert (await _send(hass, 1, "haventory/distinct_values"))["success"] is True
+    assert (await _send(hass, 2, "haventory/distinct_values", filter={}))["success"] is True
 
-    res = await _send(hass, 2, "haventory/distinct_values", bogus=1)
+    res = await _send(hass, 3, "haventory/distinct_values", bogus=1)
     assert res["success"] is False
     assert res["error"]["code"] == "invalid_format"
+
+
+async def _seed_facets(hass: HomeAssistant) -> None:
+    """Two categories and three tags across four items, two of them low on stock."""
+
+    await _send(
+        hass,
+        1,
+        "haventory/item/create",
+        name="Hammer",
+        category="Tools",
+        tags=["red"],
+        quantity=0,
+        low_stock_threshold=1,
+    )
+    await _send(hass, 2, "haventory/item/create", name="Wrench", category="Tools", tags=["blue"])
+    await _send(
+        hass,
+        3,
+        "haventory/item/create",
+        name="Novel",
+        category="Books",
+        tags=["blue", "paper"],
+        quantity=0,
+        low_stock_threshold=1,
+    )
+    await _send(hass, 4, "haventory/item/create", name="Atlas", category="Books", tags=["paper"])
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_prices_both_facets_against_a_filter() -> None:
+    """A filtered request adds matching_count and leaves count whole-inventory."""
+
+    hass = _fresh_hass()
+    await _seed_facets(hass)
+
+    res = await _send(hass, 5, "haventory/distinct_values", filter={"low_stock_only": True})
+    assert res["success"] is True
+    result = res["result"]
+
+    categories = {c["value"]: (c["count"], c["matching_count"]) for c in result["categories"]}
+    tags = {t["value"]: (t["count"], t["matching_count"]) for t in result["tags"]}
+
+    # Hammer (Tools/red) and Novel (Books/blue+paper) are the low-stock two.
+    assert categories == {"Books": (2, 1), "Tools": (2, 1)}
+    assert tags == {"blue": (2, 1), "paper": (2, 1), "red": (1, 1)}
+    # A key picker rather than a tally: unfiltered under either request shape.
+    assert result["custom_field_keys"] == []
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_without_a_filter_carries_no_matching_count() -> None:
+    """The unfiltered shape is exactly what a card written before this sees."""
+
+    hass = _fresh_hass()
+    await _seed_facets(hass)
+
+    result = (await _send(hass, 5, "haventory/distinct_values"))["result"]
+    for entry in [*result["categories"], *result["tags"]]:
+        assert "matching_count" not in entry
+
+    # An explicit null reads as "no filter", the way location/tree reads it.
+    null_result = (await _send(hass, 6, "haventory/distinct_values", filter=None))["result"]
+    for entry in [*null_result["categories"], *null_result["tags"]]:
+        assert "matching_count" not in entry
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_keeps_every_row_when_nothing_matches() -> None:
+    """A filter matching nothing zeroes the tallies; it must not empty the list.
+
+    The same payload feeds autocomplete and the organize dialog, so a list that
+    shrank with the filter would leave both with nothing to offer.
+    """
+
+    hass = _fresh_hass()
+    await _seed_facets(hass)
+
+    result = (await _send(hass, 5, "haventory/distinct_values", filter={"q": "nothing here"}))[
+        "result"
+    ]
+
+    expected_categories = 2
+    expected_tags = 3
+    assert len(result["categories"]) == expected_categories
+    assert len(result["tags"]) == expected_tags
+    assert all(c["matching_count"] == 0 for c in result["categories"])
+    assert all(t["matching_count"] == 0 for t in result["tags"])
+    # Totals are untouched by a filter that keeps nothing.
+    assert all(c["count"] > 0 for c in result["categories"])
+
+
+@pytest.mark.asyncio
+async def test_distinct_values_rejects_an_unknown_filter_key() -> None:
+    """The new argument goes through validate_item_filter like every other one."""
+
+    hass = _fresh_hass()
+
+    res = await _send(hass, 1, "haventory/distinct_values", filter={"categorie": "Tools"})
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    assert "categorie" in res["error"]["message"]
+
+    # And a filter that is not an object at all is a validation error rather
+    # than a schema rejection carrying the client's payload.
+    res = await _send(hass, 2, "haventory/distinct_values", filter="low_stock_only")
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"


### PR DESCRIPTION
## Summary

Category and tag tallies ignored the active filter while location tallies honoured it — one sidebar column, two meanings for the same grey number. With the low-stock filter on, location rows read `8 / 37` while category rows still read `43`.

`haventory/distinct_values` now takes an optional `filter`, and every `categories` / `tags` entry gains **`matching_count` beside** its whole-inventory `count`. The card renders the pair the way `hv-location-tree` already renders its own.

**The lists never shrink.** An entry the filter keeps nothing of is present at `matching_count: 0`. The same payload feeds category/tag autocomplete and the organize dialog, and a list that dropped non-matching rows would starve both — an item editor that stops offering a category the moment the sidebar filters it out is worse than no tally at all. A test asserts the list stays whole under a filter that matches nothing.

**What it is measured against**: everything active *except* `category` and `tags`. `Store.facetCountFilters()` clears both before sending, for the reason `locationCountFilters()` already clears `locationId` — a facet priced against its own selection reads 0 on every other row exactly when the user wants to see where else the matches are. One request prices both facets, so a chosen category does not narrow the tag tallies; that is the same trade the tree already makes for its own dimension, and paying it twice would buy precision nobody asked for. `custom_field_keys` stays whole-inventory: it is a key picker, not a tally.

**Absent, not zero.** Without a `filter` the key is off every entry rather than equal to `count`, so a client can tell "unpriced" from "everything matches" — and that unfiltered shape is byte-identical to what a card written before this change sees.

Because #197 landed first, the new argument goes through `validate_item_filter` like every other filter-accepting command, so `{"categorie": "Tools"}` is refused by name rather than silently returning the whole inventory.

### Decided against the issue where it had drifted

- The issue's notes say the schema should take `vol.Optional("filter"): dict`, "spelled exactly as `haventory/location/tree` already spells it". Those two no longer agree: #197 widened `location/tree`'s to `object`, so a non-dict filter answers `validation_error` through `ws_guard` instead of an HA-core schema ERROR carrying the client's payload. **Spelled as `object`**, matching the command it was told to match rather than the literal it was told to write. A test sends `filter: "low_stock_only"` and asserts `validation_error`.
- The command moves off the bare `{"type": ...}` form, so its schema is no longer HA's `False`. `test_distinct_values_rejects_unknown_field` now pins the declared key set (`id`, `type`, `filter`) and still asserts a stray field is refused with `invalid_format`.

### `dev/v0_5_0_handover_prompts.md` was reassembled

Wave 1's three sessions each created the file independently and the five squash-merges interleaved them: three copies of the intro, H6's body sitting under H3's heading, and H1's and H3's own bodies orphaned at the bottom under no heading at all. Every section is now contiguous under its own heading, in session order. Pure reordering — a word-level diff against the merged file shows nothing dropped but the two duplicate intros. Three small corrections went in with it: H3's `#TBD` is now `#414`, and its two references to "the follow-up below" (which pointed at nothing) name the question instead. H4 is appended.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (875 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1792 passed), `npm run build` — all green.

New coverage — backend: a filtered request prices both facets while `count` stays whole-inventory; the unfiltered request (and an explicit `filter: null`) carries no `matching_count` key anywhere; a filter matching nothing leaves every entry present at 0; an unknown filter key is refused by name and a non-object filter answers `validation_error`; the schema's declared keys; case-variant categories fold into one `matching_count` while keeping the representative display label; an item whose value matches but which the filter excludes moves `count` only.

Frontend: no filter goes on the wire while nothing is narrowing; `category` and `tags_any` are stripped from the filter that is sent; a burst of `setFilters` calls coalesces to one refetch; a locally-named draft takes the priced shape (`matching_count: 0`) once the server priced the rest and the bare shape when it did not; a category row renders `1 / 2` when priced and `2` when not, while the section heading still counts rows rather than matches.

No phacc run needed here: the schema, the repository pass and the store round trip are all observable offline. (W1a confirmed `scripts/test_integration.sh` provisions cleanly in this environment.)

## Live verification

H4 in `dev/v0_5_0_handover_prompts.md`: the expanded sidebar with the low-stock filter on, in both themes — whether `8 / 37` beside `2 / 43` reads as one column or as three numbers fighting for the same 40 px is a judgement only the running card supports. Complete-but-unverified rather than incomplete.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and `docs/data_shapes.md` in sync — the optional `filter`, `matching_count`, the never-shrinking list and the absent-vs-zero rule are in both.
- [x] Essential invariants preserved — no item or location data path is touched; this reads indexes and adds one pass over already-filtered candidates.

## Screenshots (card / UI changes)

None from here — the change is a number in a running sidebar, which is exactly what H4 asks for.

## Follow-ups

- `onItemsEvent` still calls `refreshDistinctValues()` directly (uncoalesced) on every create/update/delete, so a bulk import fires one request per event. Pre-existing, and the new filter does not make it worse; worth folding into the same coalescing path if it ever shows up in a real install.

Closes #193

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdyJ3KvWKKW1WSqNYLAixQ)_