### PR TITLE
feat(services): set, clear and bump reminders from an automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,10 @@ running — which for an all-day event means today.
 Nothing is scheduled. The events are worked out whenever something reads the calendar, so
 editing a date changes the calendar immediately and no timer can drift out of step with the
 inventory. A date only exists as an event on its own day: yesterday's is gone from the
-calendar, and the **Overdue** sensor is what keeps counting it.
+calendar. For a **due date** or an **inspection date** the matching sensor keeps counting it
+after that. A **reminder** works differently: a recurring one rolls forward on its own and is
+never overdue, and a one-off whose date has passed simply leaves the calendar — no sensor
+counts it, so bump it or clear it while it is still in front of you.
 
 Notifications are an ordinary calendar automation — the same one you would write for a
 birthday:
@@ -289,17 +292,45 @@ a reminder anchored on the 31st shows 28 February and then 31 March, rather than
 to the 28th forever.
 
 When you have actually changed the filter, **bump** the reminder and the whole series moves
-on one step. From an automation or a script that is one WebSocket call:
+on one step. From an automation or a script that is one service call — say, when the smart
+plug on the boiler reports the service engineer's visit is done:
 
-```json
-{"type": "haventory/reminder/bump", "item_id": "…"}
+```yaml
+automation:
+  - alias: The filter has been changed
+    trigger:
+      platform: state
+      entity_id: input_button.hvac_filter_changed
+    action:
+      - service: haventory.reminder_bump
+        data:
+          item_id: "0f2c…"
+        response_variable: bumped
+      - service: notify.notify
+        data:
+          message: "Next filter change: {{ bumped.item.reminder_date }}"
 ```
+
+Setting and clearing a reminder are ordinary field writes, so they ride the item services:
+`haventory.item_create` and `haventory.item_update` both take `reminder_date` and
+`reminder_interval`, and `null` for either clears it.
+
+```yaml
+      - service: haventory.item_update
+        data:
+          item_id: "0f2c…"
+          reminder_date: "2026-09-01"
+          reminder_interval: { unit: months, count: 3 }
+```
+
+The same three verbs are on the WebSocket API for a client that has one open —
+`haventory/reminder/set`, `/clear` and `/bump`.
 
 Bumping counts from today when the reminder is overdue, so one you forgot for a year lands on
 its next future date rather than on another one already past. "Today" is your Home Assistant
 timezone's day, the same one the calendar rolls over on — so bumping something in the evening
 advances it to the occurrence the calendar is showing you next, wherever you live. A reminder
-you no longer want is cleared from the same editor, or with `haventory/reminder/clear`.
+you no longer want is cleared from the same editor, or by writing `null` over its date.
 
 ### Shopping list
 

--- a/custom_components/haventory/calendar_projection.py
+++ b/custom_components/haventory/calendar_projection.py
@@ -20,6 +20,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 
+from .exceptions import ValidationError
 from .models import Item, ReminderInterval
 
 LOGGER = logging.getLogger(__name__)
@@ -121,6 +122,40 @@ def next_occurrence_after(
     if interval is None:
         return None
     return _occurrence(anchor, interval, _first_step_after(anchor, interval, after))
+
+
+def bumped_reminder_date(item: Item, *, today: date) -> str:
+    """The stored anchor an item's reminder moves to when it is marked done.
+
+    The whole rule, in one place, because two surfaces ask for it — the
+    WebSocket command and the `haventory.reminder_bump` service — and two
+    answers to "where does this reminder go next" would be one answer too many.
+
+    Counted from the later of the anchor and `today`, so a reminder bumped on
+    the day it came round advances by exactly one interval, and one nobody
+    bumped for a year lands on its next *future* occurrence instead of another
+    date already past. `today` is the caller's to supply: it is the household's
+    day, and this module does not know what timezone they live in.
+    """
+
+    if item.reminder_date is None:
+        raise ValidationError("item has no reminder to bump")
+    try:
+        anchor = date.fromisoformat(item.reminder_date)
+    except ValueError as exc:
+        # Only a hand-edited store can hold one, and naming the field beats the
+        # `unknown_error` a raw parse failure answers with.
+        raise ValidationError(
+            f"stored reminder_date {item.reminder_date!r} is not a date this build can read; "
+            "set the reminder again to replace it"
+        ) from exc
+
+    following = next_occurrence_after(anchor, item.reminder_interval, max(anchor, today))
+    if following is None:
+        raise ValidationError(
+            "a reminder with no interval has no next occurrence; clear it instead"
+        )
+    return following.isoformat()
 
 
 def _iter_events(

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -17,7 +17,9 @@ from typing import Any, NoReturn
 
 import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.util import dt as dt_util
 
+from .calendar_projection import bumped_reminder_date
 from .const import DOMAIN
 from .events import notify_derived_paths_changed, notify_mutation
 from .exceptions import (
@@ -52,6 +54,11 @@ SCHEMA_ITEM_CREATE = vol.Schema(
         vol.Optional("checked_out", default=False): bool,
         vol.Optional("due_date"): str,
         vol.Optional("inspection_date"): str,
+        # Permissive on purpose, exactly as the WebSocket commands are: the
+        # shape rules live in `validate_reminder_rules`, which names what is
+        # wrong with a value far better than a schema mismatch can.
+        vol.Optional("reminder_date"): vol.Any(str, None),
+        vol.Optional("reminder_interval"): vol.Any(dict, None),
         vol.Optional("location_id"): vol.Any(str, None),
         vol.Optional("tags", default=[]): [str],
         vol.Optional("category"): vol.Any(str, None),
@@ -71,6 +78,8 @@ SCHEMA_ITEM_UPDATE = vol.Schema(
         vol.Optional("checked_out"): bool,
         vol.Optional("due_date"): vol.Any(str, None),
         vol.Optional("inspection_date"): vol.Any(str, None),
+        vol.Optional("reminder_date"): vol.Any(str, None),
+        vol.Optional("reminder_interval"): vol.Any(dict, None),
         vol.Optional("location_id"): vol.Any(str, None),
         vol.Optional("tags"): vol.Any([str], None),
         vol.Optional("category"): vol.Any(str, None),
@@ -117,6 +126,10 @@ SCHEMA_ITEM_CHECK_OUT = vol.Schema(
 )
 
 SCHEMA_ITEM_CHECK_IN = vol.Schema(
+    {vol.Required("item_id"): str, vol.Optional("expected_version"): int}
+)
+
+SCHEMA_REMINDER_BUMP = vol.Schema(
     {vol.Required("item_id"): str, vol.Optional("expected_version"): int}
 )
 
@@ -329,6 +342,39 @@ async def service_item_check_in(hass: HomeAssistant, data: dict) -> dict[str, An
         _raise_service_error(op, {"item_id": item_id}, exc)
 
 
+async def service_reminder_bump(hass: HomeAssistant, data: dict) -> dict[str, Any]:
+    """Mark a recurring reminder done and move the series on one step.
+
+    The one reminder verb that is not an ordinary field write: setting and
+    clearing a reminder are `item_update` with `reminder_date` and
+    `reminder_interval`, but "I have just done this" is a question about where
+    the series goes next, and the answer has to be the same one the card gets.
+    """
+
+    op = "reminder_bump"
+    item_id = data.get("item_id")
+    try:
+        payload = SCHEMA_REMINDER_BUMP(data)
+        repo = _get_repo(hass)
+        # The household's day, the one the calendar rolls over on.
+        update = {
+            "reminder_date": bumped_reminder_date(
+                repo.get_item(payload["item_id"]), today=dt_util.now().date()
+            )
+        }
+        item = repo.update_item(
+            payload["item_id"],
+            update,  # type: ignore[arg-type]
+            expected_version=payload.get("expected_version"),
+        )
+        await async_persist_repo(hass)
+        serialized = serialize_item(hass, item)
+        notify_mutation(hass, action="updated", item=serialized)
+        return {"item": serialized}
+    except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
+        _raise_service_error(op, {"item_id": item_id}, exc)
+
+
 async def service_location_create(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     op = "location_create"
     try:
@@ -404,6 +450,7 @@ SERVICES: tuple[tuple[str, ServiceHandler, vol.Schema], ...] = (
     ("item_set_quantity", service_item_set_quantity, SCHEMA_ITEM_SET_QTY),
     ("item_check_out", service_item_check_out, SCHEMA_ITEM_CHECK_OUT),
     ("item_check_in", service_item_check_in, SCHEMA_ITEM_CHECK_IN),
+    ("reminder_bump", service_reminder_bump, SCHEMA_REMINDER_BUMP),
     ("location_create", service_location_create, SCHEMA_LOCATION_CREATE),
     ("location_update", service_location_update, SCHEMA_LOCATION_UPDATE),
     ("location_delete", service_location_delete, SCHEMA_LOCATION_DELETE),

--- a/custom_components/haventory/services.yaml
+++ b/custom_components/haventory/services.yaml
@@ -46,6 +46,18 @@ item_create:
       example: "2025-06-01"
       selector:
         date:
+    reminder_date:
+      required: false
+      example: "2025-09-01"
+      selector:
+        date:
+    reminder_interval:
+      required: false
+      # How often the reminder repeats, as {unit, count} — unit is days, weeks
+      # or months. Leave it out for a one-off date.
+      example: {"unit": "months", "count": 3}
+      selector:
+        object:
     location_id:
       required: false
       example: "uuid-of-location"
@@ -122,6 +134,14 @@ item_update:
       required: false
       selector:
         date:
+    reminder_date:
+      required: false
+      selector:
+        date:
+    reminder_interval:
+      required: false
+      selector:
+        object:
     location_id:
       required: false
       selector:
@@ -239,6 +259,21 @@ item_check_in:
         text:
     expected_version:
       required: false
+      selector:
+        number:
+
+reminder_bump:
+  name: Bump reminder
+  description: Mark a recurring reminder done and move it on to its next occurrence
+  fields:
+    item_id:
+      required: true
+      example: "uuid-of-item"
+      selector:
+        text:
+    expected_version:
+      required: false
+      example: 2
       selector:
         number:
 

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -134,6 +134,10 @@
       "name": "Check in item",
       "description": "Mark an item as not checked out."
     },
+    "reminder_bump": {
+      "name": "Bump reminder",
+      "description": "Mark a recurring reminder done and move it on to its next occurrence."
+    },
     "location_create": {
       "name": "Create location",
       "description": "Create a new storage location."

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -134,6 +134,10 @@
       "name": "Check in item",
       "description": "Mark an item as not checked out."
     },
+    "reminder_bump": {
+      "name": "Bump reminder",
+      "description": "Mark a recurring reminder done and move it on to its next occurrence."
+    },
     "location_create": {
       "name": "Create location",
       "description": "Create a new storage location."

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -10,7 +10,7 @@ import asyncio
 import functools
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from typing import Any, TypedDict, cast
 
 import voluptuous as vol
@@ -27,7 +27,7 @@ from . import import_export, todo_bridge
 from . import media as media_mod
 from . import storage as storage_mod
 from .areas import async_get_area_registry
-from .calendar_projection import next_occurrence_after
+from .calendar_projection import bumped_reminder_date
 from .const import (
     ATTACHMENT_MANUAL_MIME_TYPES,
     ATTACHMENT_PICTURE_MIME_TYPES,
@@ -1400,25 +1400,8 @@ async def ws_reminder_bump(
     """
 
     item = _repo(hass).get_item(msg["item_id"])
-    if item.reminder_date is None:
-        raise ValidationError("item has no reminder to bump")
-    try:
-        anchor = date.fromisoformat(item.reminder_date)
-    except ValueError as exc:
-        # Only a hand-edited store can hold one. Naming it beats the
-        # `unknown_error` a raw parse failure would answer with.
-        raise ValidationError(
-            f"stored reminder_date {item.reminder_date!r} is not a date this build can read; "
-            "set the reminder again to replace it"
-        ) from exc
-    following = next_occurrence_after(
-        anchor, item.reminder_interval, max(anchor, dt_util.now().date())
-    )
-    if following is None:
-        raise ValidationError(
-            "a reminder with no interval has no next occurrence; clear it instead"
-        )
-    update = cast("ItemUpdate", {"reminder_date": following.isoformat()})
+    following = bumped_reminder_date(item, today=dt_util.now().date())
+    update = cast("ItemUpdate", {"reminder_date": following})
     await _apply_reminder(hass, conn, msg, update)
 
 

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -557,8 +557,15 @@ shapes as the WebSocket surface — no bespoke service shape exists:
     expected_version: "{{ created.item.version }}"
 ```
 
