### PR TITLE
perf(storage): stop copying the whole dataset on every save

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,13 @@ What HAventory does *not* do today, stated up front so none of it is a surprise:
 - **Scale: a few thousand items.** Every mutation re-serializes the entire inventory and
   rewrites the store blob, so write latency grows with the total item count. Measured p50
   per create: ~70 ms at 250 items, ~114 ms at 500, ~200 ms at 1000; on that curve a single
-  create trends toward ~1 s at a few thousand items. Reads don't share the problem (query
-  paths are benchmarked at 10 000 items), correctness is unaffected at any size, and no
-  limit is enforced — writes simply get slower. Treat a few thousand items as the
-  comfortable ceiling.
+  create trends toward ~1 s at a few thousand items. Those figures predate the save
+  dropping a redundant copy of the whole dataset, which took HAventory's own share of one
+  save from ~18 ms to ~6 ms at 1 000 items — a share the offline benchmarks now record, and
+  a small part of the total above, most of which is the store write itself. Reads don't
+  share the problem (query paths are benchmarked at 10 000 items), correctness is unaffected
+  at any size, and no limit is enforced — writes simply get slower. Treat a few thousand
+  items as the comfortable ceiling.
 - **No automation triggers.** The integration creates no entities and fires no events on
   the Home Assistant bus. Automations and scripts can *call* the `haventory.*` services,
   but nothing can trigger *on* an inventory change — there is no state object to watch and
