### PR TITLE
fix(storage): stamp hex status colours at a version older builds refuse

### DIFF
--- a/custom_components/haventory/migrations.py
+++ b/custom_components/haventory/migrations.py
@@ -173,3 +173,22 @@ def _backfill_attachment_fields(attachments: object) -> None:
         placed[kind] = position + 1
         entry.setdefault("title", "")
         entry.setdefault("order", position)
+
+
+def migrate_6_to_7(payload: dict[str, Any]) -> dict[str, Any]:
+    """Mark the store as one whose status colours a v6 build cannot read.
+
+    Nothing in the payload changes, and nothing needs to: every v6 document is
+    already a valid v7 one. The version exists for the shape v7 *admits* — a
+    status definition's ``color`` may be a ``#rrggbb`` literal, where v6 accepts
+    only the ten tone tokens.
+
+    The bump is what stops the two shapes sharing a stamp. Under one stamp a v6
+    build reads a store holding a literal, cannot validate the definition, and —
+    because an unreadable status definition is skipped rather than fatal — drops
+    it and rewrites every item carrying that slug to the default status,
+    persisting the loss on the next save. Stamped 7, the same build refuses the
+    store outright and the data waits for one that understands it.
+    """
+
+    return deepcopy(payload) if isinstance(payload, dict) else {}

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -38,7 +38,7 @@ from .models import seed_status_definitions, serialize_status_definition
 _LOGGER = logging.getLogger(__name__)
 
 # Current schema version for persisted payloads
-CURRENT_SCHEMA_VERSION: Final[int] = 6
+CURRENT_SCHEMA_VERSION: Final[int] = 7
 
 # Storage key under which the persisted dataset is saved
 STORAGE_KEY: Final[str] = "haventory_store"

--- a/tests/test_migrations_offline.py
+++ b/tests/test_migrations_offline.py
@@ -21,7 +21,7 @@ from custom_components.haventory.const import (
     DOMAIN,
 )
 from custom_components.haventory.exceptions import SchemaDowngradeError, StorageError
