### PR TITLE
fix(storage): count a stored row with no name as unreadable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,8 +1141,11 @@ the first public release.
   mean it. The entry stops with that error and the store is left untouched; fix the value in
   the file, or replace `haventory_store` with a backup.
 - **"HAventory could not read N item(s) / location(s) from .storage/haventory_store"**: some
-  entries in the store are structurally broken — a hand edit, a truncated write, or a
-  location whose parent chain loops back on itself. The entry stops rather than loading the
+  entries in the store are structurally broken — a hand edit, a truncated write, a row with
+  no usable name, or a location whose parent chain loops back on itself. (A name has to be
+  a non-empty string, which is what every way of creating one already requires; there is no
+  length limit on reading, so a name from before the 120-character cap still loads.) The
+  entry stops rather than loading the
   readable remainder, because HAventory saves on every change: a partial load would rewrite
   the file without those entries on the first edit and make the loss permanent. The store is
   left untouched, and the message names the first few affected ids. Fix those entries, or

--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -86,6 +86,7 @@ from .models import (
     validate_reminder_date,
     validate_reminder_interval,
     validate_reminder_rules,
+    validate_required_name,
     validate_status_definition,
 )
 from .repository import Repository
@@ -195,6 +196,22 @@ def _sorted_index_by_id(items: list[Item]) -> list[int]:
 
 def _err(path: str, message: str) -> dict[str, str]:
     return {"path": path, "message": message}
+
+
+def _validate_name_doc(value: object, path: str, errors: list[dict[str, str]]) -> None:
+    """The write paths' name rule, reported into ``errors`` rather than raised.
+
+    Items and locations share it, and so does the load path — a document may
+    only name something a store could have held.
+    """
+
+    try:
+        trimmed = validate_required_name(value)
+    except ValidationError as err:
+        errors.append(_err(path, str(err)))
+        return
+    if len(trimmed) > NAME_MAX_LENGTH:
+        errors.append(_err(path, f"name must be at most {NAME_MAX_LENGTH} characters"))
 
 
 def _warn(code: str, path: str, message: str, **fields: Any) -> dict[str, Any]:
@@ -333,11 +350,7 @@ def _validate_location_doc(
 ) -> str | None:
     base = f"locations[{idx}]"
     lid = _validate_uuid4(doc.get("id"), f"{base}.id", errors)
-    name = doc.get("name")
-    if not isinstance(name, str) or not name.strip():
-        errors.append(_err(f"{base}.name", "name is required and must be a non-empty string"))
-    elif len(name.strip()) > NAME_MAX_LENGTH:
-        errors.append(_err(f"{base}.name", f"name must be at most {NAME_MAX_LENGTH} characters"))
+    _validate_name_doc(doc.get("name"), f"{base}.name", errors)
     parent_id = doc.get("parent_id")
     if parent_id is not None:
         _validate_uuid4(parent_id, f"{base}.parent_id", errors)
@@ -421,11 +434,7 @@ def _validate_item_doc(
 ) -> str | None:
     base = f"items[{idx}]"
     iid = _validate_uuid4(doc.get("id"), f"{base}.id", errors)
-    name = doc.get("name")
-    if not isinstance(name, str) or not name.strip():
-        errors.append(_err(f"{base}.name", "name is required and must be a non-empty string"))
-    elif len(name.strip()) > NAME_MAX_LENGTH:
-        errors.append(_err(f"{base}.name", f"name must be at most {NAME_MAX_LENGTH} characters"))
+    _validate_name_doc(doc.get("name"), f"{base}.name", errors)
     _validate_optional_text_doc(doc.get("description"), f"{base}.description", errors)
     _validate_optional_text_doc(doc.get("category"), f"{base}.category", errors)
     qty = doc.get("quantity", 1)

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -496,19 +496,38 @@ def normalize_tags(tags: list[str] | None) -> list[str]:
     return result
 
 
