### PR TITLE
fix(import): validate reminder and inspection dates, and keep the calendar up on one it cannot read

### DIFF
--- a/custom_components/haventory/calendar_projection.py
+++ b/custom_components/haventory/calendar_projection.py
@@ -14,12 +14,22 @@ occurrences the window covers, and none of them is written anywhere.
 
 from __future__ import annotations
 
+import logging
 from calendar import monthrange
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 
 from .models import Item, ReminderInterval
+
+LOGGER = logging.getLogger(__name__)
+
+# Which unreadable stored dates have already been reported, as
+# ``(item_id, field, value)``. The projection runs on every calendar read, so an
+# unguarded warning would repeat for as long as the row is there; one line per
+# distinct bad value is what makes the log worth reading. Bounded by the
+# inventory, and only ever holds rows no write path could have produced.
+_REPORTED_UNREADABLE: set[tuple[str, str, str]] = set()
 
 # The dated fields on `Item`, and the word each one contributes to an event's
 # summary. `due_date` only exists while an item is checked out
@@ -127,8 +137,8 @@ def _item_events(item: Item, start: date, end: date, *, limit: int) -> Iterator[
     ):
         if stored is None:
             continue
-        day = date.fromisoformat(stored)
-        if not (start <= day < end):
+        day = _stored_date(item, f"{kind}_date", stored)
+        if day is None or not (start <= day < end):
             continue
         yield _event(item, kind, summary, day, uid=f"{item.id}:{kind}")
 
@@ -145,7 +155,9 @@ def _reminder_events(item: Item, start: date, end: date, *, limit: int) -> Itera
 
     if item.reminder_date is None:
         return
-    anchor = date.fromisoformat(item.reminder_date)
+    anchor = _stored_date(item, "reminder_date", item.reminder_date)
+    if anchor is None:
+        return
     interval = item.reminder_interval
     summary = f"{item.name} reminder"
 
@@ -168,6 +180,36 @@ def _reminder_events(item: Item, start: date, end: date, *, limit: int) -> Itera
             item, KIND_REMINDER, summary, day, uid=f"{item.id}:{KIND_REMINDER}:{day.isoformat()}"
         )
         step += 1
+
+
+def _stored_date(item: Item, field: str, stored: str) -> date | None:
+    """Read one stored date, or none if this build cannot parse it.
+
+    Every write path validates these, so a value that lands here came from a
+    hand-edited store or an import written before the import side validated
+    them. Skipping the row's own occurrences costs that row its events; raising
+    would cost every item on the calendar theirs, because one projection serves
+    the whole entity.
+    """
+
+    try:
+        return date.fromisoformat(stored)
+    except ValueError:
+        key = (str(item.id), field, stored)
+        if key not in _REPORTED_UNREADABLE:
+            _REPORTED_UNREADABLE.add(key)
+            LOGGER.warning(
+                "Leaving an item off the calendar: its %s is not a date this build can read",
+                field,
+                extra={
+                    "op": "calendar_projection",
+                    "item_id": str(item.id),
+                    "item_name": item.name,
+                    "field": field,
+                    "value": stored,
+                },
+            )
+        return None
 
 
 def _first_step_on_or_after(anchor: date, interval: ReminderInterval, target: date) -> int:

--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -84,6 +84,10 @@ from .models import (
     serialize_status_definition,
     validate_attachment_meta,
     validate_due_date_rules,
+    validate_inspection_date,
+    validate_reminder_date,
+    validate_reminder_interval,
+    validate_reminder_rules,
     validate_status_definition,
 )
 from .repository import Repository
@@ -506,6 +510,8 @@ def _validate_item_doc(
                 )
             )
     _validate_due_date_doc(base, doc, errors)
+    _validate_inspection_date_doc(base, doc, errors)
+    _validate_reminder_doc(base, doc, errors)
     return iid
 
 