-from custom_components.haventory.migrations import migrate, migrate_5_to_6
+from custom_components.haventory.migrations import migrate, migrate_5_to_6, migrate_6_to_7
 from custom_components.haventory.storage import (
     CURRENT_SCHEMA_VERSION,
     STORE_COLLECTIONS,
@@ -364,3 +364,68 @@ def test_v5_to_v6_is_idempotent() -> None:
     twice = migrate_5_to_6(deepcopy(once))
 
     assert twice == once
+
+
+#: The version from which a status ``color`` may be a ``#rrggbb`` literal rather
+#: than one of the ten tone tokens, and the one below it.
+_HEX_STATUS_COLOUR_VERSION = 7
+_TOKEN_ONLY_COLOUR_VERSION = _HEX_STATUS_COLOUR_VERSION - 1
+
+
+def _v6_payload_with_token_colour() -> dict[str, Any]:
+    """A v6 store: every status colour is a tone token, which v6 and v7 both read."""
+
+    return {
+        "schema_version": _TOKEN_ONLY_COLOUR_VERSION,
+        "items": {"i1": {"id": "i1", "name": "Drill", "status": "loaned", "attachments": []}},
+        "locations": {"l1": {"id": "l1", "name": "Garage"}},
+        "statuses": {
+            "ok": {"slug": "ok", "label": "OK", "order": 0, "color": "green", "icon": "check"},
+            "loaned": {
+                "slug": "loaned",
+                "label": "Loaned out",
+                "order": 1,
+                "color": "blue",
+                "icon": "check",
+            },
+        },
+    }
+
+
+def test_v6_to_v7_changes_nothing_but_the_stamp() -> None:
+    """v7 admits a wider colour; it does not rewrite what v6 already stored."""
+
+    payload = _v6_payload_with_token_colour()
+    before = deepcopy(payload)
+
+    out = migrate(
+        payload,
+        from_version=_TOKEN_ONLY_COLOUR_VERSION,
+        to_version=_HEX_STATUS_COLOUR_VERSION,
+    )
+
+    assert out["schema_version"] == _HEX_STATUS_COLOUR_VERSION
+    for key in ("items", "locations", "statuses"):
+        assert out[key] == before[key]
+
+
+def test_v6_to_v7_is_idempotent() -> None:
+    """The step itself, re-applied — not the driver, which would skip it."""
+
+    payload = _v6_payload_with_token_colour()
+
+    once = migrate_6_to_7(deepcopy(payload))
+    twice = migrate_6_to_7(deepcopy(once))
+
+    assert twice == once
+
+
+def test_v6_to_v7_does_not_alias_the_payload_it_was_given() -> None:
+    """A no-op step still copies, or a caller's dict is the migrated one."""
+
+    payload = _v6_payload_with_token_colour()
+
+    out = migrate_6_to_7(payload)
+    out["statuses"]["loaned"]["color"] = "#3366cc"
+
+    assert payload["statuses"]["loaned"]["color"] == "blue"

--- a/tests/test_storage_offline.py
+++ b/tests/test_storage_offline.py
@@ -36,6 +36,9 @@ from homeassistant.helpers.storage import Store as HAStore
 #: is the payload that step rewrites.
 _STATUS_BACKFILL_VERSION = 5
 _ATTACHMENTS_BACKFILL_VERSION = 6
+#: The version from which a status ``color`` may be a ``#rrggbb`` literal rather
+#: than one of the ten tone tokens. Builds below it reject the literal.
+_HEX_STATUS_COLOUR_VERSION = 7
 
 
 @pytest.mark.asyncio
@@ -288,6 +291,49 @@ async def test_newer_schema_version_is_refused_and_store_untouched() -> None:
 
     # Nothing was rewritten: version, unknown fields and all.
     assert await raw_store.async_load() == pre_payload
+
+
+@pytest.mark.asyncio
+async def test_a_hex_status_colour_is_stamped_beyond_the_builds_that_refuse_it() -> None:
+    """The colour shape and the stamp have to move together.
+
+    A status ``color`` may be a ``#rrggbb`` literal, which earlier builds
+    validate against the ten tone tokens and reject. Rejecting a status
+    definition is not fatal there — it is skipped, and every item carrying its
+    slug reads back as the default status — so the store has to announce itself
+    as one those builds cannot read. Stamping the wider shape at a version they
+    accept is what turns a refusal into silent data loss.
+    """
+
+    hass = HomeAssistant()
+    key = "test_store_hex_status_colour_is_stamped"
+
+    written_by_this_build = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": {"i1": {"id": "i1", "name": "Drill", "status": "loaned", "attachments": []}},
+        "locations": {},
+        "statuses": {
+            "loaned": {
+                "slug": "loaned",
+                "label": "Loaned out",
+                "order": 1,
+                "color": "#3366cc",
+                "icon": "check",
+            }
+        },
+    }
+    raw_store = HAStore(hass, CURRENT_SCHEMA_VERSION, key)
+    await raw_store.async_save(deepcopy(written_by_this_build))
+
+    # The last version whose colour vocabulary is tokens only.
+    reader = DomainStore(hass, key=key, version=_HEX_STATUS_COLOUR_VERSION - 1)
+
+    with pytest.raises(SchemaDowngradeError):
+        await reader.async_load()
+
+    # Refused without a rewrite: the colour and the item's status both survive
+    # for whichever build the user runs next.
+    assert await raw_store.async_load() == written_by_this_build
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A status colour may be a `#rrggbb` literal (#418), but the store kept stamping `schema_version: 6` — the same value 0.4.3 writes. A store holding a literal therefore looked readable to 0.4.3: it validates the colour against the ten tone tokens, rejects it, and because an unreadable status definition is skipped rather than fatal, drops the definition, reads every item on that slug back as the default status, and persists the loss on the first save. One warning line in the log is all the user gets.

This bumps `CURRENT_SCHEMA_VERSION` to 7 with a no-op `migrate_6_to_7`, so the downgrade refusal the storage layer already implements actually fires and the data waits for a build that understands it.

**Behaviour change worth carrying into the release notes:** every 0.5.0 store now refuses to load on 0.4.3, not only one that uses a literal. That is the intended trade — a coarse stamp that refuses beats a fine one that guesses, and stamping conditionally on the colours in use would make the version non-deterministic.

Sequencing note: #229 collapses the migration chain before the public release. This adds one step to it; if #229 lands after this, the collapse should absorb it.

Closes #436

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

The commit is deliberately `fix:` with no `!` and no `BREAKING CHANGE:` footer. The downgrade path does change behaviour, but marking it breaking would drive release-please at a version number this release is not meant to take.

## How was this tested?

Both gates green locally on `6ba716c`.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (923 passed, 22 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (1812 passed), `npm run build`

Four tests added — three in `tests/test_migrations_offline.py`, one in `tests/test_storage_offline.py`:

- `test_v6_to_v7_changes_nothing_but_the_stamp` — the step restamps and rewrites nothing
- `test_v6_to_v7_is_idempotent` — the step itself re-applied, not the driver, which would skip it
- `test_v6_to_v7_does_not_alias_the_payload_it_was_given` — a no-op step that returned its input would hand the caller's dict back as the migrated one
- `test_a_hex_status_colour_is_stamped_beyond_the_builds_that_refuse_it` — the regression guard: a store carrying `#3366cc` at the current version is refused by a reader pinned one version below, and is left byte-for-byte intact

That last one was checked against a reverted constant: with `CURRENT_SCHEMA_VERSION` back at 6 it fails with `DID NOT RAISE SchemaDowngradeError`, so it guards the bug rather than passing either way.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`) — no change needed; both docs reference `schema_version` generically rather than pinning a value.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change; `ws.py` reports the constant it already imported.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`) — untouched; no item or location field changes.

## Screenshots (card / UI changes)

None — backend only, no visible card change.

## Follow-ups

Out of scope here, noted rather than fixed:

- `docs/data_shapes.md:351,382` shows `"schema_version": 4` in example export documents. Already stale before this change, so it belongs to the docs sweep in #441.
- `tests/integration/test_schema_migration.py:37` is named `test_v4_store_boots_to_v5_with_status_backfilled` but asserts against `CURRENT_SCHEMA_VERSION`. The assertion is correct and follows the bump; the name was already drifting at v6.