### PR TITLE
fix(storage): spend the lossy-load opt-in on every load and make the repair stick

### DIFF
--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -79,6 +79,7 @@ from .storage import (
     CURRENT_SCHEMA_VERSION,
     STORAGE_KEY,
     DomainStore,
+    async_backup_store,
     async_persist_immediate,
     cancel_pending_persist,
     read_schema_version,
@@ -155,6 +156,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     repository = await _async_load_repository(hass, entry, store)
     hass.data[DOMAIN]["repository"] = repository
+
+    # A load that had to leave rows behind has to reach the file, or the next
+    # restart meets the same rows and refuses all over again.
+    await _async_settle_lossy_load(hass, store, repository)
 
     # Whatever the previous boot left in Settings → Repairs described a store this
     # one just read, so none of it is true any more.
@@ -293,11 +298,66 @@ async def _async_load_repository(
             # the option this branch reads.
             _create_corrupt_store_issue(hass, load_report, store_key=store.key)
             raise ConfigEntryError(_corrupt_store_message(load_report, store_key=store.key))
-        # Spend the opt-in here, ahead of the update listener setup registers
-        # afterwards, so clearing it cannot bounce the entry through a reload of
-        # its own. One boot is all it buys: the next corruption is a new decision.
-        _clear_lossy_load_option(hass, entry)
+    # Spend the opt-in on any load that reaches here, not only the corrupt one it
+    # was set for. A reload landing on a store that reads fine — a backup put
+    # back by hand before the button was pressed, or a later boot after the fix
+    # flow's own reload failed — would otherwise leave it armed, and the next
+    # corruption would then load lossily with nobody having asked. Ahead of the
+    # update listener setup registers afterwards, so clearing it cannot bounce
+    # the entry through a reload of its own.
+    _clear_lossy_load_option(hass, entry)
     return repository
+
+
+async def _async_settle_lossy_load(
+    hass: HomeAssistant, store: DomainStore, repository: Repository
+) -> None:
+    """Write the store back the way it was just read, when rows had to be dropped.
+
+    A lossy load leaves the unreadable rows on disk, so the refusal and its card
+    come back on the next restart unless something happens to persist first — the
+    repair would hold only until the household restarts Home Assistant, and the
+    copy it took would be the only sign it ever ran.
+
+    A copy is taken here as well as in the repair flow, so no path can write the
+    readable remainder over the file while the rows it left out exist nowhere. It
+    is the same raw copy under the same key: the store has not changed since the
+    flow took its own, so the second write is the same bytes.
+    """
+
+    if not repository.last_load_report.has_corruption:
+        return
+
+    try:
+        copied = await async_backup_store(hass, source_key=store.key)
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.exception(
+            "Failed to copy the HAventory store aside after loading it with unreadable rows",
+            extra={"domain": DOMAIN, "op": "settle_lossy_load"},
+        )
+        copied = False
+    if not copied:
+        # Leaving the file as it is keeps the rows recoverable, at the price of
+        # meeting the same refusal on the next restart. The alternative writes
+        # the only copy of them away.
+        LOGGER.error(
+            "Loaded a store with unreadable rows but could not copy it aside, so it "
+            "was left as it is; the same rows will stop the next start-up",
+            extra={"domain": DOMAIN, "op": "settle_lossy_load"},
+        )
+        return
+
+    await async_persist_immediate(hass)
+    LOGGER.warning(
+        "Rewrote the HAventory store without the rows this build cannot read",
+        extra={
+            "domain": DOMAIN,
+            "op": "settle_lossy_load",
+            "dropped_items": len(repository.last_load_report.dropped_item_ids),
+            "dropped_locations": len(repository.last_load_report.dropped_location_ids),
+            "backup_key": CORRUPT_BACKUP_STORAGE_KEY,
+        },
+    )
 
 
 async def _async_forward_platforms(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -1139,11 +1199,17 @@ def _lossy_load_allowed(entry: ConfigEntry) -> bool:
 
 
 def _clear_lossy_load_option(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Take the one-boot opt-in back off the entry.
+    """Take the one-boot opt-in back off the entry, where one is still on it.
+
+    Returns early when there is nothing to spend, so the ordinary boot — every
+    boot — does not write the entry back unchanged.
 
     Guarded with getattr for the offline test harness, whose HomeAssistant stub
     has no config-entry registry — the same reason the platform forwarding is.
     """
+
+    if not _lossy_load_allowed(entry):
+        return
 
     config_entries = getattr(hass, "config_entries", None)
     update = getattr(config_entries, "async_update_entry", None)

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -119,8 +119,11 @@ REPAIR_ISSUE_IDS: tuple[str, ...] = (
 )
 
 # Set by the corrupt-store repair, read by the setup its reload triggers, and
-# cleared there. Opting in to a lossy load is a decision about one boot: leaving
-# it set would silently accept the next corruption too.
+# cleared by any setup that gets as far as a loaded repository — including one
+# that finds nothing wrong, which is where a hand-restored backup lands. Opting
+# in to a lossy load is a decision about one boot: left on the entry it would
+# silently accept the next corruption too, and that one would arrive with no
+# copy of the store taken and no card raised.
 CONF_ALLOW_LOSSY_LOAD: str = "allow_lossy_load"
 
 # Where that repair copies the raw store before the lossy load. Loading destroys

--- a/tests/integration/test_repairs.py
+++ b/tests/integration/test_repairs.py
@@ -136,3 +136,72 @@ async def test_a_clean_store_leaves_no_issue_behind(
     registry = ir.async_get(hass)
     assert registry.async_get_issue(DOMAIN, ISSUE_SCHEMA_DOWNGRADE) is None
     assert registry.async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
+
+
+async def test_the_repair_survives_a_restart_with_no_mutation_in_between(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """A household that repairs and then restarts must not land back at the refusal.
+
+    The lossy load leaves the unreadable rows on disk unless something writes the
+    store, and nothing does until the next edit — so a repair that visibly worked
+    came undone at the next start-up, with the backup file the only sign it ran.
+    """
+
+    assert await async_setup_component(hass, "repairs", {})
+    hass_storage[STORAGE_KEY] = _stored(_corrupt_store_data())
+
+    entry = await _added_entry(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is False
+    await hass.async_block_till_done()
+
+    flow_manager = repairs_flow_manager(hass)
+    assert flow_manager is not None
+    result = await flow_manager.async_init(DOMAIN, data={"issue_id": ISSUE_CORRUPT_STORE})
+    result = await flow_manager.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # The file now holds what was loaded, and the row it lost is in the copy.
+    assert set(hass_storage[STORAGE_KEY]["data"]["items"]) == {READABLE_ITEM_ID}
+    assert "not-a-uuid" in hass_storage[CORRUPT_BACKUP_STORAGE_KEY]["data"]["items"]
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
+    assert hass.data[DOMAIN]["repository"].get_counts()["items_total"] == 1
+
+
+async def test_a_clean_load_spends_an_opt_in_left_on_the_entry(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """Where the waiver lingers is where it is most dangerous.
+
+    A backup restored by hand before the button is pressed, or a boot after the
+    flow's own reload failed, both land on a store that reads fine — and an
+    opt-in left armed there is spent by the *next* corruption, which then loads
+    with no copy taken and no card raised.
+    """
+
+    hass_storage[STORAGE_KEY] = _stored(
+        {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "items": {READABLE_ITEM_ID: {"id": READABLE_ITEM_ID, "name": "Hammer"}},
+            "locations": {},
+        }
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={}, title="HAventory", options={CONF_ALLOW_LOSSY_LOAD: True}
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert CONF_ALLOW_LOSSY_LOAD not in entry.options

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -479,3 +479,114 @@ async def test_the_repair_option_is_spent_on_the_boot_it_buys(monkeypatch) -> No
     # The rest of the options survive the edit; only the opt-in is taken back.
     assert entry.options[CONF_CARD_TITLE] == "Pantry"
     assert (haven_init.DOMAIN, ISSUE_CORRUPT_STORE) not in _issues(hass)
+
+
+@pytest.mark.asyncio
+async def test_a_clean_load_spends_a_leftover_repair_option(monkeypatch) -> None:
+    """The option only lingers where it is most dangerous: on a store that reads fine.
+
+    That is where a restored backup and a failed reload both land, and a waiver
+    left armed there is spent by the *next* corruption — which arrives with no
+    copy of the store taken and no card raised.
+    """
+
+    hass = HomeAssistant()
+    hass.config_entries = _ConfigEntries()
+    entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True, CONF_CARD_TITLE: "Pantry"})
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+
+    assert CONF_ALLOW_LOSSY_LOAD not in entry.options
+    assert entry.options[CONF_CARD_TITLE] == "Pantry"
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_boot_does_not_write_the_entry_back(monkeypatch) -> None:
+    """Nothing to spend means nothing to write: every boot would otherwise touch the entry."""
+
+    hass = HomeAssistant()
+    registry = _ConfigEntries()
+    hass.config_entries = registry
+    entry = ConfigEntry(options={CONF_CARD_TITLE: "Pantry"})
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+
+    assert registry.updates == []
+
+
+@pytest.mark.asyncio
+async def test_a_lossy_load_rewrites_the_store_it_could_not_fully_read(monkeypatch) -> None:
+    """Otherwise the repair holds until the next restart and no further.
+
+    The lossy load leaves the unreadable rows on disk, so a household that
+    repairs, sees it work and restarts that evening meets the same refusal —
+    with a backup file that looks like the only thing the repair did.
+    """
+
+    hass = HomeAssistant()
+    hass.config_entries = _ConfigEntries()
+    entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True})
+    key = "test_init_lossy_load_rewrites"
+    monkeypatch.setattr(haven_init, "STORAGE_KEY", key)
+
+    payload = _corrupt_payload()
+    payload["items"]["11111111-1111-4111-8111-111111111111"] = {
+        "id": "11111111-1111-4111-8111-111111111111",
+        "name": "Readable",
+        "quantity": 1,
+    }
+    raw_store = HAStore(hass, DomainStore.HA_STORE_VERSION, key)
+    await raw_store.async_save(deepcopy(payload))
+    backup = HAStore(hass, DomainStore.HA_STORE_VERSION, CORRUPT_BACKUP_STORAGE_KEY)
+    await backup.async_remove()
+
+    try:
+        assert await haven_init.async_setup_entry(hass, entry) is True
+
+        written = await raw_store.async_load()
+        assert set(written["items"]) == {"11111111-1111-4111-8111-111111111111"}
+        # The rows that just left the store are in the copy, which is what makes
+        # rewriting it something other than deleting them.
+        assert set((await backup.async_load())["items"]) == set(payload["items"])
+    finally:
+        # The stub's backing dict is module-global, so a copy left under the real
+        # key would outlive this test.
+        await backup.async_remove()
+
+
+@pytest.mark.asyncio
+async def test_a_lossy_load_that_cannot_be_copied_leaves_the_store_alone(
+    monkeypatch, caplog
+) -> None:
+    """No copy, no rewrite: the rows stay recoverable at the price of one more refusal."""
+
+    hass = HomeAssistant()
+    hass.config_entries = _ConfigEntries()
+    entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True})
+    key = "test_init_lossy_load_no_copy"
+    monkeypatch.setattr(haven_init, "STORAGE_KEY", key)
+
+    payload = _corrupt_payload()
+    raw_store = HAStore(hass, DomainStore.HA_STORE_VERSION, key)
+    await raw_store.async_save(deepcopy(payload))
+
+    async def _no_copy(_hass, **_kwargs):  # type: ignore[no-untyped-def]
+        return False
+
+    monkeypatch.setattr(haven_init, "async_backup_store", _no_copy)
+    caplog.set_level(logging.ERROR)
+
+    assert await haven_init.async_setup_entry(hass, entry) is True
+
+    assert await raw_store.async_load() == payload
+    assert any("could not copy it aside" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

Three linked defects in the corrupt-store repair #454 shipped, all reproduced on the dev container during the V0.6.0 pre-release audit.

1. **A clean load never spent `allow_lossy_load`.** `_clear_lossy_load_option` sat inside the `if load_report.has_corruption:` branch, so a load that found nothing wrong left the option on the entry — which is exactly where a hand-restored backup, or a boot after the fix flow's own reload failed, lands.
2. **A leftover option turned the next corruption into silent data loss.** With it armed, a store that later corrupted loaded at WARNING, raised no Repairs card, wrote no backup, and dropped the unreadable row.
3. **The repair did not survive a restart.** The lossy load never rewrote the store, so the corrupt rows stayed on disk and the refusal came straight back on the next start-up.

What this PR does:

- Clears the option after **any** successful load, and only writes the entry back when there is actually something to spend (an ordinary boot no longer touches the entry).
- Adds `_async_settle_lossy_load`: after a lossy load, copy the store aside and persist the readable remainder immediately, so the file matches what was loaded and the repair is durable.
- Takes that copy **in the load path**, not only in the repair flow — so no path can write the readable remainder over the file while the rows it left out exist nowhere. If the copy fails, the store is left exactly as it is and the error says the next start-up will stop again.

The copy uses the store's own key rather than the module default, so the two halves cannot disagree about which file they are working on.

Closes #457

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1087 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`

Four new offline tests in `tests/test_init_offline.py`:

- a clean load spends a leftover option (defect 1, and the reachability of defect 2);
- an ordinary boot writes nothing back to the entry;
- a lossy load rewrites the store and the dropped rows are in the copy (defect 3);
- a lossy load whose copy fails leaves the store byte-for-byte as it was.

The one deselected test is the known local-only `test_no_unregistered_file_states_an_interpreter_version` (#442) — untracked `.claude/worktrees/` debris in this checkout, not related to this change.

Live check: the `scripts/test_integration.sh` phacc suite runs as its own CI job on this PR; the repairs flow it covers (`tests/integration/test_repairs.py`) exercises the fix flow end to end.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed — the option's contract is stated in `const.py`, which now says where it is cleared and what leaving it on would cost.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Follow-ups

None. #229 touches the same refusal paths — per that issue's note, the two should not be edited concurrently; this one lands first.
