### PR TITLE
feat(diagnostics): entry diagnostics, repairs issues and a guarded lossy load

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,3 +1076,16 @@ the first public release.
   the file without those entries on the first edit and make the loss permanent. The store is
   left untouched, and the message names the first few affected ids. Fix those entries, or
   restore `haventory_store` from a backup, then reload the integration.
+- **All three of the above also appear in Settings → Repairs**, which is where they are
+  easiest to find: the entry's error state is one line on one screen. The first two are
+  informational — nothing HAventory can do repairs a store it must not touch. The third
+  offers a **Fix** button: it copies `haventory_store` to `haventory_store_corrupt_backup`
+  and then starts HAventory with everything it could read, leaving the unreadable entries
+  out. Take that only if you would rather have the readable remainder than repair the file;
+  the copy is how you get the rest back. The offer applies to one start — a store still
+  broken at the next restart is refused again.
+- **Reporting a bug**: Settings → Devices & services → HAventory → ⋮ → **Download
+  diagnostics** writes a JSON with counts, schema versions, index-health checks, which
+  runtime pieces are loaded and whether the card bundle is deployed. It carries no item or
+  location content — no names, notes or custom-field values — so it is safe to attach to a
+  public issue. If you need the content, use the export instead.

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.loader import async_get_integration
 
 try:
@@ -53,17 +54,23 @@ from . import services as services_mod
 from . import todo_bridge as todo_mod
 from . import ws as ws_mod
 from .const import (
+    CONF_ALLOW_LOSSY_LOAD,
     CONF_CARD_TITLE,
     CONF_QUICK_FILTERS,
     CONF_SIDEBAR_PANEL_ENABLED,
+    CORRUPT_BACKUP_STORAGE_KEY,
     DEFAULT_CARD_TITLE,
     DEFAULT_SIDEBAR_PANEL_ENABLED,
     DOMAIN,
+    ISSUE_CORRUPT_SCHEMA_VERSION,
+    ISSUE_CORRUPT_STORE,
+    ISSUE_SCHEMA_DOWNGRADE,
     PANEL_ELEMENT_NAME,
     PANEL_ICON,
     PANEL_URL_PATH,
     PLATFORMS,
     QUICK_FILTER_KEYS,
+    REPAIR_ISSUE_IDS,
 )
 from .exceptions import CorruptSchemaVersionError, SchemaDowngradeError, StorageError
 from .rate_limit import RateLimitConfig, RateLimiter
@@ -146,65 +153,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     store = DomainStore(hass, key=STORAGE_KEY, version=CURRENT_SCHEMA_VERSION)
     hass.data[DOMAIN]["store"] = store
 
-    # Initialize in-memory repository for services and APIs by loading persisted state
-    try:
-        payload = await store.async_load()
-        _validate_storage_payload(payload, schema_version=store.schema_version)
-        _log_storage_health(payload, schema_version=store.schema_version)
-    except SchemaDowngradeError as exc:
-        LOGGER.error(
-            "Refusing to set up against storage written by a newer HAventory version",
-            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
-            exc_info=True,
-        )
-        # ConfigEntryError, not ConfigEntryNotReady: retrying cannot teach this build
-        # a newer schema, and the message reaches the user in the entry's error state.
-        raise ConfigEntryError(str(exc)) from exc
-    except CorruptSchemaVersionError as exc:
-        LOGGER.error(
-            "Refusing to set up against storage whose schema_version is unreadable",
-            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
-            exc_info=True,
-        )
-        # Same reasoning as the downgrade above: no number of retries turns a
-        # corrupt version into a readable one, so the entry stops with the
-        # specific message instead of backing off behind a generic one.
-        raise ConfigEntryError(str(exc)) from exc
-    except StorageError as exc:
-        LOGGER.error(
-            "Storage validation failed during setup",
-            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
-            exc_info=True,
-        )
-        raise ConfigEntryNotReady("storage validation failed") from exc
-    except Exception as exc:  # pragma: no cover - defensive
-        LOGGER.error(
-            "Failed to load storage during setup",
-            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
-            exc_info=True,
-        )
-        raise ConfigEntryNotReady("storage load failed") from exc
-    repository = Repository.from_state(payload)
-    load_report = repository.last_load_report
-    if load_report.has_corruption:
-        LOGGER.error(
-            "Refusing to set up against a store this build cannot fully read",
-            extra={
-                "domain": DOMAIN,
-                "op": "setup_storage",
-                "dropped_items": len(load_report.dropped_item_ids),
-                "dropped_locations": len(load_report.dropped_location_ids),
-                "cyclic_locations": len(load_report.cyclic_location_ids),
-                "unrooted_locations": len(load_report.unrooted_location_ids),
-            },
-        )
-        # Refuse rather than load what could be read. Every WS and service handler
-        # persists immediately, so a loaded entry rewrites the store without the
-        # unreadable rows on the very first mutation — a notification would narrate
-        # the loss, not prevent it. Refusing leaves the file intact for repair, and
-        # matches the two schema refusals above: retrying cannot fix any of them.
-        raise ConfigEntryError(_corrupt_store_message(load_report, store_key=store.key))
+    repository = await _async_load_repository(hass, entry, store)
     hass.data[DOMAIN]["repository"] = repository
+
+    # Whatever the previous boot left in Settings → Repairs described a store this
+    # one just read, so none of it is true any more.
+    _delete_refusal_issues(hass)
 
     # Which items are already low, before anything can mutate. Without this the
     # first mutation after every restart would announce `entered` for every item
@@ -255,6 +209,95 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _async_apply_sidebar_panel(hass, entry)
 
     return True
