### PR TITLE
test: one component-test harness for the card

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,15 +66,14 @@ plus `actionlint`, `hassfest`, HACS validation, CodeQL, and dependency review.
   `tests/conftest.py`); async tests use `@pytest.mark.asyncio`. The WebSocket
   stub applies each command's schema before dispatch, so an offline test sends
   frames a real client could send and gets `invalid_format` for the rest.
-  A card component test mounts through `mountComponent` from
+  Dispatch a command with `ws_send` from `tests/ws_helpers.py` — never a private
+  copy: it returns the full result envelope and takes an optional `conn=`, so a
+  test can assert on the answer, on what the handler pushed on the connection,
+  or on both. A card component test mounts through `mountComponent` from
   `cards/haventory-card/src/test.utils.ts` and reads it with `q` / `all` /
   `settle` / `componentCss` / `ownCss` from the same place — never a per-file
   copy, which is how the mount helpers drifted into dropping half the mock
   config.
-  Dispatch a command with `ws_send` from `tests/ws_helpers.py` — never a private
-  copy: it returns the full result envelope and takes an optional `conn=`, so a
-  test can assert on the answer, on what the handler pushed on the connection,
-  or on both.
 - **Conventional Commits** for commit messages *and PR titles* (a CI check
   enforces the PR title). Examples: `feat: add low-stock filter`,
   `fix: preserve location_path on move`, `docs: …`, `chore: …`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,11 @@ plus `actionlint`, `hassfest`, HACS validation, CodeQL, and dependency review.
   `tests/conftest.py`); async tests use `@pytest.mark.asyncio`. The WebSocket
   stub applies each command's schema before dispatch, so an offline test sends
   frames a real client could send and gets `invalid_format` for the rest.
+  A card component test mounts through `mountComponent` from
+  `cards/haventory-card/src/test.utils.ts` and reads it with `q` / `all` /
+  `settle` / `componentCss` / `ownCss` from the same place — never a per-file
+  copy, which is how the mount helpers drifted into dropping half the mock
+  config.
 - **Conventional Commits** for commit messages *and PR titles* (a CI check
   enforces the PR title). Examples: `feat: add low-stock filter`,
   `fix: preserve location_path on move`, `docs: …`, `chore: …`.

--- a/cards/haventory-card/src/components/hv-banner.test.ts
+++ b/cards/haventory-card/src/components/hv-banner.test.ts
@@ -1,12 +1,9 @@
 import './hv-banner';
 import type { HVBanner } from './hv-banner';
+import { mountComponent } from '../test.utils';
 
 async function mount(props: Partial<HVBanner> = {}, light = '') {
-  const el = document.createElement('hv-banner') as HVBanner;
-  Object.assign(el, props);
-  if (light) el.innerHTML = light;
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVBanner>('hv-banner', props, { light });
   return el;
 }
 

--- a/cards/haventory-card/src/components/hv-bottom-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-bottom-sheet.test.ts
@@ -1,12 +1,13 @@
 import './hv-bottom-sheet';
 import type { HVBottomSheet } from './hv-bottom-sheet';
+import { componentCss, mountComponent } from '../test.utils';
 
 async function mount(props: Partial<HVBottomSheet> = {}) {
-  const el = document.createElement('hv-bottom-sheet') as HVBottomSheet;
-  Object.assign(el, { open: true, ...props });
-  el.innerHTML = '<p>sheet body</p><div slot="footer">footer</div>';
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVBottomSheet>(
+    'hv-bottom-sheet',
+    { open: true, ...props },
+    { light: '<p>sheet body</p><div slot="footer">footer</div>' },
+  );
   return el;
 }
 
