### PR TITLE
feat(sensor): four inventory sensors and bus events for automations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,10 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-yaml
+        # Syntax only. `dev/ha_config_for_dev.yaml` uses Home Assistant's `!include`
+        # tag, which a generic loader has no constructor for and rejects as a parse
+        # error rather than as bad YAML.
+        args: [--unsafe]
       - id: end-of-file-fixer
         exclude: |
           (?x)^(

--- a/README.md
+++ b/README.md
@@ -147,6 +147,85 @@ no longer used and can be deleted; the integration ignores it either way.
 
 ---
 
+## Automations
+
+HAventory shows up in Home Assistant as **four sensors on one device**, and fires **two event
+types** on the bus. Neither needs a WebSocket client, and neither polls.
+
+### The sensors
+
+One HAventory device under Settings → Devices & services, carrying:
+
+| Sensor | What it counts |
+|---|---|
+| Items | every item in the inventory |
+| Low stock | items at or below their `low_stock_threshold` |
+| Overdue | checked-out items whose due date has passed |
+| Inspection overdue | items whose inspection date has passed |
+
+They update the moment something changes — a card edit, a `haventory.*` service call, an
+import — with no polling interval to tune. The two date-derived ones also roll over at UTC
+midnight, so "Overdue" grows overnight without anybody touching the inventory.
+
+Put "Low stock: 3" on a dashboard next to the weather and nobody has to open the card to
+know whether a shopping trip is due.
+
+### The events
+
+- `haventory_item_changed` — `action` is one of `created`, `updated`, `moved`,
+  `quantity_changed`, `checked_out`, `checked_in`, `deleted`.
+- `haventory_low_stock` — `action` is `entered` or `cleared`, fired on the crossing only.
+
+Both are fired **after** the change is written to disk, so an automation that reacts to one
+is reacting to something that is already saved.
+
+A worked example — tell whoever is home when something runs low:
+
+```yaml
+automation:
+  - alias: Notify when stock runs low
+    trigger:
+      platform: event
+      event_type: haventory_low_stock
+      event_data:
+        action: entered
+    action:
+      - service: notify.notify
+        data:
+          title: Running low
+          message: >-
+            {{ trigger.event.data.name }} is down to
+            {{ trigger.event.data.quantity }}
+            (threshold {{ trigger.event.data.low_stock_threshold }})
+```
+
+And the other direction — react to a specific item being checked out:
+
+```yaml
+automation:
+  - alias: Media room lights when the projector goes out
+    trigger:
+      platform: event
+      event_type: haventory_item_changed
+      event_data:
+        action: checked_out
+    condition: "{{ trigger.event.data.name == 'Projector' }}"
+    action:
+      - service: light.turn_on
+        target:
+          entity_id: light.media_room
+```
+
+The full payload shapes are in [`docs/data_shapes.md`](docs/data_shapes.md); the events
+carry the fields a trigger needs and no more, so an automation that wants the whole item
+calls `haventory/item/get`.
+
+Services work the other way round: every `haventory.*` service returns the entity it
+touched, so a script can chain calls through `response_variable` — see the same document's
+"Service responses".
+
+---
+
 ## Known limitations
 
 What HAventory does *not* do today, stated up front so none of it is a surprise:
@@ -163,11 +242,6 @@ What HAventory does *not* do today, stated up front so none of it is a surprise:
   benchmarked at 10 000 items), correctness is unaffected at any size, and no limit is
   enforced. Several thousand items is comfortable; past that, an edit starts to be
   something you notice.
-- **No automation triggers.** The integration creates no entities and fires no events on
-  the Home Assistant bus. Automations and scripts can *call* the `haventory.*` services,
-  but nothing can trigger *on* an inventory change — there is no state object to watch and
-  no event type to listen for. Change notification is WebSocket subscriptions only, for
-  clients holding an open connection.
 - **No admin gating.** No WebSocket command declares `require_admin`, so any logged-in
   Home Assistant user — not only administrators — can read and mutate the whole inventory.
   It is a household-wide tool, not a per-user one.

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -47,9 +47,9 @@ try:
 except ImportError:  # pragma: no cover - minimal harness without panel_custom
     async_register_panel = None  # type: ignore[assignment]
 
+from . import events, stale_files
 from . import media as media_mod
 from . import services as services_mod
