### PR TITLE
feat(services): return response data from every service

### DIFF
--- a/custom_components/haventory/serialization.py
+++ b/custom_components/haventory/serialization.py
@@ -1,0 +1,80 @@
+"""Canonical wire shapes for items and locations.
+
+One serializer per entity, shared by the two surfaces that hand entities to a
+caller: the WebSocket API and the ``haventory.*`` services. Both emit the shapes
+`docs/data_shapes.md` specifies, so a script reading a service's
+``response_variable`` and a card reading a WebSocket result parse the same dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .models import Item, Location, serialize_attachment_meta
+from .repository import Repository
+
+
+def effective_area_id_for_item(hass: HomeAssistant, item: Item) -> str | None:
+    """Resolve the effective area id for an item via its location ancestry.
+
+    Best-effort: an item with no location, a torn-down runtime, or a location
+    whose ancestry no longer resolves all answer ``None`` rather than failing a
+    serialization that is otherwise complete.
+    """
+    try:
+        if getattr(item, "location_id", None) is None:
+            return None
+        bucket = hass.data.get(DOMAIN) or {}
+        repo = cast("Repository", bucket["repository"])
+        return repo.effective_area_id(str(item.location_id))
+    except Exception:
+        return None
+
+
+def serialize_item(hass: HomeAssistant, item: Item) -> dict[str, Any]:
+    """The canonical Item shape."""
+    return {
+        "id": str(item.id),
+        "name": item.name,
+        "description": item.description,
+        "quantity": item.quantity,
+        "status": item.status,
+        "checked_out": item.checked_out,
+        "due_date": item.due_date,
+        "inspection_date": item.inspection_date,
+        "location_id": str(item.location_id) if item.location_id is not None else None,
+        "tags": list(item.tags),
+        "category": item.category,
+        "low_stock_threshold": item.low_stock_threshold,
+        "custom_fields": dict(item.custom_fields),
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+        "version": item.version,
+        "effective_area_id": effective_area_id_for_item(hass, item),
+        "location_path": {
+            "id_path": [str(x) for x in item.location_path.id_path],
+            "name_path": item.location_path.name_path,
+            "display_path": item.location_path.display_path,
+            "sort_key": item.location_path.sort_key,
+        },
+        "attachments": [serialize_attachment_meta(a) for a in item.attachments],
+    }
+
+
+def serialize_location(loc: Location) -> dict[str, Any]:
+    """The canonical Location shape."""
+    return {
+        "id": str(loc.id),
+        "name": loc.name,
+        "parent_id": str(loc.parent_id) if loc.parent_id is not None else None,
+        "area_id": str(loc.area_id) if getattr(loc, "area_id", None) is not None else None,
+        "path": {
+            "id_path": [str(x) for x in loc.path.id_path],
+            "name_path": loc.path.name_path,
+            "display_path": loc.path.display_path,
+            "sort_key": loc.path.sort_key,
+        },
+    }

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, NoReturn
 
 import voluptuous as vol
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 
 from .const import DOMAIN
 from .exceptions import (
@@ -30,6 +30,7 @@ from .exceptions import (
     log_severity,
 )
 from .repository import UNSET, Repository
+from .serialization import serialize_item, serialize_location
 from .storage import async_persist_repo as _storage_async_persist_repo
 
 LOGGER = logging.getLogger(__name__)
@@ -163,8 +164,12 @@ def _log_domain_error(op: str, context: dict[str, Any], exc: Exception) -> None:
     )
 
 
-def _raise_service_error(op: str, context: dict[str, Any], exc: Exception) -> None:
-    """Log and surface service errors so Home Assistant can report them."""
+def _raise_service_error(op: str, context: dict[str, Any], exc: Exception) -> NoReturn:
+    """Log and surface service errors so Home Assistant can report them.
+
+    Annotated ``NoReturn`` so a handler's ``except`` branch is not a path that
+    falls through to an implicit ``None`` response.
+    """
 
     _log_domain_error(op, context, exc)
     raise exc
@@ -184,18 +189,19 @@ async def async_persist_repo(hass: HomeAssistant) -> None:
 # -----------------------------
 
 
-async def service_item_create(hass: HomeAssistant, data: dict) -> None:
+async def service_item_create(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_create"
     try:
         payload = SCHEMA_ITEM_CREATE(data)
         repo = _get_repo(hass)
-        repo.create_item(payload)  # type: ignore[arg-type]
+        item = repo.create_item(payload)  # type: ignore[arg-type]
         await async_persist_repo(hass)
+        return {"item": serialize_item(hass, item)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_name": data.get("name")}, exc)
 
 
-async def service_item_update(hass: HomeAssistant, data: dict) -> None:
+async def service_item_update(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_update"
     item_id = data.get("item_id")
     try:
@@ -203,26 +209,32 @@ async def service_item_update(hass: HomeAssistant, data: dict) -> None:
         expected = payload.get("expected_version")
         update = {k: v for k, v in payload.items() if k not in {"item_id", "expected_version"}}
         repo = _get_repo(hass)
-        repo.update_item(payload["item_id"], update, expected_version=expected)  # type: ignore[arg-type]
+        item = repo.update_item(payload["item_id"], update, expected_version=expected)  # type: ignore[arg-type]
         await async_persist_repo(hass)
+        return {"item": serialize_item(hass, item)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id}, exc)
 
 
-async def service_item_delete(hass: HomeAssistant, data: dict) -> None:
+async def service_item_delete(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_delete"
     item_id = data.get("item_id")
     try:
         payload = SCHEMA_ITEM_DELETE(data)
         expected = payload.get("expected_version")
         repo = _get_repo(hass)
+        # Read the body before removing it: the delete returns nothing, and after it
+        # the item is unreachable. An unknown id raises NotFoundError here exactly as
+        # the delete would, so the pre-read adds no error surface.
+        removed = serialize_item(hass, repo.get_item(payload["item_id"]))
         repo.delete_item(payload["item_id"], expected_version=expected)
         await async_persist_repo(hass)
+        return {"item": removed}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id}, exc)
 
 
-async def service_item_move(hass: HomeAssistant, data: dict) -> None:
+async def service_item_move(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_move"
     item_id = data.get("item_id")
     try:
@@ -230,88 +242,94 @@ async def service_item_move(hass: HomeAssistant, data: dict) -> None:
         update = {"location_id": payload.get("new_location_id")}
         expected = payload.get("expected_version")
         repo = _get_repo(hass)
-        repo.update_item(payload["item_id"], update, expected_version=expected)  # type: ignore[arg-type]
+        item = repo.update_item(payload["item_id"], update, expected_version=expected)  # type: ignore[arg-type]
         await async_persist_repo(hass)
+        return {"item": serialize_item(hass, item)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(
             op, {"item_id": item_id, "new_location_id": data.get("new_location_id")}, exc
         )
 
 
-async def service_item_adjust_quantity(hass: HomeAssistant, data: dict) -> None:
+async def service_item_adjust_quantity(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_adjust_quantity"
     item_id = data.get("item_id")
     try:
         payload = SCHEMA_ITEM_ADJUST_QTY(data)
         repo = _get_repo(hass)
-        repo.adjust_quantity(
+        item = repo.adjust_quantity(
             payload["item_id"], payload["delta"], expected_version=payload.get("expected_version")
         )
         await async_persist_repo(hass)
+        return {"item": serialize_item(hass, item)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id, "delta": data.get("delta")}, exc)
 
 
-async def service_item_set_quantity(hass: HomeAssistant, data: dict) -> None:
+async def service_item_set_quantity(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_set_quantity"
     item_id = data.get("item_id")
     try:
         payload = SCHEMA_ITEM_SET_QTY(data)
         repo = _get_repo(hass)
-        repo.set_quantity(
+        item = repo.set_quantity(
             payload["item_id"],
             payload["quantity"],
             expected_version=payload.get("expected_version"),
         )
         await async_persist_repo(hass)
+        return {"item": serialize_item(hass, item)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id, "quantity": data.get("quantity")}, exc)
 
 
-async def service_item_check_out(hass: HomeAssistant, data: dict) -> None:
+async def service_item_check_out(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_check_out"
     item_id = data.get("item_id")
     try:
         payload = SCHEMA_ITEM_CHECK_OUT(data)
         repo = _get_repo(hass)
-        repo.check_out(
+        item = repo.check_out(
             payload["item_id"],
             due_date=payload["due_date"],
             expected_version=payload.get("expected_version"),
         )
         await async_persist_repo(hass)
+        return {"item": serialize_item(hass, item)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id, "due_date": data.get("due_date")}, exc)
 
 
-async def service_item_check_in(hass: HomeAssistant, data: dict) -> None:
+async def service_item_check_in(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "item_check_in"
     item_id = data.get("item_id")
     try:
         payload = SCHEMA_ITEM_CHECK_IN(data)
         repo = _get_repo(hass)
-        repo.check_in(payload["item_id"], expected_version=payload.get("expected_version"))
+        item = repo.check_in(payload["item_id"], expected_version=payload.get("expected_version"))
         await async_persist_repo(hass)
+        return {"item": serialize_item(hass, item)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id}, exc)
 
 
-async def service_location_create(hass: HomeAssistant, data: dict) -> None:
+async def service_location_create(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "location_create"
     try:
         payload = SCHEMA_LOCATION_CREATE(data)
         repo = _get_repo(hass)
-        repo.create_location(
+        loc = repo.create_location(
             name=payload["name"],
             parent_id=payload.get("parent_id"),
             area_id=payload.get("area_id"),
         )
         await async_persist_repo(hass)
+        return {"location": serialize_location(loc)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"location_name": data.get("name")}, exc)
 
 
-async def service_location_update(hass: HomeAssistant, data: dict) -> None:
+async def service_location_update(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "location_update"
     location_id = data.get("location_id")
     try:
@@ -319,25 +337,28 @@ async def service_location_update(hass: HomeAssistant, data: dict) -> None:
         new_parent = payload["new_parent_id"] if "new_parent_id" in payload else UNSET
         area_id = payload["area_id"] if "area_id" in payload else UNSET
         repo = _get_repo(hass)
-        repo.update_location(
+        loc = repo.update_location(
             payload["location_id"],
             name=payload.get("name"),
             new_parent_id=new_parent,
             area_id=area_id,
         )
         await async_persist_repo(hass)
+        return {"location": serialize_location(loc)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"location_id": location_id}, exc)
 
 
-async def service_location_delete(hass: HomeAssistant, data: dict) -> None:
+async def service_location_delete(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "location_delete"
     location_id = data.get("location_id")
     try:
         payload = SCHEMA_LOCATION_DELETE(data)
         repo = _get_repo(hass)
+        removed = serialize_location(repo.get_location(payload["location_id"]))
         repo.delete_location(payload["location_id"])
         await async_persist_repo(hass)
+        return {"location": removed}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"location_id": location_id}, exc)
 
@@ -346,7 +367,7 @@ async def service_location_delete(hass: HomeAssistant, data: dict) -> None:
 # Registration
 # -----------------------------
 
-ServiceHandler = Callable[[HomeAssistant, dict[str, Any]], Coroutine[Any, Any, None]]
+ServiceHandler = Callable[[HomeAssistant, dict[str, Any]], Coroutine[Any, Any, dict[str, Any]]]
 
 # Service name -> (handler, voluptuous schema). Home Assistant validates the call
 # against the schema before invoking the handler; the handler re-validates because
@@ -368,7 +389,7 @@ SERVICES: tuple[tuple[str, ServiceHandler, vol.Schema], ...] = (
 
 def _bind(
     hass: HomeAssistant, handler: ServiceHandler
-) -> Callable[[ServiceCall], Coroutine[Any, Any, None]]:
+) -> Callable[[ServiceCall], Coroutine[Any, Any, dict[str, Any]]]:
     """Adapt a ``(hass, data)`` handler to the ``ServiceCall`` signature HA invokes.
 
     The returned callable **must be a coroutine function**. Home Assistant classifies