-- The eight `item_*` services return `{"item": <Item>}`; the three `location_*` ones return
-  `{"location": <Location>}`.
+- The eight `item_*` services and `reminder_bump` return `{"item": <Item>}`; the three
+  `location_*` ones return `{"location": <Location>}`.
+- Reminders reach automations through the same services rather than through three of their
+  own: `item_create` and `item_update` carry `reminder_date` and `reminder_interval` (either
+  set to `null` clears it), which is what setting and clearing a reminder *is*, and
+  `reminder_bump` exists because "I have just done this" is a question about where the series
+  goes next rather than a field write. It answers the item as the bump left it, so a script
+  can template `reminder_date` out of the response. The rule behind it lives in one place,
+  `calendar_projection.bumped_reminder_date`, which the WebSocket command also calls.
 - `item_delete` and `location_delete` return the entity as it last stood, read before the
   removal. Deleting an unknown id is `not_found`, not an empty envelope.
 - The response is produced **after** the durable write, so an answer means the mutation is

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -11,6 +11,8 @@ every registered service through it and assert the repository actually changed.
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 import voluptuous as vol
 from custom_components.haventory.const import DOMAIN
@@ -18,6 +20,7 @@ from custom_components.haventory.exceptions import NotFoundError, StorageError, 
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import STORAGE_KEY
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 DUE_DATE = "2030-01-01"
@@ -62,6 +65,7 @@ async def test_all_services_are_registered(hass: HomeAssistant) -> None:
         "item_set_quantity",
         "item_check_out",
         "item_check_in",
