### PR TITLE
feat(sensor): name the four counts so an automation reads unambiguously

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,23 +162,24 @@ One HAventory device under Settings → Devices & services, carrying:
 
 | Sensor | What it counts |
 |---|---|
-| Items | every item in the inventory |
-| Low stock | items at or below their `low_stock_threshold` |
-| Overdue | checked-out items whose due date has passed |
-| Inspection overdue | items whose inspection date has passed |
+| Item count | every item in the inventory |
+| Low stock count | items at or below their `low_stock_threshold` |
+| Checked out overdue count | checked-out items whose due date has passed |
+| Inspection overdue count | items whose inspection date has passed |
 
 They update the moment something changes — a card edit, a `haventory.*` service call, an
 import — with no polling interval to tune. The two date-derived ones also roll over at UTC
-midnight, so "Overdue" grows overnight without anybody touching the inventory.
+midnight, so "Checked out overdue count" grows overnight without anybody touching the
+inventory.
 
 **UTC midnight, deliberately, and it is not the calendar's midnight.** These two counts
 compare stored dates against the UTC day, which is also the day `item/list`'s overdue
 filters use; the calendar and the reminder bump run on your Home Assistant timezone's day,
 because those are dates you read and act on rather than numbers. The two boundaries coincide
-in London and diverge everywhere else: at UTC-8 "Overdue" ticks up at 4 pm local, eight hours
-before the calendar stops showing that item as due today.
+in London and diverge everywhere else: at UTC-8 "Checked out overdue count" ticks up at 4 pm
+local, eight hours before the calendar stops showing that item as due today.
 
-Put "Low stock: 3" on a dashboard next to the weather and nobody has to open the card to
+Put "Low stock count: 3" on a dashboard next to the weather and nobody has to open the card to
 know whether a shopping trip is due.
 
 ### The events

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -77,16 +77,16 @@
   "entity": {
     "sensor": {
       "items_total": {
-        "name": "Items"
+        "name": "Item count"
       },
       "low_stock": {
-        "name": "Low stock"
+        "name": "Low stock count"
       },
       "overdue": {
-        "name": "Overdue"
+        "name": "Checked out overdue count"
       },
       "inspection_overdue": {
-        "name": "Inspection overdue"
+        "name": "Inspection overdue count"
       }
     }
   },

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -77,16 +77,16 @@
   "entity": {
     "sensor": {
       "items_total": {
-        "name": "Items"
+        "name": "Item count"
       },
       "low_stock": {
-        "name": "Low stock"
+        "name": "Low stock count"
       },
       "overdue": {
-        "name": "Overdue"
+        "name": "Checked out overdue count"
       },
       "inspection_overdue": {
-        "name": "Inspection overdue"
+        "name": "Inspection overdue count"
       }
     }
   },

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -41,6 +41,22 @@ def _entity_ids(hass: HomeAssistant, entry: MockConfigEntry) -> list[str]:
     return sorted(e.entity_id for e in _sensor_entries(hass, entry))
 
 
+def _entity_id_for(hass: HomeAssistant, entry: MockConfigEntry, key: str) -> str:
+    """Find a sensor by the count it reports rather than by its entity_id.
+
+    `unique_id` is the entry_id plus the count's key, and neither moves. The
+    entity_id is generated once, from whatever the entity was named at first
+    creation, so matching on it would tie these tests to the wording of a name.
+    """
+
+    registry = er.async_get(hass)
+    return next(
+        e.entity_id
+        for e in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if e.unique_id == f"{entry.entry_id}_{key}"
+    )
+
+
 async def test_four_sensors_land_on_one_device(hass: HomeAssistant) -> None:
     """One service device, four entities, `unique_id`s scoped to the entry."""
 
