### PR TITLE
feat(todo): mirror low-stock items onto a chosen to-do list

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,36 @@ Services work the other way round: every `haventory.*` service returns the entit
 touched, so a script can chain calls through `response_variable` — see the same document's
 "Service responses".
 
+### Shopping list
+
+Pick a to-do list once, under Settings → Devices & services → HAventory → **Configure →
+Shopping list**, and low stock writes itself onto the list the household already shares.
+An item at or below its `low_stock_threshold` appears as `Peanut butter ×2` — the name, and
+how many it takes to reach the threshold, never less than one. Restock it and the line goes
+away.
+
+The field is empty by default, and empty means off; nothing is written to any list until
+one is chosen. Any `todo.*` entity works — Home Assistant's own **Local to-do** lists, or a
+shared Google Tasks or CalDAV list.
+
+The bridge does not track edges, it converges: every change runs one pass that compares
+what is low *right now* against the lines it has already written, and issues only the
+difference. A restart, a bulk edit, a wholesale import and a missed event therefore all end
+at the same list, with nothing listed twice.
+
+Three things follow from that, worth knowing before you pick a list:
+
+- **It only ever touches its own lines.** A list you already use for other things is safe;
+  everything the bridge did not write, it leaves alone.
+- **Delete one of its lines by hand and it stays deleted** while the item is still low —
+  the bridge takes that as "handled" rather than re-adding it. It comes back the next time
+  the item leaves the low-stock set and drops into it again.
+- **Clearing the field stops the mirroring and leaves the list as it stands.** Switching to
+  a different list moves the lines across instead.
+
+An inventory change never fails because the list did: a list that is unavailable, gone, or
+refuses the write is logged as a warning, and the next change tries again.
+
 ---
 
 ## Known limitations

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -50,6 +50,7 @@ except ImportError:  # pragma: no cover - minimal harness without panel_custom
 from . import events, stale_files
 from . import media as media_mod
 from . import services as services_mod
