### PR TITLE
refactor(models): one `to_dict()` per model

### DIFF
--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -79,8 +79,6 @@ from .models import (
     normalize_text_for_sort,
     parse_uuid4,
     seed_status_definitions,
-    serialize_attachment_meta,
-    serialize_reminder_interval,
     serialize_status_definition,
     validate_attachment_meta,
     validate_due_date_rules,
@@ -133,56 +131,6 @@ _LOCATION_SOURCE_FIELDS: tuple[str, ...] = ("name", "parent_id", "area_id")
 # -----------------------------
 
 
-def _serialize_item_doc(item: Item) -> dict[str, Any]:
-    """Serialize an item to a document entry (all source + path fields)."""
-
-    return {
-        "id": str(item.id),
-        "name": item.name,
-        "description": item.description,
-        "quantity": int(item.quantity),
-        "status": item.status,
-        "checked_out": bool(item.checked_out),
-        "due_date": item.due_date,
-        "inspection_date": item.inspection_date,
-        "reminder_date": item.reminder_date,
-        "reminder_anchor": item.reminder_anchor,
-        "reminder_interval": serialize_reminder_interval(item.reminder_interval),
-        "location_id": str(item.location_id) if item.location_id is not None else None,
-        "tags": list(item.tags),
-        "category": item.category,
-        "low_stock_threshold": item.low_stock_threshold,
-        "custom_fields": dict(item.custom_fields),
-        "created_at": item.created_at,
-        "updated_at": item.updated_at,
-        "version": int(item.version),
-        "location_path": {
-            "id_path": [str(x) for x in item.location_path.id_path],
-            "name_path": list(item.location_path.name_path),
-            "display_path": item.location_path.display_path,
-            "sort_key": item.location_path.sort_key,
-        },
-        "attachments": [serialize_attachment_meta(a) for a in item.attachments],
-    }
-
-
-def _serialize_location_doc(loc: Location) -> dict[str, Any]:
-    """Serialize a location to a document entry (all source + path fields)."""
-
-    return {
-        "id": str(loc.id),
-        "name": loc.name,
-        "parent_id": str(loc.parent_id) if loc.parent_id is not None else None,
-        "area_id": str(loc.area_id) if loc.area_id is not None else None,
-        "path": {
-            "id_path": [str(x) for x in loc.path.id_path],
-            "name_path": list(loc.path.name_path),
-            "display_path": loc.path.display_path,
-            "sort_key": loc.path.sort_key,
-        },
-    }
-
-
 def build_export_document(
     repo: Repository,
     *,
@@ -213,11 +161,11 @@ def build_export_document(
             if it.location_id is not None:
                 location_ids.add(str(it.location_id))
 
-    items_docs = [_serialize_item_doc(items[i]) for i in _sorted_index_by_id(items)]
+    items_docs = [items[i].to_dict() for i in _sorted_index_by_id(items)]
     locations = [
         repo._locations_by_id[lid] for lid in sorted(location_ids) if lid in repo._locations_by_id
     ]
-    locations_docs = [_serialize_location_doc(loc) for loc in locations]
+    locations_docs = [loc.to_dict() for loc in locations]
 
     return {
         "haventory_export_version": EXPORT_VERSION,

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -73,6 +73,22 @@ class LocationPath:
     display_path: str
     sort_key: str
 
+    def to_dict(self) -> dict[str, Any]:
+        """The serialized shape, nested under an item's ``location_path`` and a
+        location's ``path``.
+
+        The lists are copied: every caller receives a payload it is free to edit,
+        and an item's own path must not change because something edited what it
+        was handed.
+        """
+
+        return {
+            "id_path": [str(entry) for entry in self.id_path],
+            "name_path": list(self.name_path),
+            "display_path": self.display_path,
+            "sort_key": self.sort_key,
+        }
+
 
 EMPTY_LOCATION_PATH = LocationPath(id_path=[], name_path=[], display_path="", sort_key="")
 
@@ -106,6 +122,21 @@ class Location:
     name: str
     area_id: str | None = None
     path: LocationPath = field(default_factory=lambda: EMPTY_LOCATION_PATH)
+
+    def to_dict(self) -> dict[str, Any]:
+        """The one serialized shape of a location.
+
+        The store, the export document and the wire all send exactly this — a
+        location has no derived field the way an item has ``effective_area_id``.
+        """
+
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "parent_id": str(self.parent_id) if self.parent_id is not None else None,
+            "area_id": str(self.area_id) if self.area_id is not None else None,
+            "path": self.path.to_dict(),
+        }
 
 
 @dataclass
@@ -214,6 +245,45 @@ class Item:
     # Deliberately absent from ItemCreate / ItemUpdate: the two attachment
     # commands own this field, so an ordinary item edit can never rewrite it.
     attachments: list[AttachmentMeta] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """The one serialized shape of an item.
+
+        This is what the store holds and what the export document carries, byte
+        for byte. The WebSocket and service surfaces send it with
+        ``effective_area_id`` added — resolved from the location tree per
+        request and never stored, which is why it is added at that boundary
+        (``serialization.serialize_item``) rather than here.
+
+        ``location_path`` is derived too, but it *is* stored: the backend
+        recomputes it on every location change and no client can write it, and
+        the store carries the last computed value so a boot has the paths
+        before the tree is walked.
+        """
+
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "description": self.description,
+            "quantity": int(self.quantity),
+            "status": self.status,
+            "checked_out": bool(self.checked_out),
+            "due_date": self.due_date,
+            "inspection_date": self.inspection_date,
+            "reminder_date": self.reminder_date,
+            "reminder_anchor": self.reminder_anchor,
+            "reminder_interval": serialize_reminder_interval(self.reminder_interval),
+            "location_id": str(self.location_id) if self.location_id is not None else None,
+            "tags": list(self.tags),
+            "category": self.category,
+            "low_stock_threshold": self.low_stock_threshold,
+            "custom_fields": dict(self.custom_fields),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "version": int(self.version),
+            "location_path": self.location_path.to_dict(),
+            "attachments": [serialize_attachment_meta(meta) for meta in self.attachments],
+        }
 
 
 class ItemCreate(TypedDict, total=False):

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -63,8 +63,6 @@ from .models import (
     seed_status_definitions,
     selected_categories,
     selected_location_ids,
-    serialize_attachment_meta,
-    serialize_reminder_interval,
     serialize_status_definition,
     sort_items,
     today_utc_date,
@@ -2359,57 +2357,15 @@ class Repository:
         afterwards. ``tests/test_storage_offline.py`` pins that.
         """
 
-        def _serialize_item(item: Item) -> dict[str, Any]:
-            return {
-                "id": str(item.id),
-                "name": item.name,
-                "description": item.description,
-                "quantity": int(item.quantity),
-                "status": item.status,
-                "checked_out": bool(item.checked_out),
-                "due_date": item.due_date,
-                "inspection_date": item.inspection_date,
-                "reminder_date": item.reminder_date,
-                "reminder_anchor": item.reminder_anchor,
-                "reminder_interval": serialize_reminder_interval(item.reminder_interval),
-                "location_id": str(item.location_id) if item.location_id is not None else None,
-                "tags": list(item.tags),
-                "category": item.category,
-                "low_stock_threshold": item.low_stock_threshold,
-                "custom_fields": dict(item.custom_fields),
-                "created_at": item.created_at,
-                "updated_at": item.updated_at,
-                "version": int(item.version),
-                "location_path": {
-                    "id_path": [str(x) for x in list(item.location_path.id_path)],
-                    "name_path": list(item.location_path.name_path),
-                    "display_path": item.location_path.display_path,
-                    "sort_key": item.location_path.sort_key,
-                },
-                "attachments": [serialize_attachment_meta(a) for a in item.attachments],
-            }
+        items_dict: dict[str, Any] = {
+            item_id: self._items_by_id[item_id].to_dict()
+            for item_id in sorted(self._items_by_id.keys())
+        }
 
-        def _serialize_location(loc: Location) -> dict[str, Any]:
-            return {
-                "id": str(loc.id),
-                "name": loc.name,
-                "parent_id": str(loc.parent_id) if loc.parent_id is not None else None,
-                "area_id": str(loc.area_id) if loc.area_id is not None else None,
-                "path": {
-                    "id_path": [str(x) for x in list(loc.path.id_path)],
-                    "name_path": list(loc.path.name_path),
-                    "display_path": loc.path.display_path,
-                    "sort_key": loc.path.sort_key,
-                },
-            }
-
-        items_dict: dict[str, Any] = {}
-        for item_id in sorted(self._items_by_id.keys()):
-            items_dict[item_id] = _serialize_item(self._items_by_id[item_id])
-
-        locations_dict: dict[str, Any] = {}
-        for loc_id in sorted(self._locations_by_id.keys()):
-            locations_dict[loc_id] = _serialize_location(self._locations_by_id[loc_id])
+        locations_dict: dict[str, Any] = {
+            loc_id: self._locations_by_id[loc_id].to_dict()
+            for loc_id in sorted(self._locations_by_id.keys())
+        }
 
         statuses_dict: dict[str, Any] = {
             slug: serialize_status_definition(self._statuses_by_slug[slug])

--- a/custom_components/haventory/serialization.py
+++ b/custom_components/haventory/serialization.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .models import Item, Location, serialize_attachment_meta, serialize_reminder_interval
+from .models import Item, Location
 from .repository import Repository
 
 
@@ -35,49 +35,20 @@ def effective_area_id_for_item(hass: HomeAssistant, item: Item) -> str | None:
 
 
 def serialize_item(hass: HomeAssistant, item: Item) -> dict[str, Any]:
-    """The canonical Item shape."""
-    return {
-        "id": str(item.id),
-        "name": item.name,
-        "description": item.description,
-        "quantity": item.quantity,
-        "status": item.status,
-        "checked_out": item.checked_out,
-        "due_date": item.due_date,
-        "inspection_date": item.inspection_date,
-        "reminder_date": item.reminder_date,
-        "reminder_anchor": item.reminder_anchor,
-        "reminder_interval": serialize_reminder_interval(item.reminder_interval),
-        "location_id": str(item.location_id) if item.location_id is not None else None,
-        "tags": list(item.tags),
-        "category": item.category,
-        "low_stock_threshold": item.low_stock_threshold,
-        "custom_fields": dict(item.custom_fields),
-        "created_at": item.created_at,
-        "updated_at": item.updated_at,
-        "version": item.version,
-        "effective_area_id": effective_area_id_for_item(hass, item),
-        "location_path": {
-            "id_path": [str(x) for x in item.location_path.id_path],
-            "name_path": item.location_path.name_path,
-            "display_path": item.location_path.display_path,
-            "sort_key": item.location_path.sort_key,
-        },
-        "attachments": [serialize_attachment_meta(a) for a in item.attachments],
-    }
+    """The canonical Item shape: what the store holds, plus the derived area.
+
+    ``effective_area_id`` is resolved from the location tree for this request
+    and never persisted, so it is added at this boundary rather than inside
+    ``Item.to_dict()`` — which is what keeps the stored and exported shapes free
+    of a field no store can answer for.
+    """
+    return {**item.to_dict(), "effective_area_id": effective_area_id_for_item(hass, item)}
 
 
 def serialize_location(loc: Location) -> dict[str, Any]:
-    """The canonical Location shape."""
-    return {
-        "id": str(loc.id),
-        "name": loc.name,
-        "parent_id": str(loc.parent_id) if loc.parent_id is not None else None,
-        "area_id": str(loc.area_id) if getattr(loc, "area_id", None) is not None else None,
-        "path": {
-            "id_path": [str(x) for x in loc.path.id_path],
-            "name_path": loc.path.name_path,
-            "display_path": loc.path.display_path,
-            "sort_key": loc.path.sort_key,
-        },
-    }
+    """The canonical Location shape, which is the stored one unchanged.
+
+    Named rather than inlined at the call sites: this is the wire surface, and a
+    location acquiring a derived field would gain it here.
+    """
+    return loc.to_dict()

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -8,7 +8,12 @@ Canonical shapes used in WebSocket payloads and storage, derived from `custom_co
 
 ### Item
 
-Object shape for persisted items and API results:
+Object shape for persisted items and API results. Everything down to `attachments` is
+the **one** shape `Item.to_dict()` produces — what the store holds and what an export
+document carries, identically. `effective_area_id` is the single field the API adds on
+top: it is resolved from the location tree per request and is never stored, so it appears
+on WebSocket results and service responses only, and never in the store or an export.
+
 ```json
 {
   "id": "uuid-v4",
@@ -36,8 +41,9 @@ Object shape for persisted items and API results:
     "display_path": "Garage / Shelf A",
     "sort_key": "garage / shelf a"
   },
-  "effective_area_id": "string|null",
-  "attachments": [ <Attachment>, ... ]
+  "attachments": [ <Attachment>, ... ],
+
+  "effective_area_id": "string|null"
 }
 ```
 

--- a/tests/fixtures/stored_payload.json
+++ b/tests/fixtures/stored_payload.json
@@ -1,0 +1,201 @@
+{
+  "items": {
+    "aaaaaaaa-0000-4000-8000-000000000001": {
+      "id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "name": "Cordless drill",
+      "description": "18V, two batteries",
+      "quantity": 2,
+      "status": "lent_out",
+      "checked_out": true,
+      "due_date": "2026-09-01",
+      "inspection_date": "2026-12-24",
+      "reminder_date": "2026-10-31",
+      "reminder_anchor": "2026-10-31",
+      "reminder_interval": {
+        "unit": "months",
+        "count": 6
+      },
+      "location_id": "aaaaaaaa-0000-4000-8000-000000000003",
+      "tags": [
+        "power",
+        "tools"
+      ],
+      "category": "Tools",
+      "low_stock_threshold": 1,
+      "custom_fields": {
+        "serial": "X-1",
+        "warranty_years": 3,
+        "registered": true
+      },
+      "created_at": "2026-08-01T10:00:00Z",
+      "updated_at": "2026-08-02T10:00:01Z",
+      "version": 2,
+      "location_path": {
+        "id_path": [
+          "aaaaaaaa-0000-4000-8000-000000000002",
+          "aaaaaaaa-0000-4000-8000-000000000004",
+          "aaaaaaaa-0000-4000-8000-000000000003"
+        ],
+        "name_path": [
+          "Garage",
+          "Shelf A",
+          "Bin 3"
+        ],
+        "display_path": "Garage / Shelf A / Bin 3",
+        "sort_key": "garage / shelf a / bin 3"
+      },
+      "attachments": [
+        {
+          "id": "11111111-1111-4111-8111-111111111111",
+          "kind": "picture",
+          "filename": "drill.jpg",
+          "mime": "image/jpeg",
+          "size": 20480,
+          "uploaded_at": "2026-08-01T09:00:00Z",
+          "title": "On the shelf",
+          "order": 0
+        },
+        {
+          "id": "22222222-2222-4222-8222-222222222222",
+          "kind": "manual",
+          "filename": "drill-manual.pdf",
+          "mime": "application/pdf",
+          "size": 512000,
+          "uploaded_at": "2026-08-01T09:05:00Z",
+          "title": "",
+          "order": 1
+        }
+      ]
+    },
+    "aaaaaaaa-0000-4000-8000-000000000005": {
+      "id": "aaaaaaaa-0000-4000-8000-000000000005",
+      "name": "Ünlabelled späre",
+      "description": null,
+      "quantity": 1,
+      "status": "ok",
+      "checked_out": false,
+      "due_date": null,
+      "inspection_date": null,
+      "reminder_date": null,
+      "reminder_anchor": null,
+      "reminder_interval": null,
+      "location_id": null,
+      "tags": [],
+      "category": null,
+      "low_stock_threshold": null,
+      "custom_fields": {},
+      "created_at": "2026-08-01T10:00:00Z",
+      "updated_at": "2026-08-01T10:00:00Z",
+      "version": 1,
+      "location_path": {
+        "id_path": [],
+        "name_path": [],
+        "display_path": "",
+        "sort_key": ""
+      },
+      "attachments": []
+    }
+  },
+  "locations": {
+    "aaaaaaaa-0000-4000-8000-000000000002": {
+      "id": "aaaaaaaa-0000-4000-8000-000000000002",
+      "name": "Garage",
+      "parent_id": null,
+      "area_id": "garage_area",
+      "path": {
+        "id_path": [
+          "aaaaaaaa-0000-4000-8000-000000000002"
+        ],
+        "name_path": [
+          "Garage"
+        ],
+        "display_path": "Garage",
+        "sort_key": "garage"
+      }
+    },
+    "aaaaaaaa-0000-4000-8000-000000000003": {
+      "id": "aaaaaaaa-0000-4000-8000-000000000003",
+      "name": "Bin 3",
+      "parent_id": "aaaaaaaa-0000-4000-8000-000000000004",
+      "area_id": null,
+      "path": {
+        "id_path": [
+          "aaaaaaaa-0000-4000-8000-000000000002",
+          "aaaaaaaa-0000-4000-8000-000000000004",
+          "aaaaaaaa-0000-4000-8000-000000000003"
+        ],
+        "name_path": [
+          "Garage",
+          "Shelf A",
+          "Bin 3"
+        ],
+        "display_path": "Garage / Shelf A / Bin 3",
+        "sort_key": "garage / shelf a / bin 3"
+      }
+    },
+    "aaaaaaaa-0000-4000-8000-000000000004": {
+      "id": "aaaaaaaa-0000-4000-8000-000000000004",
+      "name": "Shelf A",
+      "parent_id": "aaaaaaaa-0000-4000-8000-000000000002",
+      "area_id": null,
+      "path": {
+        "id_path": [
+          "aaaaaaaa-0000-4000-8000-000000000002",
+          "aaaaaaaa-0000-4000-8000-000000000004"
+        ],
+        "name_path": [
+          "Garage",
+          "Shelf A"
+        ],
+        "display_path": "Garage / Shelf A",
+        "sort_key": "garage / shelf a"
+      }
+    },
+    "aaaaaaaa-0000-4000-8000-000000000006": {
+      "id": "aaaaaaaa-0000-4000-8000-000000000006",
+      "name": "Ünsorted / Späte",
+      "parent_id": null,
+      "area_id": null,
+      "path": {
+        "id_path": [
+          "aaaaaaaa-0000-4000-8000-000000000006"
+        ],
+        "name_path": [
+          "Ünsorted / Späte"
+        ],
+        "display_path": "Ünsorted / Späte",
+        "sort_key": "unsorted / spate"
+      }
+    }
+  },
+  "statuses": {
+    "lent_out": {
+      "slug": "lent_out",
+      "label": "Lent out",
+      "order": 9,
+      "color": "blue",
+      "icon": "hand"
+    },
+    "missing": {
+      "slug": "missing",
+      "label": "Missing",
+      "order": 1,
+      "color": "amber",
+      "icon": "alert"
+    },
+    "needs_repair": {
+      "slug": "needs_repair",
+      "label": "Needs repair",
+      "order": 2,
+      "color": "amber",
+      "icon": "wrench"
+    },
+    "ok": {
+      "slug": "ok",
+      "label": "OK",
+      "order": 0,
+      "color": "green",
+      "icon": "check"
+    }
+  }
+}

--- a/tests/test_serialized_shapes_offline.py
+++ b/tests/test_serialized_shapes_offline.py
@@ -1,0 +1,251 @@
+"""One ``to_dict()`` per model, and the three shapes that come off it.
+
+An item is serialized for three places, and they are not the same shape:
+
+* the **store**, and the **export document**, which are byte-for-byte the one
+  ``Item.to_dict()`` produces;
+* the **wire** — WebSocket results and service responses — which is that plus
+  ``effective_area_id``, resolved from the location tree per request and stored
+  nowhere.
+
+Held together here rather than in the three modules that emit them: the fields
+were hand-written three times and drifted, and the way that drift shows up is a
+restore that quietly loses something, or a card that reads a key from one
+surface and not another.
+
+``tests/fixtures/stored_payload.json`` is the golden document. It was generated
+from the serializers as they stood before they were consolidated, so what the
+round trip below asserts is that the consolidation moved no byte of a store.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.import_export import build_export_document
+from custom_components.haventory.models import EMPTY_LOCATION_PATH, Item, Location, LocationPath
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.serialization import serialize_item, serialize_location
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
+from homeassistant.core import HomeAssistant
+
+GOLDEN = Path(__file__).resolve().parent / "fixtures" / "stored_payload.json"
+
+#: Exactly what an item carries in the store and in an export document, in order.
+STORED_ITEM_KEYS = (
+    "id",
+    "name",
+    "description",
+    "quantity",
+    "status",
+    "checked_out",
+    "due_date",
+    "inspection_date",
+    "reminder_date",
+    "reminder_anchor",
+    "reminder_interval",
+    "location_id",
+    "tags",
+    "category",
+    "low_stock_threshold",
+    "custom_fields",
+    "created_at",
+    "updated_at",
+    "version",
+    "location_path",
+    "attachments",
+)
+STORED_LOCATION_KEYS = ("id", "name", "parent_id", "area_id", "path")
+#: The one field the wire adds. Resolved per request; no store can answer for it.
+WIRE_ONLY_ITEM_KEYS = frozenset({"effective_area_id"})
+
+
+def golden_text() -> str:
+    return GOLDEN.read_text(encoding="utf-8")
+
+
+def golden_payload() -> dict[str, Any]:
+    return json.loads(golden_text())  # type: ignore[no-any-return]
+
+
+def dumped(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+
+def loaded_repository() -> Repository:
+    return Repository.from_state(golden_payload())
+
+
+def hass_with(repo: Repository) -> HomeAssistant:
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    return hass
+
+
+# --------------------------------------------------------------------------- #
+# The store
+# --------------------------------------------------------------------------- #
+
+
+def test_the_stored_payload_is_byte_for_byte_what_it_was() -> None:
+    """The golden document, loaded and exported again, is the golden document.
+
+    #482 pulls the stored-shape changes forward so #229's collapse lands on a
+    shape that has stopped moving. Consolidating three hand-written serializers
+    into one is exactly the kind of change that moves a byte without meaning to
+    — a lost key, a reordered field, an ``int()`` dropped — and every one of
+    those is a store this build writes differently from the last.
+    """
+    exported = loaded_repository().export_state()
+
+    assert dumped(exported) == golden_text()
+
+
+def test_the_golden_document_covers_the_fields_that_could_drift() -> None:
+    """A golden file is only worth what it contains.
+
+    Byte equality against a document of two empty items would pass through any
+    of the mistakes above, so the coverage the fixture is supposed to have is
+    asserted rather than assumed.
+    """
+    payload = golden_payload()
+    items = list(payload["items"].values())
+    filled = next(item for item in items if item["name"] == "Cordless drill")
+
+    # Every field spelled out, and a second item carrying the null/empty
+    # spelling of each optional one.
+    assert tuple(filled) == STORED_ITEM_KEYS
+    assert any(item["reminder_interval"] is None for item in items)
+    assert any(item["location_path"]["id_path"] == [] for item in items)
+    assert any(item["attachments"] == [] for item in items)
+
+    # The parts most easily lost: a custom status, a three-deep path, an
+    # accented name that normalises differently, both attachment kinds, and a
+    # custom field of each scalar type.
+    assert "lent_out" in payload["statuses"]
+    assert filled["location_path"]["name_path"] == ["Garage", "Shelf A", "Bin 3"]
+    assert any("ü" in loc["name"].lower() for loc in payload["locations"].values())
+    assert [a["kind"] for a in filled["attachments"]] == ["picture", "manual"]
+    assert sorted(type(v).__name__ for v in filled["custom_fields"].values()) == [
+        "bool",
+        "int",
+        "str",
+    ]
+
+
+@pytest.mark.parametrize("collection", ["items", "locations"])
+def test_a_changed_entity_breaks_the_golden_comparison(collection: str) -> None:
+    """The comparison has to be able to fail, on both collections.
+
+    A byte-equality assertion is worthless if the two sides are computed from
+    each other, and this is the check that they are not.
+    """
+    payload = golden_payload()
+    entity = next(iter(payload[collection].values()))
+    entity["name"] = f"{entity['name']} (edited)"
+
+    assert dumped(Repository.from_state(payload).export_state()) != golden_text()
+
+
+# --------------------------------------------------------------------------- #
+# The three surfaces
+# --------------------------------------------------------------------------- #
+
+
+def test_the_export_document_carries_the_stored_item_shape() -> None:
+    """The document is a restore, so it holds what the store holds.
+
+    ``docs/data_shapes.md`` describes it as every source field plus the
+    denormalized paths; that is now the same object the store gets, so nothing
+    can be added to one without the other.
+    """
+    repo = loaded_repository()
+
+    document = build_export_document(repo, schema_version=CURRENT_SCHEMA_VERSION)
+
+    assert [tuple(entry) for entry in document["items"]] == [STORED_ITEM_KEYS] * 2
+    assert [tuple(entry) for entry in document["locations"]] == [STORED_LOCATION_KEYS] * 4
+    stored = golden_payload()
+    assert {entry["id"]: entry for entry in document["items"]} == stored["items"]
+    assert {entry["id"]: entry for entry in document["locations"]} == stored["locations"]
+
+
+def test_the_wire_item_is_the_stored_item_plus_the_derived_area() -> None:
+    """The one difference between the wire and the store, asserted as the only one."""
+    repo = loaded_repository()
+    hass = hass_with(repo)
+    item = next(item for item in repo.list_items()["items"] if item.name == "Cordless drill")
+
+    payload = serialize_item(hass, item)
+
+    assert set(payload) - set(STORED_ITEM_KEYS) == WIRE_ONLY_ITEM_KEYS
+    assert set(STORED_ITEM_KEYS) - set(payload) == set()
+    assert {key: payload[key] for key in STORED_ITEM_KEYS} == item.to_dict()
+    # Inherited from the tree's root, which is the Garage and carries the area.
+    assert payload["effective_area_id"] == "garage_area"
+
+
+def test_the_wire_location_is_the_stored_location() -> None:
+    """A location has no derived field, so the two shapes are one."""
+    repo = loaded_repository()
+    location = next(loc for loc in repo._locations_by_id.values() if loc.name == "Bin 3")
+
+    assert serialize_location(location) == location.to_dict()
+    assert tuple(serialize_location(location)) == STORED_LOCATION_KEYS
+
+
+def test_an_item_with_no_location_serializes_a_null_area() -> None:
+    """The wire's one extra field has to answer for an item that has no tree.
+
+    ``effective_area_id`` is resolved per request and best-effort, so the
+    interesting case is the one where the resolution has nothing to walk.
+    """
+    repo = loaded_repository()
+    hass = hass_with(repo)
+    orphan = next(item for item in repo.list_items()["items"] if item.location_id is None)
+
+    payload = serialize_item(hass, orphan)
+
+    assert payload["effective_area_id"] is None
+    assert payload["location_path"] == EMPTY_LOCATION_PATH.to_dict()
+
+
+# --------------------------------------------------------------------------- #
+# The copies
+# --------------------------------------------------------------------------- #
+
+
+def test_a_serialized_payload_cannot_be_edited_back_into_the_repository() -> None:
+    """Every caller gets a payload it owns.
+
+    The collections are copied out, so an import plan or a card-bound frame can
+    be rewritten in place without the repository's own item changing under it —
+    which, for a mutable field on a live object, would be a corruption with no
+    write path behind it and nothing in a log.
+    """
+    item = Item(
+        id=uuid.uuid4(),
+        name="Drill",
+        tags=["power"],
+        custom_fields={"serial": "X-1"},
+        location_path=LocationPath(
+            id_path=[], name_path=["Garage"], display_path="Garage", sort_key="garage"
+        ),
+    )
+    location = Location(id=item.id, parent_id=None, name="Garage", path=item.location_path)
+
+    payload = item.to_dict()
+    payload["tags"].append("stolen")
+    payload["custom_fields"]["serial"] = "tampered"
+    payload["location_path"]["name_path"].append("Nowhere")
+    location.to_dict()["path"]["name_path"].append("Nowhere")
+
+    assert item.tags == ["power"]
+    assert item.custom_fields == {"serial": "X-1"}
+    assert item.location_path.name_path == ["Garage"]
+    assert location.path.name_path == ["Garage"]


### PR DESCRIPTION
## Summary

An item was serialized by three hand-written functions — `repository.py`'s (the store),
`import_export.py`'s (the export document) and `serialization.py`'s (the wire) — and they
had drifted. Now there is one `Item.to_dict()`, one `Location.to_dict()` and one
`LocationPath.to_dict()`, all on the models, and the three surfaces are that object:

- **store** and **export document** — `to_dict()` unchanged, byte for byte identical
- **wire** (WebSocket results, service responses) — `to_dict()` plus `effective_area_id`,
  resolved from the location tree per request and stored nowhere

`export_state`, `build_export_document` and `serialize_item`/`serialize_location` all
became a call. ~90 lines of duplicated field lists are gone.

**Plan decision carried: the stored form is exactly today's**, which is what #482 needs so
#229's collapse lands on a shape that has stopped moving. Pinned by a golden document
generated from the *old* serializers and committed: loading it and exporting it again
reproduces the file byte for byte.

Closes #482

## Type of change

- [x] Refactor (no functional change)
- [x] Documentation / tooling / CI (`docs/data_shapes.md`)

## Decisions taken against drifted notes

#482's field table does not match the tree it describes. Verified against the code **and**
against the dev instance's live `.storage/haventory_store`.

1. **The stored item already carries `location_path`.** The issue's table lists
   `attachments` as the stored form's only extra, and its prose says "`location_path` is
   derived and deliberately not stored". Both are wrong. `repository.py` has written it
   since before this milestone, `load_state` reads it back (with a `sort_key` backfill for
   pre-WP4 stores), and every item in the dev store has it:

   ```
   item keys: ['id', 'name', 'description', 'quantity', 'status', 'checked_out',
   'due_date', 'inspection_date', 'reminder_date', 'reminder_anchor',
   'reminder_interval', 'location_id', 'tags', 'category', 'low_stock_threshold',
   'custom_fields', 'created_at', 'updated_at', 'version', 'location_path', 'attachments']
   ```

   **Decided against the note: `location_path` stays stored.** §6.1's rule is that the
   stored form is *exactly today's*, and today's has it. Removing it would be the one
   thing this PR must not do — change the stored payload — and the collapse would then be
   staged against a shape that had just moved. The issue's *intent* still holds and is
   implemented: `location_path` acquires no new stored form, and `effective_area_id`
   acquires none at all.

   `Item.to_dict()`'s docstring now says why `location_path` is both derived and stored,
   so the next reader does not have to re-derive this.

2. **The store and the export document were already the same shape.** The table implies
   the export carries `location_path` and the store does not; in fact the two functions
   were field-for-field identical, down to the `int()`/`bool()` coercions. So the
   consolidation is a three-into-one, not a two-into-one with a wrapper.

3. **`effective_area_id` moves to the end of the wire payload.** It sat between `version`
   and `location_path`; `{**item.to_dict(), "effective_area_id": ...}` puts it last. JSON
   object order is not a contract and nothing reads by position — and the docs' own
   ordering already matched neither the code nor itself. `docs/data_shapes.md` is updated
   to the order the wire now emits, with a sentence saying what had never been stated
   there: everything down to `attachments` is the one stored shape, and
   `effective_area_id` is the single field the API adds and the store never holds.

4. **§4's "assets-branch recipe the `run-haventory` skill documents" does not exist.** No
   such recipe is in `SKILL.md` and no assets branch is on the remote. Screenshot evidence
   below is described rather than embedded; nothing here is visible anyway.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1175 passed, 22
      skipped**; `uv run ruff check .` → all checks passed; `uv run ruff format --check .`
      → 169 files already formatted; `uv run mypy` → no issues in 24 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` → clean; `npm run typecheck` →
      clean; `npx vitest run` → **1860 passed (63 files)**; `npm run build` → clean.
- [x] phacc: `scripts/test_integration.sh` through the Docker recipe → **102 passed**.

### The golden document

`tests/fixtures/stored_payload.json` was generated from the serializers **as they stood
before this change**, then committed. `test_the_stored_payload_is_byte_for_byte_what_it_was`
loads it and exports it again and compares the rendered JSON as text — so a lost key, a
reordered field or a dropped `int()` all fail.

A golden file is only worth what it holds, so
`test_the_golden_document_covers_the_fields_that_could_drift` asserts its coverage: every
item key in order; a second item carrying the null/empty spelling of every optional field;
a custom status; a three-deep location path; an accented name that normalises differently
(`Ünsorted / Späte` → `unsorted / spate`); both attachment kinds, one titled and one not;
and a custom field of each scalar type. `test_a_changed_entity_breaks_the_golden_comparison`
is the control, parametrised over both collections — it edits one name and asserts the
comparison says no.

### The three surfaces

- `test_the_export_document_carries_the_stored_item_shape` — the document's entries have
  the stored key tuple, in order, and equal the stored entries.
- `test_the_wire_item_is_the_stored_item_plus_the_derived_area` — `effective_area_id` is
  the *only* difference, asserted in both directions, and it resolves to the tree root's
  area.
- `test_the_wire_location_is_the_stored_location` — a location has no derived field.
- `test_an_item_with_no_location_serializes_a_null_area` — the derived field's edge case.
- `test_a_serialized_payload_cannot_be_edited_back_into_the_repository` — see below.

### One behaviour improves

The wire serializer handed callers the item's own `tags`, `custom_fields` and
`location_path.name_path` lists, unwrapped. Consolidating onto `to_dict()` gives every
surface copies, so a caller editing a payload can no longer reach into the repository —
which would have been a corruption with no write path behind it and nothing in a log. That
is the last test above.

### Live checks (dev HA, HA 2026.7.4, 1087 items / 89 locations / 11 statuses)

Deployed and restarted. Setup clean, `healthy: true`, `issues: []`, all 1087 items and 89
locations loaded.

**§6.1's check — export → preview → import round-trips with zero changes.** Exported the
whole live inventory and handed it straight back to `haventory/import/preview` under all
three policies. Identical under each:

```
exported: 1087 items, 89 locations, 11 statuses
counts: items    {add: 0, update: 0, conflict: 0, unchanged: 1087, total: 1087}
        locations{add: 0, update: 0, conflict: 0, unchanged: 89,   total: 89}
errors: []      attachments: {referenced: 53, missing: 0}
```

Every entity classified `unchanged` is the strong form of the claim: the export's fields
compare equal to the repository's, one by one, across a real household's data.

**The stored shape did not move.** After the CRUD smoke's writes, read off the container's
`.storage/haventory_store`:

```
top-level: ['items', 'locations', 'schema_version', 'statuses']
item keys: [... 21 keys, 'location_path', 'attachments']   # identical to before
loc keys : ['id', 'name', 'parent_id', 'area_id', 'path']
lp keys  : ['id_path', 'name_path', 'display_path', 'sort_key']
```

**The wire shape is the stored one plus the derived field**, read from a live
`haventory/item/list`: 22 keys, `effective_area_id` last. On an item under a location tree
whose root carries an area, `haventory/item/get` returns
`display_path: 'Bedroom / Nightstand'`, `effective_area_id: 'bedroom'`; on one whose tree
root has no area, `null`. Both correct.

**`driver.py smoke`** — the full CRUD flow, all 9 steps `[PASS]`, `SMOKE OK`: create
location → create item → denormalized `location_path` present → case-insensitive search →
`expected_version` update → stale-version `conflict` → adjust quantity → delete both.

**The card still renders.** Screenshotted `/dashboard-dev/0` with `drill` typed into the
search box: 23 of 23 matching items, rows showing their location paths and categories
(`Garage · Hardware`), an attachment thumbnail, and the four quick-filter pills with live
counts — i.e. `location_path`, `attachments` and the stats all arriving intact through the
reordered payload.

`log_sweep.py --since 20m` → **PASS (blocking=0)**. The one EXPECTED record is the smoke's
own deliberate stale-version conflict.

Instance left as found: 1087 items, 89 locations. Nothing needed restoring — the smoke
cleans up after itself and preview writes nothing.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases, plus a control that proves the
      golden comparison can fail).
- [x] Docs updated where behavior changed (`docs/data_shapes.md`, decision 3).
- [x] WebSocket API keys unchanged; `docs/backend_api_contract.md` needed no edit — it
      references the Item shape rather than restating it.
- [x] Essential invariants preserved: `location_path` still denormalized and still stored,
      `version` still the optimistic-concurrency token, search untouched.

## Screenshots (card / UI changes)

None — no card change. The card screenshot described above is evidence that the wire
still feeds it, not a visual change.
