### PR TITLE
fix(todo): stop a list that cannot delete collecting one orphan line per crossing

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,11 @@ reinstall, move to another HACS channel, or clear a bad config entry.
 To delete the data as well — after exporting a backup, if you might want it later:
 
 1. Remove the integration and stop Home Assistant.
-2. Delete `<config>/.storage/haventory_store`.
-3. Start Home Assistant.
+2. Delete `<config>/.storage/haventory_store`, and `<config>/.storage/haventory_todo_links`
+   if you ever pointed HAventory at a shopping list — it records which lines on that list
+   are HAventory's, by item name.
+3. Delete `<config>/haventory/attachments/` if you attached photos or manuals.
+4. Start Home Assistant.
 
 Upgrading from a version that copied the card into `<config>/www/haventory/`? That copy is
 no longer used and can be deleted; the integration ignores it either way.
@@ -310,8 +313,10 @@ how many it takes to reach the threshold, never less than one. Restock it and th
 away.
 
 The field is empty by default, and empty means off; nothing is written to any list until
-one is chosen. Any `todo.*` entity works — Home Assistant's own **Local to-do** lists, or a
-shared Google Tasks or CalDAV list.
+one is chosen. Any `todo.*` entity that can both add and delete lines works — Home
+Assistant's own **Local to-do** lists, or a shared Google Tasks or CalDAV list. A list that
+can only be added to is not offered in the picker: restocking could never take its lines
+back off, so it would collect one per low-stock crossing with nothing able to clear them.
 
 The bridge does not track edges, it converges: every change runs one pass that compares
 what is low *right now* against the lines it has already written, and issues only the
@@ -326,7 +331,8 @@ Three things follow from that, worth knowing before you pick a list:
   the bridge takes that as "handled" rather than re-adding it. It comes back the next time
   the item leaves the low-stock set and drops into it again.
 - **Clearing the field stops the mirroring and leaves the list as it stands.** Switching to
-  a different list moves the lines across instead.
+  a different list moves the lines across instead — from whichever list is answering at the
+  time, so switching away from one that is unavailable leaves its lines where they are.
 
 An inventory change never fails because the list did: a list that is unavailable, gone, or
 refuses the write is logged as a warning, and the next change tries again.

--- a/custom_components/haventory/config_flow.py
+++ b/custom_components/haventory/config_flow.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers.selector import (
+    EntityFilterSelectorConfig,
     EntitySelector,
     EntitySelectorConfig,
     SelectSelector,
@@ -49,7 +50,7 @@ from .const import (
 # The domain the shopping-list picker offers, taken from the module that calls
 # its services: a picker offering entities those calls cannot target would let a
 # household choose a list the bridge then refuses to write to.
-from .todo_bridge import TODO_DOMAIN
+from .todo_bridge import TODO_DOMAIN, TODO_FEATURE_DELETE_ITEM_NAME
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
@@ -137,7 +138,18 @@ def _todo_schema(current: dict[str, Any]) -> vol.Schema:
             vol.Optional(
                 CONF_TODO_ENTITY_ID,
                 description={"suggested_value": chosen or None},
-            ): EntitySelector(EntitySelectorConfig(domain=TODO_DOMAIN)),
+            ): EntitySelector(
+                EntitySelectorConfig(
+                    filter=EntityFilterSelectorConfig(
+                        domain=TODO_DOMAIN,
+                        # A list that can be written to but not deleted from
+                        # collects one line per low-stock crossing and nothing
+                        # HAventory can do ever clears them. Not offering it is
+                        # the only way a household cannot choose wrongly here.
+                        supported_features=[TODO_FEATURE_DELETE_ITEM_NAME],
+                    )
+                )
+            ),
         }
     )
 

--- a/custom_components/haventory/todo_bridge.py
+++ b/custom_components/haventory/todo_bridge.py
@@ -46,6 +46,15 @@ SERVICE_ADD_ITEM = "add_item"
 SERVICE_REMOVE_ITEM = "remove_item"
 SERVICE_UPDATE_ITEM = "update_item"
 