@@ -61,8 +62,7 @@ describe('hv-bottom-sheet', () => {
   });
 
   it('caps its width and centres itself so a wide screen does not stretch the content', () => {
-    const styles = (customElements.get('hv-bottom-sheet') as typeof HVBottomSheet).styles;
-    const css = (Array.isArray(styles) ? styles : [styles]).map((s) => String(s.cssText)).join('\n');
+    const css = componentCss('hv-bottom-sheet');
     const rule = css.slice(css.indexOf('.sheet {'), css.indexOf('@keyframes')).replace(/\s+/g, ' ');
 
     // min() keeps a phone full-bleed and stops a 2560px desktop from spreading
@@ -75,8 +75,7 @@ describe('hv-bottom-sheet', () => {
   // sheet at its cap could stand taller than the screen actually showing and
   // push its sticky footer under the URL bar.
   it('caps its height against the viewport that is really visible', () => {
-    const styles = (customElements.get('hv-bottom-sheet') as typeof HVBottomSheet).styles;
-    const css = (Array.isArray(styles) ? styles : [styles]).map((s) => String(s.cssText)).join('\n');
+    const css = componentCss('hv-bottom-sheet');
     expect(css).toMatch(/max-height: 92dvh/);
     expect(css).not.toMatch(/max-height: 92vh/);
   });

--- a/cards/haventory-card/src/components/hv-bulk-bar.test.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.test.ts
@@ -1,5 +1,5 @@
 import './hv-bulk-bar';
-import { makeItem } from '../test.utils';
+import { all, componentCss, makeItem, mountComponent, q } from '../test.utils';
 import { describeFailure } from './hv-bulk-bar';
 import type { BulkRunDetail, HVBulkBar } from './hv-bulk-bar';
 import type { BulkFailure, LocationTreeNode } from '../store/types';
@@ -26,22 +26,18 @@ function failure(itemId: string, code: string, message = 'boom'): BulkFailure {
 }
 
 async function mount(props: Partial<HVBulkBar> = {}) {
-  const el = document.createElement('hv-bulk-bar') as HVBulkBar;
-  el.selectedCount = 42;
-  el.locationTree = tree;
-  el.distinct = {
-    categories: [{ value: 'Hardware', count: 3 }],
-    tags: [{ value: 'metric', count: 2 }],
-    custom_field_keys: [],
-  };
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVBulkBar>('hv-bulk-bar', {
+    selectedCount: 42,
+    locationTree: tree,
+    distinct: {
+      categories: [{ value: 'Hardware', count: 3 }],
+      tags: [{ value: 'metric', count: 2 }],
+      custom_field_keys: [],
+    },
+    ...props,
+  });
   return el;
 }
-
-const q = (el: HVBulkBar, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-const all = (el: HVBulkBar, sel: string) => [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
 
 function runs(el: HVBulkBar) {
   const seen: BulkRunDetail[] = [];
@@ -293,16 +289,8 @@ describe('describeFailure', () => {
 // theme — and a running batch's Cancel that was a bare native button on top of
 // it, unstyled where every sibling control was a pill.
 describe('hv-bulk-bar: the band belongs to the theme', () => {
-  const barCss = () => {
-    const styles = (customElements.get('hv-bulk-bar') as typeof HVBulkBar).styles;
-    return (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
-  };
-
   it('takes its fill and its ink from tokens rather than from hex', () => {
-    const css = barCss();
+    const css = componentCss('hv-bulk-bar');
     expect(css).toMatch(/\.bar, \.progress \{[^}]*background: var\(--hv-selection-bar\)/);
     expect(css).toMatch(/\.bar, \.progress \{[^}]*color: var\(--hv-on-selection-bar\)/);
     expect(css).toMatch(/\.band-button\.danger \{[^}]*color: var\(--hv-on-selection-bar-danger\)/);
@@ -322,7 +310,7 @@ describe('hv-bulk-bar: the band belongs to the theme', () => {
   it('keeps the failure count and Cancel together at the trailing edge', async () => {
     const el = await mount({ progress: { done: 3, total: 4, failed: 1, label: 'Moving' } });
     expect(q(el, '[data-testid="bulk-progress-failed"]')?.className).toBe('failed');
-    expect(barCss()).toMatch(/\.progress \.spacer \{ margin-left: auto; \}/);
+    expect(componentCss('hv-bulk-bar')).toMatch(/\.progress \.spacer \{ margin-left: auto; \}/);
   });
 });
 

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1,8 +1,17 @@
 import './hv-card-shell';
-import { makeMockHass, makeItem, stubViewport } from '../test.utils';
+import { Store } from '../store/store';
+import {
+  componentCss,
+  makeItem,
+  makeMockHass,
+  mountComponent,
+  mountStore,
+  q,
+  settle,
+  stubViewport,
+} from '../test.utils';
 import { DISCARD_PROMPT } from '../ui/discard';
 import { base, tokens } from '../ui/tokens';
-import { Store } from '../store/store';
 import type { HVCardShell } from './hv-card-shell';
 import type { Item, Location } from '../store/types';
 
@@ -23,22 +32,16 @@ function loc(id: string, name: string, parentId: string | null = null): Location
 }
 
 async function mountShell(opts: { items?: Item[]; locations?: Location[]; mobile?: boolean } = {}) {
-  const hass = makeMockHass({ items: opts.items ?? [], locations: opts.locations ?? [] });
-  const store = new Store(hass, { retryBaseMs: 0 });
-  await store.init();
-
-  const el = document.createElement('hv-card-shell') as HVCardShell;
-  el.store = store;
-  el.forceMobile = opts.mobile ?? false;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return { el, store, hass, sr: el.shadowRoot as ShadowRoot };
+  const { hass, store } = await mountStore({
+    items: opts.items ?? [],
+    locations: opts.locations ?? [],
+  });
+  const { el, sr } = await mountComponent<HVCardShell>('hv-card-shell', {
+    store,
+    forceMobile: opts.mobile ?? false,
+  });
+  return { el, store, hass, sr };
 }
-
-const settle = async (el: HVCardShell) => {
-  await new Promise((r) => setTimeout(r, 0));
-  await el.updateComplete;
-};
 
 describe('hv-card-shell: header', () => {
   it('shows the configured heading and the live stat badges', async () => {
@@ -504,15 +507,15 @@ describe('hv-card-shell: search and filters', () => {
 
 describe('hv-card-shell: list and footer', () => {
   it('shows skeleton rows before the first list resolves', async () => {
-    const hass = makeMockHass({ items: [] });
-    const store = new Store(hass, { retryBaseMs: 0 });
-    const el = document.createElement('hv-card-shell') as HVCardShell;
-    el.store = store;
-    el.forceMobile = false;
-    document.body.appendChild(el);
-    await el.updateComplete;
+    // Deliberately not `mountStore`: the skeleton is what shows before the
+    // first list resolves, so this store must not be initialised.
+    const store = new Store(makeMockHass({ items: [] }), { retryBaseMs: 0 });
+    const { el } = await mountComponent<HVCardShell>('hv-card-shell', {
+      store,
+      forceMobile: false,
+    });
 
-    const list = el.shadowRoot?.querySelector('hv-list') as HTMLElement;
+    const list = q(el, 'hv-list')!;
     expect(list.shadowRoot?.querySelector('[data-testid="list-skeleton"]')).toBeTruthy();
   });
 
@@ -717,7 +720,7 @@ describe('hv-card-shell: banners', () => {
     // Re-apply deliberately calls updateItem with no expectedVersion: the whole
     // point is to land on top of whatever the other client wrote. Passing the
     // stale version here would make the retry fail exactly as the first attempt
-    // did, so the missing third argument is load-bearing.
+    // did, so the third argument has to stay absent.
     const { el, store, hass, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'A' })] });
     store['pushError'](
       { code: 'conflict', message: 'version conflict' },
@@ -762,27 +765,19 @@ describe('hv-card-shell: banners', () => {
 });
 
 describe('hv-card-shell: narrow header', () => {
-  const headerCss = () => {
-    const styles = (customElements.get('hv-card-shell') as typeof HVCardShell).styles;
-    return (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
-  };
-
   // The title is `flex: 1` among siblings that are all `flex: none`, so it
   // absorbed every pixel the badges and buttons needed: 40px for a 78px
   // heading at 375px, and 0px at 320px. jsdom cannot lay this out, so the
   // stylesheet is what gets asserted.
   it('wraps the badges onto their own row on a phone', () => {
-    const css = headerCss();
+    const css = componentCss('hv-card-shell');
     expect(css).toMatch(/:host\(\[mobile\]\) \.header \{ flex-wrap: wrap; \}/);
     expect(css).toMatch(/:host\(\[mobile\]\) \.badges \{[^}]*flex-basis: 100%/);
   });
 
   it('leaves the desktop header on one row', () => {
     // `.badges { margin-left: auto }` is what right-aligns them there.
-    expect(headerCss()).toMatch(/\.badges \{ display: flex; align-items: center; gap: 6px; margin-left: auto; \}/);
+    expect(componentCss('hv-card-shell')).toMatch(/\.badges \{ display: flex; align-items: center; gap: 6px; margin-left: auto; \}/);
   });
 
   it('renders no badge row at all when a phone has nothing to badge', async () => {
@@ -810,7 +805,7 @@ describe('hv-card-shell: narrow header', () => {
     expect(badge?.textContent?.trim()).toBe('1 checked out');
     // Three badges with large counts will not always make one line of a 320px
     // phone, and an unwrapped row pushes the last one off the side of the card.
-    expect(headerCss()).toMatch(/:host\(\[mobile\]\) \.badges \{[^}]*flex-wrap: wrap/);
+    expect(componentCss('hv-card-shell')).toMatch(/:host\(\[mobile\]\) \.badges \{[^}]*flex-wrap: wrap/);
   });
 
   it('counts a checked-out phone badge as reason enough to draw the row', async () => {
@@ -820,20 +815,12 @@ describe('hv-card-shell: narrow header', () => {
 });
 
 describe('hv-card-shell: touch targets', () => {
-  const shellCss = () => {
-    const styles = (customElements.get('hv-card-shell') as typeof HVCardShell).styles;
-    return (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
-  };
-
   // One declaration on the card host, inherited into every nested shadow root.
   // It only works because `--hv-tap-min` is absent from `tokens` — every
   // component redeclares those on its own `:host`, which would shadow an
   // inherited value at the first boundary.
   it('publishes a 44px target size to every nested component', () => {
-    expect(shellCss()).toMatch(/:host\(\[mobile\]\) \{[^}]*--hv-tap-min: 44px/);
+    expect(componentCss('hv-card-shell')).toMatch(/:host\(\[mobile\]\) \{[^}]*--hv-tap-min: 44px/);
   });
 
   it('does not declare the target size in the shared token block', () => {
@@ -846,26 +833,26 @@ describe('hv-card-shell: touch targets', () => {
   });
 
   it('sizes the header actions from it rather than hard-coding 36px', () => {
-    const css = shellCss();
+    const css = componentCss('hv-card-shell');
     expect(css).toMatch(/\.add\.round \{ width: var\(--hv-tap-min, 36px\)/);
     expect(css).toMatch(/\.header \.expand \{ width: var\(--hv-tap-min, 36px\)/);
     expect(css).toMatch(/:host\(\[mobile\]\) \.icon-toggle \{ width: var\(--hv-tap-min, 40px\)/);
   });
 
   it('gives the stat badges a tappable height on a phone', () => {
-    expect(shellCss()).toMatch(/:host\(\[mobile\]\) \.badge \{[^}]*min-height: var\(--hv-tap-min, auto\)/);
+    expect(componentCss('hv-card-shell')).toMatch(/:host\(\[mobile\]\) \.badge \{[^}]*min-height: var\(--hv-tap-min, auto\)/);
   });
 
   // iOS Safari zooms the page whenever a field under 16px takes focus, and does
   // not zoom back out. Every field on the card was 12.5–14.5px.
   it('publishes a 16px field size so iOS does not zoom on focus', () => {
-    expect(shellCss()).toMatch(/:host\(\[mobile\]\) \{[^}]*--hv-input-font: 16px/);
+    expect(componentCss('hv-card-shell')).toMatch(/:host\(\[mobile\]\) \{[^}]*--hv-input-font: 16px/);
     expect(String(tokens.cssText)).not.toMatch(/--hv-input-font/);
     expect(String(base.cssText)).toMatch(/\.hv-input \{[^}]*font: 400 var\(--hv-input-font, 13\.5px\)/);
   });
 
   it('keeps the card search field reading from it', () => {
-    expect(shellCss()).toMatch(/\.search input \{[^}]*font: 400 var\(--hv-input-font, 13\.5px\)/);
+    expect(componentCss('hv-card-shell')).toMatch(/\.search input \{[^}]*font: 400 var\(--hv-input-font, 13\.5px\)/);
   });
 });
 
@@ -1754,8 +1741,7 @@ describe('hv-card-shell: full view', () => {
     const expand = sr.querySelector('[data-testid="expand-toggle"]') as HTMLElement;
     expect(expand.classList.contains('expand')).toBe(true);
 
-    const styles = (customElements.get('hv-card-shell') as typeof HVCardShell).styles;
-    const cssText = (Array.isArray(styles) ? styles : [styles]).map((s) => String(s.cssText)).join('\n');
+    const cssText = componentCss('hv-card-shell');
     const rule = cssText.slice(cssText.indexOf('.header .expand'), cssText.indexOf('.search-row'));
     expect(rule).toMatch(/border:\s*1px solid/);
   });

--- a/cards/haventory-card/src/components/hv-checkout-popover.test.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.test.ts
@@ -1,22 +1,17 @@
 import './hv-checkout-popover';
-import { makeItem } from '../test.utils';
+import { all, componentCss, makeItem, mountComponent, q } from '../test.utils';
 import { addDays, formatDate } from '../ui/relative-time';
 import type { HVCheckoutPopover } from './hv-checkout-popover';
 import type { Item } from '../store/types';
 
 async function mount(item: Partial<Item> = {}, props: Partial<HVCheckoutPopover> = {}) {
-  const el = document.createElement('hv-checkout-popover') as HVCheckoutPopover;
-  el.item = makeItem(item);
-  el.open = true;
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVCheckoutPopover>('hv-checkout-popover', {
+    item: makeItem(item),
+    open: true,
+    ...props,
+  });
   return el;
 }
-
-const q = (el: HVCheckoutPopover, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-const all = (el: HVCheckoutPopover, sel: string) =>
-  [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
 
 describe('hv-checkout-popover: check-out', () => {
   it('renders nothing without an item or when closed', async () => {
@@ -223,19 +218,11 @@ describe('hv-checkout-popover: placement', () => {
 
 describe('hv-checkout-popover: where it draws and how big it is are separate asks', () => {
   /** jsdom lays out no shadow DOM, so the sizes are asserted on the stylesheet. */
-  const popoverCss = () => {
-    const styles = (customElements.get('hv-checkout-popover') as typeof HVCheckoutPopover).styles;
-    return (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
-  };
-
   // As one flag, a caller that could not draw the inline step could not ask for
   // finger-sized controls either — and the surfaces that open this as a centred
   // dialog on a phone are exactly that caller.
   it('hangs every thumb size on touch, and only the step itself on inline', () => {
-    const css = popoverCss();
+    const css = componentCss('hv-checkout-popover');
     for (const sel of ['.offset', '.custom input', '.date', '.actions', '.confirm', '.none-button']) {
       expect(css, sel).toContain(`:host([touch]) ${sel} {`);
     }

--- a/cards/haventory-card/src/components/hv-chip-input.test.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.test.ts
@@ -1,18 +1,15 @@
 import './hv-chip-input';
 import type { HVChipInput } from './hv-chip-input';
+import { all, mountComponent, q } from '../test.utils';
 
 async function mount(props: Partial<HVChipInput> = {}) {
-  const el = document.createElement('hv-chip-input') as HVChipInput;
-  el.values = [];
-  el.suggestions = [];
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVChipInput>('hv-chip-input', {
+    values: [],
+    suggestions: [],
+    ...props,
+  });
   return el;
 }
-
-const q = (el: HVChipInput, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-const all = (el: HVChipInput, sel: string) => [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
 
 function changes(el: HVChipInput) {
   const seen: string[][] = [];

--- a/cards/haventory-card/src/components/hv-column-picker.test.ts
+++ b/cards/haventory-card/src/components/hv-column-picker.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import './hv-column-picker';
 import type { ColumnKey } from '../store/columns';
 import type { HVColumnPicker } from './hv-column-picker';
+import { mountComponent } from '../test.utils';
 
 type Picker = HTMLElement & {
   open: boolean;
@@ -11,12 +12,7 @@ type Picker = HTMLElement & {
 };
 
 async function mount(props: Partial<Picker>): Promise<Picker> {
-  const el = document.createElement('hv-column-picker') as Picker;
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await customElements.whenDefined('hv-column-picker');
-  el.open = true;
-  if (el.updateComplete) await el.updateComplete;
+  const { el } = await mountComponent<Picker>('hv-column-picker', { ...props, open: true });
   return el;
 }
 

--- a/cards/haventory-card/src/components/hv-confirm.test.ts
+++ b/cards/haventory-card/src/components/hv-confirm.test.ts
@@ -1,11 +1,13 @@
 import './hv-confirm';
 import type { HVConfirm } from './hv-confirm';
+import { mountComponent } from '../test.utils';
 
 async function mount(props: Partial<HVConfirm> = {}) {
-  const el = document.createElement('hv-confirm') as HVConfirm;
-  Object.assign(el, { open: true, heading: 'Delete 42 items?', ...props });
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVConfirm>('hv-confirm', {
+    open: true,
+    heading: 'Delete 42 items?',
+    ...props,
+  });
   return el;
 }
 

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -1,5 +1,5 @@
 import './hv-data-table';
-import { makeItem } from '../test.utils';
+import { all, componentCss, makeItem, mountComponent, q } from '../test.utils';
 import { ACTIONS_COLUMN_WIDTH } from '../store/columns';
 import { rowMenuEntries } from './hv-list-row';
 import type { HVDataTable } from './hv-data-table';
@@ -7,26 +7,14 @@ import type { OverflowMenuEntry } from './hv-overflow-menu';
 import type { Item, Sort } from '../store/types';
 
 async function mount(items: Partial<Item>[], props: Partial<HVDataTable> = {}) {
-  const el = document.createElement('hv-data-table') as HVDataTable;
-  el.items = items.map((i) => makeItem(i));
-  el.columns = ['quantity', 'category', 'tags', 'due_date', 'updated_at'];
-  el.sort = { field: 'updated_at', order: 'desc' };
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVDataTable>('hv-data-table', {
+    items: items.map((i) => makeItem(i)),
+    columns: ['quantity', 'category', 'tags', 'due_date', 'updated_at'],
+    sort: { field: 'updated_at', order: 'desc' },
+    ...props,
+  });
   return el;
 }
-
-const q = (el: HVDataTable, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-const all = (el: HVDataTable, sel: string) => [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
-
-const tableCss = () => {
-  const styles = (customElements.get('hv-data-table') as typeof HVDataTable).styles;
-  return (Array.isArray(styles) ? styles : [styles])
-    .map((s) => String(s.cssText))
-    .join('\n')
-    .replace(/\s+/g, ' ');
-};
 
 describe('hv-data-table: area', () => {
   const AREAS = [{ id: 'area-kitchen', name: 'Kitchen' }];
@@ -173,7 +161,7 @@ describe('hv-data-table: a path too long for its column', () => {
   // item's only line, normal white-space processing drops them and the two
   // segments either side run together.
   it('wraps between segments rather than clipping at the cell edge', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     expect(css).toMatch(/\.cell\.path \{[^}]*flex-wrap: wrap/);
     expect(css).toMatch(/\.cell\.path > \.hv-chip-line-text \{[^}]*display: flex/);
     expect(css).toMatch(/\.cell\.path > \.hv-chip-line-text \{[^}]*flex-wrap: wrap/);
@@ -184,7 +172,7 @@ describe('hv-data-table: a path too long for its column', () => {
   // The last resort, for one segment wider than the whole column: an ellipsis
   // on the segment, never a hard cut — and the title above still has the truth.
   it('elides a single segment only once there is no break left to take', () => {
-    expect(tableCss()).toMatch(
+    expect(componentCss('hv-data-table')).toMatch(
       /\.hv-path-seg \{[^}]*min-width: 0;[^}]*overflow: hidden;[^}]*text-overflow: ellipsis/,
     );
   });
@@ -196,7 +184,7 @@ describe('hv-data-table: narrow screens', () => {
   // was clipped by the shell: rows measured clientWidth 634 / scrollWidth 854
   // at 375px, and three columns could not be reached by any gesture.
   it('scrolls sideways rather than clipping columns away', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     expect(css).toMatch(/:host \{[^}]*overflow-x: auto/);
     expect(css).toMatch(/:host \{[^}]*min-width: 0/);
   });
@@ -209,7 +197,7 @@ describe('hv-data-table: narrow screens', () => {
   // The host measured scrollWidth 874 against clientWidth 390 and never moved
   // off scrollLeft 0.
   it('contains the overscroll on the box that owns both axes', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     expect(css).toMatch(/:host \{[^}]*overscroll-behavior: contain/);
     expect(css).not.toMatch(/\.body \{[^}]*overscroll-behavior/);
   });
@@ -217,18 +205,18 @@ describe('hv-data-table: narrow screens', () => {
   it('sizes the header and body to the grid minimum so they scroll together', () => {
     // Left at the container width they would stay 375px wide while their
     // tracks painted past the edge, cutting the row dividers short.
-    expect(tableCss()).toMatch(/\.head, \.body \{ min-width: min-content; \}/);
+    expect(componentCss('hv-data-table')).toMatch(/\.head, \.body \{ min-width: min-content; \}/);
   });
 
   it('grows the checkbox hit area for touch without growing the box', () => {
     // 16px is right for a dense table; 16px of tappable area is not.
-    expect(tableCss()).toMatch(
+    expect(componentCss('hv-data-table')).toMatch(
       /\.box::after \{[^}]*inset: calc\(\(var\(--hv-tap-min, 16px\) - 16px\) \/ -2\)/,
     );
   });
 
   it('gives the sort headers a tappable height', () => {
-    expect(tableCss()).toMatch(/\.head button\.sort \{[^}]*min-height: var\(--hv-tap-min, auto\)/);
+    expect(componentCss('hv-data-table')).toMatch(/\.head button\.sort \{[^}]*min-height: var\(--hv-tap-min, auto\)/);
   });
 
   // jsdom computes no layout, so nothing here can watch a cell hold its place;
@@ -237,7 +225,7 @@ describe('hv-data-table: narrow screens', () => {
   // rows in a vertical scroll box of their own would pin `left` to a box that
   // never moves sideways — passing every offline check while doing nothing.
   it('scrolls both axes on one box, so a pinned cell has something to pin to', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     expect(css).toMatch(/:host \{[^}]*overflow-y: auto/);
     expect(css).not.toMatch(/\.body \{[^}]*overflow/);
     // Its own height rather than the leftover space, or it would stretch to the
@@ -246,7 +234,7 @@ describe('hv-data-table: narrow screens', () => {
   });
 
   it('holds the header against the top of that same box', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     expect(css).toMatch(/\.head \{[^}]*position: sticky/);
     expect(css).toMatch(/\.head \{[^}]*top: 0/);
     // Opaque, or the rows read through it as they pass underneath.
@@ -254,7 +242,7 @@ describe('hv-data-table: narrow screens', () => {
   });
 
   it('pins the name column and its header at the phone breakpoint', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     // The same width the full view drops its sidebar at.
     expect(css).toMatch(/@media \(max-width: 700px\) \{ \.name-head, \.name-cell, \.select-cell \{/);
     expect(css).toMatch(
@@ -275,7 +263,7 @@ describe('hv-data-table: narrow screens', () => {
     // an offset short of the track would leave the name over the checkboxes.
     // The gap between the two pinned cells travels with the name, or the
     // columns underneath show through it.
-    expect(tableCss()).toMatch(
+    expect(componentCss('hv-data-table')).toMatch(
       /:host\(\[selectable\]\) \.name-head, :host\(\[selectable\]\) \.name-cell \{ left: calc\(var\(--hv-table-pad-x\) \+ 40px\); margin-left: calc\(-1 \* var\(--hv-table-gap\)\); padding-left: var\(--hv-table-gap\)/,
     );
   });
@@ -283,7 +271,7 @@ describe('hv-data-table: narrow screens', () => {
   // The wash is painted on the row, which the pinned cells cover; a colour
   // would not do, because the dark half of the wash is translucent.
   it('repaints the row wash on the pinned cells', () => {
-    expect(tableCss()).toMatch(
+    expect(componentCss('hv-data-table')).toMatch(
       /\.row:hover \.name-cell,[^{]*\.row\.selected \.select-cell \{ background-image: linear-gradient\(var\(--hv-row-hover\), var\(--hv-row-hover\)\)/,
     );
   });
@@ -292,7 +280,7 @@ describe('hv-data-table: narrow screens', () => {
   // cover rides with the content and the shade with the box, so the shade shows
   // exactly while there is something further right.
   it('fades the edge it can still be scrolled towards', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     expect(css).toMatch(
       /:host \{ background: linear-gradient\(var\(--hv-surface\), var\(--hv-surface\)\) right \/ 28px 100% no-repeat local/,
     );
@@ -347,7 +335,7 @@ describe('hv-data-table: columns', () => {
     // Every tag, whole: no cut-off set and no "+N" standing in for one.
     expect(chips.map((c) => c.textContent?.trim())).toEqual(tags.map((t) => `#${t}`));
 
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     expect(css).toMatch(/\.tags \{[^}]*flex-wrap: wrap/);
     expect(css).not.toMatch(/\.tags \{[^}]*overflow: hidden/);
   });
@@ -446,7 +434,7 @@ describe('hv-data-table: the name cell picks one chip', () => {
   });
 
   it('keeps the name itself the only part of the cell that gives way', () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     // The cell shares its shrink rule with the two other pinned cells.
     expect(css).toMatch(/\.name-cell,[^{]*\{[^}]*min-width: 0/);
     expect(/\.name \{([^}]*)\}/.exec(css)?.[1]).toContain('text-overflow: ellipsis');
@@ -865,7 +853,7 @@ describe('hv-data-table: selection mode', () => {
   });
 
   it('keeps the sort-header reset off the header checkbox', async () => {
-    const css = tableCss();
+    const css = componentCss('hv-data-table');
     // Unscoped, this rule matches every button in the header — the select-all
     // included — and its 0-1-1 beats `.box`, so the unchecked box paints
     // neither border nor fill and the target is invisible until it is used.
@@ -950,8 +938,8 @@ describe('hv-data-table: row menu', () => {
   it('rides the same hover reveal as the rest of the actions cell', async () => {
     const el = await mount([{ id: '1' }]);
     expect(menu(el).closest('.actions')).toBeTruthy();
-    expect(tableCss()).toMatch(/\.actions \{[^}]*visibility: hidden/);
-    expect(tableCss()).toMatch(/\.row:hover \.actions, \.row:focus-within \.actions \{ visibility: visible/);
+    expect(componentCss('hv-data-table')).toMatch(/\.actions \{[^}]*visibility: hidden/);
+    expect(componentCss('hv-data-table')).toMatch(/\.row:hover \.actions, \.row:focus-within \.actions \{ visibility: visible/);
   });
 
   // 26px outlined here against 30px borderless on the card's rows: two answers
@@ -960,8 +948,8 @@ describe('hv-data-table: row menu', () => {
   it('draws Edit the way the card rows draw it', async () => {
     const el = await mount([{ id: '1' }]);
     expect(q(el, '[data-testid="table-edit"]')?.classList.contains('plain')).toBe(true);
-    expect(tableCss()).toMatch(/\.actions button\.plain \{[^}]*width: 30px/);
-    expect(tableCss()).toMatch(/\.actions button\.plain \{[^}]*border: none/);
+    expect(componentCss('hv-data-table')).toMatch(/\.actions button\.plain \{[^}]*width: 30px/);
+    expect(componentCss('hv-data-table')).toMatch(/\.actions button\.plain \{[^}]*border: none/);
   });
 
   // Fixed-width circles in a fixed track: too narrow and they come out as ovals.
@@ -989,7 +977,7 @@ describe('hv-data-table: row menu', () => {
 
 describe('hv-data-table: the row is a target', () => {
   it('shows the hand on a body row and not on the header', () => {
-    expect(tableCss()).toMatch(/\.row \{[^}]*cursor: pointer/);
-    expect(tableCss()).not.toMatch(/\.head \{[^}]*cursor: pointer/);
+    expect(componentCss('hv-data-table')).toMatch(/\.row \{[^}]*cursor: pointer/);
+    expect(componentCss('hv-data-table')).not.toMatch(/\.head \{[^}]*cursor: pointer/);
   });
 });

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -1,5 +1,15 @@
 import './hv-detail-sheet';
-import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
+import {
+  all,
+  componentCss,
+  makeAttachment,
+  makeItem,
+  makeManual,
+  makeMediaBindings,
+  mountComponent,
+  q,
+  settle as settleEl,
+} from '../test.utils';
 import { DISCARD_PROMPT } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import type { HVDetailSheet } from './hv-detail-sheet';
@@ -7,17 +17,13 @@ import type { HVBottomSheet } from './hv-bottom-sheet';
 import type { Item } from '../store/types';
 
 async function mount(item: Partial<Item>, props: Partial<HVDetailSheet> = {}) {
-  const el = document.createElement('hv-detail-sheet') as HVDetailSheet;
-  el.item = makeItem(item);
-  el.open = true;
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await el.updateComplete;
+  const { el } = await mountComponent<HVDetailSheet>(
+    'hv-detail-sheet',
+    { item: makeItem(item), open: true, ...props },
+    { renders: 2 },
+  );
   return el;
 }
-
-const q = (el: HVDetailSheet, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
 
 /**
  * The lightbox is a component of its own — shared with the edit form on every
@@ -25,27 +31,17 @@ const q = (el: HVDetailSheet, sel: string) => el.shadowRoot?.querySelector(sel) 
  */
 const lightbox = (el: HVDetailSheet, sel = '[data-testid="lightbox"]') =>
   (q(el, 'hv-lightbox')?.shadowRoot?.querySelector(sel) ?? null) as HTMLElement | null;
-const all = (el: HVDetailSheet, sel: string) =>
-  [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
-
 /**
- * A host's own update does not carry its children's, and the lightbox is a
- * child now — so anything that opens or moves it needs its update too.
+ * A host's own update does not carry its children's, and the sheet renders the
+ * lightbox as a child — so anything that opens or moves it needs the child's
+ * update too.
  */
 const settle = async (el: HVDetailSheet) => {
-  await el.updateComplete;
-  await (q(el, 'hv-lightbox') as (HTMLElement & { updateComplete?: Promise<unknown> }) | null)?.updateComplete;
+  await settleEl(el);
+  await q<HTMLElement & { updateComplete?: Promise<unknown> }>(el, 'hv-lightbox')?.updateComplete;
 };
 
 /** jsdom lays out no shadow DOM, so type sizes are asserted on the sheet. */
-const sheetCss = () => {
-  const styles = (customElements.get('hv-detail-sheet') as typeof HVDetailSheet).styles;
-  return (Array.isArray(styles) ? styles : [styles])
-    .map((s) => String(s.cssText))
-    .join('\n')
-    .replace(/\s+/g, ' ');
-};
-
 function captured(el: HVDetailSheet, names: string[]) {
   const seen: string[] = [];
   for (const name of names) el.addEventListener(name, () => seen.push(name));
@@ -185,7 +181,7 @@ describe('hv-detail-sheet: read view', () => {
   // path at 12.5px was the smallest text on the sheet, while the quantity at
   // 34px was half again bigger than the item's own name.
   it('sizes the path and the quantity off one scale', () => {
-    const css = sheetCss();
+    const css = componentCss('hv-detail-sheet');
     const size = (selector: string) => {
       const rule = new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
       return Number(/font-size: ([\d.]+)px/.exec(rule)?.[1]);
@@ -1083,7 +1079,7 @@ describe('hv-detail-sheet: documents', () => {
   // to the widest row, whose tail (the Open link, the "File missing" chip) does
   // not shrink, and `overflow: hidden` clips exactly those two away.
   it('sizes the documents track off the list rather than off its widest row', () => {
-    const css = sheetCss();
+    const css = componentCss('hv-detail-sheet');
     const rule = (selector: string) =>
       new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
 
@@ -1094,7 +1090,7 @@ describe('hv-detail-sheet: documents', () => {
   // The row shrinking into its track is only worth anything if the two elements
   // it was cutting off are the ones that keep their size.
   it('leaves the Open link and the missing-file chip unshrinkable', () => {
-    const css = sheetCss();
+    const css = componentCss('hv-detail-sheet');
     const rule = (selector: string) =>
       new RegExp(`${selector} \\{([^}]*)\\}`).exec(css)?.[1] ?? '';
 

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
@@ -1,6 +1,7 @@
 import './hv-diagnostics-panel';
 import type { HVDiagnosticsPanel } from './hv-diagnostics-panel';
 import type { DegradedState, HealthResult, StatsCounts } from '../store/types';
+import { all, componentCss, mountComponent, q } from '../test.utils';
 
 const counts: StatsCounts = {
   items_total: 250,
@@ -33,23 +34,18 @@ const NO_DEGRADATION: DegradedState = {
 };
 
 async function mount(props: Partial<HVDiagnosticsPanel> = {}) {
-  const el = document.createElement('hv-diagnostics-panel') as HVDiagnosticsPanel;
-  el.open = true;
-  el.health = health();
-  el.counts = counts;
-  el.version = { integration_version: '0.0.1', schema_version: 4 };
-  el.degraded = { ...NO_DEGRADATION };
-  el.connected = { items: true, stats: true };
-  el.loadedItems = 50;
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVDiagnosticsPanel>('hv-diagnostics-panel', {
+    open: true,
+    health: health(),
+    counts,
+    version: { integration_version: '0.0.1', schema_version: 4 },
+    degraded: { ...NO_DEGRADATION },
+    connected: { items: true, stats: true },
+    loadedItems: 50,
+    ...props,
+  });
   return el;
 }
-
-const q = (el: HVDiagnosticsPanel, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-const all = (el: HVDiagnosticsPanel, sel: string) =>
-  [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
 
 describe('hv-diagnostics-panel: healthy', () => {
   it('collapses to one green line when there is nothing to report', async () => {
@@ -125,11 +121,7 @@ describe('hv-diagnostics-panel: not live', () => {
 describe('hv-diagnostics-panel: fits the screen', () => {
   /** jsdom lays out no shadow DOM, so sizing rules are asserted on the sheet. */
   const css = () => {
-    const styles = (customElements.get('hv-diagnostics-panel') as typeof HVDiagnosticsPanel).styles;
-    return (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    return componentCss('hv-diagnostics-panel');
   };
 
   // The centring grid's implicit track was auto-sized, so it took the panel's

--- a/cards/haventory-card/src/components/hv-filter-chips.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.test.ts
@@ -3,6 +3,7 @@ import './hv-filter-chips';
 import { chipsFor, clearedValueFor } from './hv-filter-chips';
 import { defaultFilters } from '../store/store';
 import type { Location, StatusDefinition, StoreFilters } from '../store/types';
+import { mountComponent } from '../test.utils';
 
 type Chips = HTMLElement & {
   filters: StoreFilters;
@@ -30,11 +31,7 @@ const nested = (areaId: string | null): Location[] => [
 ];
 
 async function mount(props: Partial<Chips>): Promise<Chips> {
-  const el = document.createElement('hv-filter-chips') as Chips;
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await customElements.whenDefined('hv-filter-chips');
-  if (el.updateComplete) await el.updateComplete;
+  const { el } = await mountComponent<Chips>('hv-filter-chips', props);
   return el;
 }
 

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -2,6 +2,7 @@ import './hv-filter-panel';
 import type { HVFilterPanel } from './hv-filter-panel';
 import { defaultFilters } from '../store/store';
 import type { DistinctValues, Location, LocationTreeNode, StatusDefinition, StoreFilters } from '../store/types';
+import { all, componentCss, mountComponent, q } from '../test.utils';
 
 const distinct: DistinctValues = {
   categories: [
@@ -49,14 +50,13 @@ const tree: LocationTreeNode[] = [
 ];
 
 async function mount(filters: Partial<StoreFilters> = {}, props: Partial<HVFilterPanel> = {}) {
-  const el = document.createElement('hv-filter-panel') as HVFilterPanel;
-  el.filters = { ...defaultFilters(), ...filters };
-  el.distinct = distinct;
-  el.locationTree = tree;
-  el.areas = [{ id: 'area-garage', name: 'Garage' }];
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVFilterPanel>('hv-filter-panel', {
+    filters: { ...defaultFilters(), ...filters },
+    distinct,
+    locationTree: tree,
+    areas: [{ id: 'area-garage', name: 'Garage' }],
+    ...props,
+  });
   return el;
 }
 
@@ -66,10 +66,8 @@ function changes(el: HVFilterPanel) {
   return seen;
 }
 
-const q = (el: HVFilterPanel, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement;
-const all = (el: HVFilterPanel, sel: string) => [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
 const label = (el: HVFilterPanel, testid: string) =>
-  (q(el, `[data-testid="${testid}"]`).textContent ?? '').replace(/\s+/g, ' ').trim();
+  (q(el, `[data-testid="${testid}"]`)!.textContent ?? '').replace(/\s+/g, ' ').trim();
 
 /** The flat cache behind `tree`, where only the root carries the area. */
 const nestedLocations = (areaId: string | null): Location[] => [
@@ -103,7 +101,7 @@ describe('hv-filter-panel: category', () => {
       'Consumables',
       'Adhesives',
     ]);
-    const more = q(el, '[data-testid="filter-category-more"]');
+    const more = q(el, '[data-testid="filter-category-more"]')!;
     expect(more.textContent).toContain('1');
 
     more.click();
@@ -115,8 +113,8 @@ describe('hv-filter-panel: category', () => {
   // a value used as both a category and a tag appears in each of them.
   it('tells a category chip from a tag chip without the group heading', async () => {
     const el = await mount();
-    const category = q(el, '[data-testid="filter-category"]');
-    const tag = q(el, '[data-testid="filter-tag"]');
+    const category = q(el, '[data-testid="filter-category"]')!;
+    const tag = q(el, '[data-testid="filter-tag"]')!;
 
     expect(tag.classList.contains('tag')).toBe(true);
     expect(category.classList.contains('tag')).toBe(false);
@@ -133,7 +131,7 @@ describe('hv-filter-panel: category', () => {
     const el = await mount();
     el.filters = { ...el.filters, tags: ['metric'] };
     await el.updateComplete;
-    const tag = q(el, '[data-testid="filter-tag"][data-value="metric"]');
+    const tag = q(el, '[data-testid="filter-tag"][data-value="metric"]')!;
 
     expect(tag.getAttribute('aria-pressed')).toBe('true');
     expect(tag.querySelector('svg')).toBeTruthy();
@@ -234,11 +232,11 @@ describe('hv-filter-panel: status', () => {
   // "OK" is not a state worth marking.
   it('fills a selected status with its own tone and leaves the default plain', async () => {
     const el = await mount({ status: 'needs_repair' });
-    const chip = q(el, '[data-testid="filter-status"][data-value="needs_repair"]');
+    const chip = q(el, '[data-testid="filter-status"][data-value="needs_repair"]')!;
     expect(chip.classList.contains('on')).toBe(true);
     expect(chip.classList.contains('tone-amber')).toBe(true);
     expect(
-      q(el, '[data-testid="filter-status"][data-value="ok"]').classList.contains('tone-green'),
+      q(el, '[data-testid="filter-status"][data-value="ok"]')!.classList.contains('tone-green'),
     ).toBe(false);
   });
 
@@ -252,11 +250,11 @@ describe('hv-filter-panel: status', () => {
     const on = q(
       await mount({ status: 'sold' }, { statuses }),
       '[data-testid="filter-status"][data-value="sold"]',
-    );
+    )!;
     expect(on.style.getPropertyValue('--hv-status-bg')).toBe('#2f6f4f');
     expect(on.style.getPropertyValue('--hv-status-fg')).toBe('#ffffff');
 
-    const off = q(await mount({}, { statuses }), '[data-testid="filter-status"][data-value="sold"]');
+    const off = q(await mount({}, { statuses }), '[data-testid="filter-status"][data-value="sold"]')!;
     expect(off.getAttribute('style')).toBeNull();
   });
 });
@@ -296,7 +294,7 @@ describe('hv-filter-panel: tags', () => {
   it('lowercases a typed tag on commit, matching how the backend stores it', async () => {
     const el = await mount();
     const seen = changes(el);
-    const input = q(el, '[data-testid="filter-tag-add"]').querySelector('input') as HTMLInputElement;
+    const input = q(el, '[data-testid="filter-tag-add"]')!.querySelector('input') as HTMLInputElement;
 
     input.value = '  Metric-Fine  ';
     input.dispatchEvent(new Event('input'));
@@ -308,7 +306,7 @@ describe('hv-filter-panel: tags', () => {
   it('ignores a duplicate or empty typed tag', async () => {
     const el = await mount({ tags: ['metric'] });
     const seen = changes(el);
-    const input = q(el, '[data-testid="filter-tag-add"]').querySelector('input') as HTMLInputElement;
+    const input = q(el, '[data-testid="filter-tag-add"]')!.querySelector('input') as HTMLInputElement;
 
     input.value = 'metric';
     input.dispatchEvent(new Event('input'));
@@ -331,7 +329,7 @@ describe('hv-filter-panel: tags', () => {
   // directly above an unrelated row, so what it applied to was anyone's guess.
   it('keeps the any/all toggle beside its own heading', async () => {
     const el = await mount();
-    const segmented = q(el, '[data-testid="filter-tags-mode"]').parentElement as HTMLElement;
+    const segmented = q(el, '[data-testid="filter-tags-mode"]')!.parentElement as HTMLElement;
 
     expect(segmented.style.marginLeft).toBe('');
     // Immediately after the heading it qualifies, in the same head row.
@@ -380,7 +378,7 @@ describe('hv-filter-panel: show only vs sort', () => {
       },
     );
     const tallyOf = (testid: string) =>
-      q(el, `[data-testid="${testid}"]`).querySelector('.hv-tally')?.textContent?.trim();
+      q(el, `[data-testid="${testid}"]`)!.querySelector('.hv-tally')?.textContent?.trim();
 
     expect(tallyOf('filter-low-stock-only')).toBe('102');
     expect(tallyOf('filter-checked-out')).toBe('82');
@@ -390,7 +388,7 @@ describe('hv-filter-panel: show only vs sort', () => {
 
   it('prints no tally at all when the counts have not arrived', async () => {
     const el = await mount();
-    expect(q(el, '[data-testid="filter-low-stock-only"]').querySelector('.hv-tally')).toBe(null);
+    expect(q(el, '[data-testid="filter-low-stock-only"]')!.querySelector('.hv-tally')).toBe(null);
   });
 
   it('carries the same tallies into the phone layout', async () => {
@@ -408,13 +406,13 @@ describe('hv-filter-panel: show only vs sort', () => {
         },
       },
     );
-    expect(q(el, '[data-testid="filter-overdue"]').textContent).toContain('1');
-    expect(q(el, '[data-testid="filter-orphans"]').textContent).toContain('2');
+    expect(q(el, '[data-testid="filter-overdue"]')!.textContent).toContain('1');
+    expect(q(el, '[data-testid="filter-orphans"]')!.textContent).toContain('2');
   });
 
   it('offers every sort field the backend supports', async () => {
     const el = await mount();
-    const options = [...q(el, '[data-testid="filter-sort-field"]').querySelectorAll('option')].map(
+    const options = [...q(el, '[data-testid="filter-sort-field"]')!.querySelectorAll('option')].map(
       (o) => (o as HTMLOptionElement).value,
     );
     expect(options).toEqual([
@@ -430,11 +428,11 @@ describe('hv-filter-panel: show only vs sort', () => {
 
   it('labels the direction for the field being sorted', async () => {
     const el = await mount();
-    expect(q(el, '[data-order="desc"]').textContent?.trim()).toBe('Newest');
+    expect(q(el, '[data-order="desc"]')!.textContent?.trim()).toBe('Newest');
 
     el.filters = { ...el.filters, sort: { field: 'name', order: 'asc' } };
     await el.updateComplete;
-    expect(q(el, '[data-order="desc"]').textContent?.trim()).toBe('Descending');
+    expect(q(el, '[data-order="desc"]')!.textContent?.trim()).toBe('Descending');
   });
 
   it('changes sort direction without changing the field', async () => {
@@ -449,7 +447,7 @@ describe('hv-filter-panel: dates and location', () => {
   it('turns a date input into the ISO instant the backend compares against', async () => {
     const el = await mount();
     const seen = changes(el);
-    const input = q(el, '[data-testid="filter-updated-date"]').querySelector(
+    const input = q(el, '[data-testid="filter-updated-date"]')!.querySelector(
       'input',
     ) as HTMLInputElement;
 
@@ -559,7 +557,7 @@ describe('hv-filter-panel: dates and location', () => {
         ],
       },
     );
-    expect(q(el, '[data-testid="filter-location"]').textContent).toContain('Garage › Shelf A');
+    expect(q(el, '[data-testid="filter-location"]')!.textContent).toContain('Garage › Shelf A');
   });
 
   it('names the area the picked location inherits, matching the chip row wording', async () => {
@@ -594,8 +592,8 @@ describe('hv-filter-panel: dates and location', () => {
 describe('hv-filter-panel: footer and staging', () => {
   it('summarises how many filters are on and how many items match', async () => {
     const el = await mount({ categories: ['Hardware'], checkedOutOnly: true }, { total: 38, grandTotal: 250 });
-    expect(q(el, '[data-testid="filter-summary"]').textContent).toContain('2 filters active');
-    expect(q(el, '[data-testid="filter-summary"]').textContent).toContain('38 of 250 match');
+    expect(q(el, '[data-testid="filter-summary"]')!.textContent).toContain('2 filters active');
+    expect(q(el, '[data-testid="filter-summary"]')!.textContent).toContain('38 of 250 match');
   });
 
   it('hides the footer on mobile, where the sheet owns those controls', async () => {
@@ -685,8 +683,7 @@ describe('hv-filter-panel: native control affordances', () => {
   // The sort field draws its own chevron next to the <select>. Without
   // resetting the UA appearance the browser draws a second one beside it.
   it('suppresses the browser-drawn arrow on selects it decorates itself', () => {
-    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
-    const cssText = (Array.isArray(sheet) ? sheet : [sheet]).map((s) => String(s.cssText)).join('\n');
+    const cssText = componentCss('hv-filter-panel');
     const selectRule = cssText.slice(cssText.indexOf('.field select'));
     expect(selectRule).toContain('appearance: none');
   });
@@ -696,13 +693,12 @@ describe('hv-filter-panel: native control affordances', () => {
   it('lets the select own the whole field, chevron included', async () => {
     const el = await mount();
     for (const testid of ['filter-sort-field', 'filter-area']) {
-      const field = q(el, `[data-testid="${testid}"]`);
+      const field = q(el, `[data-testid="${testid}"]`)!;
       expect(field.classList.contains('select-field')).toBe(true);
       expect(field.querySelector('.chevron')).not.toBe(null);
     }
 
-    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
-    const cssText = (Array.isArray(sheet) ? sheet : [sheet]).map((s) => String(s.cssText)).join('\n');
+    const cssText = componentCss('hv-filter-panel');
     const chevronRule = cssText.slice(cssText.indexOf('.field .chevron'));
     expect(chevronRule).toContain('pointer-events: none');
   });
@@ -711,11 +707,7 @@ describe('hv-filter-panel: native control affordances', () => {
   // hover wash: the only clue it could be pressed arrived after the pointer was
   // already on it, and a touch screen never provided that clue at all.
   it('draws the comparison flip as a control at rest, not only on hover', () => {
-    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
-    const cssText = (Array.isArray(sheet) ? sheet : [sheet])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const cssText = componentCss('hv-filter-panel');
 
     const rule = /\.field \.direction \{([^}]*)\}/.exec(cssText)?.[1] ?? '';
     expect(rule, 'no .field .direction rule').not.toBe('');
@@ -731,11 +723,7 @@ describe('hv-filter-panel: native control affordances', () => {
   // control in the panel — was the largest text on the page. Desktop has always
   // matched its chips at 12.5px.
   it('sizes its fields like the chips beside them, in both layouts', () => {
-    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
-    const css = (Array.isArray(sheet) ? sheet : [sheet])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-filter-panel');
 
     // The selector is matched as a literal, so every regex metacharacter in it
     // has to reach the pattern escaped — the backslash included, or an escape
@@ -767,8 +755,8 @@ describe('hv-filter-panel: changed', () => {
         .map((s) => s.textContent?.trim())
         .join(' ');
 
-    expect(visibleText(q(el, '[data-testid="filter-updated-date"]'))).toMatch(/updated/i);
-    expect(visibleText(q(el, '[data-testid="filter-created-date"]'))).toMatch(/created/i);
+    expect(visibleText(q(el, '[data-testid="filter-updated-date"]')!)).toMatch(/updated/i);
+    expect(visibleText(q(el, '[data-testid="filter-created-date"]')!)).toMatch(/created/i);
   });
 
   it('keeps the two date inputs wired to their own filter keys', async () => {
@@ -846,7 +834,7 @@ describe('hv-filter-panel: inspection due', () => {
   // so it has to carry the same forward-looking wording as the editor.
   it('names the inspection sort field for the date it holds', async () => {
     const el = await mount();
-    const labels = [...q(el, '[data-testid="filter-sort-field"]').querySelectorAll('option')].map(
+    const labels = [...q(el, '[data-testid="filter-sort-field"]')!.querySelectorAll('option')].map(
       (o) => (o as HTMLOptionElement).textContent?.trim(),
     );
     expect(labels).toContain('Next inspection');
@@ -870,7 +858,7 @@ describe('hv-filter-panel: inspection due', () => {
           },
         },
       );
-      const chip = q(el, '[data-testid="filter-inspection-due"]');
+      const chip = q(el, '[data-testid="filter-inspection-due"]')!;
       expect(chip.textContent, `mobile=${mobile}`).toContain('Inspection due');
       expect(chip.textContent, `mobile=${mobile}`).toContain('5');
 
@@ -921,14 +909,14 @@ describe('hv-filter-panel: pressed state', () => {
       for (const chip of STATEFUL_CHIPS) {
         const off = await mount({}, { mobile });
         expect(
-          q(off, chip.sel).getAttribute('aria-pressed'),
+          q(off, chip.sel)!.getAttribute('aria-pressed'),
           `${chip.name} off, mobile=${mobile}`,
         ).toBe('false');
         off.remove();
 
         const on = await mount(chip.on, { mobile });
         expect(
-          q(on, chip.sel).getAttribute('aria-pressed'),
+          q(on, chip.sel)!.getAttribute('aria-pressed'),
           `${chip.name} on, mobile=${mobile}`,
         ).toBe('true');
         on.remove();
@@ -970,7 +958,7 @@ describe('hv-filter-panel: pressed state', () => {
     for (const mobile of [false, true]) {
       const el = await mount({ lowStockOnly: true, includeSubtree: true, lowStockFirst: true }, { mobile });
       for (const testid of ROWS) {
-        const row = q(el, `[data-testid="${testid}"]`);
+        const row = q(el, `[data-testid="${testid}"]`)!;
         // "Low stock" is a chip on a desktop and a row in the sheet; the other
         // two are rows at both widths.
         if (!mobile && testid === 'filter-low-stock-only') continue;
@@ -989,7 +977,7 @@ describe('hv-filter-panel: pressed state', () => {
   // with `on`.
   it('tints a warning chip when it is selected, never at rest', async () => {
     const el = await mount({}, { mobile: true });
-    const chipOf = (testid: string) => q(el, `[data-testid="${testid}"]`);
+    const chipOf = (testid: string) => q(el, `[data-testid="${testid}"]`)!;
 
     for (const testid of ['filter-low-stock-only', 'filter-overdue', 'filter-inspection-due']) {
       expect(chipOf(testid).classList.contains('warning'), testid).toBe(false);
@@ -1005,11 +993,7 @@ describe('hv-filter-panel: pressed state', () => {
   // The row's on state has to be the shared chip's on state, not a second set
   // of colours that happens to look similar.
   it('takes its on state from the shared chip rule, warning variant included', () => {
-    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
-    const css = (Array.isArray(sheet) ? sheet : [sheet])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-filter-panel');
 
     expect(css).toMatch(/\.hv-chip\.toggle\.on \{[^}]*background: var\(--hv-primary-tint\)/);
     expect(css).toMatch(/\.hv-chip\.toggle\.warning\.on \{[^}]*background: var\(--hv-warn-bg\)/);
@@ -1021,25 +1005,21 @@ describe('hv-filter-panel: pressed state', () => {
 
   it('reserves the mark so a row keeps its label in place as it is pressed', async () => {
     const el = await mount({}, { mobile: true });
-    const row = q(el, '[data-testid="filter-low-stock-only"]');
+    const row = q(el, '[data-testid="filter-low-stock-only"]')!;
     expect(row.getAttribute('aria-pressed')).toBe('false');
     expect(row.querySelector('.mark'), 'off rows still hold the slot open').toBeTruthy();
 
     const el2 = await mount({ lowStockOnly: true }, { mobile: true });
-    expect(q(el2, '[data-testid="filter-low-stock-only"]').querySelector('.mark svg')).toBeTruthy();
+    expect(q(el2, '[data-testid="filter-low-stock-only"]')!.querySelector('.mark svg')).toBeTruthy();
 
-    const sheet = (customElements.get('hv-filter-panel') as typeof HVFilterPanel).styles;
-    const css = (Array.isArray(sheet) ? sheet : [sheet])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-filter-panel');
     expect(css).toMatch(/\.check \.mark \{[^}]*width: 12px/);
     expect(css).toMatch(/:host\(\[mobile\]\) \.check \.mark \{[^}]*width: 15px/);
   });
 
   it('flips as the filter is applied, not only on mount', async () => {
     const el = await mount();
-    const chip = () => q(el, '[data-testid="filter-overdue"]');
+    const chip = () => q(el, '[data-testid="filter-overdue"]')!;
     expect(chip().getAttribute('aria-pressed')).toBe('false');
 
     (chip() as HTMLButtonElement).click();
@@ -1052,7 +1032,7 @@ describe('hv-filter-panel: pressed state', () => {
   it('presses a selected tag no item currently carries', async () => {
     const el = await mount({ tags: ['nobody-uses-this'] });
     expect(
-      q(el, '[data-testid="filter-tag"][data-value="nobody-uses-this"]').getAttribute(
+      q(el, '[data-testid="filter-tag"][data-value="nobody-uses-this"]')!.getAttribute(
         'aria-pressed',
       ),
     ).toBe('true');
@@ -1062,7 +1042,7 @@ describe('hv-filter-panel: pressed state', () => {
     for (const mobile of [false, true]) {
       const fresh = await mount({}, { mobile });
       const state = (el: HVFilterPanel, testid: string) =>
-        q(el, `[data-testid="${testid}"]`).getAttribute('aria-pressed');
+        q(el, `[data-testid="${testid}"]`)!.getAttribute('aria-pressed');
 
       // Sub-locations are included by default; low-stock-first is not.
       expect(state(fresh, 'filter-include-subtree'), `mobile=${mobile}`).toBe('true');

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,9 +1,8 @@
 import './hv-full-view';
-import { makeMockHass, makeItem, stubViewport } from '../test.utils';
+import { componentCss, makeItem, mountComponent, mountStore, q, settle, stubViewport } from '../test.utils';
 import { deepActiveElement } from '../ui/dialog-focus';
 import { DISCARD_PROMPT } from '../ui/discard';
 import { NARROW_QUERY } from '../ui/responsive';
-import { Store } from '../store/store';
 import type { HVFullView } from './hv-full-view';
 import type { Item, Location, StatusDefinition } from '../store/types';
 
@@ -33,48 +32,32 @@ async function mount(
     narrow?: boolean;
   } = {},
 ) {
-  const hass = makeMockHass({
+  const { hass, store } = await mountStore({
     items: opts.items ?? [],
     locations: opts.locations ?? [],
     areas: opts.areas ?? [],
     ...(opts.statuses ? { statuses: opts.statuses } : {}),
   });
-  const store = new Store(hass, { retryBaseMs: 0 });
-  await store.init();
-
-  const el = document.createElement('hv-full-view') as HVFullView;
-  el.store = store;
-  el.columns = ['quantity', 'category'];
-  if (opts.embedded) el.embedded = true;
-  if (opts.narrow) el.narrow = true;
-  el.open = true;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await el.updateComplete;
-  return { el, store, hass, sr: el.shadowRoot as ShadowRoot };
+  const { el, sr } = await mountComponent<HVFullView>(
+    'hv-full-view',
+    {
+      store,
+      columns: ['quantity', 'category'],
+      ...(opts.embedded ? { embedded: true } : {}),
+      ...(opts.narrow ? { narrow: true } : {}),
+      open: true,
+    },
+    { renders: 2 },
+  );
+  return { el, store, hass, sr };
 }
 
-const settle = async (el: HVFullView) => {
-  await new Promise((r) => setTimeout(r, 0));
-  await el.updateComplete;
-};
-
-const q = (sr: ShadowRoot, sel: string) => sr.querySelector(sel) as HTMLElement | null;
-
 /** jsdom lays out no shadow DOM, so layout rules are asserted on the stylesheet. */
-const fullCss = () => {
-  const styles = (customElements.get('hv-full-view') as typeof HVFullView).styles;
-  return (Array.isArray(styles) ? styles : [styles])
-    .map((s) => String(s.cssText))
-    .join('\n')
-    .replace(/\s+/g, ' ');
-};
-
 describe('hv-full-view: phone-width app bar', () => {
   // Everything responsive in this component lives in one media query, because
   // the surface is fixed to the viewport rather than sized by the card.
   const narrow = () => {
-    const css = fullCss();
+    const css = componentCss('hv-full-view');
     const start = css.indexOf('@media (max-width: 700px)');
     expect(start, 'no narrow-viewport block').toBeGreaterThan(-1);
     return css.slice(start);
@@ -90,7 +73,7 @@ describe('hv-full-view: phone-width app bar', () => {
     // `flex: 1` alone leaves min-width at auto, so the field refuses to
     // compress below its content and shoves its siblings off the bar. The
     // desktop block puts a floor back under it — see the wide-bar describe.
-    expect(fullCss()).toMatch(/\.appbar \.search \{[^}]*min-width: 0/);
+    expect(componentCss('hv-full-view')).toMatch(/\.appbar \.search \{[^}]*min-width: 0/);
   });
 
   it('lets the heading give way rather than the controls after it', () => {
@@ -114,7 +97,7 @@ describe('hv-full-view: phone-width app bar', () => {
     expect(narrow()).toMatch(/\.appbar \.search \{[^}]*flex: 1 0 100%/);
     // A basis is a content-box width, so without this the field came out 24px
     // wider than the line it fills and hung off the right edge of the bar.
-    expect(fullCss()).toMatch(/\.appbar \.search \{[^}]*box-sizing: border-box/);
+    expect(componentCss('hv-full-view')).toMatch(/\.appbar \.search \{[^}]*box-sizing: border-box/);
   });
 
   // The bar came to 178px of a 844px screen: 16px search text and three 44px
@@ -136,7 +119,7 @@ describe('hv-full-view: phone-width app bar', () => {
   // screen — 751px of it below a fold nothing could scroll past — and a
   // 1280x900 desktop was losing the surface's own footer the same way.
   it('gives the filter panel a ceiling and something to scroll', () => {
-    const css = fullCss();
+    const css = componentCss('hv-full-view');
     const rule = /\.panel-holder \{([^}]*)\}/.exec(css)?.[1] ?? '';
     expect(rule).toMatch(/flex-direction: column/);
     expect(rule).toMatch(/max-height: min\(\d+dvh, calc\(100% - \d+px\)\)/);
@@ -158,7 +141,7 @@ describe('hv-full-view: phone-width app bar', () => {
     // The commit row is a sibling of the scroll box, not inside it, so the
     // count on the apply button stays visible while the filters move.
     expect(scroll.querySelector('.panel-foot')).toBe(null);
-    expect(fullCss()).toMatch(/\.panel-foot \{[^}]*flex: none/);
+    expect(componentCss('hv-full-view')).toMatch(/\.panel-foot \{[^}]*flex: none/);
   });
 
   it('keeps the count pills shorter than the actions above them', () => {
@@ -179,7 +162,7 @@ describe('hv-full-view: phone-width app bar', () => {
     // of these for a card measured at 600px or under — an ordinary dashboard
     // column on a desktop. The guaranteed-invalid value rather than a number,
     // so each consumer keeps the size it was written with.
-    const shell = /\.shell \{([^}]*)\}/.exec(fullCss())?.[1] ?? '';
+    const shell = /\.shell \{([^}]*)\}/.exec(componentCss('hv-full-view'))?.[1] ?? '';
     expect(shell).toMatch(/--hv-tap-min: initial/);
     expect(shell).toMatch(/--hv-input-font: initial/);
   });
@@ -248,7 +231,7 @@ describe('hv-full-view: phone-width app bar', () => {
 // content area, which is what this block exists to stop.
 describe('hv-full-view: wide app bar', () => {
   const wide = () => {
-    const css = fullCss();
+    const css = componentCss('hv-full-view');
     const start = css.indexOf('@media (min-width: 701px)');
     expect(start, 'no wide-viewport block').toBeGreaterThan(-1);
     // Stop at the phone block so a rule from it can never satisfy these.
@@ -260,7 +243,7 @@ describe('hv-full-view: wide app bar', () => {
   // must not leave a width where neither does.
   it('picks up exactly where the phone block leaves off', () => {
     expect(NARROW_QUERY).toBe('(max-width: 700px)');
-    expect(fullCss()).toContain('@media (min-width: 701px)');
+    expect(componentCss('hv-full-view')).toContain('@media (min-width: 701px)');
   });
 
   it('puts a floor under the search rather than letting the pills eat it', () => {
@@ -379,7 +362,7 @@ describe('hv-full-view: embedded', () => {
   });
 
   it('is sized by its host rather than by the viewport', () => {
-    const css = fullCss();
+    const css = componentCss('hv-full-view');
     expect(css).toContain(':host([embedded]) { display: block; height: 100%; }');
     expect(css).toContain(
       ':host([embedded]) .shell { position: relative; inset: auto; height: 100%; box-shadow: none; }',
@@ -389,7 +372,7 @@ describe('hv-full-view: embedded', () => {
   // The embedded rules override the shell's box and nothing else: the grid rows
   // and the sideways pan are what the layout inside depends on.
   it('keeps the shell a two-row grid that can be panned sideways', () => {
-    const css = fullCss();
+    const css = componentCss('hv-full-view');
     expect(css).toContain('.shell { position: fixed; inset: 0; display: grid; grid-template-rows: auto 1fr;');
     expect(css).toContain('overflow-x: auto;');
   });
@@ -897,8 +880,8 @@ describe('hv-full-view: sidebar facets', () => {
   it('lines the three tallies up in one column', () => {
     // The Locations heading ends in a button and the other two in nothing, so
     // without a reserved slot its number sits an icon-button's width inboard.
-    expect(fullCss()).toMatch(/\.head-action \{[^}]*width: var\(--hv-tap-min, 34px\)/);
-    expect(fullCss()).toMatch(/\.head-action \{[^}]*flex: none/);
+    expect(componentCss('hv-full-view')).toMatch(/\.head-action \{[^}]*width: var\(--hv-tap-min, 34px\)/);
+    expect(componentCss('hv-full-view')).toMatch(/\.head-action \{[^}]*flex: none/);
   });
 
   it('says so when a facet has nothing in it yet', async () => {
@@ -1457,7 +1440,7 @@ describe('hv-full-view: editing', () => {
   // was free to be squeezed — it opened about 130px tall, a field and a half,
   // and never came near the ceiling meant to bound it.
   it('refuses to be squeezed by the table below it', () => {
-    const rule = /\.editor-holder \{([^}]*)\}/.exec(fullCss())?.[1] ?? '';
+    const rule = /\.editor-holder \{([^}]*)\}/.exec(componentCss('hv-full-view'))?.[1] ?? '';
     expect(rule, 'no .editor-holder rule').not.toBe('');
     expect(rule).toMatch(/flex: none/);
     // A ceiling is still wanted — the form is taller than a short viewport.
@@ -1470,7 +1453,7 @@ describe('hv-full-view: editing', () => {
   // the layout. Hidden on both axes, those 18px could not be reached: the ⋮ was
   // sliced in half and the editor's Save sat flush against the screen edge.
   it('can be panned sideways when the layout is wider than the screen', () => {
-    const rule = /\.shell \{([^}]*)\}/.exec(fullCss())?.[1] ?? '';
+    const rule = /\.shell \{([^}]*)\}/.exec(componentCss('hv-full-view'))?.[1] ?? '';
     expect(rule, 'no .shell rule').not.toBe('');
     expect(rule).toMatch(/overflow-x: auto/);
     // Vertical stays clipped: the surface is the viewport, and the boxes
@@ -1488,7 +1471,7 @@ describe('hv-full-view: editing', () => {
   // clips and cannot scroll — the footer and the sticky Save/Cancel bar were
   // both off the screen with no gesture that could reach them.
   it('leaves the footer its room on a landscape phone', () => {
-    const rule = /\.editor-holder \{([^}]*)\}/.exec(fullCss())?.[1] ?? '';
+    const rule = /\.editor-holder \{([^}]*)\}/.exec(componentCss('hv-full-view'))?.[1] ?? '';
     const ceiling = /max-height: min\((\d+)dvh, calc\(100% - (\d+)px\)\)/.exec(rule);
     expect(ceiling, `ceiling ignores the room the column has: ${rule}`).not.toBe(null);
 
@@ -1760,7 +1743,7 @@ describe('hv-full-view: phone-width children', () => {
   it('takes the shut holder out of the layout it would otherwise pad', async () => {
     const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
     expect((sr.getElementById('full-view-filter-panel') as HTMLElement).hidden).toBe(true);
-    expect(fullCss()).toMatch(/\.panel-holder\[hidden\] \{[^}]*display: none/);
+    expect(componentCss('hv-full-view')).toMatch(/\.panel-holder\[hidden\] \{[^}]*display: none/);
 
     (q(sr, '[data-testid="full-filters-toggle"]') as HTMLButtonElement).click();
     await settle(el);
@@ -1912,7 +1895,7 @@ describe('hv-full-view: app bar filters', () => {
   // rather than the card's pale tints, because a tint over an already-coloured
   // bar is unreadable in dark mode.
   it('colours low and overdue the way the card does', () => {
-    const css = fullCss();
+    const css = componentCss('hv-full-view');
     expect(css).toMatch(/\.appbar \.hv-chip\.warning \{[^}]*background: var\(--hv-amber\)/);
     expect(css).toMatch(/\.appbar \.hv-chip\.error \{[^}]*background: var\(--hv-error\)/);
   });

--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -1,6 +1,7 @@
 import './hv-import-sheet';
 import type { HVImportSheet } from './hv-import-sheet';
 import type { ImportPreview, ImportSummary } from '../store/types';
+import { all, mountComponent, q } from '../test.utils';
 
 const VALID_DOC = '{"haventory_export_version":1,"items":[],"locations":[]}';
 
@@ -42,16 +43,9 @@ function summary(): ImportSummary {
 }
 
 async function mount(props: Partial<HVImportSheet> = {}) {
-  const el = document.createElement('hv-import-sheet') as HVImportSheet;
-  el.open = true;
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVImportSheet>('hv-import-sheet', { open: true, ...props });
   return el;
 }
-
-const q = (el: HVImportSheet, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-const all = (el: HVImportSheet, sel: string) => [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
 
 async function type(el: HVImportSheet, text: string) {
   const area = q(el, '[data-testid="import-text"]') as HTMLTextAreaElement;

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1,5 +1,17 @@
 import './hv-item-editor';
-import { makeAttachment, makeItem, makeManual, makeMediaBindings, stubViewport } from '../test.utils';
+import {
+  all,
+  componentCss,
+  makeAttachment,
+  makeItem,
+  makeManual,
+  makeMediaBindings,
+  mountComponent,
+  ownCss,
+  q,
+  settle,
+  stubViewport,
+} from '../test.utils';
 import { DISCARD_PROMPT } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { addDays } from '../ui/relative-time';
@@ -28,30 +40,21 @@ const tree: LocationTreeNode[] = [
 ];
 
 async function mount(item: Item | null, props: Partial<HVItemEditor> = {}) {
-  const el = document.createElement('hv-item-editor') as HVItemEditor;
-  el.item = item;
-  el.locationTree = tree;
-  el.locations = [garage];
-  el.categorySuggestions = ['Hardware', 'Tools'];
-  el.tagSuggestions = ['metric', 'm4'];
-  el.customFieldKeys = ['serial', 'warranty_until'];
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVItemEditor>('hv-item-editor', {
+    item,
+    locationTree: tree,
+    locations: [garage],
+    categorySuggestions: ['Hardware', 'Tools'],
+    tagSuggestions: ['metric', 'm4'],
+    customFieldKeys: ['serial', 'warranty_until'],
+    ...props,
+  });
   return el;
 }
 
-const q = (el: HVItemEditor, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-const all = (el: HVItemEditor, sel: string) =>
-  [...(el.shadowRoot?.querySelectorAll(sel) ?? [])] as HTMLElement[];
-
 /** jsdom lays out no shadow DOM, so layout rules are asserted on the sheet. */
 const editorCss = () => {
-  const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-  return (Array.isArray(styles) ? styles : [styles])
-    .map((s) => String(s.cssText))
-    .join('\n')
-    .replace(/\s+/g, ' ');
+  return componentCss('hv-item-editor');
 };
 
 async function type(el: HVItemEditor, testid: string, value: string) {
@@ -240,11 +243,7 @@ describe('hv-item-editor: field parity', () => {
     expect(q(el, '.due-label')?.classList).not.toContain('muted');
     expect(q(el, '[data-testid="editor-due-hint"]')).toBe(null);
 
-    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-item-editor');
     expect(css).toMatch(/\.hv-input:disabled \{[^}]*color: var\(--hv-text-tertiary\)/);
     expect(css).toMatch(/\.hv-input:disabled \{[^}]*-webkit-text-fill-color/);
   });
@@ -354,11 +353,7 @@ describe('hv-item-editor: field parity', () => {
   });
 
   it('stacks the checkout box on a phone rather than halving a date field', () => {
-    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-item-editor');
 
     // Half of a 375px screen, minus the box padding, is under the ~140px a
     // native date input needs before it clips its own placeholder.
@@ -794,11 +789,7 @@ describe('hv-item-editor: category picker', () => {
     expect(list?.getAttribute('style')).toMatch(/left: -?\d+px/);
     expect(list?.getAttribute('style')).toMatch(/z-index: \d+/);
 
-    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-item-editor');
     expect(css).toMatch(/\.list-holder\.floating \{[^}]*position: fixed/);
     // The location tree is the opposite case — it is *meant* to open the form.
     expect(css).toMatch(/\.tree-holder, \.list-holder \{[^}]*margin-top: 6px/);
@@ -963,11 +954,7 @@ describe('hv-item-editor: typed custom fields', () => {
   });
 
   it('lays a row out from its own width, not from the card-wide mobile flag', () => {
-    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-item-editor');
 
     // The editor is a desktop row in one host and a phone sheet in another, so
     // `mobile` (which describes the card) must not decide this layout.
@@ -2427,11 +2414,7 @@ describe('hv-item-editor: touch targets and the shared tally', () => {
     expect(q(el, '[data-testid="editor-cf-tally"]')?.classList.contains('hv-tally')).toBe(true);
     // This component's own sheet may place the tally and nothing more — size
     // and dimming belong to the one declaration in `base`.
-    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-    const own = String((styles as { cssText: string }[])[(styles as unknown[]).length - 1].cssText).replace(
-      /\s+/g,
-      ' ',
-    );
+    const own = ownCss('hv-item-editor');
     for (const [, body] of own.matchAll(/\.hv-tally[^{]*\{([^}]*)\}/g)) {
       expect(body).not.toMatch(/font-size|opacity|color/);
     }
@@ -2676,11 +2659,9 @@ describe('hv-item-editor: one label recipe, one note size', () => {
   });
 
   it('reads its small print at one size', () => {
-    const styles = (customElements.get('hv-item-editor') as typeof HVItemEditor).styles;
-    const sheets = Array.isArray(styles) ? styles : [styles];
     // This component's own block; the shared sheets ahead of it answer for
     // every surface and are not this form's to consolidate.
-    const own = String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+    const own = ownCss('hv-item-editor');
 
     expect(own).toMatch(/:host \{[^}]*--hv-editor-note: 12px/);
     // One declaration, and nothing left of the 11.5/12.5px band around it.
@@ -2700,11 +2681,7 @@ describe('hv-item-editor: one label recipe, one note size', () => {
 
   // The tag field sat a point smaller than every input beside it.
   it('sets the tag input at the same size as the other fields', () => {
-    const styles = (customElements.get('hv-chip-input') as unknown as { styles: { cssText: string }[] }).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-chip-input');
     expect(css).toContain('font: 400 var(--hv-input-font, 13.5px) var(--hv-font)');
   });
 
@@ -2777,9 +2754,8 @@ describe('hv-item-editor: photos open full-size', () => {
     q(el, 'hv-lightbox')?.shadowRoot?.querySelector('[data-testid="lightbox"]') as HTMLElement | null;
 
   const settleBox = async (el: HVItemEditor) => {
-    await el.updateComplete;
-    await (q(el, 'hv-lightbox') as (HTMLElement & { updateComplete?: Promise<unknown> }) | null)
-      ?.updateComplete;
+    await settle(el);
+    await q<HTMLElement & { updateComplete?: Promise<unknown> }>(el, 'hv-lightbox')?.updateComplete;
   };
 
   it('opens the photo that was clicked', async () => {

--- a/cards/haventory-card/src/components/hv-lightbox.test.ts
+++ b/cards/haventory-card/src/components/hv-lightbox.test.ts
@@ -1,34 +1,22 @@
 import './hv-lightbox';
-import { makeAttachment, makeItem, makeMediaBindings } from '../test.utils';
+import { componentCss, makeAttachment, makeItem, makeMediaBindings, mountComponent, q, settle } from '../test.utils';
 import type { HVLightbox } from './hv-lightbox';
 import type { Item } from '../store/types';
 
 const shots = (n: number) => Array.from({ length: n }, (_, i) => makeAttachment({ id: `att-${i + 1}` }));
 
 async function mount(item: Partial<Item>, index: number | null = null) {
-  const el = document.createElement('hv-lightbox') as HVLightbox;
-  el.item = makeItem(item);
-  el.media = makeMediaBindings();
-  el.index = index;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await el.updateComplete;
+  const { el } = await mountComponent<HVLightbox>(
+    'hv-lightbox',
+    { item: makeItem(item), media: makeMediaBindings(), index },
+    { renders: 2 },
+  );
   return el;
 }
 
-const q = (el: HVLightbox, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
 const panel = (el: HVLightbox) => q(el, '[data-testid="lightbox"]');
 const shown = (el: HVLightbox) => (q(el, 'img') as HTMLImageElement | null)?.getAttribute('alt');
 const counter = (el: HVLightbox) => q(el, '[data-testid="lightbox-counter"]')?.textContent?.trim();
-
-/**
- * Two passes: the URL for a photo this component has not shown yet is signed
- * asynchronously, so the first render after a move has no `src` to draw with.
- */
-const settle = async (el: HVLightbox) => {
-  await el.updateComplete;
-  await el.updateComplete;
-};
 
 const press = async (el: HVLightbox, key: string) => {
   panel(el)?.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
@@ -41,11 +29,7 @@ const tap = async (el: HVLightbox, testid: string) => {
 };
 
 const lightboxCss = () => {
-  const styles = (customElements.get('hv-lightbox') as typeof HVLightbox).styles;
-  return (Array.isArray(styles) ? styles : [styles])
-    .map((s) => String(s.cssText))
-    .join('\n')
-    .replace(/\s+/g, ' ');
+  return componentCss('hv-lightbox');
 };
 
 /** Photos at full size, shared by the phone sheet and the edit form's strip. */

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -1,5 +1,5 @@
 import './hv-list-row';
-import { makeAttachment, makeItem, makeManual, makeMediaBindings } from '../test.utils';
+import { componentCss, makeAttachment, makeItem, makeManual, makeMediaBindings, mountComponent, q } from '../test.utils';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { elideMobilePath, elidePath, isLowStock, rowMenuEntries } from './hv-list-row';
 import { toIsoDate } from '../ui/relative-time';
@@ -7,15 +7,9 @@ import type { HVListRow } from './hv-list-row';
 import type { Item } from '../store/types';
 
 async function mount(item: Partial<Item>, props: Partial<HVListRow> = {}) {
-  const el = document.createElement('hv-list-row') as HVListRow;
-  el.item = makeItem(item);
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVListRow>('hv-list-row', { item: makeItem(item), ...props });
   return el;
 }
-
-const q = (el: HVListRow, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
 
 function captured(el: HVListRow, names: string[]) {
   const seen: string[] = [];
@@ -528,8 +522,7 @@ describe('hv-list-row: truncation', () => {
   // jsdom does not lay shadow DOM out, so the stylesheet itself is the only
   // thing here worth asserting on — and the bug was entirely in the stylesheet.
   const styleText = () => {
-    const styles = (customElements.get('hv-list-row') as typeof HVListRow).styles;
-    return (Array.isArray(styles) ? styles : [styles]).map((s) => String(s.cssText)).join('\n');
+    return componentCss('hv-list-row');
   };
   const rule = (selector: string) => {
     const css = styleText();
@@ -696,11 +689,7 @@ describe('hv-list-row: document marker', () => {
   // stops eliding the moment it shares a line with the mark unless it gives
   // that minimum up.
   it('leaves the name able to shrink on that line', () => {
-    const styles = (customElements.get('hv-list-row') as typeof HVListRow).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-list-row');
     expect(css).toMatch(/\.name-line \{[^}]*display: flex/);
     expect(css).toMatch(/\.name \{[^}]*min-width: 0[^}]*text-overflow: ellipsis/);
   });
@@ -708,11 +697,7 @@ describe('hv-list-row: document marker', () => {
 
 describe('hv-list-row: the row is a target', () => {
   it('shows the hand a button would', () => {
-    const styles = (customElements.get('hv-list-row') as typeof HVListRow).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-list-row');
     // The shared `button { cursor: pointer }` cannot reach a role=row div, and
     // every chip, pill and menu beside the row already shows the hand.
     expect(css).toMatch(/\.row \{[^}]*cursor: pointer/);

--- a/cards/haventory-card/src/components/hv-list.test.ts
+++ b/cards/haventory-card/src/components/hv-list.test.ts
@@ -1,14 +1,13 @@
 import { html } from 'lit';
 import './hv-list';
 import type { HVList } from './hv-list';
-import { makeItem } from '../test.utils';
+import { componentCss, makeItem, mountComponent } from '../test.utils';
 
 async function mount(props: Partial<HVList> = {}) {
-  const el = document.createElement('hv-list') as HVList;
-  el.items = [makeItem({ id: 'a', name: 'A' }), makeItem({ id: 'b', name: 'B' })];
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVList>('hv-list', {
+    items: [makeItem({ id: 'a', name: 'A' }), makeItem({ id: 'b', name: 'B' })],
+    ...props,
+  });
   return el;
 }
 
@@ -91,8 +90,7 @@ describe('hv-list: editing', () => {
   });
 
   it('gives the scroller more room while editing', () => {
-    const css = (customElements.get('hv-list') as typeof HVList).styles;
-    const text = (Array.isArray(css) ? css : [css]).map((s) => String(s.cssText)).join('\n');
+    const text = componentCss('hv-list');
     // the compact cap still exists...
     expect(text).toContain('--hv-list-max-height');
     // ...and a taller one applies while an editor is open

--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -3,6 +3,7 @@ import type { HVLocationTree } from './hv-location-tree';
 import { chip } from '../ui/chip';
 import { browseRow } from '../ui/browse-row';
 import type { LocationTreeNode } from '../store/types';
+import { componentCss, mountComponent, ownCss, q } from '../test.utils';
 
 function node(
   id: string,
@@ -34,19 +35,13 @@ const tree: LocationTreeNode[] = [
 ];
 
 async function mount(props: Partial<HVLocationTree> = {}) {
-  const el = document.createElement('hv-location-tree') as HVLocationTree;
-  el.nodes = tree;
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
+  const { el } = await mountComponent<HVLocationTree>('hv-location-tree', { nodes: tree, ...props });
   return el;
 }
 
 const rows = (el: HVLocationTree) =>
   [...(el.shadowRoot?.querySelectorAll('[data-testid="tree-row"]') ?? [])] as HTMLElement[];
 const ids = (el: HVLocationTree) => rows(el).map((r) => r.dataset.id);
-const q = (el: HVLocationTree, sel: string) => el.shadowRoot?.querySelector(sel) as HTMLElement | null;
-
 describe('hv-location-tree: hierarchy', () => {
   it('starts collapsed, showing only the roots', async () => {
     const el = await mount();
@@ -161,11 +156,7 @@ describe('hv-location-tree: counts and decorations', () => {
     expect(row.querySelector('svg[data-icon="mapMarkerOff"]')).toBeTruthy();
     expect(row.querySelector('svg[data-icon="alert"]')).toBe(null);
 
-    const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-location-tree');
     expect(css).not.toMatch(/\.row\.orphans \{[^}]*hv-warn/);
   });
 
@@ -441,9 +432,7 @@ describe('hv-location-tree: area grouping', () => {
   // full view's sidebar and the organize dialog's — so its size is settled
   // here, once, for both.
   it('sets both band labels at row size, leaving the shared chip its smaller one', () => {
-    const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
-    const sheets = Array.isArray(styles) ? styles : [styles];
-    const own = String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+    const own = ownCss('hv-location-tree');
     // Tracks whatever a browse row is set to rather than restating a number
     // beside it, and both bands are named by one rule so neither can drift.
     expect(own).toMatch(/\.area-name \.hv-area-chip, \.area-none \{ font-size: inherit/);
@@ -650,11 +639,7 @@ describe('hv-location-tree: manage mode', () => {
   // measured at 390px, the count link came to 14px tall and the ⋮ to 26×26
   // beside 44px controls on the other three tabs.
   it('sizes the managed row for a finger, matching the dialog it renders in', () => {
-    const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-location-tree');
 
     // WCAG 2.2 asks 24px of any pointer, wherever the count is a link.
     expect(css).toMatch(/\.count\.link \{[^}]*min-height: 24px/);
@@ -672,11 +657,7 @@ describe('hv-location-tree: manage mode', () => {
   // which is what keeps the tightening scoped: the sidebar, the filter panel
   // and the editor's location field declare nothing and take the fallback.
   it('takes the organize dialog\'s row rhythm only when it is hosted there', () => {
-    const styles = (customElements.get('hv-location-tree') as typeof HVLocationTree).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-location-tree');
 
     expect(css).toMatch(/\.hv-browse-row \{[^}]*padding: var\(--hv-organize-row-pad, 7px\) 12px/);
     // Nothing here declares it — a tree that declared its own would answer for

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1,6 +1,5 @@
 import './hv-organize-dialog';
-import { makeMockHass, makeItem } from '../test.utils';
-import { Store } from '../store/store';
+import { all, componentCss, makeItem, mountComponent, mountStore, q, settle } from '../test.utils';
 import { HVOrganizeDialog } from './hv-organize-dialog';
 import type { OrganizeTab } from './hv-organize-dialog';
 import type { AreaRef, Item, Location, StatusDefinition } from '../store/types';
@@ -37,41 +36,23 @@ async function mount(
     mobile?: boolean;
   } = {},
 ) {
-  const hass = makeMockHass({
+  const { hass, store } = await mountStore({
     items: opts.items ?? [],
     locations: opts.locations ?? [],
     areas: opts.areas ?? AREAS,
     ...(opts.statuses ? { statuses: opts.statuses } : {}),
   });
-  const store = new Store(hass, { retryBaseMs: 0 });
-  await store.init();
-
-  const el = document.createElement('hv-organize-dialog') as HVOrganizeDialog;
-  el.store = store;
-  el.tab = opts.tab ?? 'locations';
-  el.mobile = opts.mobile ?? false;
-  el.open = true;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await el.updateComplete;
-  return { el, store, hass, sr: el.shadowRoot as ShadowRoot };
+  const { el, sr } = await mountComponent<HVOrganizeDialog>(
+    'hv-organize-dialog',
+    { store, tab: opts.tab ?? 'locations', mobile: opts.mobile ?? false, open: true },
+    { renders: 2 },
+  );
+  return { el, store, hass, sr };
 }
-
-const settle = async (el: HVOrganizeDialog) => {
-  await new Promise((r) => setTimeout(r, 0));
-  await el.updateComplete;
-};
-
-const q = (sr: ShadowRoot, sel: string) => sr.querySelector(sel) as HTMLElement | null;
-const all = (sr: ShadowRoot, sel: string) => [...sr.querySelectorAll(sel)] as HTMLElement[];
 
 /** jsdom lays out no shadow DOM, so geometry is asserted on the stylesheet. */
 const dialogCss = () => {
-  const styles = (customElements.get('hv-organize-dialog') as typeof HVOrganizeDialog).styles;
-  return (Array.isArray(styles) ? styles : [styles])
-    .map((s) => String(s.cssText))
-    .join('\n')
-    .replace(/\s+/g, ' ');
+  return componentCss('hv-organize-dialog');
 };
 
 describe('hv-organize-dialog: shell', () => {
@@ -1358,11 +1339,8 @@ describe('hv-organize-dialog: statuses', () => {
   // The bug this guards against paints nothing and throws nothing: the swatch
   // still reads as selected, so only a screenshot catches it.
   it('leaves the chip fill to the pair the chip reads, on every swatch rule', () => {
-    const css = HVOrganizeDialog.styles
-      .map((sheet) => (sheet as { cssText?: string }).cssText ?? '')
-      .join('\n')
-      // Comments quote property names freely.
-      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Comments quote property names freely.
+    const css = componentCss('hv-organize-dialog').replace(/\/\*[\s\S]*?\*\//g, '');
 
     for (const block of css.matchAll(/([^{}]*\.swatch[^{}]*)\{([^}]*)\}/g)) {
       const [selector, body] = [block[1].trim(), block[2]];

--- a/cards/haventory-card/src/components/hv-overflow-menu.test.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.test.ts
@@ -2,13 +2,11 @@ import './hv-overflow-menu';
 import { placeMenu } from './hv-overflow-menu';
 import type { HVOverflowMenu } from './hv-overflow-menu';
 import { NARROW_QUERY } from '../ui/responsive';
+import { componentCss, mountComponent, q } from '../test.utils';
 
 async function mount(entries: HVOverflowMenu['entries']) {
-  const el = document.createElement('hv-overflow-menu') as HVOverflowMenu;
-  el.entries = entries;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  (el.shadowRoot?.querySelector('[data-testid="overflow-trigger"]') as HTMLButtonElement).click();
+  const { el } = await mountComponent<HVOverflowMenu>('hv-overflow-menu', { entries });
+  q<HTMLButtonElement>(el, '[data-testid="overflow-trigger"]')!.click();
   await el.updateComplete;
   return el;
 }
@@ -68,11 +66,7 @@ describe('hv-overflow-menu', () => {
 
 describe('hv-overflow-menu: narrow screens', () => {
   const narrow = () => {
-    const styles = (customElements.get('hv-overflow-menu') as typeof HVOverflowMenu).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-overflow-menu');
     const start = css.indexOf(`@media ${NARROW_QUERY}`);
     expect(start, 'no narrow-viewport block').toBeGreaterThan(-1);
     return css.slice(start);
@@ -163,12 +157,11 @@ describe('hv-overflow-menu: narrow screens', () => {
   it('hands focus back to whatever opened it', async () => {
     // A real pointer click focuses the trigger before the menu opens; jsdom's
     // programmatic click does not, so focus it explicitly to reproduce that.
-    const el = document.createElement('hv-overflow-menu') as HVOverflowMenu;
-    el.entries = [{ id: 'refresh', label: 'Refresh data' }];
-    document.body.appendChild(el);
-    await el.updateComplete;
+    const { el } = await mountComponent<HVOverflowMenu>('hv-overflow-menu', {
+      entries: [{ id: 'refresh', label: 'Refresh data' }],
+    });
 
-    const trigger = el.shadowRoot?.querySelector('[data-testid="overflow-trigger"]') as HTMLButtonElement;
+    const trigger = q<HTMLButtonElement>(el, '[data-testid="overflow-trigger"]')!;
     trigger.focus();
     trigger.click();
     await el.updateComplete;
@@ -192,11 +185,7 @@ describe('hv-overflow-menu: escaping ancestor clips', () => {
   // The first .menu block is the base rule; the sheet's overrides live in the
   // narrow @media block after it.
   const baseMenuRule = () => {
-    const styles = (customElements.get('hv-overflow-menu') as typeof HVOverflowMenu).styles;
-    const css = (Array.isArray(styles) ? styles : [styles])
-      .map((s) => String(s.cssText))
-      .join('\n')
-      .replace(/\s+/g, ' ');
+    const css = componentCss('hv-overflow-menu');
     return /\.menu \{[^}]*\}/.exec(css)?.[0] ?? '';
   };
 

--- a/cards/haventory-card/src/haventory-card-editor.test.ts
+++ b/cards/haventory-card/src/haventory-card-editor.test.ts
@@ -1,5 +1,6 @@
 import './haventory-card-editor';
 import type { HAventoryCardEditor, HAventoryCardConfig } from './haventory-card-editor';
+import { mountComponent } from './test.utils';
 
 // jsdom does not define `ha-form` — Home Assistant does, at runtime — so the
 // node stays an unknown element. That is exactly the seam worth testing: what
@@ -12,12 +13,9 @@ type Form = HTMLElement & {
 };
 
 async function mount(config: HAventoryCardConfig) {
-  const el = document.createElement('haventory-card-editor') as HAventoryCardEditor & {
-    updateComplete: Promise<unknown>;
-    shadowRoot: ShadowRoot;
-  };
-  document.body.appendChild(el);
-  await customElements.whenDefined('haventory-card-editor');
+  const { el } = await mountComponent<
+    HAventoryCardEditor & { updateComplete: Promise<unknown>; shadowRoot: ShadowRoot }
+  >('haventory-card-editor');
   el.setConfig(config);
   await el.updateComplete;
   return el;

--- a/cards/haventory-card/src/haventory-card.test.ts
+++ b/cards/haventory-card/src/haventory-card.test.ts
@@ -1,5 +1,5 @@
 import './index';
-import { makeMockHass, makeItem } from './test.utils';
+import { makeItem, makeMockHass, mountComponent, settle } from './test.utils';
 import { COLUMN_PREFS_STORAGE_KEY, DEFAULT_COLUMNS } from './store/columns';
 import type { HAventoryCard } from './index';
 
@@ -13,9 +13,7 @@ async function mountCard(
     quickFilters?: string[] | null;
   } = {},
 ) {
-  const el = document.createElement('haventory-card') as Card;
-  document.body.appendChild(el);
-  await customElements.whenDefined('haventory-card');
+  const { el, sr } = await mountComponent<Card>('haventory-card');
   el.setConfig(config);
   el.hass = makeMockHass({
     items: opts.items ?? [],
@@ -23,13 +21,8 @@ async function mountCard(
     quickFilters: opts.quickFilters,
   });
   await el.updateComplete;
-  return { el, sr: el.shadowRoot as ShadowRoot };
+  return { el, sr };
 }
-
-const settle = async (el: Card) => {
-  await new Promise((r) => setTimeout(r, 0));
-  await el.updateComplete;
-};
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -98,9 +91,7 @@ describe('haventory-card: the Lovelace element', () => {
   });
 
   it('rejects a config that is not an object at all', async () => {
-    const el = document.createElement('haventory-card') as Card;
-    document.body.appendChild(el);
-    await customElements.whenDefined('haventory-card');
+    const { el } = await mountComponent<Card>('haventory-card');
     expect(() => el.setConfig('nope')).toThrow(/Invalid config/);
   });
 

--- a/cards/haventory-card/src/haventory-panel.test.ts
+++ b/cards/haventory-card/src/haventory-panel.test.ts
@@ -1,5 +1,5 @@
 import './haventory-panel';
-import { makeMockHass, makeItem, stubViewport } from './test.utils';
+import { makeItem, makeMockHass, mountComponent, q, settle, stubViewport } from './test.utils';
 import { COLUMN_PREFS_STORAGE_KEY, DEFAULT_COLUMNS } from './store/columns';
 import type { HAventoryPanel } from './haventory-panel';
 
@@ -24,27 +24,21 @@ async function mountPanel(
     quickFilters?: string[] | null;
   } = {},
 ) {
-  const el = document.createElement('haventory-panel') as Panel;
-  document.body.appendChild(el);
-  await customElements.whenDefined('haventory-panel');
-  if (opts.config !== undefined) el.panel = { config: opts.config };
-  if (opts.narrow) el.narrow = true;
-  if (opts.withHass !== false) {
-    el.hass = makeMockHass({
-      items: opts.items ?? [],
-      cardTitle: opts.cardTitle,
-      quickFilters: opts.quickFilters,
-    });
-  }
-  await el.updateComplete;
-  const sr = el.shadowRoot as ShadowRoot;
-  return { el, sr, view: () => sr.querySelector('[data-testid="panel-full-view"]') as FullView };
+  const { el, sr } = await mountComponent<Panel>('haventory-panel', {
+    ...(opts.config !== undefined ? { panel: { config: opts.config } } : {}),
+    ...(opts.narrow ? { narrow: true } : {}),
+    ...(opts.withHass !== false
+      ? {
+          hass: makeMockHass({
+            items: opts.items ?? [],
+            cardTitle: opts.cardTitle,
+            quickFilters: opts.quickFilters,
+          }),
+        }
+      : {}),
+  });
+  return { el, sr, view: () => q<FullView>(sr, '[data-testid="panel-full-view"]')! };
 }
-
-const settle = async (el: Panel) => {
-  await new Promise((r) => setTimeout(r, 0));
-  await el.updateComplete;
-};
 
 afterEach(() => {
   document.body.innerHTML = '';

--- a/cards/haventory-card/src/test.utils.test.ts
+++ b/cards/haventory-card/src/test.utils.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { makeItem, makeMockHass } from './test.utils';
+import './components/hv-banner';
+import {
+  all,
+  componentCss,
+  makeItem,
+  makeMockHass,
+  mountComponent,
+  mountStore,
+  ownCss,
+  q,
+  settle,
+} from './test.utils';
+import type { HVBanner } from './components/hv-banner';
 import type { Item } from './store/types';
 
 // Fixtures must not order themselves off the wall clock: the default sort is
@@ -50,5 +62,71 @@ describe('makeItem fixtures', () => {
     });
 
     expect(page.items.map((i) => i.id)).toEqual(['1', '2']);
+  });
+});
+
+// The harness decides what a component test is able to check, so the properties
+// the 22 component files lean on are pinned here rather than inferred from them.
+describe('component-test harness', () => {
+  it('assigns properties before connecting, so the first render sees them', async () => {
+    const { el, sr } = await mountComponent<HVBanner>('hv-banner', { kind: 'error' });
+
+    expect(el.isConnected).toBe(true);
+    expect(sr).toBeTruthy();
+    // A property applied after connection would have needed a second render.
+    expect(q(el, '.banner')?.classList.contains('error')).toBe(true);
+  });
+
+  it('places light-DOM content where a slot can pick it up', async () => {
+    const { el } = await mountComponent<HVBanner>(
+      'hv-banner',
+      {},
+      { light: '<span id="slotted">boom</span>' },
+    );
+
+    expect(el.querySelector('#slotted')?.textContent).toBe('boom');
+  });
+
+  it('reads a shadow root through the element or through the root itself', async () => {
+    const { el, sr } = await mountComponent<HVBanner>('hv-banner', {}, { light: '<b>a</b><b>b</b>' });
+
+    expect(q(el, '.banner')).toBe(q(sr, '.banner'));
+    expect(all(el, 'slot')).toHaveLength(all(sr, 'slot').length);
+    expect(q(el, '.no-such-thing')).toBe(null);
+    expect(all(el, '.no-such-thing')).toEqual([]);
+  });
+
+  it('forwards the whole MockConfig to the store it builds', async () => {
+    const { hass, store } = await mountStore({
+      items: [makeItem({ id: '1', name: 'Hammer' })],
+      areas: [{ id: 'area-garage', name: 'Garage' }],
+      statuses: [{ slug: 'lent_out', label: 'Lent out', order: 40, color: 'blue' }],
+    });
+
+    // Statuses and areas are the two a per-file mount used to drop.
+    expect(store.state.value.areasCache?.areas.map((a) => a.id)).toEqual(['area-garage']);
+    expect(store.state.value.statuses?.map((s) => s.slug)).toContain('lent_out');
+    expect(store.state.value.items.map((i) => i.name)).toEqual(['Hammer']);
+    expect(hass.callWS).toBeTypeOf('function');
+  });
+
+  it('tells a component block apart from the fragments ahead of it', () => {
+    const whole = componentCss('hv-banner');
+    const own = ownCss('hv-banner');
+
+    expect(whole).toContain(own);
+    expect(own.length).toBeLessThan(whole.length);
+    // Both are whitespace-normalized, so a rule reads as one line either way.
+    expect(whole).not.toMatch(/\n/);
+    expect(() => componentCss('hv-not-a-component')).toThrow(/no styles/);
+  });
+
+  it('settles a render that another render queued', async () => {
+    const { el } = await mountComponent<HVBanner>('hv-banner', { kind: 'info' });
+
+    el.kind = 'warning';
+    await settle(el);
+
+    expect(q(el, '.banner')?.classList.contains('warning')).toBe(true);
   });
 });

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -1,3 +1,6 @@
+import type { CSSResult } from 'lit';
+
+import { Store } from './store/store';
 import type {
   AnyEventPayload,
   AreaRef,
@@ -17,7 +20,7 @@ import type {
 // event payload, not the `{id, type:'event', event}` envelope.
 type SubCb = (event: AnyEventPayload) => void;
 
-interface MockConfig {
+export interface MockConfig {
   items?: Item[];
   locations?: Location[];
   conflictOnUpdate?: boolean;
@@ -1005,4 +1008,140 @@ export function stubViewport(matches: boolean): () => void {
   return () => {
     window.matchMedia = original;
   };
+}
+
+// ---------------------------------------------------------------------------
+// Component-test harness
+// ---------------------------------------------------------------------------
+
+/** What a mounted component hands back: the element and its shadow root. */
+export interface Mounted<T extends HTMLElement> {
+  el: T;
+  sr: ShadowRoot;
+}
+
+export interface MountOptions {
+  /** Light-DOM markup, set before the element is connected. */
+  light?: string;
+  /**
+   * Render passes to await after connecting. One is enough for a component that
+   * draws itself; a component that renders another Lit element and then reads
+   * it needs two, because the child's first update is queued by the parent's.
+   */
+  renders?: number;
+}
+
+/** A Lit element seen from a test: the render-settled promise is all we need. */
+type Renderable = HTMLElement & { updateComplete?: Promise<unknown> };
+
+/**
+ * Create a component, set its properties, connect it, and wait for it to draw.
+ *
+ * Every component test mounts through here, so the ordering is the same
+ * everywhere: properties are assigned *before* the element is connected, which
+ * is what a Lit component's first render sees, and the custom element is
+ * awaited as defined before the first `updateComplete` is read — an element
+ * that has not been upgraded yet has no such property.
+ */
+export async function mountComponent<T extends HTMLElement>(
+  tag: string,
+  props: Partial<T> = {},
+  options: MountOptions = {},
+): Promise<Mounted<T>> {
+  const el = document.createElement(tag) as T;
+  Object.assign(el, props);
+  if (options.light) el.innerHTML = options.light;
+  document.body.appendChild(el);
+  await customElements.whenDefined(tag);
+  for (let i = 0; i < (options.renders ?? 1); i++) {
+    await (el as Renderable).updateComplete;
+  }
+  return { el, sr: el.shadowRoot as ShadowRoot };
+}
+
+/**
+ * A mock hass and an initialised `Store` over it, for the components that take
+ * one. The whole `MockConfig` is forwarded — statuses and areas included — so a
+ * test that needs a household vocabulary does not have to build its own hass.
+ */
+export async function mountStore(config: MockConfig = {}): Promise<{
+  hass: MockHass;
+  store: Store;
+}> {
+  const hass = makeMockHass(config);
+  // No retry backoff: a test that provokes a failure would otherwise wait it out.
+  const store = new Store(hass, { retryBaseMs: 0 });
+  await store.init();
+  return { hass, store };
+}
+
+/** The first match for a selector, from an element's shadow root or from a root itself. */
+export function q<T extends Element = HTMLElement>(
+  root: Element | DocumentFragment,
+  selector: string,
+): T | null {
+  return queryRoot(root).querySelector(selector) as T | null;
+}
+
+/** Every match for a selector, in document order. */
+export function all<T extends Element = HTMLElement>(
+  root: Element | DocumentFragment,
+  selector: string,
+): T[] {
+  return [...queryRoot(root).querySelectorAll(selector)] as T[];
+}
+
+function queryRoot(root: Element | DocumentFragment): ParentNode {
+  return 'shadowRoot' in root && root.shadowRoot ? root.shadowRoot : root;
+}
+
+/**
+ * Wait for everything a click or a property write set in motion.
+ *
+ * The macrotask boundary is what separates this from awaiting `updateComplete`
+ * alone: it drains the microtask queue first, so a render that another render
+ * queued has already been scheduled by the time the element is awaited.
+ */
+export async function settle(el: HTMLElement): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await (el as Renderable).updateComplete;
+}
+
+/**
+ * Everything a component draws with: its own block plus every shared fragment,
+ * whitespace-normalized so a rule reads as one line.
+ *
+ * jsdom lays nothing out, so a layout or type-size rule is asserted against the
+ * stylesheet rather than against a measured box.
+ */
+export function componentCss(tag: string): string {
+  return sheetsOf(tag)
+    .map((sheet) => String(sheet.cssText))
+    .join('\n')
+    .replace(/\s+/g, ' ');
+}
+
+/**
+ * A component's *own* block — the last fragment, after the shared ones.
+ *
+ * The distinction decides what a `not.toMatch` proves: against
+ * {@link componentCss} it says "nothing draws this", which a shared fragment
+ * would falsify; against this it says "this component does not restate what the
+ * shared fragment already gives it".
+ */
+export function ownCss(tag: string): string {
+  const sheets = sheetsOf(tag);
+  return String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
+}
+
+/**
+ * A component's style fragments, in the order it lists them.
+ *
+ * The fragments themselves rather than their text, so a test can assert that a
+ * shared sheet *is* one of them rather than that its rules appear somewhere.
+ */
+export function sheetsOf(tag: string): CSSResult[] {
+  const ctor = customElements.get(tag) as { styles?: CSSResult | CSSResult[] } | undefined;
+  if (!ctor?.styles) throw new Error(`${tag} has no styles`);
+  return Array.isArray(ctor.styles) ? ctor.styles : [ctor.styles];
 }

--- a/cards/haventory-card/src/ui/browse-row.test.ts
+++ b/cards/haventory-card/src/ui/browse-row.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { CSSResult } from 'lit';
 import { browseRow } from './browse-row';
 
 import '../components/hv-full-view';
 import '../components/hv-location-tree';
+import { ownCss, sheetsOf } from '../test.utils';
 
 /**
  * The two shadow roots that draw a row you browse by. They render one under the
@@ -12,18 +12,6 @@ import '../components/hv-location-tree';
  * drifted 4px of height and 22px of label inset apart.
  */
 const BROWSERS = ['hv-full-view', 'hv-location-tree'];
-
-function sheetsOf(tag: string): CSSResult[] {
-  const ctor = customElements.get(tag) as { styles?: CSSResult | CSSResult[] } | undefined;
-  if (!ctor?.styles) throw new Error(`${tag} has no styles`);
-  return Array.isArray(ctor.styles) ? ctor.styles : [ctor.styles];
-}
-
-/** A component's own block — the last fragment, after the shared ones. */
-function ownCss(tag: string): string {
-  const sheets = sheetsOf(tag);
-  return String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
-}
 
 describe('ui/browse-row: one row in two shadow roots', () => {
   it('reaches both roots that draw one', () => {

--- a/cards/haventory-card/src/ui/chip.test.ts
+++ b/cards/haventory-card/src/ui/chip.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import type { CSSResult } from 'lit';
 import { chip } from './chip';
 import { base, tokens } from './tokens';
 
@@ -14,6 +13,7 @@ import '../components/hv-item-editor';
 import '../components/hv-list-row';
 import '../components/hv-location-tree';
 import '../components/hv-organize-dialog';
+import { ownCss, sheetsOf } from '../test.utils';
 
 /** Every surface that marks something with a chip. */
 const CHIPPED = [
@@ -29,18 +29,6 @@ const CHIPPED = [
   'hv-location-tree',
   'hv-organize-dialog',
 ];
-
-function sheetsOf(tag: string): CSSResult[] {
-  const ctor = customElements.get(tag) as { styles?: CSSResult | CSSResult[] } | undefined;
-  if (!ctor?.styles) throw new Error(`${tag} has no styles`);
-  return Array.isArray(ctor.styles) ? ctor.styles : [ctor.styles];
-}
-
-/** A component's own block — the last fragment, after the shared ones. */
-function ownCss(tag: string): string {
-  const sheets = sheetsOf(tag);
-  return String(sheets[sheets.length - 1].cssText).replace(/\s+/g, ' ');
-}
 
 describe('ui/chip: the shared fragment', () => {
   it('reaches every surface that draws a chip', () => {

--- a/cards/haventory-card/src/ui/dialog-sheet.test.ts
+++ b/cards/haventory-card/src/ui/dialog-sheet.test.ts
@@ -1,8 +1,8 @@
-import type { CSSResult } from 'lit';
 import '../components/hv-column-picker';
 import '../components/hv-confirm';
 import '../components/hv-diagnostics-panel';
 import '../components/hv-import-sheet';
+import { componentCss, mountComponent } from '../test.utils';
 
 /**
  * The four host dialogs, which have to end up alike: on a phone the card raises
@@ -11,21 +11,11 @@ import '../components/hv-import-sheet';
  */
 const DIALOGS = ['hv-column-picker', 'hv-confirm', 'hv-import-sheet', 'hv-diagnostics-panel'] as const;
 
-const cssOf = (tag: string) => {
-  const styles = (customElements.get(tag) as unknown as { styles: CSSResult | CSSResult[] }).styles;
-  return (Array.isArray(styles) ? styles : [styles])
-    .map((s) => String(s.cssText))
-    .join('\n')
-    .replace(/\s+/g, ' ');
-};
-
 const mount = async (tag: string, mobile: boolean) => {
-  const el = document.createElement(tag) as HTMLElement & { open: boolean; mobile: boolean };
-  el.open = true;
-  el.mobile = mobile;
-  document.body.appendChild(el);
-  await customElements.whenDefined(tag);
-  await (el as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+  const { el } = await mountComponent<HTMLElement & { open: boolean; mobile: boolean }>(tag, {
+    open: true,
+    mobile,
+  });
   return el;
 };
 
@@ -36,7 +26,7 @@ afterEach(() => {
 describe('host dialogs: one phone presentation', () => {
   it('rises from the bottom edge, full width, under mobile', () => {
     for (const tag of DIALOGS) {
-      const css = cssOf(tag);
+      const css = componentCss(tag);
       expect(css, tag).toMatch(/:host\(\[mobile\]\) \.wrap \{[^}]*place-items: end stretch/);
       expect(css, tag).toMatch(/:host\(\[mobile\]\) \.panel \{[^}]*width: 100%/);
       expect(css, tag).toMatch(
@@ -48,7 +38,7 @@ describe('host dialogs: one phone presentation', () => {
 
   it('keeps the centred dialog when it is not on a phone', () => {
     for (const tag of DIALOGS) {
-      const css = cssOf(tag);
+      const css = componentCss(tag);
       expect(css, tag).toMatch(/[^)] \.wrap \{[^}]*place-items: center/);
       expect(css, tag).toMatch(/[^)] \.panel \{[^}]*border-radius: var\(--hv-radius-dialog\)/);
     }
@@ -71,7 +61,7 @@ describe('host dialogs: one phone presentation', () => {
   // A sheet sits against the bottom edge, where a phone's home indicator is.
   it('clears the safe area under the bottom row of actions', () => {
     for (const tag of DIALOGS) {
-      expect(cssOf(tag), tag).toMatch(
+      expect(componentCss(tag), tag).toMatch(
         /:host\(\[mobile\]\) \.panel \{[^}]*padding-bottom: max\(12px, env\(safe-area-inset-bottom\)\)/,
       );
     }


### PR DESCRIPTION
## Summary

The sibling of #427, on the card side. Every component test file re-implemented the same handful of helpers, each slightly differently, and the divergence decided what a test could check: a `mount()` that spelt out only part of the `MockConfig` could not give its component a household vocabulary, and a cssText reader that joined every style fragment proved something different from one that read only the component's own block.

`src/test.utils.ts` — which already held `makeMockHass` / `makeItem` / `stubViewport` — now also holds:

| helper | what it replaces |
|---|---|
| `mountComponent(tag, props, {light, renders})` | 26 local `mount()`s. Properties are assigned **before** connection (what a Lit first render sees), the element is awaited as defined before `updateComplete` is read, and `renders: 2` names the "a component that renders another needs two passes" case that four files were spelling as a repeated `await`. |
| `mountStore(config)` | the `makeMockHass` + `new Store(hass, {retryBaseMs: 0})` + `init()` triple in three files. Takes the **whole `MockConfig`** — statuses and areas included. |
| `q` / `all` | 14 and 8 local copies. Both take an element *or* a shadow root, so the two files that threaded an `sr` around did not have to change a call site. |
| `settle` | 7 local copies, 5 of them identical. |
| `componentCss(tag)` / `ownCss(tag)` | ~30 readers across 16 files, in two shapes. |
| `sheetsOf(tag)` | the fragment-identity lookup `chip.test.ts` and `browse-row.test.ts` each had. |

**The two cssText readers stay two, deliberately.** That is the drift the issue names, and merging them would have silently weakened assertions: against `componentCss` a `not.toMatch` says "nothing draws this", which a shared fragment falsifies; against `ownCss` it says "this component does not restate what the shared fragment already gives it". Both now exist once, under names that say which is which, and the doc comment on each says what a guard written against it proves.

Every `src/components/*.test.ts` imports the harness, and every per-file `mount` is a thin wrapper. Four specializations stayed local, each with the reason in a comment rather than as an accident:

- `hv-detail-sheet` and `hv-item-editor` settle a nested `hv-lightbox` as well; both now call the shared `settle` first and add only the child's update.
- `hv-column-picker` finds its own style block by content, because its own block is *not* the last fragment there — the shared-phone-sheet block sits after it, so `ownCss` would read the wrong one.
- One `hv-card-shell` test builds a `Store` it deliberately does **not** `init()`, because the skeleton is what shows before the first list resolves.

### Where the issue's description has gone stale

Recorded here rather than by editing the issue, per the milestone plan's rule. The issue says 21 files have a `mount()` that "builds a `makeMockHass`, constructs a `Store`, appends the element and awaits `updateComplete` twice". Against the tree today, **three** of the 22 component files build a hass and a store (`hv-card-shell`, `hv-full-view`, `hv-organize-dialog`); the rest create an element and assign properties. That is why the shared mount is split in two — `mountComponent` for all 26 mounts, `mountStore` for the three that need a store — rather than one helper that would build and initialise a store for 23 files that never look at it. The acceptance criterion the split serves (the full `MockConfig` forwarded, statuses and areas included) is met by `mountStore`, and pinned by a test.

The other counts hold: 14 files declared a `q`, 8 an `all`, 7 a `settle`, and the cssText readers came in the two shapes the issue describes plus the `ownCss` variant in `src/ui/chip.test.ts`.

**No assertion was deleted without a replacement.** Across the 30 migrated test files the `expect(` count is 2732 before and 2732 after; the only change in the total is `test.utils.test.ts`, which gains 17 for the six new harness tests. A reader who wants to check that mechanically: `git show <base>:<file>` against each file and count.

`CONTRIBUTING.md` names the harness under the test-driven convention, so the next component test does not add a 23rd mount.

Closes #307

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

Test-only change; no file under `custom_components/haventory/` or `cards/haventory-card/src/components/*.ts` (the components themselves) was touched. Both gates green:

- [x] Frontend (`cards/haventory-card`): `npx eslint .` (no errors, no warnings), `npm run typecheck`, `npx vitest run` → **1810 passed, 62 files** (1804 before, +6 harness tests), `npm run build` clean.
- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 903 passed, 22 skipped; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all clean. Untouched by this diff.

The six new tests in `src/test.utils.test.ts` pin the properties the 22 component files lean on: properties applied before the first render, light DOM reaching a slot, `q`/`all` reading through either an element or a shadow root, `mountStore` forwarding statuses and areas, `componentCss` containing `ownCss` (and both whitespace-normalized), and `settle` catching a render that another render queued.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case — `componentCss` on a tag with no styles throws; `q`/`all` on a miss return `null`/`[]`).
- [x] Docs updated where behavior changed (`CONTRIBUTING.md`; no shipped behavior changed).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None — the components themselves are unchanged, only the tests around them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuPaxBz6ub6X2jheqqxgiL)_