@@ -524,6 +530,57 @@ def _validate_due_date_doc(base: str, doc: dict[str, Any], errors: list[dict[str
         validate_due_date_rules(checked_out=bool(doc.get("checked_out", False)), due_date=due_date)
     except ValidationError as exc:
         errors.append(_err(f"{base}.due_date", str(exc)))
+
+
+def _validate_inspection_date_doc(
+    base: str, doc: dict[str, Any], errors: list[dict[str, str]]
+) -> None:
+    """Hold an imported inspection date to the format every write path enforces."""
+
+    inspection_date = doc.get("inspection_date")
+    if inspection_date is None:
+        return
+    try:
+        validate_inspection_date(inspection_date)
+    except ValidationError as exc:
+        errors.append(_err(f"{base}.inspection_date", str(exc)))
+
+
+def _validate_reminder_doc(base: str, doc: dict[str, Any], errors: list[dict[str, str]]) -> None:
+    """Hold an imported reminder to the rules every write path enforces.
+
+    Both halves matter, and they fail differently. An anchor nothing can parse
+    reaches the calendar, which derives its occurrences from stored dates on
+    every read. A misspelled unit — ``"month"`` for ``"months"`` — is read by the
+    deliberately tolerant loader as no recurrence at all, so the document would
+    import clean and the recurrence would be gone with nothing saying so.
+    """
+
+    reminder_date = doc.get("reminder_date")
+    interval = doc.get("reminder_interval")
+    refused = False
+
+    if reminder_date is not None:
+        try:
+            validate_reminder_date(reminder_date)
+        except ValidationError as exc:
+            errors.append(_err(f"{base}.reminder_date", str(exc)))
+            refused = True
+    if interval is not None:
+        try:
+            validate_reminder_interval(interval)
+        except ValidationError as exc:
+            errors.append(_err(f"{base}.reminder_interval", str(exc)))
+            refused = True
+    if refused:
+        return
+
+    # The rule binding the two lives in one place rather than being restated
+    # here; the interval is the half that is wrong when it fires.
+    try:
+        validate_reminder_rules(reminder_date=reminder_date, reminder_interval=interval)
+    except ValidationError as exc:
+        errors.append(_err(f"{base}.reminder_interval", str(exc)))
 
 
 def _canonical_item(doc: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -1395,7 +1395,15 @@ async def ws_reminder_bump(
     item = _repo(hass).get_item(msg["item_id"])
     if item.reminder_date is None:
         raise ValidationError("item has no reminder to bump")
-    anchor = date.fromisoformat(item.reminder_date)
+    try:
+        anchor = date.fromisoformat(item.reminder_date)
+    except ValueError as exc:
+        # Only a hand-edited store can hold one. Naming it beats the
+        # `unknown_error` a raw parse failure would answer with.
+        raise ValidationError(
+            f"stored reminder_date {item.reminder_date!r} is not a date this build can read; "
+            "set the reminder again to replace it"
+        ) from exc
     following = next_occurrence_after(
         anchor, item.reminder_interval, max(anchor, date.fromisoformat(today_utc_date()))
     )

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -426,9 +426,15 @@ With a filter on the request, each category and tag entry also carries `matching
   references (e.g. an item's `location_id` with no matching location) all surface here.
   A document is held to what `Repository.load_state` accepts, not to the write path's input
   caps: the rules every release has enforced — the 120-character name limit, canonical
-  timestamps, the `due_date` ⇔ `checked_out` invariant, statuses the document can name — are
+  timestamps, the `due_date` ⇔ `checked_out` invariant, every date's calendar validity
+  (`due_date`, `inspection_date`, `reminder_date`), the `{unit, count}` shape of
+  `reminder_interval` and its need for an anchor, statuses the document can name — are
   checked, and the free-text/collection caps are not, because a store written before those
   caps existed exports data that must import back. See "Input caps" below.
+- A `reminder_interval` whose unit is misspelled is a **rejected row**, not a silent loss.
+  The load path is tolerant of one it cannot read — a row still has an item and an anchor
+  worth keeping — so an unchecked import would have stored the item with its recurrence
+  quietly gone.
 - `warnings` is present on every preview, empty or not, valid or not: one shape to render.
 
 `ImportWarning` — a non-blocking finding about an otherwise usable document:
@@ -562,7 +568,11 @@ shapes as the WebSocket surface — no bespoke service shape exists:
 ### Validation notes
 
 - UUIDs must be version 4.
-- Dates use `YYYY-MM-DD` and are validated for real calendar dates.
+- Dates use `YYYY-MM-DD` and are validated for real calendar dates — on every write path
+  and on import alike.
+- The calendar derives its occurrences from those stored dates on every read. One it cannot
+  parse — reachable only by hand-editing the store — costs that item its occurrences and is
+  logged once; the rest of the inventory still renders.
 - `name` trimmed; max length 120 for items and locations.
 - `custom_fields` keys must be non-empty strings; values must be scalars.
 

--- a/tests/test_calendar_offline.py
+++ b/tests/test_calendar_offline.py
@@ -9,6 +9,7 @@ type at all.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import UTC, date, datetime, timedelta, timezone
 
@@ -330,3 +331,64 @@ def test_next_occurrence_after_a_one_off_is_none() -> None:
     """A one-off has nothing to move to; the caller decides to clear it instead."""
 
     assert next_occurrence_after(date(2026, 8, 14), None, date(2026, 8, 14)) is None
+
+
+# -----------------------------
+# Dates this build cannot read — one row's problem, not the entity's
+# -----------------------------
+
+
+def test_a_reminder_date_that_cannot_be_parsed_costs_only_that_item(caplog) -> None:
+    """One unreadable row used to answer 500 for every window and every item.
+
+    The projection serves the whole entity, so raising on a row nobody can parse
+    takes every other item's occurrences down with it. Only a hand-edited store
+    can produce one now — every write path and the import side refuse it — and
+    the answer is to leave that item off and say so once.
+    """
+
+    broken = _reminder("Boiler", anchor="2026-08-10")
+    broken.reminder_date = "next week"
+    ladder = _item("Ladder", due="2026-08-10")
+
+    with caplog.at_level(logging.WARNING):
+        events = build_events([broken, ladder], WINDOW_START, WINDOW_END)
+
+    assert [e.summary for e in events] == ["Ladder due back"]
+    assert any("not a date this build can read" in record.message for record in caplog.records)
+
+
+def test_an_unreadable_due_or_inspection_date_is_skipped_the_same_way() -> None:
+    """All three dated fields reach the same parse, so all three need the same guard."""
+
+    broken_due = _item("Ladder", due="whenever")
+    broken_inspection = _item("Extinguisher", inspection="2026-13-40")
+    fine = _item("Drill", inspection="2026-08-20")
+
+    events = build_events([broken_due, broken_inspection, fine], WINDOW_START, WINDOW_END)
+
+    assert [e.summary for e in events] == ["Drill inspection"]
+
+
+def test_the_next_event_walk_survives_an_unreadable_date() -> None:
+    """The entity's state comes from this walk, so it fails the same way or not at all."""
+
+    broken = _reminder("Boiler", anchor="2026-08-10")
+    broken.reminder_date = "next week"
+
+    assert next_event([broken], date(2026, 8, 1)) is None
+    assert next_event([broken, _item("Ladder", due="2026-08-10")], date(2026, 8, 1)) is not None
+
+
+def test_one_unreadable_value_is_reported_once_however_often_it_is_read(caplog) -> None:
+    """A calendar read happens on every state write; a warning per read is a log nobody reads."""
+
+    broken = _reminder("Boiler", anchor="2026-08-10")
+    broken.reminder_date = "not-a-date-at-all"
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            build_events([broken], WINDOW_START, WINDOW_END)
+
+    matching = [r for r in caplog.records if "not a date this build can read" in r.message]
+    assert len(matching) == 1

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -688,6 +688,23 @@ def _envelope(item: dict) -> dict:
     [
         ({"name": "n" * (NAME_MAX_LENGTH + 1)}, "items[0].name"),
         ({"due_date": "2026-01-01"}, "items[0].due_date"),
+        ({"inspection_date": "soon"}, "items[0].inspection_date"),
+        ({"reminder_date": "next week"}, "items[0].reminder_date"),
+        ({"reminder_date": "2026-02-30"}, "items[0].reminder_date"),
+        # A misspelled unit is the one the tolerant loader would drop in silence.
+        (
+            {"reminder_date": "2026-09-01", "reminder_interval": {"unit": "month", "count": 3}},
+            "items[0].reminder_interval",
+        ),
+        (
+            {"reminder_date": "2026-09-01", "reminder_interval": {"unit": "months", "count": 0}},
+            "items[0].reminder_interval",
+        ),
+        # An interval with nothing to count from produces no occurrence, ever.
+        (
+            {"reminder_interval": {"unit": "months", "count": 3}},
+            "items[0].reminder_interval",
+        ),
     ],
 )
 def test_preview_holds_an_imported_item_to_the_always_enforced_rules(
@@ -1252,3 +1269,40 @@ def test_an_older_export_compares_as_unchanged_against_a_reminderless_item() -> 
     )
 
     assert report["counts"]["items"]["unchanged"] == SEEDED_ITEMS
+
+
+def test_preview_accepts_a_reminder_the_write_path_would_accept() -> None:
+    """The new checks refuse bad rows, not reminders."""
+
+    repo = Repository()
+    report, target = ie.plan_import(
+        repo,
+        _envelope(
+            _item_doc(
+                reminder_date="2026-09-01",
+                reminder_interval={"unit": "months", "count": 3},
+            )
+        ),
+        current_schema_version=CURRENT_SCHEMA_VERSION,
+    )
+
+    assert report["valid"] is True, report["errors"]
+    assert target is not None
+
+
+def test_preview_names_the_row_and_the_field_a_bad_date_is_in() -> None:
+    """A refusal nobody can act on is a refusal that costs the whole document.
+
+    The user reads one message; it has to say which item and which field, or
+    finding the row means reading the export by hand.
+    """
+
+    repo = Repository()
+    doc = _envelope(_item_doc())
+    doc["items"].append(_item_doc(id="33333333-3333-4333-8333-333333333333", reminder_date="soon"))
+
+    report, _ = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert report["valid"] is False
+    errors = {e["path"] for e in report["errors"]}
+    assert errors == {"items[1].reminder_date"}

--- a/tests/test_ws_reminders_offline.py
+++ b/tests/test_ws_reminders_offline.py
@@ -272,3 +272,24 @@ async def test_a_stale_expected_version_is_a_conflict() -> None:
 
     assert res["success"] is False
     assert res["error"]["code"] == "conflict"
+
+
+@pytest.mark.asyncio
+async def test_bump_names_a_stored_anchor_it_cannot_read() -> None:
+    """A hand-edited store is the only way in, and `unknown_error` says nothing.
+
+    No write path and no import can store one, so the answer's job is to point
+    at the field and at the way out rather than to report a crash.
+    """
+
+    hass = _hass()
+    item_id = await _item(hass)
+    await ws_send(hass, 2, "haventory/reminder/set", item_id=item_id, reminder_date="2026-09-01")
+    repo = hass.data[DOMAIN]["repository"]
+    repo.get_item(item_id).reminder_date = "next week"
+
+    res = await ws_send(hass, 3, "haventory/reminder/bump", item_id=item_id)
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    assert "reminder_date" in res["error"]["message"]


### PR DESCRIPTION
## Summary

Two halves of one defect, both from the V0.6.0 pre-release audit.

**Import accepted dates no write path would.** `_validate_item_doc` validated `due_date`, the timestamps, the status and the tags, but never looked at `reminder_date`, `reminder_interval` or `inspection_date` — while `docs/data_shapes.md` promised "Dates use `YYYY-MM-DD` and are validated for real calendar dates". A merge import carrying `"reminder_date": "next week"` passed preview *and* execute and persisted.

**One unreadable row took the whole calendar down.** The projection derives occurrences from stored dates on every read, with no guard, so from that moment `GET /api/calendars/calendar.haventory` answered 500 for every window, every mutation logged a `ValueError: Invalid isoformat string` through the dispatcher, and `reminder/bump` on that item answered `unknown_error`.

Changes:

- `_validate_item_doc` now runs `_validate_inspection_date_doc` and `_validate_reminder_doc` beside the existing due-date check. Errors are attributed per field, so a refusal names the row and the field. The rule binding an interval to an anchor is read from `validate_reminder_rules` rather than restated.
- A misspelled unit (`"month"` for `"months"`) is a **rejected row**, not a silent loss — the tolerant loader would otherwise have stored the item with its recurrence quietly gone.
- `calendar_projection` skips an item whose stored date it cannot parse, keeps the entity up for every other item, and logs once per distinct bad value (the projection runs on every read, so an unguarded warning repeats forever).
- `ws_reminder_bump` names an unreadable stored anchor instead of answering `unknown_error`.
- `docs/data_shapes.md` says what import checks and what an unparsable stored date costs.

The remaining way in is a hand-edited store. Tightening the *load* side — the corruption detector and the model validator disagreeing about what a valid row is — is #466, which is filed for V0.7.0 and covers the same class of defect; this PR deliberately does not widen into it.

Closes #458

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1096 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`

New offline tests:

- six more rows on the "always enforced rules" parametrize — a garbage reminder date, a date that is not a real calendar day, a garbage inspection date, a misspelled unit, a zero count, an interval with no anchor;
- a valid reminder still previews clean, and a refusal names `items[1].reminder_date` rather than the document;
- the projection: an unreadable reminder costs only that item, the same holds for due and inspection dates, `next_event` survives one, and one bad value is reported once however often it is read;
- `reminder/bump` on a hand-broken anchor answers `validation_error` naming the field.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated — `docs/data_shapes.md`, both the import bullet and the validation notes.
- [x] No WebSocket command shape change; the bump refusal is a new message under the existing `validation_error` code.
- [x] Essential invariants preserved.

## Follow-ups

None new. Related: #466 (a stored row missing `name` loads as an empty-string item) is the load-side half of "the corruption detector and the model validator disagree", already filed for V0.7.0.
