### PR TITLE
test: one WebSocket send helper for the offline suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,10 @@ plus `actionlint`, `hassfest`, HACS validation, CodeQL, and dependency review.
   `tests/conftest.py`); async tests use `@pytest.mark.asyncio`. The WebSocket
   stub applies each command's schema before dispatch, so an offline test sends
   frames a real client could send and gets `invalid_format` for the rest.
+  Dispatch a command with `ws_send` from `tests/ws_helpers.py` — never a private
+  copy: it returns the full result envelope and takes an optional `conn=`, so a
+  test can assert on the answer, on what the handler pushed on the connection,
+  or on both.
 - **Conventional Commits** for commit messages *and PR titles* (a CI check
   enforces the PR title). Examples: `feat: add low-stock filter`,
   `fix: preserve location_path on move`, `docs: …`, `chore: …`.

--- a/tests/test_entry_removal_refusal_offline.py
+++ b/tests/test_entry_removal_refusal_offline.py
@@ -32,31 +32,9 @@ from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import RecordingConn, ws_send
+
 WS_LOGGER = "custom_components.haventory.ws"
-
-
-class _StubConn:
-    """Connection stub that keeps every message sent to it."""
-
-    def __init__(self) -> None:
-        self.messages: list[dict] = []
-
-    def send_message(self, msg: dict) -> None:
-        self.messages.append(msg)
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, conn=None, **payload):
-    """Dispatch one WS command through the stub registry, as a client would."""
-
-    for handler in hass.data.get("__ws_commands__", []):
-        if not callable(handler) or getattr(handler, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        target = conn if conn is not None else _StubConn()
-        res = await handler(hass, target, req)
-        return res if res is not None else target.messages[-1]
-    raise AssertionError(f"No handler responded for type {type_}")
 
 
 async def _setup_entry(hass: HomeAssistant) -> ConfigEntry:
@@ -97,11 +75,11 @@ async def test_command_refuses_after_removal(command: str, payload: dict) -> Non
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    assert (await _send(hass, 1, command, **payload))["success"] is True
+    assert (await ws_send(hass, 1, command, **payload))["success"] is True
 
     await async_remove_entry(hass, entry)
 
-    res = await _send(hass, 2, command, **payload)
+    res = await ws_send(hass, 2, command, **payload)
     assert res["success"] is False, res
     assert res["error"]["code"] == "storage_error"
 
@@ -115,7 +93,7 @@ async def test_refusal_is_mapped_not_an_unhandled_crash(caplog) -> None:
     await async_remove_entry(hass, entry)
 
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
-    res = await _send(hass, 1, "haventory/item/create", name="Nope")
+    res = await ws_send(hass, 1, "haventory/item/create", name="Nope")
 
     assert res["error"]["code"] == "storage_error"
     assert res["error"]["data"]["op"] == "item_create"
@@ -140,7 +118,7 @@ async def test_removal_stops_persistence(monkeypatch) -> None:
     await async_remove_entry(hass, entry)
     saved.clear()  # removal's own flush is test_removal_flushes_before_dropping's business
 
-    res = await _send(hass, 1, "haventory/item/create", name="Ghost")
+    res = await ws_send(hass, 1, "haventory/item/create", name="Ghost")
 
     assert res["success"] is False
     assert saved == []
@@ -216,8 +194,8 @@ async def test_removal_drops_live_subscriptions() -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    conn = _StubConn()
-    assert (await _send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
+    conn = RecordingConn()
+    assert (await ws_send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
     await async_remove_entry(hass, entry)
     conn.messages.clear()
@@ -234,14 +212,14 @@ async def test_re_adding_the_entry_restores_service() -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    created = await _send(hass, 1, "haventory/item/create", name="Screwdriver")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Screwdriver")
     assert created["success"] is True
 
     await async_remove_entry(hass, entry)
-    assert (await _send(hass, 2, "haventory/item/list"))["success"] is False
+    assert (await ws_send(hass, 2, "haventory/item/list"))["success"] is False
 
     assert await async_setup_entry(hass, ConfigEntry()) is True
 
-    listed = await _send(hass, 3, "haventory/item/list")
+    listed = await ws_send(hass, 3, "haventory/item/list")
     assert listed["success"] is True, listed
     assert [item["name"] for item in listed["result"]["items"]] == ["Screwdriver"]

--- a/tests/test_entry_unload_refusal_offline.py
+++ b/tests/test_entry_unload_refusal_offline.py
@@ -36,38 +36,7 @@ from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-
-class _StubConn:
-    """Connection stub that keeps every message sent to it."""
-
-    def __init__(self) -> None:
-        self.messages: list[dict] = []
-
-    def send_message(self, msg: dict) -> None:
-        self.messages.append(msg)
-
-
-def _handler(hass: HomeAssistant, type_: str):
-    """The registered handler for one command type, as HA would dispatch to it."""
-
-    for handler in hass.data.get("__ws_commands__", []):
-        if callable(handler) and getattr(handler, "_ws_command", None) == type_:
-            return handler
-    raise AssertionError(f"No handler registered for type {type_}")
-
-
-async def _call(handler, hass: HomeAssistant, _id: int, type_: str, conn=None, **payload):
-    """Send one command straight to a handler, bypassing the stub registry."""
-
-    req = {"id": _id, "type": type_}
-    req.update(payload)
-    target = conn if conn is not None else _StubConn()
-    res = await handler(hass, target, req)
-    return res if res is not None else target.messages[-1]
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, conn=None, **payload):
-    return await _call(_handler(hass, type_), hass, _id, type_, conn=conn, **payload)
+from ws_helpers import RecordingConn, ws_call, ws_handler, ws_send
 
 
 async def _setup_entry(hass: HomeAssistant) -> ConfigEntry:
@@ -109,12 +78,12 @@ async def test_command_refuses_while_unloaded(command: str, payload: dict) -> No
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    handler = _handler(hass, command)
-    assert (await _call(handler, hass, 1, command, **payload))["success"] is True
+    handler = ws_handler(hass, command)
+    assert (await ws_call(handler, hass, 1, command, **payload))["success"] is True
 
     await async_unload_entry(hass, entry)
 
-    res = await _call(handler, hass, 2, command, **payload)
+    res = await ws_call(handler, hass, 2, command, **payload)
     assert res["success"] is False, res
     assert res["error"]["code"] == "storage_error"
 
@@ -213,9 +182,11 @@ async def test_unload_tells_open_subscribers_their_topic_stopped() -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    conn = _StubConn()
+    conn = RecordingConn()
     for sub_id, topic in ((11, "items"), (12, "locations"), (13, "stats")):
-        assert (await _send(hass, sub_id, "haventory/subscribe", conn=conn, topic=topic))["success"]
+        assert (await ws_send(hass, sub_id, "haventory/subscribe", conn=conn, topic=topic))[
+            "success"
+        ]
     conn.messages.clear()
 
     await async_unload_entry(hass, entry)
@@ -235,8 +206,8 @@ async def test_unload_drops_live_subscriptions() -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    conn = _StubConn()
-    assert (await _send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
+    conn = RecordingConn()
+    assert (await ws_send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
     await async_unload_entry(hass, entry)
     conn.messages.clear()
@@ -268,8 +239,8 @@ async def test_teardown_signal_outranks_the_event_budget() -> None:
         )
     )
     hass.data[DOMAIN]["rate_limiter"] = limiter
-    conn = _StubConn()
-    assert (await _send(hass, 5, "haventory/subscribe", conn=conn, topic="items"))["success"]
+    conn = RecordingConn()
+    assert (await ws_send(hass, 5, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
     # Drain the global budget, then prove an ordinary broadcast is now dropped.
     assert limiter.allow_event_broadcast() is True
@@ -293,16 +264,16 @@ async def test_setup_after_unload_serves_again() -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    created = await _send(hass, 1, "haventory/item/create", name="Screwdriver")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Screwdriver")
     assert created["success"] is True
-    handler = _handler(hass, "haventory/item/list")
+    handler = ws_handler(hass, "haventory/item/list")
 
     await async_unload_entry(hass, entry)
-    assert (await _call(handler, hass, 2, "haventory/item/list"))["success"] is False
+    assert (await ws_call(handler, hass, 2, "haventory/item/list"))["success"] is False
 
     assert await async_setup_entry(hass, ConfigEntry()) is True
 
-    listed = await _call(handler, hass, 3, "haventory/item/list")
+    listed = await ws_call(handler, hass, 3, "haventory/item/list")
     assert listed["success"] is True, listed
     assert [item["name"] for item in listed["result"]["items"]] == ["Screwdriver"]
 
@@ -320,18 +291,18 @@ async def test_a_reload_writes_nothing_while_it_is_refusing(monkeypatch) -> None
         saved.append(payload)
 
     monkeypatch.setattr(store, "async_save", _record)
-    handler = _handler(hass, "haventory/item/create")
+    handler = ws_handler(hass, "haventory/item/create")
 
     await async_unload_entry(hass, entry)
     saved.clear()  # unload's own flush is test_unload_flushes_before_dropping's business
 
-    res = await _call(handler, hass, 1, "haventory/item/create", name="Ghost")
+    res = await ws_call(handler, hass, 1, "haventory/item/create", name="Ghost")
 
     assert res["success"] is False
     assert saved == []
 
     assert await async_setup_entry(hass, ConfigEntry()) is True
-    listed = await _send(hass, 2, "haventory/item/list")
+    listed = await ws_send(hass, 2, "haventory/item/list")
     assert [item["name"] for item in listed["result"]["items"]] == []
 
 
@@ -341,11 +312,11 @@ async def test_refusal_is_mapped_not_an_unhandled_crash(caplog) -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    handler = _handler(hass, "haventory/item/create")
+    handler = ws_handler(hass, "haventory/item/create")
     await async_unload_entry(hass, entry)
 
     caplog.set_level(logging.DEBUG, logger="custom_components.haventory.ws")
-    res = await _call(handler, hass, 1, "haventory/item/create", name="Nope")
+    res = await ws_call(handler, hass, 1, "haventory/item/create", name="Nope")
 
     assert res["error"]["code"] == "storage_error"
     assert res["error"]["data"]["op"] == "item_create"

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -38,20 +38,11 @@ from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainSt
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import ws_send
+
 # The `_seed` helper always creates exactly this many items and locations.
 SEEDED_ITEMS = 2
 SEEDED_LOCATIONS = 2
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        return await h(hass, None, req)
-    raise AssertionError("No handler responded for type " + type_)
 
 
 def _new_hass() -> HomeAssistant:
@@ -126,7 +117,7 @@ async def test_ws_export_returns_document() -> None:
     hass = _new_hass()
     _seed(hass.data[DOMAIN]["repository"])
 
-    res = await _send(hass, 1, "haventory/export")
+    res = await ws_send(hass, 1, "haventory/export")
     assert res["success"] is True, res
     doc = res["result"]
     assert doc["haventory_export_version"] == ie.EXPORT_VERSION
@@ -144,7 +135,7 @@ async def test_ws_export_invalid_filter_field() -> None:
     """
 
     hass = _new_hass()
-    res = await _send(hass, 1, "haventory/export", filter="not-an-object")
+    res = await ws_send(hass, 1, "haventory/export", filter="not-an-object")
     assert res["success"] is False, res
     assert res["error"]["code"] == "validation_error"
 
@@ -154,7 +145,7 @@ async def test_ws_export_unknown_filter_key_is_named() -> None:
     """A typo'd filter key is refused rather than dropped, and named."""
 
     hass = _new_hass()
-    res = await _send(hass, 1, "haventory/export", filter={"search": "hammer"})
+    res = await ws_send(hass, 1, "haventory/export", filter={"search": "hammer"})
     assert res["success"] is False, res
     assert res["error"]["code"] == "validation_error"
     assert "search" in res["error"]["message"]
@@ -189,20 +180,20 @@ async def test_round_trip_via_ws_execute() -> None:
 
     src = _new_hass()
     _seed(src.data[DOMAIN]["repository"])
-    exported = (await _send(src, 1, "haventory/export"))["result"]
+    exported = (await ws_send(src, 1, "haventory/export"))["result"]
 
     dst = _new_hass()
-    preview = await _send(dst, 2, "haventory/import/preview", document=exported)
+    preview = await ws_send(dst, 2, "haventory/import/preview", document=exported)
     assert preview["success"] is True
     assert preview["result"]["valid"] is True
     assert preview["result"]["counts"]["items"]["add"] == SEEDED_ITEMS
 
-    applied = await _send(dst, 3, "haventory/import/execute", document=exported)
+    applied = await ws_send(dst, 3, "haventory/import/execute", document=exported)
     assert applied["success"] is True, applied
     assert applied["result"]["applied"] is True
     assert applied["result"]["totals"]["items_total"] == SEEDED_ITEMS
 
-    re_export = (await _send(dst, 4, "haventory/export"))["result"]
+    re_export = (await ws_send(dst, 4, "haventory/export"))["result"]
     assert re_export["items"] == exported["items"]
     assert re_export["locations"] == exported["locations"]
 
@@ -382,7 +373,7 @@ def test_plan_import_rejects_unknown_policy() -> None:
 async def test_ws_import_execute_invalid_document_is_validation_error() -> None:
     hass = _new_hass()
     bad = {"haventory_export_version": 1, "schema_version": CURRENT_SCHEMA_VERSION, "items": 3}
-    res = await _send(hass, 1, "haventory/import/execute", document=bad)
+    res = await ws_send(hass, 1, "haventory/import/execute", document=bad)
     assert res["success"] is False, res
     assert res["error"]["code"] == "validation_error"
     assert res["error"]["data"]["errors"]
@@ -416,7 +407,7 @@ async def test_ws_import_execute_rolls_back_on_persist_failure() -> None:
 
     hass.data[DOMAIN]["store"] = _FailingStore()
 
-    res = await _send(hass, 1, "haventory/import/execute", document=doc)
+    res = await ws_send(hass, 1, "haventory/import/execute", document=doc)
     assert res["success"] is False, res
     assert res["error"]["code"] == "storage_error"
     # State rolled back: the new item must NOT be present and counts unchanged.
@@ -606,7 +597,7 @@ async def test_import_preview_reports_references_with_no_file_on_this_install() 
     repo.add_attachment(item.id, validate_attachment_meta(_attachment_doc()))
     doc = _doc_from(repo)
 
-    res = await _send(hass, 1, "haventory/import/preview", document=doc, policy="merge")
+    res = await ws_send(hass, 1, "haventory/import/preview", document=doc, policy="merge")
 
     assert res["success"] is True
     assert res["result"]["attachments"] == {"referenced": 1, "missing": 1}
@@ -635,7 +626,7 @@ async def test_import_replace_deletes_a_file_whose_metadata_it_overwrote() -> No
     document = _doc_from(repo)
     document["items"][0]["attachments"] = []
     document["items"][0]["name"] = "Drill (restored)"
-    res = await _send(hass, 1, "haventory/import/execute", document=document, policy="replace")
+    res = await ws_send(hass, 1, "haventory/import/execute", document=document, policy="replace")
 
     assert res["success"] is True, res
     assert repo.get_item(item.id).attachments == []
@@ -658,7 +649,7 @@ async def test_import_merge_keeps_a_file_the_document_does_not_mention() -> None
     document = _doc_from(repo)
     document["items"][0]["attachments"] = []
     document["items"][0]["name"] = "Drill (restored)"
-    res = await _send(hass, 1, "haventory/import/execute", document=document, policy="merge")
+    res = await ws_send(hass, 1, "haventory/import/execute", document=document, policy="merge")
 
     assert res["success"] is True, res
     assert [str(a.id) for a in repo.get_item(item.id).attachments] == [str(meta.id)]
@@ -982,7 +973,7 @@ async def test_ws_import_preview_carries_the_warnings() -> None:
     hass = _new_hass()
     hass.data[DOMAIN]["repository"].create_item({"name": "Hammer"})
 
-    res = await _send(
+    res = await ws_send(
         hass, 1, "haventory/import/preview", document=_envelope(_rebuilt_item_doc("Hammer"))
     )
 

--- a/tests/test_integration_bootstrap_offline.py
+++ b/tests/test_integration_bootstrap_offline.py
@@ -13,6 +13,8 @@ from custom_components.haventory.storage import DomainStore
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import ws_send
+
 
 @pytest.mark.asyncio
 async def test_async_setup_initializes_domain_bucket() -> None:
@@ -76,16 +78,5 @@ async def test_async_setup_entry_loads_repository_from_store_and_ws_reads() -> N
     assert repo.get_item(item.id).name == "SeedItem"
 
     # And WS commands are registered and can read the same item
-    handlers = hass.data.get("__ws_commands__", [])
-
-    async def _send(_id: int, type_: str, **payload):
-        for h in handlers:
-            if not callable(h) or getattr(h, "_ws_command", None) != type_:
-                continue
-            req = {"id": _id, "type": type_}
-            req.update(payload)
-            return await h(hass, None, req)
-        raise AssertionError("No handler responded for type " + type_)
-
-    res = await _send(1, "haventory/item/get", item_id=item.id)
+    res = await ws_send(hass, 1, "haventory/item/get", item_id=item.id)
     assert res["success"] is True and res["result"]["id"] == str(item.id)

--- a/tests/test_item_input_validation_offline.py
+++ b/tests/test_item_input_validation_offline.py
@@ -9,7 +9,6 @@ Regression coverage for the PR #91 review:
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 from typing import Any
 
 import pytest
@@ -30,6 +29,8 @@ from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
+
+from ws_helpers import ws_send
 
 # -----------------------------
 # Repository / model boundary
@@ -100,19 +101,6 @@ def test_low_stock_threshold_rejects_bool() -> None:
 # -----------------------------
 
 
-def _get_handler(
-    hass: HomeAssistant, type_: str
-) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
-    for h in hass.data.get("__ws_commands__", []):
-        if callable(h) and getattr(h, "_ws_command", None) == type_:
-            return h
-    raise AssertionError("No handler for " + type_)
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload: Any) -> dict:
-    return await _get_handler(hass, type_)(hass, None, {"id": _id, "type": type_, **payload})
-
-
 def _make_hass() -> HomeAssistant:
     hass = HomeAssistant()
     bucket = hass.data.setdefault(DOMAIN, {})
@@ -125,32 +113,32 @@ def _make_hass() -> HomeAssistant:
 @pytest.mark.asyncio
 async def test_ws_create_non_text_category_is_validation_error_no_phantom() -> None:
     hass = _make_hass()
-    res = await _send(hass, 1, "haventory/item/create", name="Widget", category=["oops"])
+    res = await ws_send(hass, 1, "haventory/item/create", name="Widget", category=["oops"])
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
     # Nothing was indexed or counted.
-    stats = await _send(hass, 2, "haventory/stats")
+    stats = await ws_send(hass, 2, "haventory/stats")
     assert stats["result"]["items_total"] == 0
-    listed = await _send(hass, 3, "haventory/item/list")
+    listed = await ws_send(hass, 3, "haventory/item/list")
     assert listed["result"]["items"] == []
 
 
 @pytest.mark.asyncio
 async def test_ws_set_quantity_bool_is_validation_error() -> None:
     hass = _make_hass()
-    created = await _send(hass, 1, "haventory/item/create", name="Widget", quantity=1)
+    created = await ws_send(hass, 1, "haventory/item/create", name="Widget", quantity=1)
     item_id = created["result"]["id"]
 
-    res = await _send(hass, 2, "haventory/item/set_quantity", item_id=item_id, quantity=True)
+    res = await ws_send(hass, 2, "haventory/item/set_quantity", item_id=item_id, quantity=True)
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
 
-    res = await _send(hass, 3, "haventory/item/adjust_quantity", item_id=item_id, delta=True)
+    res = await ws_send(hass, 3, "haventory/item/adjust_quantity", item_id=item_id, delta=True)
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
 
     # Quantity is still the int we created with.
-    got = await _send(hass, 4, "haventory/item/get", item_id=item_id)
+    got = await ws_send(hass, 4, "haventory/item/get", item_id=item_id)
     assert got["result"]["quantity"] == 1
     assert got["result"]["quantity"] is not True
 
@@ -216,7 +204,7 @@ def test_create_accepts_at_the_cap_and_refuses_over_it(
 @pytest.mark.asyncio
 async def test_ws_create_over_a_cap_is_validation_error_no_phantom() -> None:
     hass = _make_hass()
-    res = await _send(
+    res = await ws_send(
         hass,
         1,
         "haventory/item/create",
@@ -225,7 +213,7 @@ async def test_ws_create_over_a_cap_is_validation_error_no_phantom() -> None:
     )
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
-    listed = await _send(hass, 2, "haventory/item/list")
+    listed = await ws_send(hass, 2, "haventory/item/list")
     assert listed["result"]["items"] == []
 
 

--- a/tests/test_item_status_offline.py
+++ b/tests/test_item_status_offline.py
@@ -31,6 +31,8 @@ from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store as HAStore
 
+from ws_helpers import ws_send
+
 # -----------------------------
 # Models
 # -----------------------------
@@ -256,18 +258,6 @@ async def test_domain_store_migrates_v4_store_on_load() -> None:
 # -----------------------------
 
 
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        resp = await h(hass, None, req)
-        return resp
-    raise AssertionError("No handler responded for type " + type_)
-
-
 def _new_hass() -> HomeAssistant:
     hass = HomeAssistant()
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
@@ -280,16 +270,16 @@ def _new_hass() -> HomeAssistant:
 async def test_ws_item_create_and_update_status() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/item/create", name="Hammer", status="missing")
+    res = await ws_send(hass, 1, "haventory/item/create", name="Hammer", status="missing")
     assert res["success"] is True
     assert res["result"]["status"] == "missing"
     item_id = res["result"]["id"]
 
-    res = await _send(hass, 2, "haventory/item/update", item_id=item_id, status="needs_repair")
+    res = await ws_send(hass, 2, "haventory/item/update", item_id=item_id, status="needs_repair")
     assert res["success"] is True
     assert res["result"]["status"] == "needs_repair"
 
-    res = await _send(hass, 3, "haventory/item/get", item_id=item_id)
+    res = await ws_send(hass, 3, "haventory/item/get", item_id=item_id)
     assert res["result"]["status"] == "needs_repair"
 
 
@@ -297,16 +287,16 @@ async def test_ws_item_create_and_update_status() -> None:
 async def test_ws_item_create_defaults_status_and_rejects_bad_values() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/item/create", name="Hammer")
+    res = await ws_send(hass, 1, "haventory/item/create", name="Hammer")
     assert res["success"] is True
     assert res["result"]["status"] == "ok"
     item_id = res["result"]["id"]
 
-    res = await _send(hass, 2, "haventory/item/create", name="Drill", status="lost")
+    res = await ws_send(hass, 2, "haventory/item/create", name="Drill", status="lost")
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
 
-    res = await _send(hass, 3, "haventory/item/update", item_id=item_id, status=None)
+    res = await ws_send(hass, 3, "haventory/item/update", item_id=item_id, status=None)
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
 
@@ -314,15 +304,15 @@ async def test_ws_item_create_defaults_status_and_rejects_bad_values() -> None:
 @pytest.mark.asyncio
 async def test_ws_item_list_filters_by_status() -> None:
     hass = _new_hass()
-    await _send(hass, 1, "haventory/item/create", name="Hammer", status="missing")
-    await _send(hass, 2, "haventory/item/create", name="Wrench")
+    await ws_send(hass, 1, "haventory/item/create", name="Hammer", status="missing")
+    await ws_send(hass, 2, "haventory/item/create", name="Wrench")
 
-    res = await _send(hass, 3, "haventory/item/list", filter={"status": "missing"})
+    res = await ws_send(hass, 3, "haventory/item/list", filter={"status": "missing"})
     assert res["success"] is True
     assert [i["name"] for i in res["result"]["items"]] == ["Hammer"]
     assert res["result"]["total"] == 1
 
-    res = await _send(hass, 4, "haventory/item/list", filter={"status": "bogus"})
+    res = await ws_send(hass, 4, "haventory/item/list", filter={"status": "bogus"})
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
 
@@ -330,14 +320,14 @@ async def test_ws_item_list_filters_by_status() -> None:
 @pytest.mark.asyncio
 async def test_ws_stats_and_health_reflect_status() -> None:
     hass = _new_hass()
-    await _send(hass, 1, "haventory/item/create", name="Hammer", status="missing")
-    await _send(hass, 2, "haventory/item/create", name="Drill", status="needs_repair")
+    await ws_send(hass, 1, "haventory/item/create", name="Hammer", status="missing")
+    await ws_send(hass, 2, "haventory/item/create", name="Drill", status="needs_repair")
 
-    res = await _send(hass, 3, "haventory/stats")
+    res = await ws_send(hass, 3, "haventory/stats")
     assert res["result"]["missing_count"] == 1
     assert res["result"]["needs_repair_count"] == 1
 
-    res = await _send(hass, 4, "haventory/health")
+    res = await ws_send(hass, 4, "haventory/health")
     assert res["result"]["healthy"] is True
     assert res["result"]["issues"] == []
 
@@ -345,10 +335,10 @@ async def test_ws_stats_and_health_reflect_status() -> None:
 @pytest.mark.asyncio
 async def test_ws_bulk_item_update_sets_status() -> None:
     hass = _new_hass()
-    res = await _send(hass, 1, "haventory/item/create", name="Hammer")
+    res = await ws_send(hass, 1, "haventory/item/create", name="Hammer")
     item_id = res["result"]["id"]
 
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/items/bulk",

--- a/tests/test_storage_concurrency_offline.py
+++ b/tests/test_storage_concurrency_offline.py
@@ -23,6 +23,8 @@ from custom_components.haventory.storage import (
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import ws_send
+
 # Named constants for test assertions
 RAPID_MUTATION_COUNT = 3
 
@@ -405,21 +407,10 @@ async def test_ws_mutations_use_immediate_persistence(monkeypatch):
 
     monkeypatch.setattr(storage_mod, "async_persist_repo", track_immediate)
 
-    # Helper to send WS commands
-    async def _send(_id: int, type_: str, **payload):
-        handlers = hass.data.get("__ws_commands__", [])
-        for h in handlers:
-            if not callable(h) or getattr(h, "_ws_command", None) != type_:
-                continue
-            req = {"id": _id, "type": type_}
-            req.update(payload)
-            return await h(hass, None, req)
-        raise AssertionError("No handler responded for type " + type_)
-
     # Execute multiple WS mutations
-    await _send(1, "haventory/item/create", name="Item 1")
-    await _send(2, "haventory/item/create", name="Item 2")
-    await _send(3, "haventory/item/create", name="Item 3")
+    await ws_send(hass, 1, "haventory/item/create", name="Item 1")
+    await ws_send(hass, 2, "haventory/item/create", name="Item 2")
+    await ws_send(hass, 3, "haventory/item/create", name="Item 3")
 
     # Each WS mutation should trigger an immediate persist
     assert len(immediate_calls) == RAPID_MUTATION_COUNT

--- a/tests/test_ws_areas_offline.py
+++ b/tests/test_ws_areas_offline.py
@@ -14,17 +14,7 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        resp = await h(hass, None, req)
-        return resp
-    raise AssertionError("No handler responded for type " + type_)
+from ws_helpers import ws_send
 
 
 @pytest.mark.asyncio
@@ -41,7 +31,7 @@ async def test_ws_areas_list_returns_registry_entries() -> None:
     reg._add("a1", "Garage")  # type: ignore[attr-defined]
     reg._add("a2", "Office")  # type: ignore[attr-defined]
 
-    res = await _send(hass, 1, "haventory/areas/list")
+    res = await ws_send(hass, 1, "haventory/areas/list")
     assert res["success"] is True and isinstance(res["result"].get("areas"), list)
     ids = {a["id"] for a in res["result"]["areas"]}
     assert ids == {"a1", "a2"}

--- a/tests/test_ws_bulk_offline.py
+++ b/tests/test_ws_bulk_offline.py
@@ -14,17 +14,7 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        resp = await h(hass, None, req)
-        return resp
-    raise AssertionError("No handler responded for type " + type_)
+from ws_helpers import ws_send
 
 
 @pytest.mark.asyncio
@@ -45,7 +35,7 @@ async def test_bulk_mixed_results_and_single_persist(monkeypatch) -> None:
     monkeypatch.setattr(store, "async_save", _spy_save)
 
     # Seed an item
-    created = await _send(hass, 1, "haventory/item/create", name="Hammer", quantity=1)
+    created = await ws_send(hass, 1, "haventory/item/create", name="Hammer", quantity=1)
     item_id = created["result"]["id"]
 
     ops = [
@@ -67,7 +57,7 @@ async def test_bulk_mixed_results_and_single_persist(monkeypatch) -> None:
         {"op_id": "bad2", "kind": "unknown", "payload": {}},
     ]
 
-    res = await _send(hass, 2, "haventory/items/bulk", operations=ops)
+    res = await ws_send(hass, 2, "haventory/items/bulk", operations=ops)
     assert res["success"] is True
     results = res["result"]["results"]
     assert results["ok1"]["success"] is True and results["ok2"]["success"] is True
@@ -95,22 +85,22 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
     monkeypatch.setattr(store, "async_save", _spy_save)
 
     # Empty operations list
-    res = await _send(hass, 1, "haventory/items/bulk", operations=[])
+    res = await ws_send(hass, 1, "haventory/items/bulk", operations=[])
     assert res["success"] is True and res["result"]["results"] == {}
     assert calls["count"] == 0  # nothing to persist
 
     # Invalid operations type: the command declares `operations` as `object`, so
     # the frame reaches the handler and is answered through the guard.
-    res = await _send(hass, 2, "haventory/items/bulk", operations="oops")
+    res = await ws_send(hass, 2, "haventory/items/bulk", operations="oops")
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
     # The shape of each entry is the handler's to check too.
-    res = await _send(hass, 3, "haventory/items/bulk", operations=["oops"])
+    res = await ws_send(hass, 3, "haventory/items/bulk", operations=["oops"])
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
     # Duplicate op_id: the batch is refused whole, because results are keyed by
     # op_id and a repeat would leave the caller one verdict for two operations.
-    created = await _send(hass, 4, "haventory/item/create", name="X", quantity=1)
+    created = await ws_send(hass, 4, "haventory/item/create", name="X", quantity=1)
     iid = created["result"]["id"]
     START_QTY = 1
     ops = [
@@ -125,12 +115,12 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
             "payload": {"item_id": iid, "quantity": 3},
         },
     ]
-    res = await _send(hass, 5, "haventory/items/bulk", operations=ops)
+    res = await ws_send(hass, 5, "haventory/items/bulk", operations=ops)
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
     assert "dup" in res["error"]["message"]
     # Nothing ran: the quantity is still what item/create left it at.
-    got = await _send(hass, 6, "haventory/item/get", item_id=iid)
+    got = await ws_send(hass, 6, "haventory/item/get", item_id=iid)
     assert got["result"]["quantity"] == START_QTY
 
     # `1` and `"1"` are one id, not two — the result map normalizes with str().
@@ -138,7 +128,7 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
         {"op_id": 1, "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 2}},
         {"op_id": "1", "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 3}},
     ]
-    res = await _send(hass, 7, "haventory/items/bulk", operations=ops_mixed)
+    res = await ws_send(hass, 7, "haventory/items/bulk", operations=ops_mixed)
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
     # Distinct ids still return one result each.
@@ -146,6 +136,6 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
         {"op_id": "a", "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 2}},
         {"op_id": "b", "kind": "item_set_quantity", "payload": {"item_id": iid, "quantity": 3}},
     ]
-    res = await _send(hass, 8, "haventory/items/bulk", operations=ops_ok)
+    res = await ws_send(hass, 8, "haventory/items/bulk", operations=ops_ok)
     assert res["success"] is True
     assert set(res["result"]["results"]) == {"a", "b"}

--- a/tests/test_ws_distinct_values_offline.py
+++ b/tests/test_ws_distinct_values_offline.py
@@ -20,16 +20,7 @@ from custom_components.haventory.ws import setup as ws_setup
 from custom_components.haventory.ws import ws_distinct_values
 from homeassistant.core import HomeAssistant
 
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        return await h(hass, None, req)
-    raise AssertionError("No handler responded for type " + type_)
+from ws_helpers import ws_send
 
 
 def _fresh_hass() -> HomeAssistant:
@@ -46,15 +37,15 @@ async def test_distinct_values_returns_categories_and_tags_with_counts() -> None
 
     hass = _fresh_hass()
 
-    await _send(hass, 1, "haventory/item/create", name="Hammer", category="Tools", tags=["red"])
-    await _send(
+    await ws_send(hass, 1, "haventory/item/create", name="Hammer", category="Tools", tags=["red"])
+    await ws_send(
         hass, 2, "haventory/item/create", name="Wrench", category="Tools", tags=["red", "blue"]
     )
-    await _send(hass, 3, "haventory/item/create", name="Novel", category="Books", tags=["blue"])
+    await ws_send(hass, 3, "haventory/item/create", name="Novel", category="Books", tags=["blue"])
     # An item with neither category nor tags must not contribute to either list.
-    await _send(hass, 4, "haventory/item/create", name="Mystery Box")
+    await ws_send(hass, 4, "haventory/item/create", name="Mystery Box")
 
-    res = await _send(hass, 5, "haventory/distinct_values")
+    res = await ws_send(hass, 5, "haventory/distinct_values")
     assert res["success"] is True
     result = res["result"]
 
@@ -77,11 +68,11 @@ async def test_distinct_values_groups_categories_case_insensitively() -> None:
 
     hass = _fresh_hass()
 
-    await _send(hass, 1, "haventory/item/create", name="A", category="Books")
-    await _send(hass, 2, "haventory/item/create", name="B", category="Books")
-    await _send(hass, 3, "haventory/item/create", name="C", category="books")
+    await ws_send(hass, 1, "haventory/item/create", name="A", category="Books")
+    await ws_send(hass, 2, "haventory/item/create", name="B", category="Books")
+    await ws_send(hass, 3, "haventory/item/create", name="C", category="books")
 
-    res = await _send(hass, 4, "haventory/distinct_values")
+    res = await ws_send(hass, 4, "haventory/distinct_values")
     categories = res["result"]["categories"]
 
     expected_grouped_count = 3
@@ -97,7 +88,7 @@ async def test_distinct_values_empty_repository() -> None:
     """An empty repository yields empty category, tag, and custom-field lists."""
 
     hass = _fresh_hass()
-    res = await _send(hass, 1, "haventory/distinct_values")
+    res = await ws_send(hass, 1, "haventory/distinct_values")
     assert res["success"] is True
     assert res["result"] == {"categories": [], "tags": [], "custom_field_keys": []}
 
@@ -107,14 +98,14 @@ async def test_distinct_values_returns_custom_field_keys() -> None:
     """Distinct custom-field keys across all items are returned, sorted."""
 
     hass = _fresh_hass()
-    await _send(
+    await ws_send(
         hass,
         1,
         "haventory/item/create",
         name="Drill",
         custom_fields={"Voltage": 18, "warranty_until": "2027-01-01"},
     )
-    await _send(
+    await ws_send(
         hass,
         2,
         "haventory/item/create",
@@ -122,7 +113,7 @@ async def test_distinct_values_returns_custom_field_keys() -> None:
         custom_fields={"Voltage": 20, "serial": "abc"},
     )
 
-    res = await _send(hass, 3, "haventory/distinct_values")
+    res = await ws_send(hass, 3, "haventory/distinct_values")
     # Distinct keys, sorted case-insensitively; "Voltage" appears once.
     assert res["result"]["custom_field_keys"] == ["serial", "Voltage", "warranty_until"]
 
@@ -138,10 +129,10 @@ async def test_distinct_values_rejects_unknown_field() -> None:
     hass = _fresh_hass()
     assert set(ws_distinct_values._ws_schema.schema) == {"id", "type", "filter"}
 
-    assert (await _send(hass, 1, "haventory/distinct_values"))["success"] is True
-    assert (await _send(hass, 2, "haventory/distinct_values", filter={}))["success"] is True
+    assert (await ws_send(hass, 1, "haventory/distinct_values"))["success"] is True
+    assert (await ws_send(hass, 2, "haventory/distinct_values", filter={}))["success"] is True
 
-    res = await _send(hass, 3, "haventory/distinct_values", bogus=1)
+    res = await ws_send(hass, 3, "haventory/distinct_values", bogus=1)
     assert res["success"] is False
     assert res["error"]["code"] == "invalid_format"
 
@@ -149,7 +140,7 @@ async def test_distinct_values_rejects_unknown_field() -> None:
 async def _seed_facets(hass: HomeAssistant) -> None:
     """Two categories and three tags across four items, two of them low on stock."""
 
-    await _send(
+    await ws_send(
         hass,
         1,
         "haventory/item/create",
@@ -159,8 +150,8 @@ async def _seed_facets(hass: HomeAssistant) -> None:
         quantity=0,
         low_stock_threshold=1,
     )
-    await _send(hass, 2, "haventory/item/create", name="Wrench", category="Tools", tags=["blue"])
-    await _send(
+    await ws_send(hass, 2, "haventory/item/create", name="Wrench", category="Tools", tags=["blue"])
+    await ws_send(
         hass,
         3,
         "haventory/item/create",
@@ -170,7 +161,7 @@ async def _seed_facets(hass: HomeAssistant) -> None:
         quantity=0,
         low_stock_threshold=1,
     )
-    await _send(hass, 4, "haventory/item/create", name="Atlas", category="Books", tags=["paper"])
+    await ws_send(hass, 4, "haventory/item/create", name="Atlas", category="Books", tags=["paper"])
 
 
 @pytest.mark.asyncio
@@ -180,7 +171,7 @@ async def test_distinct_values_prices_both_facets_against_a_filter() -> None:
     hass = _fresh_hass()
     await _seed_facets(hass)
 
-    res = await _send(hass, 5, "haventory/distinct_values", filter={"low_stock_only": True})
+    res = await ws_send(hass, 5, "haventory/distinct_values", filter={"low_stock_only": True})
     assert res["success"] is True
     result = res["result"]
 
@@ -201,12 +192,12 @@ async def test_distinct_values_without_a_filter_carries_no_matching_count() -> N
     hass = _fresh_hass()
     await _seed_facets(hass)
 
-    result = (await _send(hass, 5, "haventory/distinct_values"))["result"]
+    result = (await ws_send(hass, 5, "haventory/distinct_values"))["result"]
     for entry in [*result["categories"], *result["tags"]]:
         assert "matching_count" not in entry
 
     # An explicit null reads as "no filter", the way location/tree reads it.
-    null_result = (await _send(hass, 6, "haventory/distinct_values", filter=None))["result"]
+    null_result = (await ws_send(hass, 6, "haventory/distinct_values", filter=None))["result"]
     for entry in [*null_result["categories"], *null_result["tags"]]:
         assert "matching_count" not in entry
 
@@ -222,7 +213,7 @@ async def test_distinct_values_keeps_every_row_when_nothing_matches() -> None:
     hass = _fresh_hass()
     await _seed_facets(hass)
 
-    result = (await _send(hass, 5, "haventory/distinct_values", filter={"q": "nothing here"}))[
+    result = (await ws_send(hass, 5, "haventory/distinct_values", filter={"q": "nothing here"}))[
         "result"
     ]
 
@@ -242,13 +233,13 @@ async def test_distinct_values_rejects_an_unknown_filter_key() -> None:
 
     hass = _fresh_hass()
 
-    res = await _send(hass, 1, "haventory/distinct_values", filter={"categorie": "Tools"})
+    res = await ws_send(hass, 1, "haventory/distinct_values", filter={"categorie": "Tools"})
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
     assert "categorie" in res["error"]["message"]
 
     # And a filter that is not an object at all is a validation error rather
     # than a schema rejection carrying the client's payload.
-    res = await _send(hass, 2, "haventory/distinct_values", filter="low_stock_only")
+    res = await ws_send(hass, 2, "haventory/distinct_values", filter="low_stock_only")
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"

--- a/tests/test_ws_effective_area_offline.py
+++ b/tests/test_ws_effective_area_offline.py
@@ -17,17 +17,7 @@ from custom_components.haventory.ws import _item_matches_filter
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        resp = await h(hass, None, req)
-        return resp
-    raise AssertionError("No handler responded for type " + type_)
+from ws_helpers import ws_send
 
 
 @pytest.mark.asyncio
@@ -45,7 +35,7 @@ async def test_effective_area_id_present_from_ancestor() -> None:
     shelf = repo.create_location(name="Shelf A", parent_id=garage.id)
     bin1 = repo.create_location(name="Bin 1", parent_id=shelf.id)
 
-    created = await _send(
+    created = await ws_send(
         hass,
         1,
         "haventory/item/create",
@@ -56,11 +46,11 @@ async def test_effective_area_id_present_from_ancestor() -> None:
     )
     iid = created["result"]["id"]
 
-    got = await _send(hass, 2, "haventory/item/get", item_id=iid)
+    got = await ws_send(hass, 2, "haventory/item/get", item_id=iid)
     assert got["success"] is True
     assert got["result"].get("effective_area_id") == "wohnzimmer"
 
-    listed = await _send(hass, 3, "haventory/item/list")
+    listed = await ws_send(hass, 3, "haventory/item/list")
     assert any(
         it.get("id") == iid and it.get("effective_area_id") == "wohnzimmer"
         for it in listed["result"]["items"]
@@ -80,11 +70,11 @@ async def test_effective_area_id_none_when_no_area() -> None:
     root = repo.create_location(name="Root")  # no area
     child = repo.create_location(name="Child", parent_id=root.id)  # no area
 
-    created = await _send(
+    created = await ws_send(
         hass, 1, "haventory/item/create", name="NoArea", location_id=str(child.id)
     )
     iid = created["result"]["id"]
-    got = await _send(hass, 2, "haventory/item/get", item_id=iid)
+    got = await ws_send(hass, 2, "haventory/item/get", item_id=iid)
     assert got["success"] is True
     assert got["result"].get("effective_area_id") in (None,)
 
@@ -102,17 +92,17 @@ async def test_effective_area_id_updates_on_area_change_without_version_bump() -
     # Root without area -> effective_area_id None
     root = repo.create_location(name="Root")
     leaf = repo.create_location(name="Leaf", parent_id=root.id)
-    created = await _send(hass, 1, "haventory/item/create", name="A", location_id=str(leaf.id))
+    created = await ws_send(hass, 1, "haventory/item/create", name="A", location_id=str(leaf.id))
     iid = created["result"]["id"]
 
-    before = await _send(hass, 2, "haventory/item/get", item_id=iid)
+    before = await ws_send(hass, 2, "haventory/item/get", item_id=iid)
     ver_before = before["result"]["version"]
     assert before["result"].get("effective_area_id") is None
 
     # Assign area to ancestor; effective_area_id should change, version should not
     repo.update_location(root.id, area_id="kitchen")
 
-    after = await _send(hass, 3, "haventory/item/get", item_id=iid)
+    after = await ws_send(hass, 3, "haventory/item/get", item_id=iid)
     ver_after = after["result"]["version"]
     assert after["result"].get("effective_area_id") == "kitchen"
     assert ver_after == ver_before
@@ -137,7 +127,7 @@ async def test_subscription_matcher_agrees_with_item_list_on_area() -> None:
     garage = repo.create_location(name="Garage", area_id="garage")
 
     for name, loc in (("Whisk", drawer), ("Spanner", garage), ("Loose screw", None)):
-        await _send(
+        await ws_send(
             hass,
             1,
             "haventory/item/create",
@@ -145,10 +135,10 @@ async def test_subscription_matcher_agrees_with_item_list_on_area() -> None:
             location_id=str(loc.id) if loc is not None else None,
         )
 
-    listed = await _send(hass, 2, "haventory/item/list", filter={"area_id": "kitchen"})
+    listed = await ws_send(hass, 2, "haventory/item/list", filter={"area_id": "kitchen"})
     by_list = {it["name"] for it in listed["result"]["items"]}
 
-    everything = await _send(hass, 3, "haventory/item/list")
+    everything = await ws_send(hass, 3, "haventory/item/list")
     by_matcher = {
         it["name"]
         for it in everything["result"]["items"]

--- a/tests/test_ws_error_mapping_offline.py
+++ b/tests/test_ws_error_mapping_offline.py
@@ -16,7 +16,6 @@ Scenarios:
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Coroutine
 from typing import Any
 
 import pytest
@@ -28,29 +27,7 @@ from custom_components.haventory.ws import UNEXPECTED_ERROR_MESSAGE
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-
-def _get_handler(
-    hass: HomeAssistant, type_: str
-) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if callable(h) and getattr(h, "_ws_command", None) == type_:
-            return h
-    raise AssertionError("No handler found for type " + type_)
-
-
-async def _send(hass: HomeAssistant, conn: object, _id: int, type_: str, **payload: Any) -> dict:
-    handler = _get_handler(hass, type_)
-    req = {"id": _id, "type": type_, **payload}
-    return await handler(hass, conn, req)
-
-
-class _ConnCollect:
-    def __init__(self) -> None:
-        self.messages: list[dict[str, Any]] = []
-
-    def send_message(self, msg: dict[str, Any]) -> None:
-        self.messages.append(msg)
+from ws_helpers import RecordingConn, ws_send
 
 
 def _make_hass(*, with_repo: bool = True) -> HomeAssistant:
@@ -88,8 +65,8 @@ async def test_unexpected_exception_maps_to_unknown_error_without_leaking(monkey
         raise RuntimeError("SECRET-INTERNAL-DETAIL")
 
     monkeypatch.setattr(ws_module, "_serialize_item", _boom)
-    conn = _ConnCollect()
-    res = await _send(hass, conn, 5, "haventory/item/create", name="Widget")
+    conn = RecordingConn()
+    res = await ws_send(hass, 5, "haventory/item/create", conn=conn, name="Widget")
 
     assert res["success"] is False
     assert res["error"]["code"] == "unknown_error"
@@ -118,7 +95,7 @@ async def test_repo_dependent_commands_map_missing_repo_to_storage_error(type_: 
     """Missing repository surfaces as storage_error, not an escaped exception."""
 
     hass = _make_hass(with_repo=False)
-    res = await _send(hass, _ConnCollect(), 6, type_)
+    res = await ws_send(hass, 6, type_)
 
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
@@ -127,7 +104,7 @@ async def test_repo_dependent_commands_map_missing_repo_to_storage_error(type_: 
 @pytest.mark.asyncio
 async def test_subscribe_bad_topic_maps_to_validation_error() -> None:
     hass = _make_hass()
-    res = await _send(hass, _ConnCollect(), 7, "haventory/subscribe", topic="nope")
+    res = await ws_send(hass, 7, "haventory/subscribe", topic="nope")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -138,16 +115,16 @@ async def test_subscribe_bad_topic_maps_to_validation_error() -> None:
 async def test_unsubscribe_validates_subscription_id() -> None:
     hass = _make_hass()
 
-    res = await _send(hass, _ConnCollect(), 8, "haventory/unsubscribe", subscription="abc")
+    res = await ws_send(hass, 8, "haventory/unsubscribe", subscription="abc")
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
 
-    res = await _send(hass, _ConnCollect(), 9, "haventory/unsubscribe", subscription={"x": 1})
+    res = await ws_send(hass, 9, "haventory/unsubscribe", subscription={"x": 1})
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
 
     # Numeric strings remain accepted.
-    res = await _send(hass, _ConnCollect(), 10, "haventory/unsubscribe", subscription="42")
+    res = await ws_send(hass, 10, "haventory/unsubscribe", subscription="42")
     assert res["success"] is True
 
 
@@ -159,12 +136,12 @@ async def test_bulk_malformed_custom_fields_payload_fails_only_that_op() -> None
     repo = hass.data[DOMAIN]["repository"]
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
-    conn = _ConnCollect()
-    res = await _send(
+    conn = RecordingConn()
+    res = await ws_send(
         hass,
-        conn,
         11,
         "haventory/items/bulk",
+        conn=conn,
         operations=[
             {
                 "op_id": "bad-set",
@@ -203,9 +180,8 @@ async def test_bulk_payload_field_validation_errors() -> None:
     repo = hass.data[DOMAIN]["repository"]
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
-    res = await _send(
+    res = await ws_send(
         hass,
-        _ConnCollect(),
         13,
         "haventory/items/bulk",
         operations=[
@@ -252,9 +228,8 @@ async def test_bulk_unexpected_per_op_error_is_contained(monkeypatch) -> None:
 
     monkeypatch.setattr(ws_module, "_op_item_update", _boom)
 
-    res = await _send(
+    res = await ws_send(
         hass,
-        _ConnCollect(),
         12,
         "haventory/items/bulk",
         operations=[
@@ -285,8 +260,8 @@ async def test_broadcast_failure_does_not_fail_the_command(monkeypatch) -> None:
     """A raising event sender must not turn a successful mutation into an error."""
 
     hass = _make_hass()
-    conn = _ConnCollect()
-    sub = await _send(hass, conn, 100, "haventory/subscribe", topic="items")
+    conn = RecordingConn()
+    sub = await ws_send(hass, 100, "haventory/subscribe", conn=conn, topic="items")
     assert sub["success"] is True
 
     def _boom(*_args: Any, **_kwargs: Any) -> None:
@@ -294,7 +269,7 @@ async def test_broadcast_failure_does_not_fail_the_command(monkeypatch) -> None:
 
     monkeypatch.setattr(ws_module, "_send_event_message", _boom)
 
-    res = await _send(hass, conn, 101, "haventory/item/create", name="Widget")
+    res = await ws_send(hass, 101, "haventory/item/create", conn=conn, name="Widget")
     assert res["success"] is True
     repo = hass.data[DOMAIN]["repository"]
     assert repo.get_counts()["items_total"] == 1

--- a/tests/test_ws_helpers_offline.py
+++ b/tests/test_ws_helpers_offline.py
@@ -1,0 +1,116 @@
+"""Offline tests for the shared WebSocket send helper.
+
+Every offline WS test dispatches through ``tests/ws_helpers.py``, so what it
+returns and how it treats ``conn`` decide what those tests are able to assert.
+The three properties pinned here are the ones the rest of the suite leans on:
+the **full envelope** comes back (success and failure alike), a caller-supplied
+connection is the one the handler writes to, and a command nobody registered
+fails loudly rather than returning nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.ws import setup as ws_setup
+from homeassistant.core import HomeAssistant
+
+from ws_helpers import RecordingConn, ws_call, ws_handler, ws_send
+
+# One frame id, reused: what matters is that the envelope echoes the one sent.
+FRAME_ID = 7
+
+
+def _make_hass() -> HomeAssistant:
+    hass = HomeAssistant()
+    bucket = hass.data.setdefault(DOMAIN, {})
+    bucket["repository"] = Repository()
+    bucket["store"] = DomainStore(hass)
+    ws_setup(hass)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_send_returns_the_whole_result_envelope() -> None:
+    """Not just ``result``: the id, the type and the success flag come back too."""
+
+    hass = _make_hass()
+
+    res = await ws_send(hass, FRAME_ID, "haventory/item/create", name="Hammer")
+
+    assert res["id"] == FRAME_ID
+    assert res["type"] == "result"
+    assert res["success"] is True
+    assert res["result"]["name"] == "Hammer"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_command_is_returned_not_raised() -> None:
+    """The error envelope is a return value, so a test can read its code and data."""
+
+    hass = _make_hass()
+
+    res = await ws_send(hass, FRAME_ID, "haventory/item/get", item_id="not-a-uuid")
+
+    assert res["id"] == FRAME_ID
+    assert res["success"] is False
+    assert res["error"]["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_conn_is_optional_and_receives_what_the_handler_pushes() -> None:
+    """Passing a connection is what lets a test read events off the wire."""
+
+    hass = _make_hass()
+    conn = RecordingConn()
+
+    assert (await ws_send(hass, 1, "haventory/subscribe", conn=conn, topic="items"))["success"]
+    await ws_send(hass, 2, "haventory/item/create", name="Chisel")
+
+    events = conn.events(topic="items")
+    assert [ev["action"] for ev in events] == ["created"]
+    assert events[0]["item"]["name"] == "Chisel"
+    # A different topic is filtered out, and the unfiltered read sees the same one.
+    assert conn.events(topic="locations") == []
+    assert conn.events() == events
+
+
+@pytest.mark.asyncio
+async def test_omitting_conn_still_answers() -> None:
+    """The 11-of-22 case: no connection to hand over, and the envelope still returns."""
+
+    hass = _make_hass()
+
+    res = await ws_send(hass, 1, "haventory/stats")
+
+    assert res["success"] is True
+    assert res["result"]["items_total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_captured_handler_can_be_called_after_the_lookup() -> None:
+    """``ws_handler`` + ``ws_call`` split the lookup from the send.
+
+    The unload tests need exactly this: real Home Assistant cannot unregister a
+    WebSocket command, so they hold the handler across teardown and call it the
+    way a client on a still-registered command does.
+    """
+
+    hass = _make_hass()
+    handler = ws_handler(hass, "haventory/item/list")
+
+    res = await ws_call(handler, hass, FRAME_ID, "haventory/item/list")
+
+    assert res["id"] == FRAME_ID
+    assert res["result"]["items"] == []
+
+
+def test_an_unregistered_command_fails_loudly() -> None:
+    """A typo in a command name must not read as an empty answer."""
+
+    hass = _make_hass()
+
+    with pytest.raises(AssertionError, match="haventory/nope"):
+        ws_handler(hass, "haventory/nope")

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -32,21 +32,11 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import ws_send
+
 
 def _repo_of(hass: HomeAssistant) -> Repository:
     return hass.data[DOMAIN]["repository"]
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        resp = await h(hass, None, req)
-        return resp
-    raise AssertionError("No handler responded for type " + type_)
 
 
 @pytest.mark.asyncio
@@ -59,21 +49,21 @@ async def test_item_create_get_update_delete_success() -> None:
     ws_setup(hass)
 
     # Create
-    res = await _send(hass, 1, "haventory/item/create", name="Hammer", quantity=2)
+    res = await ws_send(hass, 1, "haventory/item/create", name="Hammer", quantity=2)
     assert res["id"] == 1 and res["type"] == "result" and res["success"] is True
     assert isinstance(res.get("result"), dict) and "id" in res["result"]
     item_id = res["result"]["id"]
 
     # Get
-    res = await _send(hass, 2, "haventory/item/get", item_id=item_id)
+    res = await ws_send(hass, 2, "haventory/item/get", item_id=item_id)
     assert res["success"] is True and res["result"]["id"] == item_id
 
     # Update
-    res = await _send(hass, 3, "haventory/item/update", item_id=item_id, name="Hammer Pro")
+    res = await ws_send(hass, 3, "haventory/item/update", item_id=item_id, name="Hammer Pro")
     assert res["success"] is True and res["result"]["name"] == "Hammer Pro"
 
     # Delete
-    res = await _send(hass, 4, "haventory/item/delete", item_id=item_id)
+    res = await ws_send(hass, 4, "haventory/item/delete", item_id=item_id)
     assert res["success"] is True and res["result"] is None
 
 
@@ -93,10 +83,10 @@ async def test_item_update_normalizes_a_tag_list_carrying_a_null() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Battery")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Battery")
     item_id = created["result"]["id"]
 
-    res = await _send(
+    res = await ws_send(
         hass, 2, "haventory/item/update", item_id=item_id, tags=["Li-Ion", None, " spare "]
     )
 
@@ -104,7 +94,7 @@ async def test_item_update_normalizes_a_tag_list_carrying_a_null() -> None:
     assert res["result"]["tags"] == ["li-ion", "spare"]
 
     # The narrow schemas hold the line for the commands that declare `[str]`.
-    refused = await _send(hass, 3, "haventory/item/add_tags", item_id=item_id, tags=["x", None])
+    refused = await ws_send(hass, 3, "haventory/item/add_tags", item_id=item_id, tags=["x", None])
     assert refused["success"] is False
     assert refused["error"]["code"] == "invalid_format"
 
@@ -119,26 +109,26 @@ async def test_item_quantity_and_checkout_helpers() -> None:
     ws_setup(hass)
 
     initial_quantity = 1
-    created = await _send(hass, 1, "haventory/item/create", name="Box", quantity=initial_quantity)
+    created = await ws_send(hass, 1, "haventory/item/create", name="Box", quantity=initial_quantity)
     item_id = created["result"]["id"]
 
     delta_quantity = 2
     expected_after_adjust = initial_quantity + delta_quantity
-    res = await _send(
+    res = await ws_send(
         hass, 2, "haventory/item/adjust_quantity", item_id=item_id, delta=delta_quantity
     )
     assert res["result"]["quantity"] == expected_after_adjust
 
     target_quantity = 5
-    res = await _send(
+    res = await ws_send(
         hass, 3, "haventory/item/set_quantity", item_id=item_id, quantity=target_quantity
     )
     assert res["result"]["quantity"] == target_quantity
 
-    res = await _send(hass, 4, "haventory/item/check_out", item_id=item_id, due_date="2030-01-01")
+    res = await ws_send(hass, 4, "haventory/item/check_out", item_id=item_id, due_date="2030-01-01")
     assert res["result"]["checked_out"] is True
 
-    res = await _send(hass, 5, "haventory/item/check_in", item_id=item_id)
+    res = await ws_send(hass, 5, "haventory/item/check_in", item_id=item_id)
     assert res["result"]["checked_out"] is False
 
 
@@ -156,19 +146,19 @@ async def test_item_check_out_due_date_is_optional() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     item_id = created["result"]["id"]
 
     # Omitted entirely
-    res = await _send(hass, 2, "haventory/item/check_out", item_id=item_id)
+    res = await ws_send(hass, 2, "haventory/item/check_out", item_id=item_id)
     assert res["success"] is True
     assert res["result"]["checked_out"] is True
     assert res["result"]["due_date"] is None
 
-    await _send(hass, 3, "haventory/item/check_in", item_id=item_id)
+    await ws_send(hass, 3, "haventory/item/check_in", item_id=item_id)
 
     # Explicit null
-    res = await _send(hass, 4, "haventory/item/check_out", item_id=item_id, due_date=None)
+    res = await ws_send(hass, 4, "haventory/item/check_out", item_id=item_id, due_date=None)
     assert res["success"] is True
     assert res["result"]["checked_out"] is True
     assert res["result"]["due_date"] is None
@@ -184,16 +174,16 @@ async def test_item_list_pagination_cursor_passthrough() -> None:
     ws_setup(hass)
 
     # Seed a couple items
-    await _send(hass, 1, "haventory/item/create", name="A")
-    await _send(hass, 2, "haventory/item/create", name="B")
+    await ws_send(hass, 1, "haventory/item/create", name="A")
+    await ws_send(hass, 2, "haventory/item/create", name="B")
 
-    res = await _send(hass, 3, "haventory/item/list", limit=1)
+    res = await ws_send(hass, 3, "haventory/item/list", limit=1)
     assert res["success"] is True
     assert isinstance(res["result"].get("items"), list)
     cursor = res["result"].get("next_cursor")
 
     if cursor:
-        res2 = await _send(hass, 4, "haventory/item/list", limit=1, cursor=cursor)
+        res2 = await ws_send(hass, 4, "haventory/item/list", limit=1, cursor=cursor)
         assert res2["success"] is True
 
 
@@ -207,20 +197,20 @@ async def test_error_mapping_validation_and_not_found_and_conflict() -> None:
     ws_setup(hass)
 
     # validation_error: negative quantity
-    v = await _send(hass, 1, "haventory/item/set_quantity", item_id="x", quantity=-1)
+    v = await ws_send(hass, 1, "haventory/item/set_quantity", item_id="x", quantity=-1)
     assert v["success"] is False and v["error"]["code"] == "validation_error"
     # Context includes op and input fields
     assert v["error"].get("context", v["error"].get("data", {})).get("op") == "item_set_quantity"
 
     # not_found: get by unknown id
-    n = await _send(hass, 2, "haventory/item/get", item_id="00000000-0000-4000-8000-000000000000")
+    n = await ws_send(hass, 2, "haventory/item/get", item_id="00000000-0000-4000-8000-000000000000")
     assert n["success"] is False and n["error"]["code"] == "not_found"
     assert n["error"].get("context", n["error"].get("data", {})).get("op") == "item_get"
 
     # conflict: create then update with stale expected_version
-    c = await _send(hass, 3, "haventory/item/create", name="Widget")
+    c = await ws_send(hass, 3, "haventory/item/create", name="Widget")
     iid = c["result"]["id"]
-    stale = await _send(
+    stale = await ws_send(
         hass, 4, "haventory/item/update", item_id=iid, expected_version=999, name="X"
     )
     assert stale["success"] is False and stale["error"]["code"] == "conflict"
@@ -249,30 +239,32 @@ async def test_ws_mutations_persist_to_store(monkeypatch) -> None:
     monkeypatch.setattr(store, "async_save", _spy_save)
 
     # Create triggers persist
-    created = await _send(hass, 1, "haventory/item/create", name="Hammer")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Hammer")
     assert calls["count"] >= 1
     item_id = created["result"]["id"]
     # Update triggers persist
-    await _send(hass, 2, "haventory/item/update", item_id=item_id, name="HammerX")
+    await ws_send(hass, 2, "haventory/item/update", item_id=item_id, name="HammerX")
     # Adjust quantity triggers persist
-    await _send(hass, 3, "haventory/item/adjust_quantity", item_id=item_id, delta=1)
+    await ws_send(hass, 3, "haventory/item/adjust_quantity", item_id=item_id, delta=1)
     # Delete triggers persist
-    await _send(hass, 4, "haventory/item/delete", item_id=item_id)
+    await ws_send(hass, 4, "haventory/item/delete", item_id=item_id)
     MIN_PERSISTS_TOTAL = 4
     assert calls["count"] >= MIN_PERSISTS_TOTAL
 
     # Validation: set_quantity negative
-    res = await _send(hass, 1, "haventory/item/set_quantity", item_id="x", quantity=-1)
+    res = await ws_send(hass, 1, "haventory/item/set_quantity", item_id="x", quantity=-1)
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
     # Not found
-    res = await _send(hass, 2, "haventory/item/get", item_id="00000000-0000-4000-8000-000000000000")
+    res = await ws_send(
+        hass, 2, "haventory/item/get", item_id="00000000-0000-4000-8000-000000000000"
+    )
     assert res["success"] is False and res["error"]["code"] == "not_found"
 
     # Conflict: create, then update with stale version
-    created = await _send(hass, 3, "haventory/item/create", name="Widget")
+    created = await ws_send(hass, 3, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
-    stale = await _send(
+    stale = await ws_send(
         hass, 4, "haventory/item/update", item_id=item_id, expected_version=999, name="X"
     )
     assert stale["success"] is False and stale["error"]["code"] == "conflict"
@@ -288,7 +280,7 @@ async def test_inspection_date_in_create_update_get() -> None:
     ws_setup(hass)
 
     # Create item with inspection_date
-    res = await _send(
+    res = await ws_send(
         hass, 1, "haventory/item/create", name="Calibration Tool", inspection_date="2024-03-15"
     )
     assert res["success"] is True
@@ -296,19 +288,19 @@ async def test_inspection_date_in_create_update_get() -> None:
     item_id = res["result"]["id"]
 
     # Get item and verify inspection_date is returned
-    res = await _send(hass, 2, "haventory/item/get", item_id=item_id)
+    res = await ws_send(hass, 2, "haventory/item/get", item_id=item_id)
     assert res["success"] is True
     assert res["result"]["inspection_date"] == "2024-03-15"
 
     # Update inspection_date
-    res = await _send(
+    res = await ws_send(
         hass, 3, "haventory/item/update", item_id=item_id, inspection_date="2024-09-30"
     )
     assert res["success"] is True
     assert res["result"]["inspection_date"] == "2024-09-30"
 
     # Clear inspection_date
-    res = await _send(hass, 4, "haventory/item/update", item_id=item_id, inspection_date=None)
+    res = await ws_send(hass, 4, "haventory/item/update", item_id=item_id, inspection_date=None)
     assert res["success"] is True
     assert res["result"]["inspection_date"] is None
 
@@ -322,28 +314,28 @@ async def test_item_list_reports_filtered_total() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    await _send(hass, 1, "haventory/item/create", name="Hammer", category="tools")
-    await _send(hass, 2, "haventory/item/create", name="Wrench", category="tools")
-    await _send(hass, 3, "haventory/item/create", name="Glue", category="misc")
+    await ws_send(hass, 1, "haventory/item/create", name="Hammer", category="tools")
+    await ws_send(hass, 2, "haventory/item/create", name="Wrench", category="tools")
+    await ws_send(hass, 3, "haventory/item/create", name="Glue", category="misc")
 
     seeded = 3
-    res = await _send(hass, 4, "haventory/item/list", limit=1)
+    res = await ws_send(hass, 4, "haventory/item/list", limit=1)
     assert res["success"] is True
     assert res["result"]["total"] == seeded
     assert len(res["result"]["items"]) == 1
 
     # A later page still reports the full total
-    res_page2 = await _send(
+    res_page2 = await ws_send(
         hass, 5, "haventory/item/list", limit=1, cursor=res["result"]["next_cursor"]
     )
     assert res_page2["result"]["total"] == seeded
 
     tools = 2
-    filtered = await _send(hass, 6, "haventory/item/list", filter={"category": "tools"}, limit=1)
+    filtered = await ws_send(hass, 6, "haventory/item/list", filter={"category": "tools"}, limit=1)
     assert filtered["result"]["total"] == tools
     assert len(filtered["result"]["items"]) == 1
 
-    empty = await _send(hass, 7, "haventory/item/list", filter={"q": "zzz-not-there"})
+    empty = await ws_send(hass, 7, "haventory/item/list", filter={"q": "zzz-not-there"})
     assert empty["result"]["total"] == 0
     assert empty["result"]["items"] == []
 
@@ -417,12 +409,12 @@ async def test_attachment_add_and_remove_bump_the_version(upload) -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     item_id = created["result"]["id"]
     assert created["result"]["attachments"] == []
 
     upload("upload-1")
-    added = await _send(
+    added = await ws_send(
         hass,
         2,
         "haventory/item/attachment/add",
@@ -440,7 +432,7 @@ async def test_attachment_add_and_remove_bump_the_version(upload) -> None:
     assert attachments[0]["filename"] == "drill.png"
     assert added["result"]["version"] == created["result"]["version"] + 1
 
-    removed = await _send(
+    removed = await ws_send(
         hass,
         3,
         "haventory/item/attachment/remove",
@@ -462,7 +454,7 @@ async def test_attachment_add_announces_the_item_as_updated(upload, monkeypatch)
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     broadcasts: list[tuple[str, str]] = []
     monkeypatch.setattr(
         ws_mod,
@@ -471,7 +463,7 @@ async def test_attachment_add_announces_the_item_as_updated(upload, monkeypatch)
     )
 
     upload("upload-1")
-    await _send(
+    await ws_send(
         hass,
         2,
         "haventory/item/attachment/add",
@@ -489,11 +481,11 @@ async def test_attachment_add_refuses_a_stale_expected_version(upload) -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     item_id = created["result"]["id"]
 
     upload("upload-1")
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/item/attachment/add",
@@ -517,7 +509,7 @@ async def test_attachment_add_on_an_unknown_item_is_not_found(upload) -> None:
     ws_setup(hass)
 
     upload("upload-1")
-    res = await _send(
+    res = await ws_send(
         hass,
         1,
         "haventory/item/attachment/add",
@@ -538,9 +530,9 @@ async def test_attachment_add_reports_an_unknown_file_id_as_not_found(upload) ->
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
 
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/item/attachment/add",
@@ -559,10 +551,10 @@ async def test_attachment_add_refuses_a_file_whose_bytes_are_not_an_image(upload
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     upload("upload-1", b'<svg xmlns="http://www.w3.org/2000/svg"><script/></svg>')
 
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/item/attachment/add",
@@ -590,11 +582,11 @@ async def test_attachment_add_consumes_the_upload_handle_off_the_event_loop(uplo
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     directory = upload("upload-1")
     loop_thread = threading.get_ident()
 
-    added = await _send(
+    added = await ws_send(
         hass,
         2,
         "haventory/item/attachment/add",
@@ -619,11 +611,11 @@ async def test_attachment_add_tears_the_upload_down_off_the_loop_when_it_is_refu
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     directory = upload("upload-1", b'<svg xmlns="http://www.w3.org/2000/svg"><script/></svg>')
     loop_thread = threading.get_ident()
 
-    refused = await _send(
+    refused = await ws_send(
         hass,
         2,
         "haventory/item/attachment/add",
@@ -652,7 +644,7 @@ async def test_attachment_add_tears_the_upload_down_when_the_command_is_cancelle
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     directory = upload("upload-1")
 
     consuming = asyncio.Event()
@@ -664,7 +656,7 @@ async def test_attachment_add_tears_the_upload_down_when_the_command_is_cancelle
     monkeypatch.setattr(media_mod, "async_consume_upload", _hang)
 
     task = asyncio.create_task(
-        _send(
+        ws_send(
             hass,
             2,
             "haventory/item/attachment/add",
@@ -687,17 +679,17 @@ async def test_attachment_remove_deletes_the_file_and_the_item_delete_cascades(u
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     item_id = created["result"]["id"]
     upload("upload-1")
-    added = await _send(
+    added = await ws_send(
         hass, 2, "haventory/item/attachment/add", item_id=item_id, file_id="upload-1"
     )
     meta = _repo_of(hass).get_item(item_id).attachments[0]
     path = media_mod.attachment_path(media_mod.media_root(hass), item_id, str(meta.id), meta.mime)
     assert path.is_file()
 
-    await _send(
+    await ws_send(
         hass,
         3,
         "haventory/item/attachment/remove",
@@ -708,14 +700,14 @@ async def test_attachment_remove_deletes_the_file_and_the_item_delete_cascades(u
 
     # And deleting the item takes its remaining files with it.
     upload("upload-2")
-    await _send(hass, 4, "haventory/item/attachment/add", item_id=item_id, file_id="upload-2")
+    await ws_send(hass, 4, "haventory/item/attachment/add", item_id=item_id, file_id="upload-2")
     second = _repo_of(hass).get_item(item_id).attachments[0]
     second_path = media_mod.attachment_path(
         media_mod.media_root(hass), item_id, str(second.id), second.mime
     )
     assert second_path.is_file()
 
-    await _send(hass, 5, "haventory/item/delete", item_id=item_id)
+    await ws_send(hass, 5, "haventory/item/delete", item_id=item_id)
     assert not second_path.exists()
 
 
@@ -726,9 +718,9 @@ async def test_attachment_remove_of_an_unknown_id_is_not_found() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
 
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/item/attachment/remove",
@@ -749,15 +741,15 @@ async def test_attachment_update_retitles_and_bumps_the_version(upload) -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Dishwasher")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Dishwasher")
     item_id = created["result"]["id"]
     upload("upload-1")
-    added = await _send(
+    added = await ws_send(
         hass, 2, "haventory/item/attachment/add", item_id=item_id, file_id="upload-1"
     )
     attachment_id = added["result"]["attachments"][0]["id"]
 
-    res = await _send(
+    res = await ws_send(
         hass,
         3,
         "haventory/item/attachment/update",
@@ -778,14 +770,14 @@ async def test_attachment_update_reports_a_stale_version_as_conflict(upload) -> 
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Dishwasher")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Dishwasher")
     item_id = created["result"]["id"]
     upload("upload-1")
-    added = await _send(
+    added = await ws_send(
         hass, 2, "haventory/item/attachment/add", item_id=item_id, file_id="upload-1"
     )
 
-    res = await _send(
+    res = await ws_send(
         hass,
         3,
         "haventory/item/attachment/update",
@@ -806,15 +798,17 @@ async def test_attachment_reorder_makes_the_named_first_one_the_cover(upload) ->
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     item_id = created["result"]["id"]
     upload("upload-1")
-    await _send(hass, 2, "haventory/item/attachment/add", item_id=item_id, file_id="upload-1")
+    await ws_send(hass, 2, "haventory/item/attachment/add", item_id=item_id, file_id="upload-1")
     _stage_upload("upload-2")
-    two = await _send(hass, 3, "haventory/item/attachment/add", item_id=item_id, file_id="upload-2")
+    two = await ws_send(
+        hass, 3, "haventory/item/attachment/add", item_id=item_id, file_id="upload-2"
+    )
     first, second = (a["id"] for a in two["result"]["attachments"])
 
-    res = await _send(
+    res = await ws_send(
         hass,
         4,
         "haventory/item/attachment/reorder",
@@ -837,14 +831,16 @@ async def test_attachment_reorder_refuses_a_partial_list(upload) -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Drill")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     item_id = created["result"]["id"]
     upload("upload-1")
-    await _send(hass, 2, "haventory/item/attachment/add", item_id=item_id, file_id="upload-1")
+    await ws_send(hass, 2, "haventory/item/attachment/add", item_id=item_id, file_id="upload-1")
     _stage_upload("upload-2")
-    two = await _send(hass, 3, "haventory/item/attachment/add", item_id=item_id, file_id="upload-2")
+    two = await ws_send(
+        hass, 3, "haventory/item/attachment/add", item_id=item_id, file_id="upload-2"
+    )
 
-    res = await _send(
+    res = await ws_send(
         hass,
         4,
         "haventory/item/attachment/reorder",
@@ -879,7 +875,7 @@ async def test_item_list_refuses_an_unknown_filter_key_by_name() -> None:
 
     hass = _hass_with_items()
 
-    res = await _send(hass, 1, "haventory/item/list", filter={"query": "Item 0"})
+    res = await ws_send(hass, 1, "haventory/item/list", filter={"query": "Item 0"})
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -890,7 +886,7 @@ async def test_item_list_refuses_an_unknown_filter_key_by_name() -> None:
 async def test_item_list_refuses_an_unknown_sort_field() -> None:
     hass = _hass_with_items()
 
-    res = await _send(hass, 1, "haventory/item/list", sort={"field": "colour", "order": "asc"})
+    res = await ws_send(hass, 1, "haventory/item/list", sort={"field": "colour", "order": "asc"})
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -902,7 +898,7 @@ async def test_item_list_refuses_an_empty_cursor() -> None:
 
     hass = _hass_with_items()
 
-    res = await _send(hass, 1, "haventory/item/list", limit=2, cursor="")
+    res = await ws_send(hass, 1, "haventory/item/list", limit=2, cursor="")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -912,7 +908,7 @@ async def test_item_list_refuses_an_empty_cursor() -> None:
 async def test_item_list_refuses_an_undecodable_cursor() -> None:
     hass = _hass_with_items()
 
-    res = await _send(hass, 1, "haventory/item/list", limit=2, cursor="garbage")
+    res = await ws_send(hass, 1, "haventory/item/list", limit=2, cursor="garbage")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -922,7 +918,7 @@ async def test_item_list_refuses_an_undecodable_cursor() -> None:
 async def test_item_list_refuses_a_non_integer_limit() -> None:
     hass = _hass_with_items()
 
-    res = await _send(hass, 1, "haventory/item/list", limit="two")
+    res = await ws_send(hass, 1, "haventory/item/list", limit="two")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -934,7 +930,7 @@ async def test_item_list_still_serves_a_full_known_filter_and_pages() -> None:
 
     hass = _hass_with_items()
 
-    listed = await _send(
+    listed = await ws_send(
         hass,
         1,
         "haventory/item/list",
@@ -945,7 +941,7 @@ async def test_item_list_still_serves_a_full_known_filter_and_pages() -> None:
     assert listed["success"] is True, listed
     assert [i["name"] for i in listed["result"]["items"]] == ["Item 0", "Item 1"]
 
-    page2 = await _send(
+    page2 = await ws_send(
         hass,
         2,
         "haventory/item/list",

--- a/tests/test_ws_locations_offline.py
+++ b/tests/test_ws_locations_offline.py
@@ -17,18 +17,7 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    # Exact match on the command each handler is registered under
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        resp = await h(hass, None, req)
-        return resp
-    raise AssertionError("No handler responded for type " + type_)
+from ws_helpers import ws_send
 
 
 @pytest.mark.asyncio
@@ -45,22 +34,22 @@ async def test_location_crud_and_tree() -> None:
     area_uuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
     reg._add(area_uuid, "Garage")  # type: ignore[attr-defined]
 
-    res_root = await _send(hass, 1, "haventory/location/create", name="Root", area_id=area_uuid)
+    res_root = await ws_send(hass, 1, "haventory/location/create", name="Root", area_id=area_uuid)
     root_id = res_root["result"]["id"]
-    res_child = await _send(hass, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
+    res_child = await ws_send(hass, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
     child_id = res_child["result"]["id"]
 
     # Get
-    res = await _send(hass, 3, "haventory/location/get", location_id=root_id)
+    res = await ws_send(hass, 3, "haventory/location/get", location_id=root_id)
     assert res["success"] is True and res["result"]["id"] == root_id
 
     # List
-    res = await _send(hass, 4, "haventory/location/list")
+    res = await ws_send(hass, 4, "haventory/location/list")
     expected_locations_count = 2  # root + child
     assert res["success"] is True and len(res["result"]) == expected_locations_count
 
     # Tree
-    res = await _send(hass, 5, "haventory/location/tree")
+    res = await ws_send(hass, 5, "haventory/location/tree")
     assert res["success"] is True
     tree = res["result"]
     assert isinstance(tree, list) and len(tree) == 1
@@ -78,19 +67,19 @@ async def test_ws_location_create_update_area_validation() -> None:
     ws_setup(hass)
 
     # Unknown area on create → validation_error
-    bad = await _send(hass, 1, "haventory/location/create", name="X", area_id="missing")
+    bad = await ws_send(hass, 1, "haventory/location/create", name="X", area_id="missing")
     assert bad["success"] is False and bad["error"]["code"] == "validation_error"
 
     # Seed area, create ok
     reg = await async_get_area_registry(hass)
     area_uuid1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
     reg._add(area_uuid1, "Garage")  # type: ignore[attr-defined]
-    created = await _send(hass, 2, "haventory/location/create", name="A", area_id=area_uuid1)
+    created = await ws_send(hass, 2, "haventory/location/create", name="A", area_id=area_uuid1)
     assert created["success"] is True and created["result"]["area_id"] == area_uuid1
     loc_id = created["result"]["id"]
 
     # Unknown area on update → validation_error
-    upd_bad = await _send(
+    upd_bad = await ws_send(
         hass, 3, "haventory/location/update", location_id=loc_id, area_id="missing"
     )
     assert upd_bad["success"] is False and upd_bad["error"]["code"] == "validation_error"
@@ -98,7 +87,7 @@ async def test_ws_location_create_update_area_validation() -> None:
     # Add second area and update ok
     area_uuid2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
     reg._add(area_uuid2, "Office")  # type: ignore[attr-defined]
-    updated = await _send(
+    updated = await ws_send(
         hass, 4, "haventory/location/update", location_id=loc_id, area_id=area_uuid2
     )
     assert updated["success"] is True and updated["result"]["area_id"] == area_uuid2
@@ -118,12 +107,12 @@ async def test_ws_location_create_update_area_with_non_uuid_id() -> None:
     reg = await async_get_area_registry(hass)
     reg._add("kitchen", "Kitchen")  # type: ignore[attr-defined]
 
-    created = await _send(hass, 1, "haventory/location/create", name="Root", area_id="kitchen")
+    created = await ws_send(hass, 1, "haventory/location/create", name="Root", area_id="kitchen")
     assert created["success"] is True and created["result"]["area_id"] == "kitchen"
     loc_id = created["result"]["id"]
 
     reg._add("garage", "Garage")  # type: ignore[attr-defined]
-    updated = await _send(
+    updated = await ws_send(
         hass, 2, "haventory/location/update", location_id=loc_id, area_id="garage"
     )
     assert updated["success"] is True and updated["result"]["area_id"] == "garage"
@@ -156,21 +145,21 @@ async def test_ws_location_mutations_persist_to_store(monkeypatch) -> None:
 
     monkeypatch.setattr(store, "async_save", _spy_save)
 
-    root = await _send(hass, 1, "haventory/location/create", name="Root")
+    root = await ws_send(hass, 1, "haventory/location/create", name="Root")
     rid = root["result"]["id"]
-    await _send(hass, 2, "haventory/location/update", location_id=rid, name="Root2")
-    await _send(hass, 3, "haventory/location/delete", location_id=rid)
+    await ws_send(hass, 2, "haventory/location/update", location_id=rid, name="Root2")
+    await ws_send(hass, 3, "haventory/location/delete", location_id=rid)
     MIN_PERSISTS_TOTAL = 3
     assert calls["count"] >= MIN_PERSISTS_TOTAL
 
     # Not found
-    res = await _send(
+    res = await ws_send(
         hass, 1, "haventory/location/get", location_id="00000000-0000-4000-8000-000000000000"
     )
     assert res["success"] is False and res["error"]["code"] == "not_found"
 
     # Validation: create with empty name
-    res = await _send(hass, 2, "haventory/location/create", name="")
+    res = await ws_send(hass, 2, "haventory/location/create", name="")
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
 
@@ -192,14 +181,16 @@ async def test_location_move_subtree_persists(monkeypatch) -> None:
     monkeypatch.setattr(store, "async_save", _spy_save)
 
     # Create a small tree: Root -> Shelf
-    res_root = await _send(hass, 10, "haventory/location/create", name="Root")
+    res_root = await ws_send(hass, 10, "haventory/location/create", name="Root")
     root_id = res_root["result"]["id"]
-    res_child = await _send(hass, 11, "haventory/location/create", name="Shelf", parent_id=root_id)
+    res_child = await ws_send(
+        hass, 11, "haventory/location/create", name="Shelf", parent_id=root_id
+    )
     child_id = res_child["result"]["id"]
 
     before = calls["count"]
     # Move subtree: Shelf -> root (new_parent_id=None)
-    res_move = await _send(
+    res_move = await ws_send(
         hass, 12, "haventory/location/move_subtree", location_id=child_id, new_parent_id=None
     )
     assert res_move["success"] is True
@@ -217,16 +208,16 @@ async def test_location_tree_includes_item_counts() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    root = await _send(hass, 1, "haventory/location/create", name="Garage")
+    root = await ws_send(hass, 1, "haventory/location/create", name="Garage")
     root_id = root["result"]["id"]
-    child = await _send(hass, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
+    child = await ws_send(hass, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
     child_id = child["result"]["id"]
 
-    await _send(hass, 3, "haventory/item/create", name="Car", location_id=root_id)
-    await _send(hass, 4, "haventory/item/create", name="Wrench", location_id=child_id)
-    await _send(hass, 5, "haventory/item/create", name="Orphan")
+    await ws_send(hass, 3, "haventory/item/create", name="Car", location_id=root_id)
+    await ws_send(hass, 4, "haventory/item/create", name="Wrench", location_id=child_id)
+    await ws_send(hass, 5, "haventory/item/create", name="Orphan")
 
-    res = await _send(hass, 6, "haventory/location/tree")
+    res = await ws_send(hass, 6, "haventory/location/tree")
     assert res["success"] is True
     node = res["result"][0]
     subtree_total = 2
@@ -239,7 +230,7 @@ async def test_location_tree_includes_item_counts() -> None:
     # Moving the wrench out of the tree drops both counts
     items = hass.data[DOMAIN]["repository"].list_items(flt={"q": "wrench"})["items"]
     hass.data[DOMAIN]["repository"].update_item(items[0].id, {"location_id": None})
-    res2 = await _send(hass, 8, "haventory/location/tree")
+    res2 = await ws_send(hass, 8, "haventory/location/tree")
     node2 = res2["result"][0]
     assert node2["direct_item_count"] == 1
     assert node2["subtree_item_count"] == 1
@@ -256,17 +247,17 @@ async def test_location_tree_reports_matching_counts_for_a_filter() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    root = await _send(hass, 1, "haventory/location/create", name="Garage")
+    root = await ws_send(hass, 1, "haventory/location/create", name="Garage")
     root_id = root["result"]["id"]
-    child = await _send(hass, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
+    child = await ws_send(hass, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
     child_id = child["result"]["id"]
 
     create = "haventory/item/create"
-    await _send(hass, 3, create, name="Car", location_id=root_id, category="Auto")
-    await _send(hass, 4, create, name="Wrench", location_id=child_id, category="Tools")
-    await _send(hass, 5, create, name="Saw", location_id=child_id, category="Tools")
+    await ws_send(hass, 3, create, name="Car", location_id=root_id, category="Auto")
+    await ws_send(hass, 4, create, name="Wrench", location_id=child_id, category="Tools")
+    await ws_send(hass, 5, create, name="Saw", location_id=child_id, category="Tools")
 
-    res = await _send(hass, 6, "haventory/location/tree", filter={"category": "Tools"})
+    res = await ws_send(hass, 6, "haventory/location/tree", filter={"category": "Tools"})
     assert res["success"] is True
     node = res["result"][0]
     matching_subtree = 2
@@ -279,9 +270,9 @@ async def test_location_tree_reports_matching_counts_for_a_filter() -> None:
 
     # Without a filter the keys are absent rather than zero, so a client can tell
     # "nothing matches" from "nothing was asked".
-    plain = await _send(hass, 7, "haventory/location/tree")
+    plain = await ws_send(hass, 7, "haventory/location/tree")
     assert "matching_subtree_count" not in plain["result"][0]
 
     # A malformed filter is rejected like anywhere else, not silently ignored.
-    bad = await _send(hass, 8, "haventory/location/tree", filter={"updated_after": "2024/01/01"})
+    bad = await ws_send(hass, 8, "haventory/location/tree", filter={"updated_after": "2024/01/01"})
     assert bad["success"] is False and bad["error"]["code"] == "validation_error"

--- a/tests/test_ws_logging_offline.py
+++ b/tests/test_ws_logging_offline.py
@@ -10,9 +10,9 @@ One policy governs every error the API boundary logs:
   rather than a failure.
 - ``exc_info`` only where a traceback says something the message does not.
 
-The conflict and not-found cases are load-bearing: ``release_testing_plan.md``
-exit criterion 4 forbids any traceback from ``custom_components.haventory`` in
-the HA log, and the release run deliberately provokes both.
+The conflict and not-found cases are what the release run checks:
+``release_testing_plan.md`` exit criterion 4 forbids any traceback from
+``custom_components.haventory`` in the HA log, and the run provokes both.
 """
 
 from __future__ import annotations

--- a/tests/test_ws_logging_offline.py
+++ b/tests/test_ws_logging_offline.py
@@ -31,30 +31,11 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import RecordingConn, ws_send
+
 WS_LOGGER = "custom_components.haventory.ws"
 SERVICES_LOGGER = "custom_components.haventory.services"
 RATE_LIMIT_LOGGER = "custom_components.haventory.rate_limit"
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, conn: object = None, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        return await h(hass, conn, req)
-    raise AssertionError("No handler responded for type " + type_)
-
-
-class _ConnStub:
-    """A stable connection identity, so the limiter keys one bucket for it."""
-
-    def __init__(self) -> None:
-        self.messages: list[dict[str, Any]] = []
-
-    def send_message(self, msg: dict[str, Any]) -> None:
-        self.messages.append(msg)
 
 
 def _make_hass(limiter: RateLimiter | None = None) -> HomeAssistant:
@@ -88,7 +69,7 @@ async def test_validation_error_logs_warning_without_traceback(caplog) -> None:
     hass = _make_hass()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(hass, 1, "haventory/item/set_quantity", item_id="any", quantity=-1)
+    res = await ws_send(hass, 1, "haventory/item/set_quantity", item_id="any", quantity=-1)
     assert res["success"] is False and res["error"]["code"] == "validation_error"
 
     record = _only(caplog)
@@ -102,7 +83,9 @@ async def test_not_found_logs_warning_without_traceback(caplog) -> None:
     hass = _make_hass()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(hass, 2, "haventory/item/get", item_id="00000000-0000-4000-8000-000000000000")
+    res = await ws_send(
+        hass, 2, "haventory/item/get", item_id="00000000-0000-4000-8000-000000000000"
+    )
     assert res["success"] is False and res["error"]["code"] == "not_found"
 
     record = _only(caplog)
@@ -116,13 +99,13 @@ async def test_conflict_logs_warning_without_traceback(caplog) -> None:
     """A stale ``expected_version`` is an HTTP-409 equivalent, not a crash."""
 
     hass = _make_hass()
-    created = await _send(hass, 1, "haventory/item/create", name="Widget")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
     caplog.clear()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(
+    res = await ws_send(
         hass, 3, "haventory/item/update", item_id=item_id, expected_version=999, name="X"
     )
     assert res["success"] is False and res["error"]["code"] == "conflict"
@@ -149,11 +132,13 @@ async def test_rate_limited_logs_warning_without_traceback(caplog) -> None:
         )
     )
     hass = _make_hass(limiter)
-    conn = _ConnStub()
+    # One connection object across both sends: the limiter keys a bucket per
+    # connection identity, so a second object would get a fresh budget.
+    conn = RecordingConn()
     caplog.set_level(logging.DEBUG)
 
-    assert (await _send(hass, 1, "haventory/ping", conn=conn))["success"] is True
-    res = await _send(hass, 2, "haventory/ping", conn=conn)
+    assert (await ws_send(hass, 1, "haventory/ping", conn=conn))["success"] is True
+    res = await ws_send(hass, 2, "haventory/ping", conn=conn)
     assert res["success"] is False and res["error"]["code"] == "rate_limited"
 
     # The rejection never reaches the WS error boundary; the limiter owns the
@@ -181,7 +166,7 @@ async def test_storage_error_logs_error_with_traceback(caplog, monkeypatch) -> N
     monkeypatch.setattr(hass.data[DOMAIN]["store"], "async_save", _raise)
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(hass, 1, "haventory/item/create", name="X")
+    res = await ws_send(hass, 1, "haventory/item/create", name="X")
     assert res["success"] is False and res["error"]["code"] == "storage_error"
 
     record = _only(caplog)
@@ -202,7 +187,7 @@ async def test_unknown_error_logs_error_with_traceback(caplog, monkeypatch) -> N
     monkeypatch.setattr(hass.data[DOMAIN]["repository"], "create_item", _boom)
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(hass, 1, "haventory/item/create", name="X")
+    res = await ws_send(hass, 1, "haventory/item/create", name="X")
     assert res["success"] is False and res["error"]["code"] == "unknown_error"
 
     record = _only(caplog)
@@ -235,7 +220,7 @@ async def test_not_loaded_refusal_logs_warning_without_traceback(caplog) -> None
     hass = _make_unloaded_hass()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(hass, 1, "haventory/item/create", name="X")
+    res = await ws_send(hass, 1, "haventory/item/create", name="X")
     assert res["success"] is False and res["error"]["code"] == "storage_error"
 
     record = _only(caplog)
@@ -253,9 +238,9 @@ async def test_not_loaded_refusal_keeps_the_storage_error_envelope() -> None:
     """
 
     hass = _make_unloaded_hass()
-    conn = _ConnStub()
+    conn = RecordingConn()
 
-    res = await _send(hass, 1, "haventory/item/list", conn=conn)
+    res = await ws_send(hass, 1, "haventory/item/list", conn=conn)
 
     assert res["error"]["code"] == "storage_error"
     assert res["error"]["data"]["op"] == "item_list"
@@ -279,7 +264,7 @@ async def test_a_retrying_client_leaves_no_tracebacks(caplog) -> None:
     # Frame ids start at 1: Home Assistant refuses a non-positive id outright,
     # so a 0 would never reach the handler whose logging is under test.
     for i in range(1, retries + 1):
-        assert (await _send(hass, i, "haventory/stats"))["error"]["code"] == "storage_error"
+        assert (await ws_send(hass, i, "haventory/stats"))["error"]["code"] == "storage_error"
 
     records = _records(caplog)
     assert len(records) == retries
@@ -299,7 +284,7 @@ async def test_a_real_storage_failure_still_logs_error_with_traceback(caplog, mo
     monkeypatch.setattr(hass.data[DOMAIN]["store"], "async_save", _raise)
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(hass, 1, "haventory/item/create", name="X")
+    res = await ws_send(hass, 1, "haventory/item/create", name="X")
     assert res["success"] is False and res["error"]["code"] == "storage_error"
 
     record = _only(caplog)
@@ -331,13 +316,13 @@ async def test_service_not_loaded_refusal_logs_warning_without_traceback(caplog)
 @pytest.mark.asyncio
 async def test_bulk_conflict_logs_warning_without_traceback(caplog) -> None:
     hass = _make_hass()
-    created = await _send(hass, 1, "haventory/item/create", name="Widget")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
     caplog.clear()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/items/bulk",
@@ -360,7 +345,7 @@ async def test_bulk_conflict_logs_warning_without_traceback(caplog) -> None:
 @pytest.mark.asyncio
 async def test_bulk_unexpected_error_logs_error_with_traceback(caplog, monkeypatch) -> None:
     hass = _make_hass()
-    created = await _send(hass, 1, "haventory/item/create", name="Widget")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
     def _boom(*_args: Any, **_kwargs: Any) -> None:
@@ -370,7 +355,7 @@ async def test_bulk_unexpected_error_logs_error_with_traceback(caplog, monkeypat
     caplog.clear()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/items/bulk",
@@ -399,7 +384,7 @@ async def test_all_failed_bulk_logs_only_its_per_op_lines(caplog) -> None:
     caplog.clear()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    res = await _send(
+    res = await ws_send(
         hass,
         1,
         "haventory/items/bulk",
@@ -421,13 +406,13 @@ async def test_partly_successful_bulk_still_logs_its_summary(caplog) -> None:
     """The summary survives where it still says something: a batch that changed state."""
 
     hass = _make_hass()
-    created = await _send(hass, 1, "haventory/item/create", name="Widget")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
     caplog.clear()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
-    await _send(
+    await ws_send(
         hass,
         2,
         "haventory/items/bulk",

--- a/tests/test_ws_rate_limit_offline.py
+++ b/tests/test_ws_rate_limit_offline.py
@@ -12,7 +12,6 @@ Covers:
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 from typing import Any
 
 import custom_components.haventory as haven_init
@@ -46,6 +45,8 @@ from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import RecordingConn, ws_send
+
 
 class _FakeClock:
     def __init__(self) -> None:
@@ -63,32 +64,6 @@ def clock(monkeypatch) -> _FakeClock:
     fake = _FakeClock()
     monkeypatch.setattr(rate_limit_module, "_monotonic", fake)
     return fake
-
-
-def _get_handler(
-    hass: HomeAssistant, type_: str
-) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if callable(h) and getattr(h, "_ws_command", None) == type_:
-            return h
-    raise AssertionError("No handler found for type " + type_)
-
-
-async def _send(hass: HomeAssistant, conn: object, _id: int, type_: str, **payload: Any) -> dict:
-    handler = _get_handler(hass, type_)
-    return await handler(hass, conn, {"id": _id, "type": type_, **payload})
-
-
-class _ConnStub:
-    def __init__(self) -> None:
-        self.messages: list[dict[str, Any]] = []
-
-    def send_message(self, msg: dict[str, Any]) -> None:
-        self.messages.append(msg)
-
-    def events(self) -> list[dict[str, Any]]:
-        return [m for m in self.messages if m.get("type") == "event"]
 
 
 def _make_hass(limiter: RateLimiter | None = None) -> HomeAssistant:
@@ -150,9 +125,9 @@ def test_token_bucket_rejects_non_positive_parameters() -> None:
 @pytest.mark.asyncio
 async def test_no_limiter_means_unlimited() -> None:
     hass = _make_hass(limiter=None)
-    conn = _ConnStub()
+    conn = RecordingConn()
     for i in range(50):
-        res = await _send(hass, conn, i + 1, "haventory/ping")
+        res = await ws_send(hass, i + 1, "haventory/ping", conn=conn)
         assert res["success"] is True
 
 
@@ -160,9 +135,9 @@ async def test_no_limiter_means_unlimited() -> None:
 async def test_disabled_limiter_means_unlimited(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(enabled=False, commands_burst=1.0))
     hass = _make_hass(limiter)
-    conn = _ConnStub()
+    conn = RecordingConn()
     for i in range(50):
-        res = await _send(hass, conn, i + 1, "haventory/ping")
+        res = await ws_send(hass, i + 1, "haventory/ping", conn=conn)
         assert res["success"] is True
     assert limiter.dropped_commands == 0
 
@@ -181,12 +156,12 @@ def test_default_config_is_disabled() -> None:
 async def test_per_connection_command_limit(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(commands_per_second=1.0, commands_burst=2.0))
     hass = _make_hass(limiter)
-    conn_a = _ConnStub()
-    conn_b = _ConnStub()
+    conn_a = RecordingConn()
+    conn_b = RecordingConn()
 
-    assert (await _send(hass, conn_a, 1, "haventory/ping"))["success"] is True
-    assert (await _send(hass, conn_a, 2, "haventory/ping"))["success"] is True
-    res = await _send(hass, conn_a, 3, "haventory/ping")
+    assert (await ws_send(hass, 1, "haventory/ping", conn=conn_a))["success"] is True
+    assert (await ws_send(hass, 2, "haventory/ping", conn=conn_a))["success"] is True
+    res = await ws_send(hass, 3, "haventory/ping", conn=conn_a)
     assert res["success"] is False
     assert res["error"]["code"] == "rate_limited"
     assert res["error"]["message"] == RATE_LIMITED_MESSAGE
@@ -195,11 +170,11 @@ async def test_per_connection_command_limit(clock: _FakeClock) -> None:
     assert conn_a.messages[-1] == res
 
     # Another connection has its own budget.
-    assert (await _send(hass, conn_b, 4, "haventory/ping"))["success"] is True
+    assert (await ws_send(hass, 4, "haventory/ping", conn=conn_b))["success"] is True
 
     # Refill re-allows the first connection.
     clock.advance(1.0)
-    assert (await _send(hass, conn_a, 5, "haventory/ping"))["success"] is True
+    assert (await ws_send(hass, 5, "haventory/ping", conn=conn_a))["success"] is True
     assert limiter.dropped_commands == 1
 
 
@@ -208,10 +183,10 @@ async def test_global_command_limit(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(global_commands_per_second=1.0, global_commands_burst=3.0))
     hass = _make_hass(limiter)
 
-    conns = [_ConnStub() for _ in range(4)]
+    conns = [RecordingConn() for _ in range(4)]
     outcomes = []
     for i, conn in enumerate(conns):
-        res = await _send(hass, conn, i + 1, "haventory/ping")
+        res = await ws_send(hass, i + 1, "haventory/ping", conn=conn)
         outcomes.append(res["success"])
     # Fresh per-connection budgets, but the global bucket allows only 3.
     assert outcomes == [True, True, True, False]
@@ -222,11 +197,11 @@ async def test_global_command_limit(clock: _FakeClock) -> None:
 async def test_rate_limited_command_does_not_execute(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(commands_burst=1.0))
     hass = _make_hass(limiter)
-    conn = _ConnStub()
+    conn = RecordingConn()
 
-    res = await _send(hass, conn, 1, "haventory/item/create", name="First")
+    res = await ws_send(hass, 1, "haventory/item/create", conn=conn, name="First")
     assert res["success"] is True
-    res = await _send(hass, conn, 2, "haventory/item/create", name="Second")
+    res = await ws_send(hass, 2, "haventory/item/create", conn=conn, name="Second")
     assert res["success"] is False
     assert res["error"]["code"] == "rate_limited"
     repo = hass.data[DOMAIN]["repository"]
@@ -242,8 +217,8 @@ async def test_rate_limited_command_does_not_execute(clock: _FakeClock) -> None:
 async def test_per_connection_event_limit(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(events_per_second=1.0, events_burst=1.0))
     hass = _make_hass(limiter)
-    subscriber = _ConnStub()
-    sub = await _send(hass, subscriber, 100, "haventory/subscribe", topic="items")
+    subscriber = RecordingConn()
+    sub = await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items")
     assert sub["success"] is True
 
     ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
@@ -270,14 +245,18 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
     assert limiter.dropped_events == 0
 
     # A subscriber on another topic does not consume the budget either.
-    other = _ConnStub()
-    assert (await _send(hass, other, 99, "haventory/subscribe", topic="locations"))["success"]
+    other = RecordingConn()
+    assert (await ws_send(hass, 99, "haventory/subscribe", conn=other, topic="locations"))[
+        "success"
+    ]
     ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
     assert limiter.dropped_events == 0
 
     # The budget is still intact for the first real delivery.
-    subscriber = _ConnStub()
-    assert (await _send(hass, subscriber, 100, "haventory/subscribe", topic="items"))["success"]
+    subscriber = RecordingConn()
+    assert (await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items"))[
+        "success"
+    ]
     ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
     assert len(subscriber.events()) == 1
 
@@ -290,13 +269,13 @@ async def test_one_event_consumes_one_token_across_multiple_subscriptions(
 
     limiter = RateLimiter(_config(events_per_second=1.0, events_burst=1.0))
     hass = _make_hass(limiter)
-    conn = _ConnStub()
-    assert (await _send(hass, conn, 301, "haventory/subscribe", topic="items"))["success"]
-    assert (await _send(hass, conn, 302, "haventory/subscribe", topic="items"))["success"]
+    conn = RecordingConn()
+    assert (await ws_send(hass, 301, "haventory/subscribe", conn=conn, topic="items"))["success"]
+    assert (await ws_send(hass, 302, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
     ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
     # Both subscriptions receive the event; only one token was spent.
-    assert {m.get("id") for m in conn.events()} == {301, 302}
+    assert {m["id"] for m in conn.messages if m["type"] == "event"} == {301, 302}
 
     ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
     delivered_before_drop = 2  # both subscriptions got the FIRST event only
@@ -308,10 +287,10 @@ async def test_one_event_consumes_one_token_across_multiple_subscriptions(
 async def test_global_event_limit_drops_for_all_subscribers(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(global_events_per_second=1.0, global_events_burst=1.0))
     hass = _make_hass(limiter)
-    sub_a = _ConnStub()
-    sub_b = _ConnStub()
-    assert (await _send(hass, sub_a, 100, "haventory/subscribe", topic="items"))["success"]
-    assert (await _send(hass, sub_b, 101, "haventory/subscribe", topic="items"))["success"]
+    sub_a = RecordingConn()
+    sub_b = RecordingConn()
+    assert (await ws_send(hass, 100, "haventory/subscribe", conn=sub_a, topic="items"))["success"]
+    assert (await ws_send(hass, 101, "haventory/subscribe", conn=sub_b, topic="items"))["success"]
 
     ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
     ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
@@ -327,14 +306,18 @@ async def test_event_drop_does_not_fail_the_command(clock: _FakeClock) -> None:
         _config(global_events_per_second=1.0, global_events_burst=1.0, commands_burst=1000.0)
     )
     hass = _make_hass(limiter)
-    subscriber = _ConnStub()
-    actor = _ConnStub()
-    assert (await _send(hass, subscriber, 100, "haventory/subscribe", topic="items"))["success"]
-    assert (await _send(hass, subscriber, 101, "haventory/subscribe", topic="stats"))["success"]
+    subscriber = RecordingConn()
+    actor = RecordingConn()
+    assert (await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items"))[
+        "success"
+    ]
+    assert (await ws_send(hass, 101, "haventory/subscribe", conn=subscriber, topic="stats"))[
+        "success"
+    ]
 
     # One create emits an item event + a counts event to this subscriber; the
     # budget of one means something gets dropped, but the command must succeed.
-    res = await _send(hass, actor, 1, "haventory/item/create", name="Widget")
+    res = await ws_send(hass, 1, "haventory/item/create", conn=actor, name="Widget")
     assert res["success"] is True
     assert limiter.dropped_events >= 1
 
@@ -348,12 +331,12 @@ async def test_event_drop_does_not_fail_the_command(clock: _FakeClock) -> None:
 async def test_health_exposes_rate_limit_counters(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(commands_burst=1.0))
     hass = _make_hass(limiter)
-    conn = _ConnStub()
-    assert (await _send(hass, conn, 1, "haventory/ping"))["success"] is True
-    assert (await _send(hass, conn, 2, "haventory/ping"))["success"] is False
+    conn = RecordingConn()
+    assert (await ws_send(hass, 1, "haventory/ping", conn=conn))["success"] is True
+    assert (await ws_send(hass, 2, "haventory/ping", conn=conn))["success"] is False
 
     clock.advance(10.0)
-    res = await _send(hass, conn, 3, "haventory/health")
+    res = await ws_send(hass, 3, "haventory/health", conn=conn)
     assert res["success"] is True
     rl = res["result"]["rate_limit"]
     assert rl == {"enabled": True, "dropped_commands": 1, "dropped_events": 0}
@@ -362,7 +345,7 @@ async def test_health_exposes_rate_limit_counters(clock: _FakeClock) -> None:
 @pytest.mark.asyncio
 async def test_health_reports_disabled_without_limiter() -> None:
     hass = _make_hass(limiter=None)
-    res = await _send(hass, _ConnStub(), 1, "haventory/health")
+    res = await ws_send(hass, 1, "haventory/health", conn=RecordingConn())
     assert res["success"] is True
     assert res["result"]["rate_limit"] == {
         "enabled": False,
@@ -561,7 +544,7 @@ async def test_setup_entry_wires_rate_limiter_from_entry_options(monkeypatch) ->
 # -----------------------------
 
 
-class _ConnWithSubscriptions(_ConnStub):
+class _ConnWithSubscriptions(RecordingConn):
     def __init__(self) -> None:
         super().__init__()
         self.subscriptions: dict[Any, Any] = {}
@@ -571,7 +554,7 @@ class _ConnWithSubscriptions(_ConnStub):
 async def test_close_cleanup_registers_in_conn_subscriptions() -> None:
     hass = _make_hass()
     conn = _ConnWithSubscriptions()
-    res = await _send(hass, conn, 200, "haventory/subscribe", topic="items")
+    res = await ws_send(hass, 200, "haventory/subscribe", conn=conn, topic="items")
     assert res["success"] is True
 
     # The cleanup callable is registered where real HA invokes it on close.
@@ -590,7 +573,7 @@ async def test_rate_limit_state_cleanup_via_conn_subscriptions(clock: _FakeClock
     limiter = RateLimiter(_config())
     hass = _make_hass(limiter)
     conn = _ConnWithSubscriptions()
-    assert (await _send(hass, conn, 1, "haventory/ping"))["success"] is True
+    assert (await ws_send(hass, 1, "haventory/ping", conn=conn))["success"] is True
     assert conn in limiter._conn_states
 
     cleanup = conn.subscriptions.get("haventory/rate_limit_cleanup")

--- a/tests/test_ws_schema_validation_offline.py
+++ b/tests/test_ws_schema_validation_offline.py
@@ -32,18 +32,10 @@ from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import RecordingConn, ws_send
+
 INVALID_FORMAT = "invalid_format"
 PROBE_DEFAULT_LIMIT = 25
-
-
-class _ConnCollect:
-    """Capture stub standing in for HA's ActiveConnection."""
-
-    def __init__(self) -> None:
-        self.messages: list[dict[str, Any]] = []
-
-    def send_message(self, msg: dict[str, Any]) -> None:
-        self.messages.append(msg)
 
 
 class _Probe:
@@ -72,16 +64,8 @@ class _Probe:
 
         for handler in self._hass.data.get("__ws_commands__", []):
             if getattr(handler, "_ws_command", None) == self.command:
-                return await handler(self._hass, _ConnCollect(), frame)
+                return await handler(self._hass, RecordingConn(), frame)
         raise AssertionError("probe command was not registered")
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload: Any) -> dict[str, Any]:
-    for h in hass.data.get("__ws_commands__", []):
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        return await h(hass, None, {"id": _id, "type": type_, **payload})
-    raise AssertionError("No handler responded for type " + type_)
 
 
 def _fresh_hass() -> HomeAssistant:
@@ -230,7 +214,7 @@ async def test_a_refusal_is_answered_on_the_connection() -> None:
 
     hass = HomeAssistant()
     probe = _Probe(hass, {vol.Required("type"): "test/probe", vol.Required("name"): str})
-    conn = _ConnCollect()
+    conn = RecordingConn()
 
     for handler in hass.data["__ws_commands__"]:
         if getattr(handler, "_ws_command", None) == probe.command:
@@ -254,7 +238,7 @@ async def test_a_real_command_refuses_a_wrong_typed_field_and_mutates_nothing() 
     hass = _fresh_hass()
     repo = hass.data[DOMAIN]["repository"]
 
-    res = await _send(hass, 1, "haventory/item/create", name="Hammer", tags="chisel")
+    res = await ws_send(hass, 1, "haventory/item/create", name="Hammer", tags="chisel")
 
     assert res["success"] is False
     assert res["error"]["code"] == INVALID_FORMAT
@@ -279,7 +263,7 @@ async def test_the_widened_fields_answer_validation_error_and_mutate_nothing() -
         {"name": 42},
         {"name": "Hammer", "quantity": 1.5},
     ):
-        res = await _send(hass, 1, "haventory/item/create", **payload)
+        res = await ws_send(hass, 1, "haventory/item/create", **payload)
         assert res["success"] is False, payload
         assert res["error"]["code"] == "validation_error", payload
 

--- a/tests/test_ws_statuses_offline.py
+++ b/tests/test_ws_statuses_offline.py
@@ -18,6 +18,8 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import ws_send
+
 
 def _new_hass() -> HomeAssistant:
     hass = HomeAssistant()
@@ -25,16 +27,6 @@ def _new_hass() -> HomeAssistant:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
     return hass
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    for h in hass.data.get("__ws_commands__", []):
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        return await h(hass, None, req)
-    raise AssertionError("No handler responded for type " + type_)
 
 
 Broadcast = tuple[str, str, dict | None]
@@ -67,7 +59,7 @@ def _topics(seen: list[Broadcast]) -> list[tuple[str, str]]:
 async def test_list_returns_the_vocabulary_in_display_order() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/status/list")
+    res = await ws_send(hass, 1, "haventory/status/list")
 
     assert res["success"] is True
     assert [d["slug"] for d in res["result"]] == ["ok", "missing", "needs_repair"]
@@ -85,7 +77,7 @@ async def test_create_defines_a_status_and_broadcasts(monkeypatch) -> None:
     hass = _new_hass()
     seen = _record_broadcasts(monkeypatch)
 
-    res = await _send(
+    res = await ws_send(
         hass, 1, "haventory/status/create", slug="lent_out", label="Lent out", color="blue"
     )
 
@@ -100,7 +92,7 @@ async def test_create_defines_a_status_and_broadcasts(monkeypatch) -> None:
 async def test_create_defaults_the_appearance_when_none_is_given() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/status/create", slug="lent_out", label="Lent out")
+    res = await ws_send(hass, 1, "haventory/status/create", slug="lent_out", label="Lent out")
 
     assert res["result"]["color"] == DEFAULT_STATUS_COLOR
 
@@ -109,7 +101,7 @@ async def test_create_defaults_the_appearance_when_none_is_given() -> None:
 async def test_create_refuses_a_duplicate_slug() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/status/create", slug="missing", label="Gone")
+    res = await ws_send(hass, 1, "haventory/status/create", slug="missing", label="Gone")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -121,7 +113,7 @@ async def test_create_refuses_a_colour_outside_the_palette() -> None:
 
     hass = _new_hass()
 
-    res = await _send(
+    res = await ws_send(
         hass, 1, "haventory/status/create", slug="lent_out", label="Lent out", color="puce"
     )
 
@@ -135,7 +127,7 @@ async def test_create_accepts_a_literal_colour() -> None:
 
     hass = _new_hass()
 
-    res = await _send(
+    res = await ws_send(
         hass, 1, "haventory/status/create", slug="lent_out", label="Lent out", color="#2F6F4F"
     )
 
@@ -146,17 +138,17 @@ async def test_create_accepts_a_literal_colour() -> None:
 @pytest.mark.asyncio
 async def test_update_renames_without_touching_items(monkeypatch) -> None:
     hass = _new_hass()
-    created = await _send(hass, 1, "haventory/item/create", name="Saw", status="needs_repair")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Saw", status="needs_repair")
     before = created["result"]["version"]
     seen = _record_broadcasts(monkeypatch)
 
-    res = await _send(hass, 2, "haventory/status/update", slug="needs_repair", label="Broken")
+    res = await ws_send(hass, 2, "haventory/status/update", slug="needs_repair", label="Broken")
 
     assert res["success"] is True
     assert res["result"]["label"] == "Broken"
     assert ("statuses", "updated") in _topics(seen)
     assert ("items", "updated") not in _topics(seen)
-    still = await _send(hass, 3, "haventory/item/get", item_id=created["result"]["id"])
+    still = await ws_send(hass, 3, "haventory/item/get", item_id=created["result"]["id"])
     assert still["result"]["version"] == before
 
 
@@ -164,7 +156,7 @@ async def test_update_renames_without_touching_items(monkeypatch) -> None:
 async def test_update_of_an_unknown_slug_is_not_found() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/status/update", slug="lent_out", label="Lent out")
+    res = await ws_send(hass, 1, "haventory/status/update", slug="lent_out", label="Lent out")
 
     assert res["success"] is False
     assert res["error"]["code"] == "not_found"
@@ -175,7 +167,9 @@ async def test_reorder_rewrites_display_order(monkeypatch) -> None:
     hass = _new_hass()
     seen = _record_broadcasts(monkeypatch)
 
-    res = await _send(hass, 1, "haventory/status/reorder", slugs=["needs_repair", "ok", "missing"])
+    res = await ws_send(
+        hass, 1, "haventory/status/reorder", slugs=["needs_repair", "ok", "missing"]
+    )
 
     assert res["success"] is True
     assert [d["slug"] for d in res["result"]] == ["needs_repair", "ok", "missing"]
@@ -186,7 +180,7 @@ async def test_reorder_rewrites_display_order(monkeypatch) -> None:
 async def test_reorder_refuses_a_partial_list() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/status/reorder", slugs=["ok", "missing"])
+    res = await ws_send(hass, 1, "haventory/status/reorder", slugs=["ok", "missing"])
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -201,7 +195,7 @@ async def test_reorder_refuses_a_partial_list() -> None:
 async def test_delete_refuses_the_default_status() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/status/delete", slug="ok")
+    res = await ws_send(hass, 1, "haventory/status/delete", slug="ok")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -212,12 +206,12 @@ async def test_delete_removes_an_unused_status(monkeypatch) -> None:
     hass = _new_hass()
     seen = _record_broadcasts(monkeypatch)
 
-    res = await _send(hass, 1, "haventory/status/delete", slug="needs_repair")
+    res = await ws_send(hass, 1, "haventory/status/delete", slug="needs_repair")
 
     assert res["success"] is True
     assert res["result"]["reassigned"] == 0
     assert ("statuses", "deleted") in _topics(seen)
-    listed = await _send(hass, 2, "haventory/status/list")
+    listed = await ws_send(hass, 2, "haventory/status/list")
     assert [d["slug"] for d in listed["result"]] == ["ok", "missing"]
 
 
@@ -226,24 +220,24 @@ async def test_delete_refuses_a_status_in_use_without_a_target() -> None:
     """An item whose status names nothing would be silently coerced on reload."""
 
     hass = _new_hass()
-    await _send(hass, 1, "haventory/item/create", name="Ladder", status="missing")
+    await ws_send(hass, 1, "haventory/item/create", name="Ladder", status="missing")
 
-    res = await _send(hass, 2, "haventory/status/delete", slug="missing")
+    res = await ws_send(hass, 2, "haventory/status/delete", slug="missing")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
-    listed = await _send(hass, 3, "haventory/status/list")
+    listed = await ws_send(hass, 3, "haventory/status/list")
     assert "missing" in [d["slug"] for d in listed["result"]]
 
 
 @pytest.mark.asyncio
 async def test_delete_with_a_target_moves_the_items_and_broadcasts_both(monkeypatch) -> None:
     hass = _new_hass()
-    created = await _send(hass, 1, "haventory/item/create", name="Ladder", status="missing")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Ladder", status="missing")
     item_id = created["result"]["id"]
     seen = _record_broadcasts(monkeypatch)
 
-    res = await _send(hass, 2, "haventory/status/delete", slug="missing", reassign_to="ok")
+    res = await ws_send(hass, 2, "haventory/status/delete", slug="missing", reassign_to="ok")
 
     assert res["success"] is True
     assert res["result"]["reassigned"] == 1
@@ -256,7 +250,7 @@ async def test_delete_with_a_target_moves_the_items_and_broadcasts_both(monkeypa
     # attaching a payload here would silently turn a refetch into a one-item
     # patch and strand every other moved row.
     assert [payload for topic, _action, payload in seen if topic == "items"] == [None]
-    moved = await _send(hass, 3, "haventory/item/get", item_id=item_id)
+    moved = await ws_send(hass, 3, "haventory/item/get", item_id=item_id)
     assert moved["result"]["status"] == "ok"
     assert moved["result"]["version"] == created["result"]["version"] + 1
 
@@ -264,9 +258,9 @@ async def test_delete_with_a_target_moves_the_items_and_broadcasts_both(monkeypa
 @pytest.mark.asyncio
 async def test_delete_refuses_an_unknown_reassign_target() -> None:
     hass = _new_hass()
-    await _send(hass, 1, "haventory/item/create", name="Ladder", status="missing")
+    await ws_send(hass, 1, "haventory/item/create", name="Ladder", status="missing")
 
-    res = await _send(hass, 2, "haventory/status/delete", slug="missing", reassign_to="nowhere")
+    res = await ws_send(hass, 2, "haventory/status/delete", slug="missing", reassign_to="nowhere")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -283,7 +277,7 @@ async def test_statuses_is_a_subscribable_topic() -> None:
 
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/subscribe", topic="statuses")
+    res = await ws_send(hass, 1, "haventory/subscribe", topic="statuses")
 
     assert res["success"] is True
 
@@ -292,7 +286,7 @@ async def test_statuses_is_a_subscribable_topic() -> None:
 async def test_an_unknown_topic_is_still_refused() -> None:
     hass = _new_hass()
 
-    res = await _send(hass, 1, "haventory/subscribe", topic="nonsense")
+    res = await ws_send(hass, 1, "haventory/subscribe", topic="nonsense")
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"

--- a/tests/test_ws_storage_error_offline.py
+++ b/tests/test_ws_storage_error_offline.py
@@ -29,33 +29,14 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import RecordingConn, ws_send
 
-class _ConnStub:
-    """Collects everything the backend sends, so tests can read the wire."""
 
-    def __init__(self) -> None:
-        self.messages: list[dict[str, Any]] = []
-
-    def send_message(self, msg: dict[str, Any]) -> None:
-        self.messages.append(msg)
+class _ConnStub(RecordingConn):
+    """Accepts a close callback and drops it: nothing here drives disconnect."""
 
     def on_close(self, callback: Callable[[], None]) -> None:
         pass
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, conn: object = None, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        return await h(hass, conn, req)
-    raise AssertionError("No handler responded for type " + type_)
-
-
-def _events(conn: _ConnStub) -> list[dict[str, Any]]:
-    return [m["event"] for m in conn.messages if m.get("type") == "event"]
 
 
 def _make_hass() -> tuple[HomeAssistant, Repository, DomainStore]:
@@ -84,7 +65,7 @@ async def test_ws_maps_storage_error_and_logs(caplog, monkeypatch) -> None:
 
     caplog.set_level(logging.ERROR, logger="custom_components.haventory.ws")
 
-    res = await _send(hass, 1, "haventory/item/create", name="X")
+    res = await ws_send(hass, 1, "haventory/item/create", name="X")
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
 
@@ -193,18 +174,18 @@ async def test_failed_persist_delivers_no_event(
 
     conn = _ConnStub()
     for sub_id, topic in ((901, "items"), (902, "locations"), (903, "stats")):
-        res = await _send(hass, sub_id, "haventory/subscribe", conn=conn, topic=topic)
+        res = await ws_send(hass, sub_id, "haventory/subscribe", conn=conn, topic=topic)
         assert res["success"] is True
     conn.messages.clear()
 
     _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    res = await _send(hass, 1, command, conn=conn, **build(str(item.id), str(child.id)))
+    res = await ws_send(hass, 1, command, conn=conn, **build(str(item.id), str(child.id)))
 
     assert res["success"] is False, f"{shape} should have failed"
     assert res["error"]["code"] == "storage_error"
-    assert _events(conn) == [], f"{shape} leaked an event for a write that failed"
+    assert conn.events() == [], f"{shape} leaked an event for a write that failed"
 
 
 @pytest.mark.asyncio
@@ -220,13 +201,13 @@ async def test_failed_persist_in_bulk_discards_the_whole_batch(monkeypatch, capl
     second = repo.create_item({"name": "Two", "quantity": 1})
 
     conn = _ConnStub()
-    await _send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
+    await ws_send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
     conn.messages.clear()
 
     _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    res = await _send(
+    res = await ws_send(
         hass,
         1,
         "haventory/items/bulk",
@@ -247,7 +228,7 @@ async def test_failed_persist_in_bulk_discards_the_whole_batch(monkeypatch, capl
 
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
-    assert _events(conn) == []
+    assert conn.events() == []
 
 
 # -----------------------------------------------------------------------------
@@ -268,7 +249,7 @@ async def test_event_reaches_subscriber_only_after_the_write_resolves(monkeypatc
     hass, _repo, store = _make_hass()
 
     conn = _ConnStub()
-    await _send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
+    await ws_send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
     conn.messages.clear()
 
     write_entered = asyncio.Event()
@@ -276,24 +257,24 @@ async def test_event_reaches_subscriber_only_after_the_write_resolves(monkeypatc
     events_seen_during_write: list[dict[str, Any]] = []
 
     async def _slow_save(*_args, **_kwargs):
-        events_seen_during_write.extend(_events(conn))
+        events_seen_during_write.extend(conn.events())
         write_entered.set()
         await finish_write.wait()
 
     monkeypatch.setattr(store, "async_save", _slow_save)
 
-    task = asyncio.create_task(_send(hass, 1, "haventory/item/create", conn=conn, name="Anvil"))
+    task = asyncio.create_task(ws_send(hass, 1, "haventory/item/create", conn=conn, name="Anvil"))
     await asyncio.wait_for(write_entered.wait(), timeout=5)
 
     # The write is open. Nothing may have reached the subscriber yet.
     assert events_seen_during_write == []
-    assert _events(conn) == []
+    assert conn.events() == []
 
     finish_write.set()
     res = await asyncio.wait_for(task, timeout=5)
 
     assert res["success"] is True
-    actions = [ev.get("action") for ev in _events(conn)]
+    actions = [ev.get("action") for ev in conn.events()]
     assert actions == ["created"], "the created event must arrive once, after the write"
 
 
@@ -315,7 +296,7 @@ async def test_failed_create_stays_in_memory_until_restart(monkeypatch, caplog) 
     _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    res = await _send(hass, 1, "haventory/item/create", name="Fragile Item")
+    res = await ws_send(hass, 1, "haventory/item/create", name="Fragile Item")
 
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
@@ -339,7 +320,7 @@ async def test_failed_delete_stays_removed_in_memory_until_restart(monkeypatch, 
     _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    res = await _send(hass, 1, "haventory/item/delete", item_id=str(item.id))
+    res = await ws_send(hass, 1, "haventory/item/delete", item_id=str(item.id))
 
     assert res["success"] is False
     assert res["error"]["code"] == "storage_error"
@@ -358,7 +339,7 @@ async def test_failed_update_keeps_the_new_value_in_memory(monkeypatch, caplog) 
     _fail_next_save(monkeypatch, store)
     caplog.set_level(logging.ERROR)
 
-    res = await _send(
+    res = await ws_send(
         hass,
         1,
         "haventory/item/update",

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -13,7 +13,7 @@ Scenarios:
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -25,14 +25,19 @@ from custom_components.haventory.ws import _broadcast_event, _subs_bucket
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from ws_helpers import RecordingConn, ws_send
 
-class _ConnStub:
+
+class _ConnStub(RecordingConn):
+    """A connection with close callbacks but no subscription registry.
+
+    Deliberately missing ``subscriptions``, which is what exercises the
+    ``on_close`` fallback path.
+    """
+
     def __init__(self) -> None:
-        self.messages: list[dict[str, Any]] = []
+        super().__init__()
         self._close_callbacks: list[Callable[[], None]] = []
-
-    def send_message(self, msg: dict[str, Any]) -> None:
-        self.messages.append(msg)
 
     def on_close(self, callback: Callable[[], None]) -> None:
         self._close_callbacks.append(callback)
@@ -111,35 +116,6 @@ class _SlottedHAConn:
         self.subscriptions.clear()
 
 
-def _get_handler(
-    hass: HomeAssistant, type_: str
-) -> Callable[[HomeAssistant, object, dict], Coroutine[Any, Any, dict]]:
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if callable(h) and getattr(h, "_ws_command", None) == type_:
-            return h
-    raise AssertionError("No handler found for type " + type_)
-
-
-async def _send(hass: HomeAssistant, conn: object, _id: int, type_: str, **payload):
-    handler = _get_handler(hass, type_)
-    req = {"id": _id, "type": type_}
-    req.update(payload)
-    return await handler(hass, conn, req)
-
-
-def _extract_events(conn: _ConnStub, *, topic: str | None = None) -> list[dict[str, Any]]:
-    events: list[dict[str, Any]] = []
-    for m in conn.messages:
-        if m.get("type") != "event":
-            continue
-        ev = m.get("event") or {}
-        if topic is not None and ev.get("topic") != topic:
-            continue
-        events.append(ev)
-    return events
-
-
 @pytest.mark.asyncio
 async def test_subscribe_receives_item_created_and_counts() -> None:
     """Subscribe to items and stats; creating an item emits item+counts events."""
@@ -152,17 +128,17 @@ async def test_subscribe_receives_item_created_and_counts() -> None:
     conn = _ConnStub()
 
     # Subscribe to items and stats on same connection with different ids
-    res = await _send(hass, conn, 101, "haventory/subscribe", topic="items")
+    res = await ws_send(hass, 101, "haventory/subscribe", conn=conn, topic="items")
     assert res["success"] is True
-    res = await _send(hass, conn, 102, "haventory/subscribe", topic="stats")
+    res = await ws_send(hass, 102, "haventory/subscribe", conn=conn, topic="stats")
     assert res["success"] is True
 
     # Trigger mutation
-    created = await _send(hass, conn, 1, "haventory/item/create", name="Hammer", quantity=1)
+    created = await ws_send(hass, 1, "haventory/item/create", conn=conn, name="Hammer", quantity=1)
     assert created["success"] is True
 
-    item_events = _extract_events(conn, topic="items")
-    stats_events = _extract_events(conn, topic="stats")
+    item_events = conn.events(topic="items")
+    stats_events = conn.events(topic="stats")
 
     assert any(
         ev.get("action") == "created" and isinstance(ev.get("item"), dict) for ev in item_events
@@ -184,23 +160,23 @@ async def test_unsubscribe_stops_events() -> None:
     conn = _ConnStub()
 
     # Subscribe to items
-    res = await _send(hass, conn, 201, "haventory/subscribe", topic="items")
+    res = await ws_send(hass, 201, "haventory/subscribe", conn=conn, topic="items")
     assert res["success"] is True
 
     # First create triggers an item event
-    await _send(hass, conn, 1, "haventory/item/create", name="Box")
-    assert len(_extract_events(conn, topic="items")) >= 1
+    await ws_send(hass, 1, "haventory/item/create", conn=conn, name="Box")
+    assert len(conn.events(topic="items")) >= 1
 
     # Unsubscribe using the subscription id
-    res = await _send(hass, conn, 202, "haventory/unsubscribe", subscription=201)
+    res = await ws_send(hass, 202, "haventory/unsubscribe", conn=conn, subscription=201)
     assert res["success"] is True
 
     # Clear previous messages
     conn.messages.clear()
 
     # Further mutations should not deliver to this subscription
-    await _send(hass, conn, 2, "haventory/item/create", name="Tape")
-    assert _extract_events(conn, topic="items") == []
+    await ws_send(hass, 2, "haventory/item/create", conn=conn, name="Tape")
+    assert conn.events(topic="items") == []
 
 
 @pytest.mark.asyncio
@@ -215,16 +191,16 @@ async def test_double_subscribe_and_unsubscribe_edge() -> None:
     conn = _ConnStub()
 
     # Two subscriptions for same topic with different ids
-    await _send(hass, conn, 401, "haventory/subscribe", topic="stats")
-    await _send(hass, conn, 402, "haventory/subscribe", topic="stats")
+    await ws_send(hass, 401, "haventory/subscribe", conn=conn, topic="stats")
+    await ws_send(hass, 402, "haventory/subscribe", conn=conn, topic="stats")
 
     # Unsubscribe unknown id should succeed and not crash
-    res = await _send(hass, conn, 499, "haventory/unsubscribe", subscription=999)
+    res = await ws_send(hass, 499, "haventory/unsubscribe", conn=conn, subscription=999)
     assert res["success"] is True
 
     # Trigger mutation and ensure at least one event delivered
-    await _send(hass, conn, 1, "haventory/item/create", name="Hammer")
-    events = _extract_events(conn, topic="stats")
+    await ws_send(hass, 1, "haventory/item/create", conn=conn, name="Hammer")
+    events = conn.events(topic="stats")
     assert any(ev.get("action") == "counts" for ev in events)
 
 
@@ -238,7 +214,7 @@ async def test_subscriptions_cleanup_on_connection_close() -> None:
     ws_setup(hass)
 
     conn = _ConnStub()
-    await _send(hass, conn, 901, "haventory/subscribe", topic="items")
+    await ws_send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
 
     subs = _subs_bucket(hass)
     assert subs.get(conn)
@@ -260,28 +236,30 @@ async def test_location_filters_subtree_and_direct_only() -> None:
     conn = _ConnStub()
 
     # Create a small location tree: root -> child
-    root = await _send(hass, conn, 1, "haventory/location/create", name="Root")
+    root = await ws_send(hass, 1, "haventory/location/create", conn=conn, name="Root")
     root_id = root["result"]["id"]
-    child = await _send(hass, conn, 2, "haventory/location/create", name="Shelf", parent_id=root_id)
+    child = await ws_send(
+        hass, 2, "haventory/location/create", conn=conn, name="Shelf", parent_id=root_id
+    )
     child_id = child["result"]["id"]
 
     # Two subscriptions:
     # - 301: subtree under root
     # - 302: direct-only for child
-    await _send(
+    await ws_send(
         hass,
-        conn,
         301,
         "haventory/subscribe",
+        conn=conn,
         topic="items",
         location_id=root_id,
         include_subtree=True,
     )
-    await _send(
+    await ws_send(
         hass,
-        conn,
         302,
         "haventory/subscribe",
+        conn=conn,
         topic="items",
         location_id=child_id,
         include_subtree=False,
@@ -289,14 +267,8 @@ async def test_location_filters_subtree_and_direct_only() -> None:
 
     # Create in child: both subs should receive (subtree and direct child)
     conn.messages.clear()
-    item1 = await _send(
-        hass,
-        conn,
-        3,
-        "haventory/item/create",
-        name="Wrench",
-        quantity=1,
-        location_id=child_id,
+    item1 = await ws_send(
+        hass, 3, "haventory/item/create", conn=conn, name="Wrench", quantity=1, location_id=child_id
     )
     assert item1["success"] is True
     # Expect 2 events with different ids (subscription ids)
@@ -309,11 +281,11 @@ async def test_location_filters_subtree_and_direct_only() -> None:
 
     # Create in root: only subtree subscription (301) should receive
     conn.messages.clear()
-    item2 = await _send(
+    item2 = await ws_send(
         hass,
-        conn,
         4,
         "haventory/item/create",
+        conn=conn,
         name="Screwdriver",
         quantity=1,
         location_id=root_id,
@@ -362,15 +334,15 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
 
     SUB_ID_INSPECTION = 401
     SUB_ID_EVERYTHING = 402
-    await _send(
+    await ws_send(
         hass,
-        conn,
         SUB_ID_INSPECTION,
         "haventory/subscribe",
+        conn=conn,
         topic="items",
         inspection_overdue_only=True,
     )
-    await _send(hass, conn, SUB_ID_EVERYTHING, "haventory/subscribe", topic="items")
+    await ws_send(hass, SUB_ID_EVERYTHING, "haventory/subscribe", conn=conn, topic="items")
 
     def item_event_ids() -> set[object]:
         return {
@@ -381,11 +353,11 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
 
     # A missed inspection reaches both subscriptions.
     conn.messages.clear()
-    late = await _send(
+    late = await ws_send(
         hass,
-        conn,
         3,
         "haventory/item/create",
+        conn=conn,
         name="Ladder",
         inspection_date=_utc_day_offset(-1),
     )
@@ -395,11 +367,11 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
     # Due today is not late yet, so the filtered subscription hears nothing —
     # the same strictly-before boundary the filter and the count use.
     conn.messages.clear()
-    due_today = await _send(
+    due_today = await ws_send(
         hass,
-        conn,
         4,
         "haventory/item/create",
+        conn=conn,
         name="Harness",
         inspection_date=_utc_day_offset(0),
     )
@@ -408,7 +380,7 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
 
     # And an item with no inspection date at all never matches.
     conn.messages.clear()
-    undated = await _send(hass, conn, 5, "haventory/item/create", name="Bucket")
+    undated = await ws_send(hass, 5, "haventory/item/create", conn=conn, name="Bucket")
     assert undated["success"] is True
     assert item_event_ids() == {SUB_ID_EVERYTHING}
 
@@ -433,10 +405,14 @@ async def test_area_filter_constrains_delivered_events() -> None:
     SUB_ID_KITCHEN = 501
     SUB_ID_EVERYTHING = 502
     SUB_ID_NULL_AREA = 503
-    await _send(hass, conn, SUB_ID_KITCHEN, "haventory/subscribe", topic="items", area_id="kitchen")
-    await _send(hass, conn, SUB_ID_EVERYTHING, "haventory/subscribe", topic="items")
+    await ws_send(
+        hass, SUB_ID_KITCHEN, "haventory/subscribe", conn=conn, topic="items", area_id="kitchen"
+    )
+    await ws_send(hass, SUB_ID_EVERYTHING, "haventory/subscribe", conn=conn, topic="items")
     # An explicit null is "no area filter", not "items with no area".
-    await _send(hass, conn, SUB_ID_NULL_AREA, "haventory/subscribe", topic="items", area_id=None)
+    await ws_send(
+        hass, SUB_ID_NULL_AREA, "haventory/subscribe", conn=conn, topic="items", area_id=None
+    )
 
     def item_event_ids() -> set[object]:
         return {
@@ -447,16 +423,16 @@ async def test_area_filter_constrains_delivered_events() -> None:
 
     # An item deep under the kitchen inherits its area and reaches all three.
     conn.messages.clear()
-    inside = await _send(
-        hass, conn, 1, "haventory/item/create", name="Whisk", location_id=str(drawer.id)
+    inside = await ws_send(
+        hass, 1, "haventory/item/create", conn=conn, name="Whisk", location_id=str(drawer.id)
     )
     assert inside["success"] is True
     assert item_event_ids() == {SUB_ID_KITCHEN, SUB_ID_EVERYTHING, SUB_ID_NULL_AREA}
 
     # An item in another area does not.
     conn.messages.clear()
-    outside = await _send(
-        hass, conn, 2, "haventory/item/create", name="Spanner", location_id=str(garage.id)
+    outside = await ws_send(
+        hass, 2, "haventory/item/create", conn=conn, name="Spanner", location_id=str(garage.id)
     )
     assert outside["success"] is True
     assert item_event_ids() == {SUB_ID_EVERYTHING, SUB_ID_NULL_AREA}
@@ -464,7 +440,7 @@ async def test_area_filter_constrains_delivered_events() -> None:
     # Neither does an item with no location: its effective_area_id is null, and a
     # null resolves to no area rather than to every area.
     conn.messages.clear()
-    orphan = await _send(hass, conn, 3, "haventory/item/create", name="Loose screw")
+    orphan = await ws_send(hass, 3, "haventory/item/create", conn=conn, name="Loose screw")
     assert orphan["success"] is True
     assert orphan["result"]["effective_area_id"] is None
     assert item_event_ids() == {SUB_ID_EVERYTHING, SUB_ID_NULL_AREA}
@@ -488,18 +464,18 @@ async def test_area_and_location_filters_are_conjunctive() -> None:
 
     SUB_ID_BOTH = 601
     SUB_ID_UNUSED_AREA = 602
-    await _send(
+    await ws_send(
         hass,
-        conn,
         SUB_ID_BOTH,
         "haventory/subscribe",
+        conn=conn,
         topic="items",
         area_id="kitchen",
         location_id=str(drawer.id),
     )
     # An area no item resolves to simply never matches; it is not an error.
-    await _send(
-        hass, conn, SUB_ID_UNUSED_AREA, "haventory/subscribe", topic="items", area_id="attic"
+    await ws_send(
+        hass, SUB_ID_UNUSED_AREA, "haventory/subscribe", conn=conn, topic="items", area_id="attic"
     )
 
     def item_event_ids() -> set[object]:
@@ -510,12 +486,16 @@ async def test_area_and_location_filters_are_conjunctive() -> None:
         }
 
     conn.messages.clear()
-    await _send(hass, conn, 1, "haventory/item/create", name="Whisk", location_id=str(drawer.id))
+    await ws_send(
+        hass, 1, "haventory/item/create", conn=conn, name="Whisk", location_id=str(drawer.id)
+    )
     assert item_event_ids() == {SUB_ID_BOTH}
 
     # Right area, wrong location.
     conn.messages.clear()
-    await _send(hass, conn, 2, "haventory/item/create", name="Jar", location_id=str(shelf.id))
+    await ws_send(
+        hass, 2, "haventory/item/create", conn=conn, name="Jar", location_id=str(shelf.id)
+    )
     assert item_event_ids() == set()
 
 
@@ -541,32 +521,36 @@ async def test_location_area_change_emits_no_item_events() -> None:
     kitchen = repo.create_location(name="Kitchen", area_id="kitchen")
     garage = repo.create_location(name="Garage", area_id="garage")
     drawer = repo.create_location(name="Drawer", parent_id=kitchen.id)
-    await _send(hass, conn, 1, "haventory/item/create", name="Whisk", location_id=str(drawer.id))
+    await ws_send(
+        hass, 1, "haventory/item/create", conn=conn, name="Whisk", location_id=str(drawer.id)
+    )
 
     SUB_ID_KITCHEN = 701
-    await _send(hass, conn, SUB_ID_KITCHEN, "haventory/subscribe", topic="items", area_id="kitchen")
-    await _send(hass, conn, 702, "haventory/subscribe", topic="locations")
+    await ws_send(
+        hass, SUB_ID_KITCHEN, "haventory/subscribe", conn=conn, topic="items", area_id="kitchen"
+    )
+    await ws_send(hass, 702, "haventory/subscribe", conn=conn, topic="locations")
 
     conn.messages.clear()
-    moved = await _send(
+    moved = await ws_send(
         hass,
-        conn,
         2,
         "haventory/location/move_subtree",
+        conn=conn,
         location_id=str(drawer.id),
         new_parent_id=str(garage.id),
     )
     assert moved["success"] is True
 
-    assert [ev.get("action") for ev in _extract_events(conn, topic="locations")] == ["moved"]
-    assert _extract_events(conn, topic="items") == []
+    assert [ev.get("action") for ev in conn.events(topic="locations")] == ["moved"]
+    assert conn.events(topic="items") == []
 
     # The item is genuinely out of the kitchen now, and the next event about it
     # goes only to subscriptions watching where it landed.
     conn.messages.clear()
-    listed = await _send(hass, conn, 3, "haventory/item/list", filter={"area_id": "garage"})
+    listed = await ws_send(hass, 3, "haventory/item/list", conn=conn, filter={"area_id": "garage"})
     assert [it["name"] for it in listed["result"]["items"]] == ["Whisk"]
-    assert _extract_events(conn, topic="items") == []
+    assert conn.events(topic="items") == []
 
 
 @pytest.mark.asyncio
@@ -586,7 +570,7 @@ async def test_framework_unsubscribe_events_tears_down_subscription() -> None:
 
     sub_id = 501
     conn = _HAConnStub()
-    res = await _send(hass, conn, sub_id, "haventory/subscribe", topic="items")
+    res = await ws_send(hass, sub_id, "haventory/subscribe", conn=conn, topic="items")
     assert res["success"] is True
 
     # The zero-arg teardown is registered under the message id — exactly what core's
@@ -595,8 +579,8 @@ async def test_framework_unsubscribe_events_tears_down_subscription() -> None:
     assert callable(conn.subscriptions[sub_id])
 
     # Events flow while subscribed.
-    await _send(hass, conn, 1, "haventory/item/create", name="Box")
-    assert len(_extract_events(conn, topic="items")) >= 1
+    await ws_send(hass, 1, "haventory/item/create", conn=conn, name="Box")
+    assert len(conn.events(topic="items")) >= 1
 
     # Emulate core ``unsubscribe_events``: the id is found -> success (no not_found).
     assert conn.core_unsubscribe_events(sub_id) is True
@@ -605,8 +589,8 @@ async def test_framework_unsubscribe_events_tears_down_subscription() -> None:
 
     # No further deliveries after teardown.
     conn.messages.clear()
-    await _send(hass, conn, 2, "haventory/item/create", name="Tape")
-    assert _extract_events(conn, topic="items") == []
+    await ws_send(hass, 2, "haventory/item/create", conn=conn, name="Tape")
+    assert conn.events(topic="items") == []
 
 
 @pytest.mark.asyncio
@@ -621,10 +605,10 @@ async def test_dedicated_unsubscribe_clears_framework_registry() -> None:
 
     sub_id = 601
     conn = _HAConnStub()
-    await _send(hass, conn, sub_id, "haventory/subscribe", topic="stats")
+    await ws_send(hass, sub_id, "haventory/subscribe", conn=conn, topic="stats")
     assert sub_id in conn.subscriptions
 
-    res = await _send(hass, conn, 602, "haventory/unsubscribe", subscription=sub_id)
+    res = await ws_send(hass, 602, "haventory/unsubscribe", conn=conn, subscription=sub_id)
     assert res["success"] is True
     assert sub_id not in conn.subscriptions
     assert conn not in _subs_bucket(hass)
@@ -652,8 +636,8 @@ async def test_subscribe_on_slotted_connection_never_stamps_attribute() -> None:
     # Two subscribes on the same connection must not raise, must register the per-id
     # framework teardown for each, and must leave exactly one connection-cleanup entry.
     sub_a, sub_b = 701, 702
-    r1 = await _send(hass, conn, sub_a, "haventory/subscribe", topic="items")
-    r2 = await _send(hass, conn, sub_b, "haventory/subscribe", topic="stats")
+    r1 = await ws_send(hass, sub_a, "haventory/subscribe", conn=conn, topic="items")
+    r2 = await ws_send(hass, sub_b, "haventory/subscribe", conn=conn, topic="stats")
     assert r1["success"] is True
     assert r2["success"] is True
     assert sub_a in conn.subscriptions
@@ -697,31 +681,31 @@ async def test_location_ids_scopes_a_subscription_to_several_locations() -> None
     SUB_ID_TWO = 601
     SUB_ID_DIRECT = 602
     SUB_ID_UNION = 603
-    await _send(
+    await ws_send(
         hass,
-        conn,
         SUB_ID_TWO,
         "haventory/subscribe",
+        conn=conn,
         topic="items",
         location_ids=[str(kitchen.id), str(garage.id)],
     )
     # One flag for the whole selection: without the subtree, only the two
     # locations themselves count, not the drawer under the kitchen.
-    await _send(
+    await ws_send(
         hass,
-        conn,
         SUB_ID_DIRECT,
         "haventory/subscribe",
+        conn=conn,
         topic="items",
         location_ids=[str(kitchen.id), str(garage.id)],
         include_subtree=False,
     )
     # The scalar and the list are one selection, not two conditions.
-    await _send(
+    await ws_send(
         hass,
-        conn,
         SUB_ID_UNION,
         "haventory/subscribe",
+        conn=conn,
         topic="items",
         location_id=str(cellar.id),
         location_ids=[str(garage.id)],
@@ -735,20 +719,26 @@ async def test_location_ids_scopes_a_subscription_to_several_locations() -> None
         }
 
     conn.messages.clear()
-    await _send(hass, conn, 1, "haventory/item/create", name="Whisk", location_id=str(drawer.id))
+    await ws_send(
+        hass, 1, "haventory/item/create", conn=conn, name="Whisk", location_id=str(drawer.id)
+    )
     assert item_event_ids() == {SUB_ID_TWO}
 
     conn.messages.clear()
-    await _send(hass, conn, 2, "haventory/item/create", name="Spanner", location_id=str(garage.id))
+    await ws_send(
+        hass, 2, "haventory/item/create", conn=conn, name="Spanner", location_id=str(garage.id)
+    )
     assert item_event_ids() == {SUB_ID_TWO, SUB_ID_DIRECT, SUB_ID_UNION}
 
     conn.messages.clear()
-    await _send(hass, conn, 3, "haventory/item/create", name="Jam", location_id=str(cellar.id))
+    await ws_send(
+        hass, 3, "haventory/item/create", conn=conn, name="Jam", location_id=str(cellar.id)
+    )
     assert item_event_ids() == {SUB_ID_UNION}
 
     # An item with no location reaches no location-scoped subscription.
     conn.messages.clear()
-    await _send(hass, conn, 4, "haventory/item/create", name="Loose screw")
+    await ws_send(hass, 4, "haventory/item/create", conn=conn, name="Loose screw")
     assert item_event_ids() == set()
 
 
@@ -759,8 +749,8 @@ async def test_subscribe_refuses_location_ids_that_is_not_a_list() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    res = await _send(
-        hass, _ConnStub(), 1, "haventory/subscribe", topic="items", location_ids="not-a-list"
+    res = await ws_send(
+        hass, 1, "haventory/subscribe", conn=_ConnStub(), topic="items", location_ids="not-a-list"
     )
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"

--- a/tests/test_ws_utils_offline.py
+++ b/tests/test_ws_utils_offline.py
@@ -27,26 +27,7 @@ from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-
-class _StubConn:
-    def __init__(self) -> None:
-        self.last = None
-
-    def send_message(self, msg):
-        self.last = msg
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        conn = _StubConn()
-        res = await h(hass, conn, req)
-        return res if res is not None else conn.last
-    raise AssertionError("No handler responded for type " + type_)
+from ws_helpers import ws_send
 
 
 @pytest.mark.asyncio
@@ -57,7 +38,7 @@ async def test_ping_echo_and_ts() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 1, "haventory/ping", echo={"hello": "world"})
+    res = await ws_send(hass, 1, "haventory/ping", echo={"hello": "world"})
     assert res["success"] is True
     assert res["result"]["echo"] == {"hello": "world"}
     assert isinstance(res["result"]["ts"], str) and len(res["result"]["ts"]) > 0
@@ -71,7 +52,7 @@ async def test_version_reports_integration_and_schema() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 2, "haventory/version")
+    res = await ws_send(hass, 2, "haventory/version")
     assert res["success"] is True
     assert res["result"]["integration_version"] == INTEGRATION_VERSION
     # In offline tests, store may not exist; default to CURRENT_SCHEMA_VERSION
@@ -88,7 +69,7 @@ async def test_config_reports_configured_card_title() -> None:
     bucket["card_title"] = "Pantry"
     ws_setup(hass)
 
-    res = await _send(hass, 5, "haventory/config")
+    res = await ws_send(hass, 5, "haventory/config")
     assert res["success"] is True
     assert res["result"]["card_title"] == "Pantry"
 
@@ -101,7 +82,7 @@ async def test_config_falls_back_to_default_card_title() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 6, "haventory/config")
+    res = await ws_send(hass, 6, "haventory/config")
     assert res["success"] is True
     assert res["result"]["card_title"] == DEFAULT_CARD_TITLE
 
@@ -116,7 +97,7 @@ async def test_config_reports_the_configured_quick_filter_pills() -> None:
     bucket["quick_filters"] = ["total", "low_stock"]
     ws_setup(hass)
 
-    res = await _send(hass, 7, "haventory/config")
+    res = await ws_send(hass, 7, "haventory/config")
     assert res["success"] is True
     assert res["result"]["quick_filters"] == ["total", "low_stock"]
 
@@ -131,7 +112,7 @@ async def test_config_reports_an_empty_pill_choice_as_empty() -> None:
     bucket["quick_filters"] = []
     ws_setup(hass)
 
-    res = await _send(hass, 8, "haventory/config")
+    res = await ws_send(hass, 8, "haventory/config")
     assert res["success"] is True
     assert res["result"]["quick_filters"] == []
 
@@ -144,7 +125,7 @@ async def test_config_reports_no_pill_choice_as_null() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 9, "haventory/config")
+    res = await ws_send(hass, 9, "haventory/config")
     assert res["success"] is True
     assert res["result"]["quick_filters"] is None
 
@@ -157,7 +138,7 @@ async def test_config_reports_the_status_vocabulary() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 7, "haventory/config")
+    res = await ws_send(hass, 7, "haventory/config")
 
     assert res["result"]["statuses"] == [
         {"slug": "ok", "label": "OK", "order": 0, "color": "green", "icon": "check"},
@@ -180,7 +161,7 @@ async def test_config_reports_the_attachment_caps_and_accepted_types() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 8, "haventory/config")
+    res = await ws_send(hass, 8, "haventory/config")
 
     media = res["result"]["media"]
     assert media["picture_mime_types"] == list(ATTACHMENT_PICTURE_MIME_TYPES)
@@ -203,7 +184,7 @@ async def test_stats_returns_counts() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 3, "haventory/stats")
+    res = await ws_send(hass, 3, "haventory/stats")
     assert res["success"] is True
     counts = res["result"]
     assert set(counts.keys()) == {
@@ -231,7 +212,7 @@ async def test_stats_carries_status_counts_beside_the_legacy_keys() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = repo
     ws_setup(hass)
 
-    res = await _send(hass, 31, "haventory/stats")
+    res = await ws_send(hass, 31, "haventory/stats")
 
     counts = res["result"]
     # "ok" is counted even though the index deliberately does not bucket it.
@@ -248,7 +229,7 @@ async def test_health_is_healthy_for_fresh_repo() -> None:
     hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
     ws_setup(hass)
 
-    res = await _send(hass, 4, "haventory/health")
+    res = await ws_send(hass, 4, "haventory/health")
     assert res["success"] is True
     body = res["result"]
     assert isinstance(body, dict)

--- a/tests/test_ws_wrappers_offline.py
+++ b/tests/test_ws_wrappers_offline.py
@@ -16,26 +16,7 @@ from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-
-class _StubConn:
-    def __init__(self) -> None:
-        self.last = None
-
-    def send_message(self, msg):
-        self.last = msg
-
-
-async def _send(hass: HomeAssistant, _id: int, type_: str, **payload):
-    handlers = hass.data.get("__ws_commands__", [])
-    for h in handlers:
-        if not callable(h) or getattr(h, "_ws_command", None) != type_:
-            continue
-        req = {"id": _id, "type": type_}
-        req.update(payload)
-        conn = _StubConn()
-        resp = await h(hass, conn, req)
-        return resp if resp is not None else conn.last
-    raise AssertionError("No handler responded for type " + type_)
+from ws_helpers import ws_send
 
 
 @pytest.mark.asyncio
@@ -47,11 +28,11 @@ async def test_add_remove_tags_success_and_normalization() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Thing")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Thing")
     item_id = created["result"]["id"]
 
     # Add tags with mixed case/whitespace and duplicates
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/item/add_tags",
@@ -63,7 +44,7 @@ async def test_add_remove_tags_success_and_normalization() -> None:
     assert res["result"]["tags"] == ["alpha", "beta"]
 
     # Remove tags (normalize) and ensure subtraction
-    res = await _send(
+    res = await ws_send(
         hass,
         3,
         "haventory/item/remove_tags",
@@ -75,9 +56,9 @@ async def test_add_remove_tags_success_and_normalization() -> None:
 
     # A non-string tag is refused by the command's `[str]` schema, so the
     # handler never runs and the item keeps the tags it had.
-    res = await _send(hass, 4, "haventory/item/add_tags", item_id=item_id, tags=["gamma", None])
+    res = await ws_send(hass, 4, "haventory/item/add_tags", item_id=item_id, tags=["gamma", None])
     assert res["success"] is False and res["error"]["code"] == "invalid_format"
-    res = await _send(hass, 5, "haventory/item/get", item_id=item_id)
+    res = await ws_send(hass, 5, "haventory/item/get", item_id=item_id)
     assert res["result"]["tags"] == ["alpha"]
 
 
@@ -90,11 +71,11 @@ async def test_update_custom_fields_set_unset_and_validation_error() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Widget")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
     # Set two fields
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/item/update_custom_fields",
@@ -107,7 +88,7 @@ async def test_update_custom_fields_set_unset_and_validation_error() -> None:
     assert res["result"]["custom_fields"]["size"] == SIZE_VALUE
 
     # Unset one field
-    res = await _send(
+    res = await ws_send(
         hass,
         3,
         "haventory/item/update_custom_fields",
@@ -118,7 +99,7 @@ async def test_update_custom_fields_set_unset_and_validation_error() -> None:
     assert "size" not in res["result"]["custom_fields"]
 
     # Invalid set payload: list value is not a scalar
-    res = await _send(
+    res = await ws_send(
         hass,
         4,
         "haventory/item/update_custom_fields",
@@ -137,16 +118,16 @@ async def test_set_low_stock_threshold_affects_counts() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Nails", quantity=1)
+    created = await ws_send(hass, 1, "haventory/item/create", name="Nails", quantity=1)
     item_id = created["result"]["id"]
 
     # Initially, with no threshold, low_stock_count should be 0
-    stats = await _send(hass, 2, "haventory/stats")
+    stats = await ws_send(hass, 2, "haventory/stats")
     assert stats["success"] is True and stats["result"]["low_stock_count"] == 0
 
     # Set threshold to 2 -> item is low stock (1 <= 2)
     LOW_STOCK_THRESHOLD = 2
-    res = await _send(
+    res = await ws_send(
         hass,
         3,
         "haventory/item/set_low_stock_threshold",
@@ -156,7 +137,7 @@ async def test_set_low_stock_threshold_affects_counts() -> None:
     assert res["success"] is True
     assert res["result"]["low_stock_threshold"] == LOW_STOCK_THRESHOLD
 
-    stats2 = await _send(hass, 4, "haventory/stats")
+    stats2 = await ws_send(hass, 4, "haventory/stats")
     assert stats2["result"]["low_stock_count"] == 1
 
 
@@ -169,13 +150,13 @@ async def test_item_move_updates_location() -> None:
     hass.data[DOMAIN]["store"] = DomainStore(hass)
     ws_setup(hass)
 
-    created = await _send(hass, 1, "haventory/item/create", name="Box")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Box")
     item_id = created["result"]["id"]
 
-    loc = await _send(hass, 2, "haventory/location/create", name="Shelf A")
+    loc = await ws_send(hass, 2, "haventory/location/create", name="Shelf A")
     loc_id = loc["result"]["id"]
 
-    res = await _send(hass, 3, "haventory/item/move", item_id=item_id, location_id=loc_id)
+    res = await ws_send(hass, 3, "haventory/item/move", item_id=item_id, location_id=loc_id)
     assert res["success"] is True and res["result"]["location_id"] == loc_id
 
 
@@ -190,12 +171,12 @@ async def test_unknown_command_and_type_errors() -> None:
 
     # Unknown command type: ensure no handler responds
     with pytest.raises(AssertionError):
-        await _send(hass, 99, "haventory/does_not_exist")
+        await ws_send(hass, 99, "haventory/does_not_exist")
 
     # Type errors inside payload for wrappers that validate
-    created = await _send(hass, 1, "haventory/item/create", name="Thing")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Thing")
     iid = created["result"]["id"]
-    res = await _send(
+    res = await ws_send(
         hass,
         2,
         "haventory/item/set_quantity",

--- a/tests/ws_helpers.py
+++ b/tests/ws_helpers.py
@@ -1,0 +1,110 @@
+"""One way for an offline test to send a WebSocket command.
+
+Home Assistant is stubbed offline (``tests/conftest.py``), so a test cannot open a
+connection and speak the protocol. It dispatches straight to the handler the stub
+registry holds under a command name — which is what these helpers do, once, for
+every test file:
+
+* :func:`ws_send` builds the frame, dispatches it and hands back the **full result
+  envelope** (``{"id", "type", "success", "result"|"error"}``), so a test can assert
+  on the envelope, on ``result`` or on ``error`` without unwrapping anything first.
+* ``conn`` is a first-class optional argument on every one of them. Pass a
+  :class:`RecordingConn` to read what the handler pushed on the connection —
+  subscription events, a broadcast, a teardown notice. Leave it out and the stub
+  registry supplies its own throwaway connection.
+* :func:`ws_handler` and :func:`ws_call` are the split version, for the one case
+  that needs it: capturing a handler *before* an entry unloads and calling it
+  afterwards, the way a client sending on a still-registered command does.
+
+The frame goes through the same schema validation an ``ActiveConnection`` applies,
+so a payload no real client could send comes back as ``invalid_format`` rather than
+reaching the handler.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from homeassistant.core import HomeAssistant
+
+
+class WsHandler(Protocol):
+    """What the stub registry stores: a dispatchable, command-tagged coroutine."""
+
+    _ws_command: str
+
+    def __call__(
+        self, hass: HomeAssistant, conn: object, msg: dict[str, Any]
+    ) -> Awaitable[dict[str, Any] | None]: ...
+
+
+class RecordingConn:
+    """Stands in for HA's ``ActiveConnection``, keeping everything sent to it.
+
+    Only the surface a handler touches on the way out. A test that needs more —
+    a subscription registry, close callbacks — subclasses this and adds it.
+    """
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def send_message(self, msg: dict[str, Any]) -> None:
+        self.messages.append(msg)
+
+    def events(self, *, topic: str | None = None) -> list[dict[str, Any]]:
+        """The event payloads pushed on this connection, oldest first.
+
+        Returns the inner ``event`` object, which is where ``topic``, ``action``
+        and the payload live; the enclosing message carries only the envelope.
+        """
+
+        out: list[dict[str, Any]] = []
+        for msg in self.messages:
+            if msg.get("type") != "event":
+                continue
+            event = msg.get("event") or {}
+            if topic is not None and event.get("topic") != topic:
+                continue
+            out.append(event)
+        return out
+
+
+def ws_handler(hass: HomeAssistant, type_: str) -> WsHandler:
+    """The registered handler for one command type, as HA would dispatch to it."""
+
+    for handler in hass.data.get("__ws_commands__", []):
+        if callable(handler) and getattr(handler, "_ws_command", None) == type_:
+            return handler
+    raise AssertionError(f"No handler registered for type {type_}")
+
+
+async def ws_call(
+    handler: WsHandler,
+    hass: HomeAssistant,
+    _id: int,
+    type_: str,
+    *,
+    conn: object = None,
+    **payload: Any,
+) -> dict[str, Any]:
+    """Send one frame to an already-looked-up handler and return its envelope."""
+
+    res = await handler(hass, conn, {"id": _id, "type": type_, **payload})
+    assert res is not None, f"{type_} answered nothing on the connection or as a result"
+    return res
+
+
+async def ws_send(
+    hass: HomeAssistant,
+    _id: int,
+    type_: str,
+    *,
+    conn: object = None,
+    **payload: Any,
+) -> dict[str, Any]:
+    """Dispatch one WebSocket command as a client would, and return its envelope."""
+
+    return await ws_call(ws_handler(hass, type_), hass, _id, type_, conn=conn, **payload)


### PR DESCRIPTION
## Summary

Twenty-two offline test files each carried a private `_send()` that dispatched a WebSocket command — eight distinct declarations between them (the issue counts 14 bodies and 7 annotation-stripped signatures; same shape, different way of counting). The divergence decided what a test could check: eleven of the files took no connection at all, so a test living in one of them could not assert anything the handler pushed on the wire without first rewriting its own file's helper.

`tests/ws_helpers.py` now holds one of each:

- **`ws_send(hass, id, type_, *, conn=None, **payload)`** — looks the handler up, builds the frame, dispatches it, and returns the **full result envelope** (`id` / `type` / `success` / `result` | `error`). `conn` is keyword-only so a payload key can never land in it by position.
- **`ws_handler` / `ws_call`** — the same thing split in two, for the one case that needs it: `tests/test_entry_unload_refusal_offline.py` captures a handler *before* the entry unloads and calls it afterwards, because real HA cannot unregister a WebSocket command.
- **`RecordingConn`** — so `conn=` has something to pass. `messages` plus an `events(topic=…)` reader, which replaces two of the three module-level event readers that had grown up around it.

All 403 call sites moved onto them; every local `_send` is gone, along with four byte-identical `_get_handler` lookups, three connection stubs that were exactly "collect the messages", and two more that no longer had a caller. Stubs that were deliberately *different* stayed — `_SlottedHAConn` (no `__dict__`, on purpose), `_HAConnStub` (subscription registry), `_ConnWithSubscriptions`, and the two `on_close` variants — now as thin subclasses or, where subclassing would defeat the point, untouched.

Two smaller things fell out of the same pass and are in the diff:

- `tests/test_ws_error_mapping_offline.py` was constructing a throwaway connection at seven call sites purely because its `_send` required one positionally. Nothing read them; with `conn` optional they are gone.
- `tests/test_ws_rate_limit_offline.py` keeps constructing one explicitly, where a distinct connection identity is what the limiter keys its bucket on and so is the point of the test.

**No assertion was deleted without a replacement.** The 22 migrated files carry 1001 `assert` statements before this change and 1001 after; where a helper disappeared, its callers now read the same data through the shared one (`_extract_events(conn, topic=…)` → `conn.events(topic=…)`, `_events(conn)` → `conn.events()`, and one id-reading assertion in the rate-limit tests reads `conn.messages` directly, since `RecordingConn.events()` returns the inner event payload where the envelope id is not).

`tests/test_ws_helpers_offline.py` pins the helper's own contract — the whole envelope on success, the error envelope returned rather than raised, `conn` optional and receiving what the handler pushes, the captured-handler split, and an unregistered command failing loudly instead of answering `None`.

`CONTRIBUTING.md` now names the helper under the test-driven convention, which is what stops the next WS test writing a ninth variant.

Closes #357

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

Test-only change; nothing under `custom_components/haventory/` or `cards/` moved. Both gates green:

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **909 passed, 22 skipped** (903 before, +6 for the new helper tests); `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (**1804 passed, 62 files**), `npm run build` — all green and untouched by this diff.

Note for anyone provisioning a fresh cloud session: `uv sync` fails here until `uv python install 3.14` has run, because no interpreter at the floor is preinstalled in the image. The python-build-standalone download itself works.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`CONTRIBUTING.md`; no shipped behavior changed, so no `README.md` / API-doc change).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, the API is untouched.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None — no card change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuPaxBz6ub6X2jheqqxgiL)_