+from . import todo_bridge as todo_mod
 from . import ws as ws_mod
 from .const import (
     CONF_CARD_TITLE,
@@ -230,6 +231,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if callable(add_listener) and callable(on_unload):
         on_unload(add_listener(_async_options_updated))
 
+    # The shopping-list bridge, after the repository it reads and the update
+    # listener above: its first pass needs the low-stock set, and an options
+    # change has to reach it.
+    await todo_mod.async_setup(hass, entry)
+
     # Register services
     services_mod.setup(hass)
 
@@ -368,6 +374,10 @@ async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> Non
     # Covers the toggle and a renamed card alike: the sidebar entry carries the
     # card title, and re-registering is how a changed one reaches the sidebar.
     await _async_apply_sidebar_panel(hass, entry)
+    # A changed shopping list is applied by converging on it: the pass takes the
+    # lines off whichever list they were written to and puts them on the new one.
+    todo_mod.apply_options(hass, entry)
+    await todo_mod.async_reconcile(hass)
     LOGGER.info(
         "Applied updated HAventory options",
         extra={"domain": DOMAIN, "op": "options_updated"},

--- a/custom_components/haventory/config_flow.py
+++ b/custom_components/haventory/config_flow.py
@@ -8,6 +8,8 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -26,6 +28,7 @@ from .const import (
     CONF_RATE_LIMIT_GLOBAL_EVENTS_BURST,
     CONF_RATE_LIMIT_GLOBAL_EVENTS_PER_SECOND,
     CONF_SIDEBAR_PANEL_ENABLED,
+    CONF_TODO_ENTITY_ID,
     DEFAULT_CARD_TITLE,
     DEFAULT_QUICK_FILTERS,
     DEFAULT_RATE_LIMIT_COMMANDS_BURST,
@@ -38,17 +41,29 @@ from .const import (
     DEFAULT_RATE_LIMIT_GLOBAL_EVENTS_BURST,
     DEFAULT_RATE_LIMIT_GLOBAL_EVENTS_PER_SECOND,
     DEFAULT_SIDEBAR_PANEL_ENABLED,
+    DEFAULT_TODO_ENTITY_ID,
     DOMAIN,
     QUICK_FILTER_KEYS,
 )
 
+# The domain the shopping-list picker offers, taken from the module that calls
+# its services: a picker offering entities those calls cannot target would let a
+# household choose a list the bridge then refuses to write to.
+from .todo_bridge import TODO_DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 
-# Form-only key grouping the rate-limit fields into one collapsible block. It
-# is a presentation device: `_flatten_options` folds the block away again, so
-# the stored options — and everything reading them — stay flat.
+# Form-only keys grouping fields into collapsible blocks. Both are presentation
+# devices: `_flatten_options` folds the blocks away again, so the stored options
+# — and everything reading them — stay flat.
 SECTION_RATE_LIMIT = "rate_limit"
+SECTION_TODO = "todo"
+
+# Ordered as the form shows them, and the one list `_flatten_options` folds. A
+# section added to the schema and not to this tuple would be stored nested,
+# where nothing looks for it.
+OPTION_SECTIONS: tuple[str, ...] = (SECTION_TODO, SECTION_RATE_LIMIT)
 
 # Filled into the rate-limit section's `{docs_url}`. Translation strings may not
 # contain URLs (hassfest rejects them), so the link target is supplied as a
@@ -94,6 +109,37 @@ def clean_quick_filters(value: Any) -> list[str]:
         return list(DEFAULT_QUICK_FILTERS)
     chosen = {entry for entry in value if isinstance(entry, str)}
     return [key for key in QUICK_FILTER_KEYS if key in chosen]
+
+
+def clean_todo_entity_id(value: Any) -> str:
+    """Normalize the chosen shopping list to an entity id, or `""` for off.
+
+    A cleared entity selector submits no value at all rather than an empty one,
+    so "absent" and "off" have to arrive at the same answer here. The option is
+    stored as a string either way, and the bridge reads `""` as "not
+    configured" — there is no third state for it to distinguish.
+    """
+    if not isinstance(value, str):
+        return DEFAULT_TODO_ENTITY_ID
+    return value.strip()
+
+
+def _todo_schema(current: dict[str, Any]) -> vol.Schema:
+    """Build the shopping-list section's schema: one to-do entity, or nothing.
+
+    `suggested_value` rather than `default`: voluptuous re-inserts a default
+    when the key is absent, which is exactly what a cleared field submits, so a
+    default would make the list impossible to unpick once chosen.
+    """
+    chosen = clean_todo_entity_id(current.get(CONF_TODO_ENTITY_ID))
+    return vol.Schema(
+        {
+            vol.Optional(
+                CONF_TODO_ENTITY_ID,
+                description={"suggested_value": chosen or None},
+            ): EntitySelector(EntitySelectorConfig(domain=TODO_DOMAIN)),
+        }
+    )
 
 
 def _quick_filters_selector() -> SelectSelector:
@@ -182,6 +228,13 @@ def _options_schema(current: dict[str, Any]) -> vol.Schema:
                     current.get(CONF_QUICK_FILTERS, list(DEFAULT_QUICK_FILTERS))
                 ),
             ): _quick_filters_selector(),
+            # Collapsed until a list is chosen: the bridge is off by default,
+            # and a household that has not asked for a shopping list should not
+            # meet an entity picker on the way to renaming its card.
+            vol.Required(SECTION_TODO): section(
+                _todo_schema(current),
+                {"collapsed": not clean_todo_entity_id(current.get(CONF_TODO_ENTITY_ID))},
+            ),
             # Collapsed while the whole block is untouched, so the common case
             # is a form with one field; a customized limiter opens expanded
             # rather than hiding the values behind a header. No default on the
@@ -196,11 +249,12 @@ def _options_schema(current: dict[str, Any]) -> vol.Schema:
 
 
 def _flatten_options(user_input: dict[str, Any]) -> dict[str, Any]:
-    """Fold the rate-limit section back into the flat keys the limiter reads."""
-    flat = {key: value for key, value in user_input.items() if key != SECTION_RATE_LIMIT}
-    nested = user_input.get(SECTION_RATE_LIMIT)
-    if isinstance(nested, dict):
-        flat.update(nested)
+    """Fold the form's sections back into the flat keys the runtime reads."""
+    flat = {key: value for key, value in user_input.items() if key not in OPTION_SECTIONS}
+    for name in OPTION_SECTIONS:
+        nested = user_input.get(name)
+        if isinstance(nested, dict):
+            flat.update(nested)
     return flat
 
 
@@ -212,6 +266,9 @@ class HAventoryOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             options = _flatten_options(user_input)
             options[CONF_CARD_TITLE] = clean_card_title(options.get(CONF_CARD_TITLE))
+            # Unconditionally, unlike the pills below: a cleared selector sends
+            # nothing, and "nothing" is the answer that turns the bridge off.
+            options[CONF_TODO_ENTITY_ID] = clean_todo_entity_id(options.get(CONF_TODO_ENTITY_ID))
             # Only when the form carried the field: writing it unconditionally
             # would turn "never chose" into an explicit list on any submission
             # that skipped it, and the two are different answers downstream.

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -80,6 +80,24 @@ PANEL_ELEMENT_NAME: str = "haventory-panel"
 PANEL_ICON: str = "haventory:logo"
 
 # -----------------------------
+# Shopping list (config-entry option)
+# -----------------------------
+# Which Home Assistant to-do list the low-stock set is mirrored onto. Empty
+# means off, which is the default: a household that has not chosen a list gets
+# nothing written to any of them. One option rather than a list plus an enable
+# toggle — a toggle could only ever disagree with the entity it guards.
+
+CONF_TODO_ENTITY_ID: str = "todo_entity_id"
+DEFAULT_TODO_ENTITY_ID: str = ""
+
+# The bridge's link map gets a `Store` of its own rather than a section of the
+# inventory payload: it is bookkeeping about another integration's entity, and a
+# new key in the inventory payload would bump `CURRENT_SCHEMA_VERSION` and leak
+# into the `{schema_version, items, locations}` document import/export writes.
+TODO_LINKS_STORAGE_KEY: str = "haventory_todo_links"
+TODO_LINKS_STORAGE_VERSION: int = 1
+
+# -----------------------------
 # Item attachments
 # -----------------------------
 # Files attached to an item live under the config directory, outside the

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -34,6 +34,16 @@
           "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. Item total is the exception in a second way: only the card draws it as a pill, and only at full width — the sidebar page and the full view print the total in their header instead, whether or not it is ticked here. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
         },
         "sections": {
+          "todo": {
+            "name": "Shopping list",
+            "description": "Mirrors low-stock items onto a Home Assistant to-do list. An item at or below its low-stock threshold appears as a line naming it and how many to buy, and the line comes off again once the item is restocked. Leave the list empty to keep this off, which is the default. Clearing it later stops the mirroring and leaves whatever is on the list alone; picking a different list moves the lines across instead.",
+            "data": {
+              "todo_entity_id": "To-do list"
+            },
+            "data_description": {
+              "todo_entity_id": "Any to-do list this Home Assistant knows, including one the household already shares. HAventory only ever touches the lines it wrote itself, so a list you use for other things is safe to pick."
+            }
+          },
           "rate_limit": {
             "name": "WebSocket rate limiting",
             "description": "Caps how fast one client may use HAventory: over-budget commands are refused instead of executed, and surplus live-update events are dropped. Off by default — ordinary card use never comes close. Turn it on when something you don't fully control talks to HAventory, such as a wall panel stuck reconnecting or a script in a loop; leave it off during large imports and stress tests. What each setting means, and how to tell whether limiting is firing: {docs_url}",

--- a/custom_components/haventory/todo_bridge.py
+++ b/custom_components/haventory/todo_bridge.py
@@ -1,0 +1,405 @@
+"""Mirror the low-stock set onto a Home Assistant to-do list.
+
+The bridge converges instead of reacting. Every trigger runs one pass that
+compares what is low *right now* against the map of lines this integration put
+on the list, and issues only the difference. That is what makes a restart, a
+re-fired event, a dropped event and a wholesale import all land on the same
+list: nothing remembers "did I already add this" except the map, and the map is
+persisted beside the inventory rather than inside it.
+
+Identity on the list is the summary the bridge wrote. `todo.add_item` answers
+nothing — Home Assistant registers it with the default `SupportsResponse.NONE`
+— so there is no uid to record, and none is needed: `todo.remove_item` and
+`todo.update_item` both match their `item` field against a uid *or* a summary.
+
+Nothing here may fail a mutation. By the time a pass runs the inventory write
+has already happened, so a to-do list that refuses is a warning, never a
+rollback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.storage import Store
+
+from .const import (
+    CONF_TODO_ENTITY_ID,
+    DEFAULT_TODO_ENTITY_ID,
+    DOMAIN,
+    EVENT_ITEM_CHANGED,
+    EVENT_LOW_STOCK,
+    TODO_LINKS_STORAGE_KEY,
+    TODO_LINKS_STORAGE_VERSION,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+TODO_DOMAIN = "todo"
+SERVICE_ADD_ITEM = "add_item"
+SERVICE_REMOVE_ITEM = "remove_item"
+SERVICE_UPDATE_ITEM = "update_item"
+
+# The multiplication sign, U+00D7 — not the letter x a line like "Peanut butter
+# x2" would carry. It is what the card prints against a quantity, so the list
+# and the card read the same way.
+MULTIPLICATION_SIGN = "\u00d7"
+
+# `hass.data[DOMAIN]` keys, all entry-scoped — unload empties the bucket and the
+# next setup rebuilds them.
+_LINKS_KEY = "todo_links"
+_STORE_KEY = "todo_link_store"
+_LOCK_KEY = "todo_lock"
+_ENTITY_KEY = "todo_entity_id"
+
+
+def summary_for(name: str, quantity: int, threshold: int) -> str:
+    """The line the list carries: what to buy, and how many of it.
+
+    The count is the shortfall — how many it takes to reach the threshold —
+    floored at 1, because an item with a threshold of 0 is low at a quantity of
+    0, and a line asking the household to buy none of something is not one.
+    """
+
+    return f"{name} {MULTIPLICATION_SIGN}{max(threshold - quantity, 1)}"
+
+
+def configured_entity_id(entry: ConfigEntry) -> str:
+    """The list this entry mirrors onto, or `""` when the bridge is off."""
+
+    options = getattr(entry, "options", None) or {}
+    value = options.get(CONF_TODO_ENTITY_ID, DEFAULT_TODO_ENTITY_ID)
+    return value.strip() if isinstance(value, str) else DEFAULT_TODO_ENTITY_ID
+
+
+def apply_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Record which list the bridge writes to, from the entry's options."""
+
+    hass.data.setdefault(DOMAIN, {})[_ENTITY_KEY] = configured_entity_id(entry)
+
+
+async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Load the link map, subscribe to the mutation events, run a first pass."""
+
+    bucket = hass.data.setdefault(DOMAIN, {})
+    store: Store[dict[str, Any]] = Store(hass, TODO_LINKS_STORAGE_VERSION, TODO_LINKS_STORAGE_KEY)
+    bucket[_STORE_KEY] = store
+    bucket[_LOCK_KEY] = asyncio.Lock()
+    bucket[_LINKS_KEY] = await _async_load_links(store)
+    apply_options(hass, entry)
+
+    on_unload = getattr(entry, "async_on_unload", None)
+    bus = getattr(hass, "bus", None)
+    listen = getattr(bus, "async_listen", None)
+    if callable(listen) and callable(on_unload):
+        # The public automation surface rather than a hook in every mutation
+        # handler. Both events, because neither covers the other: a rename or a
+        # quantity edit that leaves an item low fires only `item_changed`, and
+        # the bulk path — which passes no item — fires only `low_stock`. A
+        # mutation firing both runs the pass twice, and the second finds the
+        # list already converged and calls nothing.
+        async def _on_inventory_event(_event: Any) -> None:
+            await async_reconcile(hass)
+
+        for event_type in (EVENT_ITEM_CHANGED, EVENT_LOW_STOCK):
+            on_unload(listen(event_type, _on_inventory_event))
+
+    listen_once = getattr(bus, "async_listen_once", None)
+    if getattr(hass, "is_running", True) or not (callable(listen_once) and callable(on_unload)):
+        await async_reconcile(hass)
+        return
+
+    # A list owned by another integration may not be in the state machine yet
+    # while Home Assistant is still starting, and the pass refuses to write to a
+    # list it cannot see. Waiting for the start event is what lets a restart
+    # converge on its own, without anything in the inventory having to change.
+    async def _on_started(_event: Any) -> None:
+        await async_reconcile(hass)
+
+    on_unload(listen_once(EVENT_HOMEASSISTANT_STARTED, _on_started))
+
+
+async def async_reconcile(hass: HomeAssistant) -> None:
+    """Bring the configured list in line with what is low right now.
+
+    Never raises. The mutation that triggered the pass is already on disk, and a
+    to-do list that refuses must not turn a saved change into a failed one.
+    """
+
+    bucket = hass.data.get(DOMAIN)
+    if not isinstance(bucket, dict):
+        return
+    lock = bucket.get(_LOCK_KEY)
+    if lock is None:
+        # No bridge in this bucket: the entry was torn down between the write
+        # and this call, or never set one up.
+        return
+
+    try:
+        async with lock:
+            await _async_reconcile_locked(hass, bucket)
+    except Exception:
+        LOGGER.exception(
+            "Failed to reconcile the to-do list",
+            extra={"domain": DOMAIN, "op": "todo_reconcile"},
+        )
+
+
+async def _async_reconcile_locked(hass: HomeAssistant, bucket: dict[str, Any]) -> None:
+    """One pass, with the bridge lock held so two triggers cannot interleave."""
+
+    repo = bucket.get("repository")
+    links: dict[str, dict[str, str]] | None = bucket.get(_LINKS_KEY)
+    if repo is None or links is None:
+        return
+
+    entity_id: str = bucket.get(_ENTITY_KEY) or ""
+    if not entity_id:
+        # Off. The map is kept rather than retracted: clearing the option means
+        # "stop managing the list", not "delete what is on it", and keeping it
+        # is what lets a household that switches the bridge back on carry on
+        # instead of listing everything a second time.
+        return
+
+    if not _list_is_available(hass, entity_id):
+        LOGGER.warning(
+            "The configured to-do list is unavailable; leaving it untouched",
+            extra={"domain": DOMAIN, "op": "todo_reconcile", "entity_id": entity_id},
+        )
+        return
+
+    desired = _desired_summaries(repo)
+    before = {item_id: dict(link) for item_id, link in links.items()}
+    try:
+        await _async_retract(hass, links, desired, entity_id)
+        await _async_restate(hass, links, desired, entity_id)
+        await _async_extend(hass, links, desired, entity_id)
+    finally:
+        # Compared against the snapshot rather than flagged along the way, in
+        # `finally`, so a pass that dies halfway still records the lines it did
+        # write — losing them would mean writing them all a second time.
+        if links != before:
+            await _async_save_links(bucket)
+
+
+async def _async_retract(
+    hass: HomeAssistant,
+    links: dict[str, dict[str, str]],
+    desired: dict[str, str],
+    entity_id: str,
+) -> None:
+    """Take back every line whose item is no longer low, or is on another list.
+
+    First of the three phases: one item leaving the low-stock set while another
+    enters it can produce the same line, and removing after adding would take
+    the new one straight back off. A link naming a different list belongs to a
+    household that changed the option, and comes off the list it was written to
+    before `_async_extend` writes it to the new one.
+    """
+
+    for item_id, link in list(links.items()):
+        if item_id in desired and link["entity_id"] == entity_id:
+            continue
+        await _async_remove_line(hass, link)
+        del links[item_id]
+
+
+async def _async_restate(
+    hass: HomeAssistant,
+    links: dict[str, dict[str, str]],
+    desired: dict[str, str],
+    entity_id: str,
+) -> None:
+    """Rewrite a line whose count or item name has moved on.
+
+    The shortfall is what the line is for, so a stale one is wrong rather than
+    merely old.
+    """
+
+    for item_id, summary in desired.items():
+        link = links.get(item_id)
+        if link is None or link["summary"] == summary:
+            continue
+        if await _async_rename_line(hass, entity_id, link["summary"], summary):
+            link["summary"] = summary
+
+
+async def _async_extend(
+    hass: HomeAssistant,
+    links: dict[str, dict[str, str]],
+    desired: dict[str, str],
+    entity_id: str,
+) -> None:
+    """Put a line on the list for every low item that has none."""
+
+    for item_id, summary in desired.items():
+        if item_id in links:
+            continue
+        if await _async_add_line(hass, entity_id, summary):
+            links[item_id] = {"entity_id": entity_id, "summary": summary}
+
+
+def _desired_summaries(repo: Any) -> dict[str, str]:
+    """What the list should carry right now, keyed by item id.
+
+    Read off the low-stock index rather than through `list_items`, which
+    paginates — a page limit would silently cap the shopping list.
+    """
+
+    desired: dict[str, str] = {}
+    for item_id in repo.low_stock_item_ids:
+        item = repo.get_item(item_id)
+        threshold = item.low_stock_threshold
+        if threshold is None:
+            continue
+        desired[item_id] = summary_for(item.name, item.quantity, threshold)
+    return desired
+
+
+def _list_is_available(hass: HomeAssistant, entity_id: str) -> bool:
+    """Whether the configured list is in the state machine and answering.
+
+    Home Assistant does not raise when an entity service names an entity that is
+    missing or unavailable — it logs and drops the call — so a pass without this
+    check would record a link for a line that was never written.
+    """
+
+    state = hass.states.get(entity_id)
+    return state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+
+
+async def _async_add_line(hass: HomeAssistant, entity_id: str, summary: str) -> bool:
+    """Put one line on the list. False leaves it unlinked, so the next pass retries."""
+
+    try:
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            SERVICE_ADD_ITEM,
+            {"entity_id": entity_id, "item": summary},
+            blocking=True,
+        )
+    except HomeAssistantError:
+        LOGGER.warning(
+            "Could not add a line to the to-do list; the next change retries it",
+            extra={
+                "domain": DOMAIN,
+                "op": "todo_add",
+                "entity_id": entity_id,
+                "summary": summary,
+            },
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+async def _async_remove_line(hass: HomeAssistant, link: dict[str, str]) -> None:
+    """Take one line back off the list, and give up the link either way.
+
+    Everything Home Assistant refuses here is permanent — the line was deleted
+    by hand, the list cannot delete, the list is gone — and a link held for a
+    line that cannot be retracted would stop that item from ever being listed
+    again.
+    """
+
+    try:
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            SERVICE_REMOVE_ITEM,
+            {"entity_id": link["entity_id"], "item": link["summary"]},
+            blocking=True,
+        )
+    except HomeAssistantError:
+        LOGGER.warning(
+            "Could not remove a line from the to-do list; dropping the link and "
+            "leaving the line to be cleared by hand",
+            extra={
+                "domain": DOMAIN,
+                "op": "todo_remove",
+                "entity_id": link["entity_id"],
+                "summary": link["summary"],
+            },
+            exc_info=True,
+        )
+
+
+async def _async_rename_line(
+    hass: HomeAssistant, entity_id: str, previous: str, summary: str
+) -> bool:
+    """Restate a line in place. False keeps the link on the text already there."""
+
+    try:
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            SERVICE_UPDATE_ITEM,
+            {"entity_id": entity_id, "item": previous, "rename": summary},
+            blocking=True,
+        )
+    except HomeAssistantError:
+        LOGGER.warning(
+            "Could not restate a line on the to-do list; it keeps the count it was written with",
+            extra={
+                "domain": DOMAIN,
+                "op": "todo_rename",
+                "entity_id": entity_id,
+                "summary": summary,
+            },
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+async def _async_load_links(store: Store[dict[str, Any]]) -> dict[str, dict[str, str]]:
+    """Read the persisted map, keeping only the rows a pass can act on.
+
+    A row missing either half cannot be retracted, and holding it would keep its
+    item off the list for good; dropping it costs at most one duplicate line.
+    """
+
+    try:
+        payload = await store.async_load()
+    except Exception:
+        LOGGER.warning(
+            "Could not read the to-do link map; starting from an empty one",
+            extra={"domain": DOMAIN, "op": "todo_links_load"},
+            exc_info=True,
+        )
+        return {}
+
+    links: dict[str, dict[str, str]] = {}
+    raw = payload.get("links") if isinstance(payload, dict) else None
+    if not isinstance(raw, dict):
+        return links
+    for item_id, link in raw.items():
+        if not isinstance(item_id, str) or not isinstance(link, dict):
+            continue
+        entity_id = link.get("entity_id")
+        summary = link.get("summary")
+        if isinstance(entity_id, str) and entity_id and isinstance(summary, str) and summary:
+            links[item_id] = {"entity_id": entity_id, "summary": summary}
+    return links
+
+
+async def _async_save_links(bucket: dict[str, Any]) -> None:
+    """Write the map out. A failed write costs duplicates, never the inventory."""
+
+    store = bucket.get(_STORE_KEY)
+    links = bucket.get(_LINKS_KEY)
+    if store is None or links is None:
+        return
+
+    try:
+        await store.async_save({"links": links})
+    except Exception:
+        LOGGER.warning(
+            "Could not save the to-do link map; lines already on the list may be written again",
+            extra={"domain": DOMAIN, "op": "todo_links_save"},
+            exc_info=True,
+        )

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -34,6 +34,16 @@
           "quick_filters": "The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. Item total is the exception in a second way: only the card draws it as a pill, and only at full width — the sidebar page and the full view print the total in their header instead, whether or not it is ticked here. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change."
         },
         "sections": {
+          "todo": {
+            "name": "Shopping list",
+            "description": "Mirrors low-stock items onto a Home Assistant to-do list. An item at or below its low-stock threshold appears as a line naming it and how many to buy, and the line comes off again once the item is restocked. Leave the list empty to keep this off, which is the default. Clearing it later stops the mirroring and leaves whatever is on the list alone; picking a different list moves the lines across instead.",
+            "data": {
+              "todo_entity_id": "To-do list"
+            },
+            "data_description": {
+              "todo_entity_id": "Any to-do list this Home Assistant knows, including one the household already shares. HAventory only ever touches the lines it wrote itself, so a list you use for other things is safe to pick."
+            }
+          },
           "rate_limit": {
             "name": "WebSocket rate limiting",
             "description": "Caps how fast one client may use HAventory: over-budget commands are refused instead of executed, and surplus live-update events are dropped. Off by default — ordinary card use never comes close. Turn it on when something you don't fully control talks to HAventory, such as a wall panel stuck reconnecting or a script in a loop; leave it off during large imports and stress tests. What each setting means, and how to tell whether limiting is firing: {docs_url}",

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -22,7 +22,7 @@ try:
 except ImportError:  # pragma: no cover - offline harness without the component
     process_uploaded_file = None
 
-from . import import_export
+from . import import_export, todo_bridge
 from . import media as media_mod
 from . import storage as storage_mod
 from .areas import async_get_area_registry
@@ -2451,6 +2451,10 @@ async def ws_import_execute(
     # wants one signal, not one per row. The low-stock diff still runs, so a
     # restock done by import announces itself, and the sensors still repaint.
     notify_mutation(hass, action="reloaded")
+    # And the shopping list explicitly, because that diff is the only bus signal
+    # a wholesale swap produces: a document that renames items or changes their
+    # quantities without moving the low-stock set fires nothing at all.
+    await todo_bridge.async_reconcile(hass)
 
     summary = {
         "applied": True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,11 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
     # homeassistant.const
     ha_const = types.ModuleType("homeassistant.const")
     ha_const.Platform = types.SimpleNamespace(SENSOR="sensor", CALENDAR="calendar")
+    # Verbatim from HA: the to-do bridge compares an entity's state against these
+    # two, and defers its first pass until Home Assistant says it has started.
+    ha_const.EVENT_HOMEASSISTANT_STARTED = "homeassistant_started"
+    ha_const.STATE_UNAVAILABLE = "unavailable"
+    ha_const.STATE_UNKNOWN = "unknown"
     sys.modules["homeassistant.const"] = ha_const
 
     # homeassistant.core
@@ -112,15 +117,17 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             return os.path.join(self.config_dir, *parts)
 
     class _Bus:  # type: ignore[override]
-        """Stand in for HA's event bus, recording what was fired.
+        """Stand in for HA's event bus, recording what was fired and who listens.
 
-        Real HA dispatches to listeners; offline there are none, so the record
-        *is* the observable behaviour — without it `events.py` cannot be tested
-        here at all.
+        Real HA dispatches a fired event to its listeners; here the two records
+        stay separate and a test drives a listener itself. That keeps `async_fire`
+        synchronous — HA's is too — without the stub having to schedule the
+        coroutine listeners the real bus runs as tasks.
         """
 
         def __init__(self) -> None:
             self.fired: list[tuple[str, dict]] = []
+            self.listeners: list[tuple[str, object]] = []
 
         def async_fire(self, event_type, event_data=None, *_args, **_kwargs) -> None:
             self.fired.append((event_type, dict(event_data or {})))
@@ -128,11 +135,62 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def events_of(self, event_type: str) -> list[dict]:
             return [data for kind, data in self.fired if kind == event_type]
 
+        def async_listen(self, event_type, listener, *_args, **_kwargs):
+            entry = (event_type, listener)
+            self.listeners.append(entry)
+
+            def _remove() -> None:
+                if entry in self.listeners:
+                    self.listeners.remove(entry)
+
+            return _remove
+
+        # HA's one-shot listener removes itself once fired; nothing offline
+        # fires through the bus, so recording it is the whole behaviour.
+        async_listen_once = async_listen
+
+        def listeners_for(self, event_type: str) -> list[object]:
+            return [listener for kind, listener in self.listeners if kind == event_type]
+
+    class _State:  # type: ignore[override]
+        """The two fields anything offline reads off a state object."""
+
+        def __init__(self, entity_id: str, state: str) -> None:
+            self.entity_id = entity_id
+            self.state = state
+
+    class _States:  # type: ignore[override]
+        """Stand in for HA's state machine, for the reads only.
+
+        The to-do bridge asks whether the list it was pointed at is there and
+        answering before it writes to it, so a test has to be able to say that
+        it is not. Nothing offline sets state through this — the integration
+        publishes state through entity platforms, which the offline suite does
+        not run.
+        """
+
+        def __init__(self) -> None:
+            self._states: dict[str, _State] = {}
+
+        def get(self, entity_id: str):
+            return self._states.get(entity_id)
+
+        def async_set(self, entity_id: str, state: str, *_args, **_kwargs) -> None:
+            self._states[entity_id] = _State(entity_id, state)
+
+        def async_remove(self, entity_id: str) -> None:
+            self._states.pop(entity_id, None)
+
     class HomeAssistant:  # type: ignore[override]
         def __init__(self) -> None:
             self.data = {}
             self.config = _Config()
             self.bus = _Bus()
+            self.states = _States()
+            # HA's own "startup is over" flag. Offline there is no startup, so
+            # it starts true — which is what every test but the ones about
+            # deferring the bridge's first pass wants.
+            self.is_running = True
             self.dispatcher_sends: list[tuple[str, tuple]] = []
             self.dispatcher_connects: list[tuple[str, object]] = []
 
@@ -340,6 +398,31 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
                     raise vol.Invalid(f"{entry!r} is not one of {offered}")
             return list(values) if self.config.get("multiple") else value
 
+    # A TypedDict in HA, like SelectSelectorConfig above.
+    def EntitySelectorConfig(**kwargs):  # type: ignore[override]
+        return dict(kwargs)
+
+    class EntitySelector:  # type: ignore[override]
+        """Stand in for HA's entity picker, validating the domain it restricts to.
+
+        Enough to hold the shopping-list field to `todo.*` entities: HA's own
+        selector checks the entity id's shape and its domain, and the option is
+        stored as whatever string comes back.
+        """
+
+        def __init__(self, config=None) -> None:  # type: ignore[no-untyped-def]
+            self.config = dict(config or {})
+
+        def __call__(self, value):  # type: ignore[no-untyped-def]
+            if not isinstance(value, str) or value.count(".") != 1:
+                raise vol.Invalid(f"{value!r} is not an entity id")
+            domain = self.config.get("domain")
+            if domain and value.split(".")[0] != domain:
+                raise vol.Invalid(f"{value!r} is not in the {domain} domain")
+            return value
+
+    ha_helpers_selector.EntitySelector = EntitySelector
+    ha_helpers_selector.EntitySelectorConfig = EntitySelectorConfig
     ha_helpers_selector.SelectSelector = SelectSelector
     ha_helpers_selector.SelectSelectorConfig = SelectSelectorConfig
     ha_helpers_selector.SelectSelectorMode = SelectSelectorMode
@@ -361,6 +444,14 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
         async def async_save(self, data):
             _IN_MEMORY_STORE[self.key] = data
+
+        async def async_remove(self):
+            """Delete the stored payload, as HA's `Store.async_remove` does.
+
+            The backing dict is module-global and outlives a test, so a suite
+            whose subject *loads* at setup needs a way to start from nothing.
+            """
+            _IN_MEMORY_STORE.pop(self.key, None)
 
     ha_helpers_storage.Store = Store
     sys.modules["homeassistant.helpers.storage"] = ha_helpers_storage

--- a/tests/integration/test_config_entry.py
+++ b/tests/integration/test_config_entry.py
@@ -270,6 +270,7 @@ async def test_the_options_flow_stores_a_pill_choice_the_card_then_reads(
             CONF_CARD_TITLE: "HAventory",
             CONF_SIDEBAR_PANEL_ENABLED: True,
             CONF_QUICK_FILTERS: ["overdue", "low_stock"],
+            "todo": {},
             "rate_limit": {},
         },
     )
@@ -297,6 +298,7 @@ async def test_the_options_flow_refuses_a_pill_it_does_not_offer(hass: HomeAssis
                 CONF_CARD_TITLE: "HAventory",
                 CONF_SIDEBAR_PANEL_ENABLED: True,
                 CONF_QUICK_FILTERS: ["sideways"],
+                "todo": {},
                 "rate_limit": {},
             },
         )

