### PR TITLE
fix(events): announce a status reassignment and repaint after a location rename

### DIFF
--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -4,7 +4,13 @@ The WebSocket broadcasts in `ws.py` reach subscribed clients; these reach the
 rest of Home Assistant. Every mutation path — WebSocket handler, `haventory.*`
 service, bulk operation, import — calls `notify_mutation` after its durable
 write, which fires `haventory_item_changed`, diffs the low-stock set to fire
-`haventory_low_stock`, and dispatches the signal the sensors repaint on.
+`haventory_low_stock`, and dispatches the signal the sensors repaint on. A
+command that rewrites many items at once calls `notify_bulk_mutation` instead:
+same events per item, one diff and one repaint for the batch.
+
+A location mutation calls `notify_derived_paths_changed`, which repaints without
+announcing anything on the bus — the items underneath it did not change, only
+the path denormalized onto them.
 
 Bus events bypass the rate limiter: it budgets WebSocket subscription traffic,
 and these are internal to Home Assistant.
@@ -13,6 +19,7 @@ and these are internal to Home Assistant.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -78,21 +85,7 @@ def notify_mutation(
             return
 
         if item is not None:
-            _fire(
-                hass,
-                EVENT_ITEM_CHANGED,
-                {
-                    "action": action,
-                    "item_id": item.get("id"),
-                    "name": item.get("name"),
-                    "quantity": item.get("quantity"),
-                    "location_id": item.get("location_id"),
-                    "location_path": (item.get("location_path") or {}).get("display_path"),
-                    "effective_area_id": item.get("effective_area_id"),
-                    "version": item.get("version"),
-                    "ts": iso_utc_now(),
-                },
-            )
+            _fire_item_changed(hass, action, item)
 
         _fire_low_stock_transitions(hass, bucket, item=item)
 
@@ -102,6 +95,81 @@ def notify_mutation(
             "Failed to notify a mutation",
             extra={"domain": DOMAIN, "op": "notify_mutation", "action": action},
         )
+
+
+def notify_bulk_mutation(
+    hass: HomeAssistant, *, action: str, items: Sequence[dict[str, Any]]
+) -> None:
+    """Announce one command that rewrote many items, after the persist.
+
+    One `haventory_item_changed` per item, because an automation subscribed to it
+    is watching items rather than commands — a bulk command that announced
+    nothing would be the one hole in "fired on every path". One low-stock diff
+    and one repaint for the whole batch, because both describe the inventory as a
+    whole and running them per row would repaint every sensor once per row.
+    """
+
+    try:
+        bucket = hass.data.get(DOMAIN)
+        if bucket is None:
+            return
+
+        for item in items:
+            _fire_item_changed(hass, action, item)
+
+        # `item=None`: the diff covers the batch, and no single row is the one
+        # a crossing should be attributed to.
+        _fire_low_stock_transitions(hass, bucket, item=None)
+
+        async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.exception(
+            "Failed to notify a bulk mutation",
+            extra={"domain": DOMAIN, "op": "notify_bulk_mutation", "action": action},
+        )
+
+
+def notify_derived_paths_changed(hass: HomeAssistant) -> None:
+    """Repaint what reads location data, without announcing an item mutation.
+
+    A rename or a re-parent rewrites the denormalized `location_path` on every
+    item underneath it, and the calendar renders each event's description from
+    that path — so an entity holding a state derived from the old path has
+    nothing to invalidate it until local midnight or until some item happens to
+    be edited.
+
+    The dispatcher signal only: `haventory_item_changed` stays unfired, because a
+    derived-path rewrite deliberately moves neither an item's `version` nor its
+    `updated_at`, and the documented action vocabulary has no location word.
+    """
+
+    try:
+        if hass.data.get(DOMAIN) is None:
+            return
+        async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.exception(
+            "Failed to repaint after a location change",
+            extra={"domain": DOMAIN, "op": "notify_derived_paths_changed"},
+        )
+
+
+def _fire_item_changed(hass: HomeAssistant, action: str, item: dict[str, Any]) -> None:
+    _fire(
+        hass,
+        EVENT_ITEM_CHANGED,
+        {
+            "action": action,
+            "item_id": item.get("id"),
+            "name": item.get("name"),
+            "quantity": item.get("quantity"),
+            "location_id": item.get("location_id"),
+            "location_path": (item.get("location_path") or {}).get("display_path"),
+            "effective_area_id": item.get("effective_area_id"),
+            "version": item.get("version"),
+            "ts": iso_utc_now(),
+        },
+    )
 
 
 def _fire_low_stock_transitions(

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -322,13 +322,14 @@ class Repository:
 
     def delete_status(
         self, slug: str, *, reassign_to: str | None = None
-    ) -> tuple[StatusDefinition, int]:
+    ) -> tuple[StatusDefinition, list[str]]:
         """Remove a definition, optionally moving the items that carry it.
 
         Refuses while items still reference the slug unless given somewhere to
         put them: an item whose status names nothing would be coerced to the
-        default on the next load, silently. Returns what was removed and how
-        many items moved.
+        default on the next load, silently. Returns what was removed and the ids
+        of the items that moved — the caller announces each of them, so a count
+        would leave it re-deriving which ones they were.
         """
 
         if slug == DEFAULT_ITEM_STATUS:
@@ -349,13 +350,13 @@ class Repository:
             if reassign_to not in self._statuses_by_slug:
                 raise ValidationError(f"status '{reassign_to}' not found")
 
-        moved = self._reassign_status(slug, reassign_to) if reassign_to is not None else 0
+        moved = self._reassign_status(slug, reassign_to) if reassign_to is not None else []
         del self._statuses_by_slug[slug]
         self._status_to_item_ids.pop(slug, None)
         self._increment_generation()
         return current, moved
 
-    def _reassign_status(self, slug: str, target: str) -> int:
+    def _reassign_status(self, slug: str, target: str) -> list[str]:
         """Move every item on ``slug`` to ``target``, as ordinary item edits."""
 
         # Materialized first: the loop reindexes, which mutates the bucket the
@@ -370,7 +371,7 @@ class Repository:
                 version=current.version + 1,
             )
             self._reindex_item_replacement(current, updated)