-from . import stale_files
 from . import ws as ws_mod
 from .const import (
     CONF_CARD_TITLE,
@@ -61,6 +61,7 @@ from .const import (
     PANEL_ELEMENT_NAME,
     PANEL_ICON,
     PANEL_URL_PATH,
+    PLATFORMS,
     QUICK_FILTER_KEYS,
 )
 from .exceptions import CorruptSchemaVersionError, SchemaDowngradeError, StorageError
@@ -204,6 +205,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryError(_corrupt_store_message(load_report, store_key=store.key))
     hass.data[DOMAIN]["repository"] = repository
 
+    # Which items are already low, before anything can mutate. Without this the
+    # first mutation after every restart would announce `entered` for every item
+    # that was low before it.
+    events.seed_low_stock_snapshot(hass)
+
     # Serve attachment files, and collect the ones nothing references any more.
     # Both need the repository, so both come after it is in the bucket.
     _register_media_view(hass)
@@ -230,6 +236,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register WebSocket commands
     ws_mod.setup(hass)
 
+    # Entity platforms, after the repository is in the bucket the entities read
+    # so the first state write has data. Guarded like the update-listener wiring
+    # below: the offline HomeAssistant stub has no `config_entries`.
+    await _async_forward_platforms(hass, entry)
+
     # Serve the bundled card and point the frontend at it
     await _register_frontend_module(hass)
 
@@ -238,6 +249,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _async_apply_sidebar_panel(hass, entry)
 
     return True
+
+
+async def _async_forward_platforms(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Set up the entity platforms this entry owns, where there are any."""
+
+    config_entries = getattr(hass, "config_entries", None)
+    forward = getattr(config_entries, "async_forward_entry_setups", None)
+    if forward is None:
+        return
+    await forward(entry, list(PLATFORMS))
+
+
+async def _async_unload_platforms(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Take the entity platforms down before the bucket they read is emptied."""
+
+    config_entries = getattr(hass, "config_entries", None)
+    unload = getattr(config_entries, "async_unload_platforms", None)
+    if unload is None:
+        return True
+    return bool(await unload(entry, list(PLATFORMS)))
 
 
 def _register_media_view(hass: HomeAssistant) -> None:
@@ -424,7 +455,7 @@ async def _async_teardown_entry(hass: HomeAssistant, *, op: str) -> None:
     _drop_entry_runtime(hass)
 
 
-async def async_unload_entry(hass: HomeAssistant, _entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry.
 
     An unloaded entry owns nothing, so it serves nothing: the runtime goes the
@@ -437,9 +468,14 @@ async def async_unload_entry(hass: HomeAssistant, _entry: ConfigEntry) -> bool:
     # Ahead of the teardown, which empties the bucket the handler list lives in.
     _cleanup_ws_test_stub_registry(hass)
 
+    # Before the teardown too: the entities read the repository out of that
+    # bucket, and an entity still registered against an emptied one reports
+    # unavailable rather than being gone.
+    unloaded = await _async_unload_platforms(hass, entry)
+
     await _async_teardown_entry(hass, op="unload")
 
-    return True
+    return unloaded
 
 
 def _drop_entry_runtime(hass: HomeAssistant) -> None:

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -1,8 +1,13 @@
 """Constants for the HAventory integration.
 
 Defines the integration domain, the public integration version, the card
-title option, and the option keys/defaults for WebSocket rate limiting.
+title option, the option keys/defaults for WebSocket rate limiting, the entity
+platforms and the sensor catalog, and the Home Assistant bus event types.
 """
+
+from dataclasses import dataclass
+
+from homeassistant.const import Platform
 
 # Integration domain used across all modules and entity unique IDs
 DOMAIN: str = "haventory"
@@ -192,3 +197,57 @@ DEFAULT_RATE_LIMIT_EVENTS_PER_SECOND: float = 50.0
 DEFAULT_RATE_LIMIT_EVENTS_BURST: float = 200.0
 DEFAULT_RATE_LIMIT_GLOBAL_EVENTS_PER_SECOND: float = 500.0
 DEFAULT_RATE_LIMIT_GLOBAL_EVENTS_BURST: float = 1000.0
+
+# -----------------------------
+# Entity platforms
+# -----------------------------
+
+PLATFORMS: tuple[Platform, ...] = (Platform.SENSOR,)
+
+
+@dataclass(frozen=True, slots=True)
+class HaventorySensorDescription:
+    """One inventory count exposed as a sensor.
+
+    ``key`` is a key of ``Repository.get_counts()`` and the suffix of the
+    entity's ``unique_id``; ``translation_key`` names the entry under
+    ``entity.sensor`` in `strings.json`. ``date_derived`` marks the two counts
+    that move with the calendar rather than with a mutation, which is what makes
+    them subscribe to the UTC-midnight rollover as well as to mutations.
+    """
+
+    key: str
+    translation_key: str
+    icon: str
+    date_derived: bool = False
+
+
+# Four of the nine keys `get_counts()` returns. The rest stay card- and
+# WebSocket-only: a fresh install opening with nine entities is a worse default
+# than four, and promoting one later is additive.
+SENSOR_DESCRIPTIONS: tuple[HaventorySensorDescription, ...] = (
+    HaventorySensorDescription("items_total", "items_total", "mdi:package-variant-closed"),
+    HaventorySensorDescription("low_stock_count", "low_stock", "mdi:package-down"),
+    HaventorySensorDescription("overdue_count", "overdue", "mdi:calendar-alert", date_derived=True),
+    HaventorySensorDescription(
+        "inspection_overdue_count", "inspection_overdue", "mdi:clipboard-alert", date_derived=True
+    ),
+)
+
+# -----------------------------
+# Home Assistant bus events
+# -----------------------------
+# Fired after the durable write, from WebSocket mutations and `haventory.*`
+# service calls alike, so an automation can trigger on the inventory without a
+# WebSocket client. Payload shapes: docs/data_shapes.md.
+
+EVENT_ITEM_CHANGED: str = "haventory_item_changed"
+EVENT_LOW_STOCK: str = "haventory_low_stock"
+
+# Dispatcher signal the sensors listen on. Bus events are the public contract;
+# this is the internal nudge that repaints the entities.
+SIGNAL_COUNTS_UPDATED: str = "haventory_counts_updated"
+
+# `hass.data[DOMAIN]` key holding the previous low-stock id set. Seeded at setup
+# so a restart re-announces nothing, and diffed on every notification.
+DATA_LOW_STOCK_SNAPSHOT: str = "low_stock_snapshot"

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -1,0 +1,166 @@
+"""Home Assistant bus events and the sensor nudge behind them.
+
+The WebSocket broadcasts in `ws.py` reach subscribed clients; these reach the
+rest of Home Assistant. Every mutation path — WebSocket handler, `haventory.*`
+service, bulk operation, import — calls `notify_mutation` after its durable
+write, which fires `haventory_item_changed`, diffs the low-stock set to fire
+`haventory_low_stock`, and dispatches the signal the sensors repaint on.
+
+Bus events bypass the rate limiter: it budgets WebSocket subscription traffic,
+and these are internal to Home Assistant.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import (
+    DATA_LOW_STOCK_SNAPSHOT,
+    DOMAIN,
+    EVENT_ITEM_CHANGED,
+    EVENT_LOW_STOCK,
+    SIGNAL_COUNTS_UPDATED,
+)
+from .models import iso_utc_now
+
+LOGGER = logging.getLogger(__name__)
+
+# The WebSocket items vocabulary, reused verbatim: an automation and a card
+# client describe the same mutation with the same word.
+ITEM_ACTIONS: frozenset[str] = frozenset(
+    {"created", "updated", "moved", "quantity_changed", "checked_out", "checked_in", "deleted"}
+)
+
+
+def seed_low_stock_snapshot(hass: HomeAssistant) -> None:
+    """Record which items are low at setup, so a restart re-announces nothing.
+
+    Called once the repository is in the bucket. Without it the first mutation
+    after every restart would diff against an empty set and fire `entered` for
+    every item that was already low before the restart.
+    """
+
+    bucket = hass.data.get(DOMAIN)
+    if bucket is None:
+        return
+    repo = bucket.get("repository")
+    bucket[DATA_LOW_STOCK_SNAPSHOT] = repo.low_stock_item_ids if repo is not None else frozenset()
+
+
+def notify_mutation(
+    hass: HomeAssistant,
+    *,
+    action: str,
+    item: dict[str, Any] | None = None,
+) -> None:
+    """Announce a mutation on the HA bus and repaint the sensors.
+
+    Call it **after** the persist, on every path: the contract's "an event
+    implies a durable write" rule holds on the bus as well as on the wire.
+
+    ``item`` is the serialized item the mutation produced — for a delete, the
+    body as it last stood. A bulk path that rewrote many items at once passes
+    none, which still diffs the low-stock set and still repaints the sensors.
+
+    Best-effort, like the WebSocket broadcasts: a mutation that is already
+    written must not fail because something downstream of it did.
+    """
+
+    try:
+        bucket = hass.data.get(DOMAIN)
+        if bucket is None:
+            # The entry tore down between the write and this call. Nothing to
+            # notify and nothing to diff against.
+            return
+
+        if item is not None:
+            _fire(
+                hass,
+                EVENT_ITEM_CHANGED,
+                {
+                    "action": action,
+                    "item_id": item.get("id"),
+                    "name": item.get("name"),
+                    "quantity": item.get("quantity"),
+                    "location_id": item.get("location_id"),
+                    "location_path": (item.get("location_path") or {}).get("display_path"),
+                    "effective_area_id": item.get("effective_area_id"),
+                    "version": item.get("version"),
+                    "ts": iso_utc_now(),
+                },
+            )
+
+        _fire_low_stock_transitions(hass, bucket, item=item)
+
+        async_dispatcher_send(hass, SIGNAL_COUNTS_UPDATED)
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.exception(
+            "Failed to notify a mutation",
+            extra={"domain": DOMAIN, "op": "notify_mutation", "action": action},
+        )
+
+
+def _fire_low_stock_transitions(
+    hass: HomeAssistant, bucket: dict[str, Any], *, item: dict[str, Any] | None
+) -> None:
+    """Fire `entered` / `cleared` for the ids that crossed the threshold.
+
+    A set diff rather than a per-handler check: one place then covers single
+    mutations, `haventory/items/bulk` and import execute alike, and no handler
+    needs a pre-mutation read of its own.
+    """
+
+    repo = bucket.get("repository")
+    if repo is None:
+        return
+
+    previous: frozenset[str] = bucket.get(DATA_LOW_STOCK_SNAPSHOT) or frozenset()
+    current = repo.low_stock_item_ids
+    if current == previous:
+        return
+    bucket[DATA_LOW_STOCK_SNAPSHOT] = current
+
+    for item_id in current - previous:
+        _fire(hass, EVENT_LOW_STOCK, _low_stock_payload(repo, item_id, "entered", item))
+    for item_id in previous - current:
+        # A deleted item is gone by the time the diff runs, so `cleared` for it
+        # carries the id and a null name rather than a lookup that would raise.
+        _fire(hass, EVENT_LOW_STOCK, _low_stock_payload(repo, item_id, "cleared", item))
+
+
+def _low_stock_payload(
+    repo: Any, item_id: str, action: str, mutated: dict[str, Any] | None
+) -> dict[str, Any]:
+    if mutated is not None and mutated.get("id") == item_id:
+        name = mutated.get("name")
+        quantity = mutated.get("quantity")
+        threshold = mutated.get("low_stock_threshold")
+    else:
+        try:
+            stored = repo.get_item(item_id)
+        except Exception:
+            name = quantity = threshold = None
+        else:
+            name = stored.name
+            quantity = stored.quantity
+            threshold = stored.low_stock_threshold
+    return {
+        "action": action,
+        "item_id": item_id,
+        "name": name,
+        "quantity": quantity,
+        "low_stock_threshold": threshold,
+        "ts": iso_utc_now(),
+    }
+
+
+def _fire(hass: HomeAssistant, event_type: str, payload: dict[str, Any]) -> None:
+    bus = getattr(hass, "bus", None)
+    fire = getattr(bus, "async_fire", None)
+    if fire is None:
+        return
+    fire(event_type, payload)

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -1652,6 +1652,17 @@ class Repository:
     # Public API — Counts
     # -----------------------------
 
+    @property
+    def low_stock_item_ids(self) -> frozenset[str]:
+        """The ids currently below their low-stock threshold.
+
+        A snapshot, not a view: the low-stock bus events are a diff of this set
+        against the one taken before the mutation, and a caller holding the live
+        index would be diffing it against itself.
+        """
+
+        return frozenset(self._low_stock_item_ids)
+
     def get_counts(self) -> dict[str, Any]:
         """Aggregate counts for ``haventory/stats``, ``haventory/health`` and events.
 

--- a/custom_components/haventory/sensor.py
+++ b/custom_components/haventory/sensor.py
@@ -1,0 +1,120 @@
+"""Four inventory counts as sensor entities on one HAventory device.
+
+Push only — no coordinator and no polling. Two things move a state: a mutation,
+through the dispatcher signal `events.notify_mutation` sends, and UTC midnight,
+for the two counts that are derived from the calendar and so change with no
+mutation at all.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_utc_time_change
+
+from .const import (
+    DOMAIN,
+    INTEGRATION_VERSION,
+    SENSOR_DESCRIPTIONS,
+    SIGNAL_COUNTS_UPDATED,
+    HaventorySensorDescription,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddConfigEntryEntitiesCallback
+) -> None:
+    """Add one sensor per count in the catalog."""
+
+    async_add_entities(
+        HaventoryCountSensor(hass, entry, description) for description in SENSOR_DESCRIPTIONS
+    )
+
+
+class HaventoryCountSensor(SensorEntity):
+    """One count from `Repository.get_counts()`."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, description: HaventorySensorDescription
+    ) -> None:
+        self._hass = hass
+        self._description = description
+        self._attr_translation_key = description.translation_key
+        self._attr_icon = description.icon
+        # entry_id, not a domain-global string: removing and re-adding the entry
+        # is a fresh install, and must not resurrect the removed entry's
+        # entity_ids.
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="HAventory",
+            manufacturer="HAventory",
+            model="Inventory",
+            sw_version=INTEGRATION_VERSION,
+            entry_type="service",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to the two things that move this count."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, SIGNAL_COUNTS_UPDATED, self._handle_update)
+        )
+        if self._description.date_derived:
+            # `overdue_count` and `inspection_overdue_count` are derived from
+            # today's date against stored dates, so they move at midnight with
+            # nothing having been mutated. UTC, because the counts themselves
+            # compare against a UTC date.
+            self.async_on_remove(
+                async_track_utc_time_change(
+                    self.hass, self._handle_time_change, hour=0, minute=0, second=0
+                )
+            )
+
+    @callback
+    def _handle_update(self) -> None:
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_time_change(self, _now: Any) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Unavailable while no config entry is loaded to read counts from."""
+
+        return self._counts() is not None
+
+    @property
+    def native_value(self) -> int | None:
+        counts = self._counts()
+        if counts is None:
+            return None
+        value = counts.get(self._description.key)
+        return int(value) if value is not None else None
+
+    def _counts(self) -> dict[str, Any] | None:
+        repo = (self.hass.data.get(DOMAIN) or {}).get("repository")
+        if repo is None:
+            return None
+        try:
+            return dict(repo.get_counts())
+        except Exception:  # pragma: no cover - defensive
+            LOGGER.exception(
+                "Failed to read counts for a sensor",
+                extra={"domain": DOMAIN, "op": "sensor_counts", "key": self._description.key},
+            )
+            return None

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -19,6 +19,7 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 
 from .const import DOMAIN
+from .events import notify_mutation
 from .exceptions import (
     ConflictError,
     NotFoundError,
@@ -196,7 +197,9 @@ async def service_item_create(hass: HomeAssistant, data: dict) -> dict[str, Any]
         repo = _get_repo(hass)
         item = repo.create_item(payload)  # type: ignore[arg-type]
         await async_persist_repo(hass)
-        return {"item": serialize_item(hass, item)}
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="created", item=serialized)
+        return {"item": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_name": data.get("name")}, exc)
 
@@ -211,7 +214,9 @@ async def service_item_update(hass: HomeAssistant, data: dict) -> dict[str, Any]
         repo = _get_repo(hass)
         item = repo.update_item(payload["item_id"], update, expected_version=expected)  # type: ignore[arg-type]
         await async_persist_repo(hass)
-        return {"item": serialize_item(hass, item)}
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="updated", item=serialized)
+        return {"item": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id}, exc)
 
@@ -229,6 +234,7 @@ async def service_item_delete(hass: HomeAssistant, data: dict) -> dict[str, Any]
         removed = serialize_item(hass, repo.get_item(payload["item_id"]))
         repo.delete_item(payload["item_id"], expected_version=expected)
         await async_persist_repo(hass)
+        notify_mutation(hass, action="deleted", item=removed)
         return {"item": removed}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id}, exc)
@@ -244,7 +250,9 @@ async def service_item_move(hass: HomeAssistant, data: dict) -> dict[str, Any]:
         repo = _get_repo(hass)
         item = repo.update_item(payload["item_id"], update, expected_version=expected)  # type: ignore[arg-type]
         await async_persist_repo(hass)
-        return {"item": serialize_item(hass, item)}
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="moved", item=serialized)
+        return {"item": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(
             op, {"item_id": item_id, "new_location_id": data.get("new_location_id")}, exc
@@ -261,7 +269,9 @@ async def service_item_adjust_quantity(hass: HomeAssistant, data: dict) -> dict[
             payload["item_id"], payload["delta"], expected_version=payload.get("expected_version")
         )
         await async_persist_repo(hass)
-        return {"item": serialize_item(hass, item)}
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="quantity_changed", item=serialized)
+        return {"item": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id, "delta": data.get("delta")}, exc)
 
@@ -278,7 +288,9 @@ async def service_item_set_quantity(hass: HomeAssistant, data: dict) -> dict[str
             expected_version=payload.get("expected_version"),
         )
         await async_persist_repo(hass)
-        return {"item": serialize_item(hass, item)}
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="quantity_changed", item=serialized)
+        return {"item": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id, "quantity": data.get("quantity")}, exc)
 
@@ -295,7 +307,9 @@ async def service_item_check_out(hass: HomeAssistant, data: dict) -> dict[str, A
             expected_version=payload.get("expected_version"),
         )
         await async_persist_repo(hass)
-        return {"item": serialize_item(hass, item)}
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="checked_out", item=serialized)
+        return {"item": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id, "due_date": data.get("due_date")}, exc)
 
@@ -308,7 +322,9 @@ async def service_item_check_in(hass: HomeAssistant, data: dict) -> dict[str, An
         repo = _get_repo(hass)
         item = repo.check_in(payload["item_id"], expected_version=payload.get("expected_version"))
         await async_persist_repo(hass)
-        return {"item": serialize_item(hass, item)}
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="checked_in", item=serialized)
+        return {"item": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"item_id": item_id}, exc)
 

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -64,6 +64,22 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "items_total": {
+        "name": "Items"
+      },
+      "low_stock": {
+        "name": "Low stock"
+      },
+      "overdue": {
+        "name": "Overdue"
+      },
+      "inspection_overdue": {
+        "name": "Inspection overdue"
+      }
+    }
+  },
   "selector": {
     "quick_filters": {
       "options": {

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -64,6 +64,22 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "items_total": {
+        "name": "Items"
+      },
+      "low_stock": {
+        "name": "Low stock"
+      },
+      "overdue": {
+        "name": "Overdue"
+      },
+      "inspection_overdue": {
+        "name": "Inspection overdue"
+      }
+    }
+  },
   "selector": {
     "quick_filters": {
       "options": {

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -36,6 +36,7 @@ from .const import (
     MAX_MANUALS_PER_ITEM,
     MAX_PICTURES_PER_ITEM,
 )
+from .events import notify_mutation
 from .exceptions import (
     ConflictError,
     NotFoundError,
@@ -1245,6 +1246,7 @@ async def ws_item_create(
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="created", payload={"item": serialized})
+    notify_mutation(hass, action="created", item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1298,6 +1300,7 @@ async def ws_item_update(
     action = "moved" if "location_id" in update else "updated"
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
+    notify_mutation(hass, action=action, item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1332,6 +1335,7 @@ async def ws_item_delete(
         action="deleted",
         payload={"item": serialized_before},
     )
+    notify_mutation(hass, action="deleted", item=serialized_before)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), None))
 
@@ -1357,6 +1361,7 @@ async def ws_item_adjust_quantity(
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
+    notify_mutation(hass, action="quantity_changed", item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1387,6 +1392,7 @@ async def ws_item_set_quantity(
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
+    notify_mutation(hass, action="quantity_changed", item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1412,6 +1418,7 @@ async def ws_item_check_out(
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="checked_out", payload={"item": serialized})
+    notify_mutation(hass, action="checked_out", item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1432,6 +1439,7 @@ async def ws_item_check_in(
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="checked_in", payload={"item": serialized})
+    notify_mutation(hass, action="checked_in", item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1460,6 +1468,7 @@ async def ws_item_add_tags(
     )
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
+    notify_mutation(hass, action=action, item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1488,6 +1497,7 @@ async def ws_item_remove_tags(
     )
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
+    notify_mutation(hass, action=action, item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1518,6 +1528,7 @@ async def ws_item_update_custom_fields(
     )
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
+    notify_mutation(hass, action=action, item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1546,6 +1557,7 @@ async def ws_item_set_low_stock_threshold(
     )
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
+    notify_mutation(hass, action=action, item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1644,6 +1656,7 @@ async def ws_item_attachment_add(
     # letting the error through the way every other mutation does.
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
+    notify_mutation(hass, action="updated", item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1677,6 +1690,7 @@ async def ws_item_attachment_remove(
     await _persist_repo(hass)
     await media_mod.async_delete_attachments(hass, [(str(updated.id), removed)])
     _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
+    notify_mutation(hass, action="updated", item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1707,6 +1721,7 @@ async def ws_item_attachment_update(
     serialized = serialize_item(hass, updated)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
+    notify_mutation(hass, action="updated", item=serialized)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1740,6 +1755,7 @@ async def ws_item_attachment_reorder(
     serialized = serialize_item(hass, updated)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
+    notify_mutation(hass, action="updated", item=serialized)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1767,6 +1783,7 @@ async def ws_item_move(
     )
     await _persist_repo(hass)
     _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
+    notify_mutation(hass, action=action, item=serialized)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -1882,6 +1899,7 @@ async def ws_items_bulk(
 
         for _op_id, serialized, action in successful_ops:
             _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
+            notify_mutation(hass, action=action, item=serialized)
 
         _broadcast_counts(hass)
 
@@ -2429,6 +2447,10 @@ async def ws_import_execute(
     _broadcast_event(hass, topic="items", action="reloaded", payload=None)
     _broadcast_event(hass, topic="locations", action="reloaded", payload=None)
     _broadcast_counts(hass)
+    # No per-item bus event — an import rewrites the dataset and an automation
+    # wants one signal, not one per row. The low-stock diff still runs, so a
+    # restock done by import announces itself, and the sensors still repaint.
+    notify_mutation(hass, action="reloaded")
 
     summary = {
         "applied": True,

--- a/dev/ha_config_for_dev.yaml
+++ b/dev/ha_config_for_dev.yaml
@@ -21,3 +21,11 @@ http:
   server_port: 8123
 
 websocket_api:
+
+# HAventory fires `haventory_item_changed` / `haventory_low_stock` on the bus, and
+# the only way to check that an automation really triggers on one is to have an
+# automation. Without these includes Home Assistant never reads the files the UI
+# editor and the config API write to, so an automation created there exists on disk
+# and nowhere else.
+automation: !include automations.yaml
+script: !include scripts.yaml

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -151,6 +151,35 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - `items/bulk` shares one write across the whole batch, so a failed write costs the batch its `results` map: the command answers `storage_error` and none of its operations broadcast.
   - The rate limiter can still drop an event that was persisted — see "Rate limiting". The implication runs one way only: an event means a durable write, but a durable write does not guarantee an event.
 
+### Home Assistant bus events
+
+Everything above is WebSocket traffic, delivered to subscribed clients. HAventory also fires
+two event types on the **Home Assistant bus**, so an automation can trigger on the inventory
+with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
+
+| Event type | Fired when | `action` |
+|---|---|---|
+| `haventory_item_changed` | an item is mutated | `created`, `updated`, `moved`, `quantity_changed`, `checked_out`, `checked_in`, `deleted` |
+| `haventory_low_stock` | an item crosses its `low_stock_threshold` | `entered`, `cleared` |
+
+- **The same "an event implies a durable write" rule holds here**: both are fired after the
+  persist, on every path — WebSocket handlers and `haventory.*` service calls alike. A
+  mutation that fails to persist fires nothing.
+- **The `action` vocabulary is the WebSocket one**, so a trigger and a subscription describe
+  the same mutation with the same word.
+- **`haventory_low_stock` is a set diff, not a per-handler check.** The set of low-stock ids
+  is snapshotted when the entry sets up — so a restart re-announces nothing — and diffed
+  after every mutation. One `entered` on the crossing, nothing while it stays low, one
+  `cleared` on restock or deletion. A wholesale `import/execute` diffs the same way rather
+  than announcing every row.
+- **The rate limiter does not apply.** It budgets WebSocket subscription traffic; bus events
+  are internal to Home Assistant, on the same reasoning as the `unavailable` notice.
+- **Bus events carry no item body beyond the trigger fields** — no `custom_fields`, no
+  `description`. An automation that needs the whole item calls `haventory/item/get`.
+- **Locations fire no bus event.** None of the counts a sensor exposes can move on a location
+  mutation: the repository refuses to delete a location that still holds items or children,
+  and a rename or re-anchor only rewrites derived fields.
+
 ### Items
 
 - `haventory/item/create`

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -474,6 +474,45 @@ against the repository:
 - `area_id` reads the item's `effective_area_id`, so it selects the same area `ItemFilter.area_id` does. An item with no location carries `effective_area_id: null` and matches no area filter; a `null` or omitted `area_id` on the subscription means no area filter at all. `area_id` applies to the `items` topic only.
 - Filters combine with AND, and every one of them is applied to the payload as it stands *after* the mutation. An item that leaves a filtered set produces no event for that subscription, so a client tracking one re-lists rather than waiting for a departure event — including after a `locations` `moved` event, which is the only signal that a subtree's `effective_area_id` was rewritten.
 
+### Home Assistant bus events
+
+Fired on the HA bus after the durable write, from WebSocket mutations and `haventory.*`
+service calls alike. Separate from the WebSocket events above and unaffected by the rate
+limiter; see the API contract's "Home Assistant bus events".
+
+`haventory_item_changed`:
+```json
+{
+  "action": "created|updated|moved|quantity_changed|checked_out|checked_in|deleted",
+  "item_id": "uuid-v4",
+  "name": "string",
+  "quantity": 0,
+  "location_id": "uuid-v4|null",
+  "location_path": "Garage / Shelf A",
+  "effective_area_id": "string|null",
+  "version": 1,
+  "ts": "ISO8601Z"
+}
+```
+
+`haventory_low_stock`:
+```json
+{
+  "action": "entered|cleared",
+  "item_id": "uuid-v4",
+  "name": "string|null",
+  "quantity": 0,
+  "low_stock_threshold": 0,
+  "ts": "ISO8601Z"
+}
+```
+
+`location_path` is the **display path string**, not the object the WebSocket Item carries —
+a trigger template wants one readable value. The payload is trigger fodder: it deliberately
+omits `custom_fields`, `description`, `tags` and the rest, and an automation that needs them
+calls `haventory/item/get`. On a `cleared` fired for an item that was deleted, `name`,
+`quantity` and `low_stock_threshold` come from the body the delete removed.
+
 ### Service responses
 
 Every `haventory.*` service declares `SupportsResponse.OPTIONAL` and answers with the same

--- a/stubs/homeassistant/core.pyi
+++ b/stubs/homeassistant/core.pyi
@@ -5,9 +5,11 @@ back to Any via __getattr__. See pyproject [tool.mypy] mypy_path.
 """
 
 import asyncio
-from collections.abc import Coroutine, Mapping
+from collections.abc import Callable, Coroutine, Mapping
 from enum import StrEnum
 from typing import Any
+
+def callback[C: Callable[..., Any]](func: C) -> C: ...
 
 class SupportsResponse(StrEnum):
     NONE = "none"

--- a/stubs/homeassistant/helpers/dispatcher.pyi
+++ b/stubs/homeassistant/helpers/dispatcher.pyi
@@ -1,0 +1,11 @@
+"""Minimal Home Assistant stubs for offline type checking."""
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+def async_dispatcher_send(hass: HomeAssistant, signal: str, *args: Any) -> None: ...
+def async_dispatcher_connect(
+    hass: HomeAssistant, signal: str, target: Callable[..., Any]
+) -> Callable[[], None]: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,10 +111,30 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def path(self, *parts: str) -> str:
             return os.path.join(self.config_dir, *parts)
 
+    class _Bus:  # type: ignore[override]
+        """Stand in for HA's event bus, recording what was fired.
+
+        Real HA dispatches to listeners; offline there are none, so the record
+        *is* the observable behaviour — without it `events.py` cannot be tested
+        here at all.
+        """
+
+        def __init__(self) -> None:
+            self.fired: list[tuple[str, dict]] = []
+
+        def async_fire(self, event_type, event_data=None, *_args, **_kwargs) -> None:
+            self.fired.append((event_type, dict(event_data or {})))
+
+        def events_of(self, event_type: str) -> list[dict]:
+            return [data for kind, data in self.fired if kind == event_type]
+
     class HomeAssistant:  # type: ignore[override]
         def __init__(self) -> None:
             self.data = {}
             self.config = _Config()
+            self.bus = _Bus()
+            self.dispatcher_sends: list[tuple[str, tuple]] = []
+            self.dispatcher_connects: list[tuple[str, object]] = []
 
         def async_create_background_task(self, target, name, eager_start=True):
             """Stand in for HA's tracked-task helper; the real one also cancels on shutdown."""
@@ -344,6 +364,27 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
     ha_helpers_storage.Store = Store
     sys.modules["homeassistant.helpers.storage"] = ha_helpers_storage
+
+    # homeassistant.helpers.dispatcher — the signal the sensors repaint on.
+    # Offline there is no entity platform to receive it, so the stub only has to
+    # let `events.notify_mutation` run; `hass` records the sends for tests.
+    ha_helpers_dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
+
+    def async_dispatcher_send(hass, signal, *args):  # type: ignore[override]
+        hass.dispatcher_sends.append((signal, args))
+
+    def async_dispatcher_connect(hass, signal, target):  # type: ignore[override]
+        hass.dispatcher_connects.append((signal, target))
+
+        def _remove() -> None:
+            hass.dispatcher_connects.remove((signal, target))
+
+        return _remove
+
+    ha_helpers_dispatcher.async_dispatcher_send = async_dispatcher_send
+    ha_helpers_dispatcher.async_dispatcher_connect = async_dispatcher_connect
+    ha_helpers.dispatcher = ha_helpers_dispatcher
+    sys.modules["homeassistant.helpers.dispatcher"] = ha_helpers_dispatcher
 
     # homeassistant.components.websocket_api
     ha_components = types.ModuleType("homeassistant.components")

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,174 @@
+"""Integration: HAventory events on the real Home Assistant bus.
+
+The offline stub records what `events.py` asked the bus to fire; only a real bus
+shows that a listener — and so an automation trigger — actually receives it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.haventory.const import DOMAIN, EVENT_ITEM_CHANGED, EVENT_LOW_STOCK
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry, async_capture_events
+
+LOW_THRESHOLD = 3
+CREATED_QUANTITY = 2
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+def _data(events: list[Event]) -> list[dict[str, Any]]:
+    return [dict(e.data) for e in events]
+
+
+async def test_a_service_call_reaches_a_bus_listener(hass: HomeAssistant) -> None:
+    """`hass.bus.async_listen` sees `haventory_item_changed` from a service."""
+
+    await _setup(hass)
+    captured = async_capture_events(hass, EVENT_ITEM_CHANGED)
+
+    await hass.services.async_call(
+        DOMAIN, "item_create", {"name": "Torch", "quantity": CREATED_QUANTITY}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert len(captured) == 1
+    payload = _data(captured)[0]
+    assert payload["action"] == "created"
+    assert payload["name"] == "Torch"
+    assert payload["quantity"] == CREATED_QUANTITY
+    assert payload["version"] == 1
+    assert payload["ts"].endswith("Z")
+
+
+async def test_a_websocket_mutation_reaches_a_bus_listener(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    await _setup(hass)
+    captured = async_capture_events(hass, EVENT_ITEM_CHANGED)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Torch"})
+    assert (await client.receive_json())["success"] is True
+    await hass.async_block_till_done()
+
+    assert [p["action"] for p in _data(captured)] == ["created"]
+
+
+async def test_low_stock_fires_entered_and_cleared(hass: HomeAssistant) -> None:
+    """The transition an automation triggers on, both ways, from a service call."""
+
+    await _setup(hass)
+    captured = async_capture_events(hass, EVENT_LOW_STOCK)
+
+    created = await hass.services.async_call(
+        DOMAIN,
+        "item_create",
+        {"name": "Batteries", "quantity": 10, "low_stock_threshold": LOW_THRESHOLD},
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+    assert captured == []
+
+    item_id = created["item"]["id"]
+    await hass.services.async_call(
+        DOMAIN, "item_set_quantity", {"item_id": item_id, "quantity": 1}, blocking=True
+    )
+    await hass.async_block_till_done()
+    assert [p["action"] for p in _data(captured)] == ["entered"]
+    assert _data(captured)[0]["item_id"] == item_id
+    assert _data(captured)[0]["low_stock_threshold"] == LOW_THRESHOLD
+
+    await hass.services.async_call(
+        DOMAIN, "item_set_quantity", {"item_id": item_id, "quantity": 10}, blocking=True
+    )
+    await hass.async_block_till_done()
+    assert [p["action"] for p in _data(captured)] == ["entered", "cleared"]
+
+
+async def test_a_real_automation_triggers_on_low_stock(hass: HomeAssistant) -> None:
+    """The story #218 promises, through HA's automation engine rather than a listener.
+
+    An event trigger with an `action: entered` filter, and a template that reads
+    the payload — which is what pins the event's field names as a public API and
+    not just as a dict this integration happens to fire.
+    """
+
+    await _setup(hass)
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "alias": "notify on low stock",
+                "trigger": {
+                    "platform": "event",
+                    "event_type": EVENT_LOW_STOCK,
+                    "event_data": {"action": "entered"},
+                },
+                "action": {
+                    "event": "haventory_test_automation_ran",
+                    "event_data": {
+                        "item": "{{ trigger.event.data.name }}",
+                        "quantity": "{{ trigger.event.data.quantity }}",
+                    },
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    fired = async_capture_events(hass, "haventory_test_automation_ran")
+
+    created = await hass.services.async_call(
+        DOMAIN,
+        "item_create",
+        {"name": "Batteries", "quantity": 10, "low_stock_threshold": LOW_THRESHOLD},
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+    # Above the threshold: the trigger's `entered` filter has nothing to match.
+    assert fired == []
+
+    await hass.services.async_call(
+        DOMAIN,
+        "item_set_quantity",
+        {"item_id": created["item"]["id"], "quantity": 1},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert [dict(e.data) for e in fired] == [{"item": "Batteries", "quantity": 1}]
+
+
+async def test_a_restart_re_announces_nothing(hass: HomeAssistant, hass_storage) -> None:
+    """Setting up against a store that already holds low items fires no event."""
+
+    entry = await _setup(hass)
+    await hass.services.async_call(
+        DOMAIN,
+        "item_create",
+        {"name": "Batteries", "quantity": 1, "low_stock_threshold": LOW_THRESHOLD},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    captured = async_capture_events(hass, EVENT_LOW_STOCK)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert captured == []
+    assert hass.data[DOMAIN]["repository"].low_stock_item_ids

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -1,0 +1,149 @@
+"""Integration: the four count sensors on the HAventory device.
+
+Everything here needs machinery the offline stub does not have — an entity
+platform, a device registry, `hass.config_entries`, and a service registry that
+dispatches. The offline suite can only check the catalog the entities are built
+from (`tests/test_sensor_offline.py`).
+"""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.haventory.const import DOMAIN, SENSOR_DESCRIPTIONS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+LOW_THRESHOLD = 3
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+def _entity_ids(hass: HomeAssistant, entry: MockConfigEntry) -> list[str]:
+    registry = er.async_get(hass)
+    return sorted(e.entity_id for e in er.async_entries_for_config_entry(registry, entry.entry_id))
+
+
+async def test_four_sensors_land_on_one_device(hass: HomeAssistant) -> None:
+    """One service device, four entities, `unique_id`s scoped to the entry."""
+
+    entry = await _setup(hass)
+
+    entity_registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert len(entries) == len(SENSOR_DESCRIPTIONS)
+
+    assert {e.unique_id for e in entries} == {
+        f"{entry.entry_id}_{d.key}" for d in SENSOR_DESCRIPTIONS
+    }
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert device is not None
+    assert {e.device_id for e in entries} == {device.id}
+
+    # `_attr_has_entity_name` plus a translation key: HA builds the friendly name
+    # from the device name and the `entity.sensor` block, so a missing entry is
+    # visible as an entity_id where a name should be.
+    for entity_id in _entity_ids(hass, entry):
+        state = hass.states.get(entity_id)
+        assert state is not None, entity_id
+        assert state.attributes["friendly_name"].startswith("HAventory ")
+        assert not state.attributes["friendly_name"].endswith("HAventory ")
+
+
+async def test_items_total_moves_on_a_service_call_with_no_polling(hass: HomeAssistant) -> None:
+    """`haventory.item_create` repaints the sensor — the path that emitted nothing.
+
+    No `async_update_entity`, no time travel: if the push were missing the state
+    would still read 0 here.
+    """
+
+    entry = await _setup(hass)
+    total = next(e for e in _entity_ids(hass, entry) if e.endswith("_items"))
+
+    assert hass.states.get(total).state == "0"
+
+    await hass.services.async_call(DOMAIN, "item_create", {"name": "Torch"}, blocking=True)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(total).state == "1"
+
+
+async def test_items_total_moves_on_a_websocket_mutation(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """The other write path pushes the same way."""
+
+    entry = await _setup(hass)
+    total = next(e for e in _entity_ids(hass, entry) if e.endswith("_items"))
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Torch"})
+    assert (await client.receive_json())["success"] is True
+    await hass.async_block_till_done()
+
+    assert hass.states.get(total).state == "1"
+
+
+async def test_low_stock_sensor_tracks_the_threshold(hass: HomeAssistant) -> None:
+    entry = await _setup(hass)
+    low = next(e for e in _entity_ids(hass, entry) if e.endswith("_low_stock"))
+
+    created = await hass.services.async_call(
+        DOMAIN,
+        "item_create",
+        {"name": "Batteries", "quantity": 10, "low_stock_threshold": LOW_THRESHOLD},
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(low).state == "0"
+
+    await hass.services.async_call(
+        DOMAIN,
+        "item_set_quantity",
+        {"item_id": created["item"]["id"], "quantity": 1},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(low).state == "1"
+
+
+async def test_unload_removes_the_entities(hass: HomeAssistant) -> None:
+    """An unloaded entry serves nothing, entities included."""
+
+    entry = await _setup(hass)
+    entity_ids = _entity_ids(hass, entry)
+    assert entity_ids
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    for entity_id in entity_ids:
+        state = hass.states.get(entity_id)
+        assert state is None or state.state == "unavailable", entity_id
+
+
+@pytest.mark.parametrize("descriptor", SENSOR_DESCRIPTIONS, ids=lambda d: d.key)
+async def test_each_sensor_reports_its_count(hass: HomeAssistant, descriptor) -> None:
+    """Every entity reads its own key, so none of them is wired to the wrong one."""
+
+    entry = await _setup(hass)
+    repo = hass.data[DOMAIN]["repository"]
+
+    registry = er.async_get(hass)
+    entity_id = next(
+        e.entity_id
+        for e in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if e.unique_id == f"{entry.entry_id}_{descriptor.key}"
+    )
+
+    assert hass.states.get(entity_id).state == str(repo.get_counts()[descriptor.key])

--- a/tests/test_events_offline.py
+++ b/tests/test_events_offline.py
@@ -1,0 +1,238 @@
+"""Offline tests for the Home Assistant bus events.
+
+Scenarios:
+- every item mutation fires exactly one `haventory_item_changed` with the
+  documented keys, and the action vocabulary matches the WebSocket one
+- low-stock transitions fire once on the crossing and not again below it
+- a restock fires `cleared`; deleting a low item fires `cleared` with no name
+- the snapshot seeded at setup keeps a restart from re-announcing
+- a torn-down entry makes the helper a no-op rather than a `KeyError`
+"""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.haventory import events as events_mod
+from custom_components.haventory.const import (
+    DATA_LOW_STOCK_SNAPSHOT,
+    DOMAIN,
+    EVENT_ITEM_CHANGED,
+    EVENT_LOW_STOCK,
+    SIGNAL_COUNTS_UPDATED,
+)
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.serialization import serialize_item
+from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.ws import setup as ws_setup
+from homeassistant.core import HomeAssistant
+
+from ws_helpers import ws_send
+
+LOW_THRESHOLD = 3
+
+
+def _hass() -> tuple[HomeAssistant, Repository]:
+    hass = HomeAssistant()
+    repo = Repository()
+    hass.data[DOMAIN] = {"repository": repo}
+    events_mod.seed_low_stock_snapshot(hass)
+    return hass, repo
+
+
+def _create(repo: Repository, hass: HomeAssistant, **payload):
+    item = repo.create_item({"quantity": 10, **payload})  # type: ignore[arg-type]
+    return item, serialize_item(hass, item)
+
+
+@pytest.mark.asyncio
+async def test_every_websocket_item_mutation_reaches_the_bus() -> None:
+    """Each WS item command fires a bus event, with the action it broadcast.
+
+    An automation trigger and a card subscription describing the same mutation
+    with different words would be two vocabularies to document and keep in step,
+    so the bus action is asserted against the one the WS event carried.
+    """
+
+    hass = HomeAssistant()
+    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    events_mod.seed_low_stock_snapshot(hass)
+    ws_setup(hass)
+
+    created = await ws_send(hass, 1, "haventory/item/create", name="Widget", quantity=5)
+    item_id = created["result"]["id"]
+
+    commands: list[tuple[str, dict]] = [
+        ("haventory/item/update", {"item_id": item_id, "name": "Widget Pro"}),
+        ("haventory/item/move", {"item_id": item_id, "location_id": None}),
+        ("haventory/item/adjust_quantity", {"item_id": item_id, "delta": -1}),
+        ("haventory/item/set_quantity", {"item_id": item_id, "quantity": 7}),
+        ("haventory/item/check_out", {"item_id": item_id, "due_date": "2030-01-01"}),
+        ("haventory/item/check_in", {"item_id": item_id}),
+        ("haventory/item/delete", {"item_id": item_id}),
+    ]
+    for index, (command, payload) in enumerate(commands, start=2):
+        res = await ws_send(hass, index, command, **payload)
+        assert res["success"] is True, (command, res)
+
+    fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
+    assert len(fired) == len(commands) + 1
+    assert {e["action"] for e in fired} <= events_mod.ITEM_ACTIONS
+    assert fired[0]["action"] == "created"
+    assert fired[-1]["action"] == "deleted"
+    assert {e["item_id"] for e in fired} == {item_id}
+
+
+def test_a_mutation_fires_one_item_changed_with_the_documented_keys() -> None:
+    hass, repo = _hass()
+    loc = repo.create_location(name="Shelf")
+    item, serialized = _create(repo, hass, name="Widget", location_id=str(loc.id))
+
+    events_mod.notify_mutation(hass, action="created", item=serialized)
+
+    fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
+    assert len(fired) == 1
+    payload = fired[0]
+    assert set(payload) == {
+        "action",
+        "item_id",
+        "name",
+        "quantity",
+        "location_id",
+        "location_path",
+        "effective_area_id",
+        "version",
+        "ts",
+    }
+    assert payload["action"] == "created"
+    assert payload["item_id"] == str(item.id)
+    assert payload["name"] == "Widget"
+    assert payload["location_path"] == "Shelf"
+    assert payload["version"] == item.version
+    # Trigger fodder only: an automation that wants the body calls haventory/item/get.
+    assert "custom_fields" not in payload
+    assert "description" not in payload
+
+    # The sensors repaint off the dispatcher, not off the bus event.
+    assert hass.dispatcher_sends == [(SIGNAL_COUNTS_UPDATED, ())]
+
+
+def test_a_bulk_style_notification_carries_no_item_event() -> None:
+    """An import rewrites the dataset; one signal, not one event per row."""
+
+    hass, repo = _hass()
+    _create(repo, hass, name="Widget")
+
+    events_mod.notify_mutation(hass, action="reloaded")
+
+    assert hass.bus.events_of(EVENT_ITEM_CHANGED) == []
+    assert hass.dispatcher_sends == [(SIGNAL_COUNTS_UPDATED, ())]
+
+
+def test_crossing_the_threshold_fires_entered_once() -> None:
+    hass, repo = _hass()
+    item, _ = _create(repo, hass, name="Batteries", low_stock_threshold=LOW_THRESHOLD)
+
+    updated = repo.set_quantity(str(item.id), LOW_THRESHOLD - 1)
+    events_mod.notify_mutation(hass, action="quantity_changed", item=serialize_item(hass, updated))
+    entered = hass.bus.events_of(EVENT_LOW_STOCK)
+    assert [e["action"] for e in entered] == ["entered"]
+    assert entered[0]["item_id"] == str(item.id)
+    assert entered[0]["name"] == "Batteries"
+    assert entered[0]["low_stock_threshold"] == LOW_THRESHOLD
+
+    # A further drop is still low stock — the set did not change, so nothing fires.
+    updated = repo.set_quantity(str(item.id), 0)
+    events_mod.notify_mutation(hass, action="quantity_changed", item=serialize_item(hass, updated))
+    assert len(hass.bus.events_of(EVENT_LOW_STOCK)) == 1
+
+
+def test_a_restock_fires_cleared() -> None:
+    hass, repo = _hass()
+    item, _ = _create(repo, hass, name="Batteries", quantity=1, low_stock_threshold=LOW_THRESHOLD)
+    events_mod.notify_mutation(hass, action="created", item=serialize_item(hass, item))
+    assert [e["action"] for e in hass.bus.events_of(EVENT_LOW_STOCK)] == ["entered"]
+
+    restocked = repo.set_quantity(str(item.id), 10)
+    events_mod.notify_mutation(
+        hass, action="quantity_changed", item=serialize_item(hass, restocked)
+    )
+    assert [e["action"] for e in hass.bus.events_of(EVENT_LOW_STOCK)] == ["entered", "cleared"]
+
+
+def test_deleting_a_low_item_clears_it_with_no_name() -> None:
+    """The item is gone by the time the diff runs, so the id is all there is."""
+
+    hass, repo = _hass()
+    item, _ = _create(repo, hass, name="Batteries", quantity=1, low_stock_threshold=LOW_THRESHOLD)
+    events_mod.notify_mutation(hass, action="created", item=serialize_item(hass, item))
+
+    removed = serialize_item(hass, item)
+    repo.delete_item(str(item.id))
+    events_mod.notify_mutation(hass, action="deleted", item=removed)
+
+    cleared = [e for e in hass.bus.events_of(EVENT_LOW_STOCK) if e["action"] == "cleared"]
+    assert len(cleared) == 1
+    assert cleared[0]["item_id"] == str(item.id)
+    # The delete's own payload names it; a lookup would have raised.
+    assert cleared[0]["name"] == "Batteries"
+
+
+def test_the_seeded_snapshot_keeps_a_restart_quiet() -> None:
+    """A store loaded with low items announces nothing until something changes."""
+
+    hass = HomeAssistant()
+    repo = Repository()
+    item = repo.create_item(  # type: ignore[arg-type]
+        {"name": "Batteries", "quantity": 1, "low_stock_threshold": LOW_THRESHOLD}
+    )
+    # The entry sets up against a store that already holds a low item.
+    hass.data[DOMAIN] = {"repository": repo}
+    events_mod.seed_low_stock_snapshot(hass)
+    assert hass.data[DOMAIN][DATA_LOW_STOCK_SNAPSHOT] == frozenset({str(item.id)})
+
+    unrelated = repo.create_item({"name": "Rope", "quantity": 5})  # type: ignore[arg-type]
+    events_mod.notify_mutation(hass, action="created", item=serialize_item(hass, unrelated))
+
+    assert hass.bus.events_of(EVENT_LOW_STOCK) == []
+
+
+def test_an_emptied_bucket_is_a_no_op() -> None:
+    """A mutation racing the entry's teardown must not raise out of the helper."""
+
+    hass, repo = _hass()
+    _item, serialized = _create(repo, hass, name="Widget")
+
+    hass.data.pop(DOMAIN)
+    events_mod.notify_mutation(hass, action="created", item=serialized)
+    assert hass.bus.fired == []
+
+    # A bucket that survived but lost its repository is the same story.
+    hass.data[DOMAIN] = {}
+    events_mod.notify_mutation(hass, action="created", item=serialized)
+    assert hass.bus.events_of(EVENT_LOW_STOCK) == []
+
+
+@pytest.mark.parametrize("action", sorted(events_mod.ITEM_ACTIONS))
+def test_every_action_in_the_vocabulary_fires(action: str) -> None:
+    hass, repo = _hass()
+    _item, serialized = _create(repo, hass, name="Widget")
+
+    events_mod.notify_mutation(hass, action=action, item=serialized)
+
+    fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
+    assert [e["action"] for e in fired] == [action]
+
+
+def test_low_stock_ids_are_a_snapshot_not_the_live_index() -> None:
+    """The diff is against a set taken before the mutation, so it cannot alias."""
+
+    repo = Repository()
+    item = repo.create_item(  # type: ignore[arg-type]
+        {"name": "Batteries", "quantity": 1, "low_stock_threshold": LOW_THRESHOLD}
+    )
+    before = repo.low_stock_item_ids
+    assert before == frozenset({str(item.id)})
+
+    repo.set_quantity(str(item.id), 10)
+    assert repo.low_stock_item_ids == frozenset()
+    assert before == frozenset({str(item.id)})

--- a/tests/test_sensor_offline.py
+++ b/tests/test_sensor_offline.py
@@ -1,0 +1,77 @@
+"""Offline tests for the sensor catalog.
+
+`sensor.py` itself is not imported here: nothing offline stubs
+`homeassistant.components.sensor`, so the entity class belongs to the phacc
+suite (`tests/integration/test_sensor.py`). What is checkable offline is the
+catalog it is built from — that every descriptor names a real count, that the
+`unique_id` suffixes cannot collide, and that the names the frontend shows exist
+in both translation files.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from custom_components.haventory.const import PLATFORMS, SENSOR_DESCRIPTIONS
+from custom_components.haventory.repository import Repository
+
+PACKAGE = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
+EXPECTED_SENSOR_COUNT = 4
+
+
+def test_every_descriptor_names_a_count_the_repository_computes() -> None:
+    """A key `get_counts()` does not return would be a sensor stuck at unknown."""
+
+    counts = Repository().get_counts()
+    missing = [d.key for d in SENSOR_DESCRIPTIONS if d.key not in counts]
+    assert missing == []
+
+
+def test_the_four_promoted_counts_are_the_documented_ones() -> None:
+    """The other counts stay card- and WebSocket-only; promoting one is additive."""
+
+    assert [d.key for d in SENSOR_DESCRIPTIONS] == [
+        "items_total",
+        "low_stock_count",
+        "overdue_count",
+        "inspection_overdue_count",
+    ]
+    assert len(SENSOR_DESCRIPTIONS) == EXPECTED_SENSOR_COUNT
+
+
+def test_unique_id_suffixes_and_translation_keys_are_distinct() -> None:
+    """Two entities sharing a suffix would collide on one `unique_id`."""
+
+    assert len({d.key for d in SENSOR_DESCRIPTIONS}) == len(SENSOR_DESCRIPTIONS)
+    assert len({d.translation_key for d in SENSOR_DESCRIPTIONS}) == len(SENSOR_DESCRIPTIONS)
+
+
+def test_only_the_calendar_derived_counts_track_midnight() -> None:
+    """The other two move on a mutation, and a midnight rewrite would be noise."""
+
+    assert {d.key for d in SENSOR_DESCRIPTIONS if d.date_derived} == {
+        "overdue_count",
+        "inspection_overdue_count",
+    }
+
+
+def test_the_sensor_platform_is_the_only_one_forwarded() -> None:
+    """The calendar entity is #187's, not this platform's."""
+
+    assert [str(p) for p in PLATFORMS] == ["sensor"]
+
+
+def test_every_translation_key_is_named_in_both_translation_files() -> None:
+    """A missing entry shows the entity_id in the UI instead of a name.
+
+    `test_translation_flow_sections_match_strings` holds the two files equal;
+    this holds them to the catalog, which that equality cannot see.
+    """
+
+    for name in ("strings.json", "translations/en.json"):
+        catalog = json.loads((PACKAGE / name).read_text(encoding="utf-8"))
+        sensors = catalog["entity"]["sensor"]
+        assert set(sensors) == {d.translation_key for d in SENSOR_DESCRIPTIONS}, name
+        assert all(entry.keys() == {"name"} for entry in sensors.values()), name
+        assert all(entry["name"].strip() for entry in sensors.values()), name

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -17,7 +17,7 @@ import pytest
 import voluptuous as vol
 import yaml
 from custom_components.haventory import services as services_mod
-from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.const import DOMAIN, EVENT_ITEM_CHANGED
 from custom_components.haventory.exceptions import ConflictError, NotFoundError, StorageError
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
@@ -371,6 +371,66 @@ async def test_delete_answers_once_and_then_raises_not_found() -> None:
     assert first["item"]["id"] == item_id
     with pytest.raises(NotFoundError):
         await services_mod.service_item_delete(hass, {"item_id": item_id})
+
+
+@pytest.mark.asyncio
+async def test_every_item_service_reaches_the_bus() -> None:
+    """A service mutation fires the same bus event its WebSocket twin does.
+
+    `services.py` imports no `ws` module, so before this it emitted nothing at
+    all: `haventory.item_create` left every sensor stale and triggered no
+    automation.
+    """
+
+    hass = HomeAssistant()
+    _repo, item_id, _loc_id = await _seeded(hass)
+
+    calls = [
+        (services_mod.service_item_update, {"item_id": item_id, "name": "Widget Pro"}, "updated"),
+        (
+            services_mod.service_item_move,
+            {"item_id": item_id, "new_location_id": None},
+            "moved",
+        ),
+        (
+            services_mod.service_item_adjust_quantity,
+            {"item_id": item_id, "delta": -1},
+            "quantity_changed",
+        ),
+        (
+            services_mod.service_item_set_quantity,
+            {"item_id": item_id, "quantity": 7},
+            "quantity_changed",
+        ),
+        (
+            services_mod.service_item_check_out,
+            {"item_id": item_id, "due_date": "2030-01-01"},
+            "checked_out",
+        ),
+        (services_mod.service_item_check_in, {"item_id": item_id}, "checked_in"),
+        (services_mod.service_item_delete, {"item_id": item_id}, "deleted"),
+    ]
+    for handler, payload, _action in calls:
+        await handler(hass, payload)
+
+    fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
+    # The seed created one item and one location; the location fires nothing.
+    assert [e["action"] for e in fired] == ["created", *(action for _h, _p, action in calls)]
+    assert {e["item_id"] for e in fired} == {item_id}
+
+
+@pytest.mark.asyncio
+async def test_a_failed_service_fires_no_event() -> None:
+    """The event follows the durable write, so a rejected call announces nothing."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+
+    with pytest.raises(NotFoundError):
+        await services_mod.service_item_update(hass, {"item_id": "nope", "name": "Ghost"})
+
+    assert hass.bus.fired == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

HAventory stops being an app that runs *in* Home Assistant and becomes something HA can
see: four counts as sensors on one device, and two event types on the bus an automation can
trigger on. No coordinator, no polling.

- **`sensor.py`** — `items_total`, `low_stock_count`, `overdue_count`,
  `inspection_overdue_count`, one service device (`identifiers={(DOMAIN, entry.entry_id)}`,
  `sw_version=INTEGRATION_VERSION`), `unique_id = f"{entry_id}_{key}"`. Mutations repaint
  them through a dispatcher signal; the two calendar-derived counts additionally track UTC
  midnight, which moves them with no mutation at all.
- **`events.py`** — `notify_mutation` fires `haventory_item_changed`, diffs the low-stock id
  set for `haventory_low_stock`, and dispatches the repaint signal. Called after the durable
  write on every path, so the contract's "an event implies a durable write" rule holds on
  the bus too.
- **Both write paths.** `services.py` imported no `ws` module and emitted nothing at all, so
  `haventory.item_create` left every sensor stale and triggered no automation. It now
  notifies after each persist, with the same action vocabulary its WebSocket twin uses.
- **Low stock by set diff, not per handler.** Snapshotted at setup — so a restart
  re-announces nothing — and diffed after every mutation, which covers single mutations,
  `items/bulk` and `import/execute` in one place.
- **`Repository.low_stock_item_ids`** replaces reaching into `_debug_get_internal_indexes()`
  for the live set; it returns a `frozenset` copy, because a caller holding the live index
  would be diffing it against itself.
- README's "No automation triggers" limitation is retired and replaced by an **Automations**
  section with two worked examples; `docs/backend_api_contract.md` and `docs/data_shapes.md`
  gain the bus-event sections.

Closes #218

## Decisions against the issue notes

Recorded here rather than edited into the issue, per §4 of
`dev/V0_6_0_implementation.md`. Every `file.py:NNN` anchor in the 2026-08-05 notes had
drifted; symbols were located by name.

1. **Locations fire no bus event, and the three `location_*` services do not notify.** The
   notes say "each `services.py` handler after `await async_persist_repo(hass)`". Against the
   code, no location mutation can move any of the four counts: `delete_location` refuses
   while the location holds items or children, and create/update only rewrite derived fields.
   A dispatcher signal that provably cannot change a state is noise. Documented in the
   contract's new section so the omission is a stated rule rather than a gap.
2. **`import/execute` notifies without an item.** `notify_mutation(hass, action="reloaded")`
   fires no `haventory_item_changed` — an import rewrites the dataset and an automation wants
   one signal, not one per row — but still runs the low-stock diff and repaints the sensors.
   The notes' "one place covers … import execute alike" is satisfied by the diff, not by
   per-row events.
3. **`available` on the sensors.** Not in the notes. Without it an entity outliving its
   entry reports its last value; it now reports unavailable, which is what the unload test
   asserts.
4. **The `unique_id` uses `entry.entry_id`**, as the notes specify — remove-and-re-add is a
   fresh install and must not resurrect the removed entry's entity_ids.

Also, two things the notes flagged as unanswerable offline, now answered by the phacc run
and CI's hassfest: the import homes are
`homeassistant.components.sensor.{SensorEntity,SensorStateClass}`,
`homeassistant.helpers.device_registry.DeviceInfo`,
`homeassistant.helpers.entity_platform.AddConfigEntryEntitiesCallback` and
`homeassistant.helpers.event.async_track_utc_time_change`; and `manifest.json` needs no
change for a sensor platform.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `978 passed, 22 skipped` (was 954); `ruff check` clean,
      `ruff format --check` clean, `mypy` clean (18 source files).
- [x] Frontend (`cards/haventory-card`): eslint clean, `tsc --noEmit` clean,
      `1822 passed (62 files)`, build OK. No card source change.
- [x] phacc (`scripts/test_integration.sh`): **68 passed** (was 54) — the 14 new cases in
      `tests/integration/test_sensor.py` and `tests/integration/test_events.py`.

New offline cover: `tests/test_events_offline.py` (17 cases — the documented payload keys,
the WS handlers all reaching the bus, one `entered` on the crossing and nothing below it,
`cleared` on restock and on delete, the seeded snapshot keeping a restart quiet, an emptied
bucket as a no-op), `tests/test_sensor_offline.py` (the catalog: every descriptor names a
real count, distinct `unique_id` suffixes, only the calendar-derived two track midnight,
and every `translation_key` present in **both** translation files), plus the service-side
bus cases in `tests/test_services_offline.py`. `tests/conftest.py` gains the `bus` and
`dispatcher` stubs — without a `bus`, `events.py` is untestable offline at all.

## Live checks (dev Docker HA, HA 2026.7.4)

**1. The device page shows four sensors with sensible names and ids.**

```
sensor.haventory_items                 state= 1085  HAventory Items               mdi:package-variant-closed
sensor.haventory_low_stock             state=  160  HAventory Low stock           mdi:package-down
sensor.haventory_overdue               state=   42  HAventory Overdue             mdi:calendar-alert
sensor.haventory_inspection_overdue    state=   26  HAventory Inspection overdue  mdi:clipboard-alert
```

All four `state_class: measurement`. The device registry entry:
`name "HAventory", manufacturer "HAventory", model "Inventory", sw_version "0.5.0",
entry_type "service"`. Settings → Devices & services → HAventory renders a **Service info**
card ("Inventory by HAventory", "Version 0.5.0") beside a **Sensors** card listing
Inspection overdue 26, Items 1,085, Low stock 160, Overdue 42, each with its icon.
(Screenshot captured on the dev machine; this repo attaches no binaries and no prior PR
embeds one, so the page is described. The four names and the Sensors heading are asserted
out of the live DOM, not read off the image.)

**2. `items_total` moves on a WS mutation *and* on a service call, with no polling.** One
WebSocket connection, states read straight after each mutation, no `async_update_entity` and
no forced refresh — a missing push would leave the value where it was:

```json
{"ws_mutation":      {"before": "1085", "after": "1086"},
 "service_mutation": {"before": "1086", "after": "1087"},
 "low_stock":        {"before": "160",  "after": "161"},
 "low_stock_cleared": "160",
 "after_cleanup_total": "1085"}
```

The `service_mutation` line is the path that emitted nothing before this PR. Both probe
items were deleted afterwards, and the total returned to where it started.

**3. The bus events, captured over `subscribe_events` during the run above:**

```
haventory_item_changed  created           Live Sensor Probe WS       qty 9   v1
haventory_item_changed  created           Live Sensor Probe Service  qty 10  v1
haventory_item_changed  quantity_changed  Live Sensor Probe Service  qty 1   v2
haventory_low_stock     entered           Live Sensor Probe Service  qty 1   threshold 3
haventory_item_changed  quantity_changed  Live Sensor Probe Service  qty 20  v3
haventory_low_stock     cleared           Live Sensor Probe Service  qty 20  threshold 3
haventory_item_changed  deleted           Live Sensor Probe WS       qty 9   v1
haventory_item_changed  deleted           Live Sensor Probe Service  qty 20  v3
```

One `entered` on the crossing and one `cleared` on restock — not one per mutation.

**4. A real automation triggers on `haventory_low_stock`, end to end.** Created through HA's
own config API (the path the UI editor uses), with an `action: entered` filter and templates
reading the payload:

```json
{"automation_created": true,
 "fired_before_crossing": [],
 "fired_after_crossing": [{"item": "Live Automation Probe", "quantity": 1, "threshold": 3}],
 "automation_removed": true}
```

`fired_before_crossing` is the control that stops this being vacuous: creating the item at
quantity 10, above its threshold of 3, fires nothing — so the trigger's filter is doing real
work rather than matching everything.

**5. Log sweep clean.** `log_sweep.py --since 40m` over the whole session: `116 records,
BLOCKING: 0, KNOWN: 0, EXPECTED: 0 — verdict: PASS`.

**Waived: the UTC-midnight rollover on a long-running instance.** Checking it live means
either waiting for midnight UTC or moving the container's clock, which would invalidate every
other reading in this run. It is covered structurally instead: `test_sensor_offline.py` pins
which two descriptors carry `date_derived`, and only those subscribe to
`async_track_utc_time_change(hour=0, minute=0, second=0)`. The counts themselves compare
against `today_utc_date()`, so UTC — not local — is the right rollover.

### One repo change the live checks forced

`dev/ha_config_for_dev.yaml` had no `automation:` / `script:` include, so Home Assistant
never read the files its own UI editor and config API write to. The first attempt at check 4
therefore "passed" with an automation that existed on disk and nowhere else — it fired
nothing, and would have kept firing nothing however broken the events were. The include is
added, and `check-yaml` moves to syntax-only because a generic YAML loader has no constructor
for HA's `!include` tag. (That hook is pre-commit only; CI does not run it.)

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated — README "Automations" section (the "No automation triggers" limitation is
      gone), `docs/backend_api_contract.md` "Home Assistant bus events",
      `docs/data_shapes.md` payload shapes. The full user-first README rewrite stays #217.
- [x] WebSocket API unchanged — bus events sit beside the broadcasts, none is altered.
- [x] `entity.sensor` repeated byte-identically in `strings.json` and `translations/en.json`
      (both written from one dict, so they cannot drift);
      `test_translation_flow_sections_match_strings` and the new catalog test both hold.
- [x] Invariants preserved: case-insensitive search, derived `location_path`, optimistic
      `version` — all untouched.
- [x] `RETIRED_PATHS` untouched — `sensor.py` and `events.py` are new, nothing deleted or
      renamed.

## Follow-ups

- **Filed as an issue**: a `haventory.*` service mutation reaches no WebSocket subscriber and
  emits no `stats/counts`, so an open card does not repaint. This PR fixes the entity and bus
  half only; the WebSocket half is the same gap seen from the other side.
- The five promoted-only counts (`checked_out_count`, `missing_count`, `needs_repair_count`,
  `locations_total`, `no_location_count`) and the `status_counts` map stay card- and
  WebSocket-only. Promoting one later is additive — a descriptor and two translation entries.
  Not filed: it is a preference, not a defect.
