### PR TITLE
feat(calendar): project due and inspection dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,9 +246,8 @@ Offline tests stub HA via `tests/conftest.py`.
   and [#231](https://github.com/chrreiter/HAventory/issues/231) sweep the rest).
 - Naming: domain/package `haventory`, services `haventory.*`, built assets
   `custom_components/haventory/www/` served at `/haventory_static/`, calendar entity
-  `calendar.haventory` — a name reserved for the calendar work
-  ([#187](https://github.com/chrreiter/HAventory/issues/187)), staged for the automation
-  milestone, not an entity that exists today.
+  `calendar.haventory` — pinned by the constant `CALENDAR_UNIQUE_ID`, which is what a
+  household's automations and dashboards name, so it does not move.
 - Report out-of-scope findings under a "Follow-ups" note rather than fixing them.
 
 See the README "Developer Checklist" for the full backend/frontend/CI checklist.
@@ -263,10 +262,13 @@ See the README "Developer Checklist" for the full backend/frontend/CI checklist.
 - **Areas are HA's, not ours.** The integration reads the area registry and never creates
   areas. An item's area is inherited from its location tree's root, exposed as
   `effective_area_id`, and shown with one chip vocabulary wherever the card marks an area.
-- **Reminders/calendar, when built, ride HA-native primitives** — a `CalendarEntity` plus
-  automations, not a bespoke scheduler. Staged for the automation milestone
-  ([#187](https://github.com/chrreiter/HAventory/issues/187)); do not start it before that
-  milestone is the current one.
+- **Reminders/calendar ride HA-native primitives** — `calendar.haventory` is a
+  `CalendarEntity`, and notifications are the household's own automations calling
+  `notify.notify`. Occurrences are **derived on read**, never scheduled and never stored:
+  `calendar_projection.py` turns the dates on items into events for whatever window is
+  asked about, and `calendar.py` is the Home Assistant wrapper over it. Do not add a timer,
+  a queue or a stored occurrence table — the only time-driven piece is a midnight state
+  rewrite so "next event" rolls over.
 
 ## Where work is tracked
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ no longer used and can be deleted; the integration ignores it either way.
 
 ## Automations
 
-HAventory shows up in Home Assistant as **four sensors on one device**, and fires **two event
-types** on the bus. Neither needs a WebSocket client, and neither polls.
+HAventory shows up in Home Assistant as **four sensors and a calendar on one device**, and
+fires **two event types** on the bus. None of it needs a WebSocket client, and none of it
+polls.
 
 ### The sensors
 
@@ -223,6 +224,47 @@ calls `haventory/item/get`.
 Services work the other way round: every `haventory.*` service returns the entity it
 touched, so a script can chain calls through `response_variable` — see the same document's
 "Service responses".
+
+### The calendar
+
+`calendar.haventory` puts the dates already on your items onto a calendar dashboard, beside
+school holidays and bin collections:
+
+| Event | Where the date comes from |
+|---|---|
+| `Ladder due back` | the `due_date` on a checked-out item |
+| `Extinguisher inspection` | the `inspection_date` on any item |
+
+Each is an all-day event on its date, described by the item's location path. The entity's
+own state is whatever happens next — `on` with the nearest event in its attributes, `off`
+when nothing is coming.
+
+Nothing is scheduled. The events are worked out whenever something reads the calendar, so
+editing a date changes the calendar immediately and no timer can drift out of step with the
+inventory. A date only exists as an event on its own day: yesterday's is gone from the
+calendar, and the **Overdue** sensor is what keeps counting it.
+
+Notifications are an ordinary calendar automation — the same one you would write for a
+birthday:
+
+```yaml
+automation:
+  - alias: Say what the inventory wants today
+    trigger:
+      platform: calendar
+      event: start
+      entity_id: calendar.haventory
+    action:
+      - service: notify.notify
+        data:
+          title: HAventory
+          message: >-
+            {{ trigger.calendar_event.summary }}
+            ({{ trigger.calendar_event.description }})
+```
+
+Add `offset: "-48:0:0"` to the trigger to be told two days ahead instead — useful for a
+return date somebody has to act on before it arrives.
 
 ### Shopping list
 
@@ -966,9 +1008,8 @@ through [private reporting](SECURITY.md), never a public issue.
 
 - Domain/package: `haventory` under `custom_components/haventory`; services `haventory.*`;
   built assets `custom_components/haventory/www/`, served at `/haventory_static/`;
-  calendar entity `calendar.haventory` — a reserved name for the calendar work
-  ([#187](https://github.com/chrreiter/HAventory/issues/187)), staged after the first
-  public release, not an entity that exists today.
+  calendar entity `calendar.haventory`, whose `unique_id` is the constant
+  `haventory_calendar`.
 - Logging: avoid reserved `LogRecord` keys in logger extras — use `item_name` /
   `location_name`, not `name`.
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,9 @@ school holidays and bin collections:
 | `Extinguisher inspection` | the `inspection_date` on any item |
 
 Each is an all-day event on its date, described by the item's location path. The entity's
-own state is whatever happens next — `on` with the nearest event in its attributes, `off`
-when nothing is coming.
+attributes always carry the nearest event still to come, however far out it is; its state
+follows Home Assistant's own convention and reads `on` only while an event is actually
+running — which for an all-day event means today.
 
 Nothing is scheduled. The events are worked out whenever something reads the calendar, so
 editing a date changes the calendar immediately and no timer can drift out of step with the

--- a/custom_components/haventory/calendar.py
+++ b/custom_components/haventory/calendar.py
@@ -1,0 +1,152 @@
+"""`calendar.haventory` — the dates already on items, as all-day events.
+
+A wrapper over `calendar_projection`: this module owns the Home Assistant types
+and the two things that move the entity's state, and holds no projection logic
+of its own.
+
+Nothing is scheduled. Occurrences are derived whenever something reads them, so
+the only time-driven piece is a midnight rewrite that lets "the next event" roll
+over on a day nobody touched the inventory.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_time_change
+from homeassistant.util import dt as dt_util
+
+from .calendar_projection import ProjectedEvent, build_events, next_event, window_dates
+from .const import CALENDAR_UNIQUE_ID, DOMAIN, INTEGRATION_VERSION, SIGNAL_INVENTORY_CHANGED
+from .models import Item
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddConfigEntryEntitiesCallback
+) -> None:
+    """Add the one calendar this integration has."""
+
+    async_add_entities([HaventoryCalendar(entry)])
+
+
+class HaventoryCalendar(CalendarEntity):
+    """Due and inspection dates across the inventory, projected on read."""
+
+    _attr_has_entity_name = True
+    # No name of its own. With `has_entity_name` that marks the entity as the
+    # device's own feature, which is what makes the entity_id the reserved
+    # `calendar.haventory` rather than the device name plus a suffix.
+    _attr_name = None
+    _attr_should_poll = False
+    _attr_icon = "mdi:calendar-clock"
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        # A constant, where the sensors scope theirs to the entry: the manifest
+        # declares `single_config_entry`, so there is never a second one to tell
+        # this apart from, and the reserved entity_id is pinned to this string.
+        self._attr_unique_id = CALENDAR_UNIQUE_ID
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="HAventory",
+            manufacturer="HAventory",
+            model="Inventory",
+            sw_version=INTEGRATION_VERSION,
+            entry_type="service",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to the two things that move the reported event."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, SIGNAL_INVENTORY_CHANGED, self._handle_update)
+        )
+        # Local midnight, not UTC: the stored dates are calendar days as the
+        # household wrote them, and rolling over at UTC midnight would move the
+        # state mid-afternoon for anyone far enough east or west.
+        self.async_on_remove(
+            async_track_time_change(self.hass, self._handle_time_change, hour=0, minute=0, second=0)
+        )
+
+    @callback
+    def _handle_update(self) -> None:
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_time_change(self, _now: datetime) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Unavailable while no config entry is loaded to read items from."""
+
+        return self._items() is not None
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """The occurrence happening now or next, across the whole inventory."""
+
+        items = self._items()
+        if items is None:
+            return None
+        upcoming = next_event(items, dt_util.now().date())
+        return _as_calendar_event(upcoming) if upcoming is not None else None
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        """Every occurrence the requested range touches."""
+
+        items = self._items()
+        if items is None:
+            return []
+        start, end = window_dates(dt_util.as_local(start_date), dt_util.as_local(end_date))
+        return [_as_calendar_event(event) for event in build_events(items, start, end)]
+
+    def _items(self) -> list[Item] | None:
+        """Every item, or none while the entry is unloaded.
+
+        The whole inventory rather than a date-range query: a range would be a
+        new repository index that goes stale at midnight with no mutation to
+        invalidate it, for a walk already bounded by the few-thousand-item
+        ceiling the README states.
+        """
+
+        repo = (self.hass.data.get(DOMAIN) or {}).get("repository")
+        if repo is None:
+            return None
+        try:
+            result: dict[str, Any] = repo.list_items()
+        except Exception:  # pragma: no cover - defensive
+            LOGGER.exception(
+                "Failed to read items for the calendar",
+                extra={"domain": DOMAIN, "op": "calendar_items"},
+            )
+            return None
+        return list(result["items"])
+
+
+def _as_calendar_event(event: ProjectedEvent) -> CalendarEvent:
+    """Wrap a projected occurrence in Home Assistant's own event type.
+
+    Both bounds stay `date` rather than `datetime`: that is what Home Assistant
+    reads as all-day, and a datetime would pin the occurrence to a time of day
+    the household never gave.
+    """
+
+    return CalendarEvent(
+        start=event.start,
+        end=event.end,
+        summary=event.summary,
+        description=event.description or None,
+        uid=event.uid,
+    )

--- a/custom_components/haventory/calendar_projection.py
+++ b/custom_components/haventory/calendar_projection.py
@@ -1,0 +1,121 @@
+"""Projection of stored item dates onto calendar occurrences.
+
+Home Assistant is not imported here. The entity in `calendar.py` is a thin
+wrapper over these functions, which keeps the projection testable in the offline
+suite — importing `calendar.py` there would mean standing in for the entity
+platform, the device registry and the time helpers, none of which the projection
+itself touches.
+
+Nothing is scheduled and nothing is stored: an occurrence exists because a date
+on an item falls inside the window somebody asked about.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+
+from .models import Item
+
+# The two dated fields on `Item`, and the word each one contributes to an
+# event's summary. `due_date` only exists while an item is checked out
+# (`models.validate_due_date_rules`), so the due half of the calendar is the
+# checked-out population.
+KIND_DUE = "due"
+KIND_INSPECTION = "inspection"
+
+_ONE_DAY = timedelta(days=1)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedEvent:
+    """One all-day occurrence derived from one date on one item.
+
+    `end` follows the all-day convention Home Assistant expects — exclusive, the
+    day after `start`. `uid` is stable across reads so a client that saw the
+    occurrence before recognises it again.
+    """
+
+    uid: str
+    summary: str
+    description: str
+    start: date
+    end: date
+    item_id: str
+    kind: str
+
+
+def window_dates(start: datetime, end: datetime) -> tuple[date, date]:
+    """Reduce a datetime range to the half-open range of days it touches.
+
+    All-day occurrences have no time of day, so a range is only ever compared
+    day by day. The exclusive end rounds *up* past any time component: a request
+    for the next four hours from midday overlaps today's all-day occurrences, and
+    truncating would answer with nothing.
+
+    Both bounds are read in whatever offset they carry — the caller converts to
+    local time first, because a UTC-stamped midnight is the previous day for half
+    the world.
+    """
+
+    last = end.date()
+    return start.date(), (last + _ONE_DAY if end.time() != time.min else last)
+
+
+def build_events(items: Iterable[Item], start: date, end: date) -> list[ProjectedEvent]:
+    """Every occurrence inside `[start, end)`, ordered for display.
+
+    A date exactly on `start` is included and one exactly on `end` is not, which
+    is the same half-open rule Home Assistant applies to the all-day events this
+    produces.
+    """
+
+    return sorted(_iter_events(items, start, end), key=_order)
+
+
+def next_event(items: Iterable[Item], on_or_after: date) -> ProjectedEvent | None:
+    """The earliest occurrence from `on_or_after` onwards, or none.
+
+    What the entity reports as its state. An all-day occurrence covers the whole
+    of its day, so today's counts as current rather than past.
+
+    Unbounded ahead rather than scanning a fixed horizon: a date years out is
+    still the next thing that happens if nothing is nearer, and picking a horizon
+    would be picking how far ahead the state stops being true.
+    """
+
+    return min(_iter_events(items, on_or_after, date.max), key=_order, default=None)
+
+
+def _iter_events(items: Iterable[Item], start: date, end: date) -> Iterator[ProjectedEvent]:
+    for item in items:
+        yield from _item_events(item, start, end)
+
+
+def _item_events(item: Item, start: date, end: date) -> Iterator[ProjectedEvent]:
+    for kind, stored, summary in (
+        (KIND_DUE, item.due_date, f"{item.name} due back"),
+        (KIND_INSPECTION, item.inspection_date, f"{item.name} inspection"),
+    ):
+        if stored is None:
+            continue
+        day = date.fromisoformat(stored)
+        if not (start <= day < end):
+            continue
+        yield ProjectedEvent(
+            uid=f"{item.id}:{kind}",
+            summary=summary,
+            # The path is what tells one "Fire extinguisher inspection" from the
+            # next; an item with no location contributes an empty one.
+            description=item.location_path.display_path,
+            start=day,
+            end=day + _ONE_DAY,
+            item_id=str(item.id),
+            kind=kind,
+        )
+
+
+def _order(event: ProjectedEvent) -> tuple[date, str, str]:
+    # `uid` last so the order is total: two items can share a name and a date.
+    return (event.start, event.summary, event.uid)

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -220,7 +220,17 @@ DEFAULT_RATE_LIMIT_GLOBAL_EVENTS_BURST: float = 1000.0
 # Entity platforms
 # -----------------------------
 
-PLATFORMS: tuple[Platform, ...] = (Platform.SENSOR,)
+PLATFORMS: tuple[Platform, ...] = (Platform.SENSOR, Platform.CALENDAR)
+
+# -----------------------------
+# Calendar
+# -----------------------------
+
+# The calendar's `unique_id`. Constant rather than entry-scoped like the
+# sensors': `single_config_entry` in the manifest means there is never a second
+# entry to distinguish, and `calendar.haventory` is a reserved name that this
+# string is what pins.
+CALENDAR_UNIQUE_ID: str = "haventory_calendar"
 
 
 @dataclass(frozen=True, slots=True)
@@ -262,9 +272,10 @@ SENSOR_DESCRIPTIONS: tuple[HaventorySensorDescription, ...] = (
 EVENT_ITEM_CHANGED: str = "haventory_item_changed"
 EVENT_LOW_STOCK: str = "haventory_low_stock"
 
-# Dispatcher signal the sensors listen on. Bus events are the public contract;
-# this is the internal nudge that repaints the entities.
-SIGNAL_COUNTS_UPDATED: str = "haventory_counts_updated"
+# Dispatcher signal every entity this integration owns listens on — the counts
+# and the calendar alike, since both are derived from the same items. Bus events
+# are the public contract; this is the internal nudge that repaints entities.
+SIGNAL_INVENTORY_CHANGED: str = "haventory_inventory_changed"
 
 # `hass.data[DOMAIN]` key holding the previous low-stock id set. Seeded at setup
 # so a restart re-announces nothing, and diffed on every notification.

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -23,7 +23,7 @@ from .const import (
     DOMAIN,
     EVENT_ITEM_CHANGED,
     EVENT_LOW_STOCK,
-    SIGNAL_COUNTS_UPDATED,
+    SIGNAL_INVENTORY_CHANGED,
 )
 from .models import iso_utc_now
 
@@ -96,7 +96,7 @@ def notify_mutation(
 
         _fire_low_stock_transitions(hass, bucket, item=item)
 
-        async_dispatcher_send(hass, SIGNAL_COUNTS_UPDATED)
+        async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
     except Exception:  # pragma: no cover - defensive
         LOGGER.exception(
             "Failed to notify a mutation",

--- a/custom_components/haventory/sensor.py
+++ b/custom_components/haventory/sensor.py
@@ -23,7 +23,7 @@ from .const import (
     DOMAIN,
     INTEGRATION_VERSION,
     SENSOR_DESCRIPTIONS,
-    SIGNAL_COUNTS_UPDATED,
+    SIGNAL_INVENTORY_CHANGED,
     HaventorySensorDescription,
 )
 
@@ -71,7 +71,7 @@ class HaventoryCountSensor(SensorEntity):
         """Subscribe to the two things that move this count."""
 
         self.async_on_remove(
-            async_dispatcher_connect(self.hass, SIGNAL_COUNTS_UPDATED, self._handle_update)
+            async_dispatcher_connect(self.hass, SIGNAL_INVENTORY_CHANGED, self._handle_update)
         )
         if self._description.date_derived:
             # `overdue_count` and `inspection_overdue_count` are derived from

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -101,15 +101,45 @@ async def test_async_get_events_projects_both_dated_fields(hass: HomeAssistant) 
     assert projected[0]["end"] == (due + timedelta(days=1)).isoformat()
 
 
-async def test_checking_an_item_out_with_a_due_date_moves_the_state(hass: HomeAssistant) -> None:
-    """A mutation repaints the entity with no polling and no time travel."""
+async def test_checking_an_item_out_due_today_turns_the_calendar_on(hass: HomeAssistant) -> None:
+    """A mutation repaints the entity with no polling and no time travel.
+
+    `on` means an event is running now, which for an all-day occurrence means
+    today's — `test_an_upcoming_date_is_announced_while_the_state_stays_off`
+    covers the other half.
+    """
 
     await _setup(hass)
     assert hass.states.get(ENTITY_ID).state == "off"
 
     item = await _create(hass, name="Ladder")
+    today = dt_util.now().date()
+
+    await hass.services.async_call(
+        DOMAIN,
+        "item_check_out",
+        {"item_id": item["id"], "due_date": today.isoformat()},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == "on"
+    assert state.attributes["message"] == "Ladder due back"
+    assert state.attributes["all_day"] is True
+    assert state.attributes["start_time"].startswith(today.isoformat())
+
+
+async def test_an_upcoming_date_is_announced_while_the_state_stays_off(
+    hass: HomeAssistant,
+) -> None:
+    """Home Assistant's `on` is "happening now", so a future date announces itself
+    through the attributes an automation's template reads."""
+
+    await _setup(hass)
     due = dt_util.now().date() + timedelta(days=2)
 
+    item = await _create(hass, name="Ladder")
     await hass.services.async_call(
         DOMAIN,
         "item_check_out",
@@ -119,9 +149,9 @@ async def test_checking_an_item_out_with_a_due_date_moves_the_state(hass: HomeAs
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_ID)
-    assert state.state == "on"
+    assert state.state == "off"
     assert state.attributes["message"] == "Ladder due back"
-    assert state.attributes["all_day"] is True
+    assert state.attributes["start_time"].startswith(due.isoformat())
 
 
 async def test_the_reported_event_is_the_nearest_one(hass: HomeAssistant) -> None:
@@ -142,7 +172,11 @@ async def test_a_past_date_is_not_reported_as_upcoming(hass: HomeAssistant) -> N
 
     await _create(hass, name="Extinguisher", inspection_date=yesterday.isoformat())
 
-    assert hass.states.get(ENTITY_ID).state == "off"
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == "off"
+    # No event at all, rather than a past one that merely is not running: the
+    # state alone cannot tell those apart.
+    assert "message" not in state.attributes
 
 
 async def test_unload_removes_the_entity(hass: HomeAssistant) -> None:

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -1,0 +1,156 @@
+"""Integration: `calendar.haventory` on the HAventory device.
+
+The entity itself is only real here — offline there is no entity platform, no
+device registry and no `hass.config_entries`, so the reserved entity_id, the
+`unique_id` and the state transitions cannot be observed there. The projection
+the entity wraps is covered offline (`tests/test_calendar_offline.py`).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from custom_components.haventory.const import CALENDAR_UNIQUE_ID, DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+ENTITY_ID = "calendar.haventory"
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def _create(hass: HomeAssistant, **payload) -> dict:
+    result = await hass.services.async_call(
+        DOMAIN, "item_create", payload, blocking=True, return_response=True
+    )
+    await hass.async_block_till_done()
+    return result["item"]
+
+
+async def test_the_calendar_takes_the_reserved_entity_id_and_a_constant_unique_id(
+    hass: HomeAssistant,
+) -> None:
+    """`calendar.haventory` is the name the repository reserved for this entity."""
+
+    entry = await _setup(hass)
+
+    registry = er.async_get(hass)
+    entity = registry.async_get(ENTITY_ID)
+    assert entity is not None
+    assert entity.unique_id == CALENDAR_UNIQUE_ID
+    assert entity.config_entry_id == entry.entry_id
+
+    # The friendly name comes from the device, which is what `_attr_name = None`
+    # under `has_entity_name` buys — and is why the entity_id carries no suffix.
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["friendly_name"] == "HAventory"
+
+
+async def test_it_joins_the_same_device_as_the_sensors(hass: HomeAssistant) -> None:
+    entry = await _setup(hass)
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert device is not None
+
+    registry = er.async_get(hass)
+    entity = registry.async_get(ENTITY_ID)
+    assert entity.device_id == device.id
+
+
+async def test_an_empty_inventory_reports_no_event(hass: HomeAssistant) -> None:
+    await _setup(hass)
+
+    assert hass.states.get(ENTITY_ID).state == "off"
+
+
+async def test_async_get_events_projects_both_dated_fields(hass: HomeAssistant) -> None:
+    """The range read a calendar dashboard performs."""
+
+    await _setup(hass)
+    today = dt_util.now().date()
+    due = today + timedelta(days=3)
+    inspection = today + timedelta(days=5)
+
+    await _create(hass, name="Ladder", checked_out=True, due_date=due.isoformat())
+    await _create(hass, name="Extinguisher", inspection_date=inspection.isoformat())
+
+    window_end = dt_util.start_of_local_day() + timedelta(days=30)
+    events = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {"entity_id": ENTITY_ID, "end_date_time": window_end},
+        blocking=True,
+        return_response=True,
+    )
+
+    projected = events[ENTITY_ID]["events"]
+    assert [e["summary"] for e in projected] == ["Ladder due back", "Extinguisher inspection"]
+    # All-day: HA renders `start`/`end` as bare dates, exclusive end.
+    assert projected[0]["start"] == due.isoformat()
+    assert projected[0]["end"] == (due + timedelta(days=1)).isoformat()
+
+
+async def test_checking_an_item_out_with_a_due_date_moves_the_state(hass: HomeAssistant) -> None:
+    """A mutation repaints the entity with no polling and no time travel."""
+
+    await _setup(hass)
+    assert hass.states.get(ENTITY_ID).state == "off"
+
+    item = await _create(hass, name="Ladder")
+    due = dt_util.now().date() + timedelta(days=2)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "item_check_out",
+        {"item_id": item["id"], "due_date": due.isoformat()},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == "on"
+    assert state.attributes["message"] == "Ladder due back"
+    assert state.attributes["all_day"] is True
+
+
+async def test_the_reported_event_is_the_nearest_one(hass: HomeAssistant) -> None:
+    await _setup(hass)
+    today = dt_util.now().date()
+
+    await _create(hass, name="Boiler", inspection_date=(today + timedelta(days=90)).isoformat())
+    await _create(hass, name="Smoke alarm", inspection_date=(today + timedelta(days=7)).isoformat())
+
+    assert hass.states.get(ENTITY_ID).attributes["message"] == "Smoke alarm inspection"
+
+
+async def test_a_past_date_is_not_reported_as_upcoming(hass: HomeAssistant) -> None:
+    """Overdue is a count, not a calendar state: the day is gone."""
+
+    await _setup(hass)
+    yesterday = dt_util.now().date() - timedelta(days=1)
+
+    await _create(hass, name="Extinguisher", inspection_date=yesterday.isoformat())
+
+    assert hass.states.get(ENTITY_ID).state == "off"
+
+
+async def test_unload_removes_the_entity(hass: HomeAssistant) -> None:
+    entry = await _setup(hass)
+    assert hass.states.get(ENTITY_ID) is not None
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is None or state.state == "unavailable"

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -26,9 +26,19 @@ async def _setup(hass: HomeAssistant) -> MockConfigEntry:
     return entry
 
 
-def _entity_ids(hass: HomeAssistant, entry: MockConfigEntry) -> list[str]:
+def _sensor_entries(hass: HomeAssistant, entry: MockConfigEntry) -> list[er.RegistryEntry]:
+    """Only this platform's entities — the entry also owns `calendar.haventory`."""
+
     registry = er.async_get(hass)
-    return sorted(e.entity_id for e in er.async_entries_for_config_entry(registry, entry.entry_id))
+    return [
+        e
+        for e in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if e.domain == "sensor"
+    ]
+
+
+def _entity_ids(hass: HomeAssistant, entry: MockConfigEntry) -> list[str]:
+    return sorted(e.entity_id for e in _sensor_entries(hass, entry))
 
 
 async def test_four_sensors_land_on_one_device(hass: HomeAssistant) -> None:
@@ -36,8 +46,7 @@ async def test_four_sensors_land_on_one_device(hass: HomeAssistant) -> None:
 
     entry = await _setup(hass)
 
-    entity_registry = er.async_get(hass)
-    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    entries = _sensor_entries(hass, entry)
     assert len(entries) == len(SENSOR_DESCRIPTIONS)
 
     assert {e.unique_id for e in entries} == {

--- a/tests/test_calendar_offline.py
+++ b/tests/test_calendar_offline.py
@@ -1,0 +1,188 @@
+"""Offline tests for the calendar projection.
+
+`calendar.py` itself is not imported here: it is a wrapper over these functions
+and everything it adds — the entity platform, the device registry, the midnight
+rewrite — belongs to the phacc suite (`tests/integration/test_calendar.py`).
+What is checkable offline is the projection, which touches no Home Assistant
+type at all.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime, timedelta, timezone
+
+import pytest
+from custom_components.haventory.calendar_projection import (
+    KIND_DUE,
+    KIND_INSPECTION,
+    build_events,
+    next_event,
+    window_dates,
+)
+from custom_components.haventory.models import Item, LocationPath
+
+WINDOW_START = date(2026, 8, 1)
+WINDOW_END = date(2026, 9, 1)
+
+
+def _item(
+    name: str,
+    *,
+    due: str | None = None,
+    inspection: str | None = None,
+    path: str = "Garage / Shelf A",
+) -> Item:
+    return Item(
+        id=uuid.uuid4(),
+        name=name,
+        checked_out=due is not None,
+        due_date=due,
+        inspection_date=inspection,
+        location_path=LocationPath(
+            id_path=[], name_path=path.split(" / ") if path else [], display_path=path, sort_key=""
+        ),
+    )
+
+
+def test_one_due_and_one_inspection_yield_two_all_day_events() -> None:
+    """The happy path: both dated fields project, each as a one-day event."""
+
+    ladder = _item("Ladder", due="2026-08-10")
+    extinguisher = _item("Extinguisher", inspection="2026-08-20", path="Hall")
+
+    events = build_events([ladder, extinguisher], WINDOW_START, WINDOW_END)
+
+    assert [e.summary for e in events] == ["Ladder due back", "Extinguisher inspection"]
+    assert [e.uid for e in events] == [f"{ladder.id}:{KIND_DUE}", f"{extinguisher.id}:inspection"]
+    assert [e.description for e in events] == ["Garage / Shelf A", "Hall"]
+    # All-day, in Home Assistant's exclusive-end convention.
+    for event in events:
+        assert event.end == event.start + timedelta(days=1)
+    assert events[0].start == date(2026, 8, 10)
+
+
+def test_a_window_that_excludes_both_dates_yields_nothing() -> None:
+    events = build_events(
+        [_item("Ladder", due="2026-08-10"), _item("Extinguisher", inspection="2026-08-20")],
+        date(2026, 10, 1),
+        date(2026, 11, 1),
+    )
+
+    assert events == []
+
+
+def test_the_window_includes_its_start_and_excludes_its_end() -> None:
+    """Half-open, so two adjoining windows never report the same day twice."""
+
+    on_start = _item("On start", inspection=WINDOW_START.isoformat())
+    on_end = _item("On end", inspection=WINDOW_END.isoformat())
+    before = _item("Before", inspection="2026-07-31")
+
+    events = build_events([on_start, on_end, before], WINDOW_START, WINDOW_END)
+
+    assert [e.summary for e in events] == ["On start inspection"]
+
+
+def test_an_item_with_both_dates_yields_two_distinct_events() -> None:
+    """One item, two occurrences — and neither uid collides with the other."""
+
+    both = _item("Ladder", due="2026-08-10", inspection="2026-08-12")
+
+    events = build_events([both], WINDOW_START, WINDOW_END)
+
+    assert {e.uid for e in events} == {f"{both.id}:{KIND_DUE}", f"{both.id}:{KIND_INSPECTION}"}
+    assert {e.item_id for e in events} == {str(both.id)}
+
+
+def test_an_item_with_neither_date_contributes_nothing() -> None:
+    assert build_events([_item("Hammer")], WINDOW_START, WINDOW_END) == []
+
+
+def test_an_item_with_no_location_still_projects() -> None:
+    """A location is not what makes a date real — the description is just empty."""
+
+    events = build_events([_item("Ladder", due="2026-08-10", path="")], WINDOW_START, WINDOW_END)
+
+    assert [e.description for e in events] == [""]
+
+
+def test_events_are_ordered_by_day_then_totally() -> None:
+    """Two items sharing a name and a day still come back in a stable order."""
+
+    later = _item("Ladder", inspection="2026-08-20")
+    twin_a = _item("Ladder", inspection="2026-08-10")
+    twin_b = _item("Ladder", inspection="2026-08-10")
+
+    events = build_events([later, twin_a, twin_b], WINDOW_START, WINDOW_END)
+
+    assert [e.start for e in events] == [date(2026, 8, 10), date(2026, 8, 10), date(2026, 8, 20)]
+    assert [e.uid for e in events[:2]] == sorted(
+        [f"{twin_a.id}:inspection", f"{twin_b.id}:inspection"]
+    )
+
+
+def test_next_event_reports_today_and_ignores_the_past() -> None:
+    """An all-day occurrence covers its whole day, so today's is current."""
+
+    today = date(2026, 8, 14)
+    items = [
+        _item("Yesterday", inspection="2026-08-13"),
+        _item("Today", inspection=today.isoformat()),
+        _item("Tomorrow", inspection="2026-08-15"),
+    ]
+
+    assert next_event(items, today).summary == "Today inspection"
+
+
+def test_next_event_reaches_past_any_fixed_horizon() -> None:
+    """A date years out is still the next thing that happens."""
+
+    assert next_event([_item("Boiler", inspection="2031-03-01")], date(2026, 8, 14)) is not None
+
+
+def test_next_event_is_none_when_nothing_is_dated() -> None:
+    assert next_event([_item("Hammer")], date(2026, 8, 14)) is None
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [
+        # A calendar view asks midnight to midnight: the days are exactly those.
+        (
+            datetime(2026, 8, 1, tzinfo=UTC),
+            datetime(2026, 9, 1, tzinfo=UTC),
+            (date(2026, 8, 1), date(2026, 9, 1)),
+        ),
+        # "The next four hours" from midday overlaps today's all-day events, so
+        # the exclusive end has to round up past the time component.
+        (
+            datetime(2026, 8, 14, 12, 0, tzinfo=UTC),
+            datetime(2026, 8, 14, 16, 0, tzinfo=UTC),
+            (date(2026, 8, 14), date(2026, 8, 15)),
+        ),
+        # The offset the caller hands over is the one the days are read in.
+        (
+            datetime(2026, 8, 1, 0, 0, tzinfo=timezone(timedelta(hours=13))),
+            datetime(2026, 8, 2, 0, 0, tzinfo=timezone(timedelta(hours=13))),
+            (date(2026, 8, 1), date(2026, 8, 2)),
+        ),
+    ],
+    ids=["midnight-to-midnight", "part-of-a-day", "far-east-offset"],
+)
+def test_window_dates_covers_every_day_the_range_touches(
+    start: datetime, end: datetime, expected: tuple[date, date]
+) -> None:
+    assert window_dates(start, end) == expected
+
+
+def test_a_part_day_window_finds_the_all_day_event_it_overlaps() -> None:
+    """The reason `window_dates` rounds up, stated as the behaviour it buys."""
+
+    start, end = window_dates(
+        datetime(2026, 8, 14, 12, 0, tzinfo=UTC), datetime(2026, 8, 14, 16, 0, tzinfo=UTC)
+    )
+
+    events = build_events([_item("Ladder", due="2026-08-14")], start, end)
+
+    assert [e.summary for e in events] == ["Ladder due back"]

--- a/tests/test_events_offline.py
+++ b/tests/test_events_offline.py
@@ -18,7 +18,7 @@ from custom_components.haventory.const import (
     DOMAIN,
     EVENT_ITEM_CHANGED,
     EVENT_LOW_STOCK,
-    SIGNAL_COUNTS_UPDATED,
+    SIGNAL_INVENTORY_CHANGED,
 )
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.serialization import serialize_item
@@ -113,7 +113,7 @@ def test_a_mutation_fires_one_item_changed_with_the_documented_keys() -> None:
     assert "description" not in payload
 
     # The sensors repaint off the dispatcher, not off the bus event.
-    assert hass.dispatcher_sends == [(SIGNAL_COUNTS_UPDATED, ())]
+    assert hass.dispatcher_sends == [(SIGNAL_INVENTORY_CHANGED, ())]
 
 
 def test_a_bulk_style_notification_carries_no_item_event() -> None:
@@ -125,7 +125,7 @@ def test_a_bulk_style_notification_carries_no_item_event() -> None:
     events_mod.notify_mutation(hass, action="reloaded")
 
     assert hass.bus.events_of(EVENT_ITEM_CHANGED) == []
-    assert hass.dispatcher_sends == [(SIGNAL_COUNTS_UPDATED, ())]
+    assert hass.dispatcher_sends == [(SIGNAL_INVENTORY_CHANGED, ())]
 
 
 def test_crossing_the_threshold_fires_entered_once() -> None:

--- a/tests/test_sensor_offline.py
+++ b/tests/test_sensor_offline.py
@@ -56,10 +56,12 @@ def test_only_the_calendar_derived_counts_track_midnight() -> None:
     }
 
 
-def test_the_sensor_platform_is_the_only_one_forwarded() -> None:
-    """The calendar entity is #187's, not this platform's."""
+def test_the_forwarded_platforms_are_the_two_this_integration_owns() -> None:
+    """A platform in the tuple with no module beside it fails setup outright."""
 
-    assert [str(p) for p in PLATFORMS] == ["sensor"]
+    assert [str(p) for p in PLATFORMS] == ["sensor", "calendar"]
+    for platform in PLATFORMS:
+        assert (PACKAGE / f"{platform}.py").is_file(), platform
 
 
 def test_every_translation_key_is_named_in_both_translation_files() -> None:


### PR DESCRIPTION
## Summary

`calendar.haventory` — the dates already stored on items, rendered as all-day events on
whatever calendar dashboard the household already looks at.

Every `due_date` (checked-out items, by the model's own invariant) and every
`inspection_date` becomes an all-day event: summary the item name plus `due back` /
`inspection`, description the item's `location_path.display_path`, `uid` a stable
`{item_id}:due` / `{item_id}:inspection`. Occurrences are **derived on read** — nothing is
scheduled, nothing is stored, and the only time-driven piece is a midnight state rewrite so
"the next event" rolls over on a day nobody touched the inventory.

Notifications stay out of the integration: an ordinary calendar automation calls
`notify.notify`, and the README ships the worked example.

Refs #187 — slice A of two. The issue stays open for slice B (stored reminders,
`haventory/reminder/*`, schema v7 → v8).

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Decisions taken against the 2026-08-05 implementation notes

The notes are the design; where the tree has moved under them, this is what was decided
and why. Recorded here rather than in the issue, per `dev/V0_6_0_implementation.md` §4.

**1. The projection lives in its own HA-free module, not in `calendar.py`.**
The notes put `build_events` inside `calendar.py` and asked `tests/conftest.py` to stub
`homeassistant.components.calendar` so the offline suite could import it. Importing
`calendar.py` offline actually needs *five* stubs — `components.calendar`,
`helpers.device_registry`, `helpers.entity_platform`, `helpers.event` and `util.dt` — none
of which any assertion would exercise; they would exist purely to permit an import, which
is the shape of stub this repo has already been bitten by. `sensor.py` (#218, merged one PR
ago, and written after these notes) set the precedent: the platform module is not imported
offline at all, and what *is* checkable offline lives beside it. So the projection is
`calendar_projection.py`, importing nothing from Home Assistant, and `calendar.py` is a thin
wrapper covered by phacc. This is also what the notes' own rationale asked for — "keeping
the projection logic free of HA types is what lets the offline suite test it **without
stubbing** `homeassistant.components.calendar`". No conftest change was needed.

**2. No `strings.json` / `translations/en.json` entity block.**
The notes list "the entity name" in both files. With `_attr_has_entity_name = True` and
`_attr_name = None`, Home Assistant treats the entity as the device's own feature: the
friendly name *is* the device name, and the entity_id is the slugified device name —
`calendar.haventory`, which is the reserved name. A `translation_key` would have produced
`calendar.haventory_<key>` instead. Verified in phacc and against the dev HA (below).

**3. `unique_id` is the constant `haventory_calendar`, unlike the sensors'.**
Both the issue and the session plan call for a constant, and `single_config_entry: true`
means there is never a second entry to distinguish it from. The sensors' entry-scoped ids
stay as they are — they are not wrong, they are answering a question the calendar does not
have. `CALENDAR_UNIQUE_ID` is the single spelling.

**4. `SIGNAL_COUNTS_UPDATED` → `SIGNAL_INVENTORY_CHANGED`.**
The calendar repaints on the same dispatcher signal the sensors do, because it fires on
every mutation including the bulk paths that pass no item (the `haventory_item_changed` bus
event does not, so it would have missed bulk edits and imports). A constant named
"counts updated" stops being true the moment a non-count entity listens on it, so it was
renamed rather than reused as-is. Mechanical, seven lines, no behaviour change.

**5. `async_get_events` rounds its exclusive end up past any time component.**
A window like "the next four hours from midday" overlaps today's all-day occurrences;
truncating both bounds to dates would answer it with nothing. `window_dates` handles that,
and both halves are tested offline.

**6. Midnight rollover is local, not UTC** — where the two date-derived sensors use
`async_track_utc_time_change`. The stored dates are calendar days as the household wrote
them, and a UTC rollover moves the state mid-afternoon far enough east or west. The
sensors' counts are documented as UTC-derived, so they stay as they are.

**7. `haventory/calendar/list_events` stays reserved and unimplemented**, per the notes:
the card already gets both dates on every item from `haventory/item/list`.

Slice A adds no WebSocket command and changes no serialized shape, so
`docs/backend_api_contract.md` and `docs/data_shapes.md` are untouched — the notes say the
same, and slice B is what changes them.

## One thing the code taught us

Home Assistant's `CalendarEntity.state` is `on` only while an event is **running** — for an
all-day event, only on its own day — and the *attributes* carry the next event however far
out it is. An early draft of both a test and a README sentence assumed `on` meant "something
is coming". Both now say what HA actually does, and
`test_an_upcoming_date_is_announced_while_the_state_stays_off` pins it.

## Two edits outside the feature

- **`CLAUDE.md`** — the naming bullet's "not an entity that exists today" and the pillar's
  "do not start it before that milestone" were both true only until this merges. The pillar
  now states the constraint that outlives the work: occurrences are derived on read, and
  nothing here gets a timer, a queue or a stored occurrence table.
- **`tests/integration/test_sensor.py`** — `test_four_sensors_land_on_one_device` counted
  *every* entity on the config entry, so the calendar made it 5 ≠ 4. Scoped to the sensor
  domain. The sensor platform's own guard test (`PLATFORMS == ["sensor"]`) became
  `["sensor", "calendar"]` plus a check that every platform named has a module beside it.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1011 passed, 22
      skipped**; `uv run ruff check .` → clean; `uv run ruff format --check .` → clean;
      `uv run mypy` → clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` → **1822 passed / 62 files**, `npm run build` → clean. (Untouched by
      this PR; run per the commit gate.)
- [x] phacc: `scripts/test_integration.sh` → **84 passed**, including the 10 new
      `tests/integration/test_calendar.py` cases.

New offline cover, `tests/test_calendar_offline.py` (17 cases): the happy path, a window
excluding everything, inclusive start / exclusive end, an item with both dates, an item with
neither, an item with no location, total ordering for two items sharing a name and a day,
`next_event` including today and reaching past any fixed horizon, and the `window_dates`
table plus the behaviour it buys.

New phacc cover, `tests/integration/test_calendar.py`: the reserved entity_id and the
constant `unique_id`, the shared device, an empty inventory, `calendar.get_events` over a
range, a check-out due today turning the state `on`, an upcoming date announced while the
state stays `off`, the nearest event winning, a past date reported not at all, and unload.

## Live checks (dev Docker HA, `run-haventory`)

Deployed with `scripts/reload_addon.sh --container home-assistant --sleep 30`;
`{"ok": true, "version": {"integration_version": "0.5.0", "schema_version": 7}}`.

**The entity exists with the constant `unique_id`:**

```
$ driver.py send '{"type":"config/entity_registry/get","entity_id":"calendar.haventory"}'
{
  "entity_id": "calendar.haventory",
  "unique_id": "haventory_calendar",
  "platform": "haventory",
  "device_id": "8797dbc406124c7736607b44cfcf3305",
  "original_name": null,
  "name": null
}
```

`original_name: null` is decision 2 working: the friendly name comes from the device, which
is why the entity_id carries no suffix.

**It projects the real store** — `calendar.get_events`, 10-day window, against the dev
instance's populated inventory (24 events; excerpt):

```
2026-08-14  Camping Stove #0520 inspection    Basement / Freezer
2026-08-15  Board Game #0759 due back         Living Room / Bookshelf
2026-08-16  Motor Oil #0375 inspection        Garage / Workbench / Drawer 1
2026-08-16  S3 Ladder due back
2026-08-19  Work Gloves #1 due back
```

`S3 Ladder` is a fresh item created and checked out through `haventory.item_create` +
`haventory.item_check_out` during this check — the mutation moved the calendar with no
polling — and it has no location, which is the empty-description edge case reaching the
real entity.

**It renders on a calendar dashboard** — HA's own Kalender panel, HAventory listed as a
calendar source with its own mark, events across the month:

> Screenshot taken (`screenshot.mjs --path /calendar --element ha-panel-calendar`): HA's
> month grid for August 2026, "HAventory" checked in the calendar list on the left with the
> integration's own mark beside it, and blue all-day chips on 24 of the 31 days — e.g. the
> 14th carries "Camping Stove #05…" and "Label Roll #0755 in…", the 16th carries "S3 Ladder
> due bac…" next to "Motor Oil #0375 ins…". Not embedded: this repo's PR bodies record
> evidence as text.

**The notify automation fires** — a calendar trigger on `calendar.haventory` with an offset
computed to land ~90 s out, action `persistent_notification.create` templated from
`trigger.calendar_event`:

```
last_triggered = 2026-08-14 17:01:23.005677+00:00   (the computed fire time, to the second)

$ driver.py send '{"type":"persistent_notification/get"}'
[
  {
    "message": "Sock Bundle #0117 due back | Bedroom / Wardrobe / Right Half",
    "notification_id": "s3_probe",
    "title": "HAventory",
    "created_at": "2026-08-14T17:01:23.005898+00:00"
  }
]
```

The message is templated purely from `trigger.calendar_event.summary` and `.description`,
so it is the projection's own summary and location path arriving through HA's calendar
trigger — not a value the probe supplied. (`Sock Bundle` rather than the probe's own item
because every event starting that midnight fires at the same offset and they share one
`notification_id`; the last one wins, which is fine for the question being asked.)

The probe automation, its items and the notification were removed afterwards; the dev
inventory is back as it was.

Nothing about this entity is cosmetic-only, so no live check is waived.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`README.md` calendar section + the two
      reservation statements; `CLAUDE.md`). `docs/backend_api_contract.md` /
      `docs/data_shapes.md` unchanged — no command and no shape moved.
- [x] WebSocket API unchanged.
- [x] Essential invariants preserved — the calendar only reads; `location_path`,
      `version` and search are untouched.
- [x] No file deleted or renamed under `custom_components/haventory/`, so `RETIRED_PATHS`
      is unchanged.

## Follow-ups

- The calendar walks `repo.list_items()` on every read. At the few-thousand-item ceiling
  the README already states that is microseconds, and a date-range index would go stale at
  midnight with no mutation to invalidate it — but it is worth remembering if the ceiling
  ever moves. Not filed: it clears no real-world bar today.
