### PR TITLE
docs: fix two comments that no longer describe their code

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -558,9 +558,10 @@ destructive clean-start mode), then `Online smoke test completed successfully.`
 - **`HA_CONTAINER` turns `smoke_online.sh` destructive**: when set, the script
   `rm -f`s `haventory_store` inside that container and restarts HA before testing —
   all dev items/locations are gone. Leave it unset unless you *want* a wiped store.
-- **`item/list` filter key is `q`, not `query`/`search` — and unknown filter keys are
-  silently ignored**, so a typo'd filter matches *everything* instead of erroring.
-  If a "filtered" list looks unfiltered, check the key.
+- **`item/list` filter key is `q`, not `query`/`search`.** A typo'd key is refused, not
+  dropped: the reply is `validation_error` naming it (`unknown filter key(s): …`), in a
+  filter and a sort alike. So an empty-looking result is a real result, and a request that
+  errors on a key you thought was valid is the API telling you the key does not exist.
 - **`location_path` shape** is `{id_path, name_path, display_path, sort_key}` (see
   `docs/data_shapes.md`) — not `names`/`ids`.
 - **Login bypass**: the HA frontend accepts an injected `hassTokens` localStorage entry
@@ -599,7 +600,9 @@ destructive clean-start mode), then `Online smoke test completed successfully.`
   still restarting. `docker ps`, `docker start home-assistant`, wait ~30 s, retry;
   `docker logs home-assistant --since 2m` for startup errors.
 - **Smoke step `[FAIL] item/list case-insensitive search` returning many items**: the
-  filter key regression above (`q` silently ignored → match-all).
+  `q` predicate reached the repository and matched too much, so look at the search index
+  and its casefold/accent normalization — a filter key that failed to apply would have
+  come back as a `validation_error` instead, not as a wide result.
 - **Every card harness times out waiting for `haventory-card`, and the panel is fine**:
   the dashboard is gone, not the card. `node card_views.mjs` says `0 view(s)`; put it back
   with the recipe in "Putting the card back on a dashboard".

--- a/.claude/skills/run-haventory/driver.py
+++ b/.claude/skills/run-haventory/driver.py
@@ -176,8 +176,8 @@ async def cmd_smoke(base: str, token: str) -> int:
             )
             version = item["version"]
 
-            # Case-insensitive search is a load-bearing invariant: query in lowercase.
-            # NOTE: the filter key is `q` — unknown keys are silently ignored (match-all).
+            # Search is case-insensitive, so a lowercase query has to find a mixed-case
+            # name. The filter key is `q`; any other key is refused as a validation_error.
             frame = await ha.send(
                 {"type": "haventory/item/list", "filter": {"q": item_name.lower()}}
             )

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -1105,8 +1105,6 @@ def create_item_from_create(
         reminder_date=payload.get("reminder_date"),
         reminder_interval=payload.get("reminder_interval"),
     )
-    # Setting a reminder is saying where its series starts, so the anchor
-    # follows the date. Only a bump moves one without the other.
 
     location_id: uuid.UUID | None = None
     if location_id_raw is not None:
@@ -1131,6 +1129,8 @@ def create_item_from_create(
         due_date=normalized_due_date,
         inspection_date=normalized_inspection_date,
         reminder_date=normalized_reminder_date,
+        # Setting a reminder is saying where its series starts, so the anchor
+        # follows the date. Only a bump moves one without the other.
         reminder_anchor=normalized_reminder_date,
         reminder_interval=reminder_interval,
         location_id=location_id,


### PR DESCRIPTION
Closes #481.

Two comments that no longer described the code beside them, plus a third copy of the second one that the issue did not name.

## What changed

**`models.py`** — the reminder-anchor note sat twenty-six lines above the `reminder_anchor=` line it explains, directly over `location_id`, where it read as a note about the location lookup. Moved onto the line it describes.

**`.claude/skills/run-haventory/SKILL.md`** — the `item/list` filter-key gotcha claimed unknown filter keys are silently ignored, so a typo'd filter matches everything. Since #197 they are refused with a `validation_error` naming the key. The gotcha now says that, and the Troubleshooting entry that leaned on it now points at the search index and its casefold/accent normalization, which is what a too-wide result can still mean. The `q`-not-`query`/`search` half was correct and stays.

**`.claude/skills/run-haventory/driver.py`** — the same stale claim, third copy, in the comment above the case-insensitive search check (`:179-180`). Left alone it would have kept re-teaching what SKILL.md just stopped teaching. Its "load-bearing" phrasing is replaced with what the check actually covers, per the plain-words rule.

## Decision not pre-decided

Fixing the `driver.py` copy was not in the issue. It is the same wrong sentence, in the same skill package, one directory away — leaving it would have meant the skill contradicted itself. Same defect, so it rides here rather than becoming an issue.

## Tests

No behaviour change, no new test, as the issue says. Both gates green: `pytest -q`, `ruff check`, `ruff format --check`, `mypy`, and the card's `eslint` / `typecheck` / `vitest` (1843 passed) / `build`.

## Follow-ups

`tests/test_toolchain_pins.py::test_no_unregistered_file_states_an_interpreter_version` fails on a dev host that keeps gitignored scratch inside the checkout. `swept_files()` says it collects "every committed text file" but walks the tree without consulting git, so `.claude/worktrees/`, `.agent/` and `/roadmap` — all gitignored — get swept and reported as unregistered copies of the Python floor. CI is green because a fresh checkout has none of them. Pre-existing on `main` @ 1056d88 (confirmed by stashing this branch's changes); not touched here. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)