### PR TITLE
fix(diagnostics): keep the household's own vocabulary out of the download

### DIFF
--- a/custom_components/haventory/diagnostics.py
+++ b/custom_components/haventory/diagnostics.py
@@ -3,14 +3,21 @@
 Home Assistant discovers this module by name and puts "Download diagnostics" on
 the entry's ⋮ menu; the JSON it writes is what a bug report carries.
 
-**Aggregates only — no item or location bodies at any depth.** A diagnostics
-dump answers questions about the *shape* of an install: how much is stored, what
-schema it is on, whether the indexes agree with themselves, whether the card
-bundle is even deployed. Redacting free text well enough to paste into a public
-issue is not something a name, a note or a custom field can be trusted to
-survive, and a user who wants their content already has `haventory/export`. The
-one user-authored string that does appear — the card title, out of the entry's
-options — goes through Home Assistant's redaction helper.
+**Aggregates only — no item or location bodies at any depth, and none of the
+household's own words.** A diagnostics dump answers questions about the *shape*
+of an install: how much is stored, what schema it is on, whether the indexes
+agree with themselves, whether the card bundle is even deployed. Redacting free
+text well enough to paste into a public issue is not something a name, a note or
+a custom field can be trusted to survive, and a user who wants their content
+already has `haventory/export`.
+
+Three strings a household authors could otherwise reach the file, and none does:
+the card title and the chosen shopping list go through Home Assistant's
+redaction helper, and the status slugs — `status_counts` is keyed by *every*
+defined status, and a household writes its own — are replaced with indices
+unless they are the three this integration ships. A user who is told a file is
+safe to attach and finds their own words in it has no way to know what else is
+in there.
 
 Home Assistant can call this on an entry whose setup failed, which is exactly
 when it is worth having, so every block reports what it found rather than
@@ -27,15 +34,20 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import _CARD_BUNDLE_PATH
-from .const import CONF_CARD_TITLE, DOMAIN, INTEGRATION_VERSION
+from .const import CONF_CARD_TITLE, CONF_TODO_ENTITY_ID, DOMAIN, INTEGRATION_VERSION
 from .health import collect_health_issues
+from .models import ITEM_STATUSES
 from .rate_limit import RateLimiter
 from .repository import Repository
 from .storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
 
-# The card title is the one free-text string a household writes into the entry's
-# options; everything else there is a number, a flag or an entity id.
-_REDACT_OPTIONS = {CONF_CARD_TITLE}
+# What the entry's options can carry that the household chose the words for. The
+# card title is free text. `todo_entity_id` is an entity id rather than prose,
+# but its object id is whatever the list was named — `todo.alices_shopping` — and
+# the diagnostic question it answers, whether the bridge is configured at all,
+# survives redaction because the key stays in the dump either way. Everything
+# else there is a number or a flag.
+_REDACT_OPTIONS = {CONF_CARD_TITLE, CONF_TODO_ENTITY_ID}
 
 
 def _bundle_state(path: Path) -> dict[str, Any]:
@@ -59,10 +71,36 @@ def _repository_block(repo: Repository | None) -> dict[str, Any]:
     issues, counts = collect_health_issues(repo)
     return {
         "loaded": True,
-        "counts": counts,
+        "counts": _without_household_status_names(counts),
         "generation": repo.generation,
         "health_issues": issues,
     }
+
+
+def _without_household_status_names(counts: dict[str, Any]) -> dict[str, Any]:
+    """Report the spread across statuses without the household's words for them.
+
+    `status_counts` is keyed by every defined slug, and the slug constraint —
+    lowercase, digits and underscores, up to 64 of them — does nothing to stop
+    one being a name. The diagnostic value is whether items are spread across
+    statuses or piled on one, and that survives the anonymisation; the three this
+    integration ships stay readable, because a report saying `needs_repair` is
+    easier to act on than one saying `custom_2`.
+    """
+
+    status_counts = counts.get("status_counts")
+    if not isinstance(status_counts, dict):  # pragma: no cover - defensive
+        return counts
+
+    anonymized: dict[str, Any] = {}
+    household = 0
+    for slug, count in status_counts.items():
+        if slug in ITEM_STATUSES:
+            anonymized[slug] = count
+            continue
+        household += 1
+        anonymized[f"custom_{household}"] = count
+    return {**counts, "status_counts": anonymized}
 
 
 def _rate_limit_block(limiter: RateLimiter | None) -> dict[str, Any] | None:

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 import json
 import uuid
 
