### PR TITLE
refactor(storage): stop persisting the write-only `_generation`

### DIFF
--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -2313,10 +2313,13 @@ class Repository:
 
     @property
     def generation(self) -> int:
-        """Current repository generation for optimistic locking and debugging.
+        """How many times this process has modified the repository.
 
-        The generation counter increments on every state modification and can
-        be used to detect stale snapshots or track changes for debugging.
+        Reported by ``haventory/health`` and the diagnostics dump, and useful for
+        telling a snapshot apart from a later one *within one run*. It is not
+        stored, so it starts near zero on every boot and says nothing about how
+        much the household has changed — the item ``version`` field is the
+        persisted counter, and the one optimistic concurrency runs on.
         """
         return self._generation
 
@@ -2417,7 +2420,6 @@ class Repository:
             "items": items_dict,
             "locations": locations_dict,
             "statuses": statuses_dict,
-            "_generation": self._generation,
         }
 
     def load_state(self, data: dict[str, Any]) -> None:
@@ -2438,8 +2440,11 @@ class Repository:
         if not isinstance(data, dict):
             return
 
-        # Restore generation counter from persisted state
-        self._generation = int(data.get("_generation", 0))
+        # The generation counter is not restored, and stores written by older
+        # builds carry a `_generation` key that is ignored here. It counts this
+        # process's mutations for the health command and the diagnostics dump;
+        # nothing compares it across a restart, and the item `version` field —
+        # which is persisted — is what optimistic concurrency runs on.
 
         # Statuses BEFORE the item loop, or ``coerce_item_status`` would see
         # only the built-ins and rewrite every item on a custom status to "ok"

--- a/tests/test_repository_items_offline.py
+++ b/tests/test_repository_items_offline.py
@@ -393,11 +393,16 @@ async def test_generation_property_accessor() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generation_export_and_load_roundtrip() -> None:
-    """Generation counter persists across export/load cycles."""
+async def test_generation_does_not_survive_an_export_and_load() -> None:
+    """The counter is this process's, and the export does not carry it.
+
+    A repository built from a stored payload starts counting again from the load
+    itself, however long the household has been running. What the round trip must
+    carry is the data, which is asserted here beside it so a change that dropped
+    both would not read as this one.
+    """
     repo = Repository()
 
-    # Create some data
     item1 = repo.create_item(ItemCreate(name="Item 1"))
     item2 = repo.create_item(ItemCreate(name="Item 2"))
     loc = repo.create_location(name="Location")
@@ -405,19 +410,16 @@ async def test_generation_export_and_load_roundtrip() -> None:
     generation_before = repo.generation
     assert generation_before > 0
 
-    # Export state
     state = repo.export_state()
-    assert "_generation" in state
-    assert state["_generation"] == generation_before
+    assert "_generation" not in state
 
-    # Create new repo and load state
     new_repo = Repository.from_state(state)
 
-    # Generation should be restored and incremented during load
-    # (load calls _index_item/_add_location for each entity, incrementing generation)
-    assert new_repo.generation > generation_before
+    # Nothing in the payload can move the counter: the same data loaded with a
+    # stale key beside it reaches exactly the same number, so what the loaded
+    # repository reports is its own indexing and nothing the exporter had done.
+    assert Repository.from_state({**state, "_generation": 9999}).generation == new_repo.generation
 
-    # Verify data integrity
     assert len(new_repo.list_items()["items"]) == LOADED_ITEM_COUNT
     assert new_repo.get_item(item1.id).name == "Item 1"
     assert new_repo.get_item(item2.id).name == "Item 2"
@@ -425,19 +427,17 @@ async def test_generation_export_and_load_roundtrip() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generation_load_state_without_generation() -> None:
-    """Loading state without _generation field initializes to 0."""
+async def test_a_stored_generation_from_an_older_build_is_ignored() -> None:
+    """Every store written before this build carries the key, and keeps carrying it.
+
+    Nothing rewrites a file on load, so the key survives until the next save. It
+    must not be read back — a stale counter from the last run would make the
+    health command's number look like activity this one has not had.
+    """
     repo = Repository()
 
-    # Create state without _generation field (legacy data)
-    state = {
-        "items": {},
-        "locations": {},
-    }
+    repo.load_state({"items": {}, "locations": {}, "_generation": 4096})
 
-    repo.load_state(state)
-
-    # Should initialize to 0, then increment for load
     assert repo.generation == 1
 
 

--- a/tests/test_storage_concurrency_offline.py
+++ b/tests/test_storage_concurrency_offline.py
@@ -280,28 +280,6 @@ async def test_generation_counter_increments_on_modification():
 
 
 @pytest.mark.asyncio
-async def test_generation_persisted_and_restored():
-    """Generation counter is persisted and restored across save/load cycles."""
-    repo = Repository()
-
-    # Make some modifications
-    repo.create_item(ItemCreate(name="Item 1"))
-    repo.create_item(ItemCreate(name="Item 2"))
-    generation_before = repo.generation
-
-    # Export state
-    state = repo.export_state()
-    assert state["_generation"] == generation_before
-
-    # Create new repo and load state
-    new_repo = Repository.from_state(state)
-
-    # Generation should be restored and incremented during load
-    # (load calls _index_item for each item, incrementing generation)
-    assert new_repo.generation > generation_before
-
-
-@pytest.mark.asyncio
 async def test_concurrent_operations_with_persistence():
     """Multiple concurrent operations complete successfully with locking."""
     hass = MagicMock()

--- a/tests/test_storage_offline.py
+++ b/tests/test_storage_offline.py
@@ -8,6 +8,8 @@ Scenarios:
 - Corrupted payload (non-dict) raises StorageError
 - A payload written by a newer schema is refused without rewriting the store
 - A payload whose schema_version is not an integer is refused, never coerced
+- A saved payload carries the stored collections and the schema number, nothing else
+- A store still carrying `_generation` loads, and the key is not read back
 """
 
 from __future__ import annotations
