### PR TITLE
fix(reminders): count a bump from the local day the calendar runs on

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ They update the moment something changes — a card edit, a `haventory.*` servic
 import — with no polling interval to tune. The two date-derived ones also roll over at UTC
 midnight, so "Overdue" grows overnight without anybody touching the inventory.
 
+**UTC midnight, deliberately, and it is not the calendar's midnight.** These two counts
+compare stored dates against the UTC day, which is also the day `item/list`'s overdue
+filters use; the calendar and the reminder bump run on your Home Assistant timezone's day,
+because those are dates you read and act on rather than numbers. The two boundaries coincide
+in London and diverge everywhere else: at UTC-8 "Overdue" ticks up at 4 pm local, eight hours
+before the calendar stops showing that item as due today.
+
 Put "Low stock: 3" on a dashboard next to the weather and nobody has to open the card to
 know whether a shopping trip is due.
 
@@ -289,8 +296,10 @@ on one step. From an automation or a script that is one WebSocket call:
 ```
 
 Bumping counts from today when the reminder is overdue, so one you forgot for a year lands on
-its next future date rather than on another one already past. A reminder you no longer want
-is cleared from the same editor, or with `haventory/reminder/clear`.
+its next future date rather than on another one already past. "Today" is your Home Assistant
+timezone's day, the same one the calendar rolls over on — so bumping something in the evening
+advances it to the occurrence the calendar is showing you next, wherever you live. A reminder
+you no longer want is cleared from the same editor, or with `haventory/reminder/clear`.
 
 ### Shopping list
 

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -16,6 +16,7 @@ from typing import Any, TypedDict, cast
 import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 try:
     from homeassistant.components.file_upload import process_uploaded_file
@@ -1388,8 +1389,14 @@ async def ws_reminder_bump(
     Counted from the later of the anchor and today, so a reminder bumped on the
     day it came round advances by exactly one interval, and one nobody bumped
     for a year lands on its next *future* occurrence instead of another date
-    already past. Today is the UTC one, the same day `overdue_only` and the two
-    date-derived counts are measured against.
+    already past.
+
+    Today is the **local** one, the day the calendar runs on. A reminder is a
+    household-facing date rather than a timestamp, and bumping is what somebody
+    does in the evening — which west of Greenwich is already tomorrow in UTC, so
+    counting from the UTC day would skip the occurrence their own calendar is
+    showing them for tomorrow. The two date-derived counts still measure against
+    the UTC day; see the README's note on the two boundaries.
     """
 
     item = _repo(hass).get_item(msg["item_id"])
@@ -1405,7 +1412,7 @@ async def ws_reminder_bump(
             "set the reminder again to replace it"
         ) from exc
     following = next_occurrence_after(
-        anchor, item.reminder_interval, max(anchor, date.fromisoformat(today_utc_date()))
+        anchor, item.reminder_interval, max(anchor, dt_util.now().date())
     )
     if following is None:
         raise ValidationError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ otherwise blocks the loopback the event loop sets itself up on.
 
 import asyncio
 import dataclasses
+import datetime
 import json
 import os
 import sys
@@ -477,6 +478,30 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
     ha_helpers_dispatcher.async_dispatcher_connect = async_dispatcher_connect
     ha_helpers.dispatcher = ha_helpers_dispatcher
     sys.modules["homeassistant.helpers.dispatcher"] = ha_helpers_dispatcher
+
+    # homeassistant.util.dt — the household's own day, which is what every date a
+    # user reads or writes is measured in. `DEFAULT_TIME_ZONE` is a module
+    # attribute here exactly as it is in Home Assistant, so a test can move the
+    # instance west of Greenwich and see what a household there would.
+    ha_util = types.ModuleType("homeassistant.util")
+    ha_util_dt = types.ModuleType("homeassistant.util.dt")
+    ha_util_dt.DEFAULT_TIME_ZONE = datetime.UTC
+
+    def _now(time_zone=None):  # type: ignore[no-untyped-def]
+        return datetime.datetime.now(time_zone or ha_util_dt.DEFAULT_TIME_ZONE)
+
+    def _utcnow():  # type: ignore[no-untyped-def]
+        return datetime.datetime.now(datetime.UTC)
+
+    def _as_local(value):  # type: ignore[no-untyped-def]
+        return value.astimezone(ha_util_dt.DEFAULT_TIME_ZONE)
+
+    ha_util_dt.now = _now
+    ha_util_dt.utcnow = _utcnow
+    ha_util_dt.as_local = _as_local
+    ha_util.dt = ha_util_dt
+    sys.modules["homeassistant.util"] = ha_util
+    sys.modules["homeassistant.util.dt"] = ha_util_dt
 
     # homeassistant.components.websocket_api
     ha_components = types.ModuleType("homeassistant.components")

--- a/tests/integration/test_reminders.py
+++ b/tests/integration/test_reminders.py
@@ -216,3 +216,43 @@ async def test_an_interval_with_no_anchor_is_refused_by_the_real_dispatch(
 
     assert result["success"] is False
     assert result["error"]["code"] == "validation_error"
+
+
+async def test_an_evening_bump_west_of_greenwich_keeps_the_calendar_day(
+    hass: HomeAssistant, hass_ws_client, freezer
+) -> None:
+    """The moment the two day boundaries disagree, pinned.
+
+    18:00 in Los Angeles is 02:00 the next day in UTC. Counting the bump from the
+    UTC day therefore skipped the occurrence the household's own calendar was
+    showing them for tomorrow — silently, and only for the part of the day the
+    two disagree over, which is why neither the offline suite nor the UTC dev
+    container could see it.
+    """
+
+    await hass.config.async_set_time_zone("America/Los_Angeles")
+    await _setup(hass)
+    # After the client has authenticated: the token the fixture mints is checked
+    # against the wall clock, and a frozen one is outside its window.
+    client = await hass_ws_client(hass)
+    freezer.move_to("2026-08-15T02:00:00+00:00")
+    assert dt_util.now().date().isoformat() == "2026-08-14"
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "HVAC filter"})
+    item_id = (await client.receive_json())["result"]["id"]
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "haventory/reminder/set",
+            "item_id": item_id,
+            "reminder_date": "2026-08-14",
+            "reminder_interval": {"unit": "days", "count": 1},
+        }
+    )
+    assert (await client.receive_json())["success"]
+
+    await client.send_json({"id": 3, "type": "haventory/reminder/bump", "item_id": item_id})
+    result = await client.receive_json()
+
+    assert result["success"], result
+    assert result["result"]["reminder_date"] == "2026-08-15"

--- a/tests/test_ws_reminders_offline.py
+++ b/tests/test_ws_reminders_offline.py
@@ -11,7 +11,7 @@ Scenarios:
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta, timezone
 
 import pytest
 from custom_components.haventory.const import DOMAIN
@@ -19,6 +19,7 @@ from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from ws_helpers import ws_send
 
@@ -293,3 +294,36 @@ async def test_bump_names_a_stored_anchor_it_cannot_read() -> None:
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
     assert "reminder_date" in res["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_a_bump_counts_from_the_household_day_not_the_utc_one(monkeypatch) -> None:
+    """West of Greenwich an evening bump is already tomorrow in UTC.
+
+    The calendar rolls over at local midnight and a reminder is a household-facing
+    date, so counting from the UTC day skipped the occurrence the household's own
+    calendar was showing for tomorrow — silently, and only for the part of the day
+    the two disagree over. Neither the offline suite nor the dev container runs
+    anywhere but UTC, so the zone has to be pinned here.
+    """
+
+    hass = _hass()
+    item_id = await _item(hass)
+    # 18:00 on the 14th in Los Angeles is 02:00 on the 15th in UTC.
+    evening_local = datetime(2026, 8, 14, 18, 0, tzinfo=timezone(timedelta(hours=-8)))
+    monkeypatch.setattr(dt_util, "DEFAULT_TIME_ZONE", evening_local.tzinfo)
+    monkeypatch.setattr(dt_util, "now", lambda *_a, **_k: evening_local)
+    await ws_send(
+        hass,
+        2,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date="2026-08-14",
+        reminder_interval={"unit": "days", "count": 1},
+    )
+
+    res = await ws_send(hass, 3, "haventory/reminder/bump", item_id=item_id)
+
+    assert res["success"] is True, res
+    # The 15th — the occurrence the calendar is showing for tomorrow — not the 16th.
+    assert res["result"]["reminder_date"] == "2026-08-15"


### PR DESCRIPTION
## Summary

`haventory/reminder/bump` counted from `today_utc_date()`. The calendar deliberately runs on **local** days — its rollover is `async_track_time_change` at local midnight, its "today" is `dt_util.now().date()`. West of Greenwich the two disagree for part of every day, so a household at UTC-8 with a daily reminder anchored today, bumping at 18:00 local (02:00 UTC tomorrow), got `after` already set to tomorrow and the next occurrence landed the day *after*. The occurrence their own calendar was showing for tomorrow was skipped — no error, no gap on screen, just one reminder that never arrived.

The bump now counts from the local day, so the two surfaces a household actually sees — the calendar and the bump — agree.

**The second half of that issue was a decision, and this is it:** the two date-derived sensors stay on the UTC day and the README says so plainly. `overdue_count` and `inspection_overdue_count` are computed in `repository.py`, which imports no Home Assistant at all, and the same UTC comparison backs `item/list`'s `overdue_only` / `inspection_overdue_only` filters and the subscription matcher. Moving them means changing the repository's date arithmetic and every filter measured against it — a cross-cutting change to shipped query semantics, not a line in this fix. What the README lacked was the plain statement that the boundaries differ; it now has it, in both the sensors section and the reminders section.

Closes #461

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1101 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] phacc: `96 passed` locally

The issue notes that neither the offline suite nor the dev container can catch this, since both run UTC — so both new tests pin the moment explicitly:

- offline: a `homeassistant.util.dt` stub joins the harness (with `DEFAULT_TIME_ZONE` as a module attribute, exactly as Home Assistant has it), and the test moves the instance to UTC-8 at 18:00 local. **Verified failing before the change** (`2026-08-16` where `2026-08-15` is right).
- integration: `test_an_evening_bump_west_of_greenwich_keeps_the_calendar_day` sets the instance timezone to `America/Los_Angeles` and freezes the clock at `2026-08-15T02:00Z`, which is 18:00 on the 14th there. **Verified failing without the fix.** The freeze happens after the WebSocket client authenticates — the fixture's token is checked against the wall clock and a frozen one falls outside its window.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error case).
- [x] Docs updated — `README.md`, both places a day boundary is now stated.
- [x] No WebSocket command shape change.
- [x] Essential invariants preserved.

## Follow-ups

One decision is recorded rather than filed: whether the whole integration should move to the local day. It would make `overdue_count`, `inspection_overdue_count`, `overdue_only`, `inspection_overdue_only` and the subscription matcher all read the household's day, at the price of teaching an HA-free repository what a timezone is. Worth a look in a later milestone; documented on purpose for now, which is one of the two endings #461 asks for.