@@ -284,8 +287,10 @@ Every feature/fix ships with tests — happy path plus at least one edge/error c
 Performance benchmarks live in `tests/test_repository_benchmarks_offline.py`,
 including the WP4 percentile scenarios (item list: 50-item page p50 ≤ 30 ms /
 p95 ≤ 75 ms; `move_subtree` p50 ≤ 80 ms / p95 ≤ 150 ms on the 2k-items /
-60-locations typical dataset). They print results always and fail on budget
-misses only with `ASSERT_BUDGETS=1`:
+60-locations typical dataset) and the persistence curve at 250 / 500 / 1 000
+items, which is what a save costs the event loop before Home Assistant's own
+write. They print results always and fail on budget misses only with
+`ASSERT_BUDGETS=1`:
 
 ```bash
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ASSERT_BUDGETS=1 uv run pytest -q tests/test_repository_benchmarks_offline.py -s

--- a/README.md
+++ b/README.md
@@ -151,16 +151,18 @@ no longer used and can be deleted; the integration ignores it either way.
 
 What HAventory does *not* do today, stated up front so none of it is a surprise:
 
-- **Scale: a few thousand items.** Every mutation re-serializes the entire inventory and
-  rewrites the store blob, so write latency grows with the total item count. Measured p50
-  per create: ~70 ms at 250 items, ~114 ms at 500, ~200 ms at 1000; on that curve a single
-  create trends toward ~1 s at a few thousand items. Those figures predate the save
-  dropping a redundant copy of the whole dataset, which took HAventory's own share of one
-  save from ~18 ms to ~6 ms at 1 000 items — a share the offline benchmarks now record, and
-  a small part of the total above, most of which is the store write itself. Reads don't
-  share the problem (query paths are benchmarked at 10 000 items), correctness is unaffected
-  at any size, and no limit is enforced — writes simply get slower. Treat a few thousand
-  items as the comfortable ceiling.
+- **Scale: writes get slower as the inventory grows.** Every mutation re-serializes the
+  entire inventory and rewrites the store blob, so an edit costs more the more you have.
+  Measured against a real Home Assistant, one editor at a time — which is what a household
+  is — create p50 runs 2.5 ms on an empty store, 9.5 ms at 1 000 items, 17 ms at 2 000 and
+  43 ms at 5 000: linear at roughly 8 µs per item, with the persist about three quarters of
+  it. At and above ~3 000 items the p95 spikes to 230–280 ms against a 21–37 ms median, so
+  the occasional slow save arrives before the median becomes a problem. Bulk operations and
+  import write **once per batch** rather than once per row, so the paths that change many
+  items at a time do not multiply the cost. Reads don't share the problem (query paths are
+  benchmarked at 10 000 items), correctness is unaffected at any size, and no limit is
+  enforced. Several thousand items is comfortable; past that, an edit starts to be
+  something you notice.
 - **No automation triggers.** The integration creates no entities and fires no events on
   the Home Assistant bus. Automations and scripts can *call* the `haventory.*` services,
   but nothing can trigger *on* an inventory change — there is no state object to watch and

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -198,9 +198,19 @@ class DomainStore:
         return deepcopy(data)
 
     async def async_save(self, data: dict[str, Any]) -> None:
-        """Persist the dataset ensuring schema_version is up-to-date."""
+        """Persist the dataset, ensuring schema_version is up to date.
 
-        payload = deepcopy(data) if isinstance(data, dict) else {}
+        The copy is one level deep: enough that the defaults below land on this
+        method's dict rather than the caller's, and no deeper. The collections
+        underneath are handed over, not duplicated — ``Repository.export_state``
+        builds every one of them fresh on each call and keeps no reference, so a
+        deep copy would rebuild the whole dataset a second time on the event
+        loop for nothing. At a thousand items that copy measured longer than
+        building the payload and encoding it put together, and it grows with the
+        inventory the way both of those do.
+        """
+
+        payload = dict(data) if isinstance(data, dict) else {}
         payload.setdefault("schema_version", self._schema_version)
         for name in STORE_COLLECTIONS:
             payload.setdefault(name, {})

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -484,7 +484,7 @@ letter (e.g. "Éclairage" or "Übriges"), and a handful of items with **no** loc
 
 ## H8 — #200 where the per-mutation time at 250 / 500 / 1000 items actually goes
 
-**Branch / PR**: `claude/v0-5-0-w3-storage-scaling` / #NNN
+**Branch / PR**: `claude/v0-5-0-w3-storage-scaling` / #429
 **Why this needs a real HA**: #200's numbers — per-create p50 of 70 ms @250, 114 ms @500,
 200 ms @1000 — were measured over a real WebSocket against a real store on disk. The
 offline suite can measure everything HAventory itself does for one save, and it now does

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -484,6 +484,21 @@ letter (e.g. "Éclairage" or "Übriges"), and a handful of items with **no** loc
 
 ## H8 — #200 where the per-mutation time at 250 / 500 / 1000 items actually goes
 
+**Answered** — [#200 comment](https://github.com/chrreiter/HAventory/issues/200#issuecomment-5267185373).
+The ~180 ms this handover set out to find is not a per-create cost: `stress.py bulk` drives
+eight connections and every mutation persists under one lock, so its p50 is roughly
+*connections × one save*. One writer at 1 000 items waits 9.5 ms, of which 7.8 ms is the
+persist — 3.87 ms `export_state` and 3.74 ms Home Assistant's `Store`. Recommendation on
+the issue is to close it as not-planned, with single-writer latency linear at ~8.4 µs/item
+and ~5 000 items as the reopen trigger.
+
+Two corrections to what is written below, kept visible because they are the parts that
+misled: **step 3 cannot work as written** — `cmd_bulk` deletes what it created and calls
+`cleanup_prefix` in its `finally`, so a second run always starts from an empty store; the
+store-size curve the local session substituted answers the same question directly. And the
+`elapsed_ms` in step 4 **never reaches the log** — Home Assistant's formatter drops `extra=`
+fields, so the figure has to be put into the message text by instrumenting the container.
+
 **Branch / PR**: `claude/v0-5-0-w3-storage-scaling` / #429
 **Why this needs a real HA**: #200's numbers — per-create p50 of 70 ms @250, 114 ms @500,
 200 ms @1000 — were measured over a real WebSocket against a real store on disk. The

--- a/dev/v0_5_0_handover_prompts.md
+++ b/dev/v0_5_0_handover_prompts.md
@@ -479,3 +479,91 @@ letter (e.g. "Éclairage" or "Übriges"), and a handful of items with **no** loc
 - One screenshot showing the accented location's rows in place among the paths.
 - Any cursor-related log line, or an explicit "none" — that is the whole answer here.
 - Paste the result as a comment on #204 and reply on the PR thread.
+
+---
+
+## H8 — #200 where the per-mutation time at 250 / 500 / 1000 items actually goes
+
+**Branch / PR**: `claude/v0-5-0-w3-storage-scaling` / #NNN
+**Why this needs a real HA**: #200's numbers — per-create p50 of 70 ms @250, 114 ms @500,
+200 ms @1000 — were measured over a real WebSocket against a real store on disk. The
+offline suite can measure everything HAventory itself does for one save, and it now does
+(`tests/test_repository_benchmarks_offline.py::test_benchmark_persist_payload_by_inventory_size`),
+but it cannot see Home Assistant's own `Store` write: the JSON encode, the temp-file write
+and the rename. That write is the part this issue's premise is about, and it is the part
+only a real instance shows.
+
+The offline half already answered one question. Building the payload and handing it to the
+store cost 3.7 / 8.5 / 17.9 ms at 250 / 500 / 1000 items, of which a full deep copy of the
+whole dataset was two thirds; the PR removes the copy and the same measurement is now
+1.0 / 2.2 / 6.3 ms. So **at most ~18 ms of the measured 200 ms was ever HAventory's own
+serialization**, and after the PR it is ~6 ms. The remaining ~180 ms is somewhere this
+handover has to find before anyone builds a delta-persistence path for it.
+
+### Setup
+
+    set -a; . ./.env; set +a
+    bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
+
+Start from an inventory that is **empty of stress fixtures** — `stress.py` cleans up after
+itself, but confirm `haventory/stats`' `items_total` before starting, and record it. The
+curve is about how the cost grows with what is already stored, so a store that starts at
+3 000 items measures a different question.
+
+### Steps
+
+1. Record the baseline: `uv run python .claude/skills/test-haventory/stress.py baseline`,
+   and note `items_total` and the store file's size on disk:
+
+       docker exec home-assistant sh -c 'ls -l /config/.storage/haventory_store'
+
+2. Run the curve: `uv run python .claude/skills/test-haventory/stress.py bulk 1000`.
+   It creates in checkpoints of 250 → 500 → 1000 and prints p50/p95/p99 per checkpoint.
+   Record all three checkpoints, and the store file's size again at the end.
+3. Run it a **second time** without cleaning up in between, so the second run's 250-item
+   checkpoint lands on a store that already holds 1 000 items. That is the pair the issue's
+   own follow-up comment asks for — p50 at the start versus at the end of a run at a known
+   item count — and it separates "cost grows with the store" from "cost grows within a run".
+4. While the 1000-item checkpoint is running, capture where the time goes. With
+   `logger` set to `debug` for `custom_components.haventory.storage`, each save logs
+   `persist_complete` with `elapsed_ms` — that figure covers `export_state` **plus** Home
+   Assistant's write. Compare its median against the ~6 ms the offline benchmark reports
+   for the same item count: the difference is HA's `Store`, and that difference is the whole
+   question.
+
+       # in configuration.yaml, then restart
+       logger:
+         default: warning
+         logs:
+           custom_components.haventory.storage: debug
+
+5. Note whether the container's `/config` sits on the same disk as everything else and
+   whether it is a network mount — a 780 KB write plus an fsync behaves very differently on
+   an SSD and on a NAS share, and a number measured on one says nothing about the other.
+
+### What "pass" looks like
+
+There is no pass here; there is an answer, and either answer is a good outcome:
+
+- **If `persist_complete`'s `elapsed_ms` is a small fraction of the per-create p50** — say
+  under 20 ms at 1 000 items while p50 is 200 ms — then persistence is not what makes a
+  create slow, the premise of #200 does not hold at this scale, and the issue should be
+  **closed as not-planned with these numbers in the comment**. The next question would be a
+  different issue about where the other 180 ms goes (WS round trip, event fan-out,
+  broadcast).
+- **If `elapsed_ms` is most of the per-create p50 and grows linearly with the store**, the
+  issue stands and the numbers size the fix: a delta or sharded persistence path, which
+  takes `CURRENT_SCHEMA_VERSION` up with a migration, and which the PR deliberately did not
+  build without this measurement.
+- Either way, the second run's 250-checkpoint p50 against the first run's tells you whether
+  the growth is in the store size or in the run.
+
+### What to send back
+
+- The two `stress.py bulk 1000` outputs in full — six checkpoint lines, both runs.
+- The median and max of `persist_complete`'s `elapsed_ms` at the 1000-item checkpoint:
+
+      docker logs home-assistant 2>&1 | grep persist_complete | tail -400
+
+- The store file's size at the start and at the end, and whether `/config` is a local disk.
+- Paste the result as a comment on #200 and reply on the PR thread.

--- a/tests/test_repository_benchmarks_offline.py
+++ b/tests/test_repository_benchmarks_offline.py
@@ -13,6 +13,8 @@ import time
 import pytest
 from custom_components.haventory.models import ItemCreate
 from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import DomainStore
+from homeassistant.core import HomeAssistant
 
 # Time budgets in seconds (conservative estimates)
 BUDGET_CREATE_1K_ITEMS = 1.0
@@ -219,3 +221,62 @@ async def test_benchmark_wp4_move_subtree_percentiles() -> None:
         samples.append((time.perf_counter() - start) * 1000)
     p50, p95 = _percentiles(samples)
     _print_percentiles("move_subtree (typical)", p50, p95, MOVE_BUDGET_P50_MS, MOVE_BUDGET_P95_MS)
+
+
+# The store is one JSON document rewritten in full on every mutation, so the
+# work a save costs is proportional to the whole inventory rather than to the
+# edit. These sizes are the ones the persistence numbers are quoted at.
+PERSIST_SIZES = (250, 500, 1000)
+
+# Per-save budget for everything HAventory itself does on the event loop:
+# building the payload and handing it to the store. Home Assistant's own file
+# write sits outside this and no offline run can see it.
+PERSIST_BUDGET_P50_MS = 60.0
+PERSIST_BUDGET_P95_MS = 120.0
+
+
+def _build_sized_dataset(n_items: int) -> Repository:
+    """An inventory of ``n_items`` with fields filled the way a household fills them."""
+
+    repo = Repository()
+    garage = repo.create_location(name="Garage")
+    shelves = [repo.create_location(name=f"Shelf {i}", parent_id=str(garage.id)) for i in range(10)]
+    for i in range(n_items):
+        repo.create_item(
+            ItemCreate(
+                name=f"Item {i:05d}",
+                description="A representative description of a household object.",
+                quantity=i % 7,
+                location_id=str(shelves[i % len(shelves)].id),
+                tags=["metric", "spare", f"batch-{i % 20}"],
+                category=f"Category {i % 12}",
+                custom_fields={"serial": f"SN-{i:08d}", "warranty_until": "2030-01-01"},
+            )
+        )
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_benchmark_persist_payload_by_inventory_size() -> None:
+    """What one save costs the event loop at 250 / 500 / 1000 items.
+
+    Printed as a curve rather than a single number: the question this answers is
+    how the cost *grows*, which is what decides whether the persistence path
+    needs restructuring or only the constant taking out of it.
+    """
+
+    for size in PERSIST_SIZES:
+        repo = _build_sized_dataset(size)
+        store = DomainStore(HomeAssistant(), key=f"bench_persist_{size}")
+        repo.export_state()  # warm any lazily built index the export reads
+
+        samples = []
+        for _ in range(10):
+            start = time.perf_counter()
+            await store.async_save(repo.export_state())
+            samples.append((time.perf_counter() - start) * 1000)
+
+        p50, p95 = _percentiles(samples)
+        _print_percentiles(
+            f"persist ({size} items)", p50, p95, PERSIST_BUDGET_P50_MS, PERSIST_BUDGET_P95_MS
+        )

--- a/tests/test_storage_offline.py
+++ b/tests/test_storage_offline.py
@@ -483,3 +483,77 @@ async def test_a_stored_collection_survives_a_repository_roundtrip() -> None:
         assert reloaded[name], f"{name} was emptied by the roundtrip"
     assert [i["name"] for i in reloaded["items"].values()] == ["Drill"]
     assert [loc["name"] for loc in reloaded["locations"].values()] == ["Garage"]
+
+
+@pytest.mark.asyncio
+async def test_save_leaves_the_caller_payload_alone() -> None:
+    """The defaults the save stamps on land on its own dict, not the caller's.
+
+    A payload built for one save would otherwise come back carrying a
+    ``schema_version`` it never had, which a caller comparing two exports — or
+    building an export document — would then have to strip.
+    """
+
+    hass = HomeAssistant()
+    store = DomainStore(hass, key="test_store_caller_payload")
+    payload: dict[str, Any] = {"items": {}}
+
+    await store.async_save(payload)
+
+    assert payload == {"items": {}}
+    assert "schema_version" not in payload
+    assert (await store.async_load())["schema_version"] == CURRENT_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_a_later_mutation_cannot_reach_what_was_stored() -> None:
+    """Editing the inventory after a save does not rewrite the saved payload.
+
+    The save copies one level deep, so the isolation comes from
+    ``export_state`` building fresh collections rather than from the store
+    duplicating them. This is the property that has to hold; if a future export
+    starts handing out the repository's own dicts, this test is what fails.
+    """
+
+    hass = HomeAssistant()
+    store = DomainStore(hass, key="test_store_post_save_mutation")
+    repo = Repository()
+    item = repo.create_item(ItemCreate(name="Hammer", quantity=1))
+
+    await store.async_save(repo.export_state())
+
+    repo.update_item(str(item.id), {"name": "Renamed", "quantity": 99})
+    repo.create_item(ItemCreate(name="Second", quantity=1))
+
+    stored = await store.async_load()
+    assert [entry["name"] for entry in stored["items"].values()] == ["Hammer"]
+    assert next(iter(stored["items"].values()))["quantity"] == 1
+
+
+@pytest.mark.asyncio
+async def test_save_does_not_duplicate_the_dataset(monkeypatch) -> None:
+    """What reaches Home Assistant's Store is the caller's collections, not copies.
+
+    Copying them costs the event loop a second full pass over the inventory on
+    every mutation, which is the whole reason the save copies one level and not
+    more. A deep copy reintroduced here would pass every other test in this file
+    and only show up as a growing stall on a large store.
+    """
+
+    hass = HomeAssistant()
+    store = DomainStore(hass, key="test_store_no_duplication")
+    seen: list[dict[str, Any]] = []
+
+    async def _capture(payload: dict[str, Any]) -> None:
+        seen.append(payload)
+
+    monkeypatch.setattr(store._store, "async_save", _capture)
+    repo = Repository()
+    repo.create_item(ItemCreate(name="Hammer", quantity=1))
+    payload = repo.export_state()
+
+    await store.async_save(payload)
+
+    assert len(seen) == 1
+    for name in STORE_COLLECTIONS:
+        assert seen[0][name] is payload[name], name


### PR DESCRIPTION
## Summary

#200 asks for a delta-persistence path. This PR **measured first**, as the milestone plan requires, landed the one thing the measurement indicts, and handed over the part it could not measure here. That handover (**H8**) has since come back, and it answers the question: see [#200's comment](https://github.com/chrreiter/HAventory/issues/200#issuecomment-5267185373) and "What H8 found" below.

### The change

`DomainStore.async_save` deep-copied the payload it was handed before giving it to Home Assistant's `Store`. `Repository.export_state` builds every collection fresh on each call — `str()`, `list()`, `dict()`, and two serializers that do the same — and `async_persist_repo`, the only production caller, drops its reference immediately. So the copy duplicated the entire inventory on the event loop, on every mutation, to protect against an aliasing that does not exist.

The copy is now one level deep — enough to keep the method's own `setdefault` defaults off the caller's dict, and no more.

**Measured against a real Home Assistant** (dedicated instance, empty store, ext4 on a local volume, 12 CPUs), medians:

| | `export_state` | HA `Store` write | total save | 8-conn bulk curve (250/500/1000) |
|---|---:|---:|---:|---|
| before | 3.19 ms | 15.09 ms | **18.36 ms** | 34.2 / 69.8 / 127.3 ms |
| after | 3.87 ms | 3.74 ms | **7.81 ms** | 22.2 / 42.1 / 56.9 ms |

A save at 1 000 items went **18.4 ms → 7.8 ms**, and the eight-connection curve **127 ms → 57 ms**. (The copy lived inside `async_save`, so before the change it lands in the store column.)

The offline benchmark this PR adds predicted it closely: 5.20 ms `export_state` and 4.30 ms encode at 1 000 items against 3.87 ms and 3.74 ms live.

Nothing about the persistence contract moves. WS and service handlers still save immediately and errors still propagate as `storage_error`; shutdown and unload still flush immediately; debounced saves are still internal-only and still scheduled through `hass.async_create_background_task`. Nothing on disk changes shape, so `CURRENT_SCHEMA_VERSION` stays where it is and there is no migration.

Three tests hold what the deep copy was standing in for:

- `test_save_leaves_the_caller_payload_alone` — the schema-version default lands on the store's dict, not the caller's.
- `test_a_later_mutation_cannot_reach_what_was_stored` — editing the inventory after a save does not rewrite the saved payload. This is the property that actually matters, and it comes from `export_state` building fresh collections; if a future export starts handing out the repository's own dicts, this is what fails.
- `test_save_does_not_duplicate_the_dataset` — what reaches HA's `Store` **is** the caller's collections. This one fails deterministically if a deep copy is reintroduced, which no timing test can promise in CI.

### What H8 found

The premise this PR was written under — "~180 ms of the measured 200 ms is somewhere an offline run cannot see" — was wrong, and the live measurement corrects it in a way worth stating plainly:

**That 180 ms does not exist as a per-create cost.** `stress.py bulk` drives eight connections, and every mutation persists under one `asyncio.Lock`, so each create waits behind up to seven other saves. At a fixed ~1 000 items, varying only the writer count: 10.9 / 19.0 / 38.9 / 84.8 / 190.7 ms at 1 / 2 / 4 / 8 / 16 connections — linear in connections, straight down the line. #200's 200 ms is eight writers queued behind a ~7 ms save, not a service time.

**Home Assistant's `Store` is not the hidden cost either.** At 1 000 items it is 3.74 ms of a 7.81 ms save, and past ~750 items it is the smaller half. After this PR, this integration's own serialization is about two thirds of a save.

**What one editor actually waits for**, single connection: 2.5 ms empty, 4.7 ms @250, 6.1 ms @500, 9.5 ms @1000, 17.4 ms @2000, 43.2 ms @5000 — linear at ~8.4 µs/item. So persistence *is* the dominant cost of a mutation and #200's premise holds; the thing it dominates is 10 ms, not 200 ms.

`README.md`'s scale limitation quoted the queued figures as per-create cost and attributed most of them to the store write. Both are corrected in this PR against the measured single-writer curve, along with the p95 spike (230–280 ms against a 21–37 ms median) that arrives at ~3 000 items before the median becomes a problem.

### Why the delta path is still not built

`haventory/items/bulk` and import already persist **once per batch**, so the paths that change many items at a time never multiply the write. The per-mutation rewrite only applies to one-at-a-time edits, which is exactly where it is cheap. A sharded or journalled store is a schema change with a recovery surface, and a 10 ms edit does not justify it.

H8's recommendation on #200 is to **close it as not-planned** with the numbers recorded and an explicit reopen trigger: single-writer latency is linear at ~8.4 µs/item, so a real install above ~5 000 items (43 ms measured, ~85 ms projected at 10 k) is where this becomes worth building.

This PR therefore says **`Refs #200`, not `Closes`** — closing as *not planned* is the owner's call, and a PR reference would close it as completed.