@@ -376,11 +397,12 @@ def _bind(
     function nor a ``@callback`` is dispatched via ``async_add_executor_job``. A
     plain ``lambda call: handler(hass, ...)`` therefore runs on a worker thread,
     where it only *constructs* the coroutine — which HA then returns as the service
-    response and never awaits, so the mutation silently never happens.
+    response and never awaits, so the mutation silently never happens, and the
+    caller's ``response_variable`` is handed the coroutine object.
     """
 
-    async def _handle(call: ServiceCall) -> None:
-        await handler(hass, dict(call.data))
+    async def _handle(call: ServiceCall) -> dict[str, Any]:
+        return await handler(hass, dict(call.data))
 
     return _handle
 
@@ -398,7 +420,15 @@ def setup(hass: HomeAssistant) -> None:
         bucket["services_registered"] = True
         return
 
+    # OPTIONAL, not ONLY: every one of these is a mutation first and an answer
+    # second, so a caller that omits `response_variable` must keep working.
     for name, handler, schema in SERVICES:
-        hass.services.async_register(DOMAIN, name, _bind(hass, handler), schema)
+        hass.services.async_register(
+            DOMAIN,
+            name,
+            _bind(hass, handler),
+            schema,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
 
     bucket["services_registered"] = True

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -57,7 +57,6 @@ from .models import (
     iso_utc_now,
     new_uuid4,
     normalize_tags,
-    serialize_attachment_meta,
     serialize_status_definition,
     today_utc_date,
     validate_attachment_meta,
@@ -66,6 +65,7 @@ from .models import (
 )
 from .rate_limit import RateLimiter
 from .repository import UNSET, InternalIndexes, Repository
+from .serialization import serialize_item, serialize_location
 from .storage import CURRENT_SCHEMA_VERSION
 
 LOGGER = logging.getLogger(__name__)
@@ -315,7 +315,7 @@ def _op_item_update(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dict[
     exclude_keys = {"item_id", "expected_version"}
     update = cast("ItemUpdate", {k: v for k, v in payload.items() if k not in exclude_keys})
     updated = repo.update_item(item_id, update, expected_version=expected)
-    serialized = _serialize_item(hass, updated)
+    serialized = serialize_item(hass, updated)
     action = "moved" if "location_id" in update else "updated"
     return serialized, action
 
@@ -325,7 +325,7 @@ def _op_item_delete(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dict[
     item_id = _payload_item_id(payload)
     expected = payload.get("expected_version")
     before = repo.get_item(item_id)
-    serialized_before = _serialize_item(hass, before)
+    serialized_before = serialize_item(hass, before)
     repo.delete_item(item_id, expected_version=expected)
     return serialized_before, "deleted"
 
@@ -337,7 +337,7 @@ def _op_item_move(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dict[st
     updated = repo.update_item(
         item_id, ItemUpdate(location_id=payload.get("location_id")), expected_version=expected
     )
-    return _serialize_item(hass, updated), "moved"
+    return serialize_item(hass, updated), "moved"
 
 
 def _op_item_adjust_quantity(
@@ -348,7 +348,7 @@ def _op_item_adjust_quantity(
     updated = repo.adjust_quantity(
         item_id, _payload_int(payload, "delta"), expected_version=payload.get("expected_version")
     )
-    return _serialize_item(hass, updated), "quantity_changed"
+    return serialize_item(hass, updated), "quantity_changed"
 
 
 def _op_item_set_quantity(
@@ -358,7 +358,7 @@ def _op_item_set_quantity(
     item_id = _payload_item_id(payload)
     qty = _payload_int(payload, "quantity")
     updated = repo.set_quantity(item_id, qty, expected_version=payload.get("expected_version"))
-    return _serialize_item(hass, updated), "quantity_changed"
+    return serialize_item(hass, updated), "quantity_changed"
 
 
 def _op_item_check_out(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
@@ -367,14 +367,14 @@ def _op_item_check_out(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[di
     updated = repo.check_out(
         item_id, due_date=payload.get("due_date"), expected_version=payload.get("expected_version")
     )
-    return _serialize_item(hass, updated), "checked_out"
+    return serialize_item(hass, updated), "checked_out"
 
 
 def _op_item_check_in(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
     repo = _repo(hass)
     item_id = _payload_item_id(payload)
     updated = repo.check_in(item_id, expected_version=payload.get("expected_version"))
-    return _serialize_item(hass, updated), "checked_in"
+    return serialize_item(hass, updated), "checked_in"
 
 
 def _op_item_add_tags(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
@@ -385,7 +385,7 @@ def _op_item_add_tags(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dic
     current = repo.get_item(item_id)
     new_tags = list(dict.fromkeys(list(current.tags) + list(tags)))
     updated = repo.update_item(item_id, ItemUpdate(tags=new_tags), expected_version=expected)
-    return _serialize_item(hass, updated), "updated"
+    return serialize_item(hass, updated), "updated"
 
 
 def _op_item_remove_tags(
@@ -398,7 +398,7 @@ def _op_item_remove_tags(
     current = repo.get_item(item_id)
     new_tags = [t for t in list(current.tags) if t not in to_remove]
     updated = repo.update_item(item_id, ItemUpdate(tags=new_tags), expected_version=expected)
-    return _serialize_item(hass, updated), "updated"
+    return serialize_item(hass, updated), "updated"
 
 
 def _op_item_update_custom_fields(
@@ -419,7 +419,7 @@ def _op_item_update_custom_fields(
             raise ValidationError("unset must be a list")
         update["custom_fields_unset"] = list(unset_value)
     updated = repo.update_item(item_id, update, expected_version=expected)
-    return _serialize_item(hass, updated), "updated"
+    return serialize_item(hass, updated), "updated"
 
 
 def _op_item_set_low_stock_threshold(
@@ -433,7 +433,7 @@ def _op_item_set_low_stock_threshold(
         ItemUpdate(low_stock_threshold=payload.get("low_stock_threshold")),
         expected_version=expected,
     )
-    return _serialize_item(hass, updated), "updated"
+    return serialize_item(hass, updated), "updated"
 
 
 def _execute_item_op(
@@ -657,7 +657,7 @@ def _item_matches_filter(item: dict[str, Any], sub: _Subscription) -> bool:
     if sub.get("inspection_overdue_only") and not _payload_inspection_is_overdue(item):
         return False
     # Read the area off the payload rather than resolving it from the repository:
-    # the matcher runs once per subscription per event, and `_serialize_item` has
+    # the matcher runs once per subscription per event, and `serialize_item` has
     # already walked the location ancestry to compute the same value. An item with
     # no location carries `effective_area_id: None`, which matches no area filter.
     area_filter = sub.get("area_id")
@@ -1242,7 +1242,7 @@ async def ws_item_create(
 ) -> None:
     payload = {k: v for k, v in msg.items() if k not in {"id", "type"}}
     item = _repo(hass).create_item(payload)  # type: ignore[arg-type]
-    serialized = _serialize_item(hass, item)
+    serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="created", payload={"item": serialized})
     _broadcast_counts(hass)
@@ -1258,7 +1258,7 @@ async def ws_item_get(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     item = _repo(hass).get_item(msg["item_id"])
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), _serialize_item(hass, item)))
+    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialize_item(hass, item)))
 
 
 @websocket_api.websocket_command(
@@ -1294,7 +1294,7 @@ async def ws_item_update(
         {k: v for k, v in msg.items() if k not in {"id", "type", "item_id", "expected_version"}},
     )
     updated = _repo(hass).update_item(item_id, update, expected_version=expected)
-    serialized = _serialize_item(hass, updated)
+    serialized = serialize_item(hass, updated)
     action = "moved" if "location_id" in update else "updated"
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
@@ -1317,7 +1317,7 @@ async def ws_item_delete(
     item_id = msg["item_id"]
     repo = _repo(hass)
     before = repo.get_item(item_id)
-    serialized_before = _serialize_item(hass, before)
+    serialized_before = serialize_item(hass, before)
     repo.delete_item(item_id, expected_version=msg.get("expected_version"))
     await _persist_repo(hass)
     # After the save, for the same reason attachment/remove deletes last: an
@@ -1354,7 +1354,7 @@ async def ws_item_adjust_quantity(
     item = _repo(hass).adjust_quantity(
         msg["item_id"], _payload_int(msg, "delta"), expected_version=msg.get("expected_version")
     )
-    serialized = _serialize_item(hass, item)
+    serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     _broadcast_counts(hass)
@@ -1384,7 +1384,7 @@ async def ws_item_set_quantity(
     item = _repo(hass).set_quantity(
         msg["item_id"], qty, expected_version=msg.get("expected_version")
     )
-    serialized = _serialize_item(hass, item)
+    serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     _broadcast_counts(hass)
@@ -1409,7 +1409,7 @@ async def ws_item_check_out(
         due_date=msg.get("due_date"),
         expected_version=msg.get("expected_version"),
     )
-    serialized = _serialize_item(hass, item)
+    serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="checked_out", payload={"item": serialized})
     _broadcast_counts(hass)
@@ -1429,7 +1429,7 @@ async def ws_item_check_in(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     item = _repo(hass).check_in(msg["item_id"], expected_version=msg.get("expected_version"))
-    serialized = _serialize_item(hass, item)
+    serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="checked_in", payload={"item": serialized})
     _broadcast_counts(hass)
@@ -1638,7 +1638,7 @@ async def ws_item_attachment_add(
         max_per_kind=media_mod.max_per_item(kind),
         expected_version=expected,
     )
-    serialized = _serialize_item(hass, updated)
+    serialized = serialize_item(hass, updated)
     # A failed persist leaves the file on disk with no saved metadata; setup's
     # orphan sweep is what collects it, so there is nothing to undo here beyond
     # letting the error through the way every other mutation does.
@@ -1670,7 +1670,7 @@ async def ws_item_attachment_remove(
         str(msg["attachment_id"]),
         expected_version=msg.get("expected_version"),
     )
-    serialized = _serialize_item(hass, updated)
+    serialized = serialize_item(hass, updated)
     # Persist before unlinking: a failed save with the file still there leaves
     # an orphan the sweep collects, while the reverse order would leave stored
     # metadata pointing at bytes that are already gone.
@@ -1704,7 +1704,7 @@ async def ws_item_attachment_update(
         title=msg["title"],
         expected_version=msg.get("expected_version"),
     )
-    serialized = _serialize_item(hass, updated)
+    serialized = serialize_item(hass, updated)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
@@ -1737,7 +1737,7 @@ async def ws_item_attachment_reorder(
         list(msg["attachment_ids"]),
         expected_version=msg.get("expected_version"),
     )
-    serialized = _serialize_item(hass, updated)
+    serialized = serialize_item(hass, updated)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
@@ -1916,7 +1916,7 @@ async def ws_item_list(
         raise ValidationError("cursor must be a non-empty string")
     page = _repo(hass).list_items(flt=flt, sort=sort, limit=limit, cursor=cursor)
     result = {
-        "items": [_serialize_item(hass, it) for it in page["items"]],
+        "items": [serialize_item(hass, it) for it in page["items"]],
         "next_cursor": page.get("next_cursor"),
         "total": page["total"],
     }
@@ -1950,7 +1950,7 @@ async def ws_location_create(
     loc = _repo(hass).create_location(
         name=msg["name"], parent_id=msg.get("parent_id"), area_id=area_id
     )
-    serialized = _serialize_location(loc)
+    serialized = serialize_location(loc)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="locations", action="created", payload={"location": serialized})
     _broadcast_counts(hass)
@@ -1966,7 +1966,7 @@ async def ws_location_get(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     loc = _repo(hass).get_location(msg["location_id"])
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), _serialize_location(loc)))
+    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialize_location(loc)))
 
 
 @websocket_api.websocket_command(
@@ -2002,7 +2002,7 @@ async def ws_location_update(
     loc = repo.update_location(
         msg["location_id"], name=msg.get("name"), new_parent_id=new_parent, area_id=area_id
     )
-    serialized = _serialize_location(loc)
+    serialized = serialize_location(loc)
     await _persist_repo(hass)
     # One event per call, decided by what changed rather than by which keys the
     # request carried: an editor that sends every field on every save would
@@ -2035,7 +2035,7 @@ async def ws_location_delete(
     loc_id = msg["location_id"]
     repo = _repo(hass)
     before = repo.get_location(loc_id)
-    serialized_before = _serialize_location(before)
+    serialized_before = serialize_location(before)
     repo.delete_location(loc_id)
     await _persist_repo(hass)
     _broadcast_event(
@@ -2057,7 +2057,7 @@ async def ws_location_list(
     repo = _repo(hass)
     # Return flat list
     data = [
-        _serialize_location(repo.get_location(loc_id))
+        serialize_location(repo.get_location(loc_id))
         for loc_id in repo._debug_get_internal_indexes()["locations_by_id"]
     ]
     conn.send_message(websocket_api.result_message(msg.get("id", 0), data))
@@ -2132,71 +2132,11 @@ async def ws_location_move_subtree(
 ) -> None:
     new_parent = msg.get("new_parent_id") if "new_parent_id" in msg else UNSET
     loc = _repo(hass).update_location(msg["location_id"], new_parent_id=new_parent)
-    serialized = _serialize_location(loc)
+    serialized = serialize_location(loc)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="locations", action="moved", payload={"location": serialized})
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
-
-
-# -----------------------------
-# Serialization helpers
-# -----------------------------
-
-
-def _effective_area_id_for_item(hass: HomeAssistant, item: Item) -> str | None:
-    """Resolve the effective area id for an item via its location ancestry."""
-    try:
-        if getattr(item, "location_id", None) is None:
-            return None
-        repo = _repo(hass)
-        return repo.effective_area_id(str(item.location_id))
-    except Exception:
-        return None
-
-
-def _serialize_item(hass: HomeAssistant, item: Item) -> dict[str, Any]:
-    return {
-        "id": str(item.id),
-        "name": item.name,
-        "description": item.description,
-        "quantity": item.quantity,
-        "status": item.status,
-        "checked_out": item.checked_out,
-        "due_date": item.due_date,
-        "inspection_date": item.inspection_date,
-        "location_id": str(item.location_id) if item.location_id is not None else None,
-        "tags": list(item.tags),
-        "category": item.category,
-        "low_stock_threshold": item.low_stock_threshold,
-        "custom_fields": dict(item.custom_fields),
-        "created_at": item.created_at,
-        "updated_at": item.updated_at,
-        "version": item.version,
-        "effective_area_id": _effective_area_id_for_item(hass, item),
-        "location_path": {
-            "id_path": [str(x) for x in item.location_path.id_path],
-            "name_path": item.location_path.name_path,
-            "display_path": item.location_path.display_path,
-            "sort_key": item.location_path.sort_key,
-        },
-        "attachments": [serialize_attachment_meta(a) for a in item.attachments],
-    }
-
-
-def _serialize_location(loc: Location) -> dict[str, Any]:
-    return {
-        "id": str(loc.id),
-        "name": loc.name,
-        "parent_id": str(loc.parent_id) if loc.parent_id is not None else None,
-        "area_id": str(loc.area_id) if getattr(loc, "area_id", None) is not None else None,
-        "path": {
-            "id_path": [str(x) for x in loc.path.id_path],
-            "name_path": loc.path.name_path,
-            "display_path": loc.path.display_path,
-            "sort_key": loc.path.sort_key,
-        },
-    }
 
 
 @websocket_api.websocket_command({"type": "haventory/status/list"})

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -474,6 +474,30 @@ against the repository:
 - `area_id` reads the item's `effective_area_id`, so it selects the same area `ItemFilter.area_id` does. An item with no location carries `effective_area_id: null` and matches no area filter; a `null` or omitted `area_id` on the subscription means no area filter at all. `area_id` applies to the `items` topic only.
 - Filters combine with AND, and every one of them is applied to the payload as it stands *after* the mutation. An item that leaves a filtered set produces no event for that subscription, so a client tracking one re-lists rather than waiting for a departure event — including after a `locations` `moved` event, which is the only signal that a subtree's `effective_area_id` was rewritten.
 
+### Service responses
+
+Every `haventory.*` service declares `SupportsResponse.OPTIONAL` and answers with the same
+shapes as the WebSocket surface — no bespoke service shape exists:
+
+```yaml
+- action: haventory.item_create
+  data: { name: Torch }
+  response_variable: created
+- action: haventory.item_move
+  data:
+    item_id: "{{ created.item.id }}"
+    new_location_id: "{{ shed_id }}"
+    expected_version: "{{ created.item.version }}"
+```
+
+- The eight `item_*` services return `{"item": <Item>}`; the three `location_*` ones return
+  `{"location": <Location>}`.
+- `item_delete` and `location_delete` return the entity as it last stood, read before the
+  removal. Deleting an unknown id is `not_found`, not an empty envelope.
+- The response is produced **after** the durable write, so an answer means the mutation is
+  persisted — the same ordering the WebSocket contract states for events.
+- `OPTIONAL`, not `ONLY`: a caller that omits `response_variable` is unaffected.
+
 ### Validation notes
 
 - UUIDs must be version 4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,12 +98,13 @@ mypy_path = "custom_components:stubs"
 ignore_missing_imports = true
 warn_redundant_casts = true
 
-# WP4: the core modules are held to (per-module) strict mode. The rest of the
-# integration stays at the non-strict baseline; ratcheting them is a WP5 call.
+# The core modules are held to (per-module) strict mode; the rest of the
+# integration stays at the non-strict baseline.
 [[tool.mypy.overrides]]
 module = [
   "haventory.models",
   "haventory.repository",
+  "haventory.serialization",
   "haventory.storage",
   "haventory.ws",
 ]

--- a/stubs/homeassistant/core.pyi
+++ b/stubs/homeassistant/core.pyi
@@ -6,7 +6,13 @@ back to Any via __getattr__. See pyproject [tool.mypy] mypy_path.
 
 import asyncio
 from collections.abc import Coroutine, Mapping
+from enum import StrEnum
 from typing import Any
+
+class SupportsResponse(StrEnum):
+    NONE = "none"
+    OPTIONAL = "optional"
+    ONLY = "only"
 
 class HomeAssistant:
     data: dict[str, Any]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,8 +139,21 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def __init__(self, data=None) -> None:
             self.data = types.MappingProxyType(dict(data or {}))
 
+    class SupportsResponse(StrEnum):  # type: ignore[override]
+        """Stand in for HA's service-response classification.
+
+        ``services.py`` imports it at module scope and hands it to
+        ``async_register``, which the offline stub does not have — the member
+        identities are all the offline suite can see.
+        """
+
+        NONE = "none"
+        OPTIONAL = "optional"
+        ONLY = "only"
+
     ha_core.HomeAssistant = HomeAssistant
     ha_core.ServiceCall = ServiceCall
+    ha_core.SupportsResponse = SupportsResponse
     sys.modules["homeassistant.core"] = ha_core
 
     # homeassistant.exceptions

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -186,3 +186,78 @@ async def test_service_call_rejects_a_bad_payload(hass: HomeAssistant) -> None:
         await _call(hass, "item_create", {"name": "   "})
 
     assert repo.get_counts()["items_total"] == 0
+
+
+async def test_services_answer_when_the_caller_asks_for_a_response(hass: HomeAssistant) -> None:
+    """``return_response`` hands back the entity, so a script can chain calls.
+
+    ``supports_response`` lives in the real service registry — the offline stub
+    has none, so nothing about this classification is observable there.
+    """
+
+    repo = await _setup(hass)
+
+    created = await hass.services.async_call(
+        DOMAIN, "item_create", {"name": "Torch"}, blocking=True, return_response=True
+    )
+    await hass.async_block_till_done()
+
+    assert set(created) == {"item"}
+    item_id = created["item"]["id"]
+    assert created["item"]["name"] == "Torch"
+    assert item_id == _only_item_id(repo)
+    assert created["item"]["version"] == repo.get_item(item_id).version
+
+    # The chain the issue asks for: the response's id and version drive the next call.
+    location = await hass.services.async_call(
+        DOMAIN, "location_create", {"name": "Shed"}, blocking=True, return_response=True
+    )
+    await hass.async_block_till_done()
+    moved = await hass.services.async_call(
+        DOMAIN,
+        "item_move",
+        {
+            "item_id": item_id,
+            "new_location_id": location["location"]["id"],
+            "expected_version": created["item"]["version"],
+        },
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    assert moved["item"]["location_id"] == location["location"]["id"]
+    assert moved["item"]["location_path"]["display_path"] == "Shed"
+    assert moved["item"]["version"] == created["item"]["version"] + 1
+
+
+async def test_a_caller_that_ignores_the_response_still_mutates(hass: HomeAssistant) -> None:
+    """``OPTIONAL`` means the pre-existing call shape keeps working unchanged."""
+
+    repo = await _setup(hass)
+
+    # No `return_response`: HA returns None and the mutation still lands.
+    answer = await hass.services.async_call(DOMAIN, "item_create", {"name": "Torch"}, blocking=True)
+    await hass.async_block_till_done()
+    assert answer is None
+
+    assert repo.get_counts()["items_total"] == 1
+
+
+async def test_delete_answers_with_the_body_it_removed(hass: HomeAssistant) -> None:
+    """The response is the item as it last stood, and the repository is empty after."""
+
+    quantity = 3
+    repo = await _setup(hass)
+    await _call(hass, "item_create", {"name": "Torch", "quantity": quantity})
+    item_id = _only_item_id(repo)
+
+    removed = await hass.services.async_call(
+        DOMAIN, "item_delete", {"item_id": item_id}, blocking=True, return_response=True
+    )
+    await hass.async_block_till_done()
+
+    assert removed["item"]["id"] == item_id
+    assert removed["item"]["name"] == "Torch"
+    assert removed["item"]["quantity"] == quantity
+    assert repo.get_counts()["items_total"] == 0

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -21,7 +21,7 @@ from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import ConflictError, NotFoundError, StorageError
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 
 
 @pytest.mark.asyncio
@@ -137,9 +137,13 @@ async def test_service_registration_and_schema_errors(monkeypatch, caplog) -> No
     class _Services:
         def __init__(self) -> None:
             self._registered: list[tuple[str, str, object, object]] = []
+            self._responses: dict[str, object] = {}
 
-        def async_register(self, domain, name, handler, schema=None):  # type: ignore[no-untyped-def]
+        def async_register(  # type: ignore[no-untyped-def]
+            self, domain, name, handler, schema=None, *, supports_response=SupportsResponse.NONE
+        ):
             self._registered.append((domain, name, handler, schema))
+            self._responses[name] = supports_response
 
     hass.services = _Services()  # type: ignore[attr-defined]
 
@@ -163,6 +167,11 @@ async def test_service_registration_and_schema_errors(monkeypatch, caplog) -> No
         "location_update",
         "location_delete",
     }.issubset(names)
+
+    # OPTIONAL on every service: a caller passing `response_variable` gets the
+    # entity back, and one that omits it is unaffected. ONLY would break every
+    # existing automation that calls these without asking for a response.
+    assert set(hass.services._responses.values()) == {SupportsResponse.OPTIONAL}
 
     # Home Assistant classifies each handler with HassJob and dispatches anything
     # that is neither a coroutine function nor a @callback to the executor, where
@@ -262,3 +271,123 @@ def test_service_catalog_agrees_across_registration_yaml_and_strings() -> None:
     assert documented == registered, "services.yaml and the SERVICES table disagree"
     assert set(translated) == registered, "strings.json and the SERVICES table disagree"
     assert all(entry.keys() == {"name", "description"} for entry in translated.values())
+
+
+# -----------------------------
+# Service responses
+# -----------------------------
+
+
+async def _seeded(hass: HomeAssistant) -> tuple[Repository, str, str]:
+    """A repository holding one location and one item inside it."""
+
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    loc = await services_mod.service_location_create(hass, {"name": "Shelf"})
+    item = await services_mod.service_item_create(
+        hass, {"name": "Widget", "quantity": 5, "location_id": loc["location"]["id"]}
+    )
+    return hass.data[DOMAIN]["repository"], item["item"]["id"], loc["location"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_every_service_answers_with_the_canonical_envelope() -> None:
+    """All eleven services hand back the entity they touched.
+
+    The keys are the ones `docs/data_shapes.md` specifies for the WebSocket
+    surface, so a script's `response_variable` and a card's WS result are the
+    same dict. Returning the whole entity rather than a bare id is what makes
+    chaining work: the next call needs `version` for its `expected_version`.
+    """
+
+    hass = HomeAssistant()
+    repo, item_id, loc_id = await _seeded(hass)
+
+    item_calls = [
+        (services_mod.service_item_update, {"item_id": item_id, "name": "Widget Pro"}),
+        (services_mod.service_item_move, {"item_id": item_id, "new_location_id": None}),
+        (services_mod.service_item_adjust_quantity, {"item_id": item_id, "delta": -1}),
+        (services_mod.service_item_set_quantity, {"item_id": item_id, "quantity": 7}),
+        (services_mod.service_item_check_out, {"item_id": item_id, "due_date": "2030-01-01"}),
+        (services_mod.service_item_check_in, {"item_id": item_id}),
+    ]
+    for handler, payload in item_calls:
+        response = await handler(hass, payload)
+        assert set(response) == {"item"}, handler.__name__
+        assert response["item"]["id"] == item_id, handler.__name__
+        assert response["item"]["version"] == repo.get_item(item_id).version, handler.__name__
+
+    updated_location = await services_mod.service_location_update(
+        hass, {"location_id": loc_id, "name": "Top shelf"}
+    )
+    assert set(updated_location) == {"location"}
+    assert updated_location["location"]["name"] == "Top shelf"
+
+    # The two deletes answer with the body they removed, read before the delete.
+    removed_item = await services_mod.service_item_delete(hass, {"item_id": item_id})
+    assert removed_item["item"]["id"] == item_id
+    removed_location = await services_mod.service_location_delete(hass, {"location_id": loc_id})
+    assert removed_location["location"]["id"] == loc_id
+    assert repo.get_counts()["items_total"] == 0
+    assert repo.get_counts()["locations_total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_item_create_response_survives_json_serialization() -> None:
+    """Home Assistant puts the response on the wire; an unserializable one fails there.
+
+    Called directly, a response carrying a `uuid.UUID` or a `date` looks fine —
+    the failure only surfaces once HA hands it to a websocket or REST caller.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+
+    response = await services_mod.service_item_create(
+        hass,
+        {
+            "name": "Widget",
+            "quantity": 2,
+            "tags": ["blue"],
+            "checked_out": True,
+            "due_date": "2030-01-01",
+            "inspection_date": "2031-06-30",
+            "custom_fields": {"sku": "A-1", "count": 3, "fragile": True},
+        },
+    )
+
+    assert json.loads(json.dumps(response)) == response
+
+
+@pytest.mark.asyncio
+async def test_delete_answers_once_and_then_raises_not_found() -> None:
+    """A second delete of the same id is an error, not an empty envelope."""
+
+    hass = HomeAssistant()
+    _repo, item_id, _loc_id = await _seeded(hass)
+
+    first = await services_mod.service_item_delete(hass, {"item_id": item_id})
+    assert first["item"]["id"] == item_id
+    with pytest.raises(NotFoundError):
+        await services_mod.service_item_delete(hass, {"item_id": item_id})
+
+
+@pytest.mark.asyncio
+async def test_a_failed_persist_answers_nothing(monkeypatch) -> None:
+    """The response is produced after the write; a failed write raises instead.
+
+    Answering with an entity the store never accepted would tell the caller a
+    mutation is durable when it is not.
+    """
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+
+    async def _persist(_hass):  # type: ignore[no-untyped-def]
+        raise StorageError("persist failed")
+
+    monkeypatch.setattr(services_mod, "async_persist_repo", _persist)
+    with pytest.raises(StorageError):
+        await services_mod.service_item_create(hass, {"name": "Widget"})

--- a/tests/test_ws_error_mapping_offline.py
+++ b/tests/test_ws_error_mapping_offline.py
@@ -1,4 +1,4 @@
-"""Offline tests for the WP4 error-mapping guarantees of the WS API.
+"""Offline tests for the error-mapping guarantees of the WS API.
 
 Scenarios:
 - every registered haventory/* command is wrapped by ws_guard
@@ -64,7 +64,10 @@ async def test_unexpected_exception_maps_to_unknown_error_without_leaking(monkey
     def _boom(*_args: Any, **_kwargs: Any) -> dict:
         raise RuntimeError("SECRET-INTERNAL-DETAIL")
 
-    monkeypatch.setattr(ws_module, "_serialize_item", _boom)
+    # Patch the name in `ws`, not in `serialization`: `ws` binds the serializer into
+    # its own namespace at import, so replacing it at the source module would leave
+    # every call site here pointing at the original function.
+    monkeypatch.setattr(ws_module, "serialize_item", _boom)
     conn = RecordingConn()
     res = await ws_send(hass, 5, "haventory/item/create", conn=conn, name="Widget")
 


### PR DESCRIPTION
## Summary

All eleven `haventory.*` services declare `SupportsResponse.OPTIONAL` and answer with the
entity they touched, so a script can chain calls through `response_variable` instead of
losing the created item's id and version.

- **New `custom_components/haventory/serialization.py`** holds `serialize_item`,
  `serialize_location` and `effective_area_id_for_item`, moved out of `ws.py`. `services.py`
  imports them rather than reaching for a private name in the WebSocket module, and both
  surfaces now emit one shape.
- **Each handler binds the entity the repository already returned** and answers after
  `async_persist_repo`, so a response means the mutation is durable. The two deletes read
  the body before removing it — `delete_item` / `delete_location` return `None`, and an
  unknown id raises `NotFoundError` from the pre-read exactly as it would from the delete.
- **`OPTIONAL`, not `ONLY`**: a caller that omits `response_variable` is unaffected.
- `ServiceHandler` and `_bind` now return `dict[str, Any]`; the `async def` adapter stays,
  for the reason its docstring already gives.

Closes #219

## Decisions against the issue notes

The 2026-08-05 notes were written against an older tree. Two points where I decided against
the note and for the code, per §4 of `dev/V0_6_0_implementation.md`:

1. **The monkeypatch target in `tests/test_ws_error_mapping_offline.py`.** The note says to
   patch "the new module's symbol". `ws.py` binds the serializer into its own namespace with
   `from .serialization import serialize_item`, so patching `serialization.serialize_item`
   would leave every call site in `ws.py` pointing at the original function. The test patches
   `ws_module.serialize_item`, which is the name the call sites actually resolve; a comment
   in the test records why. (It also fails loudly rather than silently if that import shape
   ever changes — `monkeypatch.setattr` raises on a missing attribute.)
2. **Line anchors.** Every `services.py:NNN` / `ws.py:NNN` in the notes had drifted; the
   symbols were located by name. The `SERVICES` table is still eleven entries, as the note
   says.

Two smaller calls worth recording:

- `_raise_service_error` is annotated `NoReturn`. Without it, a handler's `except` branch is
  a path that falls through to an implicit `None` response, which mypy flags and which would
  be wrong if it ever happened.
- `haventory.serialization` joins the per-module strict list in `pyproject.toml`. The code
  moved out of `ws.py`, which is strict, and `disallow_untyped_calls` there means it has to
  stay fully annotated anyway. The stale `WP4`/`WP5` work-package reference in that block's
  comment is rewritten while the block is being touched, per CLAUDE.md.
- `services.yaml` and `strings.json` are untouched. hassfest (CI) is green, so a service
  declaring `SupportsResponse` needs no `response:` key in `services.yaml` — the question the
  notes flagged as unanswerable offline.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `954 passed, 22 skipped`; `ruff check` clean, `ruff format --check` clean,
      `mypy` clean (16 source files).
- [x] Frontend (`cards/haventory-card`): eslint clean, `tsc --noEmit` clean,
      `1822 passed (62 files)`, build OK. No card source change — the card reads these shapes
      over WebSocket, which this does not alter.
- [x] phacc (`scripts/test_integration.sh`): `54 passed`, including the three new cases in
      `tests/integration/test_services.py`:

  ```
  test_services_answer_when_the_caller_asks_for_a_response PASSED
  test_a_caller_that_ignores_the_response_still_mutates    PASSED
  test_delete_answers_with_the_body_it_removed             PASSED
  ```

New offline cases in `tests/test_services_offline.py`: every service's envelope and its
`version`, the JSON round-trip of a create response (a response HA cannot serialize is a
runtime failure a direct call hides), a second delete raising `NotFoundError`, and a failed
persist raising instead of answering. The registration test now asserts
`SupportsResponse.OPTIONAL` on all eleven.

## Live checks (dev Docker HA, HA 2026.7.4)

**1. HA's own service registry reports the response for all eleven.** This is the exact
condition the frontend's action tool uses — the shipped bundle gates its response request on
`"response" in hass.services[domain][service]`:

```
item_adjust_quantity -> {"optional": true}     item_set_quantity -> {"optional": true}
item_check_in        -> {"optional": true}     item_update       -> {"optional": true}
item_check_out       -> {"optional": true}     location_create   -> {"optional": true}
item_create          -> {"optional": true}     location_delete   -> {"optional": true}
item_delete          -> {"optional": true}     location_update   -> {"optional": true}
item_move            -> {"optional": true}
```

**2. A two-step script chains `item_create` → `item_move` through `response_variable`**, with
`expected_version` taken from the first response — the exact interaction #219 says is
impossible today. Run over `execute_script` against the live instance:

```yaml
- action: haventory.location_create
  data: {name: S1 Live Shed}
  response_variable: shed
- action: haventory.item_create
  data: {name: S1 Live Torch, quantity: 2}
  response_variable: created
- action: haventory.item_move
  data:
    item_id: "{{ created.item.id }}"
    new_location_id: "{{ shed.location.id }}"
    expected_version: "{{ created.item.version }}"
  response_variable: moved
- stop: chained
  response_variable: moved
```

answered with the moved item — `version: 2`, and the derived `location_path` rewritten by the
move:

```json
{"item": {"id": "e8839d7f-…", "name": "S1 Live Torch", "quantity": 2, "version": 2,
          "location_id": "6ee1d9d3-…",
          "location_path": {"display_path": "S1 Live Shed", "sort_key": "s1 live shed",
                            "name_path": ["S1 Live Shed"], "id_path": ["6ee1d9d3-…"]}}}
```

The templated `expected_version` renders to an int and satisfies the registered schema, so
the optimistic-concurrency handshake works from a script with no extra casting.

**3. Developer Tools → Actions accepts `response_variable` for these services.** Captured
with Playwright against the dev instance (PNG on the dev machine; this repo attaches no
binaries and no prior PR embeds one, so the capture is described rather than linked). The
page shows, in YAML mode:

- the action picker resolving `haventory.item_create` to its translated name, **"Create item"**,
  from `strings.json` — so the catalog join is intact;
- the YAML editor holding the call verbatim, `response_variable: created` included, with no
  validation error;
- the "All available parameters" table rendered from `services.yaml` — `name`, `description`,
  `quantity`, `status`, `checked_out`, `due_date`, … — unchanged by this PR;
- an enabled "Perform action" button.

Read back off the component afterwards: `_error: null`, `_serviceData` =
`{action: "haventory.item_create", data: {name: …, quantity: 4}}`, and
`hass.services.haventory.item_create.response` = `{optional: true}`.

**Waived, with the reason: the Response *card* rendering could not be captured.** In headless
Playwright the tool's `_response` stayed unset after "Perform action" even though the call
went through (the item was created every time) and the component's own state was otherwise
correct — `_error: null`, `_serviceData` parsed, and `hass.services.haventory.item_create.response`
= `{optional: true}`. **The control settles it**: the same harness against core
`todo.get_items` (`SupportsResponse.ONLY`) renders no Response card either, so this is the
harness, not HAventory. What the card would show is separately pinned: the exact two-step
sequence the frontend sends —
`[{action, data, response_variable: "service_result"}, {stop: "done", response_variable: "service_result"}]`
— returns the item envelope over WebSocket against this instance.

All entities the live checks created were deleted afterwards (8 items, 1 location).

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated — `docs/data_shapes.md` gains a "Service responses" section with the
      chaining example. `docs/backend_api_contract.md` covers the WebSocket surface only and
      needs no change; the user-facing README example belongs with the rewrite (#217).
- [x] WebSocket API unchanged — the serializers moved module, not shape.
- [x] Invariants preserved: `location_path` still derived (the move above shows it rewritten
      by the backend), `version` still the optimistic-concurrency token, search untouched.
- [x] `RETIRED_PATHS` untouched — `serialization.py` is new and nothing was deleted or renamed.

## Follow-ups

- The repository lookup from `hass.data[DOMAIN]` is now written five times across the package
  (`ws.py`, `services.py`, `storage.py`, `media.py`, and inline in `serialization.py`).
  Consolidating them is a tidy-up worth doing when #280 moves the runtime to
  `entry.runtime_data`, not before — it would touch every one of those modules for no
  behaviour change. Not filed: it cannot matter in a real install.
- A `haventory.*` service mutation still reaches no WebSocket subscriber, so an open card does
  not repaint. That is #218's territory and is filed separately.