@@ -42,6 +44,9 @@ _REMINDER_ANCHOR_BACKFILL_VERSION = 9
 #: The version from which a status ``color`` may be a ``#rrggbb`` literal rather
 #: than one of the ten tone tokens. Builds below it reject the literal.
 _HEX_STATUS_COLOUR_VERSION = 7
+
+#: A counter value no fresh load could reach, so reading it back would be visible.
+STALE_GENERATION = 17
 
 
 @pytest.mark.asyncio
@@ -496,6 +501,57 @@ async def test_corrupted_payload_non_dict_raises_storage_error() -> None:
     # Act + Assert
     with pytest.raises(StorageError):
         await store.async_load()
+
+
+@pytest.mark.asyncio
+async def test_a_saved_payload_carries_nothing_beyond_the_stored_collections() -> None:
+    """The store holds the household's data and the schema number, and nothing else.
+
+    The guard below runs the other way — every collection the store defines must
+    be emitted. This one closes the gap on that side: a key the repository emits
+    but the store knows nothing about is written to disk anyway, read back into
+    the load path, and becomes a field of the stored shape that nobody decided
+    on. ``_generation`` was one for the whole dev range.
+    """
+
+    hass = HomeAssistant()
+    store = DomainStore(hass, key="test_store_saved_payload_keys")
+    repo = Repository()
+    where = repo.create_location(name="Garage")
+    repo.create_item(ItemCreate(name="Screws", location_id=str(where.id)))
+
+    await store.async_save(repo.export_state())
+    written = await store.async_load()
+
+    assert set(written) == {*STORE_COLLECTIONS, "schema_version"}
+
+
+@pytest.mark.asyncio
+async def test_a_store_written_before_the_generation_was_dropped_still_loads() -> None:
+    """Every store this build inherits carries the key, and none of them may refuse.
+
+    Dropping the key took no schema bump — a build that no longer writes it and
+    one that never wrote it are the same store to read — so nothing rewrites the
+    stores that have it. They have to keep loading, and the key has to survive
+    until the next save rather than making the load fail.
+    """
+
+    hass = HomeAssistant()
+    store = DomainStore(hass, key="test_store_stale_generation_key")
+    repo = Repository()
+    repo.create_item(ItemCreate(name="Screws"))
+    legacy = {**repo.export_state(), "_generation": STALE_GENERATION}
+
+    await store.async_save(legacy)
+    payload = await store.async_load()
+    reloaded = Repository.from_state(payload)
+
+    assert payload["_generation"] == STALE_GENERATION
+    assert [item.name for item in reloaded.list_items()["items"]] == ["Screws"]
+    # Read as a key this build has no use for, not as a counter to resume: the
+    # same payload with the key stripped out reaches the same number.
+    stripped = {name: value for name, value in payload.items() if name != "_generation"}
+    assert reloaded.generation == Repository.from_state(stripped).generation
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_utils_offline.py
+++ b/tests/test_ws_utils_offline.py
@@ -3,6 +3,7 @@
 Scenarios:
 - ping returns echo and timestamp
 - version reports integration_version and schema_version
