### PR TITLE
fix(scripts): answer the config flow with the defaults its schema offers

### DIFF
--- a/scripts/ws_init_haventory.py
+++ b/scripts/ws_init_haventory.py
@@ -7,7 +7,8 @@ Usage:
 
 Behavior:
 - Starts the HAventory config flow (domain "haventory").
-- Submits empty user input (flow is single-step) to create the entry.
+- Answers each form with the defaults its returned schema offers, so setup asks
+  no questions and keeps working when the flow gains a field or a step.
 - If already configured (single instance), exits successfully.
 - Verifies integration by calling the "haventory/version" WS command.
 """
@@ -73,6 +74,51 @@ async def _expect_raw_result(ws: aiohttp.ClientWebSocketResponse, expect_id: int
 
 HTTP_ERROR_MIN_STATUS: int = 400
 
+# The flow is single-step; anything past a handful of forms is a loop between
+# this script and a step it cannot answer, not a longer setup.
+MAX_FORM_STEPS: int = 5
+
+
+def build_user_input(data_schema: object) -> dict[str, Any]:
+    """Build a form submission from the defaults the form itself offers.
+
+    ``data_schema`` is the serialized schema a config-flow form result carries:
+    a list of field descriptors with ``name``, ``required``, and — for every
+    field the flow prefills — ``default`` (or a suggested value under
+    ``description``). Answering with those keeps this script's contract of "a
+    working instance, no questions asked" without hard-coding values a later
+    release would silently drift from. A required field that offers no default
+    cannot be invented here, so it is refused by name rather than submitted
+    blank for the flow to 400 on.
+    """
+    payload: dict[str, Any] = {}
+    if not isinstance(data_schema, list):
+        return payload
+    for field in data_schema:
+        if not isinstance(field, dict):
+            continue
+        name = field.get("name")
+        if not isinstance(name, str):
+            continue
+        # A section serializes as an "expandable" wrapper around its own field
+        # list and is submitted as a nested object under the section's name.
+        if field.get("type") == "expandable":
+            payload[name] = build_user_input(field.get("schema"))
+            continue
+        if "default" in field:
+            payload[name] = field["default"]
+            continue
+        description = field.get("description")
+        if isinstance(description, dict) and "suggested_value" in description:
+            payload[name] = description["suggested_value"]
+            continue
+        if field.get("required"):
+            raise RuntimeError(
+                f"config flow field {name!r} is required but offers no default; "
+                "cannot set up without asking"
+            )
+    return payload
+
 
 async def run() -> int:  # noqa: PLR0912, PLR0915
     base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
@@ -102,6 +148,7 @@ async def run() -> int:  # noqa: PLR0912, PLR0915
             await ws.send_json(payload)
             frame = await _expect_raw_result(ws, msg_id)
             used_transport = "ws"
+            result: dict[str, Any] = frame.get("result") or {}
             if not bool(frame.get("success")):
                 err = frame.get("error") or {}
                 if err.get("code") == "unknown_command":
@@ -137,26 +184,29 @@ async def run() -> int:  # noqa: PLR0912, PLR0915
                         raise RuntimeError(f"WS command failed: {frame}")
                     result = frame.get("result") or {}
 
-            flow_type = result.get("type")
-            flow_id = result.get("flow_id")
-            # If the flow already completes here (rare), continue gracefully
-            if flow_type == "abort":
-                reason = result.get("reason")
-                if reason in {"single_instance_allowed", "already_configured"}:
-                    # Treat as success; proceed to verification
-                    pass
-                else:
-                    print(f"Config flow aborted: {reason}", file=sys.stderr)
-                    return 2
-            elif flow_type == "form":
-                # 2) Submit empty user input (single-step integration)
+            # 2) Answer each presented form with its own defaults.
+            form_steps = 0
+            while result.get("type") == "form":
+                form_steps += 1
+                if form_steps > MAX_FORM_STEPS:
+                    raise RuntimeError(
+                        f"config flow still presents forms after {MAX_FORM_STEPS} submissions"
+                    )
+                errors = result.get("errors")
+                if errors:
+                    step = result.get("step_id")
+                    raise RuntimeError(
+                        f"config flow step {step!r} rejected the submitted defaults: {errors}"
+                    )
+                user_input = build_user_input(result.get("data_schema"))
+                flow_id = result.get("flow_id")
                 if used_transport == "ws":
-                    msg_id = 2
+                    msg_id += 1
                     payload2 = {
                         "id": msg_id,
                         "type": "config_entries/flow/configure",
                         "flow_id": flow_id,
-                        "user_input": {},
+                        "user_input": user_input,
                     }
                     await ws.send_json(payload2)
                     frame2 = await _expect_raw_result(ws, msg_id)
@@ -164,38 +214,36 @@ async def run() -> int:  # noqa: PLR0912, PLR0915
                         err = frame2.get("error") or {}
                         if err.get("code") == "unknown_command":
                             # Fallback for older cores
-                            msg_id = 12
+                            msg_id += 1
                             payload2["id"] = msg_id
                             payload2["type"] = "config/flow/configure"
                             await ws.send_json(payload2)
                             frame2 = await _expect_raw_result(ws, msg_id)
                         if not bool(frame2.get("success")):
                             raise RuntimeError(f"WS command failed: {frame2}")
-                    result2 = frame2.get("result") or {}
+                    result = frame2.get("result") or {}
                 else:
-                    # HTTP configure step
+                    # The REST configure endpoint takes the user input as the
+                    # request body itself; wrapping it under a "user_input" key
+                    # reads as an unknown extra field and fails validation.
                     step_url = f"{base.rstrip('/')}/api/config/config_entries/flow/{flow_id}"
                     headers = {
                         "Authorization": f"Bearer {token}",
                         "Content-Type": "application/json",
                     }
-                    async with session.post(
-                        step_url, headers=headers, json={"user_input": {}}
-                    ) as resp:
+                    async with session.post(step_url, headers=headers, json=user_input) as resp:
                         if resp.status >= HTTP_ERROR_MIN_STATUS:
-                            raise RuntimeError(f"HTTP {resp.status} configuring flow")
-                        result2 = await resp.json()
-                # Accept create_entry or abort(single_instance_allowed)
-                rtype = result2.get("type")
-                if rtype == "abort":
-                    reason = result2.get("reason")
-                    if reason not in {"single_instance_allowed", "already_configured"}:
-                        print(f"Config flow aborted: {reason}", file=sys.stderr)
-                        return 2
-                elif rtype not in {"create_entry", "form"}:
-                    # Some cores return the created entry info directly
-                    pass
-            # else: other types are unexpected; continue to verification
+                            body = await resp.text()
+                            raise RuntimeError(f"HTTP {resp.status} configuring flow: {body}")
+                        result = await resp.json()
+
+            # A completed flow reports create_entry; an instance that already
+            # has its entry aborts, which is this script's job done as well.
+            if result.get("type") == "abort":
+                reason = result.get("reason")
+                if reason not in {"single_instance_allowed", "already_configured"}:
+                    print(f"Config flow aborted: {reason}", file=sys.stderr)
+                    return 2
 
             # 3) Verify by calling haventory/version
             msg_id = 99

--- a/tests/test_ws_init_flow_defaults.py
+++ b/tests/test_ws_init_flow_defaults.py
@@ -1,0 +1,122 @@
+"""The dev-setup script answers the config flow with the form's own defaults.
+
+``scripts/ws_init_haventory.py`` exists to stand up a working instance with no
+questions asked. The user step's fields are required, so an empty submission is
+refused with HTTP 400; the script instead builds its payload from the defaults
+in the serialized schema the flow returns. These tests pin that extraction, and
+pin the flow-side property it depends on: every field the user step requires
+offers a default the script can read.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import voluptuous as vol
+from custom_components.haventory.config_flow import _user_schema
+from custom_components.haventory.const import (
+    DEFAULT_CARD_TITLE,
+    DEFAULT_SIDEBAR_PANEL_ENABLED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from ws_init_haventory import build_user_input  # noqa: E402
+
+
+def test_answers_the_user_step_with_its_defaults() -> None:
+    """The two required fields are answered with the values the form prefills.
+
+    The descriptor list mirrors what the REST flow API returns for the user
+    step: ``voluptuous_serialize`` output, one dict per field, defaults inline.
+    """
+    data_schema = [
+        {"name": "card_title", "type": "string", "required": True, "default": DEFAULT_CARD_TITLE},
+        {
+            "name": "sidebar_panel_enabled",
+            "type": "boolean",
+            "required": True,
+            "default": DEFAULT_SIDEBAR_PANEL_ENABLED,
+        },
+    ]
+    assert build_user_input(data_schema) == {
+        "card_title": DEFAULT_CARD_TITLE,
+        "sidebar_panel_enabled": DEFAULT_SIDEBAR_PANEL_ENABLED,
+    }
+
+
+def test_a_required_field_without_a_default_is_refused_by_name() -> None:
+    """A value the form does not offer cannot be invented — the script must say which field."""
+    data_schema = [
+        {"name": "card_title", "type": "string", "required": True, "default": "HAventory"},
+        {"name": "api_key", "type": "string", "required": True},
+    ]
+    with pytest.raises(RuntimeError, match="api_key"):
+        build_user_input(data_schema)
+
+
+def test_an_optional_field_without_a_default_is_omitted() -> None:
+    """Optional and unanswered means left out, not sent as None."""
+    data_schema = [
+        {"name": "card_title", "type": "string", "required": True, "default": "HAventory"},
+        {"name": "nickname", "type": "string", "optional": True},
+    ]
+    assert build_user_input(data_schema) == {"card_title": "HAventory"}
+
+
+def test_a_suggested_value_answers_a_field_with_no_default() -> None:
+    """Suggested values ride under ``description`` in the serialized schema."""
+    data_schema = [
+        {
+            "name": "card_title",
+            "type": "string",
+            "required": True,
+            "description": {"suggested_value": "Pantry"},
+        }
+    ]
+    assert build_user_input(data_schema) == {"card_title": "Pantry"}
+
+
+def test_a_section_is_answered_as_a_nested_object() -> None:
+    """A section serializes as an expandable wrapper and submits as a nested dict."""
+    data_schema = [
+        {"name": "card_title", "type": "string", "required": True, "default": "HAventory"},
+        {
+            "name": "rate_limit",
+            "type": "expandable",
+            "schema": [
+                {"name": "enabled", "type": "boolean", "required": True, "default": False},
+                {"name": "burst", "required": True, "default": 10.0},
+            ],
+        },
+    ]
+    assert build_user_input(data_schema) == {
+        "card_title": "HAventory",
+        "rate_limit": {"enabled": False, "burst": 10.0},
+    }
+
+
+def test_a_missing_or_malformed_schema_yields_an_empty_payload() -> None:
+    """A flow result with no ``data_schema`` still submits — as the old empty payload."""
+    assert build_user_input(None) == {}
+    assert build_user_input([]) == {}
+    assert build_user_input(["not-a-dict", {"no-name": True}]) == {}
+
+
+def test_every_required_user_step_field_offers_a_default() -> None:
+    """The flow-side half of the contract the script leans on.
+
+    The script answers required fields from their defaults, so a field added to
+    the user step must ship one: without it, headless setup is back to the 400
+    this arrangement exists to prevent. This fails on the flow change itself,
+    not on the next fresh-instance provisioning.
+    """
+    for marker in _user_schema().schema:
+        assert isinstance(marker, vol.Optional | vol.Required)
+        assert marker.default is not vol.UNDEFINED, (
+            f"user-step field {marker!s} offers no default; "
+            "scripts/ws_init_haventory.py cannot answer it headlessly"
+        )


### PR DESCRIPTION
Fixes #431.

## What

`scripts/ws_init_haventory.py` submitted `{}` to the config flow's user step. Since the step gained two `vol.Required` fields (card title, sidebar preference), that submission is refused with HTTP 400 and the script cannot set up a fresh instance at all.

The script now reads each presented form's serialized `data_schema` and answers every field with the default (or suggested value) the form itself offers — the same entry the UI flow makes on accept-all-defaults. A field added to the flow later is answered the same way instead of reintroducing the 400; a required field that ships no default is refused loudly, by name.

Two adjacent transport bugs fixed on the way:

- The REST configure endpoint takes the user input as the request body itself; the old `{"user_input": {}}` wrapper reads as an unknown extra field and fails validation on its own.
- A successful WS `flow/create` response left `result` unassigned (latent `NameError`; unreachable today because current cores route flow creation over REST).

## Tests

- `tests/test_ws_init_flow_defaults.py` pins the payload building: defaults extracted, suggested values used, optional-without-default omitted, required-without-default refused by name, sections answered as nested objects, malformed schema tolerated.
- A flow-side guard asserts every required user-step field offers a default, so a future flow change that would break headless setup fails in the offline suite, not on the next fresh-instance provisioning.

## Verification

Both gates green (offline suite 950 passed; ruff/format/mypy clean; card: eslint, tsc, 1822 vitest tests, build). Live-verified against a fresh throwaway HA container (`ghcr.io/home-assistant/home-assistant:stable`, headless onboarding): first run creates the entry with the flow's defaults (`card_title: HAventory`, `sidebar_panel_enabled: true`, confirmed in `core.config_entries`), second run exits 0 on the single-instance abort. The same scenario on `main` fails with `HTTP 400 configuring flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)