+def validate_required_name(value: object) -> str:
+    """A name that survives a trim, or a ``ValidationError``. Returns it trimmed.
+
+    The one rule every item and location write path enforces, in one place, so
+    that the *load* path can enforce it too: a stored row whose name is missing,
+    ``null``, not a string, or only whitespace is not something this codebase
+    could have written, and reading it as ``""`` — or, for a ``null``, as the
+    literal ``"None"`` — puts a row in memory that no write path would accept
+    and that the first mutation afterwards makes permanent. An empty name also
+    produces no search-index tokens, and reaches the to-do bridge as a line whose
+    quantity suffix is all there is to read.
+
+    Deliberately **not** the length cap. The load path grandfathers over-cap
+    stored values elsewhere, so refusing one here would reject a store this
+    integration itself wrote.
+    """
+
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError("name is required and must be a non-empty string")
+    return value.strip()
+
+
 def validate_location_name(name: str) -> str:
     """Validate a location name and return a trimmed value.
 
-    Enforces non-empty string and maximum length consistent with item names.
+    The write path's rule: what the load path requires, plus the length cap the
+    load path deliberately does not apply.
     """
 
-    if not isinstance(name, str):
-        raise ValidationError("name is required and must be a non-empty string")
-    trimmed = name.strip()
-    if len(trimmed) == 0:
-        raise ValidationError("name is required and must be a non-empty string")
+    trimmed = validate_required_name(name)
     if len(trimmed) > NAME_MAX_LENGTH:
-        raise ValidationError("name must be at most 120 characters")
+        raise ValidationError(f"name must be at most {NAME_MAX_LENGTH} characters")
     return trimmed
 
 