+- health reports the generation this process has reached
 - config reports the configured card title, and the default when unset
 - config carries the status vocabulary and the attachment caps
 - stats returns repository counts, including the per-slug map
@@ -22,6 +23,7 @@ from custom_components.haventory.const import (
     MAX_MANUALS_PER_ITEM,
     MAX_PICTURES_PER_ITEM,
 )
+from custom_components.haventory.models import ItemCreate
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
 from custom_components.haventory.ws import setup as ws_setup
@@ -57,6 +59,29 @@ async def test_version_reports_integration_and_schema() -> None:
     assert res["result"]["integration_version"] == INTEGRATION_VERSION
     # In offline tests, store may not exist; default to CURRENT_SCHEMA_VERSION
     assert int(res["result"]["schema_version"]) == int(CURRENT_SCHEMA_VERSION)
+
+
+@pytest.mark.asyncio
+async def test_health_reports_the_generation_this_run_has_reached() -> None:
+    """The counter left the store; it did not leave the health command.
+
+    It is what a maintainer reads to see whether a repository is being written
+    to at all, and it counts this process's mutations — so it moves under
+    traffic and starts near zero after a restart, rather than continuing a
+    number the last run left behind.
+    """
+
+    hass = HomeAssistant()
+    repo = Repository()
+    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    ws_setup(hass)
+
+    before = await ws_send(hass, 30, "haventory/health")
+    repo.create_item(ItemCreate(name="Drill"))
+    after = await ws_send(hass, 31, "haventory/health")
+
+    assert before["result"]["generation"] == repo.generation - 1
+    assert after["result"]["generation"] == repo.generation
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`_generation` counts how many times *this process* has modified the repository. It feeds
`haventory/health` and the diagnostics dump, and nothing compares it across a restart —
optimistic concurrency runs on the item `version` field, which is persisted and stays so.
It was written into every store anyway, as a top-level key `storage.py`'s
`STORE_COLLECTIONS` never declared and `export_state`'s own docstring never listed.

Dropped from both sides of the payload: `export_state` no longer writes it and
`load_state` no longer reads it. A store that still carries it loads unchanged and keeps
the key until its next save.

**Plan decision carried, no schema bump.** A build that no longer writes the key and one
that never wrote it are the same store to read, so a version step here would buy nothing
and hand #229 a migration to delete.