-from custom_components.haventory.const import CONF_CARD_TITLE, DOMAIN, INTEGRATION_VERSION
+from custom_components.haventory.const import (
+    CONF_CARD_TITLE,
+    CONF_TODO_ENTITY_ID,
+    DOMAIN,
+    INTEGRATION_VERSION,
+)
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -25,6 +30,10 @@ LOCATION_ID = str(uuid.uuid4())
 CARD_TITLE = "Haus Hoffmann Vorratskammer"
 ITEM_NAME = "Zdrojova kniha 1987"
 LOCATION_NAME = "Kellerregal hinter der Heizung"
+# A status a household typed itself, stored the way a real one is, and the list
+# it mirrors low stock onto.
+CUSTOM_STATUS = "lent_to_alice"
+TODO_LIST = "todo.alices_einkaufsliste"
 
 
 def _store_data() -> dict:
@@ -36,9 +45,14 @@ def _store_data() -> dict:
                 "name": ITEM_NAME,
                 "quantity": 1,
                 "location_id": LOCATION_ID,
+                "status": CUSTOM_STATUS,
             }
         },
         "locations": {LOCATION_ID: {"id": LOCATION_ID, "name": LOCATION_NAME}},
+        "statuses": [
+            {"slug": "ok", "label": "OK", "order": 0},
+            {"slug": CUSTOM_STATUS, "label": "Lent to Alice", "order": 1},
+        ],
     }
 
 