@@ -1120,10 +1139,8 @@ def _validate_optional_text(
 
 
 def _validate_item_core_fields(name: str, quantity: int, low_stock_threshold: int | None) -> None:
-    if not isinstance(name, str) or len(name.strip()) == 0:
-        raise ValidationError("name is required and must be a non-empty string")
-    if len(name) > NAME_MAX_LENGTH:
-        raise ValidationError("name must be at most 120 characters")
+    if len(validate_required_name(name)) > NAME_MAX_LENGTH:
+        raise ValidationError(f"name must be at most {NAME_MAX_LENGTH} characters")
     if not _is_int_not_bool(quantity) or quantity < 0:
         raise ValidationError("quantity must be an integer >= 0")
     if low_stock_threshold is not None and (
@@ -1150,16 +1167,12 @@ def create_item_from_create(
         A fully-populated Item instance with defaults applied.
     """
 
-    raw_name = payload.get("name")
-    if raw_name is None:
-        raise ValidationError("name is required")
     # Type before shape: the command schema types `name` as `object` so a wrong
     # type answers `validation_error` rather than an HA-core schema rejection,
     # and `.strip()` on a non-string would reach that route as `unknown_error`.
-    if not isinstance(raw_name, str):
-        raise ValidationError("name is required and must be a non-empty string")
-    # Trim whitespace before validation and persistence
-    name = raw_name.strip()
+    # `validate_required_name` checks the type first for that reason, and
+    # returns the trimmed value this stores.
+    name = validate_required_name(payload.get("name"))
     description = payload.get("description")
     # Type before conversion, for the same reason `name` is checked before
     # `.strip()`: the command schema types `quantity` as `object`, and `int()`
@@ -1235,12 +1248,9 @@ def create_item_from_create(
 
 def _update_name_and_description(new_item: Item, update: ItemUpdate) -> None:
     if "name" in update and update["name"] is not None:
-        # Trim before validation and persistence
-        if not isinstance(update["name"], str) or len(update["name"].strip()) == 0:
-            raise ValidationError("name must be a non-empty string")
-        trimmed = update["name"].strip()
+        trimmed = validate_required_name(update["name"])
         if len(trimmed) > NAME_MAX_LENGTH:
-            raise ValidationError("name must be at most 120 characters")
+            raise ValidationError(f"name must be at most {NAME_MAX_LENGTH} characters")
         new_item.name = trimmed
     if "description" in update:
         _validate_optional_text(

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -67,6 +67,7 @@ from .models import (
     sort_items,
     today_utc_date,
     validate_location_name,
+    validate_required_name,
     validate_status_definition,
     validate_status_slug,
 )
@@ -2436,7 +2437,12 @@ class Repository:
                             if loc_data.get("parent_id") is not None
                             else None
                         ),
-                        name=str(loc_data.get("name", "")),
+                        # Not `str(...)`: a missing key would read as "" and a
+                        # stored `null` as the literal "None", both of them rows
+                        # no write path could have produced. Raising here drops
+                        # the row into the load report, which is what the
+                        # corrupt-store repair is built on.
+                        name=validate_required_name(loc_data.get("name")),
                         area_id=(
                             str(loc_data.get("area_id"))
                             if loc_data.get("area_id") is not None
@@ -2487,7 +2493,9 @@ class Repository:
                     )
                     item = Item(
                         id=parse_uuid4(str(item_data.get("id", item_id)), field_name="item.id"),
-                        name=str(item_data.get("name", "")),
+                        # See the location above: an unreadable name is a
+                        # corrupt row, not an item called "" or "None".
+                        name=validate_required_name(item_data.get("name")),
                         description=item_data.get("description"),
                         quantity=int(item_data.get("quantity", 0)),
                         # Stores written before the field existed carry no

--- a/tests/integration/test_repairs.py
+++ b/tests/integration/test_repairs.py
@@ -27,6 +27,7 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 READABLE_ITEM_ID = str(uuid.uuid4())
+NAMELESS_ITEM_ID = str(uuid.uuid4())
 
 
 def _stored(data: dict) -> dict:
@@ -205,3 +206,85 @@ async def test_a_clean_load_spends_an_opt_in_left_on_the_entry(
 
     assert entry.state is ConfigEntryState.LOADED
     assert CONF_ALLOW_LOSSY_LOAD not in entry.options
+
+
+async def test_a_row_with_no_name_reaches_the_repairs_card_and_its_fix(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """A stored ``"name": null`` is corruption, and behaves like every other kind.
+
+    It used to load: ``str(None)`` produced an item literally called ``"None"``,
+    which no write path could have created and which the next edit would have
+    made permanent. Now it is refused — and the point of asserting that here
+    rather than offline is that nothing about the *consequences* is visible
+    offline: whether an issue is actually registered, whether the fix flow runs,
+    and whether the entry comes back up with the readable remainder.
+    """
+
+    assert await async_setup_component(hass, "repairs", {})
+    hass_storage[STORAGE_KEY] = _stored(
+        {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "items": {
+                READABLE_ITEM_ID: {"id": READABLE_ITEM_ID, "name": "Hammer", "quantity": 2},
+                NAMELESS_ITEM_ID: {"id": NAMELESS_ITEM_ID, "name": None, "quantity": 1},
+            },
+            "locations": {},
+        }
+    )
+
+    entry = await _added_entry(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is False
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE)
+    assert issue is not None
+    assert issue.is_fixable is True
+    assert issue.translation_placeholders["items"] == "1"
+
+    flow_manager = repairs_flow_manager(hass)
+    assert flow_manager is not None
+    result = await flow_manager.async_init(DOMAIN, data={"issue_id": ISSUE_CORRUPT_STORE})
+    result = await flow_manager.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
+
+    repo = hass.data[DOMAIN]["repository"]
+    assert repo.get_counts()["items_total"] == 1
+    assert repo.get_item(READABLE_ITEM_ID).name == "Hammer"
+    # The dropped row survives in the copy, with its name still null — a backup
+    # that had "repaired" it to something would be worth nothing.
+    backup = hass_storage[CORRUPT_BACKUP_STORAGE_KEY]["data"]
+    assert backup["items"][NAMELESS_ITEM_ID]["name"] is None
+
+
+async def test_a_stored_name_over_the_cap_is_not_corruption(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The refusal blocks setup, so what it refuses has to be exactly right.
+
+    The load path checks non-emptiness and not the 120-character cap. An
+    over-cap name predates the cap and is data this integration itself wrote;
+    refusing it would put a household's whole instance behind a Repairs card
+    for a name that is merely long.
+    """
+
+    hass_storage[STORAGE_KEY] = _stored(
+        {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "items": {READABLE_ITEM_ID: {"id": READABLE_ITEM_ID, "name": "L" * 400}},
+            "locations": {},
+        }
+    )
+
+    entry = await _added_entry(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
+    assert hass.data[DOMAIN]["repository"].get_item(READABLE_ITEM_ID).name == "L" * 400

--- a/tests/test_load_report_offline.py
+++ b/tests/test_load_report_offline.py
@@ -6,7 +6,7 @@ whose own guard rejects a cyclic document before any state swap, and
 ``update_location`` refuses a move under a descendant. So everything here is about
 the setup path reading a file somebody else wrote.
 
-Two properties are load-bearing:
+Two properties have to hold:
 
 - the walk **terminates** — a cyclic parent chain used to be followed forever,
   once per item, during Home Assistant startup;
@@ -20,7 +20,7 @@ import logging
 import uuid
 
 import pytest
-from custom_components.haventory.models import ItemCreate
+from custom_components.haventory.models import NAME_MAX_LENGTH, ItemCreate
 from custom_components.haventory.repository import LOAD_DROP_LOG_LIMIT, LoadReport, Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
 
@@ -255,3 +255,164 @@ def test_has_corruption_covers_every_kind(report: LoadReport, expected: bool) ->
     """Setup keys off this one property, so each tuple has to feed it."""
 
     assert report.has_corruption is expected
+
+
+# --------------------------------------------------------------------------- #
+# Names the load path used to invent
+# --------------------------------------------------------------------------- #
+
+
+#: Marks a key a case wants *absent* rather than set to something unreadable.
+#: The two are different bugs — a missing key read as ``""``, a stored ``null``
+#: as the literal ``"None"`` — so both have to be reachable from one table.
+ABSENT = object()
+
+
+def _without_absent(row: dict[str, object]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if value is not ABSENT}
+
+
+def _item(item_id: str, **overrides: object) -> dict[str, object]:
+    """An item row as the store holds it, with one field bent out of shape."""
+
+    row: dict[str, object] = {
+        "id": item_id,
+        "name": "Drill",
+        "location_id": None,
+        "quantity": 1,
+        "status": "ok",
+        "checked_out": False,
+        "tags": [],
+        "custom_fields": {},
+        "version": 1,
+    }
+    row.update(overrides)
+    return _without_absent(row)
+
+
+#: Every spelling of "this row has no name". ``.get("name", "")`` answered the
+#: first with ``""`` and the second with the literal string ``"None"``; the rest
+#: are what a third-party writer or a hand-edit produces.
+UNREADABLE_NAMES: list[tuple[str, dict[str, object]]] = [
+    ("missing", {"name": ABSENT}),
+    ("null", {"name": None}),
+    ("blank", {"name": ""}),
+    ("whitespace", {"name": "   "}),
+    ("number", {"name": 42}),
+    ("list", {"name": ["Drill"]}),
+]
+UNREADABLE_IDS = [label for label, _ in UNREADABLE_NAMES]
+
+
+@pytest.mark.parametrize(("label", "overrides"), UNREADABLE_NAMES, ids=UNREADABLE_IDS)
+def test_an_item_with_no_readable_name_is_dropped(label: str, overrides: dict[str, object]) -> None:
+    """A row no write path could have produced is corrupt, not an item named "".
+
+    The write paths all refuse a name that is empty after a trim. The load path
+    used to coerce instead, which put a row in memory the model rejects and made
+    it permanent on the next save — and an empty name indexes no search tokens,
+    so the row is unfindable as well as unnameable.
+    """
+
+    item_id = str(uuid.uuid4())
+    payload = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "locations": {},
+        "items": {item_id: _item(item_id, **overrides)},
+    }
+
+    repo = Repository.from_state(payload)
+
+    assert repo.last_load_report.dropped_item_ids == (item_id,)
+    assert repo.last_load_report.has_corruption is True
+    assert repo.export_state()["items"] == {}
+
+
+@pytest.mark.parametrize(("label", "overrides"), UNREADABLE_NAMES, ids=UNREADABLE_IDS)
+def test_a_location_with_no_readable_name_is_dropped(
+    label: str, overrides: dict[str, object]
+) -> None:
+    """The location twin behaves the same — it had the identical coercion."""
+
+    loc_id = str(uuid.uuid4())
+    row = _loc(loc_id, "Garage", None)
+    row.update(overrides)
+    payload = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "locations": {loc_id: _without_absent(row)},
+        "items": {},
+    }
+
+    repo = Repository.from_state(payload)
+
+    assert repo.last_load_report.dropped_location_ids == (loc_id,)
+    assert repo.export_state()["locations"] == {}
+
+
+def test_an_unreadable_name_is_logged_at_error_like_any_other_corrupt_row(caplog) -> None:
+    """It reaches the same report and the same log line the Repairs card reads.
+
+    No new wiring was needed: ``ValidationError`` is already what both ``except``
+    blocks in ``load_state`` catch, so the row lands in ``dropped_item_ids`` and
+    feeds the corrupt-store repair that shipped with the load report.
+    """
+
+    item_id = str(uuid.uuid4())
+    payload = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "locations": {},
+        "items": {item_id: _item(item_id, name=None)},
+    }
+
+    with caplog.at_level(logging.DEBUG):
+        Repository.from_state(payload)
+
+    failures = [r for r in caplog.records if "Failed to load item" in r.getMessage()]
+    assert [r.levelno for r in failures] == [logging.ERROR]
+    assert [getattr(r, "item_id", None) for r in failures] == [item_id]
+
+
+def test_a_name_that_only_needs_trimming_still_loads() -> None:
+    """Padding is not corruption, and the row keeps the name a write would give it.
+
+    Every write path trims, so a padded stored name is a hand-edit rather than
+    something this codebase wrote — and the honest reading of it is the trimmed
+    name, not a refusal.
+    """
+
+    item_id, loc_id = str(uuid.uuid4()), str(uuid.uuid4())
+    location = _loc(loc_id, "Garage", None)
+    location["name"] = "  Garage  "
+    payload = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "locations": {loc_id: location},
+        "items": {item_id: _item(item_id, name="  Drill  ")},
+    }
+
+    repo = Repository.from_state(payload)
+
+    assert repo.last_load_report == LoadReport()
+    assert repo.get_item(item_id).name == "Drill"
+    assert repo.get_location(loc_id).name == "Garage"
+
+
+def test_a_stored_name_over_the_cap_still_loads() -> None:
+    """The cap binds what an edit may add, not what a store may already hold.
+
+    Deliberate, and the reason the load path checks non-emptiness only: an
+    over-cap name predates the cap, so refusing it here would drop rows this
+    integration itself wrote — and a corrupt-store refusal blocks setup.
+    """
+
+    item_id = str(uuid.uuid4())
+    long_name = "L" * (NAME_MAX_LENGTH + 50)
+    payload = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "locations": {},
+        "items": {item_id: _item(item_id, name=long_name)},
+    }
+
+    repo = Repository.from_state(payload)
+
+    assert repo.last_load_report == LoadReport()
+    assert repo.get_item(item_id).name == long_name