+        "reminder_bump",
         "location_create",
         "location_update",
         "location_delete",
@@ -261,3 +265,46 @@ async def test_delete_answers_with_the_body_it_removed(hass: HomeAssistant) -> N
     assert removed["item"]["name"] == "Torch"
     assert removed["item"]["quantity"] == quantity
     assert repo.get_counts()["items_total"] == 0
+
+
+async def test_reminders_are_reachable_from_an_automation(hass: HomeAssistant) -> None:
+    """The whole point of the service surface: a household can act on a reminder.
+
+    Reminders shipped WebSocket-only, and no Home Assistant automation can send a
+    WebSocket command — so "check the smoke detector every three months", the
+    automation-facing feature of the release, was unreachable from an automation.
+    """
+
+    await _setup(hass)
+
+    created = await hass.services.async_call(
+        DOMAIN,
+        "item_create",
+        {
+            "name": "HVAC filter",
+            "reminder_date": "2020-01-01",
+            "reminder_interval": {"unit": "days", "count": 7},
+        },
+        blocking=True,
+        return_response=True,
+    )
+    item_id = created["item"]["id"]
+    assert created["item"]["reminder_interval"] == {"unit": "days", "count": 7}
+
+    bumped = await hass.services.async_call(
+        DOMAIN, "reminder_bump", {"item_id": item_id}, blocking=True, return_response=True
+    )
+
+    landed = date.fromisoformat(bumped["item"]["reminder_date"])
+    assert landed > dt_util.now().date()
+    # Series-aligned, exactly as the WebSocket command leaves it.
+    assert (landed - date(2020, 1, 1)).days % 7 == 0
+
+    cleared = await hass.services.async_call(
+        DOMAIN,
+        "item_update",
+        {"item_id": item_id, "reminder_date": None, "reminder_interval": None},
+        blocking=True,
+        return_response=True,
+    )
+    assert cleared["item"]["reminder_date"] is None

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -11,17 +11,25 @@ from __future__ import annotations
 
 import inspect
 import json
