### PR TITLE
fix(services): broadcast service mutations to WebSocket subscribers

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -357,6 +357,7 @@ run either passes or says why not. All are read-only except `lifecycle_probe.py`
 | `rl_banner.mjs` | the card's rate-limit degraded-banner lifecycle, with the WS frames that caused each state |
 | `visual_pass.mjs` | every card surface still opens, at desktop and mobile widths, and every panel surface on `/haventory` |
 | `import_policies.mjs` | the import sheet describes the conflict policy the backend actually applied |
+| `two_tab.mjs` | a mutation nobody in the browser made repaints every open card |
 | `log_sweep.py` | the container log obeys the error taxonomy's severity policy |
 | `lifecycle_probe.py` | resource cache-bust rewriting, schema-downgrade refusal, entry removal/re-add |
 
@@ -422,6 +423,27 @@ the app bar shows the button that reopens HA's drawer. That last one is driven b
 `narrow` property rather than the media query, so the width has to satisfy both switches.
 
 The panel passes need no `wide` dashboard — HA gives a panel the whole content area.
+
+### Two tabs, one mutation from neither of them
+
+```bash
+cd .claude/skills/run-haventory
+node two_tab.mjs                     # via haventory.item_create, the service path
+node two_tab.mjs --ws                # via haventory/item/create, the control
+node two_tab.mjs --path /dashboard-dev/0 --out narrow
+```
+
+Two `context.newPage()` tabs are two independent HA WebSocket connections; the mutation goes
+out over a **third**, by default as the core `call_service` frame Developer Tools → Actions
+sends. So neither tab made the change and both have to repaint on their own — which is what
+separates "the backend broadcast it" from "the card that sent it patched itself".
+
+Both tabs type the probe name into the search box first, so the oracle is a row appearing out
+of nothing, next to the WS frames each tab actually received. Creates one item and deletes it
+again; screenshots land as `<out>-a.png` / `<out>-b.png`.
+
+`--ws` is the control worth running next to any failure: if the WebSocket command repaints
+both tabs and the service call does not, the gap is in the service path, not in the card.
 
 ### Import policy cross-check
 