### PR DESCRIPTION
## Summary

`load_state` built an item's name with `str(item_data.get("name", ""))`. Two faults on
one line, because `.get(key, default)` returns the default only when the key is
**absent**:

- a row with **no `name` key** loaded as an item called `""`
- a row storing an explicit **`null`** loaded as an item called `"None"`

Neither is a row any write path in this codebase can produce, and both are worse than
they look: an empty name indexes no search tokens, so the row is unfindable, and the
first mutation afterwards persists the invented name permanently. Locations had the
identical line.

`validate_required_name` in `models.py` is now the one rule — *a non-empty string after a
trim* — and everything goes through it: the item core validator, the item create and
update paths, `validate_location_name`, the import-document validators (via
`_validate_name_doc`, which reports instead of raising), and both `load_state` sites.
`ValidationError` is already what the load path's two `except` blocks catch, so an
unreadable name lands in `dropped_item_ids` / `dropped_location_ids` and feeds the
corrupt-store Repairs card with no new wiring.

**Non-empty only, not the 120-character cap.** The load path deliberately grandfathers
over-cap stored values, and refusing one here would reject a store this integration itself
wrote — behind a refusal that blocks setup.

Closes #466

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

More rows now count as corrupt, and the corrupt-store refusal blocks setup. #466 assessed
that as acceptable and it still is: no store this codebase wrote can contain such a row,
and the escape hatch is the existing "load anyway" repair, which copies the file aside
first. The live check below runs exactly that path on a 1087-item instance.