+from datetime import date
 from pathlib import Path
 
 import pytest
 import voluptuous as vol
 import yaml
+from custom_components.haventory import events as events_mod
 from custom_components.haventory import services as services_mod
 from custom_components.haventory.const import DOMAIN, EVENT_ITEM_CHANGED
-from custom_components.haventory.exceptions import ConflictError, NotFoundError, StorageError
+from custom_components.haventory.exceptions import (
+    ConflictError,
+    NotFoundError,
+    StorageError,
+    ValidationError,
+)
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from homeassistant.core import HomeAssistant, SupportsResponse
+from homeassistant.util import dt as dt_util
 
 
 @pytest.mark.asyncio
@@ -292,7 +300,7 @@ async def _seeded(hass: HomeAssistant) -> tuple[Repository, str, str]:
 
 @pytest.mark.asyncio
 async def test_every_service_answers_with_the_canonical_envelope() -> None:
-    """All eleven services hand back the entity they touched.
+    """Every service hands back the entity it touched.
 
     The keys are the ones `docs/data_shapes.md` specifies for the WebSocket
     surface, so a script's `response_variable` and a card's WS result are the
@@ -310,6 +318,15 @@ async def test_every_service_answers_with_the_canonical_envelope() -> None:
         (services_mod.service_item_set_quantity, {"item_id": item_id, "quantity": 7}),
         (services_mod.service_item_check_out, {"item_id": item_id, "due_date": "2030-01-01"}),
         (services_mod.service_item_check_in, {"item_id": item_id}),