@@ -76,7 +92,7 @@ async def test_items_total_moves_on_a_service_call_with_no_polling(hass: HomeAss
     """
 
     entry = await _setup(hass)
-    total = next(e for e in _entity_ids(hass, entry) if e.endswith("_items"))
+    total = _entity_id_for(hass, entry, "items_total")
 
     assert hass.states.get(total).state == "0"
 
@@ -92,7 +108,7 @@ async def test_items_total_moves_on_a_websocket_mutation(
     """The other write path pushes the same way."""
 
     entry = await _setup(hass)
-    total = next(e for e in _entity_ids(hass, entry) if e.endswith("_items"))
+    total = _entity_id_for(hass, entry, "items_total")
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Torch"})
@@ -104,7 +120,7 @@ async def test_items_total_moves_on_a_websocket_mutation(
 
 async def test_low_stock_sensor_tracks_the_threshold(hass: HomeAssistant) -> None:
     entry = await _setup(hass)
-    low = next(e for e in _entity_ids(hass, entry) if e.endswith("_low_stock"))
+    low = _entity_id_for(hass, entry, "low_stock_count")
 
     created = await hass.services.async_call(
         DOMAIN,
@@ -148,11 +164,6 @@ async def test_each_sensor_reports_its_count(hass: HomeAssistant, descriptor) ->
     entry = await _setup(hass)
     repo = hass.data[DOMAIN]["repository"]
 
-    registry = er.async_get(hass)
-    entity_id = next(
-        e.entity_id
-        for e in er.async_entries_for_config_entry(registry, entry.entry_id)
-        if e.unique_id == f"{entry.entry_id}_{descriptor.key}"
-    )
+    entity_id = _entity_id_for(hass, entry, descriptor.key)
 
     assert hass.states.get(entity_id).state == str(repo.get_counts()[descriptor.key])


### PR DESCRIPTION
## Summary

The four sensor names said what was being counted but not that a count was what came back,
and "Overdue" did not say overdue at *what*. In an automation editor only the name is
visible, so "Overdue" sitting next to "Inspection overdue" reads as though the first is the
general case and the second a subset of it.

It is not. `_count_overdue` walks the checked-out set alone, and a `due_date` is only valid
on a checked-out item (`validate_due_date_rules`), while `_count_inspection_overdue` walks
the whole inventory â€” an inspection date is independent of any check-out. An item can be in
either, both, or neither; `test_filter_inspection_overdue_is_independent_of_checkout`
already pins that. So each name now ends in "count", and the check-out one says which
overdue it means:

| translation key | was | now |
|---|---|---|
| `items_total` | Items | Item count |
| `low_stock` | Low stock | Low stock count |
| `overdue` | Overdue | Checked out overdue count |
| `inspection_overdue` | Inspection overdue | Inspection overdue count |

`strings.json` and `translations/en.json` stay byte-identical, which
`tests/test_sensor_offline.py` requires. The README table and the three places its prose
quotes a name move with them.

**No automation breaks on upgrade.** This changes the entity `name` only. An existing
install keeps the entity_ids it generated at first creation (`sensor.haventory_overdue` and
friends), so anything referencing an entity_id is untouched. The cost is that a *fresh*
install generates ids from the new names, so the two diverge â€”
`sensor.haventory_overdue` on an upgraded install versus
`sensor.haventory_checked_out_overdue_count` on a new one. Pinning the ids with
`suggested_object_id` plus a registry rename would close that; it is deliberately not in
this PR, and worth doing before v1.0.0 if wanted.

**A second commit fixes three integration tests the rename exposed.** They picked their
entity out with `endswith("_items")` / `endswith("_low_stock")` against the entity_id — a
string HA generates once, from the name at first creation — so a rename left the generator
matching nothing, and `next()` inside a coroutine reports that as `RuntimeError: coroutine
raised StopIteration` rather than as the missing entity it is. They now look up by
`unique_id` (entry_id + the count's key, neither of which moves), which is what
`test_each_sensor_reports_its_count` already did; that lookup is lifted into
`_entity_id_for` and used in all four places.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

A user-visible rename of the four sensor entity names, and nothing else — no code path, no
API, no stored shape. `feat` in the title because the changelog should carry it: someone
upgrading sees four names change in their entity picker.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` â€” 1156 passed, 22 skipped; `uv run ruff check .` â€” all checks passed; `uv run ruff format --check .` â€” 166 files already formatted; `uv run mypy` â€” no issues in 24 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean, `npx vitest run` â€” 63 files / 1860 tests passed, `npm run build` â€” built

`test_every_translation_key_is_named_in_both_translation_files` is the existing guard here:
it fails if a key loses its name or the two files disagree. No new test pins the literal
strings â€” a name is a name, and asserting the exact wording would only restate the file.

The claim that `overdue` is checked-out-only was confirmed by reading both counters and the
`due_date` validation, not inferred from the name.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated â€” existing structural guard covers this; see above.
- [x] Docs updated where behavior changed (`README.md`).
- [x] WebSocket API changes keep `ws.py` and the docs in sync â€” no API change; the
      `get_counts()` keys (`overdue_count`, `items_total`, â€¦) are untouched.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

None â€” the card never shows these sensors; they appear under Settings â†’ Devices & services
and in the automation editor's entity picker.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)