## Decisions taken against drifted notes

#466 is accurate about the defect; two things about *how* to fix it did not survive
contact with the tree.

1. **Named `validate_required_name`, not `validate_item_name`.** The issue asks for
   `validate_item_name` and then, in the same sentence, for "the existing item **and
   location** validators" to delegate to it — so a name saying `item` would be wrong at
   three of its five call sites, including `validate_location_name`. This repo treats a
   symbol name that lies as worse than none, so the shared rule got a shared name. Same
   function, same semantics, same call sites.

2. **The import-document validators delegate too.** The issue lists them among the write
   paths that "already enforce" the rule; they enforced their own copy of it. Both now go
   through `_validate_name_doc`, which wraps `validate_required_name` and appends to the
   error list rather than raising, so adding a rule later touches one function instead of
   five. Net −4 lines.

3. **Line numbers ignored.** Every reference in the issue (`repository.py:2438`,
   `models.py:1009-1010`, `import_export.py:470-474`, …) points somewhere else now;
   located by symbol and message string instead, per §4.

4. **One behaviour narrowed on purpose.** `_validate_item_core_fields` checked the cap
   against the *untrimmed* name while `validate_location_name` checked the trimmed one.
   It now checks the trimmed one for both. Unreachable in practice — its only caller
   already passes a trimmed name — and the two being different was not a decision anyone
   had taken.