### On #197's caps

The milestone plan asks how much of the improvement is theirs. None of it directly — the caps bound how large one item can be (`DESCRIPTION_MAX_LENGTH` 4 000, 50 tags, 50 custom fields), which bounds the blob's growth per item; they do not change the per-save cost at a given inventory size. What they do is make the numbers above a ceiling rather than a sample: an item cannot be arbitrarily larger than the ~780-byte fixture used here without hitting one of them. The `models.py` comment that sizes those caps already names this store shape as the reason, and it is still accurate.

Refs #200

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI — the README correction
- [x] Refactor (no functional change) — performance only; no observable behavior moves

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **907 passed, 22 skipped** (903 before, +4); `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1804 passed), `npm run build` — green, and untouched by this diff.
- [x] **Live, against a real Home Assistant** — the before/after table above, on a dedicated throwaway instance at this branch's head.

## Live verification

**H8 — answered.** [#200 comment](https://github.com/chrreiter/HAventory/issues/200#issuecomment-5267185373). The handover itself carried two mistakes, corrected in place in `dev/v0_5_0_handover_prompts.md` so the next reader is not sent down them: its step 3 cannot work (`cmd_bulk` deletes what it created and calls `cleanup_prefix` in its `finally`, so a second run always starts empty), and the `elapsed_ms` its step 4 asks for never reaches the log at all.

## Follow-ups

Found during the live run, filed rather than fixed here:

- **`persist_complete`'s `elapsed_ms` is unobservable in the field** — Home Assistant's log formatter drops `extra=` fields, so every structured value this integration attaches to a log record is invisible in a user's log. Measuring the save required instrumenting the container.
- **`scripts/ws_init_haventory.py` is broken** — it submits `{}` to a config flow whose two fields are now `vol.Required`, so it answers HTTP 400.
- **`stress.py`'s `load_env()` uses `setdefault`**, so an `HA_BASE_URL` / `HA_TOKEN` exported by a shell profile silently wins over the worktree's own `.env`. In this run the first baseline answered from a *shared* instance holding 1 079 items before it was caught; a `bulk 1000` would have written a thousand stress items into another session's inventory.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/). It says *copying* rather than *rewriting* on purpose — the blob is still rewritten in full, and the title becomes the changelog entry.
- [x] Tests added/updated (happy path + edge cases: caller's dict untouched, post-save mutation cannot reach the store, no duplication of the collections).
- [x] Docs updated where behavior changed (`README.md` — the scale limitation rewritten against the measured single-writer curve; the benchmark section names the new persistence scenario).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — n/a, no contract change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`). Persistence contract preserved: immediate saves on WS/service paths, immediate flush on shutdown/unload, debounce internal-only.
- [x] No file under `custom_components/haventory/` deleted or renamed, so `RETIRED_PATHS` is unchanged.

## Screenshots (card / UI changes)

None — backend only.