+
+
+async def _async_load_repository(
+    hass: HomeAssistant, entry: ConfigEntry, store: DomainStore
+) -> Repository:
+    """Read the store into a repository, or stop setup and say why in Repairs.
+
+    Four conditions end setup here. Two are refusals about the whole file —
+    written by a newer build, or carrying a `schema_version` that is not a
+    number — and one is about rows inside it this build cannot read; each puts
+    a card in Settings → Repairs beside the entry's error state, and only the
+    last is fixable. The fourth, a store that cannot be read at all right now,
+    is transient and gets a retry rather than a card.
+    """
+
+    try:
+        payload = await store.async_load()
+        _validate_storage_payload(payload, schema_version=store.schema_version)
+        _log_storage_health(payload, schema_version=store.schema_version)
+    except SchemaDowngradeError as exc:
+        LOGGER.error(
+            "Refusing to set up against storage written by a newer HAventory version",
+            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
+            exc_info=True,
+        )
+        _create_refusal_issue(hass, ISSUE_SCHEMA_DOWNGRADE, exc, store_key=store.key)
+        # ConfigEntryError, not ConfigEntryNotReady: retrying cannot teach this build
+        # a newer schema, and the message reaches the user in the entry's error state.
+        raise ConfigEntryError(str(exc)) from exc
+    except CorruptSchemaVersionError as exc:
+        LOGGER.error(
+            "Refusing to set up against storage whose schema_version is unreadable",
+            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
+            exc_info=True,
+        )
+        _create_refusal_issue(hass, ISSUE_CORRUPT_SCHEMA_VERSION, exc, store_key=store.key)
+        # Same reasoning as the downgrade above: no number of retries turns a
+        # corrupt version into a readable one, so the entry stops with the
+        # specific message instead of backing off behind a generic one.
+        raise ConfigEntryError(str(exc)) from exc
+    except StorageError as exc:
+        LOGGER.error(
+            "Storage validation failed during setup",
+            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
+            exc_info=True,
+        )
+        raise ConfigEntryNotReady("storage validation failed") from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        LOGGER.error(
+            "Failed to load storage during setup",
+            extra={"domain": DOMAIN, "op": "setup_storage", "schema_version": store.schema_version},
+            exc_info=True,
+        )
+        raise ConfigEntryNotReady("storage load failed") from exc
+    repository = Repository.from_state(payload)
+    load_report = repository.last_load_report
+    if load_report.has_corruption:
+        allowed = _lossy_load_allowed(entry)
+        LOGGER.log(
+            logging.WARNING if allowed else logging.ERROR,
+            (
+                "Loading a store this build cannot fully read, as the repair asked"
+                if allowed
+                else "Refusing to set up against a store this build cannot fully read"
+            ),
+            extra={
+                "domain": DOMAIN,
+                "op": "setup_storage",
+                "dropped_items": len(load_report.dropped_item_ids),
+                "dropped_locations": len(load_report.dropped_location_ids),
+                "cyclic_locations": len(load_report.cyclic_location_ids),
+                "unrooted_locations": len(load_report.unrooted_location_ids),
+            },
+        )
+        if not allowed:
+            # Refuse rather than load what could be read. Every WS and service handler
+            # persists immediately, so a loaded entry rewrites the store without the
+            # unreadable rows on the very first mutation — a notification would narrate
+            # the loss, not prevent it. Refusing leaves the file intact for repair, and
+            # matches the two schema refusals above: retrying cannot fix any of them.
+            # The repairs issue is the way back in: it takes a copy first, then sets
+            # the option this branch reads.
+            _create_corrupt_store_issue(hass, load_report, store_key=store.key)
+            raise ConfigEntryError(_corrupt_store_message(load_report, store_key=store.key))
+        # Spend the opt-in here, ahead of the update listener setup registers
+        # afterwards, so clearing it cannot bounce the entry through a reload of
+        # its own. One boot is all it buys: the next corruption is a new decision.
+        _clear_lossy_load_option(hass, entry)
+    return repository
 
 
 async def _async_forward_platforms(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -1027,6 +1070,92 @@ async def _unregister_frontend_module(hass: HomeAssistant) -> None:
     for item in list(resources.async_items() or []):
         if _points_at_card(item.get("url")):
             await _delete_card_resource(resources, item, op="frontend_unregister")
+
+
+def _create_refusal_issue(
+    hass: HomeAssistant, issue_id: str, exc: Exception, *, store_key: str
+) -> None:
+    """Put a schema refusal in Settings → Repairs as well as the entry's error state.
+
+    The refusal message is handed over whole rather than picked apart into
+    version numbers: it is written for the user, it already names whatever
+    disagreed, and one wording for both places is one wording to keep true.
+
+    Not fixable and not persistent. Nothing HAventory can offer repairs a store
+    it must not touch, and the issue describes the last setup attempt — a stored
+    copy would outlive a store the user has since restored.
+    """
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        is_persistent=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key=issue_id,
+        translation_placeholders={"error": str(exc), "storage_key": store_key},
+    )
+
+
+def _create_corrupt_store_issue(hass: HomeAssistant, report: LoadReport, *, store_key: str) -> None:
+    """Offer the guarded "load anyway" for a store with unreadable rows.
+
+    A warning rather than an error, and the only fixable one: the data that can
+    be read is intact, and the decision to go on without the rest is the
+    household's to make. `repairs.py` runs the fix.
+    """
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        ISSUE_CORRUPT_STORE,
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=ISSUE_CORRUPT_STORE,
+        translation_placeholders={
+            "items": str(len(report.dropped_item_ids)),
+            "locations": str(len(report.dropped_location_ids)),
+            "cyclic_locations": str(len(report.cyclic_location_ids)),
+            "storage_key": store_key,
+            "backup_key": CORRUPT_BACKUP_STORAGE_KEY,
+        },
+    )
+
+
+def _delete_refusal_issues(hass: HomeAssistant) -> None:
+    """Clear every repairs issue setup can raise. Deleting an absent one is not an error."""
+
+    for issue_id in REPAIR_ISSUE_IDS:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+def _lossy_load_allowed(entry: ConfigEntry) -> bool:
+    """Whether the corrupt-store repair has been run and its reload is now arriving."""
+
+    options = getattr(entry, "options", None) or {}
+    return bool(options.get(CONF_ALLOW_LOSSY_LOAD))
+
+
+def _clear_lossy_load_option(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Take the one-boot opt-in back off the entry.
+
+    Guarded with getattr for the offline test harness, whose HomeAssistant stub
+    has no config-entry registry — the same reason the platform forwarding is.
+    """
+
+    config_entries = getattr(hass, "config_entries", None)
+    update = getattr(config_entries, "async_update_entry", None)
+    if not callable(update):
+        return
+
+    options = {
+        key: value
+        for key, value in (getattr(entry, "options", None) or {}).items()
+        if key != CONF_ALLOW_LOSSY_LOAD
+    }
+    update(entry, options=options)
 
 
 def _corrupt_store_message(report: LoadReport, *, store_key: str) -> str:

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -98,6 +98,38 @@ TODO_LINKS_STORAGE_KEY: str = "haventory_todo_links"
 TODO_LINKS_STORAGE_VERSION: int = 1
 
 # -----------------------------
+# Repairs
+# -----------------------------
+# What setup puts in Settings → Repairs when it refuses to run. Each id is a
+# constant rather than a per-run value, so meeting the same condition on the
+# next boot updates one card instead of stacking a second, and each doubles as
+# the `translation_key` naming its entry under `issues` in `strings.json`.
+
+ISSUE_SCHEMA_DOWNGRADE: str = "schema_downgrade"
+ISSUE_CORRUPT_SCHEMA_VERSION: str = "corrupt_schema_version"
+ISSUE_CORRUPT_STORE: str = "corrupt_store"
+
+# Every issue this integration raises, so a setup that got through can clear the
+# lot without naming them one at a time — whichever of them the previous boot
+# left behind no longer describes anything.
+REPAIR_ISSUE_IDS: tuple[str, ...] = (
+    ISSUE_SCHEMA_DOWNGRADE,
+    ISSUE_CORRUPT_SCHEMA_VERSION,
+    ISSUE_CORRUPT_STORE,
+)
+
+# Set by the corrupt-store repair, read by the setup its reload triggers, and
+# cleared there. Opting in to a lossy load is a decision about one boot: leaving
+# it set would silently accept the next corruption too.
+CONF_ALLOW_LOSSY_LOAD: str = "allow_lossy_load"
+
+# Where that repair copies the raw store before the lossy load. Loading destroys
+# nothing by itself — the first mutation afterwards does, by writing the
+# repository back over the rows it could not read — so the copy is what makes
+# "load anyway" reversible.
+CORRUPT_BACKUP_STORAGE_KEY: str = "haventory_store_corrupt_backup"
+
+# -----------------------------
 # Item attachments
 # -----------------------------
 # Files attached to an item live under the config directory, outside the

--- a/custom_components/haventory/diagnostics.py
+++ b/custom_components/haventory/diagnostics.py
@@ -1,0 +1,117 @@
+"""Config-entry diagnostics for HAventory.
+
+Home Assistant discovers this module by name and puts "Download diagnostics" on
+the entry's ⋮ menu; the JSON it writes is what a bug report carries.
+
+**Aggregates only — no item or location bodies at any depth.** A diagnostics
+dump answers questions about the *shape* of an install: how much is stored, what
+schema it is on, whether the indexes agree with themselves, whether the card
+bundle is even deployed. Redacting free text well enough to paste into a public
+issue is not something a name, a note or a custom field can be trusted to
+survive, and a user who wants their content already has `haventory/export`. The
+one user-authored string that does appear — the card title, out of the entry's
+options — goes through Home Assistant's redaction helper.
+
+Home Assistant can call this on an entry whose setup failed, which is exactly
+when it is worth having, so every block reports what it found rather than
+assuming a loaded runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from . import _CARD_BUNDLE_PATH
+from .const import CONF_CARD_TITLE, DOMAIN, INTEGRATION_VERSION
+from .health import collect_health_issues
+from .rate_limit import RateLimiter
+from .repository import Repository
+from .storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
+
+# The card title is the one free-text string a household writes into the entry's
+# options; everything else there is a number, a flag or an entity id.
+_REDACT_OPTIONS = {CONF_CARD_TITLE}
+
+
+def _bundle_state(path: Path) -> dict[str, Any]:
+    """Whether the built card bundle is on disk, and how big it is.
+
+    "The card will not render" is answered here more often than anywhere else:
+    the bundle is git-ignored and produced by a build, so an install that was
+    copied rather than released can be missing it entirely.
+    """
+
+    try:
+        stat = path.stat()
+    except OSError:
+        return {"filename": path.name, "exists": False, "size_bytes": None}
+    return {"filename": path.name, "exists": True, "size_bytes": stat.st_size}
+
+
+def _repository_block(repo: Repository | None) -> dict[str, Any]:
+    if repo is None:
+        return {"loaded": False, "counts": None, "generation": None, "health_issues": None}
+    issues, counts = collect_health_issues(repo)
+    return {
+        "loaded": True,
+        "counts": counts,
+        "generation": repo.generation,
+        "health_issues": issues,
+    }
+
+
+def _rate_limit_block(limiter: RateLimiter | None) -> dict[str, Any] | None:
+    if limiter is None:
+        return None
+    return {
+        "enabled": bool(limiter.enabled),
+        "dropped_commands": limiter.dropped_commands,
+        "dropped_events": limiter.dropped_events,
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Build the diagnostics payload for the HAventory config entry."""
+
+    bucket = hass.data.get(DOMAIN) or {}
+    store = bucket.get("store")
+    repo = bucket.get("repository")
+
+    # Off the event loop, the way `stale_files` does its own filesystem work.
+    bundle = await hass.async_add_executor_job(_bundle_state, _CARD_BUNDLE_PATH)
+
+    return {
+        "integration": {"version": INTEGRATION_VERSION},
+        "storage": {
+            # `store_schema_version` is what the running store was constructed
+            # for, not what the file says: a payload on an older version is
+            # migrated during setup, and one on a newer version stops setup
+            # before a store is ever put in the bucket — which is what the
+            # `null` here means.
+            "key": store.key if isinstance(store, DomainStore) else STORAGE_KEY,
+            "supported_schema_version": CURRENT_SCHEMA_VERSION,
+            "store_schema_version": (
+                store.schema_version if isinstance(store, DomainStore) else None
+            ),
+        },
+        "repository": _repository_block(repo if isinstance(repo, Repository) else None),
+        "runtime": {
+            # Key names, never values: the bucket holds the repository itself,
+            # and a dump of it would be the whole inventory.
+            "data_keys": sorted(str(key) for key in bucket),
+            "rate_limit": _rate_limit_block(
+                bucket.get("rate_limiter")
+                if isinstance(bucket.get("rate_limiter"), RateLimiter)
+                else None
+            ),
+        },
+        "options": async_redact_data(dict(getattr(entry, "options", None) or {}), _REDACT_OPTIONS),
+        "frontend_bundle": bundle,
+    }

--- a/custom_components/haventory/health.py
+++ b/custom_components/haventory/health.py
@@ -1,0 +1,175 @@
+"""Consistency checks over a loaded repository.
+
+Every check compares the repository's indexes against the entities they index:
+an item that says it is checked out has to be in the checked-out set, a location
+bucket has to hold exactly the items pointing at it, and the counts served to
+clients have to agree with the collections they summarise. Drift here is a bug
+in the repository, not in the data, which is why the issue strings are symbol-
+like names rather than sentences — they name the invariant that broke.
+
+Two callers ask the same question: `haventory/health` over the WebSocket, and
+the config-entry diagnostics download. Both live one layer above this module, so
+neither has to import the other.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .models import DEFAULT_ITEM_STATUS, Item, Location
+from .repository import InternalIndexes, Repository
+
+
+def _collect_item_status_issues(
+    item_id: str, item: Item, status_to_item_ids: dict[str, set[str]]
+) -> list[str]:
+    """Check the item's membership in the status index against its status.
+
+    Only non-default statuses are bucketed, so a default-status item found in
+    any bucket is drift just as much as a flagged item missing from its own.
+    """
+
+    issues: list[str] = []
+    status = str(getattr(item, "status", DEFAULT_ITEM_STATUS))
+    if status != DEFAULT_ITEM_STATUS:
+        if item_id not in status_to_item_ids.get(status, set()):
+            issues.append("status_item_missing_from_index")
+    elif any(item_id in ids for ids in status_to_item_ids.values()):
+        issues.append("default_status_item_present_in_index")
+    return issues
+
+
+def _collect_item_issues(item_id: str, item: Item, idx: InternalIndexes) -> list[str]:
+    issues: list[str] = []
+    items_by_location_id = idx["items_by_location_id"]
+    locations_by_id = idx["locations_by_id"]
+    checked_out_item_ids = idx["checked_out_item_ids"]
+    low_stock_item_ids = idx["low_stock_item_ids"]
+    status_to_item_ids = idx["status_to_item_ids"]
+
+    # Normalize types for comparison (UUID vs string)
+    if str(getattr(item, "id", "")) != item_id:
+        issues.append("item_id_key_mismatch")
+
+    loc_id = getattr(item, "location_id", None)
+    loc_key = str(loc_id) if loc_id is not None else None
+    if loc_key is not None and loc_key not in locations_by_id:
+        issues.append("item_references_missing_location")
+
+    if loc_key is not None:
+        bucket_ids = items_by_location_id.get(loc_key, set())
+        if item_id not in bucket_ids:
+            issues.append("item_missing_from_items_by_location_index")
+
+    if bool(getattr(item, "checked_out", False)):
+        if item_id not in checked_out_item_ids:
+            issues.append("checked_out_item_missing_from_index")
+    elif item_id in checked_out_item_ids:
+        issues.append("non_checked_out_item_present_in_index")
+
+    issues.extend(_collect_item_status_issues(item_id, item, status_to_item_ids))
+
+    thr = getattr(item, "low_stock_threshold", None)
+    is_low = False
+    try:
+        is_low = thr is not None and int(getattr(item, "quantity", 0)) <= int(thr)
+    except TypeError, ValueError:  # pragma: no cover - defensive
+        is_low = False
+    if is_low:
+        if item_id not in low_stock_item_ids:
+            issues.append("low_stock_item_missing_from_index")
+    elif item_id in low_stock_item_ids:
+        issues.append("non_low_stock_item_present_in_index")
+    return issues
+
+
+def _check_items_consistency(idx: InternalIndexes) -> list[str]:
+    issues: list[str] = []
+    items_by_id = idx["items_by_id"]
+    for item_id, item in items_by_id.items():
+        issues.extend(_collect_item_issues(item_id, item, idx))
+    return issues
+
+
+def _check_index_references(idx: InternalIndexes) -> list[str]:
+    issues: list[str] = []
+    items_by_id = idx["items_by_id"]
+    tags_to_item_ids = idx["tags_to_item_ids"]
+    category_to_item_ids = idx["category_to_item_ids"]
+    checked_out_item_ids = idx["checked_out_item_ids"]
+    low_stock_item_ids = idx["low_stock_item_ids"]
+    items_by_location_id = idx["items_by_location_id"]
+    locations_by_id = idx["locations_by_id"]
+
+    def _assert_known_ids(name: str, ids: set[str]) -> None:
+        unknown = [x for x in ids if x not in items_by_id]
+        if unknown:
+            issues.append(f"{name}_references_unknown_item_ids")
+
+    for _tag, ids in list(tags_to_item_ids.items()):
+        _assert_known_ids("tags_index", set(ids))
+    for _cat, ids in list(category_to_item_ids.items()):
+        _assert_known_ids("category_index", set(ids))
+    for _status, ids in list(idx["status_to_item_ids"].items()):
+        _assert_known_ids("status_index", set(ids))
+
+    _assert_known_ids("checked_out_index", set(checked_out_item_ids))
+    _assert_known_ids("low_stock_index", set(low_stock_item_ids))
+
+    for loc_id, ids in list(items_by_location_id.items()):
+        if loc_id is not None and loc_id not in locations_by_id:
+            issues.append("items_by_location_references_missing_location")
+        _assert_known_ids("items_by_location_index", set(ids))
+        for iid in list(ids):
+            item = items_by_id.get(iid)
+            if item is not None and (
+                (
+                    str(getattr(item, "location_id", None))
+                    if getattr(item, "location_id", None) is not None
+                    else None
+                )
+                != loc_id
+            ):
+                issues.append("items_by_location_bucket_mismatch")
+
+    return issues
+
+
+def _check_locations_consistency(*, locations_by_id: dict[str, Location]) -> list[str]:
+    issues: list[str] = []
+    for loc_id, loc in locations_by_id.items():
+        # Normalize types for comparison (UUID vs string)
+        if str(getattr(loc, "id", "")) != loc_id:
+            issues.append("location_id_key_mismatch")
+    return issues
+
+
+def collect_health_issues(repo: Repository) -> tuple[list[str], dict[str, Any]]:
+    """Return the repository's consistency issues and the counts they were checked against.
+
+    An empty issue list is what "healthy" means. The counts come back with them
+    because the last four checks compare exactly those numbers against the
+    collections, and a caller reporting one without the other would be quoting
+    an unchecked figure.
+    """
+
+    idx = repo._debug_get_internal_indexes()
+    issues: list[str] = []
+    issues.extend(_check_items_consistency(idx))
+    issues.extend(_check_index_references(idx))
+    issues.extend(_check_locations_consistency(locations_by_id=idx["locations_by_id"]))
+
+    counts = repo.get_counts()
+    items_by_id = idx["items_by_id"]
+    locations_by_id = idx["locations_by_id"]
+    checked_out_item_ids = idx["checked_out_item_ids"]
+    low_stock_item_ids = idx["low_stock_item_ids"]
+    if counts.get("items_total") != len(items_by_id):
+        issues.append("items_total_count_mismatch")
+    if counts.get("locations_total") != len(locations_by_id):
+        issues.append("locations_total_count_mismatch")
+    if counts.get("checked_out_count") != len(checked_out_item_ids):
+        issues.append("checked_out_count_mismatch")
+    if counts.get("low_stock_count") != len(low_stock_item_ids):
+        issues.append("low_stock_count_mismatch")
+    return issues, counts

--- a/custom_components/haventory/repairs.py
+++ b/custom_components/haventory/repairs.py
@@ -1,0 +1,104 @@
+"""The fix flow behind HAventory's one fixable repairs issue.
+
+Home Assistant loads this module on demand when the user presses **Fix** on a
+repairs card, which is why nothing in the package imports it.
+
+Only the corrupt-store refusal is fixable. Setup stops rather than load a store
+whose rows it cannot all read, because every mutation persists immediately: a
+partial load rewrites the file without those rows on the first edit and makes
+the loss permanent. This flow is the way past that, and the copy it takes first
+is what makes going past it reversible — the load itself destroys nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow, RepairsFlowResult
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from .const import CONF_ALLOW_LOSSY_LOAD, DOMAIN, ISSUE_CORRUPT_STORE
+from .storage import async_backup_store
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LossyLoadRepairFlow(RepairsFlow):
+    """Back the store up, opt the next boot in to the lossy load, and reload."""
+
+    async def async_step_init(self, user_input: dict[str, str] | None = None) -> RepairsFlowResult:
+        """Start at the confirmation; there is nothing to ask before it."""
+
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Show what will be lost, and on confirmation do the three steps in order."""
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="confirm",
+                data_schema=vol.Schema({}),
+                description_placeholders=self._issue_placeholders(),
+            )
+
+        # `single_config_entry` in the manifest means there is exactly one entry
+        # to reload, so the flow does not have to carry an id that could go stale
+        # between the refusal and the press of the button.
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        if not entries:
+            return self.async_abort(reason="no_config_entry")
+        entry = entries[0]
+
+        try:
+            copied = await async_backup_store(self.hass)
+        except Exception:  # pragma: no cover - defensive
+            LOGGER.error(
+                "Failed to copy the HAventory store aside; not loading it lossily",
+                extra={"domain": DOMAIN, "op": "repair_lossy_load"},
+                exc_info=True,
+            )
+            copied = False
+        if not copied:
+            # Without the copy there is no way back from the first mutation
+            # after the load, so the offer is withdrawn rather than honoured.
+            return self.async_abort(reason="backup_failed")
+
+        self.hass.config_entries.async_update_entry(
+            entry, options={**entry.options, CONF_ALLOW_LOSSY_LOAD: True}
+        )
+        await self.hass.config_entries.async_reload(entry.entry_id)
+
+        if entry.state is not ConfigEntryState.LOADED:
+            # Aborting is what keeps the card up: Home Assistant deletes the
+            # issue when a fix flow finishes any other way, and a card that
+            # disappears while the integration is still down is a lie.
+            return self.async_abort(reason="reload_failed")
+        return self.async_create_entry(data={})
+
+    def _issue_placeholders(self) -> dict[str, str] | None:
+        """Reuse the counts the issue was created with, so the form can quote them."""
+
+        issue = ir.async_get(self.hass).async_get_issue(DOMAIN, self.issue_id)
+        return issue.translation_placeholders if issue is not None else None
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict[str, str | int | float | None] | None
+) -> RepairsFlow:
+    """Return the flow that fixes ``issue_id``.
+
+    The three arguments are the repairs platform's contract, not this module's
+    choice; HAventory's issues carry no ``data``, and the flow reads what it
+    needs off the issue registry when it runs.
+    """
+
+    if issue_id == ISSUE_CORRUPT_STORE:
+        return LossyLoadRepairFlow()
+    # Every other issue this integration raises is informational, so nothing is
+    # left to do but acknowledge it — which is what Home Assistant's own flow is.
+    return ConfirmRepairFlow()

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -26,7 +26,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from . import migrations
-from .const import DOMAIN
+from .const import CORRUPT_BACKUP_STORAGE_KEY, DOMAIN
 from .exceptions import (
     CorruptSchemaVersionError,
     NotLoadedError,
@@ -130,6 +130,39 @@ def read_schema_version(payload: Mapping[str, Any], *, missing: int) -> int:
     return value
 
 
+async def async_backup_store(
+    hass: HomeAssistant,
+    *,
+    source_key: str = STORAGE_KEY,
+    backup_key: str = CORRUPT_BACKUP_STORAGE_KEY,
+) -> bool:
+    """Copy the stored payload verbatim to a second key, returning whether there was one.
+
+    Deliberately raw: it goes around `DomainStore`, which migrates, normalizes
+    and would refuse the very payloads worth copying. The caller is the
+    corrupt-store repair, so what has to survive is exactly what is on disk —
+    unreadable rows included, since those are what the user might want back.
+    """
+
+    source: Store[dict[str, Any]] = Store(hass, DomainStore.HA_STORE_VERSION, source_key)
+    raw = await source.async_load()
+    if raw is None:
+        return False
+
+    backup: Store[dict[str, Any]] = Store(hass, DomainStore.HA_STORE_VERSION, backup_key)
+    await backup.async_save(raw)
+    _LOGGER.warning(
+        "Copied the HAventory store aside before loading it with unreadable rows",
+        extra={
+            "domain": DOMAIN,
+            "op": "backup_store",
+            "storage_key": source_key,
+            "backup_key": backup_key,
+        },
+    )
+    return True
+
+
 def _get_persist_lock(hass: HomeAssistant) -> asyncio.Lock:
     """Get or create the persistence lock for this hass instance.
 
@@ -152,15 +185,17 @@ class DomainStore:
     mechanism. All versioning is handled via `schema_version` in the payload.
     """
 
-    # HA Store wrapper version - always 1 to avoid HA's migration mechanism
-    _HA_STORE_VERSION: Final[int] = 1
+    # HA Store wrapper version - always 1 to avoid HA's migration mechanism.
+    # Public because the raw copy `async_backup_store` takes has to open the
+    # same file under the same version this wrapper wrote it with.
+    HA_STORE_VERSION: Final[int] = 1
 
     def __init__(
         self, hass: HomeAssistant, *, key: str = STORAGE_KEY, version: int = CURRENT_SCHEMA_VERSION
     ) -> None:
         self._hass = hass
         # Use constant HA Store version; our schema_version handles migrations
-        self._store: Store[dict[str, Any]] = Store(hass, self._HA_STORE_VERSION, key)
+        self._store: Store[dict[str, Any]] = Store(hass, self.HA_STORE_VERSION, key)
         self._schema_version = version
 
     @property

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -146,5 +146,31 @@
       "name": "Delete location",
       "description": "Delete a storage location."
     }