+        (
+            services_mod.service_item_update,
+            {
+                "item_id": item_id,
+                "reminder_date": "2026-09-01",
+                "reminder_interval": {"unit": "months", "count": 3},
+            },
+        ),
+        (services_mod.service_reminder_bump, {"item_id": item_id}),
     ]
     for handler, payload in item_calls:
         response = await handler(hass, payload)
@@ -451,3 +468,121 @@ async def test_a_failed_persist_answers_nothing(monkeypatch) -> None:
     monkeypatch.setattr(services_mod, "async_persist_repo", _persist)
     with pytest.raises(StorageError):
         await services_mod.service_item_create(hass, {"name": "Widget"})
+
+
+# -----------------------------
+# Reminders from an automation
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_reminder_can_be_set_and_cleared_through_item_update() -> None:
+    """No reminder-specific service for the two field writes: they are field writes.
+
+    The schemas carried `due_date` and `inspection_date` but not these two, so
+    an automation could set every date on an item except the one the release is
+    about.
+    """
+
+    hass = HomeAssistant()
+    repo, item_id, _loc_id = await _seeded(hass)
+
+    stored = await services_mod.service_item_update(
+        hass,
+        {
+            "item_id": item_id,
+            "reminder_date": "2026-09-01",
+            "reminder_interval": {"unit": "months", "count": 3},
+        },
+    )
+    assert stored["item"]["reminder_date"] == "2026-09-01"
+    assert stored["item"]["reminder_interval"] == {"unit": "months", "count": 3}
+
+    cleared = await services_mod.service_item_update(
+        hass, {"item_id": item_id, "reminder_date": None, "reminder_interval": None}
+    )
+    assert cleared["item"]["reminder_date"] is None
+    assert repo.get_item(item_id).reminder_interval is None
+
+
+@pytest.mark.asyncio
+async def test_a_reminder_created_with_the_item_is_stored() -> None:
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    hass.data[DOMAIN]["store"] = DomainStore(hass)
+
+    created = await services_mod.service_item_create(
+        hass,
+        {
+            "name": "HVAC filter",
+            "reminder_date": "2026-09-01",
+            "reminder_interval": {"unit": "months", "count": 3},
+        },
+    )
+
+    assert created["item"]["reminder_date"] == "2026-09-01"
+
+
+@pytest.mark.asyncio
+async def test_the_bump_service_moves_the_series_the_way_the_command_does() -> None:
+    """Two surfaces, one rule — `bumped_reminder_date` is the only copy of it."""
+
+    hass = HomeAssistant()
+    _repo, item_id, _loc_id = await _seeded(hass)
+    await services_mod.service_item_update(
+        hass,
+        {
+            "item_id": item_id,
+            "reminder_date": "2020-01-01",
+            "reminder_interval": {"unit": "days", "count": 7},
+        },
+    )
+
+    bumped = await services_mod.service_reminder_bump(hass, {"item_id": item_id})
+
+    landed = date.fromisoformat(bumped["item"]["reminder_date"])
+    assert landed > dt_util.now().date()
+    # Series-aligned: whole weeks from the anchor, not "today plus seven".
+    assert (landed - date(2020, 1, 1)).days % 7 == 0
+
+
+@pytest.mark.asyncio
+async def test_the_bump_service_refuses_what_the_command_refuses() -> None:
+    """A one-off has no next occurrence, and an automation gets told so."""
+
+    hass = HomeAssistant()
+    _repo, item_id, _loc_id = await _seeded(hass)
+    await services_mod.service_item_update(
+        hass, {"item_id": item_id, "reminder_date": "2026-09-01"}
+    )
+
+    with pytest.raises(ValidationError, match="no interval"):
+        await services_mod.service_reminder_bump(hass, {"item_id": item_id})
+
+    with pytest.raises(ValidationError, match="no reminder"):
+        await services_mod.service_reminder_bump(hass, {"item_id": (await _seeded(hass))[1]})
+
+
+@pytest.mark.asyncio
+async def test_the_bump_service_reaches_the_bus() -> None:
+    """It is an item edit, so an automation watching items has to see it."""
+
+    hass = HomeAssistant()
+    events_mod.seed_low_stock_snapshot(hass)
+    _repo, item_id, _loc_id = await _seeded(hass)
+    events_mod.seed_low_stock_snapshot(hass)
+    await services_mod.service_item_update(
+        hass,
+        {
+            "item_id": item_id,
+            "reminder_date": "2026-09-01",
+            "reminder_interval": {"unit": "months", "count": 3},
+        },
+    )
+    hass.bus.fired.clear()
+
+    await services_mod.service_reminder_bump(hass, {"item_id": item_id})
+
+    fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
+    assert [e["action"] for e in fired] == ["updated"]
+    assert fired[0]["item_id"] == item_id