--- a/.claude/skills/run-haventory/two_tab.mjs
+++ b/.claude/skills/run-haventory/two_tab.mjs
@@ -1,0 +1,205 @@
+// Does a mutation nobody in the browser made repaint every open card?
+//
+// Two `context.newPage()` tabs are two independent HA WebSocket connections. The
+// mutation goes out over a THIRD connection — by default as a core `call_service`
+// frame, which is exactly what Developer Tools -> Actions sends — so neither tab
+// is the one that made the change and both have to repaint on their own. Each tab
+// searches for the probe name first, so the oracle is a row appearing out of
+// nothing rather than a number nobody can attribute.
+//
+// Usage (from the skill dir):
+//   node two_tab.mjs [--ws] [--path /dashboard-dev/wide] [--out two-tab]
+//
+// --ws sends `haventory/item/create` instead of the service call: the control for
+// anything observed here that is not specific to the service path.
+
+import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { cardPath, haConfig } from "./card_views.mjs";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+
+const { base, token } = haConfig();
+const urlPath = flag("--path", null) ?? (await cardPath("wide"));
+const outPrefix = flag("--out", "two-tab");
+const PROBE = `two-tab probe ${Math.floor(Date.now() / 1000)}`;
+
+// --- a third connection, standing in for Developer Tools -> Actions ---------
+function haWs() {
+  // Node's own global WebSocket (>= 22), so the harness needs no dependency
+  // beyond the Playwright the skill already installs.
+  const socket = new WebSocket(base.replace(/^http/, "ws") + "/api/websocket");
+  let nextId = 1;
+  const pending = new Map();
+  const ready = new Promise((resolve, reject) => {
+    socket.addEventListener("error", () => reject(new Error("websocket error")));
+    socket.addEventListener("message", (ev) => {
+      const frame = JSON.parse(ev.data);
+      if (frame.type === "auth_required") socket.send(JSON.stringify({ type: "auth", access_token: token }));
+      else if (frame.type === "auth_ok") resolve();
+      else if (frame.type === "auth_invalid") reject(new Error("auth_invalid"));
+      else if (frame.type === "result" && pending.has(frame.id)) {
+        pending.get(frame.id)(frame);
+        pending.delete(frame.id);
+      }
+    });
+  });
+  return {
+    ready,
+    send: (message) =>
+      new Promise((resolve) => {
+        const id = nextId++;
+        pending.set(id, resolve);
+        socket.send(JSON.stringify({ id, ...message }));
+      }),
+    close: () => socket.close(),
+  };
+}
+
+// --- two tabs --------------------------------------------------------------
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 1280, height: 900 },
+  serviceWorkers: "block",
+});
+await context.addInitScript(
+  ([hassUrl, accessToken]) => {
+    localStorage.setItem(
+      "hassTokens",
+      JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "unused-long-lived",
+        expires_in: 1800,
+        expires: Date.now() + 365 * 24 * 3600 * 1000,
+        hassUrl,
+        clientId: hassUrl + "/",
+      }),
+    );
+  },
+  [base, token],
+);
+
+/** Every haventory event frame this tab received, oldest first. */
+function watch(page) {
+  const seen = [];
+  page.on("websocket", (ws) => {
+    ws.on("framereceived", ({ payload }) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(payload.toString());
+      } catch {
+        return;
+      }
+      // HA batches messages into a JSON array per frame.
+      for (const message of Array.isArray(parsed) ? parsed : [parsed]) {
+        // The envelope is {type:"event", id, event:{domain, topic, action}} —
+        // there is no `event.type`, and a filter looking for one matches nothing.
+        const event = message?.event;
+        if (message?.type === "event" && event?.domain === "haventory") {
+          seen.push({ topic: event.topic, action: event.action, name: event.item?.name ?? null });
+        }
+      }
+    });
+  });
+  return seen;
+}
+
+async function openTab(label) {
+  const page = await context.newPage();
+  const events = watch(page);
+  await page.goto(base + urlPath, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("haventory-card", { timeout: 30000 });
+  await page.waitForTimeout(2500);
+  return { label, page, events };
+}
+
+const tabA = await openTab("tab A");
+const tabB = await openTab("tab B");
+
+/** How many rows the card is showing, read through the shadow root. */
+async function rowCount(tab) {
+  return tab.page.locator('haventory-card hv-list-row').count();
+}
+
+/** Narrow both tabs to the probe name, so the oracle is a row that appears. */
+async function searchFor(tab, text) {
+  const box = tab.page.locator('haventory-card [data-testid="search-input"]').first();
+  await box.click();
+  await box.fill(text);
+  await tab.page.waitForTimeout(1200);
+}
+
+for (const tab of [tabA, tabB]) await searchFor(tab, PROBE);
+const before = { a: await rowCount(tabA), b: await rowCount(tabB) };
+for (const tab of [tabA, tabB]) tab.events.length = 0;
+
+// --- the mutation, from neither tab ---------------------------------------
+const driver = haWs();
+await driver.ready;
+// --ws sends the WebSocket command instead, which is the control for anything
+// this harness observes that is not about the service path.
+const viaWs = args.includes("--ws");
+const called = await driver.send(
+  viaWs
+    ? { type: "haventory/item/create", name: PROBE, quantity: 2 }
+    : {
+        type: "call_service",
+        domain: "haventory",
+        service: "item_create",
+        service_data: { name: PROBE, quantity: 2 },
+        return_response: true,
+      },
+);
+if (!called.success) {
+  console.error("mutation failed:", JSON.stringify(called));
+  process.exit(1);
+}
+const probeId = viaWs ? called.result.id : called.result.response.item.id;
+
+// No clicking, no typing, no reload: whatever changes now changed on its own.
+await tabA.page.waitForTimeout(3000);
+const after = { a: await rowCount(tabA), b: await rowCount(tabB) };
+
+await tabA.page.screenshot({ path: path.resolve(skillDir, `${outPrefix}-a.png`) });
+await tabB.page.screenshot({ path: path.resolve(skillDir, `${outPrefix}-b.png`) });
+
+// --- report ----------------------------------------------------------------
+const summarise = (events) =>
+  events.map((e) => `${e.topic}/${e.action}${e.name ? ` (${e.name})` : ""}`).join(", ") || "(none)";
+
+console.log(`probe item: ${PROBE}`);
+console.log(`view      : ${urlPath}`);
+console.log(`tab A events: ${summarise(tabA.events)}`);
+console.log(`tab B events: ${summarise(tabB.events)}`);
+console.log(`rows tab A : ${before.a} -> ${after.a}`);
+console.log(`rows tab B : ${before.b} -> ${after.b}`);
+
+const hasEvent = (events, topic, action) => events.some((e) => e.topic === topic && e.action === action);
+const checks = [
+  ["tab A received items/created", hasEvent(tabA.events, "items", "created")],
+  ["tab B received items/created", hasEvent(tabB.events, "items", "created")],
+  ["tab A received stats/counts", hasEvent(tabA.events, "stats", "counts")],
+  ["tab B received stats/counts", hasEvent(tabB.events, "stats", "counts")],
+  ["tab A repainted with no interaction", after.a === before.a + 1],
+  ["tab B repainted with no interaction", after.b === before.b + 1],
+];
+let ok = true;
+for (const [label, passed] of checks) {
+  console.log(`${passed ? "[PASS]" : "[FAIL]"} ${label}`);
+  ok = ok && passed;
+}
+
+// Leave the instance as it was found.
+const removed = await driver.send({ type: "haventory/item/delete", item_id: probeId });
+console.log(`probe deleted: ${removed.success}`);
+driver.close();
+await browser.close();
+process.exit(ok && removed.success ? 0 : 1);

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Services work the other way round: every `haventory.*` service returns the entit
 touched, so a script can chain calls through `response_variable` — see the same document's
 "Service responses".
 
+A service mutation also reaches any card left open, the same way a card's own edit does: an
+automation that restocks something repaints the list and the counts on every screen showing
+them, with nobody touching anything.
+
 ### The calendar
 
 `calendar.haventory` puts the dates already on your items onto a calendar dashboard, beside

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -1,19 +1,28 @@
-"""Home Assistant bus events and the sensor nudge behind them.
+"""Announcing a mutation — to WebSocket subscribers, to the bus, to the sensors.
 
-The WebSocket broadcasts in `ws.py` reach subscribed clients; these reach the
-rest of Home Assistant. Every mutation path — WebSocket handler, `haventory.*`
-service, bulk operation, import — calls `notify_mutation` after its durable
-write, which fires `haventory_item_changed`, diffs the low-stock set to fire
-`haventory_low_stock`, and dispatches the signal the sensors repaint on. A
-command that rewrites many items at once calls `notify_bulk_mutation` instead:
-same events per item, one diff and one repaint for the batch.
+One call per mutation path covers all three. Every path — WebSocket handler,
+`haventory.*` service, bulk operation, import — calls `notify_mutation` after
+its durable write, which broadcasts the `items` event to subscribed clients,
+fires `haventory_item_changed` on the bus, diffs the low-stock set to fire
+`haventory_low_stock`, dispatches the signal the sensors repaint on, and
+broadcasts the fresh `stats` counts. A command that rewrites many items at once
+calls `notify_bulk_mutation` instead: one `items` event and one counts event for
+the batch, a bus event per item, one diff and one repaint.
 
-A location mutation calls `notify_location_changed`, which repaints without
-announcing anything on the bus — no item changed, only the tree the items are
-counted and pathed against.
+That the two surfaces are one call is the point rather than a convenience: they
+were two, and every `haventory.*` service call reached the bus and no subscriber
+at all, so a card left open showed a stale list until something made it re-list.
+
+A location mutation calls `notify_location_mutation`, which broadcasts the
+`locations` event and the counts and repaints, but announces nothing on the bus —
+no item changed, only the tree the items are counted and pathed against.
+`notify_location_changed` is the repaint on its own, for the paths that have
+already broadcast.
 
 Bus events bypass the rate limiter: it budgets WebSocket subscription traffic,
-and these are internal to Home Assistant.
+and these are internal to Home Assistant. The WebSocket half charged here is
+charged exactly as it is when a WebSocket handler broadcasts, because it is the
+same call.
 """
 
 from __future__ import annotations
@@ -43,6 +52,29 @@ ITEM_ACTIONS: frozenset[str] = frozenset(
 )
 
 
+def _broadcast_event(
+    hass: HomeAssistant, *, topic: str, action: str, payload: dict[str, Any] | None = None
+) -> None:
+    """Hand one event to the WebSocket broadcaster.
+
+    The import is function-local because `ws.py` imports this module at its own
+    module scope; at module scope here the two would be a cycle. Python caches
+    the module, so every call after the first is a dictionary lookup.
+    """
+
+    from .ws import broadcast_event  # noqa: PLC0415 - the cycle, see above
+
+    broadcast_event(hass, topic=topic, action=action, payload=payload)
+
+
+def _broadcast_counts(hass: HomeAssistant) -> None:
+    """Hand the fresh counts to the WebSocket broadcaster. Local import as above."""
+
+    from .ws import broadcast_counts  # noqa: PLC0415 - the cycle, see above
+
+    broadcast_counts(hass)
+
+
 def seed_low_stock_snapshot(hass: HomeAssistant) -> None:
     """Record which items are low at setup, so a restart re-announces nothing.
 
@@ -63,18 +95,25 @@ def notify_mutation(
     *,
     action: str,
     item: dict[str, Any] | None = None,
+    counts: bool = True,
 ) -> None:
-    """Announce a mutation on the HA bus and repaint the sensors.
+    """Announce a mutation to subscribers and to Home Assistant, and repaint.
 
     Call it **after** the persist, on every path: the contract's "an event
-    implies a durable write" rule holds on the bus as well as on the wire.
+    implies a durable write" rule holds on the bus and on the wire alike.
 
     ``item`` is the serialized item the mutation produced — for a delete, the
-    body as it last stood. A bulk path that rewrote many items at once passes
-    none, which still diffs the low-stock set and still repaints the sensors.
+    body as it last stood. A path that rewrote the dataset wholesale passes
+    none, which broadcasts no `items` event and fires nothing on the bus, but
+    still diffs the low-stock set, still repaints the sensors and still
+    broadcasts the counts.
 
-    Best-effort, like the WebSocket broadcasts: a mutation that is already
-    written must not fail because something downstream of it did.
+    ``counts`` False is for a command emitting many item mutations in a row: it
+    calls ``notify_counts`` once when the batch is through, rather than sending
+    a whole counts object per row and charging a token for each.
+
+    Best-effort: a mutation that is already written must not fail because
+    something downstream of it did.
     """
 
     try:
@@ -85,16 +124,26 @@ def notify_mutation(
             return
 
         if item is not None:
+            _broadcast_event(hass, topic="items", action=action, payload={"item": item})
             _fire_item_changed(hass, action, item)
 
         _fire_low_stock_transitions(hass, bucket, item=item)
 
         async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
+
+        if counts:
+            _broadcast_counts(hass)
     except Exception:  # pragma: no cover - defensive
         LOGGER.exception(
             "Failed to notify a mutation",
             extra={"domain": DOMAIN, "op": "notify_mutation", "action": action},
         )
+
+
+def notify_counts(hass: HomeAssistant) -> None:
+    """Broadcast the counts alone, for a batch that suppressed them per row."""
+
+    _broadcast_counts(hass)
 
 
 def notify_bulk_mutation(
@@ -104,15 +153,21 @@ def notify_bulk_mutation(
 
     One `haventory_item_changed` per item, because an automation subscribed to it
     is watching items rather than commands — a bulk command that announced
-    nothing would be the one hole in "fired on every path". One low-stock diff
-    and one repaint for the whole batch, because both describe the inventory as a
-    whole and running them per row would repaint every sensor once per row.
+    nothing would be the one hole in "fired on every path". One WebSocket `items`
+    event, one low-stock diff, one repaint and one counts event for the whole
+    batch, because each describes the inventory as a whole and running them per
+    row would repeat the same work once per row.
     """
 
     try:
         bucket = hass.data.get(DOMAIN)
         if bucket is None:
             return
+
+        # One `items` event for the batch, carrying no row: a subscriber is
+        # being told its list is stale, not which rows moved, and a payload per
+        # row would be a whole inventory on the wire.
+        _broadcast_event(hass, topic="items", action=action, payload=None)
 
         for item in items:
             _fire_item_changed(hass, action, item)
@@ -122,11 +177,38 @@ def notify_bulk_mutation(
         _fire_low_stock_transitions(hass, bucket, item=None)
 
         async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
+        _broadcast_counts(hass)
     except Exception:  # pragma: no cover - defensive
         LOGGER.exception(
             "Failed to notify a bulk mutation",
             extra={"domain": DOMAIN, "op": "notify_bulk_mutation", "action": action},
         )
+
+
+def notify_location_mutation(
+    hass: HomeAssistant,
+    *,
+    action: str,
+    location: dict[str, Any],
+    repaint: bool = True,
+) -> None:
+    """Announce a location change to subscribers, and repaint what reads the tree.
+
+    The counterpart of ``notify_mutation`` for the other topic, and it exists for
+    the same reason: a `haventory.location_*` service reached no subscriber at
+    all while the WebSocket command beside it did.
+
+    Nothing is fired on the bus — the documented action vocabulary is about
+    items, and no item changed. ``repaint`` is False for the one edit that
+    announces a change without moving anything an entity reads: reassigning a
+    subtree's area re-anchors it for a client filtered by area, while
+    `locations_total` and every `location_path` stay exactly as they were.
+    """
+
+    _broadcast_event(hass, topic="locations", action=action, payload={"location": location})
+    if repaint:
+        notify_location_changed(hass)
+    _broadcast_counts(hass)
 
 
 def notify_location_changed(hass: HomeAssistant) -> None:

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
-from .events import notify_location_changed, notify_mutation
+from .events import notify_counts, notify_location_mutation, notify_mutation
 from .exceptions import (
     ConflictError,
     NotFoundError,
@@ -380,8 +380,9 @@ async def service_location_create(hass: HomeAssistant, data: dict) -> dict[str, 
             area_id=payload.get("area_id"),
         )
         await async_persist_repo(hass)
-        notify_location_changed(hass)
-        return {"location": serialize_location(loc)}
+        serialized = serialize_location(loc)
+        notify_location_mutation(hass, action="created", location=serialized)
+        return {"location": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"location_name": data.get("name")}, exc)
 
@@ -396,6 +397,11 @@ async def service_location_update(hass: HomeAssistant, data: dict) -> dict[str, 
         repo = _get_repo(hass)
         before = repo.get_location(payload["location_id"])
         was_named, was_below = before.name, before.parent_id
+        # The area a location sits in is resolved through its tree, so an area
+        # set on a nested row moves the root's `area_id` and leaves this row's at
+        # None. Comparing the resolved value catches both, exactly as
+        # `ws_location_update` does.
+        was_anchored_at = (was_below, repo.effective_area_id(str(before.id)))
         loc = repo.update_location(
             payload["location_id"],
             name=payload.get("name"),
@@ -403,12 +409,21 @@ async def service_location_update(hass: HomeAssistant, data: dict) -> dict[str, 
             area_id=area_id,
         )
         await async_persist_repo(hass)
-        # A rename or a re-parent rewrites the path denormalized onto every item
-        # underneath, and the calendar renders those paths. No bus event: the
-        # items themselves did not change.
-        if loc.name != was_named or loc.parent_id != was_below:
-            notify_location_changed(hass)
-        return {"location": serialize_location(loc)}
+        serialized = serialize_location(loc)
+        # One event per call, decided by what changed rather than by which keys
+        # the call carried. A rename or a re-parent also rewrites the path
+        # denormalized onto every item underneath, which the calendar renders;
+        # an area reassignment re-anchors the subtree without moving a path.
+        # No bus event either way: the items themselves did not change.
+        is_anchored_at = (loc.parent_id, repo.effective_area_id(str(loc.id)))
+        repaint = loc.name != was_named or loc.parent_id != was_below
+        if is_anchored_at != was_anchored_at:
+            notify_location_mutation(hass, action="moved", location=serialized, repaint=repaint)
+        elif loc.name != was_named:
+            notify_location_mutation(hass, action="renamed", location=serialized, repaint=repaint)
+        else:
+            notify_counts(hass)
+        return {"location": serialized}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"location_id": location_id}, exc)
 
@@ -422,7 +437,7 @@ async def service_location_delete(hass: HomeAssistant, data: dict) -> dict[str, 
         removed = serialize_location(repo.get_location(payload["location_id"]))
         repo.delete_location(payload["location_id"])
         await async_persist_repo(hass)
-        notify_location_changed(hass)
+        notify_location_mutation(hass, action="deleted", location=removed)
         return {"location": removed}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:
         _raise_service_error(op, {"location_id": location_id}, exc)

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -37,7 +37,12 @@ from .const import (
     MAX_MANUALS_PER_ITEM,
     MAX_PICTURES_PER_ITEM,
 )
-from .events import notify_bulk_mutation, notify_location_changed, notify_mutation
+from .events import (
+    notify_bulk_mutation,
+    notify_counts,
+    notify_location_mutation,
+    notify_mutation,
+)
 from .exceptions import (
     ConflictError,
     NotFoundError,
@@ -722,13 +727,20 @@ def _collect_event_deliveries(
     return deliveries
 
 
-def _broadcast_event(
+def broadcast_event(
     hass: HomeAssistant,
     *,
     topic: str,
     action: str,
     payload: dict[str, Any] | None = None,
 ) -> None:
+    """Deliver one event to every subscription that asked for it.
+
+    Public because `events.py` calls it: a mutation announces itself to
+    subscribers and to the Home Assistant bus in one call, so no write path can
+    reach one surface and miss the other.
+    """
+
     # Broadcasts are best-effort: they run after a mutation has been applied and
     # persisted, so a broadcast failure must never turn the originating command
     # into an error.
@@ -780,7 +792,7 @@ def notify_backend_unavailable(hass: HomeAssistant) -> None:
     Teardown calls this while the registry is still populated; the subscriptions
     themselves go with the rest of the runtime immediately after.
 
-    Deliberately not routed through ``_broadcast_event``: this is a lifecycle
+    Deliberately not routed through ``broadcast_event``: this is a lifecycle
     signal rather than inventory traffic, so it ignores the rate limiter. A
     connection whose event budget happened to be spent would otherwise be the one
     client left believing its topics are still live.
@@ -800,7 +812,9 @@ def notify_backend_unavailable(hass: HomeAssistant) -> None:
             )
 
 
-def _broadcast_counts(hass: HomeAssistant) -> None:
+def broadcast_counts(hass: HomeAssistant) -> None:
+    """Send the whole counts object on the `stats` topic. Public for `events.py`."""
+
     try:
         counts_payload = _repo(hass).get_counts()
     except Exception:  # pragma: no cover - defensive
@@ -808,7 +822,7 @@ def _broadcast_counts(hass: HomeAssistant) -> None:
             "Failed to broadcast counts", extra={"domain": DOMAIN, "op": "broadcast_counts"}
         )
         return
-    _broadcast_event(
+    broadcast_event(
         hass,
         topic="stats",
         action="counts",
@@ -1099,9 +1113,7 @@ async def ws_item_create(
     item = _repo(hass).create_item(payload)  # type: ignore[arg-type]
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="created", payload={"item": serialized})
     notify_mutation(hass, action="created", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1155,9 +1167,7 @@ async def ws_item_update(
     serialized = serialize_item(hass, updated)
     action = "moved" if "location_id" in update else "updated"
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     notify_mutation(hass, action=action, item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1185,14 +1195,7 @@ async def ws_item_delete(
     await media_mod.async_delete_attachments(
         hass, [(str(before.id), a) for a in before.attachments]
     )
-    _broadcast_event(
-        hass,
-        topic="items",
-        action="deleted",
-        payload={"item": serialized_before},
-    )
     notify_mutation(hass, action="deleted", item=serialized_before)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), None))
 
 
@@ -1216,9 +1219,7 @@ async def ws_item_adjust_quantity(
     )
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     notify_mutation(hass, action="quantity_changed", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1247,9 +1248,7 @@ async def ws_item_set_quantity(
     )
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="quantity_changed", payload={"item": serialized})
     notify_mutation(hass, action="quantity_changed", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1273,9 +1272,7 @@ async def ws_item_check_out(
     )
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="checked_out", payload={"item": serialized})
     notify_mutation(hass, action="checked_out", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1294,9 +1291,7 @@ async def ws_item_check_in(
     item = _repo(hass).check_in(msg["item_id"], expected_version=msg.get("expected_version"))
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="checked_in", payload={"item": serialized})
     notify_mutation(hass, action="checked_in", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1318,9 +1313,7 @@ async def _apply_reminder(
     )
     serialized = serialize_item(hass, item)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
     notify_mutation(hass, action="updated", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1402,9 +1395,7 @@ async def ws_reminder_bump(
     )
     serialized = serialize_item(hass, updated)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
     notify_mutation(hass, action="updated", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1431,9 +1422,7 @@ async def ws_item_add_tags(
         },
     )
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     notify_mutation(hass, action=action, item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1460,9 +1449,7 @@ async def ws_item_remove_tags(
         },
     )
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     notify_mutation(hass, action=action, item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1491,9 +1478,7 @@ async def ws_item_update_custom_fields(
         },
     )
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     notify_mutation(hass, action=action, item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1520,9 +1505,7 @@ async def ws_item_set_low_stock_threshold(
         },
     )
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     notify_mutation(hass, action=action, item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1619,9 +1602,7 @@ async def ws_item_attachment_add(
     # orphan sweep is what collects it, so there is nothing to undo here beyond
     # letting the error through the way every other mutation does.
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
     notify_mutation(hass, action="updated", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1653,9 +1634,7 @@ async def ws_item_attachment_remove(
     # metadata pointing at bytes that are already gone.
     await _persist_repo(hass)
     await media_mod.async_delete_attachments(hass, [(str(updated.id), removed)])
-    _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
     notify_mutation(hass, action="updated", item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1684,8 +1663,8 @@ async def ws_item_attachment_update(
     )
     serialized = serialize_item(hass, updated)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
-    notify_mutation(hass, action="updated", item=serialized)
+    # No counts event: a title and an order move nothing any count reads.
+    notify_mutation(hass, action="updated", item=serialized, counts=False)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1718,8 +1697,8 @@ async def ws_item_attachment_reorder(
     )
     serialized = serialize_item(hass, updated)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action="updated", payload={"item": serialized})
-    notify_mutation(hass, action="updated", item=serialized)
+    # No counts event: a title and an order move nothing any count reads.
+    notify_mutation(hass, action="updated", item=serialized, counts=False)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1746,9 +1725,7 @@ async def ws_item_move(
         },
     )
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
     notify_mutation(hass, action=action, item=serialized)
-    _broadcast_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1861,11 +1838,13 @@ async def ws_items_bulk(
             },
         )
 
+        # One counts event for the batch rather than one per row: each row's
+        # own event still names it, and the counts describe the inventory as a
+        # whole.
         for _op_id, serialized, action in successful_ops:
-            _broadcast_event(hass, topic="items", action=action, payload={"item": serialized})
-            notify_mutation(hass, action=action, item=serialized)
+            notify_mutation(hass, action=action, item=serialized, counts=False)
 
-        _broadcast_counts(hass)
+        notify_counts(hass)
 
     conn.send_message(websocket_api.result_message(msg.get("id", 0), {"results": results}))
 
@@ -1934,9 +1913,7 @@ async def ws_location_create(
     )
     serialized = serialize_location(loc)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="locations", action="created", payload={"location": serialized})
-    _broadcast_counts(hass)
-    notify_location_changed(hass)
+    notify_location_mutation(hass, action="created", location=serialized)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1997,18 +1974,18 @@ async def ws_location_update(
     # filtered by area re-lists on. No item events accompany it — the items
     # themselves did not change.
     is_anchored_at = (loc.parent_id, repo.effective_area_id(location_key))
+    # Only the two edits that rewrite a path repaint: an area reassignment
+    # re-anchors the subtree without changing what any path reads, and a save
+    # that changed nothing repaints nothing.
+    repaint = loc.parent_id != before.parent_id or loc.name != was_named
     if is_anchored_at != was_anchored_at:
-        _broadcast_event(hass, topic="locations", action="moved", payload={"location": serialized})
+        notify_location_mutation(hass, action="moved", location=serialized, repaint=repaint)
     elif loc.name != was_named:
-        _broadcast_event(
-            hass, topic="locations", action="renamed", payload={"location": serialized}
-        )
-    # Only the two edits that rewrite a path: an area reassignment re-anchors the
-    # subtree without changing what any path reads, and a save that changed
-    # nothing repaints nothing.
-    if loc.parent_id != before.parent_id or loc.name != was_named:
-        notify_location_changed(hass)
-    _broadcast_counts(hass)
+        notify_location_mutation(hass, action="renamed", location=serialized, repaint=repaint)
+    else:
+        # A save that rewrote no field announces nothing and repaints nothing;
+        # the counts still go out, as they do after every other command.
+        notify_counts(hass)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -2026,14 +2003,7 @@ async def ws_location_delete(
     serialized_before = serialize_location(before)
     repo.delete_location(loc_id)
     await _persist_repo(hass)
-    _broadcast_event(
-        hass,
-        topic="locations",
-        action="deleted",
-        payload={"location": serialized_before},
-    )
-    _broadcast_counts(hass)
-    notify_location_changed(hass)
+    notify_location_mutation(hass, action="deleted", location=serialized_before)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), None))
 
 
@@ -2125,10 +2095,9 @@ async def ws_location_move_subtree(
     loc = repo.update_location(msg["location_id"], new_parent_id=new_parent)
     serialized = serialize_location(loc)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="locations", action="moved", payload={"location": serialized})
-    if loc.parent_id != was_below:
-        notify_location_changed(hass)
-    _broadcast_counts(hass)
+    notify_location_mutation(
+        hass, action="moved", location=serialized, repaint=loc.parent_id != was_below
+    )
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -2168,7 +2137,7 @@ async def ws_status_create(
     created = repo.create_status(doc)
     serialized = serialize_status_definition(created)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="statuses", action="created", payload={"status": serialized})
+    broadcast_event(hass, topic="statuses", action="created", payload={"status": serialized})
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -2199,7 +2168,7 @@ async def ws_status_update(
     updated = repo.update_status(msg["slug"], changes)
     serialized = serialize_status_definition(updated)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="statuses", action="updated", payload={"status": serialized})
+    broadcast_event(hass, topic="statuses", action="updated", payload={"status": serialized})
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -2220,7 +2189,7 @@ async def ws_status_reorder(
     ordered = repo.reorder_statuses(list(msg["slugs"]))
     serialized = [serialize_status_definition(d) for d in ordered]
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="statuses", action="reordered", payload={"statuses": serialized})
+    broadcast_event(hass, topic="statuses", action="reordered", payload={"statuses": serialized})
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -2247,11 +2216,12 @@ async def ws_status_delete(
     removed, reassigned = repo.delete_status(msg["slug"], reassign_to=msg.get("reassign_to"))
     serialized = serialize_status_definition(removed)
     await _persist_repo(hass)
-    _broadcast_event(hass, topic="statuses", action="deleted", payload={"status": serialized})
+    broadcast_event(hass, topic="statuses", action="deleted", payload={"status": serialized})
     if reassigned:
         # Two topics on purpose: one card is showing the vocabulary, another is
-        # showing the items that just moved underneath it.
-        _broadcast_event(hass, topic="items", action="updated", payload=None)
+        # showing the items that just moved underneath it — that second topic is
+        # the `items` event `notify_bulk_mutation` broadcasts.
+        #
         # Each rewritten item took a new version and a new updated_at, so each
         # is an ordinary item edit as far as the bus is concerned. Announcing the
         # command and not the edits would leave an automation watching
@@ -2261,7 +2231,6 @@ async def ws_status_delete(
             action="updated",
             items=[serialize_item(hass, repo.get_item(item_id)) for item_id in reassigned],
         )
-        _broadcast_counts(hass)
     conn.send_message(
         websocket_api.result_message(
             msg.get("id", 0), {"status": serialized, "reassigned": len(reassigned)}
@@ -2428,12 +2397,14 @@ async def ws_import_execute(
     await media_mod.async_sweep_orphans(hass, repo.iter_attachments())
 
     # Tell every subscriber the dataset was replaced wholesale.
-    _broadcast_event(hass, topic="items", action="reloaded", payload=None)
-    _broadcast_event(hass, topic="locations", action="reloaded", payload=None)
-    _broadcast_counts(hass)
-    # No per-item bus event — an import rewrites the dataset and an automation
-    # wants one signal, not one per row. The low-stock diff still runs, so a
-    # restock done by import announces itself, and the sensors still repaint.
+    broadcast_event(hass, topic="items", action="reloaded", payload=None)
+    broadcast_event(hass, topic="locations", action="reloaded", payload=None)
+    # No per-item bus event and no per-item `items` event — an import rewrites
+    # the dataset, and both an automation and a card want one signal rather than
+    # one per row, which is what the two `reloaded` events above are. Passing no
+    # item leaves `notify_mutation` the rest of its job: the low-stock diff still
+    # runs, so a restock done by import announces itself, the sensors repaint,
+    # and the counts go out.
     notify_mutation(hass, action="reloaded")
     # And the shopping list explicitly, because that diff is the only bus signal
     # a wholesale swap produces: a document that renames items or changes their

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -148,6 +148,13 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
     - Locations: if `include_subtree` match the location itself or descendants; otherwise only the exact location.
   - Re-anchoring a location under a different root rewrites `effective_area_id` for its whole subtree and emits a single `locations` `moved` event; reassigning the area through `location/update` emits the same event, for the same reason — including when the `area_id` is sent for a location inside the tree rather than for its root, which is the same re-anchoring written a different way. Neither emits item events, so an area-filtered items subscription sees no departure for the items that just left its area, and no arrival for those that joined it. A client tracking a filtered set re-lists on a `locations` event rather than waiting for one — the same rule `inspection_overdue_only` carries, and the reason there is no synthetic per-item event here.
 
+- **Both write paths broadcast the same events.** A `haventory.*` service call emits exactly
+  what the WebSocket command doing the same thing emits — the `items` or `locations` event
+  and the `stats` counts — because one call in `events.py` covers both surfaces. So an
+  automation mutating the inventory repaints an open card with no interaction, and a
+  subscriber cannot tell which surface a change arrived through. The rate limiter's event
+  budget is charged identically either way, since it is the same broadcast.
+
 - **An event implies a durable write.** Every mutation command persists the change *before* it broadcasts and before it replies, so any event on any topic says the write behind it reached storage. When the write fails the caller receives `storage_error` and **no event is emitted at all** — subscribers are told nothing rather than told about a change that is not on disk. A client may therefore treat a received event as committed and never has to reconcile it against a `storage_error` another client saw for the same change.
   - The guarantee is about the wire, not about the running repository: a failed write leaves the mutation applied in memory (`import/execute` is the exception — it rolls the dataset back, because a wholesale swap has more to undo than one entity does). Nothing announces that divergence, and it ends at the next restart, which reads back whatever last reached disk.
   - `items/bulk` shares one write across the whole batch, so a failed write costs the batch its `results` map: the command answers `storage_error` and none of its operations broadcast.
@@ -178,18 +185,16 @@ with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
   are internal to Home Assistant, on the same reasoning as the `unavailable` notice.
 - **Bus events carry no item body beyond the trigger fields** — no `custom_fields`, no
   `description`. An automation that needs the whole item calls `haventory/item/get`.
-- **Locations fire no bus event** — but a rename or a re-parent still repaints. No count a
-  sensor exposes can move on a location mutation: the repository refuses to delete a location
-  that still holds items or children, and a rename or re-anchor only rewrites derived fields.
-  Counts are no longer the only thing derived from location data, though: every projected
-  calendar event's `description` is the item's `location_path.display_path`, read from a
-  cached entity state. So `location/update` and `location/move_subtree` — and the
-  `haventory.location_update` service — dispatch the repaint signal when the name or the
-  parent changed, and nothing else does: an area-only reassignment moves no path, and neither
-  `location/create` (no existing item's path can change) nor `location/delete` (refused while
-  the location holds anything) can leave a stale one behind. `haventory_item_changed` stays
-  unfired for all of them: a derived-path rewrite deliberately moves neither an item's
-  `version` nor its `updated_at`, and the action vocabulary above has no location word.
+- **Locations fire no bus event** — but most of them still repaint the entities. Two kinds of
+  location change reach something derived. A create or a delete moves `locations_total`,
+  which is a sensor. A rename or a re-parent rewrites `location_path` across the subtree, and
+  every projected calendar event's `description` is an item's `location_path.display_path`,
+  read from a cached entity state. So `location/create`, `location/delete`,
+  `location/update`, `location/move_subtree` and their `haventory.location_*` services
+  dispatch the repaint signal, with one exception: an area-only reassignment, which moves no
+  count and no path. `haventory_item_changed` stays unfired for all of them — a derived-path
+  rewrite deliberately moves neither an item's `version` nor its `updated_at`, and the action
+  vocabulary above has no location word.
 
 ### Items
 

--- a/tests/integration/test_service_broadcast.py
+++ b/tests/integration/test_service_broadcast.py
@@ -1,0 +1,140 @@
+"""Integration: a service call dispatched by Home Assistant reaches a subscriber.
+
+The offline suite awaits the service handler itself, which cannot see how Home
+Assistant dispatches it, and drives a stub connection rather than a socket. Here
+the call goes through `hass.services.async_call` and the events come back down a
+real WebSocket — which is the shape the bug was reported in: an automation runs,
+the sensors move, and the card left open on another tab keeps showing the old
+list.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from custom_components.haventory.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+EVENT_WAIT_SECONDS = 5
+
+# Subscription ids, so an assertion can say which topic a frame arrived on.
+ITEMS_SUB = 10
+STATS_SUB = 11
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def _subscribe(client, sub_id: int, topic: str) -> None:
+    await client.send_json({"id": sub_id, "type": "haventory/subscribe", "topic": topic})
+    result = await client.receive_json()
+    assert result["success"] is True, result
+
+
+async def _drain_events(client, count: int) -> list[dict]:
+    """The next `count` event frames, in arrival order.
+
+    Bounded, because the regression this file guards against is events that
+    never arrive: an unbounded read would hang the run instead of failing it.
+    """
+
+    frames: list[dict] = []
+    try:
+        async with asyncio.timeout(EVENT_WAIT_SECONDS):
+            while len(frames) < count:
+                frame = await client.receive_json()
+                if frame["type"] == "event":
+                    frames.append(frame)
+    except TimeoutError:
+        raise AssertionError(
+            f"expected {count} event frames, {len(frames)} arrived: {frames}"
+        ) from None
+    return frames
+
+
+async def test_item_create_service_delivers_items_and_counts(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """#450's acceptance, through the registry that actually dispatches."""
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+    await _subscribe(client, ITEMS_SUB, "items")
+    await _subscribe(client, STATS_SUB, "stats")
+
+    await hass.services.async_call(DOMAIN, "item_create", {"name": "Torch"}, blocking=True)
+    await hass.async_block_till_done()
+
+    frames = await _drain_events(client, 2)
+    items = next(f for f in frames if f["event"]["topic"] == "items")
+    stats = next(f for f in frames if f["event"]["topic"] == "stats")
+
+    assert items["id"] == ITEMS_SUB
+    assert items["event"]["action"] == "created"
+    assert items["event"]["item"]["name"] == "Torch"
+    assert stats["id"] == STATS_SUB
+    assert stats["event"]["action"] == "counts"
+    assert stats["event"]["counts"]["items_total"] == 1
+
+
+async def test_every_item_service_delivers_one_event_with_its_action(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """Every write path, not just the one the issue happened to name."""
+
+    await _setup(hass)
+    created = await hass.services.async_call(
+        DOMAIN, "item_create", {"name": "Widget"}, blocking=True, return_response=True
+    )
+    item_id = created["item"]["id"]
+
+    client = await hass_ws_client(hass)
+    await _subscribe(client, 20, "items")
+
+    calls: list[tuple[str, dict, str]] = [
+        ("item_update", {"item_id": item_id, "name": "Widget Pro"}, "updated"),
+        ("item_move", {"item_id": item_id, "new_location_id": None}, "moved"),
+        ("item_adjust_quantity", {"item_id": item_id, "delta": 2}, "quantity_changed"),
+        ("item_set_quantity", {"item_id": item_id, "quantity": 7}, "quantity_changed"),
+        ("item_check_out", {"item_id": item_id, "due_date": "2030-01-01"}, "checked_out"),
+        ("item_check_in", {"item_id": item_id}, "checked_in"),
+        ("item_delete", {"item_id": item_id}, "deleted"),
+    ]
+    for service, payload, _action in calls:
+        await hass.services.async_call(DOMAIN, service, payload, blocking=True)
+        await hass.async_block_till_done()
+
+    frames = await _drain_events(client, len(calls))
+    assert [f["event"]["action"] for f in frames] == [action for _s, _p, action in calls]
+
+
+async def test_location_services_deliver_locations_events(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """The other half of "a `haventory.*` mutation reaches no subscriber"."""
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+    await _subscribe(client, 30, "locations")
+
+    created = await hass.services.async_call(
+        DOMAIN, "location_create", {"name": "Garage"}, blocking=True, return_response=True
+    )
+    location_id = created["location"]["id"]
+    await hass.services.async_call(
+        DOMAIN, "location_update", {"location_id": location_id, "name": "Shed"}, blocking=True
+    )
+    await hass.services.async_call(
+        DOMAIN, "location_delete", {"location_id": location_id}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    frames = await _drain_events(client, 3)
+    assert [f["event"]["action"] for f in frames] == ["created", "renamed", "deleted"]
+    assert frames[0]["event"]["location"]["name"] == "Garage"

--- a/tests/test_entry_removal_refusal_offline.py
+++ b/tests/test_entry_removal_refusal_offline.py
@@ -200,7 +200,7 @@ async def test_removal_drops_live_subscriptions() -> None:
     await async_remove_entry(hass, entry)
     conn.messages.clear()
 
-    ws_mod._broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+    ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
 
     assert conn.messages == []
     assert hass.data[DOMAIN].get("subscriptions") in (None, {})

--- a/tests/test_entry_unload_refusal_offline.py
+++ b/tests/test_entry_unload_refusal_offline.py
@@ -212,7 +212,7 @@ async def test_unload_drops_live_subscriptions() -> None:
     await async_unload_entry(hass, entry)
     conn.messages.clear()
 
-    ws_mod._broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+    ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
 
     assert conn.messages == []
     assert hass.data[DOMAIN].get("subscriptions") in (None, {})
@@ -245,7 +245,7 @@ async def test_teardown_signal_outranks_the_event_budget() -> None:
     # Drain the global budget, then prove an ordinary broadcast is now dropped.
     assert limiter.allow_event_broadcast() is True
     conn.messages.clear()
-    ws_mod._broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+    ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
     assert conn.messages == []
 
     await async_unload_entry(hass, entry)

--- a/tests/test_service_broadcast_offline.py
+++ b/tests/test_service_broadcast_offline.py
@@ -1,0 +1,247 @@
+"""Offline tests: a `haventory.*` service mutation reaches WebSocket subscribers.
+
+The service handlers are called directly here rather than through
+``hass.services``, because the offline `HomeAssistant` stub has no service
+registry — `tests/integration/test_services.py` is where real dispatch is
+asserted. What these cover is the fan-out itself:
+
+- every item service delivers its `items` event and one `stats` counts event
+- every location service delivers its `locations` event
+- the WebSocket command beside each service delivers exactly the same events,
+  once, so folding the broadcast into `events.notify_mutation` did not start
+  sending two
+- a batch sends one counts event, not one per row
+- the rate limiter charges the WebSocket half exactly as it did, and charges the
+  bus half nothing
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from custom_components.haventory import events as events_mod
+from custom_components.haventory import rate_limit as rate_limit_module
+from custom_components.haventory import services as services_mod
+from custom_components.haventory.const import DOMAIN, EVENT_ITEM_CHANGED
+from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.ws import setup as ws_setup
+from homeassistant.core import HomeAssistant
+
+from ws_helpers import RecordingConn, ws_send
+
+_BULK_ROWS = 3
+
+
+def _hass(limiter: RateLimiter | None = None) -> HomeAssistant:
+    hass = HomeAssistant()
+    bucket = hass.data.setdefault(DOMAIN, {})
+    bucket["repository"] = Repository()
+    bucket["store"] = DomainStore(hass)
+    if limiter is not None:
+        bucket["rate_limiter"] = limiter
+    ws_setup(hass)
+    events_mod.seed_low_stock_snapshot(hass)
+    return hass
+
+
+async def _subscribed(hass: HomeAssistant, *topics: str) -> RecordingConn:
+    conn = RecordingConn()
+    for index, topic in enumerate(topics, start=900):
+        res = await ws_send(hass, index, "haventory/subscribe", conn=conn, topic=topic)
+        assert res["success"] is True, res
+    conn.messages.clear()
+    return conn
+
+
+def _actions(conn: RecordingConn, topic: str) -> list[str]:
+    return [str(ev.get("action")) for ev in conn.events(topic=topic)]
+
+
+@pytest.mark.asyncio
+async def test_the_item_create_service_reaches_an_open_subscription() -> None:
+    """The bug this file exists for: the bus heard it and no subscriber did."""
+
+    hass = _hass()
+    conn = await _subscribed(hass, "items", "stats")
+
+    result = await services_mod.service_item_create(hass, {"name": "Torch"})
+
+    items = conn.events(topic="items")
+    assert [ev["action"] for ev in items] == ["created"]
+    assert items[0]["item"]["id"] == result["item"]["id"]
+    assert _actions(conn, "stats") == ["counts"]
+    assert conn.events(topic="stats")[0]["counts"]["items_total"] == 1
+    # The bus half is untouched by the fan-out gaining a second surface.
+    assert [e["action"] for e in hass.bus.events_of(EVENT_ITEM_CHANGED)] == ["created"]
+
+
+@pytest.mark.asyncio
+async def test_every_item_service_delivers_its_own_action() -> None:
+    """One vocabulary across both surfaces, service side as well as command side."""
+
+    hass = _hass()
+    created = await services_mod.service_item_create(hass, {"name": "Widget", "quantity": 5})
+    item_id = created["item"]["id"]
+    conn = await _subscribed(hass, "items")
+
+    calls: list[tuple[Any, dict[str, Any], str]] = [
+        (services_mod.service_item_update, {"item_id": item_id, "name": "Widget Pro"}, "updated"),
+        (services_mod.service_item_move, {"item_id": item_id, "new_location_id": None}, "moved"),
+        (
+            services_mod.service_item_adjust_quantity,
+            {"item_id": item_id, "delta": -1},
+            "quantity_changed",
+        ),
+        (
+            services_mod.service_item_set_quantity,
+            {"item_id": item_id, "quantity": 7},
+            "quantity_changed",
+        ),
+        (
+            services_mod.service_item_check_out,
+            {"item_id": item_id, "due_date": "2030-01-01"},
+            "checked_out",
+        ),
+        (services_mod.service_item_check_in, {"item_id": item_id}, "checked_in"),
+        (services_mod.service_item_delete, {"item_id": item_id}, "deleted"),
+    ]
+    for handler, payload, _action in calls:
+        await handler(hass, payload)
+
+    assert _actions(conn, "items") == [action for _h, _p, action in calls]
+    assert {a for a in _actions(conn, "items")} <= events_mod.ITEM_ACTIONS
+
+
+@pytest.mark.asyncio
+async def test_the_location_services_reach_a_locations_subscription() -> None:
+    """The other half of "a `haventory.*` mutation reaches no subscriber"."""
+
+    hass = _hass()
+    conn = await _subscribed(hass, "locations")
+
+    created = await services_mod.service_location_create(hass, {"name": "Garage"})
+    location_id = created["location"]["id"]
+    await services_mod.service_location_update(hass, {"location_id": location_id, "name": "Shed"})
+    await services_mod.service_location_delete(hass, {"location_id": location_id})
+
+    assert _actions(conn, "locations") == ["created", "renamed", "deleted"]
+    # A location mutation is not an item mutation, on either surface.
+    assert hass.bus.events_of(EVENT_ITEM_CHANGED) == []
+
+
+@pytest.mark.asyncio
+async def test_a_re_parent_through_the_service_announces_a_move() -> None:
+    """`moved` and `renamed` are decided by what changed, not by the keys sent."""
+
+    hass = _hass()
+    garage = await services_mod.service_location_create(hass, {"name": "Garage"})
+    shelf = await services_mod.service_location_create(hass, {"name": "Shelf"})
+    conn = await _subscribed(hass, "locations")
+
+    await services_mod.service_location_update(
+        hass,
+        # The name is re-sent unchanged, the way an editor saving every field does.
+        {
+            "location_id": shelf["location"]["id"],
+            "name": "Shelf",
+            "new_parent_id": garage["location"]["id"],
+        },
+    )
+
+    assert _actions(conn, "locations") == ["moved"]
+
+
+@pytest.mark.asyncio
+async def test_the_command_and_the_service_deliver_the_same_events_once() -> None:
+    """Folding the broadcast into the notification must not have doubled it."""
+
+    hass = _hass()
+    conn = await _subscribed(hass, "items", "stats")
+
+    assert (await ws_send(hass, 1, "haventory/item/create", conn=conn, name="Hammer"))["success"]
+    from_command = (_actions(conn, "items"), _actions(conn, "stats"))
+    conn.messages.clear()
+
+    await services_mod.service_item_create(hass, {"name": "Chisel"})
+    from_service = (_actions(conn, "items"), _actions(conn, "stats"))
+
+    assert from_command == (["created"], ["counts"])
+    assert from_service == from_command
+
+
+@pytest.mark.asyncio
+async def test_a_bulk_command_sends_one_counts_event_for_the_batch() -> None:
+    """Per-row counts would put a whole counts object on the wire once per row."""
+
+    hass = _hass()
+    ids = [
+        (await ws_send(hass, index, "haventory/item/create", name=f"Item {index}"))["result"]["id"]
+        for index in range(1, _BULK_ROWS + 1)
+    ]
+    conn = await _subscribed(hass, "items", "stats")
+
+    res = await ws_send(
+        hass,
+        50,
+        "haventory/items/bulk",
+        conn=conn,
+        operations=[
+            {
+                "op_id": f"op{n}",
+                "kind": "item_set_quantity",
+                "payload": {"item_id": iid, "quantity": 4},
+            }
+            for n, iid in enumerate(ids)
+        ],
+    )
+    assert res["success"] is True, res
+
+    assert _actions(conn, "items") == ["quantity_changed"] * _BULK_ROWS
+    assert _actions(conn, "stats") == ["counts"]
+
+
+@pytest.mark.asyncio
+async def test_the_service_half_is_charged_the_same_event_budget(monkeypatch) -> None:
+    """The WebSocket half spends a token; the bus half spends nothing.
+
+    A service call was free of the event budget only because it emitted no
+    event. Now that it emits one, it costs exactly what the command beside it
+    costs — and the `haventory_item_changed` that goes out with it still costs
+    nothing, because the limiter budgets subscription traffic.
+    """
+
+    monkeypatch.setattr(rate_limit_module, "_monotonic", lambda: 1000.0)
+    limiter = RateLimiter(
+        RateLimitConfig(
+            enabled=True,
+            commands_per_second=1.0,
+            commands_burst=1000.0,
+            global_commands_per_second=1.0,
+            global_commands_burst=1000.0,
+            events_per_second=1.0,
+            # Two tokens: the `items` event and the `stats` event of one mutation.
+            events_burst=2.0,
+            global_events_per_second=1.0,
+            global_events_burst=1000.0,
+        )
+    )
+    hass = _hass(limiter)
+    conn = await _subscribed(hass, "items", "stats")
+
+    await services_mod.service_item_create(hass, {"name": "Torch"})
+    assert _actions(conn, "items") == ["created"]
+    assert _actions(conn, "stats") == ["counts"]
+    assert limiter.dropped_events == 0
+
+    # The budget is spent, so the next service call reaches the bus and not the
+    # wire — a dropped event, never a failed mutation.
+    result = await services_mod.service_item_create(hass, {"name": "Chisel"})
+    assert result["item"]["name"] == "Chisel"
+    assert _actions(conn, "items") == ["created"]
+    dropped_by_a_single_mutation = 2
+    assert limiter.dropped_events == dropped_by_a_single_mutation
+    fired_on_the_bus = 2
+    assert len(hass.bus.events_of(EVENT_ITEM_CHANGED)) == fired_on_the_bus

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -458,7 +458,7 @@ async def test_attachment_add_announces_the_item_as_updated(upload, monkeypatch)
     broadcasts: list[tuple[str, str]] = []
     monkeypatch.setattr(
         ws_mod,
-        "_broadcast_event",
+        "broadcast_event",
         lambda _hass, *, topic, action, payload=None: broadcasts.append((topic, action)),
     )
 

--- a/tests/test_ws_rate_limit_offline.py
+++ b/tests/test_ws_rate_limit_offline.py
@@ -224,13 +224,13 @@ async def test_per_connection_event_limit(clock: _FakeClock) -> None:
     sub = await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items")
     assert sub["success"] is True
 
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     assert len(subscriber.events()) == 1
     assert limiter.dropped_events == 1
 
     clock.advance(1.0)
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     delivered_after_refill = 2
     assert len(subscriber.events()) == delivered_after_refill
 
@@ -244,7 +244,7 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
 
     # No subscribers at all: nothing is consumed or counted.
     for _ in range(3):
-        ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+        ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     assert limiter.dropped_events == 0
 
     # A subscriber on another topic does not consume the budget either.
@@ -252,7 +252,7 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
     assert (await ws_send(hass, 99, "haventory/subscribe", conn=other, topic="locations"))[
         "success"
     ]
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     assert limiter.dropped_events == 0
 
     # The budget is still intact for the first real delivery.
@@ -260,7 +260,7 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
     assert (await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items"))[
         "success"
     ]
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     assert len(subscriber.events()) == 1
 
 
@@ -276,11 +276,11 @@ async def test_one_event_consumes_one_token_across_multiple_subscriptions(
     assert (await ws_send(hass, 301, "haventory/subscribe", conn=conn, topic="items"))["success"]
     assert (await ws_send(hass, 302, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     # Both subscriptions receive the event; only one token was spent.
     assert {m["id"] for m in conn.messages if m["type"] == "event"} == {301, 302}
 
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     delivered_before_drop = 2  # both subscriptions got the FIRST event only
     assert len(conn.events()) == delivered_before_drop
     assert limiter.dropped_events == 1
@@ -295,8 +295,8 @@ async def test_global_event_limit_drops_for_all_subscribers(clock: _FakeClock) -
     assert (await ws_send(hass, 100, "haventory/subscribe", conn=sub_a, topic="items"))["success"]
     assert (await ws_send(hass, 101, "haventory/subscribe", conn=sub_b, topic="items"))["success"]
 
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
-    ws_module._broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
     # First event reached both; second was dropped globally.
     assert len(sub_a.events()) == 1
     assert len(sub_b.events()) == 1

--- a/tests/test_ws_statuses_offline.py
+++ b/tests/test_ws_statuses_offline.py
@@ -40,7 +40,7 @@ def _record_broadcasts(monkeypatch) -> list[Broadcast]:
     def fake(hass, *, topic, action, payload=None):
         seen.append((topic, action, payload))
 
-    monkeypatch.setattr(ws_mod, "_broadcast_event", fake)
+    monkeypatch.setattr(ws_mod, "broadcast_event", fake)
     return seen
 
 

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -22,7 +22,7 @@ from custom_components.haventory.areas import async_get_area_registry
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
-from custom_components.haventory.ws import _broadcast_event, _subs_bucket
+from custom_components.haventory.ws import _subs_bucket, broadcast_event
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
@@ -305,7 +305,7 @@ async def test_location_filters_subtree_and_direct_only() -> None:
     # dataset moved wholesale and the client must re-list, and a subscription
     # watching one shelf has just as much reason to re-list as any other.
     conn.messages.clear()
-    _broadcast_event(hass, topic="items", action="updated", payload=None)
+    broadcast_event(hass, topic="items", action="updated", payload=None)
     ids = {
         m.get("id")
         for m in conn.messages


### PR DESCRIPTION
## Summary

A `haventory.*` service mutation reached the Home Assistant bus, the sensors, and nothing
else. `services.py` has never imported `ws`, and the two emitters that reach subscribed
clients were private to it — so an automation calling `haventory.item_create` moved the
dashboard sensor while the card open on another tab kept showing the old list and the old
counts until a filter change, a reload or a reconnect made it re-list. It presents as a card
that is intermittently behind rather than as an error.

| Mutation via | HA bus event | Sensors | WS `items` event | WS `stats` counts |
|---|---|---|---|---|
| `haventory/item/*` (WebSocket) | ✅ | ✅ | ✅ | ✅ |
| `haventory.item_*` (service) — before | ✅ | ✅ | ❌ | ❌ |
| `haventory.item_*` (service) — after | ✅ | ✅ | ✅ | ✅ |

The fix is the shape the issue argues for and §6.2 of the plan picks: **the broadcast rides
beside the notification, not beside each handler.** `events.notify_mutation` now broadcasts
the `items` event and the `stats` counts as well as firing on the bus, diffing the low-stock
set and repainting. The ~20 WebSocket handlers that called three things call one, and every
emitter — service, command, bulk, import — covers both surfaces by construction rather than
by remembering to. `ws.py` loses 87 lines and gains 58.

Closes #450.

### The rate limiter, which is the one constraint the issue names

Unaffected by construction. The WebSocket half is the same `broadcast_event` call it always
was, charged the same token at the same point; the bus half still charges nothing, because
the limiter budgets subscription traffic. `test_the_service_half_is_charged_the_same_event_budget`
pins both directions: a service call with a two-token budget delivers its `items` and `stats`
events and drops nothing, the next one drops both and still fires on the bus, and the
mutation succeeds either way.

### Decisions taken against the issue's notes

- **Locations are in scope.** The issue's table and its "done when" name item services only,
  but its title and its symptom are about `haventory.*`, and `haventory.location_create` /
  `_update` / `_delete` reached no `locations` subscriber either. Fixing items alone would
  leave half the reported bug behind under a PR titled "broadcast service mutations".
  `notify_location_mutation` is the counterpart for that topic — event, counts, repaint, and
  nothing on the bus, since no item changed — and both surfaces now go through it.
  `service_location_update` gained the anchor-aware `moved` / `renamed` decision
  `ws_location_update` already made, so the two surfaces announce the same word for the same
  edit.
- **`events.py` imports `ws.py` inside the function, with a `# noqa: PLC0415`.** `ws.py`
  imports `events` at module scope, so the reverse cannot be a module-scope import. The
  alternative — moving the broadcaster into a third module — drags `_subs_bucket`,
  `_rate_limiter` and `_repo` with it, which `ws.py` uses everywhere and which #280 (the next
  PR in this session) moves onto `entry.runtime_data` anyway. A two-line local import with the
  constraint written above it is the smaller and less disruptive of the two. `PLC0415` arrives
  from the blanket `PL` select rather than a deliberate choice, and the repo already carries
  several reasoned `# noqa: PL…`.
- **Two paths keep today's wire exactly, via `counts=False`.** A bulk command sends one counts
  event for the batch rather than one per row (then one `notify_counts`), and an attachment
  retitle or reorder sends none, because neither moves a count. The default is the safe
  direction: forgetting the flag costs an extra counts event, not a missing one.
- **The contract's location bullet was already stale** after #504 promoted `locations_total`
  to a sensor — it still claimed "no count a sensor exposes can move on a location mutation".
  Rewritten to the rule that now holds.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

No command, event or payload shape moves. What changes is which mutations emit the events
that were already documented — the contract said "an event implies a durable write", never
"only a WebSocket command emits one".

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` — **1209 passed, 22 skipped**; `uv run ruff check .` — all checks passed; `uv run ruff format --check .` — clean; `uv run mypy` — no issues in 24 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean, `npx vitest run` — **63 files / 1860 tests passed**, `npm run build` — built
- [x] phacc (`scripts/test_integration.sh`, the Docker recipe): **113 passed**

New tests:

- `tests/test_service_broadcast_offline.py` (7) — the item-create service reaching an open subscription; every item service delivering its own action; the location services delivering theirs; a re-parent announcing `moved` even when the name is re-sent unchanged; the command and the service delivering **the same events, once** (the guard against this refactor doubling them); one counts event for a bulk batch; and the rate-limit accounting above.
- `tests/integration/test_service_broadcast.py` (3) — the same three shapes through `hass.services.async_call` and a real socket, which is where dispatch is actually observable. The event wait is bounded, because the regression these guard against is an event that never arrives: an unbounded read would hang the run instead of failing it. Confirmed they fail — and fail *fast* — with the broadcast stubbed out.

### Live checks (dev HA 2026.7.4, 1087 items)

Two Chromium tabs on the card, which is two independent HA WebSocket connections. The
mutation goes out over a **third** connection as a core `call_service` frame — exactly what
Developer Tools → Actions sends — so neither tab is the one that made the change. Both tabs
had a search typed in first, so the oracle is a row that appears out of nothing. Harness:
`.claude/skills/run-haventory/two_tab.mjs`.

**This branch:**

```
probe item: two-tab probe
tab A events: items/created (two-tab probe), stats/counts
tab B events: items/created (two-tab probe), stats/counts
rows tab A : 0 -> 1
rows tab B : 0 -> 1
[PASS] tab A received items/created      [PASS] tab B received items/created
[PASS] tab A received stats/counts       [PASS] tab B received stats/counts
[PASS] tab A repainted with no interaction
[PASS] tab B repainted with no interaction
```

**The control — `main`'s `events.py`, `services.py` and `ws.py` copied into the same
container, same tabs, same call:**

```
tab A events: (none)
tab B events: (none)
rows tab A : 0 -> 0
rows tab B : 0 -> 0
[FAIL] × 6
```

| before (`main`) | after (this branch) |
|---|---|
| ![no row, no repaint](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s2/s2/two-tab-before.png) | ![the row appeared on its own](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s2/s2/two-tab-after.png) |

The counts pill moves with it: `1087 items` → `1088 items` on the untouched tab. The probe
item was deleted afterwards; the dev instance is back to 1087.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`docs/backend_api_contract.md`, `README.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no shape moves; the contract gains the rule about both write paths and loses a stale claim about locations.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Follow-ups

- **#505** — with a search active, a row arriving through an event is added to the list but
  not counted into the footer, which then reads "Showing 1 of 0 matching items". Visible in
  the after-screenshot above. Reproduced with a WebSocket mutation as the mutator too, so it
  predates this PR and is card-side; filed rather than fixed here.
- `.claude/skills/run-haventory/two_tab.mjs` is committed with this PR because the live
  check is worth repeating; it is a session harness, not a gate, and the `run-haventory`
  skill's own docs are not updated for it.