@@ -50,7 +64,10 @@ async def test_the_download_reports_shape_and_never_content(
     hass_storage[STORAGE_KEY] = {"version": 1, "key": STORAGE_KEY, "data": _store_data()}
 
     entry = MockConfigEntry(
-        domain=DOMAIN, data={}, options={CONF_CARD_TITLE: CARD_TITLE}, title="HAventory"
+        domain=DOMAIN,
+        data={},
+        options={CONF_CARD_TITLE: CARD_TITLE, CONF_TODO_ENTITY_ID: TODO_LIST},
+        title="HAventory",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -67,6 +84,9 @@ async def test_the_download_reports_shape_and_never_content(
     assert "repository" in payload["runtime"]["data_keys"]
     assert "frontend_bundle" in payload
 
+    # The household's own status vocabulary is reported as a spread, not by name.
+    assert payload["repository"]["counts"]["status_counts"]["custom_1"] == 1
+
     document = json.dumps(payload)
-    for secret in (ITEM_NAME, LOCATION_NAME, CARD_TITLE):
+    for secret in (ITEM_NAME, LOCATION_NAME, CARD_TITLE, CUSTOM_STATUS, TODO_LIST):
         assert secret not in document, secret

--- a/tests/test_diagnostics_offline.py
+++ b/tests/test_diagnostics_offline.py
@@ -13,8 +13,8 @@ import json
 
 import pytest
 from custom_components.haventory import diagnostics
-from custom_components.haventory.const import CONF_CARD_TITLE, DOMAIN
-from custom_components.haventory.models import ItemCreate
+from custom_components.haventory.const import CONF_CARD_TITLE, CONF_TODO_ENTITY_ID, DOMAIN
+from custom_components.haventory.models import ITEM_STATUSES, ItemCreate
 from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
@@ -25,6 +25,10 @@ STORED_TITLE = "Haus Hoffmann Vorratskammer"
 STORED_ITEM = "Zdrojova kniha 1987"
 STORED_LOCATION = "Kellerregal hinter der Heizung"
 STORED_FIELD_VALUE = "Rechnung 44-2019"
+# A status a household typed itself, and the list it mirrors low stock onto —
+# both under the entry's own vocabulary rather than an item's.
+STORED_STATUS = "lent_to_alice"
+STORED_TODO_LIST = "todo.alices_einkaufsliste"
 
 
 def _loaded_hass() -> tuple[HomeAssistant, ConfigEntry]:
@@ -33,11 +37,13 @@ def _loaded_hass() -> tuple[HomeAssistant, ConfigEntry]:
     hass = HomeAssistant()
     repo = Repository()
     where = repo.create_location(name=STORED_LOCATION)
+    repo.create_status({"slug": STORED_STATUS, "label": "Lent to Alice"})
     repo.create_item(
         ItemCreate(
             name=STORED_ITEM,
             location_id=str(where.id),
             custom_fields={"invoice": STORED_FIELD_VALUE},
+            status=STORED_STATUS,
         )
     )
     hass.data[DOMAIN] = {
@@ -46,7 +52,9 @@ def _loaded_hass() -> tuple[HomeAssistant, ConfigEntry]:
         "card_title": STORED_TITLE,
         "rate_limiter": RateLimiter(RateLimitConfig.from_options(None)),
     }
-    entry = ConfigEntry(options={CONF_CARD_TITLE: STORED_TITLE})
+    entry = ConfigEntry(
+        options={CONF_CARD_TITLE: STORED_TITLE, CONF_TODO_ENTITY_ID: STORED_TODO_LIST}
+    )
     return hass, entry
 
 
@@ -95,7 +103,14 @@ async def test_no_stored_content_reaches_the_payload() -> None:
     payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
 
     document = json.dumps(payload, default=str)
-    for stored in (STORED_ITEM, STORED_LOCATION, STORED_FIELD_VALUE, STORED_TITLE):
+    for stored in (
+        STORED_ITEM,
+        STORED_LOCATION,
+        STORED_FIELD_VALUE,
+        STORED_TITLE,
+        STORED_STATUS,
+        STORED_TODO_LIST,
+    ):
         assert stored not in document, stored
 
 
@@ -167,3 +182,36 @@ async def test_a_deployed_card_bundle_reports_its_size(monkeypatch, tmp_path) ->
 
     assert payload["frontend_bundle"]["exists"] is True
     assert payload["frontend_bundle"]["size_bytes"] == bundle.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_the_shape_of_the_status_spread_survives_the_anonymisation() -> None:
+    """The question the block answers is "spread across statuses, or piled on one".
+
+    That is worth keeping, and it does not need the household's own words: the
+    three shipped slugs stay readable so a report saying `needs_repair` can be
+    acted on, and everything else becomes an index carrying its count.
+    """
+
+    hass, entry = _loaded_hass()
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    status_counts = payload["repository"]["counts"]["status_counts"]
+    assert set(status_counts) == {*ITEM_STATUSES, "custom_1"}
+    # The one item in the fixture carries the household's status, and its count
+    # travels with the index rather than being lost to the redaction.
+    assert status_counts["custom_1"] == 1
+    assert status_counts["ok"] == 0
+
+
+@pytest.mark.asyncio
+async def test_the_shopping_list_is_redacted_rather_than_dropped() -> None:
+    """Whether the bridge is configured is a shape question; which list is not."""
+
+    hass, entry = _loaded_hass()
+
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert CONF_TODO_ENTITY_ID in payload["options"]
+    assert payload["options"][CONF_TODO_ENTITY_ID] != STORED_TODO_LIST


### PR DESCRIPTION
## Summary

The config-entry diagnostics download carried the household's own status vocabulary. `collect_health_issues` feeds `get_counts()` into the payload, and `status_counts` is keyed by **every defined status slug** — including the ones a household typed itself. The live dev download showed `rc_plum`, `night_store`, `sun_faded`, `lent_out` beside the built-ins; a real household writes `lent_to_alice` or `in_the_caravan`, and the `[a-z0-9_]{1,64}` constraint does nothing to stop a name being in there.

#454 delivered the "no inventory content" promise everywhere else — no item name, description, tag, category, custom field or location name appears at any depth. The status slugs were the one thing that slipped through, and it is the kind of leak that makes the promise itself unreliable: a user who spots their own words in a file they were told was safe has no way to know what else is in it.

- `status_counts` now reports the **shape** without the vocabulary: the three slugs this integration ships stay readable, and every other slug becomes `custom_1`, `custom_2`, … carrying its own count. "Are items spread across statuses or piled on one" survives; "which words does this household use" does not. Built-ins stay readable on purpose — a report saying `needs_repair` can be acted on where one saying `custom_2` cannot.
- **`todo_entity_id` is redacted**, which #465 asked to have decided rather than left implicit. It is an entity id rather than prose, but its object id is whatever the household named the list (`todo.alices_shopping`), and the diagnostic question it answers — is the bridge configured at all — is still visible, because redaction keeps the key. The module docstring now states all three redactions and why, instead of claiming the card title is the only authored string in the file.

Closes #465

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1109 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] phacc: `98 passed` locally

The offline fixture now stores a household-authored status and a household-named to-do list, so the existing whole-payload search — the test that stops a future contributor adding the dataset "just for debugging" — covers both. Two new tests pin the shape that survives and the fact that the list is redacted rather than dropped. **All three fail against `main`.**

The integration test downloads through the real HTTP endpoint with a custom status in the store and the to-do option set, and asserts the same.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error case).
- [x] Docs updated — the module docstring, which is where this contract is stated.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Follow-ups

None.