5. **`load_state` stores the *trimmed* name.** `validate_required_name` returns it
   trimmed, which is what every write path stores. A padded stored name is a hand-edit
   rather than something this codebase wrote, and the honest reading of it is the trimmed
   name, not a refusal. Pinned by `test_a_name_that_only_needs_trimming_still_loads`.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1190 passed, 22
      skipped** (+15); `uv run ruff check .` → all checks passed; `uv run ruff format
      --check .` → 169 files already formatted; `uv run mypy` → no issues in 24 source
      files.
- [x] Frontend (`cards/haventory-card`): `npm audit --audit-level=high` → 0
      vulnerabilities; `npx eslint .` → clean; `npm run typecheck` → clean;
      `npx vitest run` → **1860 passed (63 files)**; `npm run build` → clean.
- [x] phacc: `scripts/test_integration.sh` through the Docker recipe → **104 passed**
      (+2), including the two new cases below.

### Offline — `tests/test_load_report_offline.py`

Every spelling of "this row has no name", as one table run over items **and** locations
(12 cases): key absent, `null`, `""`, `"   "`, a number, a list. Each asserts the row
reaches `dropped_*_ids`, sets `has_corruption`, and is gone from the exported state. Plus:

- `test_an_unreadable_name_is_logged_at_error_like_any_other_corrupt_row` — same ERROR
  record, same `item_id` extra, which is what the Repairs card is built on.
- `test_a_name_that_only_needs_trimming_still_loads` — padding is not corruption.
- `test_a_stored_name_over_the_cap_still_loads` — the cap is deliberately not applied.

### phacc — `tests/integration/test_repairs.py`

The consequences are not observable offline (no issue registry, no repairs flow manager,
no config-entry reload), so:

- `test_a_row_with_no_name_reaches_the_repairs_card_and_its_fix` — a stored `"name": null`
  refuses setup, raises the fixable issue with `items: 1`, runs the flow to
  `create_entry`, comes back `LOADED` with the readable remainder, and leaves the dropped
  row in the backup **with its name still null** (a backup that had "repaired" it would be
  worth nothing).
- `test_a_stored_name_over_the_cap_is_not_corruption` — the other side. The refusal blocks
  a household's whole instance, so what it refuses has to be exactly right.

### Live check (dev HA, HA 2026.7.4, 1087 items / 89 locations)

§6.1's check, run end to end. HA stopped, one item's `name` set to `null` through the
`ha-config` volume (never a `docker cp` into a stopped container), HA started.

**1. The refusal names the row.** Entry `setup_error`:

> HAventory could not read 1 item(s) from .storage/haventory_store, so setup stopped
> instead of loading a partial inventory and overwriting the file on the next change.
> First affected ids: item `000cca15-f68c-430b-8a12-22c020995158`. …

and in the log, `ERROR … Failed to load item from persisted state` — the same record every
other corrupt row produces.

**2. The Repairs card is there and is fixable.**

```json
{"domain": "haventory", "issue_id": "corrupt_store", "is_fixable": true,
 "severity": "warning",
 "translation_placeholders": {"items": "1", "locations": "0", "cyclic_locations": "0",
   "storage_key": "haventory_store", "backup_key": "haventory_store_corrupt_backup"}}
```

Settings → Repairs shows *"1 Reparatur — HAventory cannot read part of the stored data"*.

**3. The fix runs and the backup is real.** Flow: `form`/`confirm` → `create_entry`.
Afterwards:

```
backup items : 1087 | dropped row present: True | its name: None
store  items : 1086 | dropped row present: False
store  keys  : ['items', 'locations', 'schema_version', 'statuses']
entry state  : loaded
```