+# `TodoListEntityFeature.DELETE_TODO_ITEM`, in the two spellings the two readers
+# need: the bit, to test against a state's `supported_features`, and the name an
+# entity selector's filter takes, which Home Assistant resolves by importing the
+# module. Spelled out rather than imported because the offline suite has no
+# `homeassistant.components.todo` to read them from, and both are part of Home
+# Assistant's published entity API rather than internals.
+TODO_FEATURE_DELETE_ITEM = 2
+TODO_FEATURE_DELETE_ITEM_NAME = "todo.TodoListEntityFeature.DELETE_TODO_ITEM"
+
 # The multiplication sign, U+00D7 — not the letter x a line like "Peanut butter
 # x2" would carry. It is what the card prints against a quantity, so the list
 # and the card read the same way.
@@ -206,8 +215,8 @@ async def _async_retract(
     for item_id, link in list(links.items()):
         if item_id in desired and link["entity_id"] == entity_id:
             continue
-        await _async_remove_line(hass, link)
-        del links[item_id]
+        if await _async_remove_line(hass, link):
+            del links[item_id]
 
 
 async def _async_restate(
@@ -262,6 +271,33 @@ def _desired_summaries(repo: Any) -> dict[str, str]:
     return desired
 
 
+def _list_can_delete(hass: HomeAssistant, entity_id: str) -> bool:
+    """Whether the list advertises the one feature the bridge cannot work around.
+
+    A `todo` entity is free to offer `CREATE_TODO_ITEM` without
+    `DELETE_TODO_ITEM`, and the options flow's picker only hides such a list from
+    a household choosing one now — an option set before this shipped, or through
+    the API, still names one. Read from the state the same way Home Assistant
+    reads it before refusing the service, so the two agree.
+
+    Only a list that positively says it cannot delete is treated as one. An
+    entity missing from the state machine, or one publishing no
+    `supported_features` at all, answers yes and is left to the ordinary path —
+    the old behaviour, for anything this cannot read.
+    """
+
+    state = hass.states.get(entity_id)
+    if state is None:
+        return True
+    features = getattr(state, "attributes", {}).get("supported_features")
+    if features is None:
+        return True
+    try:
+        return bool(int(features) & TODO_FEATURE_DELETE_ITEM)
+    except TypeError, ValueError:  # pragma: no cover - defensive
+        return True
+
+
 def _list_is_available(hass: HomeAssistant, entity_id: str) -> bool:
     """Whether the configured list is in the state machine and answering.
 
@@ -299,14 +335,35 @@ async def _async_add_line(hass: HomeAssistant, entity_id: str, summary: str) -> 
     return True
 
 
-async def _async_remove_line(hass: HomeAssistant, link: dict[str, str]) -> None:
-    """Take one line back off the list, and give up the link either way.
+async def _async_remove_line(hass: HomeAssistant, link: dict[str, str]) -> bool:
+    """Take one line back off the list. False keeps the link, so nothing duplicates.
 
-    Everything Home Assistant refuses here is permanent — the line was deleted
-    by hand, the list cannot delete, the list is gone — and a link held for a
+    Most of what Home Assistant refuses here is about that one line and will not
+    change — it was deleted by hand, or the list is gone — and a link held for a
     line that cannot be retracted would stop that item from ever being listed
-    again.
+    again. So the link is given up and the line, if any, is left to be cleared by
+    hand.
+
+    A list that cannot delete at all is the exception, and the only unbounded
+    one: that refusal repeats on every future crossing, and giving up the link
+    each time means the next crossing writes a fresh duplicate of a line the
+    bridge has forgotten. Keeping the link caps the damage at one stale line per
+    item — the restate phase then rewrites that line in place when the item
+    crosses again, rather than adding a second.
     """
+
+    if not _list_can_delete(hass, link["entity_id"]):
+        LOGGER.warning(
+            "The to-do list cannot delete its own lines, so this one stays on it; "
+            "keeping the link so the next crossing restates it rather than repeating it",
+            extra={
+                "domain": DOMAIN,
+                "op": "todo_remove",
+                "entity_id": link["entity_id"],
+                "summary": link["summary"],
+            },
+        )
+        return False
 
     try:
         await hass.services.async_call(
@@ -327,6 +384,7 @@ async def _async_remove_line(hass: HomeAssistant, link: dict[str, str]) -> None:
             },
             exc_info=True,
         )
+    return True
 
 
 async def _async_rename_line(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,11 +155,17 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             return [listener for kind, listener in self.listeners if kind == event_type]
 
     class _State:  # type: ignore[override]
-        """The two fields anything offline reads off a state object."""
+        """The three fields anything offline reads off a state object.
 
-        def __init__(self, entity_id: str, state: str) -> None:
+        `attributes` carries `supported_features`, which is how the to-do bridge
+        asks whether a list can delete its own lines — the same place Home
+        Assistant reads it from before refusing the service.
+        """
+
+        def __init__(self, entity_id: str, state: str, attributes: dict | None = None) -> None:
             self.entity_id = entity_id
             self.state = state
+            self.attributes = dict(attributes or {})
 
     class _States:  # type: ignore[override]
         """Stand in for HA's state machine, for the reads only.
@@ -177,8 +183,8 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def get(self, entity_id: str):
             return self._states.get(entity_id)
 
-        def async_set(self, entity_id: str, state: str, *_args, **_kwargs) -> None:
-            self._states[entity_id] = _State(entity_id, state)
+        def async_set(self, entity_id: str, state: str, attributes=None, *_args, **_kwargs) -> None:
+            self._states[entity_id] = _State(entity_id, state, attributes)
 
         def async_remove(self, entity_id: str) -> None:
             self._states.pop(entity_id, None)
@@ -404,6 +410,10 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
     def EntitySelectorConfig(**kwargs):  # type: ignore[override]
         return dict(kwargs)
 
+    # Ditto, and the nested one the entity picker's `filter` key takes.
+    def EntityFilterSelectorConfig(**kwargs):  # type: ignore[override]
+        return dict(kwargs)
+
     class EntitySelector:  # type: ignore[override]
         """Stand in for HA's entity picker, validating the domain it restricts to.
 
@@ -418,11 +428,12 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def __call__(self, value):  # type: ignore[no-untyped-def]
             if not isinstance(value, str) or value.count(".") != 1:
                 raise vol.Invalid(f"{value!r} is not an entity id")
-            domain = self.config.get("domain")
+            domain = self.config.get("domain") or (self.config.get("filter") or {}).get("domain")
             if domain and value.split(".")[0] != domain:
                 raise vol.Invalid(f"{value!r} is not in the {domain} domain")
             return value
 
+    ha_helpers_selector.EntityFilterSelectorConfig = EntityFilterSelectorConfig
     ha_helpers_selector.EntitySelector = EntitySelector
     ha_helpers_selector.EntitySelectorConfig = EntitySelectorConfig
     ha_helpers_selector.SelectSelector = SelectSelector

--- a/tests/integration/test_todo_bridge.py
+++ b/tests/integration/test_todo_bridge.py
@@ -280,3 +280,51 @@ async def test_the_options_flow_offers_the_shopping_list_field(hass: HomeAssista
     assert result["type"] == "form"
     assert result["step_id"] == "init"
     assert "todo" in result["data_schema"].schema
+
+    # And the picker only offers lists this bridge can take a line back off.
+    # Home Assistant resolves the feature name by importing the module, so a
+    # wrong string is refused when the selector is built, not when it is drawn.
+    section = result["data_schema"].schema["todo"]
+    selector = next(iter(section.schema.schema.values()))
+    assert selector.config["filter"] == [
+        {
+            "domain": ["todo"],
+            "supported_features": [int(TodoListEntityFeature.DELETE_TODO_ITEM)],
+        }
+    ]
+
+
+async def test_a_list_that_cannot_delete_keeps_one_line_rather_than_stacking_them(
+    hass: HomeAssistant, todo_list: _TestTodoList
+) -> None:
+    """An option set before the picker was filtered still names such a list.
+
+    Home Assistant refuses `todo.remove_item` on an entity without
+    `DELETE_TODO_ITEM`, and the bridge used to read that refusal as permanent and
+    give up the link — so the next crossing wrote a second line, and the one
+    after that a third, with nothing HAventory offers able to clear them.
+    """
+
+    todo_list._attr_supported_features = TodoListEntityFeature.CREATE_TODO_ITEM
+    todo_list.async_write_ha_state()
+    await _setup_haventory(hass, entity_id=LIST_ENTITY_ID)
+    item_id = await _create_low_item(hass)
+    assert todo_list.summaries == [f"Peanut butter {TIMES}2"]
+
+    for _cycle in range(3):
+        await hass.services.async_call(
+            DOMAIN,
+            "item_set_quantity",
+            {"item_id": item_id, "quantity": THRESHOLD + 1},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            DOMAIN,
+            "item_set_quantity",
+            {"item_id": item_id, "quantity": LOW_QUANTITY},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert todo_list.summaries == [f"Peanut butter {TIMES}2"]

--- a/tests/test_todo_bridge_offline.py
+++ b/tests/test_todo_bridge_offline.py
@@ -46,6 +46,10 @@ ADD = f"{todo_bridge.TODO_DOMAIN}.{todo_bridge.SERVICE_ADD_ITEM}"
 REMOVE = f"{todo_bridge.TODO_DOMAIN}.{todo_bridge.SERVICE_REMOVE_ITEM}"
 UPDATE = f"{todo_bridge.TODO_DOMAIN}.{todo_bridge.SERVICE_UPDATE_ITEM}"
 
+# `TodoListEntityFeature` bits, as a state's `supported_features` reports them.
+CREATE_ONLY = 1
+CREATE_AND_DELETE = 1 | todo_bridge.TODO_FEATURE_DELETE_ITEM
+
 
 class _Services:
     """Record the `todo.*` calls a pass makes, and refuse the named ones."""
@@ -188,10 +192,11 @@ async def test_a_refused_add_leaves_the_item_unlinked_so_the_next_pass_retries()
 
 @pytest.mark.asyncio
 async def test_a_refused_removal_gives_up_the_link() -> None:
-    """A line deleted by hand, or a list that cannot delete, is permanent.
+    """A line deleted by hand, or a list that is gone, is permanent.
 
     Holding the link would keep the item off the list for good; giving it up
-    costs at most one line the user clears themselves.
+    costs at most one line the user clears themselves. A list that cannot delete
+    at all is the exception, tested below.
     """
 
     hass, repo, services, _entry = await _bridge()
@@ -390,3 +395,74 @@ async def test_a_stored_row_missing_half_of_itself_is_dropped_on_load() -> None:
     assert hass.data[DOMAIN]["todo_links"] == {
         "kept": {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}2"}
     }
+
+
+# -----------------------------
+# A list that cannot delete its own lines
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_list_that_cannot_delete_collects_one_line_per_item_and_no_more() -> None:
+    """The one accumulation the bridge could not recover from.
+
+    Every other refusal is about one line and will not repeat. "This list cannot
+    delete" repeats on every crossing, and giving up the link each time meant the
+    next crossing wrote a fresh duplicate of a line the bridge had forgotten —
+    unbounded, and clearable by nothing HAventory offers.
+    """
+
+    hass, repo, services, _entry = await _bridge()
+    hass.states.async_set(TODO_ENTITY, "0", {"supported_features": CREATE_ONLY})
+    item = _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+    assert services.names == [ADD]
+
+    for cycle in range(3):
+        services.clear()
+        repo.set_quantity(str(item.id), THRESHOLD + 1)
+        await todo_bridge.async_reconcile(hass)
+        # Nothing is even attempted: Home Assistant would refuse it, and the
+        # link is what stops the next crossing writing a second line.
+        assert services.calls == [], cycle
+        assert list(hass.data[DOMAIN]["todo_links"]) == [str(item.id)], cycle
+
+        services.clear()
+        repo.set_quantity(str(item.id), THRESHOLD - 1)
+        await todo_bridge.async_reconcile(hass)
+        # The line already on the list is restated in place where the shortfall
+        # moved, and never added a second time.
+        assert ADD not in services.names, cycle
+
+
+@pytest.mark.asyncio
+async def test_a_list_that_can_delete_still_has_its_lines_retracted() -> None:
+    """The control: the new check must not stop an ordinary list working."""
+
+    hass, repo, services, _entry = await _bridge()
+    hass.states.async_set(TODO_ENTITY, "0", {"supported_features": CREATE_AND_DELETE})
+    item = _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+
+    services.clear()
+    repo.set_quantity(str(item.id), THRESHOLD + 1)
+    await todo_bridge.async_reconcile(hass)
+
+    assert services.names == [REMOVE]
+    assert hass.data[DOMAIN]["todo_links"] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_list_publishing_no_features_is_treated_as_it_always_was() -> None:
+    """Only a list that positively says it cannot delete gets the new treatment."""
+
+    hass, repo, services, _entry = await _bridge()
+    item = _low_item(repo)
+    await todo_bridge.async_reconcile(hass)
+
+    services.clear()
+    repo.set_quantity(str(item.id), THRESHOLD + 1)
+    await todo_bridge.async_reconcile(hass)
+
+    assert services.names == [REMOVE]
+    assert hass.data[DOMAIN]["todo_links"] == {}


### PR DESCRIPTION
## Summary

`_async_remove_line` gave up the link whenever Home Assistant refused a removal, on the reasoning that every refusal is permanent — "the line was deleted by hand, the list cannot delete, the list is gone". For the first and third that is right. For **the list cannot delete** it is not: that refusal repeats on every future crossing, and each one left a new line behind, because the bridge had forgotten the old one. The audit reproduced it with a create-only `todo` entity — 1 line, then 2, then 3, then 4 over three restock cycles, with nothing HAventory offers able to clear them.

This is the one accumulation the bridge could not recover from; every other path converges (the link map is keyed by item id, retractions are re-tried, a list switch migrates the lines).

Both halves of #459's preferred fix, since they cover different populations:

- **The picker no longer offers such a list.** The options-flow entity selector filters on `supported_features: [todo.TodoListEntityFeature.DELETE_TODO_ITEM]`, so a household never gets to choose wrongly. Home Assistant resolves that feature name by importing the module, so a wrong string is refused when the selector is built — which the integration test pins.
- **The bridge keeps the link when the list cannot delete.** The filter is a frontend hint; an option set before this shipped, or through the API, still names such a list. `_list_can_delete` reads `supported_features` off the state — the same place Home Assistant reads it before refusing the service — and returns `False` from `_async_remove_line`, so the retract phase keeps the link. The next crossing then restates that one line in place instead of adding a second. One stale line per item is the cap, and the pass no longer even attempts a call HA would refuse.

Only a list that *positively* says it cannot delete gets the new treatment: an entity missing from the state machine, or one publishing no `supported_features` at all, takes exactly the path it always did.

README: which lists are offered and why; that switching away from a list that is unavailable leaves its lines where they are (the availability check covers the new list only — #459's second note, bounded by the low-stock count at that moment); and that deleting HAventory's data means `haventory_todo_links` and the attachments directory as well as `haventory_store` — #459's first note, the file that carries item names and had no documented way to clear it.

Closes #459

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1110 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] phacc: `99 passed` locally

Offline: a create-only list cycles restock → re-cross three times and the link survives every one, with no `todo.*` call attempted and no second line added; the control — an ordinary list — still has its lines retracted; a list publishing no features behaves as before. The offline `_State` stub grows `attributes`, which is where `supported_features` lives.

Integration, against a real `TodoListEntity`:

- `test_a_list_that_cannot_delete_keeps_one_line_rather_than_stacking_them` — three restock cycles against a create-only list. **Verified failing without the guard**: `Left contains 3 more items`, i.e. the four lines the audit saw. One line with it.
- the existing options-flow test now also asserts the picker's filter, so the guard cannot be silently dropped.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated — `README.md`, the shopping-list section and the data-deletion steps.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Follow-ups

None filed. The two smaller leftovers #459 lists are handled in the README rather than in code: the links store surviving removal is now documented with the rest of the deletion steps, and switching away from an unavailable list is bounded by the low-stock count at that moment.