### PR DESCRIPTION
## Summary

Reminders could not be set, cleared or bumped from a Home Assistant automation. `SCHEMA_ITEM_CREATE` / `SCHEMA_ITEM_UPDATE` carried `due_date` and `inspection_date` but not the reminder fields, and there was no reminder service — the whole surface was WebSocket-only, which an HA automation cannot send. The README told the user to bump "From an automation or a script that is one WebSocket call" and showed a raw frame: an instruction that could not be followed.

This takes **option (a) plus the one service the README actually instructs**, per #464's own analysis:

- `reminder_date` and `reminder_interval` join `SCHEMA_ITEM_CREATE` and `SCHEMA_ITEM_UPDATE` with the same permissive `vol.Any(str, None)` / `vol.Any(dict, None)` shapes the WS commands use — the rules live in `validate_reminder_rules`, which names what is wrong far better than a schema mismatch can. Setting and clearing a reminder *are* field writes, so they need no services of their own; `null` on either clears it.
- `haventory.reminder_bump` is the exception, because "I have just done this" is a question about where the series goes next rather than a field write. It answers `{"item": <Item>}` like every other item service, so a script can template `reminder_date` straight out of `response_variable`.
- The twelve-line next-occurrence rule moves out of `ws_reminder_bump` into `calendar_projection.bumped_reminder_date`, which both surfaces call. Two answers to "where does this reminder go next" would be one too many, and the issue asked for exactly this.
- `services.yaml`, `strings.json` and `translations/en.json` all gain the new service and the two new fields (the catalog parity test holds all three to the `SERVICES` table).

**#467 in the same pass**, since it is a sentence in the same README section: the calendar text credited the **Overdue** sensor with keeping a passed date counted. That is true for due and inspection dates and false for reminders — `overdue_count` and `inspection_overdue_count` cover `due_date` and `inspection_date` only. It now says what actually happens: a recurring reminder rolls forward on its own and is never overdue, and a one-off whose date has passed leaves the calendar and is counted nowhere, so bump or clear it while it is in front of you. No behaviour change — the wording was the defect.

Closes #464
Closes #467

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1112 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] phacc: `99 passed` locally

Offline: a reminder set and cleared through `item_update`; a reminder created with the item; the bump service lands where the command lands (series-aligned, not "today plus seven"); it refuses a one-off and an item with no reminder; it reaches the bus as an `updated` item event. The canonical-envelope test now walks the bump too.

Integration: `test_reminders_are_reachable_from_an_automation` drives create → bump → clear through the **real service registry** with `return_response=True` — which is the only mode that catches a handler HA would classify as an executor job and never await. `test_all_services_are_registered` gains `reminder_bump`.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated — `README.md` (a pasteable automation, plus the reminder-vs-overdue wording) and `docs/data_shapes.md` (the service-response section).
- [x] No WebSocket command shape change; the WS bump behaves exactly as before, now through the shared helper.
- [x] Essential invariants preserved.

## Follow-ups

None. `reminder_set` / `reminder_clear` services are deliberately not added: they would be `item_update` with fewer fields, and the service picker is a household's menu rather than a mirror of the WebSocket namespace.