The last two lines are worth noting together: the repair rewrites the store, and what it
writes still has the top-level keys #496 settled — the two changes compose.

**4. Restored.** The store was snapshotted before any of this and put back byte for byte
through the volume, and `haventory_store_corrupt_backup` removed. After the restart:
`healthy: true`, `issues: []`, **1087 items / 89 locations**, no HAventory Repairs issues,
and the row that was nulled is back as `Old Textbook #0232` — visible in the panel
screenshot, bottom row.

`log_sweep.py` on the restored boot → **PASS (blocking=0)**. Sweeping a window that
includes the deliberate corruption reports one BLOCKING `HAventory ERROR`, which is the
`Failed to load item` record this change exists to produce; the sweep has no way to know
it was asked for.

**Nothing visible changed.** The card at `/dashboard-dev/0` and the panel at `/haventory`
both render as before — the panel showing all 1087 items, the location tree with its area
chips, status chips and location paths.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (12 error cases, 2 happy-path/grandfathering cases, 2 phacc
      cases).
- [x] Docs updated where behavior changed — `README.md`'s troubleshooting entry now lists
      "a row with no usable name" among what makes a store unreadable, and says the length
      cap is not applied on read.
- [x] WebSocket API unchanged.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

No UI change. The Repairs card and the restored panel were both photographed as live-check
evidence and are described above; there is no assets branch to host them on (see the
Follow-ups note in the handover).

---

## Handover

### 1. Merged / left open

All four merged, in order, each squash-merged after both gates, phacc, CI and its live
checks were green. Branches deleted.