-        return len(affected)
+        return affected
 
     # -----------------------------
     # Internal helpers — indexing

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -19,7 +19,7 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 
 from .const import DOMAIN
-from .events import notify_mutation
+from .events import notify_derived_paths_changed, notify_mutation
 from .exceptions import (
     ConflictError,
     NotFoundError,
@@ -353,6 +353,8 @@ async def service_location_update(hass: HomeAssistant, data: dict) -> dict[str, 
         new_parent = payload["new_parent_id"] if "new_parent_id" in payload else UNSET
         area_id = payload["area_id"] if "area_id" in payload else UNSET
         repo = _get_repo(hass)
+        before = repo.get_location(payload["location_id"])
+        was_named, was_below = before.name, before.parent_id
         loc = repo.update_location(
             payload["location_id"],
             name=payload.get("name"),
@@ -360,6 +362,11 @@ async def service_location_update(hass: HomeAssistant, data: dict) -> dict[str, 
             area_id=area_id,
         )
         await async_persist_repo(hass)
+        # A rename or a re-parent rewrites the path denormalized onto every item
+        # underneath, and the calendar renders those paths. No bus event: the
+        # items themselves did not change.
+        if loc.name != was_named or loc.parent_id != was_below:
+            notify_derived_paths_changed(hass)
         return {"location": serialize_location(loc)}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"location_id": location_id}, exc)

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -37,7 +37,7 @@ from .const import (
     MAX_MANUALS_PER_ITEM,
     MAX_PICTURES_PER_ITEM,
 )
-from .events import notify_mutation
+from .events import notify_bulk_mutation, notify_derived_paths_changed, notify_mutation
 from .exceptions import (
     ConflictError,
     NotFoundError,
@@ -2001,6 +2001,11 @@ async def ws_location_update(
         _broadcast_event(
             hass, topic="locations", action="renamed", payload={"location": serialized}
         )
+    # Only the two edits that rewrite a path: an area reassignment re-anchors the
+    # subtree without changing what any path reads, and a save that changed
+    # nothing repaints nothing.
+    if loc.parent_id != before.parent_id or loc.name != was_named:
+        notify_derived_paths_changed(hass)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -2112,10 +2117,14 @@ async def ws_location_move_subtree(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     new_parent = msg.get("new_parent_id") if "new_parent_id" in msg else UNSET
-    loc = _repo(hass).update_location(msg["location_id"], new_parent_id=new_parent)
+    repo = _repo(hass)
+    was_below = repo.get_location(msg["location_id"]).parent_id
+    loc = repo.update_location(msg["location_id"], new_parent_id=new_parent)
     serialized = serialize_location(loc)
     await _persist_repo(hass)
     _broadcast_event(hass, topic="locations", action="moved", payload={"location": serialized})
+    if loc.parent_id != was_below:
+        notify_derived_paths_changed(hass)
     _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
@@ -2240,10 +2249,19 @@ async def ws_status_delete(
         # Two topics on purpose: one card is showing the vocabulary, another is
         # showing the items that just moved underneath it.
         _broadcast_event(hass, topic="items", action="updated", payload=None)
+        # Each rewritten item took a new version and a new updated_at, so each
+        # is an ordinary item edit as far as the bus is concerned. Announcing the
+        # command and not the edits would leave an automation watching
+        # `haventory_item_changed` blind while a whole set moved underneath it.
+        notify_bulk_mutation(
+            hass,
+            action="updated",
+            items=[serialize_item(hass, repo.get_item(item_id)) for item_id in reassigned],
+        )
         _broadcast_counts(hass)
     conn.send_message(
         websocket_api.result_message(
-            msg.get("id", 0), {"status": serialized, "reassigned": reassigned}
+            msg.get("id", 0), {"status": serialized, "reassigned": len(reassigned)}
         )
     )
 

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -176,9 +176,18 @@ with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
   are internal to Home Assistant, on the same reasoning as the `unavailable` notice.
 - **Bus events carry no item body beyond the trigger fields** — no `custom_fields`, no
   `description`. An automation that needs the whole item calls `haventory/item/get`.
-- **Locations fire no bus event.** None of the counts a sensor exposes can move on a location
-  mutation: the repository refuses to delete a location that still holds items or children,
-  and a rename or re-anchor only rewrites derived fields.
+- **Locations fire no bus event** — but a rename or a re-parent still repaints. No count a
+  sensor exposes can move on a location mutation: the repository refuses to delete a location
+  that still holds items or children, and a rename or re-anchor only rewrites derived fields.
+  Counts are no longer the only thing derived from location data, though: every projected
+  calendar event's `description` is the item's `location_path.display_path`, read from a
+  cached entity state. So `location/update` and `location/move_subtree` — and the
+  `haventory.location_update` service — dispatch the repaint signal when the name or the
+  parent changed, and nothing else does: an area-only reassignment moves no path, and neither
+  `location/create` (no existing item's path can change) nor `location/delete` (refused while
+  the location holds anything) can leave a stale one behind. `haventory_item_changed` stays
+  unfired for all of them: a derived-path rewrite deliberately moves neither an item's
+  `version` nor its `updated_at`, and the action vocabulary above has no location word.
 
 ### Items
 
@@ -375,7 +384,11 @@ except `status/delete` with a reassign target.
   - Result: `{status: <StatusDefinition>, reassigned: number}`; emits `statuses/deleted`, and
     when `reassigned` is non-zero also `items/updated` and `stats/counts`. That `items/updated`
     carries **no `item`**: the move is a bulk rewrite, so the event is a refetch signal rather
-    than a per-item patch (see "Event payloads").
+    than a per-item patch (see "Event payloads"). On the Home Assistant bus it is the other way
+    round: one `haventory_item_changed` with action `updated` **per rewritten item**, because
+    each of them took a new `version` and a new `updated_at` and an automation subscribed to
+    that event is watching items rather than commands. The low-stock diff and the sensor
+    repaint run once for the batch.
   - **Refused while items still carry the slug and no `reassign_to` is given.** An item whose
     status names nothing would be coerced to the default on the next load, silently. With a
     target the items move and the definition is deleted in the same call, so no client can

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -188,3 +188,39 @@ async def test_unload_removes_the_entity(hass: HomeAssistant) -> None:
 
     state = hass.states.get(ENTITY_ID)
     assert state is None or state.state == "unavailable"
+
+
+async def test_a_location_rename_reaches_the_calendar_at_once(hass: HomeAssistant) -> None:
+    """The event description is the item's stored path, held in a cached state.
+
+    Nothing invalidated that state on a rename, so `calendar.haventory` kept
+    announcing the old path until local midnight or until some item happened to
+    be edited — and the README's own automation example templates exactly this
+    attribute to say where the item is.
+    """
+
+    await _setup(hass)
+    garage = (
+        await hass.services.async_call(
+            DOMAIN, "location_create", {"name": "Garage"}, blocking=True, return_response=True
+        )
+    )["location"]
+    await _create(
+        hass,
+        name="Extinguisher",
+        location_id=garage["id"],
+        inspection_date=(dt_util.now().date() + timedelta(days=7)).isoformat(),
+    )
+
+    assert hass.states.get(ENTITY_ID).attributes["description"] == "Garage"
+
+    await hass.services.async_call(
+        DOMAIN,
+        "location_update",
+        {"location_id": garage["id"], "name": "Workshop"},
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID).attributes["description"] == "Workshop"

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -172,3 +172,44 @@ async def test_a_restart_re_announces_nothing(hass: HomeAssistant, hass_storage)
 
     assert captured == []
     assert hass.data[DOMAIN]["repository"].low_stock_item_ids
+
+
+async def test_a_status_reassignment_reaches_the_bus_once_per_item(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """A bulk rewrite is still a set of item edits, and each one is announced.
+
+    `status/delete` with `reassign_to` gives every affected item a new version
+    and a new `updated_at`, but announced only the vocabulary change — so an
+    automation triggered on `haventory_item_changed` saw nothing while a whole
+    set moved underneath it.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {"id": 1, "type": "haventory/status/create", "slug": "lent_out", "label": "Lent out"}
+    )
+    assert (await client.receive_json())["success"]
+    moved = []
+    for index, name in enumerate(("Drill", "Ladder", "Torch"), start=2):
+        await client.send_json(
+            {"id": index, "type": "haventory/item/create", "name": name, "status": "lent_out"}
+        )
+        moved.append((await client.receive_json())["result"]["id"])
+    await client.send_json({"id": 10, "type": "haventory/item/create", "name": "Untouched"})
+    assert (await client.receive_json())["success"]
+
+    captured = async_capture_events(hass, EVENT_ITEM_CHANGED)
+    await client.send_json(
+        {"id": 11, "type": "haventory/status/delete", "slug": "lent_out", "reassign_to": "ok"}
+    )
+    result = await client.receive_json()
+    assert result["success"], result
+    assert result["result"]["reassigned"] == len(moved)
+    await hass.async_block_till_done()
+
+    payloads = _data(captured)
+    assert {p["item_id"] for p in payloads} == set(moved)
+    assert {p["action"] for p in payloads} == {"updated"}

--- a/tests/test_events_offline.py
+++ b/tests/test_events_offline.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import pytest
 from custom_components.haventory import events as events_mod
+from custom_components.haventory import services as services_mod
 from custom_components.haventory.const import (
     DATA_LOW_STOCK_SNAPSHOT,
     DOMAIN,
@@ -29,6 +30,8 @@ from homeassistant.core import HomeAssistant
 from ws_helpers import ws_send
 
 LOW_THRESHOLD = 3
+# One create, then the reassignment's edit.
+_AFTER_A_REASSIGNMENT = 2
 
 
 def _hass() -> tuple[HomeAssistant, Repository]:
@@ -236,3 +239,145 @@ def test_low_stock_ids_are_a_snapshot_not_the_live_index() -> None:
     repo.set_quantity(str(item.id), 10)
     assert repo.low_stock_item_ids == frozenset()
     assert before == frozenset({str(item.id)})
+
+
+# -----------------------------
+# Bulk rewrites and location edits
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_status_with_reassign_to_announces_every_item_it_rewrote() -> None:
+    """The one mutation path that moved items and told nobody.
+
+    `_reassign_status` performs ordinary item edits — a new version and a new
+    `updated_at` each — so an automation watching `haventory_item_changed` was
+    blind while a whole set moved underneath it, against a contract that says the
+    event fires on every path.
+    """
+
+    hass = HomeAssistant()
+    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    events_mod.seed_low_stock_snapshot(hass)
+    ws_setup(hass)
+    repo = hass.data[DOMAIN]["repository"]
+    moved = [repo.create_item({"name": f"Item {n}", "status": "missing"}) for n in range(3)]
+    repo.create_item({"name": "Untouched"})
+    hass.bus.fired.clear()
+
+    res = await ws_send(hass, 1, "haventory/status/delete", slug="missing", reassign_to="ok")
+
+    assert res["success"] is True, res
+    assert res["result"]["reassigned"] == len(moved)
+    fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
+    assert {e["item_id"] for e in fired} == {str(i.id) for i in moved}
+    assert {e["action"] for e in fired} == {"updated"}
+    # Each event carries the version the reassignment wrote, not the one before.
+    assert all(e["version"] == _AFTER_A_REASSIGNMENT for e in fired)
+
+
+def test_a_bulk_notification_repaints_once_however_many_items_it_names() -> None:
+    """Forty rewritten rows are one inventory change, not forty."""
+
+    hass, repo = _hass()
+    serialized = [_create(repo, hass, name=f"Widget {n}")[1] for n in range(4)]
+
+    events_mod.notify_bulk_mutation(hass, action="updated", items=serialized)
+
+    assert len(hass.bus.events_of(EVENT_ITEM_CHANGED)) == len(serialized)
+    assert hass.dispatcher_sends == [(SIGNAL_INVENTORY_CHANGED, ())]
+
+
+@pytest.mark.asyncio
+async def test_renaming_a_location_repaints_without_announcing_an_item_change() -> None:
+    """The calendar renders each event's description from the stored path.
+
+    Nothing invalidated that until local midnight or the next item edit, so a
+    renamed location kept being announced under its old name. The dispatcher
+    signal is what fires: no item's `version` or `updated_at` moved, and the bus
+    vocabulary has no location word.
+    """
+
+    hass = HomeAssistant()
+    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    events_mod.seed_low_stock_snapshot(hass)
+    ws_setup(hass)
+    repo = hass.data[DOMAIN]["repository"]
+    garage = repo.create_location(name="Garage")
+    repo.create_item({"name": "Ladder", "location_id": str(garage.id)})
+    hass.bus.fired.clear()
+    hass.dispatcher_sends.clear()
+
+    res = await ws_send(
+        hass, 1, "haventory/location/update", location_id=str(garage.id), name="Workshop"
+    )
+
+    assert res["success"] is True, res
+    assert hass.dispatcher_sends == [(SIGNAL_INVENTORY_CHANGED, ())]
+    assert hass.bus.events_of(EVENT_ITEM_CHANGED) == []
+
+
+@pytest.mark.asyncio
+async def test_a_location_save_that_changes_no_path_repaints_nothing() -> None:
+    """The control: a re-save with the same name is not a reason to recount."""
+
+    hass = HomeAssistant()
+    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    events_mod.seed_low_stock_snapshot(hass)
+    ws_setup(hass)
+    repo = hass.data[DOMAIN]["repository"]
+    garage = repo.create_location(name="Garage")
+    hass.dispatcher_sends.clear()
+
+    res = await ws_send(
+        hass, 1, "haventory/location/update", location_id=str(garage.id), name="Garage"
+    )
+
+    assert res["success"] is True, res
+    assert hass.dispatcher_sends == []
+
+
+@pytest.mark.asyncio
+async def test_moving_a_subtree_repaints_the_paths_it_rewrote() -> None:
+    """`move_subtree` rewrites every path below the moved node."""
+
+    hass = HomeAssistant()
+    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    events_mod.seed_low_stock_snapshot(hass)
+    ws_setup(hass)
+    repo = hass.data[DOMAIN]["repository"]
+    garage = repo.create_location(name="Garage")
+    cellar = repo.create_location(name="Cellar")
+    shelf = repo.create_location(name="Shelf A", parent_id=str(garage.id))
+    hass.dispatcher_sends.clear()
+
+    res = await ws_send(
+        hass,
+        1,
+        "haventory/location/move_subtree",
+        location_id=str(shelf.id),
+        new_parent_id=str(cellar.id),
+    )
+
+    assert res["success"] is True, res
+    assert hass.dispatcher_sends == [(SIGNAL_INVENTORY_CHANGED, ())]
+    assert hass.bus.events_of(EVENT_ITEM_CHANGED) == []
+
+
+@pytest.mark.asyncio
+async def test_the_location_service_repaints_the_same_way_the_command_does() -> None:
+    """An automation renaming a location must not leave the calendar behind."""
+
+    hass = HomeAssistant()
+    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    events_mod.seed_low_stock_snapshot(hass)
+    repo = hass.data[DOMAIN]["repository"]
+    garage = repo.create_location(name="Garage")
+    hass.dispatcher_sends.clear()
+
+    await services_mod.service_location_update(
+        hass, {"location_id": str(garage.id), "name": "Workshop"}
+    )
+
+    assert hass.dispatcher_sends == [(SIGNAL_INVENTORY_CHANGED, ())]
+    assert hass.bus.events_of(EVENT_ITEM_CHANGED) == []

--- a/tests/test_repository_statuses_offline.py
+++ b/tests/test_repository_statuses_offline.py
@@ -138,7 +138,7 @@ def test_an_unused_status_deletes_outright() -> None:
     removed, moved = repo.delete_status("needs_repair")
 
     assert removed.slug == "needs_repair"
-    assert moved == 0
+    assert moved == []
     assert "needs_repair" not in repo.status_slugs()
 
 
@@ -159,7 +159,8 @@ def test_reassigning_moves_the_items_and_then_deletes() -> None:
 
     removed, moved = repo.delete_status("missing", reassign_to="ok")
 
-    assert (removed.slug, moved) == ("missing", 1)
+    # The ids, not a count: the caller announces each item that moved.
+    assert (removed.slug, moved) == ("missing", [str(item.id)])
     assert "missing" not in repo.status_slugs()
     after = repo.get_item(item.id)
     assert after.status == "ok"


### PR DESCRIPTION
## Summary

Two gaps between the mutation paths and the automation surface #218 shipped. Both were code-verified in the V0.6.0 pre-release audit; both now have a test in the mode that can see them.

**#462 — `status/delete` with `reassign_to` told nobody.** `_reassign_status` performs ordinary item edits: every affected item takes `version + 1` and a fresh `updated_at`. The handler broadcast `statuses/deleted`, a payload-less `items/updated` and `stats/counts`, but never called `notify_mutation` — so no `haventory_item_changed` fired for any of the rewritten items, the low-stock set was not diffed, and the repaint signal was not dispatched. `docs/backend_api_contract.md` and `events.py`'s own docstring both said the event fires on every path; both were false here.

**#463 — a location rename repainted nothing.** A rename or re-parent rewrites the denormalized `location_path` on every item underneath it. Since #452, every projected calendar event's `description` is that path — read from a cached entity state that nothing invalidated, so `calendar.haventory` kept announcing "Garage / Shelf A" after the rename to "Workshop", until local midnight or until some item happened to be edited. The README's own automation example templates exactly that attribute to say where the item is.

Changes:

- `events.py` grows two helpers beside `notify_mutation`, and its docstring stops overclaiming:
  - `notify_bulk_mutation` — one `haventory_item_changed` per item (an automation subscribed to it is watching items, not commands), one low-stock diff and one repaint for the batch (both describe the inventory as a whole; per row they would repaint every sensor once per row).
  - `notify_derived_paths_changed` — the dispatcher signal only. `haventory_item_changed` stays unfired on purpose: a derived-path rewrite deliberately moves neither an item's `version` nor its `updated_at`, and the documented action vocabulary has no location word.
- `Repository.delete_status` returns the ids it moved instead of a count. The WS result keeps its `reassigned: number`; the caller needed the ids to announce them, and re-deriving them at the call site would have been a second copy of the same bookkeeping.
- The repaint is gated on the two edits that actually rewrite a path — name or parent. An area-only reassignment re-anchors the subtree without changing any path, `location/create` cannot affect an existing item's path, and `location/delete` is refused while the location holds anything, so none of them can leave a stale path behind.
- `docs/backend_api_contract.md`: the "Locations fire no bus event" bullet keeps its rule and gains the reason it still dispatches; `status/delete` states the per-item bus behaviour.

Closes #462
Closes #463

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1093 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] phacc: `97 passed` locally (`tests/integration`)

Offline: the reassignment announces every item it rewrote with the version it wrote; a bulk notification repaints once however many items it names; a rename repaints without a bus event; a save that changes no path repaints nothing; `move_subtree` repaints; the service path behaves like the command.

Integration (the mode that can see the entity):

- `test_a_location_rename_reaches_the_calendar_at_once` — rename a location through the service, then read `calendar.haventory`'s `description` attribute. **Verified failing without the fix** (`assert 'Garage' == 'Workshop'`) and passing with it.
- `test_a_status_reassignment_reaches_the_bus_once_per_item` — over a real WebSocket connection, with a real bus listener capturing the events.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated — `docs/backend_api_contract.md`, both bullets.
- [x] WS command shapes unchanged (`status/delete` still answers `reassigned: number`).
- [x] Essential invariants preserved — the derived-path rewrite still does not touch `version` or `updated_at`, which is why this fires the signal and not the event.

## Follow-ups

- The to-do bridge listens to the two bus events rather than this signal, so a location rename runs no extra bridge pass — correctly, since a to-do line carries no location.