+  },
+  "issues": {
+    "schema_downgrade": {
+      "title": "HAventory cannot read the stored data",
+      "description": "HAventory stopped instead of setting up: {error}\n\nThe file is `.storage/{storage_key}` in your Home Assistant configuration directory, and it has been left exactly as it was. This card clears itself once HAventory starts against a store it can read."
+    },
+    "corrupt_schema_version": {
+      "title": "HAventory cannot tell which schema the stored data uses",
+      "description": "HAventory stopped instead of setting up: {error}\n\nThe file is `.storage/{storage_key}` in your Home Assistant configuration directory, and it has been left exactly as it was. This card clears itself once HAventory starts against a store it can read."
+    },
+    "corrupt_store": {
+      "title": "HAventory cannot read part of the stored data",
+      "fix_flow": {
+        "abort": {
+          "no_config_entry": "HAventory is no longer set up, so there is nothing to reload.",
+          "backup_failed": "The copy of the stored file could not be written, so nothing was changed. Without it there would be no way back, so HAventory did not load.",
+          "reload_failed": "HAventory still did not start. The copy was written and the stored file is unchanged; check the Home Assistant log for what stopped it."
+        },
+        "step": {
+          "confirm": {
+            "title": "Load HAventory without the unreadable entries",
+            "description": "HAventory could not read {items} item(s) and {locations} location(s), and found {cyclic_locations} location(s) whose parent chain loops back on itself. It stopped rather than load the rest — it saves on every change, and the first edit would rewrite the file without them.\n\nConfirming copies `.storage/{storage_key}` to `.storage/{backup_key}` and then starts HAventory with everything it could read. The unreadable entries stay out, and the copy is how you get them back.\n\nTo keep them instead, close this dialog and repair those entries in the stored file, or restore it from a backup."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -146,5 +146,31 @@
       "name": "Delete location",
       "description": "Delete a storage location."
     }
+  },
+  "issues": {
+    "schema_downgrade": {
+      "title": "HAventory cannot read the stored data",
+      "description": "HAventory stopped instead of setting up: {error}\n\nThe file is `.storage/{storage_key}` in your Home Assistant configuration directory, and it has been left exactly as it was. This card clears itself once HAventory starts against a store it can read."
+    },
+    "corrupt_schema_version": {
+      "title": "HAventory cannot tell which schema the stored data uses",
+      "description": "HAventory stopped instead of setting up: {error}\n\nThe file is `.storage/{storage_key}` in your Home Assistant configuration directory, and it has been left exactly as it was. This card clears itself once HAventory starts against a store it can read."
+    },
+    "corrupt_store": {
+      "title": "HAventory cannot read part of the stored data",
+      "fix_flow": {
+        "abort": {
+          "no_config_entry": "HAventory is no longer set up, so there is nothing to reload.",
+          "backup_failed": "The copy of the stored file could not be written, so nothing was changed. Without it there would be no way back, so HAventory did not load.",
+          "reload_failed": "HAventory still did not start. The copy was written and the stored file is unchanged; check the Home Assistant log for what stopped it."
+        },
+        "step": {
+          "confirm": {
+            "title": "Load HAventory without the unreadable entries",
+            "description": "HAventory could not read {items} item(s) and {locations} location(s), and found {cyclic_locations} location(s) whose parent chain loops back on itself. It stopped rather than load the rest — it saves on every change, and the first edit would rewrite the file without them.\n\nConfirming copies `.storage/{storage_key}` to `.storage/{backup_key}` and then starts HAventory with everything it could read. The unreadable entries stay out, and the copy is how you get them back.\n\nTo keep them instead, close this dialog and repair those entries in the stored file, or restore it from a backup."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -48,14 +48,12 @@ from .exceptions import (
     log_exc_info,
     log_severity,
 )
+from .health import collect_health_issues
 from .import_export import POLICIES, Policy
 from .models import (
     ATTACHMENT_KINDS,
-    DEFAULT_ITEM_STATUS,
     AttachmentMeta,
-    Item,
     ItemUpdate,
-    Location,
     iso_utc_now,
     new_uuid4,
     normalize_tags,
@@ -66,7 +64,7 @@ from .models import (
     validate_sort,
 )
 from .rate_limit import RateLimiter
-from .repository import UNSET, InternalIndexes, Repository
+from .repository import UNSET, Repository
 from .serialization import serialize_item, serialize_location
 from .storage import CURRENT_SCHEMA_VERSION
 
@@ -940,153 +938,6 @@ async def ws_distinct_values(
     conn.send_message(websocket_api.result_message(msg.get("id", 0), result))
 
 
-def _collect_item_status_issues(
-    item_id: str, item: Item, status_to_item_ids: dict[str, set[str]]
-) -> list[str]:
-    """Check the item's membership in the status index against its status.
-
-    Only non-default statuses are bucketed, so a default-status item found in
-    any bucket is drift just as much as a flagged item missing from its own.
-    """
-
-    issues: list[str] = []
-    status = str(getattr(item, "status", DEFAULT_ITEM_STATUS))
-    if status != DEFAULT_ITEM_STATUS:
-        if item_id not in status_to_item_ids.get(status, set()):
-            issues.append("status_item_missing_from_index")
-    elif any(item_id in ids for ids in status_to_item_ids.values()):
-        issues.append("default_status_item_present_in_index")
-    return issues
-
-
-def _collect_item_issues(item_id: str, item: Item, idx: InternalIndexes) -> list[str]:
-    issues: list[str] = []
-    items_by_location_id = idx["items_by_location_id"]
-    locations_by_id = idx["locations_by_id"]
-    checked_out_item_ids = idx["checked_out_item_ids"]
-    low_stock_item_ids = idx["low_stock_item_ids"]
-    status_to_item_ids = idx["status_to_item_ids"]
-
-    # Normalize types for comparison (UUID vs string)
-    if str(getattr(item, "id", "")) != item_id:
-        issues.append("item_id_key_mismatch")
-
-    loc_id = getattr(item, "location_id", None)
-    loc_key = str(loc_id) if loc_id is not None else None
-    if loc_key is not None and loc_key not in locations_by_id:
-        issues.append("item_references_missing_location")
-
-    if loc_key is not None:
-        bucket_ids = items_by_location_id.get(loc_key, set())
-        if item_id not in bucket_ids:
-            issues.append("item_missing_from_items_by_location_index")
-
-    if bool(getattr(item, "checked_out", False)):
-        if item_id not in checked_out_item_ids:
-            issues.append("checked_out_item_missing_from_index")
-    elif item_id in checked_out_item_ids:
-        issues.append("non_checked_out_item_present_in_index")
-
-    issues.extend(_collect_item_status_issues(item_id, item, status_to_item_ids))
-
-    thr = getattr(item, "low_stock_threshold", None)
-    is_low = False
-    try:
-        is_low = thr is not None and int(getattr(item, "quantity", 0)) <= int(thr)
-    except TypeError, ValueError:  # pragma: no cover - defensive
-        is_low = False
-    if is_low:
-        if item_id not in low_stock_item_ids:
-            issues.append("low_stock_item_missing_from_index")
-    elif item_id in low_stock_item_ids:
-        issues.append("non_low_stock_item_present_in_index")
-    return issues
-
-
-def _check_items_consistency(idx: InternalIndexes) -> list[str]:
-    issues: list[str] = []
-    items_by_id = idx["items_by_id"]
-    for item_id, item in items_by_id.items():
-        issues.extend(_collect_item_issues(item_id, item, idx))
-    return issues
-
-
-def _check_index_references(idx: InternalIndexes) -> list[str]:
-    issues: list[str] = []
-    items_by_id = idx["items_by_id"]
-    tags_to_item_ids = idx["tags_to_item_ids"]
-    category_to_item_ids = idx["category_to_item_ids"]
-    checked_out_item_ids = idx["checked_out_item_ids"]
-    low_stock_item_ids = idx["low_stock_item_ids"]
-    items_by_location_id = idx["items_by_location_id"]
-    locations_by_id = idx["locations_by_id"]
-
-    def _assert_known_ids(name: str, ids: set[str]) -> None:
-        unknown = [x for x in ids if x not in items_by_id]
-        if unknown:
-            issues.append(f"{name}_references_unknown_item_ids")
-
-    for _tag, ids in list(tags_to_item_ids.items()):
-        _assert_known_ids("tags_index", set(ids))
-    for _cat, ids in list(category_to_item_ids.items()):
-        _assert_known_ids("category_index", set(ids))
-    for _status, ids in list(idx["status_to_item_ids"].items()):
-        _assert_known_ids("status_index", set(ids))
-
-    _assert_known_ids("checked_out_index", set(checked_out_item_ids))
-    _assert_known_ids("low_stock_index", set(low_stock_item_ids))
-
-    for loc_id, ids in list(items_by_location_id.items()):
-        if loc_id is not None and loc_id not in locations_by_id:
-            issues.append("items_by_location_references_missing_location")
-        _assert_known_ids("items_by_location_index", set(ids))
-        for iid in list(ids):
-            item = items_by_id.get(iid)
-            if item is not None and (
-                (
-                    str(getattr(item, "location_id", None))
-                    if getattr(item, "location_id", None) is not None
-                    else None
-                )
-                != loc_id
-            ):
-                issues.append("items_by_location_bucket_mismatch")
-
-    return issues
-
-
-def _check_locations_consistency(*, locations_by_id: dict[str, Location]) -> list[str]:
-    issues: list[str] = []
-    for loc_id, loc in locations_by_id.items():
-        # Normalize types for comparison (UUID vs string)
-        if str(getattr(loc, "id", "")) != loc_id:
-            issues.append("location_id_key_mismatch")
-    return issues
-
-
-def _collect_health_issues(repo: Repository) -> tuple[list[str], dict[str, int]]:
-    idx = repo._debug_get_internal_indexes()
-    issues: list[str] = []
-    issues.extend(_check_items_consistency(idx))
-    issues.extend(_check_index_references(idx))
-    issues.extend(_check_locations_consistency(locations_by_id=idx["locations_by_id"]))
-
-    counts = repo.get_counts()
-    items_by_id = idx["items_by_id"]
-    locations_by_id = idx["locations_by_id"]
-    checked_out_item_ids = idx["checked_out_item_ids"]
-    low_stock_item_ids = idx["low_stock_item_ids"]
-    if counts.get("items_total") != len(items_by_id):
-        issues.append("items_total_count_mismatch")
-    if counts.get("locations_total") != len(locations_by_id):
-        issues.append("locations_total_count_mismatch")
-    if counts.get("checked_out_count") != len(checked_out_item_ids):
-        issues.append("checked_out_count_mismatch")
-    if counts.get("low_stock_count") != len(low_stock_item_ids):
-        issues.append("low_stock_count_mismatch")
-    return issues, counts
-
-
 @websocket_api.websocket_command({"type": "haventory/health"})
 @websocket_api.async_response
 @ws_guard("health", ())
@@ -1094,7 +945,7 @@ async def ws_health(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     repo = _repo(hass)
-    issues, counts = _collect_health_issues(repo)
+    issues, counts = collect_health_issues(repo)
     healthy = len(issues) == 0
     limiter = _rate_limiter(hass)
     rate_limit = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ warn_redundant_casts = true
 # integration stays at the non-strict baseline.
 [[tool.mypy.overrides]]
 module = [
+  "haventory.health",
   "haventory.models",
   "haventory.repository",
   "haventory.serialization",

--- a/stubs/homeassistant/config_entries.pyi
+++ b/stubs/homeassistant/config_entries.pyi
@@ -1,9 +1,20 @@
 from collections.abc import Callable, Coroutine, Mapping
+from enum import Enum
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
 class ConfigFlowResult(dict[str, Any]): ...
+
+class ConfigEntryState(Enum):
+    LOADED = "loaded"
+    SETUP_ERROR = "setup_error"
+    MIGRATION_ERROR = "migration_error"
+    SETUP_RETRY = "setup_retry"
+    NOT_LOADED = "not_loaded"
+    FAILED_UNLOAD = "failed_unload"
+    SETUP_IN_PROGRESS = "setup_in_progress"
+    UNLOAD_IN_PROGRESS = "unload_in_progress"
 
 class ConfigEntry:
     entry_id: str

--- a/stubs/homeassistant/helpers/issue_registry.pyi
+++ b/stubs/homeassistant/helpers/issue_registry.pyi
@@ -1,0 +1,40 @@
+from enum import StrEnum
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+class IssueSeverity(StrEnum):
+    CRITICAL = "critical"
+    ERROR = "error"
+    WARNING = "warning"
+
+class IssueEntry:
+    domain: str
+    issue_id: str
+    is_fixable: bool | None
+    severity: IssueSeverity | None
+    translation_key: str | None
+    translation_placeholders: dict[str, str] | None
+    def __getattr__(self, name: str) -> Any: ...
+
+class IssueRegistry:
+    def async_get_issue(self, domain: str, issue_id: str) -> IssueEntry | None: ...
+    def __getattr__(self, name: str) -> Any: ...
+
+def async_get(hass: HomeAssistant) -> IssueRegistry: ...
+def async_create_issue(
+    hass: HomeAssistant,
+    domain: str,
+    issue_id: str,
+    *,
+    breaks_in_ha_version: str | None = ...,
+    data: dict[str, str | int | float | None] | None = ...,
+    is_fixable: bool,
+    is_persistent: bool = ...,
+    issue_domain: str | None = ...,
+    learn_more_url: str | None = ...,
+    severity: IssueSeverity,
+    translation_key: str,
+    translation_placeholders: dict[str, str] | None = ...,
+) -> None: ...
+def async_delete_issue(hass: HomeAssistant, domain: str, issue_id: str) -> None: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ import os
 import sys
 import tempfile
 import types
+from collections.abc import Mapping
 from enum import StrEnum
 from pathlib import Path
 
@@ -794,6 +795,65 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
     ha_helpers_area_registry.async_get = async_get
     sys.modules["homeassistant.helpers.area_registry"] = ha_helpers_area_registry
+
+    # homeassistant.helpers.issue_registry — `__init__.py` imports it at module
+    # scope to raise the setup refusals in Settings -> Repairs. The stub records
+    # what was raised and cleared, keyed the way HA keys it, so an offline test
+    # can assert both without a registry to read.
+    ha_helpers_issue_registry = types.ModuleType("homeassistant.helpers.issue_registry")
+
+    class IssueSeverity(StrEnum):  # type: ignore[override]
+        CRITICAL = "critical"
+        ERROR = "error"
+        WARNING = "warning"
+
+    def _issues(hass: HomeAssistant) -> dict:  # type: ignore[override]
+        return hass.data.setdefault("__issue_registry__", {})
+
+    def async_create_issue(  # type: ignore[override]
+        hass: HomeAssistant, domain: str, issue_id: str, **kwargs
+    ) -> None:
+        _issues(hass)[(domain, issue_id)] = dict(kwargs)
+
+    def async_delete_issue(hass: HomeAssistant, domain: str, issue_id: str) -> None:  # type: ignore[override]
+        _issues(hass).pop((domain, issue_id), None)
+
+    ha_helpers_issue_registry.IssueSeverity = IssueSeverity
+    ha_helpers_issue_registry.async_create_issue = async_create_issue
+    ha_helpers_issue_registry.async_delete_issue = async_delete_issue
+    ha_helpers.issue_registry = ha_helpers_issue_registry
+    sys.modules["homeassistant.helpers.issue_registry"] = ha_helpers_issue_registry
+
+    # homeassistant.components.diagnostics — `diagnostics.py` imports the
+    # redaction helper at module scope. Verbatim from HA's `diagnostics/util.py`
+    # down to the two skips (a `None` and an empty string are left alone), so an
+    # offline assertion about what the payload leaks means what it says.
+    ha_diagnostics = types.ModuleType("homeassistant.components.diagnostics")
+    REDACTED = "**REDACTED**"
+
+    def async_redact_data(data, to_redact):  # type: ignore[override]
+        if not isinstance(data, (Mapping, list)):
+            return data
+        if isinstance(data, list):
+            return [async_redact_data(val, to_redact) for val in data]
+
+        redacted = {**data}
+        for key, value in redacted.items():
+            if value is None:
+                continue
+            if isinstance(value, str) and not value:
+                continue
+            if key in to_redact:
+                redacted[key] = REDACTED
+            elif isinstance(value, Mapping):
+                redacted[key] = async_redact_data(value, to_redact)
+            elif isinstance(value, list):
+                redacted[key] = [async_redact_data(item, to_redact) for item in value]
+        return redacted
+
+    ha_diagnostics.REDACTED = REDACTED
+    ha_diagnostics.async_redact_data = async_redact_data
+    sys.modules["homeassistant.components.diagnostics"] = ha_diagnostics
 
     # homeassistant.loader
     ha_loader = types.ModuleType("homeassistant.loader")

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -1,0 +1,72 @@
+"""Integration: the diagnostics platform, downloaded the way a user downloads it.
+
+The offline suite can call `async_get_config_entry_diagnostics` directly, which
+proves the payload and nothing about whether Home Assistant ever finds it. This
+goes through the real HTTP endpoint the ⋮ menu links to, so it also settles what
+the offline checkout cannot: that a diagnostics platform needs no manifest entry
+and that the payload survives Home Assistant's own JSON encoder.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from custom_components.haventory.const import CONF_CARD_TITLE, DOMAIN, INTEGRATION_VERSION
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.components.diagnostics import (
+    get_diagnostics_for_config_entry,
+)
+
+ITEM_ID = str(uuid.uuid4())
+LOCATION_ID = str(uuid.uuid4())
+CARD_TITLE = "Haus Hoffmann Vorratskammer"
+ITEM_NAME = "Zdrojova kniha 1987"
+LOCATION_NAME = "Kellerregal hinter der Heizung"
+
+
+def _store_data() -> dict:
+    return {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": {
+            ITEM_ID: {
+                "id": ITEM_ID,
+                "name": ITEM_NAME,
+                "quantity": 1,
+                "location_id": LOCATION_ID,
+            }
+        },
+        "locations": {LOCATION_ID: {"id": LOCATION_ID, "name": LOCATION_NAME}},
+    }
+
+
+async def test_the_download_reports_shape_and_never_content(
+    hass: HomeAssistant, hass_storage: dict, hass_client
+) -> None:
+    """Counts, versions, health and bundle state — and not one stored name."""
+
+    hass_storage[STORAGE_KEY] = {"version": 1, "key": STORAGE_KEY, "data": _store_data()}
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={}, options={CONF_CARD_TITLE: CARD_TITLE}, title="HAventory"
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    payload = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert payload["integration"]["version"] == INTEGRATION_VERSION
+    assert payload["storage"]["supported_schema_version"] == CURRENT_SCHEMA_VERSION
+    assert payload["storage"]["store_schema_version"] == CURRENT_SCHEMA_VERSION
+    assert payload["repository"]["loaded"] is True
+    assert payload["repository"]["counts"]["items_total"] == 1
+    assert payload["repository"]["health_issues"] == []
+    assert "repository" in payload["runtime"]["data_keys"]
+    assert "frontend_bundle" in payload
+
+    document = json.dumps(payload)
+    for secret in (ITEM_NAME, LOCATION_NAME, CARD_TITLE):
+        assert secret not in document, secret

--- a/tests/integration/test_repairs.py
+++ b/tests/integration/test_repairs.py
@@ -1,0 +1,138 @@
+"""Integration: the repairs issues and the guarded lossy load, against real Home Assistant.
+
+None of this is observable offline. The offline harness has no issue registry to
+read back, no repairs flow manager to run a fix through, and no config-entry
+machinery to reload — so the whole point of the feature (a card appears, the
+button works, the entry comes up) is asserted here or nowhere.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from custom_components.haventory.const import (
+    CONF_ALLOW_LOSSY_LOAD,
+    CORRUPT_BACKUP_STORAGE_KEY,
+    DOMAIN,
+    ISSUE_CORRUPT_STORE,
+    ISSUE_SCHEMA_DOWNGRADE,
+)
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
+from homeassistant.components.repairs import repairs_flow_manager
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+READABLE_ITEM_ID = str(uuid.uuid4())
+
+
+def _stored(data: dict) -> dict:
+    return {"version": 1, "key": STORAGE_KEY, "data": data}
+
+
+def _corrupt_store_data() -> dict:
+    """One item this build can read, one whose id is not a uuid and cannot be."""
+
+    return {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "items": {
+            READABLE_ITEM_ID: {"id": READABLE_ITEM_ID, "name": "Hammer", "quantity": 2},
+            "not-a-uuid": {"id": "not-a-uuid", "name": "Broken"},
+        },
+        "locations": {},
+    }
+
+
+async def _added_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_a_newer_store_leaves_a_non_fixable_issue(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The refusal reaches Settings → Repairs, and the file it refuses is untouched."""
+
+    stored = _stored({"schema_version": CURRENT_SCHEMA_VERSION + 1, "items": {}, "locations": {}})
+    hass_storage[STORAGE_KEY] = stored
+    before = dict(stored["data"])
+
+    entry = await _added_entry(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is False
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_SCHEMA_DOWNGRADE)
+    assert issue is not None
+    assert issue.is_fixable is False
+    assert issue.severity is ir.IssueSeverity.ERROR
+    assert hass_storage[STORAGE_KEY]["data"] == before
+
+
+async def test_a_corrupt_row_offers_a_fix_that_backs_up_reloads_and_clears(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The whole flow: refuse, offer, copy aside, opt in, reload, clear the card."""
+
+    assert await async_setup_component(hass, "repairs", {})
+    hass_storage[STORAGE_KEY] = _stored(_corrupt_store_data())
+
+    entry = await _added_entry(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is False
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE)
+    assert issue is not None
+    assert issue.is_fixable is True
+    assert issue.translation_placeholders["items"] == "1"
+
+    flow_manager = repairs_flow_manager(hass)
+    assert flow_manager is not None
+    result = await flow_manager.async_init(DOMAIN, data={"issue_id": ISSUE_CORRUPT_STORE})
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    result = await flow_manager.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # The copy is what makes the load reversible, and it holds the row the load
+    # dropped — a cleaned-up copy would be worth nothing.
+    backup = hass_storage[CORRUPT_BACKUP_STORAGE_KEY]["data"]
+    assert backup["items"]["not-a-uuid"]["name"] == "Broken"
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
+
+    # Loaded with the readable remainder, and the opt-in spent rather than kept.
+    repo = hass.data[DOMAIN]["repository"]
+    assert repo.get_counts()["items_total"] == 1
+    assert repo.get_item(READABLE_ITEM_ID).name == "Hammer"
+    assert CONF_ALLOW_LOSSY_LOAD not in entry.options
+
+
+async def test_a_clean_store_leaves_no_issue_behind(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The control: nothing to refuse means nothing in Repairs."""
+
+    hass_storage[STORAGE_KEY] = _stored(
+        {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "items": {READABLE_ITEM_ID: {"id": READABLE_ITEM_ID, "name": "Hammer"}},
+            "locations": {},
+        }
+    )
+
+    entry = await _added_entry(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, ISSUE_SCHEMA_DOWNGRADE) is None
+    assert registry.async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None

--- a/tests/test_diagnostics_offline.py
+++ b/tests/test_diagnostics_offline.py
@@ -1,0 +1,169 @@
+"""Offline tests for the config-entry diagnostics payload.
+
+The point of the module is what it does *not* carry: a diagnostics JSON is
+pasted into public bug reports, and an inventory is full of names, notes and
+custom fields nobody meant to publish. One test here walks the whole serialized
+payload looking for seeded content, which is what stops a future contributor
+from adding the dataset "just for debugging".
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from custom_components.haventory import diagnostics
+from custom_components.haventory.const import CONF_CARD_TITLE, DOMAIN
+from custom_components.haventory.models import ItemCreate
+from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+STORED_TITLE = "Haus Hoffmann Vorratskammer"
+STORED_ITEM = "Zdrojova kniha 1987"
+STORED_LOCATION = "Kellerregal hinter der Heizung"
+STORED_FIELD_VALUE = "Rechnung 44-2019"
+
+
+def _loaded_hass() -> tuple[HomeAssistant, ConfigEntry]:
+    """A domain bucket in the shape a set-up entry leaves it in."""
+
+    hass = HomeAssistant()
+    repo = Repository()
+    where = repo.create_location(name=STORED_LOCATION)
+    repo.create_item(
+        ItemCreate(
+            name=STORED_ITEM,
+            location_id=str(where.id),
+            custom_fields={"invoice": STORED_FIELD_VALUE},
+        )
+    )
+    hass.data[DOMAIN] = {
+        "store": DomainStore(hass, key=STORAGE_KEY, version=CURRENT_SCHEMA_VERSION),
+        "repository": repo,
+        "card_title": STORED_TITLE,
+        "rate_limiter": RateLimiter(RateLimitConfig.from_options(None)),
+    }
+    entry = ConfigEntry(options={CONF_CARD_TITLE: STORED_TITLE})
+    return hass, entry
+
+
+@pytest.mark.asyncio
+async def test_the_payload_answers_shape_questions() -> None:
+    """Counts, both schema numbers, the generation, the health verdict, the bucket's keys."""
+
+    hass, entry = _loaded_hass()
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["storage"] == {
+        "key": STORAGE_KEY,
+        "supported_schema_version": CURRENT_SCHEMA_VERSION,
+        "store_schema_version": CURRENT_SCHEMA_VERSION,
+    }
+    repository = payload["repository"]
+    assert repository["loaded"] is True
+    assert repository["counts"]["items_total"] == 1
+    assert repository["counts"]["locations_total"] == 1
+    assert repository["health_issues"] == []
+    assert repository["generation"] == hass.data[DOMAIN]["repository"].generation
+    assert payload["runtime"]["data_keys"] == [
+        "card_title",
+        "rate_limiter",
+        "repository",
+        "store",
+    ]
+    assert payload["runtime"]["rate_limit"] == {
+        "enabled": False,
+        "dropped_commands": 0,
+        "dropped_events": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_stored_content_reaches_the_payload() -> None:
+    """Not an item name, not a location name, not a custom-field value, at any depth.
+
+    Asserted over the serialized document rather than key by key: the risk is a
+    block added later, and only a whole-payload search sees one.
+    """
+
+    hass, entry = _loaded_hass()
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    document = json.dumps(payload, default=str)
+    for stored in (STORED_ITEM, STORED_LOCATION, STORED_FIELD_VALUE, STORED_TITLE):
+        assert stored not in document, stored
+
+
+@pytest.mark.asyncio
+async def test_the_card_title_is_redacted_rather_than_dropped() -> None:
+    """The option has to still be visible as set; only its text is withheld."""
+
+    hass, entry = _loaded_hass()
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert CONF_CARD_TITLE in payload["options"]
+    assert payload["options"][CONF_CARD_TITLE] != STORED_TITLE
+
+
+@pytest.mark.asyncio
+async def test_an_unloaded_entry_still_produces_a_payload() -> None:
+    """Home Assistant offers the download on an entry whose setup failed.
+
+    That is exactly when it is worth having, so the repository block reports
+    that there is nothing loaded instead of the whole call raising.
+    """
+
+    hass = HomeAssistant()
+    hass.data[DOMAIN] = {}
+    entry = ConfigEntry()
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["repository"] == {
+        "loaded": False,
+        "counts": None,
+        "generation": None,
+        "health_issues": None,
+    }
+    assert payload["storage"]["store_schema_version"] is None
+    assert payload["storage"]["key"] == STORAGE_KEY
+    assert payload["runtime"]["data_keys"] == []
+    assert payload["runtime"]["rate_limit"] is None
+    assert payload["options"] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_missing_card_bundle_is_reported_as_missing(monkeypatch, tmp_path) -> None:
+    """A missing bundle is the first answer to "the card will not render"."""
+
+    hass, entry = _loaded_hass()
+    monkeypatch.setattr(diagnostics, "_CARD_BUNDLE_PATH", tmp_path / "haventory-card.js")
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["frontend_bundle"] == {
+        "filename": "haventory-card.js",
+        "exists": False,
+        "size_bytes": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_deployed_card_bundle_reports_its_size(monkeypatch, tmp_path) -> None:
+    """A zero-byte or truncated bundle looks the same as a missing one to a browser."""
+
+    hass, entry = _loaded_hass()
+    bundle = tmp_path / "haventory-card.js"
+    bundle.write_text("console.log('hi')\n", encoding="utf-8")
+    monkeypatch.setattr(diagnostics, "_CARD_BUNDLE_PATH", bundle)
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["frontend_bundle"]["exists"] is True
+    assert payload["frontend_bundle"]["size_bytes"] == bundle.stat().st_size

--- a/tests/test_health_offline.py
+++ b/tests/test_health_offline.py
@@ -1,0 +1,83 @@
+"""Offline tests for the repository consistency checks in `health.py`.
+
+The checks used to be private helpers inside `ws.py`; two callers ask the same
+question now, so they answer from one module. What they report has to be exactly
+what it was — these tests pin the healthy case, one index drift, and each of the
+four count comparisons.
+"""
+
+from __future__ import annotations
+
+from custom_components.haventory.health import collect_health_issues
+from custom_components.haventory.models import ItemCreate, ItemUpdate
+from custom_components.haventory.repository import Repository
+
+
+def _seeded() -> tuple[Repository, str]:
+    """A repository with a location, a plain item and a checked-out one."""
+
+    repo = Repository()
+    where = repo.create_location(name="Garage")
+    repo.create_item(ItemCreate(name="Drill", location_id=str(where.id)))
+    borrowed = repo.create_item(ItemCreate(name="Ladder", location_id=str(where.id)))
+    repo.update_item(str(borrowed.id), ItemUpdate(checked_out=True))
+    return repo, str(borrowed.id)
+
+
+def test_a_consistent_repository_reports_nothing() -> None:
+    """The healthy answer is an empty list, and the counts it was checked against."""
+
+    repo, _ = _seeded()
+
+    issues, counts = collect_health_issues(repo)
+
+    assert issues == []
+    indexes = repo._debug_get_internal_indexes()
+    assert counts["items_total"] == len(indexes["items_by_id"])
+    assert counts["locations_total"] == len(indexes["locations_by_id"])
+    assert counts["checked_out_count"] == len(indexes["checked_out_item_ids"])
+
+
+def test_an_item_missing_from_the_checked_out_index_is_reported() -> None:
+    """Drift between an item and the index that is supposed to list it.
+
+    Nothing in the repository can produce this; the checks exist because a bug
+    in it could, and a silent disagreement is the kind that survives a release.
+    """
+
+    repo, borrowed_id = _seeded()
+    repo._debug_get_internal_indexes()["checked_out_item_ids"].discard(borrowed_id)
+
+    issues, _ = collect_health_issues(repo)
+
+    assert "checked_out_item_missing_from_index" in issues
+
+
+def test_every_count_is_compared_against_the_collection_it_summarises(monkeypatch) -> None:
+    """All four count checks fire when the served numbers stop matching.
+
+    The counts come off the same collections the checks measure, so a genuine
+    disagreement is unreachable from outside — which is the point of asserting
+    the comparison itself rather than hoping it is exercised elsewhere.
+    """
+
+    repo, _ = _seeded()
+    monkeypatch.setattr(
+        Repository,
+        "get_counts",
+        lambda _self: {
+            "items_total": 99,
+            "locations_total": 99,
+            "checked_out_count": 99,
+            "low_stock_count": 99,
+        },
+    )
+
+    issues, _ = collect_health_issues(repo)
+
+    assert set(issues) == {
+        "items_total_count_mismatch",
+        "locations_total_count_mismatch",
+        "checked_out_count_mismatch",
+        "low_stock_count_mismatch",
+    }

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -8,9 +8,15 @@ from copy import deepcopy
 import custom_components.haventory as haven_init
 import pytest
 from custom_components.haventory.const import (
+    CONF_ALLOW_LOSSY_LOAD,
     CONF_CARD_TITLE,
     CONF_QUICK_FILTERS,
+    CORRUPT_BACKUP_STORAGE_KEY,
     DEFAULT_CARD_TITLE,
+    ISSUE_CORRUPT_SCHEMA_VERSION,
+    ISSUE_CORRUPT_STORE,
+    ISSUE_SCHEMA_DOWNGRADE,
+    REPAIR_ISSUE_IDS,
 )
 from custom_components.haventory.exceptions import (
     CorruptSchemaVersionError,
@@ -18,7 +24,7 @@ from custom_components.haventory.exceptions import (
 )
 from custom_components.haventory.models import ItemCreate
 from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
@@ -309,3 +315,167 @@ async def test_setup_entry_accepts_a_readable_store(monkeypatch) -> None:
 
     assert await haven_init.async_setup_entry(hass, entry) is True
     assert isinstance(hass.data[haven_init.DOMAIN]["repository"], Repository)
+
+
+def _issues(hass: HomeAssistant) -> dict:
+    """What the offline issue-registry stub recorded, keyed as HA keys it."""
+
+    return hass.data.get("__issue_registry__") or {}
+
+
+class _ConfigEntries:
+    """The one config-entry API setup calls: writing the options back.
+
+    The offline `HomeAssistant` stub has no registry at all, which is how the
+    other setup tests get away without one — but the lossy-load opt-in is spent
+    through exactly this call, so the test that asserts it is spent has to
+    provide it.
+    """
+
+    def __init__(self) -> None:
+        self.updates: list[dict] = []
+
+    def async_update_entry(self, entry: ConfigEntry, *, options: dict) -> None:
+        entry.options = dict(options)
+        self.updates.append(dict(options))
+
+
+def _corrupt_payload() -> dict:
+    return {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "locations": {},
+        "items": {
+            "not-a-uuid": {"id": "not-a-uuid", "name": "Broken"},
+            "also-not-a-uuid": {"id": "also-not-a-uuid", "name": "Also broken"},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_newer_store_also_reaches_settings_repairs(monkeypatch) -> None:
+    """The entry's error state is one screen; Repairs is the one users are sent to."""
+
+    hass = HomeAssistant()
+    entry = ConfigEntry()
+
+    async def _newer(self):  # type: ignore[no-untyped-def]
+        return {"schema_version": CURRENT_SCHEMA_VERSION + 1, "items": {}, "locations": {}}
+
+    monkeypatch.setattr(DomainStore, "async_load", _newer)
+
+    with pytest.raises(ConfigEntryError):
+        await haven_init.async_setup_entry(hass, entry)
+
+    issue = _issues(hass)[(haven_init.DOMAIN, ISSUE_SCHEMA_DOWNGRADE)]
+    assert issue["is_fixable"] is False
+    assert issue["severity"] == "error"
+    assert str(CURRENT_SCHEMA_VERSION + 1) in issue["translation_placeholders"]["error"]
+    assert issue["translation_placeholders"]["storage_key"] == STORAGE_KEY
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_schema_version_reaches_settings_repairs(monkeypatch) -> None:
+    """Its own id, so restoring a store fixes one card rather than leaving the wrong one."""
+
+    hass = HomeAssistant()
+    entry = ConfigEntry()
+
+    async def _corrupt_version(self):  # type: ignore[no-untyped-def]
+        raise CorruptSchemaVersionError("stored data has a corrupt schema_version (None)")
+
+    monkeypatch.setattr(DomainStore, "async_load", _corrupt_version)
+
+    with pytest.raises(ConfigEntryError):
+        await haven_init.async_setup_entry(hass, entry)
+
+    assert (haven_init.DOMAIN, ISSUE_CORRUPT_SCHEMA_VERSION) in _issues(hass)
+    assert (haven_init.DOMAIN, ISSUE_SCHEMA_DOWNGRADE) not in _issues(hass)
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_store_offers_the_fixable_issue(monkeypatch) -> None:
+    """The only fixable one: the readable remainder is intact, so going on is a choice."""
+
+    hass = HomeAssistant()
+    entry = ConfigEntry()
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return deepcopy(_corrupt_payload())
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    with pytest.raises(ConfigEntryError):
+        await haven_init.async_setup_entry(hass, entry)
+
+    issue = _issues(hass)[(haven_init.DOMAIN, ISSUE_CORRUPT_STORE)]
+    assert issue["is_fixable"] is True
+    assert issue["severity"] == "warning"
+    assert issue["translation_placeholders"]["items"] == "2"
+    assert issue["translation_placeholders"]["backup_key"] == CORRUPT_BACKUP_STORAGE_KEY
+
+
+@pytest.mark.asyncio
+async def test_a_store_that_loads_clears_every_issue(monkeypatch) -> None:
+    """A card describing a store the integration just read is a card that lies."""
+
+    hass = HomeAssistant()
+    entry = ConfigEntry()
+    hass.data["__issue_registry__"] = {
+        (haven_init.DOMAIN, issue_id): {} for issue_id in REPAIR_ISSUE_IDS
+    }
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+    assert _issues(hass) == {}
+
+
+@pytest.mark.asyncio
+async def test_the_repair_option_loads_the_readable_remainder(monkeypatch, caplog) -> None:
+    """What the fix flow buys: the same store, loaded, minus what could not be read."""
+
+    hass = HomeAssistant()
+    hass.config_entries = _ConfigEntries()
+    entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True})
+    payload = _corrupt_payload()
+    payload["items"]["11111111-1111-4111-8111-111111111111"] = {
+        "id": "11111111-1111-4111-8111-111111111111",
+        "name": "Readable",
+        "quantity": 1,
+    }
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return deepcopy(payload)
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+    caplog.set_level(logging.WARNING)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+
+    repository = hass.data[haven_init.DOMAIN]["repository"]
+    assert repository.get_counts()["items_total"] == 1
+    assert any("as the repair asked" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_the_repair_option_is_spent_on_the_boot_it_buys(monkeypatch) -> None:
+    """Left set, it would silently accept the next corruption too — a standing waiver."""
+
+    hass = HomeAssistant()
+    hass.config_entries = _ConfigEntries()
+    entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True, CONF_CARD_TITLE: "Pantry"})
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return deepcopy(_corrupt_payload())
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+
+    assert CONF_ALLOW_LOSSY_LOAD not in entry.options
+    # The rest of the options survive the edit; only the opt-in is taken back.
+    assert entry.options[CONF_CARD_TITLE] == "Pantry"
+    assert (haven_init.DOMAIN, ISSUE_CORRUPT_STORE) not in _issues(hass)

--- a/tests/test_storage_offline.py
+++ b/tests/test_storage_offline.py
@@ -28,6 +28,7 @@ from custom_components.haventory.storage import (
     CURRENT_SCHEMA_VERSION,
     STORE_COLLECTIONS,
     DomainStore,
+    async_backup_store,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store as HAStore
@@ -616,3 +617,38 @@ async def test_save_does_not_duplicate_the_dataset(monkeypatch) -> None:
     assert len(seen) == 1
     for name in STORE_COLLECTIONS:
         assert seen[0][name] is payload[name], name
+
+
+@pytest.mark.asyncio
+async def test_the_backup_copies_the_file_as_it_is() -> None:
+    """The corrupt-store repair needs the unreadable rows, not a cleaned-up version.
+
+    `DomainStore` migrates, normalizes and refuses; a copy taken through it
+    would leave out exactly what the user might want back, or refuse to take one
+    at all. So the backup goes straight to Home Assistant's `Store`.
+    """
+
+    hass = HomeAssistant()
+    source_key = "test_backup_source"
+    backup_key = "test_backup_target"
+    stored = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "locations": {},
+        "items": {"not-a-uuid": {"id": "not-a-uuid", "name": "Broken"}},
+    }
+    await HAStore(hass, 1, source_key).async_save(deepcopy(stored))
+
+    assert await async_backup_store(hass, source_key=source_key, backup_key=backup_key) is True
+
+    assert await HAStore(hass, 1, backup_key).async_load() == stored
+    # And the original is where it was: the copy is a copy, not a move.
+    assert await HAStore(hass, 1, source_key).async_load() == stored
+
+
+@pytest.mark.asyncio
+async def test_the_backup_reports_that_there_was_nothing_to_copy() -> None:
+    """No stored file means no guard to offer, which the caller has to be able to see."""
+
+    hass = HomeAssistant()
+
+    assert await async_backup_store(hass, source_key="test_backup_absent") is False


### PR DESCRIPTION
## Summary

Three HA-idiomatic surfaces the integration was missing, plus the module move the first of
them needs.

- **`diagnostics.py`** — config-entry diagnostics, reachable from the entry's ⋮ menu.
  Aggregates only: `INTEGRATION_VERSION`, the supported and running schema numbers, the
  repository counts, its generation, the index-health verdict, the sorted
  `hass.data[DOMAIN]` **key names**, the entry's options with `card_title` redacted, and
  whether the built card bundle is on disk and how big it is. No item or location bodies at
  any depth.
- **`health.py`** — `_collect_health_issues` and its `_check_*` helpers move out of `ws.py`
  as `collect_health_issues`. Diagnostics and `haventory/health` ask the same question, and
  having the diagnostics platform import the WebSocket layer inverts the dependency.
  `ws_health` is otherwise unchanged.
- **Repairs** — the three setup refusals now put a card in Settings → Repairs beside the
  entry's error state. The two schema refusals are informational (`ERROR`, not fixable);
  the corrupt-row refusal is **fixable** (`WARNING`), and its flow copies the store to
  `.storage/haventory_store_corrupt_backup`, sets a one-boot `allow_lossy_load` option and
  reloads. Setup honours that option, loads the readable remainder, spends the option, and
  clears every issue id whenever a store reads cleanly.

The two bullets #225 also lists were already done and are untouched here:
`single_config_entry: true` is in the manifest (pinned by
`test_manifest_declares_single_config_entry`), and `entry.runtime_data` is split out as
#280 for V0.7.0.

Closes #225

## Decisions taken against the code

The 2026-08-05 implementation notes were written against a much older tree. Where they had
drifted:

1. **The schema issues carry `{error}` + `{storage_key}`, not the two version numbers.**
   The notes asked for "the stored and supported versions as placeholders". Neither
   `SchemaDowngradeError` nor `CorruptSchemaVersionError` carries them structurally — only
   inside the message — and both messages are already written for a user and already name
   whatever disagreed (`schema_downgrade_message`, `_corrupt_schema_version_message`).
   Handing the message over whole keeps one wording for the entry's error state and the
   Repairs card; splitting it would have meant a second wording to keep true. The card
   still says exactly which versions disagree — see the live evidence below.
2. **`store_schema_version` and `supported_schema_version` are equal whenever the entry is
   loaded.** The notes describe them as a pair worth comparing; in the tree
   `DomainStore.schema_version` *is* the version this build supports (it is the constructor
   argument), and a payload on any other version is either migrated or refused before a
   store reaches the bucket. Both are reported anyway: `null` for the store version is the
   signal that setup never got that far, which is the state diagnostics is most useful in.
3. **The backup helper lives in `storage.py`, not `repairs.py`.** `async_backup_store` goes
   straight to Home Assistant's `Store`, deliberately around `DomainStore` — which
   migrates, normalizes and refuses the very payloads worth copying. Keeping it in
   `storage.py` also makes it offline-testable; `repairs.py` cannot be imported offline at
   all, since nothing in the package imports it and HA loads it on demand.
4. **The fix flow finds its entry through `async_entries(DOMAIN)`, not an issue `data`
   payload.** `single_config_entry` means there is exactly one, so the flow carries no id
   that could go stale between the refusal and the button press.
5. **A failed reload aborts the flow instead of completing it.** Home Assistant deletes an
   issue whenever a fix flow ends any way other than `ABORT`, so completing on a reload
   that did not come up would take the card away while the integration is still down.
   Three abort reasons are translated: `reload_failed`, `backup_failed`, `no_config_entry`.
6. **`is_persistent=False` on all three.** Each issue describes the last setup attempt, and
   setup runs every boot; a stored copy would outlive a store the user has since restored.
7. **No new manifest dependency for the repairs platform.** Core integrations that ship a
   `repairs.py` (`anthropic`, `backblaze_b2`, `bthome`) do not declare `repairs`, and
   hassfest on this PR is the check that settles it — as §4 of the session plan says it
   should be.
8. **`haventory.health` joins the per-module strict mypy list.** The code was strict-checked
   inside `ws.py`; moving it out would have quietly dropped it to the baseline.
9. **One wording fix found only by running it.** The confirm step first read "Selecting
   **Submit** …"; Home Assistant renders an empty-schema form's button as **OK**. It now
   says "Confirming copies …", which is true in every language.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1084 passed, 22
  skipped**; `uv run ruff check .` clean; `uv run ruff format --check .` → 166 files already
  formatted; `uv run mypy` → no issues in 24 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
  `npx vitest run` → **1843 passed** across 62 files, `npm run build` → 605.51 kB bundle.
  No card change here; the gate runs because the commit gate wants both halves.
- [x] phacc: `scripts/test_integration.sh` → **93 passed** (89 before this PR, plus the 4
  new cases), run in the `ghcr.io/astral-sh/uv:python3.14-bookworm` container this Windows
  host needs.

New tests:

| file | covers |
|---|---|
| `tests/test_health_offline.py` | the healthy verdict, one index drift, and all four count comparisons still firing after the move |
| `tests/test_diagnostics_offline.py` | the payload's shape; **no seeded name, note or custom-field value anywhere in `json.dumps(payload)`**; the redacted title; an unloaded entry; bundle present and absent |
| `tests/test_init_offline.py` (+6) | each refusal raising its own issue with the right severity and fixability; a clean store deleting all three ids; the opt-in loading the remainder and being spent, leaving the other options alone |
| `tests/test_storage_offline.py` (+2) | the backup copying the file verbatim (unreadable rows included) and leaving the original; reporting when there was nothing to copy |
| `tests/integration/test_diagnostics.py` | the platform being reachable over the real `/api/diagnostics/config_entry/…` endpoint, and its output surviving HA's JSON encoder |
| `tests/integration/test_repairs.py` | the downgrade issue landing with the store untouched; the whole fix flow — refuse → offer → copy → opt in → reload → clear; a clean store leaving no issue |

One local-only failure worth naming:
`test_no_unregistered_file_states_an_interpreter_version` fails on this machine because
that test sweeps the working directory and this checkout carries `.claude/settings.local.json`
(ignored by the developer's *global* gitignore, so invisible to the repo and to CI) plus
other sessions' stale `.claude/worktrees/`. Re-run on a clean copy of the same tree inside
the container: **1084 passed, 0 failed**. CI is the final word.

## Live verification (dev Docker HA, real store: 1087 items / 89 locations)

**A — diagnostics download.** The entry's ⋮ menu carries "Download diagnostics" (the German
dev instance shows *Diagnosedaten herunterladen*, between *Eintrag-ID kopieren* and
*Systemoptionen*). `GET /api/diagnostics/config_entry/<id>` → `200`, **3982 bytes** for a
1087-item inventory. Every distinct string in the live store was checked against the
document — 1086 item names, 81 location names, 318 descriptions, 178 custom-field values —
and **none of them appear**. `card_title` reads `**REDACTED**`. `frontend_bundle` reports
`exists: true, size_bytes: 605515`; `health_issues: []`.

**B — a store hand-stamped above `CURRENT_SCHEMA_VERSION`.** HA stopped, `schema_version`
set to 9, HA started. Entry → `setup_error`. Settings → Repairs shows one card, severity
*Fehler*, with no Fix button and only *Ignorieren*:

> **HAventory cannot read the stored data**
>
> HAventory stopped instead of setting up: stored data uses schema version 9, which is
> newer than this build supports (8); HAventory will not downgrade it. Upgrade HAventory to
> a version that understands this data, or restore a backup taken with this version. The
> stored data was left unchanged.
>
> The file is `.storage/haventory_store` in your Home Assistant configuration directory,
> and it has been left exactly as it was. This card clears itself once HAventory starts
> against a store it can read.

The store is byte-identical across the refusal — `md5 a00848a6bd57cb0afa2added42816286`
before and after, still `schema_version: 9`, still 1087 items.

**C — a store with corrupt rows, and the fix.** Two rows keyed by non-uuids injected into
the real 1087-item store. Entry → `setup_error` with the corrupt-store message naming both
ids. Settings → Repairs shows one card, severity *Warnung*, which opens straight into the
fix flow:

> **Load HAventory without the unreadable entries**
>
> HAventory could not read 2 item(s) and 0 location(s), and found 0 location(s) whose parent
> chain loops back on itself. It stopped rather than load the rest — it saves on every
> change, and the first edit would rewrite the file without them.
>
> Confirming copies `.storage/haventory_store` to `.storage/haventory_store_corrupt_backup`
> and then starts HAventory with everything it could read. The unreadable entries stay out,
> and the copy is how you get them back.
>
> To keep them instead, close this dialog and repair those entries in the stored file, or
> restore it from a backup.

Confirming it produced, in order:

- `WARNING … Loading a store this build cannot fully read, as the repair asked`
- `.storage/haventory_store_corrupt_backup` written — **1089 item rows, both corrupt ones
  present** (`not-a-uuid-row`, `second-broken-row`)
- entry → `loaded`; the HAventory sidebar entry came back; Repairs went to *Aktuell stehen
  keine Reparaturen an* and the dialog reported *Das Problem ist behoben!*
- `haventory/stats` → `items_total: 1087` — the readable remainder, the two broken rows out
- `.storage/haventory_store` still holds all **1089** rows: the load destroys nothing, the
  first mutation would
- `core.config_entries` shows `allow_lossy_load` gone and `card_title`, `quick_filters`,
  `sidebar_panel_enabled`, `todo_entity_id` and all nine rate-limit options intact — the
  opt-in was spent, nothing else touched

The dev store was restored from a snapshot afterwards: 1087 items, 89 locations,
`haventory/health` healthy, entry `loaded`, no repairs, backup file removed.

**Screenshots.** Four PNGs were captured for A, B and C (the ⋮ menu, the downgrade card, the
confirm step, the success state). Publishing them to an `assets/` branch — this repo's usual
route, since GitHub's image upload is web-UI only — was refused by the sandbox on this run,
so the card text is transcribed verbatim above instead. The files are on the owner's machine
under the session scratchpad if they should be attached.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed — `README.md` Troubleshooting gains where Repairs
  shows up, what the Fix button does, and what the diagnostics download does and does not
  carry.
- [x] WebSocket API unchanged — `ws_health` keeps its result shape, so
  `docs/backend_api_contract.md` and `docs/data_shapes.md` need no edit.
- [x] Essential invariants preserved. No file under `custom_components/haventory/` was
  deleted or renamed — the health helpers move between two modules that both ship — so
  `RETIRED_PATHS` is untouched.

## Follow-ups

- The corrupt-store repair is offered whenever setup refuses, including on a store with *no*
  readable rows at all; confirming it then loads an empty inventory with the copy as the only
  record. Not filed as an issue: it is a strictly better outcome than the refusal it
  replaces, and the copy makes it reversible either way.
- `Repository._debug_get_internal_indexes()` is now called from `health.py` rather than from
  inside `ws.py`. The name still says what it is and no lint rule objects, but a public
  accessor would read better the next time that area is touched.