| PR | title | issue |
|---|---|---|
| [#495](https://github.com/chrreiter/HAventory/pull/495) | test(brand): bind the card's mark and the social preview to one geometry | closes #285, refs #196 |
| [#496](https://github.com/chrreiter/HAventory/pull/496) | refactor(storage): stop persisting the write-only `_generation` | refs #482 |
| [#500](https://github.com/chrreiter/HAventory/pull/500) | refactor(models): one `to_dict()` per model | closes #482 |
| this one | fix(storage): count a stored row with no name as unreadable | closes #466 |

Nothing left open for the owner to merge. **One owner decision is carried**: approve the
brand artwork and file the `home-assistant/brands` PR — see part 2.

### 2. Test this by hand

1. **[HA settings] Look at the brand artwork and decide.** Open
   [`docs/assets/brand/icon.png`](https://github.com/chrreiter/HAventory/blob/main/docs/assets/brand/icon.png)
   and `icon@2x.png` on `main`. Expected: the card's mark in `#5CA1F2`, house solid,
   three crates cut out as transparent holes with a filled handle slot in each, touching
   the canvas left and right with a few pixels of transparency above and below. This is
   the one thing no test can judge — the tests prove the artwork *matches the card*, not
   that it is good enough to file.
2. **[HA settings] File the brands PR** once you are happy with it. The full body and the
   exact `gh` sequence are in [#495](https://github.com/chrreiter/HAventory/pull/495),
   under *"For the owner: the `home-assistant/brands` PR"*. It runs on an external review
   timeline, which is why #236 stages it at the start of V0.7.0. **A session must not file
   it** — it goes to another project's repository under your name. Do **not** drop
   `ignore: brands` from `.github/workflows/ci.yml` until it merges; that is #196's
   remaining half, with the store submission and the README switch.

Everything else was proved by the harness rather than left to hand-testing:

- **Nothing visible changed** — the card and the panel were both driven on the dev
  instance after each backend change and render as before, and #495's only card-source
  edit is a comment, with the built bundle byte-identical (`md5
  a1542eca4fdda842c1917c7025fe012b`) with and without it.
- **The store stopped carrying `_generation`** — read off `.storage/haventory_store` before
  and after a real mutation ([#496](https://github.com/chrreiter/HAventory/pull/496)).
- **The stored shape did not move** — a golden document generated from the old serializers
  round-trips byte for byte, and the whole live inventory exports and previews back as
  1087/89 `unchanged` ([#500](https://github.com/chrreiter/HAventory/pull/500)).
- **The corrupt-row Repairs flow** — refusal, card, fix, backup, reload and restore all run
  on the live instance (above).

### 3. Decisions taken against drifted notes

- **#482's field table is wrong: the stored item already carries `location_path`.** Verified
  in `repository.py`, in `load_state`, and in the dev instance's own store. Kept stored —
  §6.1's rule is "exactly today's", and removing it would move the stored payload, which is
  the one thing #482 forbids. #229's adopter needs this: `location_path` **is** part of the
  shape the collapse normalises onto. ([#500](https://github.com/chrreiter/HAventory/pull/500))
- **#482 says `_generation` is "never read back" — `load_state` did read it.** Removed the
  read as well as the write; a resumed counter would report activity a fresh process has
  not had. ([#496](https://github.com/chrreiter/HAventory/pull/496))
- **§6.1 names `haventory/version` as reporting the runtime generation; it does not.**
  `haventory/health` does. Tested there. ([#496](https://github.com/chrreiter/HAventory/pull/496))
- **The store and the export document were already field-identical**, so the consolidation
  is three-into-one rather than two-into-one. ([#500](https://github.com/chrreiter/HAventory/pull/500))
- **`effective_area_id` moved to the end of the wire payload**, and `docs/data_shapes.md`
  was corrected to the order the wire emits — it matched neither the code nor itself.
  ([#500](https://github.com/chrreiter/HAventory/pull/500))
- **#196's notes propose `docs/assets/brand-icon.svg` with the PNGs living only in the
  brands PR**; §6.1 asks for the rasters here, rendered from the TypeScript, so they are in
  `docs/assets/brand/` and CI checks them. `icon.png` + `icon@2x.png` only — no `logo`
  (HAventory has no separate wordmark) and no `dark_` variant (one mid-tone blue reads on
  both grounds), both verified against the brands README today.
  ([#495](https://github.com/chrreiter/HAventory/pull/495))
- **`validate_required_name`, not `validate_item_name`** — the rule is shared with
  locations, so the name is too. (this PR)

### 4. Follow-ups

Nothing was filed. Three things are named here and deliberately not issues, on CLAUDE.md's
bar that a finding earns one only when it can matter in a real install:

- **§4's "assets-branch recipe the `run-haventory` skill documents" does not exist.** No
  such recipe is in `SKILL.md`, and no assets branch is on the remote. Sessions S2–S11 will
  hit this whenever a package asks for screenshots in a PR body. The workaround that worked
  here: reference an image committed on `main` by its `raw.githubusercontent.com` URL, and
  describe the rest. A process-doc gap, not a product defect.
- **`scripts/reload_addon.sh` cannot deploy from a worktree under the Windows temp
  directory.** Git Bash maps `C:\Users\…\AppData\Local\Temp` to `/tmp`, so `REPO_ROOT`
  becomes `/tmp/claude/…` and Docker Desktop resolves that as `C:\tmp` and fails with
  `GetFileAttributesEx C:\tmp`. Deploy by hand instead: `npm run build`, then
  `MSYS_NO_PATHCONV=1 docker cp "<native-windows-path>/custom_components/haventory"
  home-assistant:/config/custom_components`, then `docker restart home-assistant`. CLAUDE.md
  is explicit that there is no Windows host support, so this is not a defect in the script.
- **`log_sweep.py` counts a deliberately provoked HAventory ERROR as BLOCKING.** Correct
  behaviour — it cannot know a corruption was asked for. Sweep a window that starts after
  the instance is restored.

### 5. State left behind

- **Dev HA**: restored and verified — 1087 items, 89 locations, `healthy: true`,
  `issues: []`, no HAventory Repairs issues, profile language untouched (German, as found).
  `haventory_store_corrupt_backup` removed. One thing to know: the restored file is the
  pre-session snapshot, so it still carries the `_generation` key; the running build ignores
  it and the next mutation drops it. The container is running this branch's code, which is
  `main` as of this merge.
- **Branches**: none. All four merged and deleted, local worktree included.
- **Next session (S2)**: `main` carries `Item.to_dict()` / `Location.to_dict()` /
  `LocationPath.to_dict()` as the single serializers. **The stored payload is settled and
  does not move again** — §4's rule. #493's repository count and #280's runtime move both
  land on `export_state`, which is now three lines; if either finds it must change what
  `to_dict()` writes, stop and report rather than changing it.
- `tests/fixtures/stored_payload.json` is a golden document generated from the *old*
  serializers. Regenerating it rather than fixing what broke it would silently undo #482.