First of the two stored-shape cuts #482 pulls forward; `refactor(models): one
`to_dict()` per model` closes it.

Refs #482

## Type of change

- [x] Refactor (no functional change)

One behaviour does change and is worth naming: the number `haventory/health` reports
starts near zero after a restart instead of continuing where the last run stopped. That
is the honest reading of a per-process counter, and the observable proof is in the live
check below — 11887 in the store, 1177 after the boot that read it.

## Decisions taken against drifted notes

#482 was written 2026-08-15 and one sentence of it does not match the tree:

1. **"never reads the stored value back" — it did.** `load_state` carried
   `self._generation = int(data.get("_generation", 0))`. So the key was not write-only;
   it was round-tripped, and a restart resumed the previous run's count. Decided against
   the note: **the read goes too.** Leaving it while dropping the write would make the
   counter resume on stores that still have the key and start from zero on ones that do
   not — the same build reporting two different things depending on how recently it had
   saved. And a resumed number is the wrong one either way: it reads as activity this
   process has not had.
2. **§6.1 says "`haventory/version` and the diagnostics payload still report the runtime
   generation".** `haventory/version` reports `integration_version` and `schema_version`
   only (`ws.py`, and `docs/backend_api_contract.md` agrees). The command that reports
   the generation is **`haventory/health`**. Tested there instead; the diagnostics half
   was already pinned by `tests/test_diagnostics_offline.py`.
3. **No docs change.** `docs/data_shapes.md` documents the *export document*, not the
   stored payload, and neither it nor `docs/backend_api_contract.md` ever mentioned
   `_generation`. Grepped both.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1166 passed, 22
      skipped**; `uv run ruff check .` → all checks passed; `uv run ruff format --check .`
      → 168 files already formatted; `uv run mypy` → no issues in 24 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npm run typecheck` →
      clean; `npx vitest run` → **1860 passed (63 files)**; `npm run build` → clean.
- [x] phacc: `scripts/test_integration.sh` through the Docker recipe → **102 passed** (a
      real HA `Store` round trip). Green on `main` before the change and after it.

### Tests changed

| test | why |
|---|---|
| `test_generation_export_and_load_roundtrip` → `test_generation_does_not_survive_an_export_and_load` | asserted `state["_generation"] == generation_before`, which is the behaviour being removed. Rewritten to assert the key is absent and that a stale one alongside the same data reaches the same number — the claim, without depending on how many increments indexing costs. |
| `test_generation_load_state_without_generation` → `test_a_stored_generation_from_an_older_build_is_ignored` | same test, other direction: the key present and large, and the counter unmoved by it. |
| `test_generation_persisted_and_restored` (`test_storage_concurrency_offline.py`) | **deleted.** Its whole subject was the round trip above, it duplicated the repository test, and it was never about concurrency. |

### Tests added

- `test_a_saved_payload_carries_nothing_beyond_the_stored_collections` — the payload that
  reaches disk has exactly `items, locations, statuses, schema_version`. The existing
  guard beside it runs the other way (every declared collection must be emitted); this
  closes the side that let `_generation` sit in the store for the whole dev range without
  anyone deciding on it.
- `test_a_store_written_before_the_generation_was_dropped_still_loads` — through
  `DomainStore.async_save`/`async_load`: the key survives the round trip on disk, the
  data loads, and the counter is not taken from it.
- `test_health_reports_the_generation_this_run_has_reached` — the counter left the store,
  not the health command; it moves under a mutation.

### Live checks (dev HA, HA 2026.7.4, 1087 items / 89 locations)

Deployed this branch into the dev container and restarted.

**The store loaded with the old key present** — proof the "no bump" decision holds on real
data, not just a fixture:

```
BEFORE any save on the new build: ['_generation', 'items', 'locations', 'schema_version', 'statuses'] _generation= 11887
```

**`haventory/health` after that boot reported `generation: 1177`** — not 11887. The stored
counter was read past, exactly as intended.

**One `item/create`, then the store again:**

```
AFTER the mutation: ['items', 'locations', 'schema_version', 'statuses']
_generation present: False
items 1088 locations 89 statuses 11 schema_version 9
```

Which is §6.1's check verbatim: the payload's top-level keys are exactly `items,
locations, statuses, schema_version`.

`log_sweep.py --since 15m` → **PASS (blocking=0)**, and the probe item was deleted, so
the instance is back at 1087 items. The store was snapshotted before any of this and the
data is unchanged; nothing needed restoring.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases — the key present, absent, and
      large).
- [x] Docs updated where behavior changed — nothing to update, see decision 3.
- [x] WebSocket API unchanged: `haventory/health` keeps reporting `generation`.
- [x] Essential invariants preserved. The item `version` field — the one optimistic
      concurrency uses — is untouched and still persisted.

## Screenshots (card / UI changes)

None; no card change.
