### PR TITLE
feat(reminders): store the series anchor so a bump keeps its day of month

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,12 @@ leave the repeat empty and it is a single date.
 
 The calendar then shows the next occurrence and the ones after it, as far ahead as whatever
 view you are looking at. Nothing is scheduled and no series is written down: the item stores
-one date and one interval however long it runs, and the occurrences are worked out when
-something reads them. A repeat measured in months keeps the day of the month it started on —
-a reminder anchored on the 31st shows 28 February and then 31 March, rather than sliding down
-to the 28th forever.
+one date, one anchor and one interval however long it runs, and the occurrences are worked
+out when something reads them. A repeat measured in months keeps the day of the month it
+started on — a reminder anchored on the 31st shows 28 February and then 31 March, rather than
+sliding down to the 28th forever — and it keeps it **however often you bump it**: bumping a
+31st reminder in a 30-day month moves it to the 30th, and the one after that is the 31st
+again.
 
 When you have actually changed the filter, **bump** the reminder and the whole series moves
 on one step. From an automation or a script that is one service call — say, when the smart

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -113,10 +113,16 @@ export interface Item {
   inspection_date: string | null;
   /**
    * Optional because a backend older than schema v8 does not send them; absent
-   * reads as no reminder. The anchor alone is a one-off; with an interval it is
-   * the start of a series the calendar expands on read.
+   * reads as no reminder. `reminder_date` alone is a one-off; with an interval
+   * it is the next occurrence of a series the calendar expands on read.
+   *
+   * `reminder_anchor` is what that series is measured from, and only the
+   * backend writes it — the editor sends a date, and the backend anchors the
+   * series on it. Read-only here, and absent from `ItemCreate` / `ItemUpdate`
+   * for that reason.
    */
   reminder_date?: string | null;
+  reminder_anchor?: string | null;
   reminder_interval?: ReminderInterval | null;
   location_id: string | null;
   tags: string[];

--- a/custom_components/haventory/calendar_projection.py
+++ b/custom_components/haventory/calendar_projection.py
@@ -20,7 +20,6 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 
-from .exceptions import ValidationError
 from .models import Item, ReminderInterval
 
 LOGGER = logging.getLogger(__name__)
@@ -124,40 +123,6 @@ def next_occurrence_after(
     return _occurrence(anchor, interval, _first_step_after(anchor, interval, after))
 
 
-def bumped_reminder_date(item: Item, *, today: date) -> str:
-    """The stored anchor an item's reminder moves to when it is marked done.
-
-    The whole rule, in one place, because two surfaces ask for it — the
-    WebSocket command and the `haventory.reminder_bump` service — and two
-    answers to "where does this reminder go next" would be one answer too many.
-
-    Counted from the later of the anchor and `today`, so a reminder bumped on
-    the day it came round advances by exactly one interval, and one nobody
-    bumped for a year lands on its next *future* occurrence instead of another
-    date already past. `today` is the caller's to supply: it is the household's
-    day, and this module does not know what timezone they live in.
-    """
-
-    if item.reminder_date is None:
-        raise ValidationError("item has no reminder to bump")
-    try:
-        anchor = date.fromisoformat(item.reminder_date)
-    except ValueError as exc:
-        # Only a hand-edited store can hold one, and naming the field beats the
-        # `unknown_error` a raw parse failure answers with.
-        raise ValidationError(
-            f"stored reminder_date {item.reminder_date!r} is not a date this build can read; "
-            "set the reminder again to replace it"
-        ) from exc
-
-    following = next_occurrence_after(anchor, item.reminder_interval, max(anchor, today))
-    if following is None:
-        raise ValidationError(
-            "a reminder with no interval has no next occurrence; clear it instead"
-        )
-    return following.isoformat()
-
-
 def _iter_events(
     items: Iterable[Item], start: date, end: date, *, limit: int = MAX_REMINDER_OCCURRENCES
 ) -> Iterator[ProjectedEvent]:
@@ -183,25 +148,33 @@ def _item_events(item: Item, start: date, end: date, *, limit: int) -> Iterator[
 def _reminder_events(item: Item, start: date, end: date, *, limit: int) -> Iterator[ProjectedEvent]:
     """Every occurrence of the item's reminder inside `[start, end)`.
 
-    With no interval the anchor is the whole series — a one-off. With one, the
-    anchor and every step after it are occurrences, and the window is what bounds
-    them; the anchor itself may be years before `start`.
+    With no interval `reminder_date` is the whole series — a one-off. With one,
+    the series is measured from `reminder_anchor` and begins at `reminder_date`:
+    the anchor is what the month steps count from, and the date is how far the
+    household has marked it done. They are equal until the first bump, so a
+    reminder nobody has bumped projects from its own date either way, and the
+    anchor may be years before `start`.
     """
 
     if item.reminder_date is None:
         return
-    anchor = _stored_date(item, "reminder_date", item.reminder_date)
-    if anchor is None:
+    occurrence = _stored_date(item, "reminder_date", item.reminder_date)
+    if occurrence is None:
         return
     interval = item.reminder_interval
     summary = f"{item.name} reminder"
 
     if interval is None:
-        if start <= anchor < end:
-            yield _event(item, KIND_REMINDER, summary, anchor, uid=f"{item.id}:{KIND_REMINDER}")
+        if start <= occurrence < end:
+            yield _event(item, KIND_REMINDER, summary, occurrence, uid=f"{item.id}:{KIND_REMINDER}")
         return
 
-    step = _first_step_on_or_after(anchor, interval, start)
+    anchor = _stored_date(item, "reminder_anchor", item.reminder_anchor or item.reminder_date)
+    if anchor is None:
+        return
+    # Nothing before the stored occurrence: those are the ones already marked
+    # done, and the window cannot un-do them.
+    step = _first_step_on_or_after(anchor, interval, max(start, occurrence))
     for _ in range(limit):
         day = _occurrence(anchor, interval, step)
         if day >= end:

--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -110,6 +110,7 @@ _ITEM_SOURCE_FIELDS: tuple[str, ...] = (
     "due_date",
     "inspection_date",
     "reminder_date",
+    "reminder_anchor",
     "reminder_interval",
     "location_id",
     "tags",
@@ -145,6 +146,7 @@ def _serialize_item_doc(item: Item) -> dict[str, Any]:
         "due_date": item.due_date,
         "inspection_date": item.inspection_date,
         "reminder_date": item.reminder_date,
+        "reminder_anchor": item.reminder_anchor,
         "reminder_interval": serialize_reminder_interval(item.reminder_interval),
         "location_id": str(item.location_id) if item.location_id is not None else None,
         "tags": list(item.tags),
@@ -549,15 +551,18 @@ def _validate_inspection_date_doc(
 def _validate_reminder_doc(base: str, doc: dict[str, Any], errors: list[dict[str, str]]) -> None:
     """Hold an imported reminder to the rules every write path enforces.
 
-    Both halves matter, and they fail differently. An anchor nothing can parse
+    All three halves matter, and they fail differently. A date nothing can parse
     reaches the calendar, which derives its occurrences from stored dates on
     every read. A misspelled unit — ``"month"`` for ``"months"`` — is read by the
     deliberately tolerant loader as no recurrence at all, so the document would
-    import clean and the recurrence would be gone with nothing saying so.
+    import clean and the recurrence would be gone with nothing saying so. An
+    anchor later than the date it belongs to describes a series this build
+    cannot walk.
     """
 
     reminder_date = doc.get("reminder_date")
     interval = doc.get("reminder_interval")
+    anchor = doc.get("reminder_anchor")
     refused = False
 
     if reminder_date is not None:
@@ -566,6 +571,33 @@ def _validate_reminder_doc(base: str, doc: dict[str, Any], errors: list[dict[str
         except ValidationError as exc:
             errors.append(_err(f"{base}.reminder_date", str(exc)))
             refused = True
+    if anchor is not None:
+        try:
+            validate_reminder_date(anchor)
+        except ValidationError as exc:
+            errors.append(_err(f"{base}.reminder_anchor", str(exc)))
+            refused = True
+        else:
+            # The anchor is where the series starts and the date is how far it
+            # has been marked done, so an anchor beyond its own date describes a
+            # series with no occurrence to lead to. Absent is fine — it reads as
+            # the date, which is what every export written before v9 carries.
+            if reminder_date is None:
+                errors.append(
+                    _err(
+                        f"{base}.reminder_anchor",
+                        "reminder_anchor requires a reminder_date to lead to",
+                    )
+                )
+                refused = True
+            elif isinstance(reminder_date, str) and anchor > reminder_date:
+                errors.append(
+                    _err(
+                        f"{base}.reminder_anchor",
+                        "reminder_anchor must not be later than reminder_date",
+                    )
+                )
+                refused = True
     if interval is not None:
         try:
             validate_reminder_interval(interval)
@@ -592,6 +624,11 @@ def _canonical_item(doc: dict[str, Any]) -> dict[str, Any]:
             out[f] = normalize_tags(doc.get("tags") or [])
         elif f == "custom_fields":
             out[f] = dict(doc.get("custom_fields") or {})
+        elif f == "reminder_anchor":
+            # Absent reads as the reminder's own date on load, so a document
+            # written before the field existed compares as unchanged against a
+            # stored item whose series has never been bumped.
+            out[f] = doc.get("reminder_anchor") or doc.get("reminder_date")
         elif f == "status":
             # An absent status reads as the default on load, so a pre-status
             # export compares as unchanged against a stored "ok" item.

--- a/custom_components/haventory/migrations.py
+++ b/custom_components/haventory/migrations.py
@@ -220,3 +220,34 @@ def migrate_7_to_8(payload: dict[str, Any]) -> dict[str, Any]:
                 item.setdefault("reminder_date", None)
                 item.setdefault("reminder_interval", None)
     return data
+
+
+def migrate_8_to_9(payload: dict[str, Any]) -> dict[str, Any]:
+    """Give every reminder the anchor its series is measured from.
+
+    v9 splits the one stored reminder date in two: ``reminder_date`` stays the
+    next occurrence nobody has marked done, and ``reminder_anchor`` is what the
+    month arithmetic counts from. Before this, a bump wrote the occurrence back
+    as the anchor, so a series on the 31st settled on the 30th — then the 28th —
+    the first time it was bumped through a short month, permanently.
+
+    Every existing reminder is one nobody has bumped *under the new rule*, and
+    for those the two are the same date. An item with no reminder gets ``None``,
+    which is what "no reminder" means in both fields.
+
+    Written rather than left absent, for the reason ``migrate_7_to_8`` gives: a
+    v8 build reading a v9 store would parse these items, keep them, and rewrite
+    them on the next save with every anchor dropped. Stamped 9, it refuses the
+    store instead and the anchors wait for a build that understands them.
+
+    Idempotent: an item already carrying the key keeps what it holds, including
+    an anchor a bump has since moved away from its date.
+    """
+
+    data = deepcopy(payload) if isinstance(payload, dict) else {}
+    items = data.get("items")
+    if isinstance(items, dict):
+        for item in items.values():
+            if isinstance(item, dict):
+                item.setdefault("reminder_anchor", item.get("reminder_date"))
+    return data

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -189,11 +189,16 @@ class Item:
     # When the item is next due for inspection — a forward-looking date, so a
     # value before today means the inspection is outstanding.
     inspection_date: str | None = None  # YYYY-MM-DD
-    # The anchor of a recurring reminder: the next date it comes round. With
-    # `reminder_interval` set it is the start of a series the calendar expands
-    # on read; alone it is a one-off. Nothing schedules from it — see
-    # `calendar_projection.py`.
+    # A reminder is three fields, and two of them are dates on purpose.
+    # `reminder_date` is the next occurrence nobody has marked done — what the
+    # calendar shows first and what a bump advances. `reminder_anchor` is what
+    # the series is measured from, and a bump leaves it alone: month steps are
+    # counted from the anchor, so a series anchored on the 31st returns to the
+    # 31st in every month that has one, however often it is bumped through a
+    # short one. The two are equal until the first bump; neither exists without
+    # the other. Nothing schedules from any of it — see `calendar_projection.py`.
     reminder_date: str | None = None  # YYYY-MM-DD
+    reminder_anchor: str | None = None  # YYYY-MM-DD
     reminder_interval: ReminderInterval | None = None
     location_id: uuid.UUID | None = None
     tags: list[str] = field(default_factory=list)
@@ -891,9 +896,9 @@ def validate_reminder_rules(
 ) -> tuple[str | None, ReminderInterval | None]:
     """Validate the pair, and hold the one rule that binds them.
 
-    An interval with no anchor has nothing to count from, so it is refused
-    rather than silently stored — an item carrying a recurrence that can never
-    produce an occurrence reads as a reminder that quietly does nothing.
+    An interval with no date has nothing to count from, so it is refused rather
+    than silently stored — an item carrying a recurrence that can never produce
+    an occurrence reads as a reminder that quietly does nothing.
     """
 
     normalized_date = validate_reminder_date(reminder_date)
@@ -901,6 +906,29 @@ def validate_reminder_rules(
     if interval is not None and normalized_date is None:
         raise ValidationError("reminder_interval requires a reminder_date to count from")
     return normalized_date, interval
+
+
+def load_reminder_anchor(value: object, *, reminder_date: str | None) -> str | None:
+    """Read a stored series anchor, falling back to the date it belongs to.
+
+    Tolerant, the way `load_reminder_interval` is: every store written before v9
+    carries no anchor, and a reminder that has never been bumped has one equal to
+    its date anyway — so "absent" and "equal" have to reach the same answer.
+
+    An anchor *after* its date describes no series this build can walk (the
+    occurrences would all start beyond the date they are supposed to lead to), so
+    it is read as the date rather than refused. Compared as text, which is what
+    fixed-width ISO dates are for.
+    """
+
+    if reminder_date is None:
+        return None
+    if not isinstance(value, str) or not value or value > reminder_date:
+        return reminder_date
+    try:
+        return normalize_date_yyyy_mm_dd(value)
+    except ValidationError:
+        return reminder_date
 
 
 def serialize_reminder_interval(interval: ReminderInterval | None) -> dict[str, Any] | None:
@@ -1077,6 +1105,8 @@ def create_item_from_create(
         reminder_date=payload.get("reminder_date"),
         reminder_interval=payload.get("reminder_interval"),
     )
+    # Setting a reminder is saying where its series starts, so the anchor
+    # follows the date. Only a bump moves one without the other.
 
     location_id: uuid.UUID | None = None
     if location_id_raw is not None:
@@ -1101,6 +1131,7 @@ def create_item_from_create(
         due_date=normalized_due_date,
         inspection_date=normalized_inspection_date,
         reminder_date=normalized_reminder_date,
+        reminder_anchor=normalized_reminder_date,
         reminder_interval=reminder_interval,
         location_id=location_id,
         tags=tags,
@@ -1168,8 +1199,14 @@ def _update_reminder(new_item: Item, update: ItemUpdate) -> None:
     """Apply either half of the reminder, holding the pair's rule across both.
 
     An update naming only one of the two is validated against the item's stored
-    other half, so clearing the anchor of a recurring reminder is refused rather
+    other half, so clearing the date of a recurring reminder is refused rather
     than leaving an interval with nothing to count from.
+
+    Writing a date re-anchors the series on it: `ItemUpdate` carries no anchor of
+    its own, deliberately, because a household picking a date is saying where the
+    series starts. `Repository.bump_reminder` is the one path that moves the date
+    and keeps the anchor, which is what makes a bumped month-end series stay on
+    its own day.
     """
 
     if "reminder_date" not in update and "reminder_interval" not in update:
@@ -1181,6 +1218,13 @@ def _update_reminder(new_item: Item, update: ItemUpdate) -> None:
     new_item.reminder_date, new_item.reminder_interval = validate_reminder_rules(
         reminder_date=date_value, reminder_interval=interval_value
     )
+    if "reminder_date" in update:
+        new_item.reminder_anchor = new_item.reminder_date
+    elif new_item.reminder_date is None:
+        # The interval was cleared alongside a date that was already absent, or
+        # the pair rule left nothing behind. An anchor without a date names a
+        # series with no next occurrence.
+        new_item.reminder_anchor = None
 
 
 def _update_location_and_path(

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -20,8 +20,10 @@ import uuid
 from collections import deque
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
+from datetime import date
 from typing import Any, NamedTuple, TypedDict
 
+from .calendar_projection import next_occurrence_after
 from .exceptions import ConflictError, NotFoundError, ValidationError
 from .models import (
     DEFAULT_ITEM_STATUS,
@@ -48,6 +50,7 @@ from .models import (
     item_is_low_stock,
     item_is_overdue,
     load_attachments,
+    load_reminder_anchor,
     load_reminder_interval,
     location_sort_key,
     monotonic_timestamp_after,
@@ -191,6 +194,23 @@ class LoadReport:
             or self.cyclic_location_ids
             or self.unrooted_location_ids
         )
+
+
+def _parse_reminder_date(value: str, field: str) -> date:
+    """Read one of an item's two reminder dates, naming it if it cannot be read.
+
+    Every write path and the import side validate these, so only a hand-edited
+    store holds one that fails here — and naming the field beats the
+    `unknown_error` a raw parse failure answers a caller with.
+    """
+
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValidationError(
+            f"stored reminder {field} {value!r} is not a date this build can read; "
+            "set the reminder again to replace it"
+        ) from exc
 
 
 class Repository:
@@ -1308,6 +1328,56 @@ class Repository:
             expected_version=expected_version,
         )
 
+    def bump_reminder(
+        self, item_id: str | uuid.UUID, *, today: date, expected_version: int | None = None
+    ) -> Item:
+        """Mark a recurring reminder done and move it on to its next occurrence.
+
+        The one write that moves `reminder_date` without re-anchoring the series,
+        which is the whole reason the anchor is stored: counted from the anchor,
+        a series on the 31st returns to the 31st in every month that has one, and
+        no occurrence is skipped on the way. Writing back the occurrence as the
+        new anchor — which is what one stored date forces — would settle the
+        series on the lowest day of month it ever met.
+
+        Counted from the later of the stored occurrence and `today`, so a
+        reminder bumped on the day it came round advances by exactly one
+        interval, and one nobody bumped for a year lands on its next *future*
+        occurrence rather than another date already past. `today` is the
+        caller's to supply: it is the household's day, and this module does not
+        know what timezone they live in.
+
+        An ordinary item edit otherwise — a new `version`, a new `updated_at`,
+        and the same optimistic-concurrency check as every other mutation.
+        """
+
+        key = str(item_id)
+        current = self._items_by_id.get(key)
+        if current is None:
+            raise NotFoundError("item not found")
+        if current.reminder_date is None:
+            raise ValidationError("item has no reminder to bump")
+        if current.reminder_interval is None:
+            raise ValidationError(
+                "a reminder with no interval has no next occurrence; clear it instead"
+            )
+
+        anchor = _parse_reminder_date(current.reminder_anchor or current.reminder_date, "anchor")
+        occurrence = _parse_reminder_date(current.reminder_date, "date")
+        following = next_occurrence_after(anchor, current.reminder_interval, max(occurrence, today))
+        if following is None:  # pragma: no cover - an interval is present above
+            raise ValidationError("this reminder has no next occurrence")
+
+        updated = self.update_item(
+            key,
+            ItemUpdate(reminder_date=following.isoformat()),
+            expected_version=expected_version,
+        )
+        # `update_item` re-anchored on the date it just wrote, because that is
+        # what every other caller means. This is the one that does not.
+        self._items_by_id[key] = replace(updated, reminder_anchor=current.reminder_anchor)
+        return self._items_by_id[key]
+
     # -----------------------------
     # Public API — Attachments
     # -----------------------------
@@ -2278,6 +2348,7 @@ class Repository:
                 "due_date": item.due_date,
                 "inspection_date": item.inspection_date,
                 "reminder_date": item.reminder_date,
+                "reminder_anchor": item.reminder_anchor,
                 "reminder_interval": serialize_reminder_interval(item.reminder_interval),
                 "location_id": str(item.location_id) if item.location_id is not None else None,
                 "tags": list(item.tags),
@@ -2449,8 +2520,14 @@ class Repository:
                         inspection_date=item_data.get("inspection_date"),
                         # Absent on every store written before v8, and read as
                         # none there — which is exactly what migrate_7_to_8
-                        # writes, so the two paths agree.
+                        # writes, so the two paths agree. The anchor is the same
+                        # story one version later: absent before v9, and equal to
+                        # the date for any reminder nobody has bumped.
                         reminder_date=item_data.get("reminder_date"),
+                        reminder_anchor=load_reminder_anchor(
+                            item_data.get("reminder_anchor"),
+                            reminder_date=item_data.get("reminder_date"),
+                        ),
                         reminder_interval=load_reminder_interval(
                             item_data.get("reminder_interval")
                         ),

--- a/custom_components/haventory/serialization.py
+++ b/custom_components/haventory/serialization.py
@@ -46,6 +46,7 @@ def serialize_item(hass: HomeAssistant, item: Item) -> dict[str, Any]:
         "due_date": item.due_date,
         "inspection_date": item.inspection_date,
         "reminder_date": item.reminder_date,
+        "reminder_anchor": item.reminder_anchor,
         "reminder_interval": serialize_reminder_interval(item.reminder_interval),
         "location_id": str(item.location_id) if item.location_id is not None else None,
         "tags": list(item.tags),

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -19,7 +19,6 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.util import dt as dt_util
 
-from .calendar_projection import bumped_reminder_date
 from .const import DOMAIN
 from .events import notify_derived_paths_changed, notify_mutation
 from .exceptions import (
@@ -356,15 +355,10 @@ async def service_reminder_bump(hass: HomeAssistant, data: dict) -> dict[str, An
     try:
         payload = SCHEMA_REMINDER_BUMP(data)
         repo = _get_repo(hass)
-        # The household's day, the one the calendar rolls over on.
-        update = {
-            "reminder_date": bumped_reminder_date(
-                repo.get_item(payload["item_id"]), today=dt_util.now().date()
-            )
-        }
-        item = repo.update_item(
+        item = repo.bump_reminder(
             payload["item_id"],
-            update,  # type: ignore[arg-type]
+            # The household's day, the one the calendar rolls over on.
+            today=dt_util.now().date(),
             expected_version=payload.get("expected_version"),
         )
         await async_persist_repo(hass)

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -38,7 +38,7 @@ from .models import seed_status_definitions, serialize_status_definition
 _LOGGER = logging.getLogger(__name__)
 
 # Current schema version for persisted payloads
-CURRENT_SCHEMA_VERSION: Final[int] = 8
+CURRENT_SCHEMA_VERSION: Final[int] = 9
 
 # Storage key under which the persisted dataset is saved
 STORAGE_KEY: Final[str] = "haventory_store"

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -27,7 +27,6 @@ from . import import_export, todo_bridge
 from . import media as media_mod
 from . import storage as storage_mod
 from .areas import async_get_area_registry
-from .calendar_projection import bumped_reminder_date
 from .const import (
     ATTACHMENT_MANUAL_MIME_TYPES,
     ATTACHMENT_PICTURE_MIME_TYPES,
@@ -1382,14 +1381,10 @@ async def ws_reminder_bump(
 ) -> None:
     """Move a reminder on to its next occurrence — "I have just done this".
 
-    The whole series moves with the anchor, which is why bumping is one command
-    rather than the client working out the next date and writing it back: two
-    clients bumping the same reminder land on the same answer.
-
-    Counted from the later of the anchor and today, so a reminder bumped on the
-    day it came round advances by exactly one interval, and one nobody bumped
-    for a year lands on its next *future* occurrence instead of another date
-    already past.
+    One command rather than the client working out the next date and writing it
+    back: the rule lives in `Repository.bump_reminder`, so two clients bumping
+    the same reminder land on the same answer, and neither of them can re-anchor
+    a series by accident.
 
     Today is the **local** one, the day the calendar runs on. A reminder is a
     household-facing date rather than a timestamp, and bumping is what somebody
@@ -1399,10 +1394,18 @@ async def ws_reminder_bump(
     the UTC day; see the README's note on the two boundaries.
     """
 
-    item = _repo(hass).get_item(msg["item_id"])
-    following = bumped_reminder_date(item, today=dt_util.now().date())
-    update = cast("ItemUpdate", {"reminder_date": following})
-    await _apply_reminder(hass, conn, msg, update)
+    repo = _repo(hass)
+    updated = repo.bump_reminder(
+        msg["item_id"],
+        today=dt_util.now().date(),
+        expected_version=msg.get("expected_version"),
+    )
+    serialized = serialize_item(hass, updated)
+    await _persist_repo(hass)
+    _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
+    notify_mutation(hass, action="updated", item=serialized)
+    _broadcast_counts(hass)
+    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
 @websocket_api.websocket_command(

--- a/dev/V0_6_0_implementation.md
+++ b/dev/V0_6_0_implementation.md
@@ -81,10 +81,11 @@ live checks queue anyway.
 - **#218 before S2 and S3.** It creates the HAventory device, the `unique_id`
   convention, the HA-bus events, and the offline `bus` stub. #232 consumes the event as
   its reconcile trigger; #187's entity joins the device and re-renders on the same event.
-- **S3 before S5.** #187 slice B is the milestone's only schema bump (v7 → v8) and the
-  last planned change to the stored shape; #229 collapses only after the shape has
-  stopped moving. If slice B slips out of the milestone, S5 moves to V0.7.0 with it
-  rather than the release moving — #236's standing rule.
+- **S3 before S5.** #187 slice B bumped the stored shape (v7 → v8), and the V0.6.0
+  pre-release audit's #460 bumped it once more (v8 → v9, the reminder's series anchor);
+  #229 collapses only after the shape has stopped moving, which it now has. If a further
+  shape change lands, S5 moves with it rather than the release moving — #236's standing
+  rule.
 - **S4 before S5.** The repairs strings and the lossy-load flow should exist in the same
   release whose sunset adopter could first meet a store it mistrusts. S4 is otherwise
   independent and runs late simply to keep `ws.py`/`strings.json` churn serial.
@@ -279,24 +280,25 @@ This PR also deletes `dev/schema_collapse_plan.md` (superseded by the issue),
 `dev/V0_6_0_concept.md` and this file — it closes the milestone's last issue.
 
 The issue's implementation notes are the design, but they were written on 2026-08-05 and
-the tree has moved three schema versions since. Decide the drifted details against the
+the tree has moved four schema versions since. Decide the drifted details against the
 code and record them in the PR body, per §4; six are known already:
 
-- `CURRENT_SCHEMA_VERSION` is **8** (`storage.py:41`), not the notes' 5, so the closed
-  adoptable set is 2–8 — 0 and 1 stay outside it deliberately. The adopter folds in the
+- `CURRENT_SCHEMA_VERSION` is **9** (`storage.py`), not the notes' 5, so the closed
+  adoptable set is 2–9 — 0 and 1 stay outside it deliberately. The adopter folds in the
   backfills of `migrate_4_to_5` (item statuses), `5_to_6`, `6_to_7` (hex status colours,
-  #436) and `7_to_8` (reminder nulls). There is no `migrate_3_to_4`; the chain no-ops
+  #436), `7_to_8` (reminder nulls) and `8_to_9` (the reminder's series anchor, #460, which
+  reads as the item's own `reminder_date`). There is no `migrate_3_to_4`; the chain no-ops
   that step.
 - **The import side ships in this same PR, or the release notes are wrong.**
   `_parse_envelope` refuses a document stamped above the running version, so the export
-  the release notes tell the owner to take first — stamped 8 — is unimportable into the
+  the release notes tell the owner to take first — stamped 9 — is unimportable into the
   collapsed build. The notes cover this; `dev/schema_collapse_plan.md`'s export → wipe →
   import crossing does not, which is one more reason this PR deletes it.
 - #454 put the repairs machinery in the path the adopter enters, so the notes'
   "`__init__.py` — no change" is stale. Two behaviours to pin with tests: a store stamped
   *inside* the adoptable range is adopted rather than routed to the schema-downgrade
   Repairs card, and the corrupt-store repair still works on a v1 store. That card's text
-  names the supported version, so "newer than this build supports (8)" becomes (1).
+  names the supported version, so "newer than this build supports (9)" becomes (1).
 - Three stored artifacts sit outside the versioned payload and the collapse moves none of
   them: `haventory_todo_links` (its own `Store` at version 1 — it survives the crossing
   intact because import preserves item ids), the entry options (`todo_entity_id`, and a

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -235,6 +235,8 @@ with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
   - `reminder_date` and `reminder_interval` are also writable through
     `haventory/item/update`, which is how the card's editor saves them beside the rest of
     an edit. These commands exist for callers with no form to carry the other fields.
+  - Writing `reminder_date` through any of them sets `reminder_anchor` to the same date:
+    picking a date is saying where the series starts. No client writes the anchor directly.
 
 - `haventory/reminder/clear`
   - Payload: `{item_id: string, expected_version?: number}`
@@ -244,12 +246,24 @@ with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
 - `haventory/reminder/bump`
   - Payload: `{item_id: string, expected_version?: number}`
   - Result: `<Item>`; emits `items/updated` and `stats/counts`.
-  - Moves the anchor to the series' next occurrence — "I have just done this". Counted from
-    the later of the stored anchor and today (UTC), so a reminder bumped on the day it came
-    round advances by exactly one interval, and one nobody bumped for a year lands on its
-    next *future* occurrence rather than another date already past.
+  - Moves `reminder_date` to the series' next occurrence — "I have just done this" — and
+    **leaves `reminder_anchor` where it is**. It is the only write that does: every other
+    path re-anchors the series on the date it writes. That is what keeps a series on the
+    31st landing on the 31st in every month that has one, however often it is bumped through
+    a short one; writing the occurrence back as the anchor would settle it on the lowest day
+    of month it ever met.
+  - Counted from the later of the stored `reminder_date` and today, so a reminder bumped on
+    the day it came round advances by exactly one interval, one nobody bumped for a year
+    lands on its next *future* occurrence rather than another date already past, and no
+    occurrence in between is skipped — a 31st series bumped in February lands on the 28th,
+    and the next one is 31 March.
+  - Today is the **local** day, the one `calendar.haventory` rolls over on, not the UTC day
+    the two date-derived counts use. A reminder is a household-facing date, and bumping is
+    what somebody does in the evening.
   - `validation_error` when the item has no reminder, and when it has one with no interval:
-    a one-off has no next occurrence, and `haventory/reminder/clear` is what ends it.
+    a one-off has no next occurrence, and `haventory/reminder/clear` is what ends it. Also
+    when the stored dates cannot be read, which only a hand-edited store produces.
+  - Takes `expected_version` like any other item edit, and answers `conflict` on a stale one.
 
 - `haventory/item/add_tags`
   - Payload: `{item_id: string, tags: string[], expected_version?: number}` (tags normalized: trimmed, casefolded, deduped)

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -20,6 +20,7 @@ Object shape for persisted items and API results:
   "due_date": "YYYY-MM-DD|null",
   "inspection_date": "YYYY-MM-DD|null",
   "reminder_date": "YYYY-MM-DD|null",
+  "reminder_anchor": "YYYY-MM-DD|null",
   "reminder_interval": {"unit": "days|weeks|months", "count": 1},
   "location_id": "uuid-v4|null",
   "tags": ["string", "..."],
@@ -51,20 +52,38 @@ A value strictly before today (UTC) means that inspection is overdue — the pop
 the `inspection_overdue_only` filter and the `inspection_overdue_count` stat. It is
 independent of `checked_out` and of `due_date`; any item can carry one.
 
-`reminder_date` is the anchor of a recurring reminder — the next date it comes round —
-and `reminder_interval` is `{unit, count}` with `unit` one of `days`, `weeks`, `months`
-and `count` an integer from 1 to 1000. `reminder_interval` is `null` for a one-off, and an
-interval with no `reminder_date` to count from is rejected as `validation_error`: it could
-never produce an occurrence.
+A reminder is **three** fields, and two of them are dates on purpose:
+
+- `reminder_date` — the next occurrence nobody has marked done. What the calendar shows
+  first, what a household picks, and what `haventory/reminder/bump` advances.
+- `reminder_anchor` — what the series is measured from. Equal to `reminder_date` until the
+  first bump, and `null` exactly when `reminder_date` is.
+- `reminder_interval` — `{unit, count}` with `unit` one of `days`, `weeks`, `months` and
+  `count` an integer from 1 to 1000. `null` for a one-off, and an interval with no
+  `reminder_date` to count from is rejected as `validation_error`: it could never produce an
+  occurrence.
+
+`reminder_anchor` is **derived on write, not client-written**: neither `ItemCreate` nor
+`ItemUpdate` carries it, and every path that writes `reminder_date` sets the anchor to that
+same date, because picking a date is saying where the series starts. `reminder/bump` and
+`haventory.reminder_bump` are the only writers that move the date and keep the anchor — which
+is the whole reason it is stored. A document may carry one, so a backup can restore a series
+mid-flight; an anchor later than its own `reminder_date`, or one with no date to lead to, is
+refused on import.
 
 Occurrences are **derived, never stored**. `calendar.haventory` expands the anchor and the
-interval over whatever window is read, so the store holds two fields however long the series
-runs. Month steps are measured from the anchor and clamped onto short months — a series
-anchored on the 31st gives 28 February and then 31 March, rather than sticking at 28. A past
-anchor is accepted and is what a reminder nobody has bumped looks like.
+interval over whatever window is read, so the store holds three fields however long the
+series runs, and everything before `reminder_date` is already done and never comes back.
+Month steps are measured from the anchor and clamped onto short months — a series anchored on
+the 31st gives 28 February and then 31 March, rather than sticking at 28, **and that holds
+after any number of bumps**: bumping a 31st series in a 30-day month lands on the 30th, and
+the one after it is the 31st again. A past anchor is accepted and is what a reminder nobody
+has bumped looks like.
 
-Stores written before schema v8 carry neither field; `migrate_7_to_8` writes both as `null`,
-which is what "no reminder" means everywhere else.
+Stores written before schema v8 carry none of the three; `migrate_7_to_8` writes the date and
+the interval as `null`, and `migrate_8_to_9` gives every reminder an anchor equal to its own
+date — which is what a series that has never been bumped under this rule has. A store from
+before v9 that carries no anchor reads the same way, so the two paths agree.
 
 `status` is a stored per-item condition: exactly one slug from the store's `statuses`
 collection, seeded with `ok`, `missing` and `needs_repair`. It is **non-nullable** — setting
@@ -90,7 +109,7 @@ Input shapes:
   - `checked_out?: boolean`
   - `due_date?: YYYY-MM-DD|null` (only valid when `checked_out` is true)
   - `inspection_date?: YYYY-MM-DD|null` (independent of check-out state)
-  - `reminder_date?: YYYY-MM-DD|null`
+  - `reminder_date?: YYYY-MM-DD|null` (also sets `reminder_anchor`)
   - `reminder_interval?: {unit, count}|null` (requires `reminder_date`)
   - `location_id?: uuid-v4|null`
   - `tags?: string[]` (normalized: trimmed, lowercased, deduped)
@@ -106,7 +125,8 @@ Input shapes:
   - `checked_out?: boolean`
   - `due_date?: YYYY-MM-DD|null` (only valid when `checked_out` is true)
   - `inspection_date?: YYYY-MM-DD|null` (null clears)
-  - `reminder_date?: YYYY-MM-DD|null` (null clears; refused while an interval is stored)
+  - `reminder_date?: YYYY-MM-DD|null` (null clears; refused while an interval is stored;
+    re-anchors the series on the date written)
   - `reminder_interval?: {unit, count}|null` (null clears; validated against the stored
     `reminder_date` when the update does not name one)
   - `location_id?: uuid-v4|null`
@@ -116,8 +136,9 @@ Input shapes:
   - `custom_fields_set?: { [k: string]: scalar }`
   - `custom_fields_unset?: string[]`
 
-Neither input shape carries `attachments`: the two attachment commands are its only
-writers, so an item save can never rewrite the list.
+Neither input shape carries `attachments` or `reminder_anchor`: the two attachment commands
+are the only writers of the first, and the second follows whatever `reminder_date` is written
+except across a bump.
 
 ### Status definitions
 

--- a/tests/integration/test_reminders.py
+++ b/tests/integration/test_reminders.py
@@ -21,9 +21,10 @@ CALENDAR = "calendar.haventory"
 PLAIN_ITEM_ID = str(uuid.uuid4())
 REMINDER_ITEM_ID = str(uuid.uuid4())
 
-# The version this slice introduces, spelled out so the assertion below reads as
-# "v8, and CURRENT_SCHEMA_VERSION agrees" rather than as a bare number.
-REMINDER_SCHEMA_VERSION = 8
+# The version the reminder's stored anchor introduces, spelled out so the
+# assertion below reads as "v9, and CURRENT_SCHEMA_VERSION agrees" rather than as
+# a bare number.
+REMINDER_SCHEMA_VERSION = 9
 _HAMMER_QUANTITY = 2
 _EVERY_THREE_MONTHS = 3
 _OCCURRENCES_IN_A_YEAR = 4
@@ -64,7 +65,7 @@ async def _setup(hass: HomeAssistant) -> MockConfigEntry:
     return entry
 
 
-async def test_a_v7_store_boots_to_v8_with_both_fields_backfilled(
+async def test_a_v7_store_boots_to_the_current_version_with_the_fields_backfilled(
     hass: HomeAssistant, hass_storage: dict
 ) -> None:
     """The upgrade an existing install takes, against a real `Store`."""
@@ -77,9 +78,10 @@ async def test_a_v7_store_boots_to_v8_with_both_fields_backfilled(
     assert persisted["schema_version"] == CURRENT_SCHEMA_VERSION == REMINDER_SCHEMA_VERSION
     for item_id in (PLAIN_ITEM_ID, REMINDER_ITEM_ID):
         assert persisted["items"][item_id]["reminder_date"] is None
+        assert persisted["items"][item_id]["reminder_anchor"] is None
         assert persisted["items"][item_id]["reminder_interval"] is None
 
-    # Nothing else moved: the upgrade adds two nulls and takes nothing away.
+    # Nothing else moved: the upgrade adds nulls and takes nothing away.
     repo = hass.data[DOMAIN]["repository"]
     assert repo.get_item(PLAIN_ITEM_ID).name == "Hammer"
     assert repo.get_item(PLAIN_ITEM_ID).quantity == _HAMMER_QUANTITY
@@ -256,3 +258,89 @@ async def test_an_evening_bump_west_of_greenwich_keeps_the_calendar_day(
 
     assert result["success"], result
     assert result["result"]["reminder_date"] == "2026-08-15"
+
+
+async def test_a_v8_store_gains_an_anchor_for_every_reminder_it_holds(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The upgrade the release before this one leaves behind, through a real `Store`.
+
+    A v8 store's `reminder_date` was both the next occurrence and the series
+    origin, because a bump wrote one over the other. Nothing can recover how far
+    such a series had already drifted, and nothing needs to: from here on it is
+    measured from wherever it currently stands.
+    """
+
+    data = _v7_store_data()
+    data["schema_version"] = 8
+    data["items"][REMINDER_ITEM_ID]["reminder_date"] = "2026-09-30"
+    data["items"][REMINDER_ITEM_ID]["reminder_interval"] = {"unit": "months", "count": 1}
+    data["items"][PLAIN_ITEM_ID]["reminder_date"] = None
+    data["items"][PLAIN_ITEM_ID]["reminder_interval"] = None
+    hass_storage[STORAGE_KEY] = {"version": 1, "key": STORAGE_KEY, "data": data}
+
+    await _setup(hass)
+
+    persisted = hass_storage[STORAGE_KEY]["data"]
+    assert persisted["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert persisted["items"][REMINDER_ITEM_ID]["reminder_anchor"] == "2026-09-30"
+    assert persisted["items"][PLAIN_ITEM_ID]["reminder_anchor"] is None
+    assert hass.data[DOMAIN]["repository"].get_item(REMINDER_ITEM_ID).reminder_anchor == (
+        "2026-09-30"
+    )
+
+
+async def test_a_bumped_month_end_series_keeps_its_day_across_a_reload(
+    hass: HomeAssistant, hass_storage: dict, hass_ws_client
+) -> None:
+    """The whole point of the stored anchor, end to end and through a restart.
+
+    Bumped once in a 30-day month, the series must still be a 31st series — on
+    the wire, in the file, and after the entry has been unloaded and set up again
+    from what was written.
+    """
+
+    entry = await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Meter reading"})
+    item_id = (await client.receive_json())["result"]["id"]
+    await client.send_json(
+        {
+            "id": 2,
+            "type": "haventory/reminder/set",
+            "item_id": item_id,
+            "reminder_date": "2026-08-31",
+            "reminder_interval": {"unit": "months", "count": 1},
+        }
+    )
+    assert (await client.receive_json())["success"]
+
+    await client.send_json({"id": 3, "type": "haventory/reminder/bump", "item_id": item_id})
+    bumped = (await client.receive_json())["result"]
+    assert (bumped["reminder_date"], bumped["reminder_anchor"]) == ("2026-09-30", "2026-08-31")
+
+    await hass.async_block_till_done()
+    stored = hass_storage[STORAGE_KEY]["data"]["items"][item_id]
+    assert (stored["reminder_date"], stored["reminder_anchor"]) == ("2026-09-30", "2026-08-31")
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    reloaded = hass.data[DOMAIN]["repository"].get_item(item_id)
+    assert reloaded.reminder_anchor == "2026-08-31"
+    # And the calendar draws the series the anchor describes, not the bump's date.
+    events = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {
+            "entity_id": CALENDAR,
+            "start_date_time": "2026-10-01 00:00:00",
+            "end_date_time": "2026-11-01 00:00:00",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert [e["start"] for e in events[CALENDAR]["events"]] == ["2026-10-31"]

--- a/tests/test_calendar_offline.py
+++ b/tests/test_calendar_offline.py
@@ -200,6 +200,7 @@ def test_a_part_day_window_finds_the_all_day_event_it_overlaps() -> None:
 def _reminder(name: str, *, anchor: str, unit: str | None = None, count: int = 1) -> Item:
     item = _item(name)
     item.reminder_date = anchor
+    item.reminder_anchor = anchor
     item.reminder_interval = ReminderInterval(unit=unit, count=count) if unit else None
     return item
 
@@ -392,3 +393,51 @@ def test_one_unreadable_value_is_reported_once_however_often_it_is_read(caplog) 
 
     matching = [r for r in caplog.records if "not a date this build can read" in r.message]
     assert len(matching) == 1
+
+
+# -----------------------------
+# A bumped series: measured from the anchor, starting at the date
+# -----------------------------
+
+
+def test_a_bumped_series_keeps_the_anchor_s_day_of_month() -> None:
+    """The stored pair, projected: anchor 31 August, marked done through September.
+
+    The occurrences the household has already dealt with are behind
+    `reminder_date` and do not come back; everything ahead is still measured from
+    the anchor, so October is the 31st rather than the 30th the bump landed on.
+    """
+
+    item = _reminder("Meter reading", anchor="2026-09-30", unit="months", count=1)
+    item.reminder_anchor = "2026-08-31"
+
+    events = build_events([item], date(2026, 8, 1), date(2027, 1, 1))
+
+    assert [e.start for e in events] == [
+        date(2026, 9, 30),
+        date(2026, 10, 31),
+        date(2026, 11, 30),
+        date(2026, 12, 31),
+    ]
+
+
+def test_occurrences_already_marked_done_stay_off_the_calendar() -> None:
+    """A window covering them is what "bumped" has to survive."""
+
+    item = _reminder("Water filter", anchor="2026-08-15", unit="weeks", count=1)
+    item.reminder_anchor = "2026-08-01"
+
+    events = build_events([item], date(2026, 8, 1), date(2026, 8, 31))
+
+    assert [e.start for e in events] == [date(2026, 8, 15), date(2026, 8, 22), date(2026, 8, 29)]
+
+
+def test_a_reminder_with_no_anchor_projects_from_its_own_date() -> None:
+    """Every store written before v9 carries none, and reads as this."""
+
+    item = _reminder("HVAC filter", anchor="2026-08-10", unit="months", count=1)
+    item.reminder_anchor = None
+
+    events = build_events([item], WINDOW_START, date(2026, 11, 1))
+
+    assert [e.start for e in events] == [date(2026, 8, 10), date(2026, 9, 10), date(2026, 10, 10)]

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -17,6 +17,8 @@ Covers the ``import_export`` module and the three WebSocket commands
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 from custom_components.haventory import import_export as ie
 from custom_components.haventory import media
@@ -1306,3 +1308,82 @@ def test_preview_names_the_row_and_the_field_a_bad_date_is_in() -> None:
     assert report["valid"] is False
     errors = {e["path"] for e in report["errors"]}
     assert errors == {"items[1].reminder_date"}
+
+
+def test_a_bumped_series_survives_an_export_and_import() -> None:
+    """The anchor is the point of the field, so a backup that loses it loses the fix.
+
+    A round trip through a document has to bring back a series measured from
+    31 August and marked done through September — not one that re-anchors on the
+    30th and drifts from there.
+    """
+
+    repo = Repository()
+    item = repo.create_item(
+        {
+            "name": "Meter reading",
+            "reminder_date": "2026-08-31",
+            "reminder_interval": {"unit": "months", "count": 1},
+        }
+    )
+    repo.bump_reminder(str(item.id), today=date(2026, 8, 31))
+    doc = ie.build_export_document(repo, schema_version=CURRENT_SCHEMA_VERSION)
+
+    exported = doc["items"][0]
+    assert (exported["reminder_date"], exported["reminder_anchor"]) == ("2026-09-30", "2026-08-31")
+
+    target = Repository()
+    report, payload = ie.plan_import(target, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+    assert report["valid"] is True, report["errors"]
+    assert payload is not None
+    target.load_state(payload)
+
+    restored = target.get_item(str(item.id))
+    assert (restored.reminder_date, restored.reminder_anchor) == ("2026-09-30", "2026-08-31")
+
+
+def test_a_document_written_before_the_anchor_existed_imports_unchanged() -> None:
+    """Every export up to v8 carries none, and a re-import must not read as an edit."""
+
+    repo = Repository()
+    _seed(repo)
+    repo.create_item(
+        {
+            "name": "HVAC filter",
+            "reminder_date": "2026-09-01",
+            "reminder_interval": {"unit": "months", "count": 3},
+        }
+    )
+    doc = ie.build_export_document(repo, schema_version=CURRENT_SCHEMA_VERSION)
+    for entry in doc["items"]:
+        entry.pop("reminder_anchor", None)
+
+    report, _payload = ie.plan_import(repo, doc, current_schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert report["valid"] is True, report["errors"]
+    assert report["counts"]["items"]["unchanged"] == report["counts"]["items"]["total"]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "path"),
+    [
+        ({"reminder_anchor": "whenever"}, "items[0].reminder_anchor"),
+        # An anchor beyond its own date leads to no occurrence at all.
+        (
+            {"reminder_date": "2026-09-01", "reminder_anchor": "2026-10-01"},
+            "items[0].reminder_anchor",
+        ),
+        ({"reminder_anchor": "2026-09-01"}, "items[0].reminder_anchor"),
+    ],
+)
+def test_preview_refuses_an_anchor_that_leads_nowhere(overrides: dict, path: str) -> None:
+    """A document is the one way an anchor could arrive that no write path allows."""
+
+    repo = Repository()
+    report, target = ie.plan_import(
+        repo, _envelope(_item_doc(**overrides)), current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    assert report["valid"] is False
+    assert target is None
+    assert path in {e["path"] for e in report["errors"]}

--- a/tests/test_migrations_offline.py
+++ b/tests/test_migrations_offline.py
@@ -26,6 +26,7 @@ from custom_components.haventory.migrations import (
     migrate_5_to_6,
     migrate_6_to_7,
     migrate_7_to_8,
+    migrate_8_to_9,
 )
 from custom_components.haventory.storage import (
     CURRENT_SCHEMA_VERSION,
@@ -492,3 +493,66 @@ def test_v7_to_v8_tolerates_a_payload_with_no_items() -> None:
         "schema_version": 7,
         "items": None,
     }
+
+
+_REMINDER_ANCHOR_VERSION = 9
+
+
+def _v8_payload() -> dict[str, Any]:
+    return {
+        "schema_version": _REMINDER_ANCHOR_VERSION - 1,
+        "items": {
+            "i1": {
+                "id": "i1",
+                "name": "HVAC filter",
+                "quantity": 1,
+                "reminder_date": "2026-09-30",
+                "reminder_interval": {"unit": "months", "count": 1},
+            },
+            "i2": {
+                "id": "i2",
+                "name": "Ladder",
+                "quantity": 1,
+                "reminder_date": None,
+                "reminder_interval": None,
+            },
+        },
+        "locations": {},
+        "statuses": {},
+    }
+
+
+def test_v8_to_v9_anchors_every_reminder_on_its_own_date() -> None:
+    """Under the old rule a bump rewrote the date, so the date *is* the anchor.
+
+    Nothing knows how far a v8 series had already drifted, and nothing needs to:
+    from here on it is measured from wherever it currently stands.
+    """
+
+    out = migrate_8_to_9(_v8_payload())
+
+    assert out["items"]["i1"]["reminder_anchor"] == "2026-09-30"
+    assert out["items"]["i2"]["reminder_anchor"] is None
+
+
+def test_v8_to_v9_keeps_an_anchor_a_bump_has_moved_away_from() -> None:
+    """Idempotence means "fills in what is absent", not "resets to the date"."""
+
+    payload = _v8_payload()
+    payload["items"]["i1"]["reminder_anchor"] = "2026-08-31"
+
+    out = migrate_8_to_9(payload)
+
+    assert out["items"]["i1"]["reminder_anchor"] == "2026-08-31"
+    assert migrate_8_to_9(out) == out
+
+
+def test_v8_to_v9_leaves_an_item_that_is_not_a_dict_alone() -> None:
+    """A corrupt row is the load report's business, not a migration's."""
+
+    payload = _v8_payload()
+    payload["items"]["broken"] = "not-an-item"
+
+    out = migrate_8_to_9(payload)
+
+    assert out["items"]["broken"] == "not-an-item"

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -586,3 +586,25 @@ async def test_the_bump_service_reaches_the_bus() -> None:
     fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
     assert [e["action"] for e in fired] == ["updated"]
     assert fired[0]["item_id"] == item_id
+
+
+@pytest.mark.asyncio
+async def test_the_bump_service_keeps_the_series_on_its_own_day() -> None:
+    """One rule, in `Repository.bump_reminder`, so both surfaces answer the same."""
+
+    hass = HomeAssistant()
+    repo, item_id, _loc_id = await _seeded(hass)
+    await services_mod.service_item_update(
+        hass,
+        {
+            "item_id": item_id,
+            "reminder_date": "2026-08-31",
+            "reminder_interval": {"unit": "months", "count": 1},
+        },
+    )
+
+    bumped = await services_mod.service_reminder_bump(hass, {"item_id": item_id})
+
+    assert bumped["item"]["reminder_date"] == "2026-09-30"
+    assert bumped["item"]["reminder_anchor"] == "2026-08-31"
+    assert repo.get_item(item_id).reminder_anchor == "2026-08-31"

--- a/tests/test_storage_offline.py
+++ b/tests/test_storage_offline.py
@@ -38,6 +38,7 @@ from homeassistant.helpers.storage import Store as HAStore
 _STATUS_BACKFILL_VERSION = 5
 _ATTACHMENTS_BACKFILL_VERSION = 6
 _REMINDER_BACKFILL_VERSION = 8
+_REMINDER_ANCHOR_BACKFILL_VERSION = 9
 #: The version from which a status ``color`` may be a ``#rrggbb`` literal rather
 #: than one of the ten tone tokens. Builds below it reject the literal.
 _HEX_STATUS_COLOUR_VERSION = 7
@@ -219,8 +220,9 @@ async def test_migration_from_v1_to_current_preserves_payload() -> None:
     migrated = await store.async_load()
 
     assert migrated["schema_version"] == CURRENT_SCHEMA_VERSION
-    # v4 -> v5 backfills the per-item status, v5 -> v6 the attachment list and
-    # v7 -> v8 the two reminder fields; everything else passes through.
+    # v4 -> v5 backfills the per-item status, v5 -> v6 the attachment list,
+    # v7 -> v8 the two reminder fields and v8 -> v9 the reminder's anchor;
+    # everything else passes through.
     expected_items = {
         "i1": {
             **pre_payload["items"]["i1"],
@@ -228,6 +230,7 @@ async def test_migration_from_v1_to_current_preserves_payload() -> None:
             "attachments": [],
             "reminder_date": None,
             "reminder_interval": None,
+            "reminder_anchor": None,
         }
     }
     assert migrated["items"] == expected_items
@@ -271,6 +274,8 @@ async def test_equal_and_older_versions_still_load(stored_version: int) -> None:
     if stored_version < _REMINDER_BACKFILL_VERSION:
         expected_items["i1"]["reminder_date"] = None
         expected_items["i1"]["reminder_interval"] = None
+    if stored_version < _REMINDER_ANCHOR_BACKFILL_VERSION:
+        expected_items["i1"]["reminder_anchor"] = None
     assert loaded["items"] == expected_items
     assert loaded["locations"] == pre_payload["locations"]
 

--- a/tests/test_ws_reminders_offline.py
+++ b/tests/test_ws_reminders_offline.py
@@ -44,6 +44,13 @@ def _today() -> date:
     return datetime.now(UTC).date()
 
 
+def _freeze(monkeypatch, today: date) -> None:
+    """Pin the household's day, which is what a bump counts from."""
+
+    frozen = datetime(today.year, today.month, today.day, tzinfo=UTC)
+    monkeypatch.setattr(dt_util, "now", lambda *_a, **_k: frozen)
+
+
 @pytest.mark.asyncio
 async def test_set_stores_the_anchor_and_the_interval() -> None:
     hass = _hass()
@@ -285,7 +292,14 @@ async def test_bump_names_a_stored_anchor_it_cannot_read() -> None:
 
     hass = _hass()
     item_id = await _item(hass)
-    await ws_send(hass, 2, "haventory/reminder/set", item_id=item_id, reminder_date="2026-09-01")
+    await ws_send(
+        hass,
+        2,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date="2026-09-01",
+        reminder_interval=MONTHLY,
+    )
     repo = hass.data[DOMAIN]["repository"]
     repo.get_item(item_id).reminder_date = "next week"
 
@@ -293,7 +307,7 @@ async def test_bump_names_a_stored_anchor_it_cannot_read() -> None:
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
-    assert "reminder_date" in res["error"]["message"]
+    assert "reminder date" in res["error"]["message"]
 
 
 @pytest.mark.asyncio
@@ -327,3 +341,143 @@ async def test_a_bump_counts_from_the_household_day_not_the_utc_one(monkeypatch)
     assert res["success"] is True, res
     # The 15th — the occurrence the calendar is showing for tomorrow — not the 16th.
     assert res["result"]["reminder_date"] == "2026-08-15"
+
+
+# -----------------------------
+# The series' own day, across any number of bumps
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_month_end_series_still_lands_on_the_31st_after_a_bump(monkeypatch) -> None:
+    """The guarantee the projection makes, now true for a reminder somebody uses.
+
+    Month steps are measured from the anchor, so a series on the 31st returns to
+    the 31st in every month that has one. Bumping used to write the occurrence
+    back as the anchor, so one pass through a 30-day month re-anchored the series
+    on the 30th — and February re-anchored it on the 28th — permanently.
+    """
+
+    hass = _hass()
+    item_id = await _item(hass)
+    _freeze(monkeypatch, date(2026, 8, 15))
+    await ws_send(
+        hass,
+        2,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date="2026-08-31",
+        reminder_interval={"unit": "months", "count": 1},
+    )
+
+    first = await ws_send(hass, 3, "haventory/reminder/bump", item_id=item_id)
+    assert first["result"]["reminder_date"] == "2026-09-30"
+    # The anchor did not move with it — that is what the next bump counts from.
+    assert first["result"]["reminder_anchor"] == "2026-08-31"
+
+    _freeze(monkeypatch, date(2026, 9, 30))
+    second = await ws_send(hass, 4, "haventory/reminder/bump", item_id=item_id)
+    assert second["result"]["reminder_date"] == "2026-10-31"
+    assert second["result"]["reminder_anchor"] == "2026-08-31"
+
+
+@pytest.mark.asyncio
+async def test_a_bump_through_february_skips_no_occurrence(monkeypatch) -> None:
+    """The worst case in the issue, and the one the rejected fix would have skipped.
+
+    A 1/31 series bumped in February lands on 2/28 — the occurrence February
+    actually has — and the one after it is 3/31, not 3/28. Advancing straight to
+    3/31 would have kept the day at the price of the household never being
+    reminded in February.
+    """
+
+    hass = _hass()
+    item_id = await _item(hass)
+    _freeze(monkeypatch, date(2027, 1, 20))
+    await ws_send(
+        hass,
+        2,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date="2027-01-31",
+        reminder_interval={"unit": "months", "count": 1},
+    )
+
+    _freeze(monkeypatch, date(2027, 2, 10))
+    first = await ws_send(hass, 3, "haventory/reminder/bump", item_id=item_id)
+    assert first["result"]["reminder_date"] == "2027-02-28"
+
+    _freeze(monkeypatch, date(2027, 2, 28))
+    second = await ws_send(hass, 4, "haventory/reminder/bump", item_id=item_id)
+    assert second["result"]["reminder_date"] == "2027-03-31"
+
+
+@pytest.mark.asyncio
+async def test_setting_a_date_re_anchors_the_series_on_it() -> None:
+    """A household picking a date is saying where the series starts."""
+
+    hass = _hass()
+    item_id = await _item(hass)
+    await ws_send(
+        hass,
+        2,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date="2026-08-31",
+        reminder_interval={"unit": "months", "count": 1},
+    )
+    await ws_send(hass, 3, "haventory/reminder/bump", item_id=item_id)
+
+    reset = await ws_send(
+        hass,
+        4,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date="2026-12-01",
+        reminder_interval={"unit": "months", "count": 1},
+    )
+
+    assert reset["result"]["reminder_date"] == "2026-12-01"
+    assert reset["result"]["reminder_anchor"] == "2026-12-01"
+
+
+@pytest.mark.asyncio
+async def test_clearing_a_reminder_takes_the_anchor_with_it() -> None:
+    """An anchor with no date names a series with no next occurrence."""
+
+    hass = _hass()
+    item_id = await _item(hass)
+    await ws_send(
+        hass,
+        2,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date="2026-08-31",
+        reminder_interval={"unit": "months", "count": 1},
+    )
+
+    cleared = await ws_send(hass, 3, "haventory/reminder/clear", item_id=item_id)
+
+    assert cleared["result"]["reminder_date"] is None
+    assert cleared["result"]["reminder_anchor"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_bump_answers_conflict_on_a_stale_version() -> None:
+    """It is an ordinary item edit, so it takes the same concurrency check."""
+
+    hass = _hass()
+    item_id = await _item(hass)
+    await ws_send(
+        hass,
+        2,
+        "haventory/reminder/set",
+        item_id=item_id,
+        reminder_date=_today().isoformat(),
+        reminder_interval={"unit": "days", "count": 7},
+    )
+
+    res = await ws_send(hass, 3, "haventory/reminder/bump", item_id=item_id, expected_version=1)
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "conflict"


### PR DESCRIPTION
## Summary

Option A from the analysis on #460, chosen by the owner.

The projection's month arithmetic is anchor-measured and correct — a series on the 31st returns to the 31st in every month that has one. `reminder/bump` destroyed that, because one stored date was carrying two meanings: the next occurrence *and* the series origin. Writing the occurrence back re-anchored the series on it, so a single pass through a 30-day month made it a 30th series and February made it a 28th series, permanently. Bump is the feature's main verb, so the guarantee held only for a reminder nobody used.

**The two meanings are now two fields.**

- `reminder_date` — the next occurrence nobody has marked done. What the calendar shows first, what a household picks, what a bump advances.
- `reminder_anchor` — what the month steps are counted from. Equal to `reminder_date` until the first bump; `null` exactly when `reminder_date` is.

Every path that writes a date anchors the series on it, because picking a date is saying where the series starts. `Repository.bump_reminder` is the one writer that moves the date and keeps the anchor — and it is a repository verb now, beside `check_in` / `check_out` / `set_quantity`, so the WebSocket command and `haventory.reminder_bump` cannot answer differently. The projection walks from the anchor and starts at the date, so occurrences already marked done never come back, even in a window that covers them.

**No occurrence is skipped.** This is the part that ruled out the issue's own option 2: a 31st series bumped in February lands on **28 February**, and the one after it is **31 March**. Advancing straight to 31 March would have kept the day at the price of never reminding the household in February.

**Schema 8 → 9.** `migrate_8_to_9` gives every reminder an anchor equal to its own date — what a series that has never been bumped under the new rule has, and the only honest answer for a v8 series whose drift nothing recorded. Written rather than left absent, for the reason `migrate_7_to_8` gives: a v8 build would otherwise parse these items and rewrite them with every anchor dropped. A pre-v9 store with no anchor reads the same way through `load_reminder_anchor`, so the migration and the load path agree; an anchor stored beyond its own date reads as the date rather than describing a series with nothing to lead to.

**Derived on write, not client-written.** `reminder_anchor` is absent from `ItemCreate` and `ItemUpdate`, and read-only in the card's `Item` type. Export documents *do* carry it, so a backup restores a series mid-flight; on import an anchor later than its own date, or one with no date to lead to, is refused, and an absent one compares as unchanged against a stored series that has never been bumped — so every export written before v9 still round-trips clean.

Closes #460

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change — the stored schema moves to 9. In-place upgrade only; a v9 store is refused by a v8 build, which is the point.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1135 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [x] Frontend: `npx eslint .`, `npm run typecheck`, `npx vitest run` (1843 passed), `npm run build`
- [x] phacc: `102 passed` locally

Offline, the behaviour the issue asked for:

- a 31st series bumped in a 30-day month lands on the 30th **and the next bump lands on the 31st** — the anchor visibly does not move;
- the February worst case, both steps: 1/31 → 2/28 → 3/31;
- setting a date re-anchors on it; clearing takes the anchor with it; a stale `expected_version` still answers `conflict`;
- the projection: a bumped series keeps the anchor's day, occurrences already done stay off the calendar, and an item with no anchor projects from its own date (every pre-v9 store);
- `migrate_8_to_9` anchors on the date, keeps an anchor a bump has moved away from, is idempotent, and leaves a corrupt row alone;
- export/import: a bumped series survives a round trip; a document written before the field existed imports as **unchanged**; three bad anchors are refused by path.

Integration, against a real `Store` and a real WebSocket connection:

- `test_a_v8_store_gains_an_anchor_for_every_reminder_it_holds` — the upgrade the previous release leaves behind.
- `test_a_bumped_month_end_series_keeps_its_day_across_a_reload` — set 31 August, bump, assert the wire and the file, then unload and set the entry up again from what was written, and read `calendar.get_events` for October: `["2026-10-31"]`. **Verified failing** with the anchor-preserving line removed: `assert ('2026-09-30', '2026-09-30') == ('2026-09-30', '2026-08-31')`, which is the defect exactly as reported.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated — `docs/data_shapes.md` (the three-field shape, the derived-on-write rule, both migrations), `docs/backend_api_contract.md` (what bump moves and what it does not), `README.md` (the month-end promise now says "however often you bump it").
- [x] `ws.py`, `docs/backend_api_contract.md` and `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved. No file deleted or renamed under `custom_components/haventory/`, so `RETIRED_PATHS` is untouched.

## Follow-ups — this changes S5's brief

`dev/V0_6_0_implementation.md` §5.5 is updated in this PR, because #229's collapse now has one more version to fold in:

- `CURRENT_SCHEMA_VERSION` is **9**, so the closed adoptable set is **2–9**.
- The adopter folds in `migrate_8_to_9` alongside the other backfills — the cheapest of them, since a v8 reminder's anchor is its own date.
- The pre-collapse export the release notes tell the owner to take is stamped **9**, and the schema-downgrade Repairs card's text becomes "(9)" → "(1)".

I will add a short comment to #229 pointing at this, since it changes what that issue asked for.