--- a/tests/integration/test_todo_bridge.py
+++ b/tests/integration/test_todo_bridge.py
@@ -1,0 +1,282 @@
+"""Integration: the low-stock bridge against a real to-do list.
+
+The offline suite records the `todo.*` calls a pass decides to make; it cannot
+show that Home Assistant dispatches them. Everything between the decision and
+the line appearing lives here: entity-service targeting by `entity_id`, the
+feature gate on `add_item` / `remove_item`, the summary matching that lets a
+line be found without a uid, and the bus listener that turns a `haventory.*`
+service call into a pass.
+
+The list is a to-do entity of this suite's own rather than `local_todo`, whose
+`ical` requirement a phacc run does not install. What it models is the contract
+`TodoListEntity` states: create, update and delete of items with uids the
+entity itself assigns.
+"""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.haventory import todo_bridge
+from custom_components.haventory.const import CONF_TODO_ENTITY_ID, DOMAIN
+from homeassistant.components.todo import (
+    TodoItem,
+    TodoItemStatus,
+    TodoListEntity,
+    TodoListEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+LIST_DOMAIN = "haventory_test_list"
+LIST_ENTITY_ID = "todo.shopping"
+THRESHOLD = 3
+LOW_QUANTITY = 1
+
+TIMES = todo_bridge.MULTIPLICATION_SIGN
+
+
+class _TestTodoList(TodoListEntity):
+    """A to-do list that keeps its items in memory and assigns its own uids."""
+
+    _attr_name = "Shopping"
+    _attr_has_entity_name = False
+    _attr_supported_features = (
+        TodoListEntityFeature.CREATE_TODO_ITEM
+        | TodoListEntityFeature.UPDATE_TODO_ITEM
+        | TodoListEntityFeature.DELETE_TODO_ITEM
+    )
+
+    def __init__(self) -> None:
+        self._attr_todo_items: list[TodoItem] = []
+        self._issued = 0
+
+    @property
+    def summaries(self) -> list[str]:
+        return [item.summary for item in self._attr_todo_items or ()]
+
+    async def async_create_todo_item(self, item: TodoItem) -> None:
+        self._issued += 1
+        item.uid = str(self._issued)
+        self._attr_todo_items = [*(self._attr_todo_items or []), item]
+        self.async_write_ha_state()
+
+    async def async_update_todo_item(self, item: TodoItem) -> None:
+        self._attr_todo_items = [
+            item if existing.uid == item.uid else existing
+            for existing in self._attr_todo_items or ()
+        ]
+        self.async_write_ha_state()
+
+    async def async_delete_todo_items(self, uids: list[str]) -> None:
+        self._attr_todo_items = [
+            existing for existing in self._attr_todo_items or () if existing.uid not in uids
+        ]
+        self.async_write_ha_state()
+
+
+class _ListFlow(ConfigFlow):
+    """The list integration's config flow, so its entry can be set up and unloaded."""
+
+
+@pytest.fixture
+async def todo_list(hass: HomeAssistant) -> _TestTodoList:
+    """A real `todo.*` entity on the state machine, backed by the class above."""
+
+    entity = _TestTodoList()
+
+    async def _setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        await hass.config_entries.async_forward_entry_setups(entry, [Platform.TODO])
+        return True
+
+    async def _setup_platform(
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        async_add_entities([entity])
+
+    mock_integration(hass, MockModule(LIST_DOMAIN, async_setup_entry=_setup_entry))
+    mock_platform(
+        hass,
+        f"{LIST_DOMAIN}.{Platform.TODO}",
+        MockPlatform(async_setup_entry=_setup_platform),
+    )
+    # Home Assistant imports an entry's `config_flow` platform before setting it
+    # up, and refuses the entry when there is none to import — registering an
+    # empty one is what lets `mock_config_flow` below supply the handler.
+    mock_platform(hass, f"{LIST_DOMAIN}.config_flow", None)
+
+    with mock_config_flow(LIST_DOMAIN, _ListFlow):
+        entry = MockConfigEntry(domain=LIST_DOMAIN)
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(LIST_ENTITY_ID) is not None
+    return entity
+
+
+async def _setup_haventory(hass: HomeAssistant, *, entity_id: str) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={CONF_TODO_ENTITY_ID: entity_id},
+        title="HAventory",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def _create_low_item(hass: HomeAssistant, *, name: str = "Peanut butter") -> str:
+    """Create an item already below its threshold, through the real service."""
+
+    await hass.services.async_call(
+        DOMAIN,
+        "item_create",
+        {"name": name, "quantity": LOW_QUANTITY, "low_stock_threshold": THRESHOLD},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    items = hass.data[DOMAIN]["repository"]._debug_get_internal_indexes()["items_by_id"]
+    return next(item_id for item_id, item in items.items() if item.name == name)
+
+
+async def test_a_service_mutation_puts_a_line_on_the_list(
+    hass: HomeAssistant, todo_list: _TestTodoList
+) -> None:
+    """The whole chain: a service call, the bus event, the pass, `todo.add_item`.
+
+    Nothing offline can assert this — the stub has no service registry, so it
+    never sees Home Assistant classify and dispatch either handler.
+    """
+
+    await _setup_haventory(hass, entity_id=LIST_ENTITY_ID)
+    assert todo_list.summaries == []
+
+    item_id = await _create_low_item(hass)
+
+    assert todo_list.summaries == [f"Peanut butter {TIMES}2"]
+    assert todo_list._attr_todo_items[0].status == TodoItemStatus.NEEDS_ACTION
+
+    # And restocking takes the line off again, matched by its summary alone —
+    # the bridge records no uid, because `todo.add_item` returns none.
+    await hass.services.async_call(
+        DOMAIN,
+        "item_set_quantity",
+        {"item_id": item_id, "quantity": THRESHOLD + 1},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert todo_list.summaries == []
+
+
+async def test_a_second_mutation_does_not_duplicate_the_line(
+    hass: HomeAssistant, todo_list: _TestTodoList
+) -> None:
+    """Convergence over a real list: the pass runs again and writes nothing new."""
+
+    await _setup_haventory(hass, entity_id=LIST_ENTITY_ID)
+    await _create_low_item(hass)
+    await _create_low_item(hass, name="Rope")
+
+    assert sorted(todo_list.summaries) == [f"Peanut butter {TIMES}2", f"Rope {TIMES}2"]
+
+
+async def test_a_deeper_shortfall_restates_the_existing_line(
+    hass: HomeAssistant, todo_list: _TestTodoList
+) -> None:
+    """`todo.update_item` finds the line by its old summary and renames it."""
+
+    await _setup_haventory(hass, entity_id=LIST_ENTITY_ID)
+    item_id = await _create_low_item(hass)
+    assert todo_list.summaries == [f"Peanut butter {TIMES}2"]
+    uid = todo_list._attr_todo_items[0].uid
+
+    await hass.services.async_call(
+        DOMAIN, "item_set_quantity", {"item_id": item_id, "quantity": 0}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert todo_list.summaries == [f"Peanut butter {TIMES}3"]
+    # Restated in place rather than replaced, so anything the household added to
+    # the line — a note, a position in the list — survives.
+    assert todo_list._attr_todo_items[0].uid == uid
+
+
+async def test_an_unconfigured_list_leaves_every_list_alone(
+    hass: HomeAssistant, todo_list: _TestTodoList
+) -> None:
+    """Off is the default, and off has to mean no `todo.*` call is dispatched."""
+
+    await _setup_haventory(hass, entity_id="")
+    await _create_low_item(hass)
+
+    assert todo_list.summaries == []
+
+
+async def test_a_list_that_is_not_there_does_not_fail_the_mutation(
+    hass: HomeAssistant, todo_list: _TestTodoList
+) -> None:
+    """An inventory write must never fail because a to-do list did.
+
+    Home Assistant answers a service call naming a missing entity with a log
+    line rather than an error, so the bridge checks the state machine itself —
+    and either way the item is created and stays created.
+    """
+
+    await _setup_haventory(hass, entity_id="todo.does_not_exist")
+    item_id = await _create_low_item(hass)
+
+    assert hass.data[DOMAIN]["repository"].get_item(item_id).quantity == LOW_QUANTITY
+    assert todo_list.summaries == []
+    assert hass.data[DOMAIN][todo_bridge._LINKS_KEY] == {}
+
+
+async def test_unloading_the_entry_stops_the_bridge_listening(
+    hass: HomeAssistant, todo_list: _TestTodoList
+) -> None:
+    """The listeners are released with the entry, not left on the bus.
+
+    Left behind, they would run a pass against an emptied bucket on every
+    mutation for the rest of the Home Assistant run.
+    """
+
+    entry = await _setup_haventory(hass, entity_id=LIST_ENTITY_ID)
+    await _create_low_item(hass)
+    assert todo_list.summaries == [f"Peanut butter {TIMES}2"]
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert todo_bridge._LINKS_KEY not in hass.data[DOMAIN]
+    # The list keeps what it had: an unloaded entry gives up its own runtime,
+    # not the household's shopping list.
+    assert todo_list.summaries == [f"Peanut butter {TIMES}2"]
+
+
+async def test_the_options_flow_offers_the_shopping_list_field(hass: HomeAssistant) -> None:
+    """The entity selector has to build under the real `selector` helper.
+
+    Offline it is a stub, so a config that Home Assistant's own selector refuses
+    would only surface here — or on the user's screen.
+    """
+
+    entry = await _setup_haventory(hass, entity_id="")
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    assert "todo" in result["data_schema"].schema

--- a/tests/test_config_flow_offline.py
+++ b/tests/test_config_flow_offline.py
@@ -17,6 +17,8 @@ import pytest
 import voluptuous as vol
 from custom_components.haventory.config_flow import (
     RATE_LIMIT_DOCS_URL,
+    SECTION_RATE_LIMIT,
+    SECTION_TODO,
     HAventoryConfigFlow,
     HAventoryOptionsFlowHandler,
 )
@@ -24,8 +26,10 @@ from custom_components.haventory.const import (
     CONF_CARD_TITLE,
     CONF_QUICK_FILTERS,
     CONF_SIDEBAR_PANEL_ENABLED,
+    CONF_TODO_ENTITY_ID,
     DEFAULT_CARD_TITLE,
     DEFAULT_SIDEBAR_PANEL_ENABLED,
+    DEFAULT_TODO_ENTITY_ID,
     QUICK_FILTER_KEYS,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -37,6 +41,14 @@ def _entry(options: dict) -> ConfigEntry:
 
 def _schema_keys(schema) -> set[str]:
     return {str(marker) for marker in schema.schema}
+
+
+def _section_schema(schema, name: str):
+    """The inner schema of one form section, by the form-only key holding it."""
+    for marker, value in schema.schema.items():
+        if str(marker) == name:
+            return value.schema
+    raise AssertionError(f"no section {name} in schema")
 
 
 def _schema_default(schema, key: str):
@@ -215,6 +227,82 @@ async def test_sidebar_toggle_sits_outside_the_rate_limit_section() -> None:
 
 
 @pytest.mark.asyncio
+async def test_the_shopping_list_section_folds_flat_and_defaults_to_off() -> None:
+    """The bridge reads one flat `todo_entity_id`; the section is form dressing.
+
+    Stored nested, the option would be invisible to everything that looks for
+    it — the bridge, and the runtime that hands it the list to write to.
+    """
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({})
+
+    form = await flow.async_step_init(user_input=None)
+    assert SECTION_TODO in _schema_keys(form["data_schema"])
+
+    result = await flow.async_step_init(
+        user_input={
+            CONF_CARD_TITLE: "Pantry",
+            SECTION_TODO: {CONF_TODO_ENTITY_ID: "todo.shopping_list"},
+        }
+    )
+    assert result["data"][CONF_TODO_ENTITY_ID] == "todo.shopping_list"
+    assert SECTION_TODO not in result["data"]
+
+
+@pytest.mark.asyncio
+async def test_a_cleared_shopping_list_stores_the_empty_string() -> None:
+    """A cleared entity selector submits nothing, and nothing has to mean off.
+
+    Left absent, the stored options would keep the previous list and the bridge
+    would go on writing to it — the field could never be unpicked.
+    """
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({CONF_TODO_ENTITY_ID: "todo.shopping_list"})
+
+    result = await flow.async_step_init(user_input={CONF_CARD_TITLE: "Pantry", SECTION_TODO: {}})
+    assert result["data"][CONF_TODO_ENTITY_ID] == DEFAULT_TODO_ENTITY_ID
+
+
+@pytest.mark.asyncio
+async def test_the_shopping_list_field_is_prefilled_with_the_stored_list() -> None:
+    """Opening the form must not read as "no list chosen" to a household that has."""
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({CONF_TODO_ENTITY_ID: "todo.shopping_list"})
+
+    form = await flow.async_step_init(user_input=None)
+    section_schema = _section_schema(form["data_schema"], SECTION_TODO)
+    for marker in section_schema.schema:
+        if str(marker) == CONF_TODO_ENTITY_ID:
+            assert marker.description == {"suggested_value": "todo.shopping_list"}
+            break
+    else:  # pragma: no cover - the field is asserted to exist above
+        raise AssertionError(f"no field {CONF_TODO_ENTITY_ID} in the {SECTION_TODO} section")
+
+
+@pytest.mark.asyncio
+async def test_the_options_form_refuses_a_list_outside_the_todo_domain() -> None:
+    """The bridge calls `todo.*` services; anything else it cannot write to."""
+
+    flow = HAventoryOptionsFlowHandler()
+    flow.config_entry = _entry({})
+
+    form = await flow.async_step_init(user_input=None)
+    with pytest.raises(vol.Invalid):
+        form["data_schema"](
+            {
+                CONF_CARD_TITLE: "Pantry",
+                CONF_SIDEBAR_PANEL_ENABLED: True,
+                CONF_QUICK_FILTERS: list(QUICK_FILTER_KEYS),
+                SECTION_TODO: {CONF_TODO_ENTITY_ID: "sensor.not_a_list"},
+                SECTION_RATE_LIMIT: {},
+            }
+        )
+
+
+@pytest.mark.asyncio
 async def test_quick_filters_prefill_every_pill_for_an_entry_that_predates_them() -> None:
     """An untouched entry opens the form with all five ticked.
 
@@ -296,7 +384,8 @@ async def test_the_options_form_refuses_a_pill_that_is_not_offered() -> None:
                 CONF_CARD_TITLE: "Pantry",
                 CONF_SIDEBAR_PANEL_ENABLED: True,
                 CONF_QUICK_FILTERS: ["sideways"],
-                "rate_limit": {},
+                SECTION_TODO: {},
+                SECTION_RATE_LIMIT: {},
             }
         )
 

--- a/tests/test_todo_bridge_offline.py
+++ b/tests/test_todo_bridge_offline.py
@@ -1,0 +1,392 @@
+"""Offline tests for the low-stock → to-do list bridge.
+
+Scenarios:
+- an item dropping to its threshold puts one line on the list; restocking takes
+  it off, and neither issues a call the other's pass already made
+- a second pass over unchanged data, and the first pass after a restart, are
+  both silent — the convergence property the whole design rests on
+- a refused add leaves the item unlinked so the next pass retries it; a refused
+  removal gives up the link instead, because nothing about it will improve
+- an unconfigured list issues no call at all, and changing the list moves the
+  lines across
+- a list that is missing or unavailable is left alone until it answers again
+- the shortfall floors at one, so a threshold of zero never asks for none
+
+The bridge's service calls are recorded rather than dispatched: the offline
+`HomeAssistant` stub has no service registry, and what these tests assert is
+which `todo.*` calls a pass decides to make.
+"""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.haventory import todo_bridge
+from custom_components.haventory.const import (
+    CONF_TODO_ENTITY_ID,
+    DOMAIN,
+    EVENT_ITEM_CHANGED,
+    EVENT_LOW_STOCK,
+    TODO_LINKS_STORAGE_KEY,
+    TODO_LINKS_STORAGE_VERSION,
+)
+from custom_components.haventory.repository import Repository
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.storage import Store
+
+TODO_ENTITY = "todo.shopping_list"
+OTHER_ENTITY = "todo.household"
+THRESHOLD = 3
+
+TIMES = todo_bridge.MULTIPLICATION_SIGN
+
+ADD = f"{todo_bridge.TODO_DOMAIN}.{todo_bridge.SERVICE_ADD_ITEM}"
+REMOVE = f"{todo_bridge.TODO_DOMAIN}.{todo_bridge.SERVICE_REMOVE_ITEM}"
+UPDATE = f"{todo_bridge.TODO_DOMAIN}.{todo_bridge.SERVICE_UPDATE_ITEM}"
+
+
+class _Services:
+    """Record the `todo.*` calls a pass makes, and refuse the named ones."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.refuse: set[str] = set()
+
+    async def async_call(self, domain, service, data=None, blocking=False, **_kwargs):
+        self.calls.append((f"{domain}.{service}", dict(data or {})))
+        if service in self.refuse:
+            raise HomeAssistantError(f"{service} refused")
+
+    @property
+    def names(self) -> list[str]:
+        return [name for name, _data in self.calls]
+
+    @property
+    def summaries(self) -> list[str]:
+        return [data.get("item") for _name, data in self.calls]
+
+    def clear(self) -> None:
+        self.calls.clear()
+
+
+async def _forget_links(hass: HomeAssistant) -> None:
+    """Empty the bridge's own store, which outlives a test in the offline stub."""
+
+    await Store(hass, TODO_LINKS_STORAGE_VERSION, TODO_LINKS_STORAGE_KEY).async_remove()
+
+
+async def _bridge(
+    *,
+    entity_id: str = TODO_ENTITY,
+    available: bool = True,
+    is_running: bool = True,
+    keep_links: bool = False,
+    repo: Repository | None = None,
+) -> tuple[HomeAssistant, Repository, _Services, ConfigEntry]:
+    """A hass with a loaded repository and the bridge set up against it.
+
+    The repository goes into the bucket before setup, as `async_setup_entry`
+    puts it there — the bridge's first pass reads it, so a test that seeds it
+    afterwards is not testing the same sequence Home Assistant runs.
+    """
+
+    hass = HomeAssistant()
+    hass.is_running = is_running
+    services = _Services()
+    hass.services = services  # type: ignore[attr-defined]
+    repository = repo if repo is not None else Repository()
+    hass.data[DOMAIN] = {"repository": repository}
+    if available:
+        hass.states.async_set(entity_id, "0")
+    if not keep_links:
+        await _forget_links(hass)
+
+    entry = ConfigEntry(options={CONF_TODO_ENTITY_ID: entity_id})
+    await todo_bridge.async_setup(hass, entry)
+    return hass, repository, services, entry
+
+
+def _low_item(repo: Repository, name: str = "Peanut butter", quantity: int = 1):
+    return repo.create_item(  # type: ignore[arg-type]
+        {"name": name, "quantity": quantity, "low_stock_threshold": THRESHOLD}
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_low_item_gets_one_line_and_a_restock_takes_it_off() -> None:
+    """The pair of calls the whole feature exists for, and nothing besides."""
+
+    hass, repo, services, _entry = await _bridge()
+    item = _low_item(repo, quantity=1)
+
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [ADD]
+    assert services.summaries == [f"Peanut butter {TIMES}2"]
+    assert services.calls[0][1]["entity_id"] == TODO_ENTITY
+
+    services.clear()
+    repo.set_quantity(str(item.id), THRESHOLD + 1)
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [REMOVE]
+    assert services.summaries == [f"Peanut butter {TIMES}2"]
+
+
+@pytest.mark.asyncio
+async def test_a_second_pass_over_unchanged_data_calls_nothing() -> None:
+    """Convergence, not edge detection: a re-fired event must cost no writes."""
+
+    hass, repo, services, _entry = await _bridge()
+    _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+    services.clear()
+
+    await todo_bridge.async_reconcile(hass)
+    await todo_bridge.async_reconcile(hass)
+    assert services.calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_first_pass_after_a_restart_is_silent() -> None:
+    """A reloaded map means a restart re-lists nothing it had already listed."""
+
+    hass, repo, services, _entry = await _bridge()
+    _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [ADD]
+
+    # The same inventory and the same link store, both loaded from scratch:
+    # that is a Home Assistant restart from the bridge's side. Setup runs a pass
+    # of its own, and it is that pass which has to stay silent.
+    reloaded = Repository()
+    reloaded.load_state(repo.export_state())
+    _restarted, _repo, services_after, _entry_after = await _bridge(keep_links=True, repo=reloaded)
+    assert services_after.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_refused_add_leaves_the_item_unlinked_so_the_next_pass_retries() -> None:
+    """A list that was busy must not cost the item its line for good."""
+
+    hass, repo, services, _entry = await _bridge()
+    services.refuse = {todo_bridge.SERVICE_ADD_ITEM}
+    _low_item(repo)
+
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [ADD]
+    assert hass.data[DOMAIN]["todo_links"] == {}
+
+    services.refuse = set()
+    services.clear()
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [ADD]
+    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+        {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}2"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_refused_removal_gives_up_the_link() -> None:
+    """A line deleted by hand, or a list that cannot delete, is permanent.
+
+    Holding the link would keep the item off the list for good; giving it up
+    costs at most one line the user clears themselves.
+    """
+
+    hass, repo, services, _entry = await _bridge()
+    item = _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+
+    services.refuse = {todo_bridge.SERVICE_REMOVE_ITEM}
+    services.clear()
+    repo.set_quantity(str(item.id), THRESHOLD + 1)
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [REMOVE]
+    assert hass.data[DOMAIN]["todo_links"] == {}
+
+    # And the retraction is not attempted a second time on the next pass.
+    services.clear()
+    await todo_bridge.async_reconcile(hass)
+    assert services.calls == []
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_list_issues_no_call_at_all() -> None:
+    """Off is the default, and off means the to-do domain is never touched."""
+
+    hass, repo, services, _entry = await _bridge(entity_id="")
+    _low_item(repo)
+
+    await todo_bridge.async_reconcile(hass)
+    assert services.calls == []
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_option_stops_writing_without_retracting() -> None:
+    """Switching the bridge off means stop managing, not delete what is there."""
+
+    hass, repo, services, entry = await _bridge()
+    _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+    services.clear()
+
+    entry.options = {CONF_TODO_ENTITY_ID: ""}
+    todo_bridge.apply_options(hass, entry)
+    await todo_bridge.async_reconcile(hass)
+    assert services.calls == []
+    assert len(hass.data[DOMAIN]["todo_links"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_changing_the_list_moves_the_lines_across() -> None:
+    """Off the list they were written to, onto the one now configured."""
+
+    hass, repo, services, entry = await _bridge()
+    _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+    services.clear()
+
+    hass.states.async_set(OTHER_ENTITY, "0")
+    entry.options = {CONF_TODO_ENTITY_ID: OTHER_ENTITY}
+    todo_bridge.apply_options(hass, entry)
+    await todo_bridge.async_reconcile(hass)
+
+    assert services.names == [REMOVE, ADD]
+    assert services.calls[0][1]["entity_id"] == TODO_ENTITY
+    assert services.calls[1][1]["entity_id"] == OTHER_ENTITY
+    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+        {"entity_id": OTHER_ENTITY, "summary": f"Peanut butter {TIMES}2"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_missing_or_unavailable_list_is_left_alone_until_it_answers() -> None:
+    """Home Assistant drops an entity service call for a missing target silently.
+
+    A pass that wrote anyway would record a link for a line nobody has.
+    """
+
+    hass, repo, services, _entry = await _bridge(available=False)
+    _low_item(repo)
+
+    await todo_bridge.async_reconcile(hass)
+    assert services.calls == []
+    assert hass.data[DOMAIN]["todo_links"] == {}
+
+    hass.states.async_set(TODO_ENTITY, STATE_UNAVAILABLE)
+    await todo_bridge.async_reconcile(hass)
+    assert services.calls == []
+
+    hass.states.async_set(TODO_ENTITY, "0")
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [ADD]
+
+
+@pytest.mark.asyncio
+async def test_a_line_is_restated_when_the_shortfall_moves() -> None:
+    """The count is what the line is for, so a stale one is wrong, not just old."""
+
+    hass, repo, services, _entry = await _bridge()
+    item = _low_item(repo, quantity=2)
+    await todo_bridge.async_reconcile(hass)
+    assert services.summaries == [f"Peanut butter {TIMES}1"]
+
+    services.clear()
+    repo.set_quantity(str(item.id), 0)
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [UPDATE]
+    assert services.calls[0][1] == {
+        "entity_id": TODO_ENTITY,
+        "item": f"Peanut butter {TIMES}1",
+        "rename": f"Peanut butter {TIMES}3",
+    }
+    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+        {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}3"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_refused_restatement_keeps_the_link_on_the_text_already_there() -> None:
+    """The line stays readable and the pass keeps matching it; the count lags."""
+
+    hass, repo, services, _entry = await _bridge()
+    item = _low_item(repo, quantity=2)
+    await todo_bridge.async_reconcile(hass)
+
+    services.refuse = {todo_bridge.SERVICE_UPDATE_ITEM}
+    services.clear()
+    repo.set_quantity(str(item.id), 0)
+    await todo_bridge.async_reconcile(hass)
+    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+        {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}1"}
+    ]
+
+
+def test_the_shortfall_never_reads_zero() -> None:
+    """An item low at a threshold of 0 still asks for one to be bought."""
+
+    assert todo_bridge.summary_for("Salt", 0, 0) == f"Salt {TIMES}1"
+    assert todo_bridge.summary_for("Batteries", 3, 3) == f"Batteries {TIMES}1"
+    assert todo_bridge.summary_for("Peanut butter", 1, 4) == f"Peanut butter {TIMES}3"
+    # The sign itself, pinned once: everything above builds its expectation out
+    # of the same constant, so only this line can catch a swapped glyph.
+    assert todo_bridge.MULTIPLICATION_SIGN == "\u00d7"
+
+
+@pytest.mark.asyncio
+async def test_setup_listens_on_both_mutation_events_and_releases_them_on_unload() -> None:
+    """Neither event covers the other, and a reload must not double-subscribe."""
+
+    hass, repo, services, entry = await _bridge()
+    assert len(hass.bus.listeners_for(EVENT_ITEM_CHANGED)) == 1
+    assert len(hass.bus.listeners_for(EVENT_LOW_STOCK)) == 1
+
+    # The listener runs the same pass a direct call does.
+    _low_item(repo)
+    for listener in hass.bus.listeners_for(EVENT_LOW_STOCK):
+        await listener(None)
+    assert services.names == [ADD]
+
+    for release in entry._on_unload:
+        release()
+    assert hass.bus.listeners == []
+
+
+@pytest.mark.asyncio
+async def test_the_first_pass_waits_for_startup_when_home_assistant_is_still_booting() -> None:
+    """A list owned by another integration may not be in the state machine yet."""
+
+    hass, repo, services, _entry = await _bridge(is_running=False)
+    _low_item(repo)
+    assert services.calls == []
+
+    started = hass.bus.listeners_for(EVENT_HOMEASSISTANT_STARTED)
+    assert len(started) == 1
+    await started[0](None)
+    assert services.names == [ADD]
+
+
+@pytest.mark.asyncio
+async def test_a_stored_row_missing_half_of_itself_is_dropped_on_load() -> None:
+    """A row that cannot be retracted would hold its item off the list for good."""
+
+    store: Store = Store(HomeAssistant(), TODO_LINKS_STORAGE_VERSION, TODO_LINKS_STORAGE_KEY)
+    await store.async_save(
+        {
+            "links": {
+                "kept": {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}2"},
+                "no-summary": {"entity_id": TODO_ENTITY},
+                "no-entity": {"summary": f"Rope {TIMES}1"},
+                "not-a-row": f"Rope {TIMES}1",
+            }
+        }
+    )
+
+    # Set up with the bridge switched off, so the pass leaves the loaded map
+    # exactly as it read it and the assertion is about the read alone.
+    hass, _repo, _services, _entry = await _bridge(entity_id="", keep_links=True)
+
+    assert hass.data[DOMAIN]["todo_links"] == {
+        "kept": {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}2"}
+    }

--- a/tests/test_ws_rate_limit_offline.py
+++ b/tests/test_ws_rate_limit_offline.py
@@ -22,6 +22,7 @@ from custom_components.haventory import rate_limit as rate_limit_module
 from custom_components.haventory import ws as ws_module
 from custom_components.haventory.config_flow import (
     SECTION_RATE_LIMIT,
+    SECTION_TODO,
     HAventoryOptionsFlowHandler,
     _options_schema,
 )
@@ -30,7 +31,9 @@ from custom_components.haventory.const import (
     CONF_RATE_LIMIT_COMMANDS_BURST,
     CONF_RATE_LIMIT_COMMANDS_PER_SECOND,
     CONF_RATE_LIMIT_ENABLED,
+    CONF_TODO_ENTITY_ID,
     DEFAULT_RATE_LIMIT_COMMANDS_BURST,
+    DEFAULT_TODO_ENTITY_ID,
     DOMAIN,
 )
 from custom_components.haventory.rate_limit import (
@@ -384,6 +387,7 @@ async def test_options_flow_shows_form_and_creates_entry() -> None:
     assert result["type"] == "create_entry"
     assert result["data"] == {
         CONF_CARD_TITLE: "Pantry",
+        CONF_TODO_ENTITY_ID: DEFAULT_TODO_ENTITY_ID,
         CONF_RATE_LIMIT_ENABLED: True,
         CONF_RATE_LIMIT_COMMANDS_PER_SECOND: 5.0,
         CONF_RATE_LIMIT_COMMANDS_BURST: 10.0,
@@ -398,7 +402,12 @@ async def test_options_flow_survives_a_missing_rate_limit_section() -> None:
     flow.config_entry = ConfigEntry(options={})
 
     result = await flow.async_step_init({CONF_CARD_TITLE: "Pantry"})
-    assert result["data"] == {CONF_CARD_TITLE: "Pantry"}
+    # The shopping list is stored either way: a submission without the section
+    # is a cleared selector, which is what turns the bridge off.
+    assert result["data"] == {
+        CONF_CARD_TITLE: "Pantry",
+        CONF_TODO_ENTITY_ID: DEFAULT_TODO_ENTITY_ID,
+    }
 
 
 def test_options_schema_collapses_only_while_untouched() -> None:
@@ -420,7 +429,7 @@ def test_options_schema_defaults_to_the_stored_options() -> None:
     schema = _options_schema(
         {CONF_CARD_TITLE: "Pantry", CONF_RATE_LIMIT_COMMANDS_PER_SECOND: stored_rate}
     )
-    filled = schema({SECTION_RATE_LIMIT: {}})
+    filled = schema({SECTION_TODO: {}, SECTION_RATE_LIMIT: {}})
     assert filled[CONF_CARD_TITLE] == "Pantry"
     assert filled[SECTION_RATE_LIMIT][CONF_RATE_LIMIT_COMMANDS_PER_SECOND] == stored_rate
     assert (
@@ -487,7 +496,12 @@ def test_options_schema_enforces_burst_minimum() -> None:
     schema = _options_schema({})
 
     def _submit(**section_fields: float) -> dict[str, Any]:
-        return schema({SECTION_RATE_LIMIT: {CONF_RATE_LIMIT_ENABLED: True, **section_fields}})
+        return schema(
+            {
+                SECTION_TODO: {},
+                SECTION_RATE_LIMIT: {CONF_RATE_LIMIT_ENABLED: True, **section_fields},
+            }
+        )
 
     base = _submit()  # defaults fill the rest
     assert base[SECTION_RATE_LIMIT][BURST] >= 1


### PR DESCRIPTION
## Summary

Pick a `todo.*` entity in the options flow and HAventory mirrors the low-stock set onto it:
an item at or below its `low_stock_threshold` appears as `Peanut butter ×2` — the name and
how many to buy to reach the threshold — and the line comes off again on restock. The field
is empty by default, and empty means off.

The bridge **converges instead of reacting**. Every trigger runs one pass that compares what
is low right now against a persisted map of the lines it wrote, and issues only the
difference. That is the whole idempotency story: a restart, a re-fired event, a dropped
event and a wholesale import all land on the same list, with no "did I already add this"
state anywhere but the map.

Triggers: the two HA bus events `haventory_item_changed` / `haventory_low_stock` (one
`hass.bus.async_listen` each, released through `entry.async_on_unload`), `async_setup_entry`,
an options change, and `ws_import_execute` — the one path a wholesale swap leaves no bus
event on.

The map lives in its own `haventory_todo_links` store, so `CURRENT_SCHEMA_VERSION` and the
`{schema_version, items, locations}` export document are untouched.

Closes #232

## The question the issue could not settle offline

> whether `todo.add_item` returns the new uid, and whether `todo.remove_item` accepts one

Answered against the running dev Home Assistant (2026.7.4), and re-checked at the declared
floor through the phacc suite (2026.6.0):

- **`todo.add_item` returns nothing.** `homeassistant/components/todo/__init__.py` registers
  it with no `supports_response`, so it defaults to `SupportsResponse.NONE`, and
  `_async_add_todo_item` returns `None`. There is no uid to record.
- **`todo.remove_item` and `todo.update_item` accept a uid *or* a summary.** Both resolve
  their `item` field through `_find_by_uid_or_summary`, which matches
  `value in (item.uid, item.summary)`.

**Chosen path: no uid at all.** The summary the bridge wrote is a sufficient handle, so the
`todo.get_items` round trip the notes hedged on is dropped — one service call per line
instead of two, and one fewer failure mode. The stored link is `{entity_id, summary}`.
`tests/integration/test_todo_bridge.py::test_a_deeper_shortfall_restates_the_existing_line`
pins this: it asserts the line keeps its uid across a rename found by the *old* summary.

## Decisions taken against the code, where the 2026-08-05 notes had drifted

| Note | What the tree says now | Decision |
|---|---|---|
| "stub `homeassistant.helpers.selector` (not currently stubbed)" | it **is** stubbed — the quick-filter pills added `SelectSelector` | extended that stub with `EntitySelector` / `EntitySelectorConfig` rather than creating it |
| "reuse the `hass.bus` stub #218 adds" | that stub only records `async_fire` | added `async_listen` / `async_listen_once` to it, so the subscription and its release are observable offline |
| `repo.list_items(flt={"low_stock_only": True})["items"]` | `list_items` paginates | read `repo.low_stock_item_ids` + `get_item` instead — a page limit would silently cap the shopping list |
| link map is `item_id -> {entity_id, uid, summary}` | see the uid answer above | `{entity_id, summary}` — nothing would ever write a uid |
| module exposes `async_setup`, `async_reconcile`, `async_unload` | `entry.async_on_unload` releases the listeners and `_drop_entry_runtime` empties the bucket | no `async_unload`: there is nothing left for it to do, and a no-op function reads as a missing one |

Four behaviours the notes did not cover, decided here:

1. **A line is restated when its shortfall moves.** The count is what the line is *for*, so a
   stale one is wrong rather than merely old — quantity 2→0 against threshold 3 rewrites
   `×1` to `×3` through `todo.update_item`, in place, keeping the uid. A refused restatement
   keeps the link on the text already on the list and retries next time.
2. **Clearing the option stops the mirroring and retracts nothing.** Switching off means
   "stop managing the list", not "delete what is on it" — silently deleting lines from a
   shared shopping list is not something an options toggle should do. The map is kept, so
   re-enabling carries on rather than listing everything twice. Changing to a *different*
   list is the opposite case and does move the lines across, because there the bridge is
   following its own lines.
3. **The pass checks the list is in the state machine before writing to it.** Home Assistant
   does not raise when an entity service names a missing or unavailable entity — it logs and
   drops the call (`helpers/service.py` filters `entity_candidates` by `e.available`, then
   calls `referenced.log_missing(...)`). Without the check the bridge would record a link for
   a line nobody has. The first pass is therefore deferred to `EVENT_HOMEASSISTANT_STARTED`
   while HA is still booting, since a list owned by another integration may not exist yet.
4. **A refused *removal* gives up the link; a refused *add* does not.** Everything HA can
   refuse on removal is permanent (line deleted by hand, list cannot delete, list is gone),
   and a link held for a line that cannot be retracted would keep that item off the list for
   good. An add that fails leaves the item unlinked so the next pass retries it.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **997 passed, 22 skipped**;
      `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` → all clean
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` (**1822 passed across 62 files**), `npm run build`,
      `npm audit --audit-level=high` (0 vulnerabilities)
- [x] phacc: `scripts/test_integration.sh` → **75 passed** (Docker, HA 2026.6.0 — the declared floor)

New tests: `tests/test_todo_bridge_offline.py` (15 cases), `tests/integration/test_todo_bridge.py`
(7 cases against a real `TodoListEntity`), plus four config-flow cases. Four existing
rate-limit tests and two phacc options-flow tests learned the new form section — the options
schema now requires it, and a submission without it was otherwise passing for the wrong reason.

## Live checks (dev Docker HA 2026.7.4, a real `local_todo` list)

A `local_todo` list was created through its own config flow (`todo.haventory_shopping`) and
selected through HAventory's real options flow. The dev store carries **1 087 items, 160 of
them low**, so enabling the option wrote 160 lines in one pass — the scale case, and it
converged.

**1. Threshold crossing, restatement, restock** — `+` added / `-` removed, per pass:

```
baseline lines on the list: 160 | dupes: 0
create qty1/thr3 : +['Peanut butter ×2']  -[]                     (160 -> 161, dupes 0)
use one -> qty 0 : +['Peanut butter ×3']  -['Peanut butter ×2']   (161 -> 161, dupes 0)
restock -> qty 5 : +[]                    -['Peanut butter ×3']   (161 -> 160, dupes 0)
low again -> qty1: +['Peanut butter ×2']  -[]                     (160 -> 161, dupes 0)
```

**2. A restart converges without duplicates** — `docker restart home-assistant`, then:

```
after restart   : +[]  -[]  (total 161 -> 161, dupes 0)
duplicate lines after restart: 0
identical to before: True
```

**3. A wholesale import converges** — first a `replace` that restocks the tracked item
(`-['Peanut butter ×2']`, 0 duplicates), then the case that isolates `ws_import_execute`'s
own reconcile: an item whose shortfall deepens while it *stays* low, so the swap fires no
`haventory_low_stock` (the set is unchanged) and no `haventory_item_changed` (import passes
no item) — nothing but the explicit call can restate it:

```
target: Nails (box) #9103  qty 13 -> 12, threshold 15
  expect: "Nails (box) #9103 ×2" -> "Nails (box) #9103 ×3"
import applied: True items: {'total': 1087, 'add': 0, 'update': 1, 'conflict': 0, 'unchanged': 1086}
after import (no bus event): +['Nails (box) #9103 ×3']  -['Nails (box) #9103 ×2']  (160 -> 160, dupes 0)
line present as expected: True | stale line gone: True
```

**4. An unavailable list warns and the mutation still succeeds** — the `local_todo` entry was
disabled over WS (`config_entries/disable`), leaving the entity `unavailable`:

```
item_create succeeded: True | name: QA unavailable-list probe | version: 1
```

```
16:37:22.310 DEBUG   [custom_components.haventory.storage]     Persisting repository state
16:37:22.326 DEBUG   [custom_components.haventory.storage]     Repository persisted successfully
16:37:22.328 WARNING [custom_components.haventory.todo_bridge] The configured to-do list is unavailable; leaving it untouched
```

Re-enabling the list and making one more change retried the pass and converged:

```
list right after the list came back: 160 lines | probe listed: False
after the next mutation: +['QA unavailable-list probe ×1']  -[]  (160 -> 161, dupes 0)
```

**5. Clearing the option stops writing and retracts nothing** (decision 2 above):

```
cleared -> stored: None
immediately after clearing:   +[]  -[]  (161 -> 161, dupes 0)
a low item created while off: +[]  -[]  (161 -> 161, dupes 0)
```

The dev instance was restored afterwards: probe items deleted, the option cleared, the
`local_todo` entry removed.

## Screenshots (card / UI changes)

**None — this slice touches no HAventory surface.** Per the issue, the card gets nothing:
the list is Home Assistant's own To-do panel, and the only new control is a section in HA's
own options dialog. Both were driven live and are evidenced above.

The To-do panel was photographed for my own check
(`.claude/skills/run-haventory/todo-panel.png`, gitignored): HA's To-do-Listen page, the
`HAventory Shopping` list selected, rows reading `Jump Leads #0853 ×3`, `Whole Milk ×1`,
`Battery Pack #0326 ×5` — with `×` rendering as U+00D7, the same sign the card prints
against a quantity.

**One check waived:** a screenshot of the options dialog's *Shopping list* section. The dev
frontend runs in German and its Configure control resisted several label- and shadow-walk
based approaches; the artifact is presentational and the substance is evidenced twice over.
The live options-flow schema, fetched from the running instance, is exactly what that dialog
renders:

```json
{ "type": "expandable", "name": "todo", "expanded": false, "required": true,
  "schema": [ { "name": "todo_entity_id", "required": false, "optional": true,
                "description": { "suggested_value": null },
                "selector": { "entity": { "domain": ["todo"], "multiple": false } } } ] }
```

and `test_the_options_flow_offers_the_shopping_list_field` asserts the form builds under
Home Assistant's real `selector` helper rather than the offline stub.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated: `README.md` gains a "Shopping list" subsection under Automations.
- [x] No WebSocket API change — `ws_import_execute` gains a reconcile call, with no command,
      no envelope and no item-shape change, so `docs/backend_api_contract.md` and
      `docs/data_shapes.md` are correctly untouched.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`,
      optimistic `version`). No `RETIRED_PATHS` edit: nothing was deleted or renamed.
- [x] `strings.json` and `translations/en.json` carry the new section byte-identically
      (`test_translation_flow_sections_match_strings`).

## Follow-ups

Not filed as issues — none of them clears the "can matter in a real install" bar on its own,
so they are recorded here instead:

- **Two warnings per mutation while the list is unavailable.** Both bus listeners run a pass
  and both find the list down. Harmless and self-limiting — it stops the moment the list
  answers — but a household with a broken list gets two log lines per edit.
- **A first enable on a large inventory writes one line per low item, sequentially.** 160
  lines against `local_todo` completed inside a single pass with no error, which is the case
  that would show a problem; nothing is batched or capped, and a cap would need a policy for
  what it drops.
- **A line deleted by hand stays deleted** while its item is still low, because the pass
  compares against the map rather than reading the list back. That is deliberate — it keeps
  the bridge from fighting a household that has already handled something — and the README
  says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
