### PR TITLE
test: bind the card's size caps to the backend's

### DIFF
--- a/cards/haventory-card/src/ui/item-form.test.ts
+++ b/cards/haventory-card/src/ui/item-form.test.ts
@@ -126,7 +126,10 @@ describe('validateForm', () => {
     expect(validateForm({ ...base(), name: 'A', customFields: rows })).toEqual([]);
   });
 
-  it('mirrors the backend size caps so the editor refuses before the round trip', () => {
+  // That these caps hold the *same* numbers as the backend is checked across the
+  // language boundary, in `tests/test_item_form_caps.py`. This covers the other
+  // half: that the editor actually enforces each one before the round trip.
+  it('refuses input past every size cap', () => {
     const over = [
       { model: { description: 'd'.repeat(4001) }, field: 'description' },
       { model: { category: 'c'.repeat(121) }, field: 'category' },

--- a/cards/haventory-card/src/ui/item-form.ts
+++ b/cards/haventory-card/src/ui/item-form.ts
@@ -50,7 +50,7 @@ export interface ItemFormModel {
 
 export const REMINDER_UNITS: readonly ReminderUnit[] = ['days', 'weeks', 'months'];
 
-/** Mirrors `REMINDER_COUNT_MAX` in `models.py`, for the same reason the other caps are. */
+/** `REMINDER_COUNT_MAX` in `models.py`, held equal to it by the test named below. */
 const REMINDER_COUNT_MAX = 1000;
 
 /** A validation problem, scoped to the field that caused it. */
@@ -62,13 +62,15 @@ export interface FieldError {
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
- * The backend's input caps, mirrored so the editor refuses before the round
+ * The backend's input caps, copied here so the editor refuses before the round
  * trip rather than showing a server error on save. These are the values in
- * `models.py`; a value the editor accepts and the backend refuses is the
- * failure mode to avoid, so they only ever move together — and so does the
- * rule they are applied under: caps refuse growth past the stored item, never
- * the stored item itself, which is how the backend treats data that predates
- * a cap.
+ * `models.py`, and `tests/test_item_form_caps.py` reads both files and fails
+ * when they disagree — including `REMINDER_UNITS` and `REMINDER_COUNT_MAX`
+ * above, and a cap added to either side alone. So they can only move together.
+ *
+ * The rule they are applied under moves with them: a cap refuses growth past
+ * the stored item, never the stored item itself, which is how the backend
+ * treats data that predates a cap.
  */
 const NAME_MAX_LENGTH = 120;
 const DESCRIPTION_MAX_LENGTH = 4000;

--- a/tests/test_item_form_caps.py
+++ b/tests/test_item_form_caps.py
@@ -1,0 +1,110 @@
+"""The card's input caps must be the backend's, and something has to say so.
+
+``cards/haventory-card/src/ui/item-form.ts`` copies the size limits out of
+``models.py`` so the editor refuses input before the round trip rather than
+showing a server error on save. Both halves are internally consistent — the
+card's own test checks the card's numbers against the card's numbers — so a
+drift shows up in neither suite:
+
+- a card cap *below* the backend's makes the editor refuse input the API would
+  have accepted, with a message naming a limit nobody set;
+- a card cap *above* it turns the client-side check into a round trip that fails
+  at the server with the ``validation_error`` the form exists to prevent.
+
+This is the same shape as ``tests/test_frontend_registration.py`` pinning
+``PANEL_ICON`` to the bundle's exported identifier, and as the platform floors in
+``tests/test_min_ha_version.py`` and ``tests/test_toolchain_pins.py``: a value
+written on both sides of a language boundary neither side can check alone. The
+caps are read out of the TypeScript with a regex, which is what those tests do to
+YAML and TOML — generating the card's constants from the Python would be a build
+step for nine numbers.
+
+The registered caps are checked by name and by value; the TypeScript is then
+swept for every ``*_MAX_*`` / ``*_MAX`` constant it declares, so a cap added on
+one side alone fails rather than passing unnoticed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from custom_components.haventory import models
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ITEM_FORM_TS = REPO_ROOT / "cards" / "haventory-card" / "src" / "ui" / "item-form.ts"
+
+#: ``const NAME_MAX_LENGTH = 120;`` — the card writes its caps as plain integers,
+#: with no numeric separators, so nothing has to be normalized away.
+TS_NUMERIC_CONST = re.compile(r"^const (?P<name>\w*MAX\w*) *(?::[^=]+)? *= *(?P<value>\d+);", re.M)
+
+#: ``export const REMINDER_UNITS: readonly ReminderUnit[] = ['days', ...];``
+TS_REMINDER_UNITS = re.compile(r"REMINDER_UNITS[^=]*= *\[(?P<items>[^\]]*)\]")
+
+#: Every size cap the editor enforces, named identically on both sides. The name
+#: is the pairing: a cap renamed on one side is a cap the other no longer holds.
+PAIRED_CAPS: tuple[str, ...] = (
+    "NAME_MAX_LENGTH",
+    "DESCRIPTION_MAX_LENGTH",
+    "CATEGORY_MAX_LENGTH",
+    "TAG_MAX_LENGTH",
+    "TAGS_MAX_COUNT",
+    "CUSTOM_FIELDS_MAX_KEYS",
+    "CUSTOM_FIELD_KEY_MAX_LENGTH",
+    "CUSTOM_FIELD_VALUE_MAX_LENGTH",
+    "REMINDER_COUNT_MAX",
+)
+
+
+def card_source() -> str:
+    return ITEM_FORM_TS.read_text(encoding="utf-8")
+
+
+def card_caps() -> dict[str, int]:
+    """Every ``MAX``-named integer constant the editor declares."""
+    return {
+        match.group("name"): int(match.group("value"))
+        for match in TS_NUMERIC_CONST.finditer(card_source())
+    }
+
+
+def card_reminder_units() -> tuple[str, ...]:
+    match = TS_REMINDER_UNITS.search(card_source())
+    assert match is not None, f"no REMINDER_UNITS declaration found in {ITEM_FORM_TS.name}"
+    return tuple(re.findall(r"['\"](\w+)['\"]", match.group("items")))
+
+
+def test_the_card_source_is_where_this_test_thinks_it_is() -> None:
+    """A moved or renamed editor would make every check below vacuously pass."""
+
+    assert ITEM_FORM_TS.is_file(), f"{ITEM_FORM_TS} is missing"
+    assert card_caps(), "no MAX-named constants parsed; the regex no longer matches the source"
+
+
+@pytest.mark.parametrize("cap", PAIRED_CAPS)
+def test_each_card_cap_equals_the_backend_cap(cap: str) -> None:
+    """Same name, same number, on both sides of the language boundary."""
+
+    parsed = card_caps()
+    assert cap in parsed, f"{ITEM_FORM_TS.name} declares no {cap}"
+    assert hasattr(models, cap), f"models.py declares no {cap}"
+    assert parsed[cap] == getattr(models, cap), (
+        f"{cap}: card has {parsed[cap]}, models.py has {getattr(models, cap)} — "
+        "the editor and the API would disagree about what to accept"
+    )
+
+
+def test_no_unregistered_cap_hides_in_the_editor() -> None:
+    """A cap added on one side alone fails, rather than passing unnoticed."""
+
+    assert set(card_caps()) == set(PAIRED_CAPS), (
+        f"unregistered in {ITEM_FORM_TS.name}: {sorted(set(card_caps()) - set(PAIRED_CAPS))}; "
+        f"registered but no longer declared there: {sorted(set(PAIRED_CAPS) - set(card_caps()))}"
+    )
+
+
+def test_the_reminder_units_match() -> None:
+    """The unit vocabulary is a cap on input too: an extra one is refused."""
+
+    assert card_reminder_units() == models.REMINDER_UNITS


### PR DESCRIPTION
Closes #480.

## What was missing

`cards/haventory-card/src/ui/item-form.ts` carries nine of the backend's size limits so the editor refuses input before the round trip. The comment said "Mirrors `REMINDER_COUNT_MAX` in `models.py`" and nothing held it up — the card's own test (`item-form.test.ts`) checked the card's numbers against the card's numbers, so each half was internally consistent and a drift would have shown up in neither suite:

- a card cap **below** the backend's makes the editor refuse input the API would accept, with a message naming a limit nobody set;
- a card cap **above** it turns the client-side check into a round trip that fails at the server with the `validation_error` the form was written to prevent.

## What this adds

`tests/test_item_form_caps.py`, in the family of `test_frontend_registration.py`, `test_min_ha_version.py` and `test_toolchain_pins.py` — a value written on both sides of a language boundary that neither side can check alone. It reads the constants out of `models.py`, reads the literals out of the TypeScript with a regex (what the existing pin tests do to YAML and TOML), and fails when they disagree.

Nine caps, paired by name, plus the reminder unit vocabulary:

| | |
|---|---|
| `NAME_MAX_LENGTH` | `DESCRIPTION_MAX_LENGTH` |
| `CATEGORY_MAX_LENGTH` | `TAG_MAX_LENGTH` |
| `TAGS_MAX_COUNT` | `CUSTOM_FIELDS_MAX_KEYS` |
| `CUSTOM_FIELD_KEY_MAX_LENGTH` | `CUSTOM_FIELD_VALUE_MAX_LENGTH` |
| `REMINDER_COUNT_MAX` | `REMINDER_UNITS` |

Three checks, matching how `test_toolchain_pins.py` enumerates its sites:

- **by name and value** — one parametrized case per cap, so a failure names the cap;
- **the sweep** — every `MAX`-named constant the editor declares must be registered here, so a cap added on one side alone fails rather than passing;
- **the guard** — the editor file must exist and parse to a non-empty set, so a moved file or a regex that stopped matching cannot make the rest vacuously pass.

## Proof it works

Changing `REMINDER_COUNT_MAX` in `models.py` alone — the issue's "Done looks like" — turns the backend suite red:

```
FAILED tests/test_item_form_caps.py::test_each_card_cap_equals_the_backend_cap[REMINDER_COUNT_MAX]
AssertionError: REMINDER_COUNT_MAX: card has 1000, models.py has 500 —
the editor and the API would disagree about what to accept
```

Both other directions were checked the same way. Editing `TAGS_MAX_COUNT` in the TypeScript alone fails its case; adding an unregistered cap to the TypeScript fails the sweep as well. All three restore to green when reverted.

## Comments

`item-form.ts` now names the test that binds the caps rather than asserting a mirror on trust, and keeps the rule that travels with them — a cap refuses growth past the stored item, never the stored item itself.

The card test's title claimed to mirror the backend while only checking the card. Renamed to what it covers — that the editor enforces each cap before the round trip — with a line pointing at where the equality is now checked. That split is the honest one: the Python test owns the numbers, the vitest test owns the enforcement.

## Decision not pre-decided

`REMINDER_UNITS` is included. The issue named it as part of what the comment claims, and it is a cap on input in the same sense — a unit the card offers and the backend refuses fails on save exactly like an oversized field. Pairing it cost one regex.

`ATTACHMENT_TITLE_MAX_LENGTH` exists in `models.py` but the item editor does not declare it, so it is not paired here; the sweep only requires that what the editor *does* declare is registered. Attachment titles are edited elsewhere.

## Tests

Backend gate green (`pytest -q`, `ruff check`, `ruff format --check`, `mypy`) and the card's `eslint` / `typecheck` / `vitest` (1843 passed) / `build`. No production code changed, so nothing to verify on the dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)