### PR TITLE
refactor: move the runtime onto `entry.runtime_data`

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -358,6 +358,7 @@ run either passes or says why not. All are read-only except `lifecycle_probe.py`
 | `visual_pass.mjs` | every card surface still opens, at desktop and mobile widths, and every panel surface on `/haventory` |
 | `import_policies.mjs` | the import sheet describes the conflict policy the backend actually applied |
 | `two_tab.mjs` | a mutation nobody in the browser made repaints every open card |
+| `reload_probe.mjs` | a reload and an options change leave the card, the panel and the sidebar working |
 | `log_sweep.py` | the container log obeys the error taxonomy's severity policy |
 | `lifecycle_probe.py` | resource cache-bust rewriting, schema-downgrade refusal, entry removal/re-add |
 
@@ -444,6 +445,25 @@ again; screenshots land as `<out>-a.png` / `<out>-b.png`.
 
 `--ws` is the control worth running next to any failure: if the WebSocket command repaints
 both tabs and the service call does not, the gap is in the service path, not in the card.
+
+### A reload and an options change, with two tabs open
+
+```bash
+cd .claude/skills/run-haventory
+node reload_probe.mjs                 # reload, then options changed and changed back
+node reload_probe.mjs --out before    # to compare two builds
+```
+
+One tab on the card, one on `/haventory`, neither touched. Reloads the entry over REST, then
+drives the **real options flow** (fresh `flow_id` per POST, every section key present, the
+values read back out of the form so the instance's own settings are restored). Watches for
+the `unavailable` notice on each open topic, for the card re-subscribing on its own, for a
+mutation afterwards still repainting it, and for the sidebar entry still being there.
+
+Two of its lines are worth reading rather than just passing: `panel after reload` records
+whether the open `/haventory` tab is still on `/haventory` — the frontend takes it to the
+default dashboard when the panel is briefly unregistered ([#507](https://github.com/chrreiter/HAventory/issues/507)) — and the run leaves one item
+behind only if the delete at the end failed.
 
 ### Import policy cross-check
 

--- a/.claude/skills/run-haventory/reload_probe.mjs
+++ b/.claude/skills/run-haventory/reload_probe.mjs
@@ -1,0 +1,228 @@
+// Does a reload — and an options change — leave the card and the panel working?
+//
+// Two tabs, one on the dashboard card and one on the sidebar panel, both left
+// alone throughout. The entry is reloaded over WebSocket (what Settings ->
+// Devices & services -> Reload sends) and then its options are rewritten through
+// the real options flow and rewritten back. What is being watched is that the
+// subscription teardown notice arrives, that the card re-subscribes on its own,
+// that a mutation afterwards still repaints it, and that the sidebar entry is
+// still there at the end.
+//
+// Usage (from the skill dir):
+//   node reload_probe.mjs [--out reload]
+
+import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { cardPath, haConfig } from "./card_views.mjs";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+
+const { base, token } = haConfig();
+const outPrefix = flag("--out", "reload");
+const PROBE = `reload probe ${Math.floor(Date.now() / 1000)}`;
+
+function haWs() {
+  const socket = new WebSocket(base.replace(/^http/, "ws") + "/api/websocket");
+  let nextId = 1;
+  const pending = new Map();
+  const ready = new Promise((resolve, reject) => {
+    socket.addEventListener("error", () => reject(new Error("websocket error")));
+    socket.addEventListener("message", (ev) => {
+      const frame = JSON.parse(ev.data);
+      if (frame.type === "auth_required") socket.send(JSON.stringify({ type: "auth", access_token: token }));
+      else if (frame.type === "auth_ok") resolve();
+      else if (frame.type === "auth_invalid") reject(new Error("auth_invalid"));
+      else if (frame.type === "result" && pending.has(frame.id)) {
+        pending.get(frame.id)(frame);
+        pending.delete(frame.id);
+      }
+    });
+  });
+  return {
+    ready,
+    send: (message) =>
+      new Promise((resolve) => {
+        const id = nextId++;
+        pending.set(id, resolve);
+        socket.send(JSON.stringify({ id, ...message }));
+      }),
+    close: () => socket.close(),
+  };
+}
+
+const rest = async (method, url, body) => {
+  const res = await fetch(base + url, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return res.json();
+};
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 1400, height: 900 },
+  serviceWorkers: "block",
+});
+await context.addInitScript(
+  ([hassUrl, accessToken]) => {
+    localStorage.setItem(
+      "hassTokens",
+      JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "unused-long-lived",
+        expires_in: 1800,
+        expires: Date.now() + 365 * 24 * 3600 * 1000,
+        hassUrl,
+        clientId: hassUrl + "/",
+      }),
+    );
+  },
+  [base, token],
+);
+
+function watch(page) {
+  const seen = [];
+  page.on("websocket", (ws) => {
+    ws.on("framereceived", ({ payload }) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(payload.toString());
+      } catch {
+        return;
+      }
+      for (const message of Array.isArray(parsed) ? parsed : [parsed]) {
+        const event = message?.event;
+        if (message?.type === "event" && event?.domain === "haventory") {
+          seen.push(`${event.topic}/${event.action}`);
+        }
+      }
+    });
+  });
+  return seen;
+}
+
+async function openTab(urlPath, root) {
+  const page = await context.newPage();
+  const events = watch(page);
+  await page.goto(base + urlPath, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(root, { timeout: 30000 });
+  await page.waitForTimeout(2500);
+  return { page, events, root };
+}
+
+const card = await openTab(await cardPath("wide"), "haventory-card");
+const panel = await openTab("/haventory", "haventory-panel");
+
+const entries = await rest("GET", "/api/config/config_entries/entry");
+const entry = entries.find((e) => e.domain === "haventory");
+console.log(`entry: ${entry.entry_id}  state=${entry.state}  title=${JSON.stringify(entry.title)}`);
+
+const sidebarBefore = await panel.page.evaluate(() =>
+  Boolean(document.querySelector("home-assistant")?.hass?.panels?.haventory),
+);
+
+// --- the reload ------------------------------------------------------------
+for (const tab of [card, panel]) tab.events.length = 0;
+await rest("POST", `/api/config/config_entries/entry/${entry.entry_id}/reload`);
+await card.page.waitForTimeout(12000);
+
+const afterReload = await rest("GET", "/api/config/config_entries/entry");
+const reloadedState = afterReload.find((e) => e.domain === "haventory").state;
+
+// A mutation from a third connection: does the card repaint on its own again?
+const driver = haWs();
+await driver.ready;
+const created = await driver.send({ type: "haventory/item/create", name: PROBE });
+if (!created.success) {
+  console.error("create failed after reload:", JSON.stringify(created));
+  process.exit(1);
+}
+await card.page.waitForTimeout(3000);
+
+const cardEvents = [...card.events];
+const panelEvents = [...panel.events];
+const panelUrlAfterReload = panel.page.url();
+const panelAfterReload = await panel.page.locator("haventory-panel").count();
+
+// --- the options change ----------------------------------------------------
+// One step, every section key required, and a fresh flow_id per POST.
+async function openOptionsForm() {
+  return rest("POST", "/api/config/config_entries/options/flow", { handler: entry.entry_id });
+}
+function valuesFrom(form) {
+  const values = {};
+  for (const field of form.data_schema ?? []) {
+    if (field.type === "expandable") continue;
+    values[field.name] = field.description?.suggested_value ?? field.default;
+  }
+  // The two collapsed sections: empty means "leave them as they are".
+  return { ...values, todo: {}, rate_limit: {} };
+}
+async function submit(values) {
+  const form = await openOptionsForm();
+  return rest("POST", `/api/config/config_entries/options/flow/${form.flow_id}`, values);
+}
+
+const baseline = valuesFrom(await openOptionsForm());
+for (const tab of [card, panel]) tab.events.length = 0;
+
+const optionsResult = await submit({ ...baseline, card_title: "Reload probe title" });
+await card.page.waitForTimeout(8000);
+const panelDuring = await panel.page.locator("haventory-panel").count();
+const restored = await submit(baseline);
+await card.page.waitForTimeout(8000);
+
+// --- what is still standing ------------------------------------------------
+const cardAlive = (await card.page.locator("haventory-card").count()) > 0;
+const panelAlive = (await panel.page.locator("haventory-panel").count()) > 0;
+const sidebarAfter = await panel.page.evaluate(() =>
+  Boolean(document.querySelector("home-assistant")?.hass?.panels?.haventory),
+);
+const rowsAfter = await card.page.locator("haventory-card hv-list-row").count();
+
+await card.page.screenshot({ path: path.resolve(skillDir, `${outPrefix}-card.png`) });
+await panel.page.screenshot({ path: path.resolve(skillDir, `${outPrefix}-panel.png`) });
+
+console.log(`entry after reload : ${reloadedState}`);
+console.log(`card events        : ${cardEvents.join(", ") || "(none)"}`);
+console.log(`panel events       : ${panelEvents.join(", ") || "(none)"}`);
+console.log(`options baseline   : ${JSON.stringify(baseline)}`);
+console.log(`options flow       : ${optionsResult.type} -> restored ${restored.type}`);
+console.log(`panel after reload : ${panelAfterReload} element(s) at ${panelUrlAfterReload}`);
+console.log(`panel mid-change   : ${panelDuring} element(s); panel url now ${panel.page.url()}`);
+console.log(`sidebar panel      : before=${sidebarBefore} after=${sidebarAfter}`);
+console.log(`rows visible       : ${rowsAfter}`);
+
+const checks = [
+  ["the entry is LOADED again", reloadedState === "loaded"],
+  ["the card was told its subscription stopped", cardEvents.includes("items/unavailable")],
+  ["the panel was told too", panelEvents.includes("items/unavailable")],
+  ["the card re-subscribed and saw the new item", cardEvents.includes("items/created")],
+  ["the panel re-subscribed and saw it too", panelEvents.includes("items/created")],
+  ["the options change was accepted and undone", optionsResult.type === "create_entry" && restored.type === "create_entry"],
+  ["the card element survived the options change", cardAlive],
+  ["the panel survived the reload", panelAfterReload > 0],
+  ["the panel element survived the options change", panelAlive],
+  ["the sidebar entry survived it", sidebarBefore && sidebarAfter],
+  ["the card is showing rows", rowsAfter > 0],
+];
+let ok = true;
+for (const [label, passed] of checks) {
+  console.log(`${passed ? "[PASS]" : "[FAIL]"} ${label}`);
+  ok = ok && passed;
+}
+
+const removed = await driver.send({ type: "haventory/item/delete", item_id: created.result.id });
+console.log(`probe deleted: ${removed.success}`);
+driver.close();
+await browser.close();
+process.exit(ok && removed.success ? 0 : 1);

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,9 @@ repos:
           # "statics" is the plural of a class's `static` members, which is what
           # Home Assistant reads a card's picker interface off. "crate" is one of
           # the three boxes the mark draws, named that in the icon geometry and in
-          # everything that reads it.
-          - --ignore-words-list=hass,batery,afterall,socio-economic,statics,crate
+          # everything that reads it. "categorie" is deliberate too: it is the
+          # near-miss filter key `distinct_values` is asked to refuse by name.
+          - --ignore-words-list=hass,batery,afterall,socio-economic,statics,crate,categorie
         exclude: |
           (?x)^(
             custom_components/haventory/www/|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,18 @@ and the two must move together, which `tests/test_toolchain_pins.py` now enforce
 ## Architecture & key files
 
 ### Backend — `custom_components/haventory/`
-- `__init__.py` — integration setup/teardown, `hass.data[DOMAIN]` wiring, persistence helpers
-  (`async_persist_repo`, `async_persist_immediate`, `async_request_persist`), Lovelace resource
-  registration, and the sidebar panel (`_async_apply_sidebar_panel`: `panel_custom` at
-  `/haventory`, remove-then-register, driven by the `sidebar_panel_enabled` option).
+- `__init__.py` — integration setup/teardown, the runtime wiring (built here, handed to
+  `entry.runtime_data`), persistence helpers (`async_persist_repo`, `async_persist_immediate`,
+  `async_request_persist`), Lovelace resource registration, and the sidebar panel
+  (`_async_apply_sidebar_panel`: `panel_custom` at `/haventory`, remove-then-register, driven
+  by the `sidebar_panel_enabled` option).
+- `runtime.py` — `HAventoryRuntime`, everything one loaded config entry owns, and the **two**
+  lookups that reach it: `loaded_runtime` refuses unless the entry is `LOADED` and is what
+  makes a command or a service go quiet once the entry is gone; `find_runtime` asks only
+  whether a runtime exists, and is what the teardown flush, the teardown broadcast and the
+  subscription close callbacks must use — they all run while the entry is *not* loaded. Only
+  the flags recording registrations Home Assistant cannot hand back (an aiohttp route, a
+  frontend module URL, a sidebar panel) stay in `hass.data[DOMAIN]`.
 - `models.py` — `Item` / `Location` dataclasses, validation, serializers. Items carry a
   denormalized `location_path` (rebuilt on location changes) and a `version` int (starts at 1,
   bumped on each *item* mutation — derived `location_path` rewrites excluded) for
@@ -84,7 +92,7 @@ and the two must move together, which `tests/test_toolchain_pins.py` now enforce
   `websocket_api.error_message` (HA's helper has no `data` param).
 - `rate_limit.py` — opt-in token-bucket rate limiting (per-connection + global, for
   commands and broadcasts). Off by default; configured via the options flow
-  (`config_flow.py`); limiter instance lives in `hass.data[DOMAIN]["rate_limiter"]`.
+  (`config_flow.py`); limiter instance lives on the runtime (`entry.runtime_data.rate_limiter`).
 - `import_export.py` — JSON import/export with `merge` / `replace` / `skip` policies and a
   read-only preview. **Import identity is the id, never the name.**
 - `stale_files.py` — `RETIRED_PATHS`, the explicit list of files earlier releases shipped

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ uniquely-named item and deletes it (best-effort cleanup even on failure).
 ### Backend (custom component)
 
 - `custom_components/haventory/` with `manifest.json`, `__init__.py`, `config_flow.py`, `services.yaml`.
-- Store: `hass.data[DOMAIN]["store"]` with versioned schema and safe writes. Migrations are
+- Store: `entry.runtime_data.store` with versioned schema and safe writes. Migrations are
   forward-only: a store written by a **newer** HAventory version is refused (setup fails with
   an "upgrade HAventory" message) and never rewritten, so a rollback cannot relabel data the
   running build cannot read.

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -75,6 +75,7 @@ from .const import (
 from .exceptions import CorruptSchemaVersionError, SchemaDowngradeError, StorageError
 from .rate_limit import RateLimitConfig, RateLimiter
 from .repository import LoadReport, Repository
+from .runtime import HAventoryConfigEntry, HAventoryRuntime, find_runtime
 from .storage import (
     CURRENT_SCHEMA_VERSION,
     STORAGE_KEY,
@@ -139,7 +140,7 @@ async def async_setup(hass: HomeAssistant, _config: dict) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: HAventoryConfigEntry) -> bool:
     """Set up HAventory from a config entry."""
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
@@ -149,13 +150,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # First, so a retired bundle is gone before the card directory is served.
     await stale_files.async_sweep_retired_files(hass)
 
-    # Expose storage manager via hass.data[DOMAIN]["store"]. Keep name compatible
-    # with tests while upgrading to a schema-aware wrapper.
     store = DomainStore(hass, key=STORAGE_KEY, version=CURRENT_SCHEMA_VERSION)
-    hass.data[DOMAIN]["store"] = store
-
     repository = await _async_load_repository(hass, entry, store)
-    hass.data[DOMAIN]["repository"] = repository
+
+    # Onto the entry, before anything that reads it: every module resolves the
+    # runtime through `hass.config_entries`, so nothing below this line would
+    # find a repository without it. Home Assistant clears it again on unload.
+    entry.runtime_data = HAventoryRuntime(
+        store=store,
+        repository=repository,
+        # Heading and pill choice served to the card by `haventory/config`.
+        card_title=_resolve_card_title(entry),
+        quick_filters=_resolve_quick_filters(entry),
+        # WebSocket rate limiting (off by default; configured via the options flow)
+        rate_limiter=RateLimiter(RateLimitConfig.from_options(getattr(entry, "options", None))),
+    )
 
     # A load that had to leave rows behind has to reach the file, or the next
     # restart meets the same rows and refuses all over again.
@@ -171,18 +180,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     events.seed_low_stock_snapshot(hass)
 
     # Serve attachment files, and collect the ones nothing references any more.
-    # Both need the repository, so both come after it is in the bucket.
+    # Both need the repository, so both come after the runtime is on the entry.
     _register_media_view(hass)
     await _async_sweep_orphaned_media(hass, repository)
 
-    # Heading and pill choice served to the card by `haventory/config`.
-    hass.data[DOMAIN]["card_title"] = _resolve_card_title(entry)
-    hass.data[DOMAIN]["quick_filters"] = _resolve_quick_filters(entry)
-
-    # WebSocket rate limiting (off by default; configured via the options flow)
-    hass.data[DOMAIN]["rate_limiter"] = RateLimiter(
-        RateLimitConfig.from_options(getattr(entry, "options", None))
-    )
     # Re-read the options when they change. Guarded with getattr so the
     # minimal offline-test ConfigEntry stubs keep working.
     add_listener = getattr(entry, "add_update_listener", None)
@@ -466,14 +467,15 @@ def _resolve_quick_filters(entry: ConfigEntry) -> list[str] | None:
     return [key for key in QUICK_FILTER_KEYS if key in known]
 
 
-async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_options_updated(hass: HomeAssistant, entry: HAventoryConfigEntry) -> None:
     """Apply changed options: card title, pills, sidebar panel, WS rate limiter."""
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["card_title"] = _resolve_card_title(entry)
-    bucket["quick_filters"] = _resolve_quick_filters(entry)
-    bucket["rate_limiter"] = RateLimiter(
-        RateLimitConfig.from_options(getattr(entry, "options", None))
-    )
+    runtime = find_runtime(hass)
+    if runtime is not None:
+        runtime.card_title = _resolve_card_title(entry)
+        runtime.quick_filters = _resolve_quick_filters(entry)
+        runtime.rate_limiter = RateLimiter(
+            RateLimitConfig.from_options(getattr(entry, "options", None))
+        )
     # Covers the toggle and a renamed card alike: the sidebar entry carries the
     # card title, and re-registering is how a changed one reaches the sidebar.
     await _async_apply_sidebar_panel(hass, entry)
@@ -495,8 +497,7 @@ async def _async_flush_pending_writes(hass: HomeAssistant, *, op: str) -> None:
     a repository that is on its way out.
     """
 
-    bucket = hass.data.get(DOMAIN) or {}
-    if bucket.get("store") is None or bucket.get("repository") is None:
+    if find_runtime(hass) is None:
         cancel_pending_persist(hass, op=op)
         return
 
@@ -546,10 +547,16 @@ def _cleanup_ws_test_stub_registry(hass: HomeAssistant) -> None:
 async def _async_teardown_entry(hass: HomeAssistant, *, op: str) -> None:
     """Give up everything the config entry owns, in the order that keeps it safe.
 
+    Every step here runs while the entry is **not** loaded — Home Assistant marks
+    it `UNLOAD_IN_PROGRESS` before calling `async_unload_entry` — so each reads
+    the runtime through `find_runtime` rather than through the loaded check a
+    client-facing command uses. A flush routed through that check would write
+    nothing and drop whatever was still unsaved.
+
     Flush first, while the repository is still reachable; then tell open
     subscribers, while the subscription registry still lists them; then hand back
-    the frontend registrations, which read the URL the bucket recorded; and only
-    then empty the bucket.
+    the frontend registrations, which read the URL the bucket recorded. Home
+    Assistant clears `runtime_data` itself once this returns.
     """
 
     await _async_flush_pending_writes(hass, op=op)
@@ -565,7 +572,7 @@ async def _async_teardown_entry(hass: HomeAssistant, *, op: str) -> None:
     # cannot load; setup registers it again.
     _remove_sidebar_panel(hass)
 
-    _drop_entry_runtime(hass)
+    _forget_registration_flags(hass)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -591,29 +598,28 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unloaded
 
 
-def _drop_entry_runtime(hass: HomeAssistant) -> None:
-    """Leave the domain bucket holding only what outlives the config entry.
+def _forget_registration_flags(hass: HomeAssistant) -> None:
+    """Forget that the WebSocket commands and services were registered.
 
-    Home Assistant has no API for unregistering a WebSocket command, so ours go
-    on listening whether the entry is unloaded, disabled or removed. Emptying the
-    bucket is what makes them refuse: `ws._repo` raises `NotLoadedError` without a
-    repository, so every command answers the contract's `storage_error` envelope
-    instead of letting a dashboard left open read — and write — state the entry
-    no longer owns. The same lookup backs the `haventory.*` service handlers.
+    Not the runtime — Home Assistant takes that back itself, and a command
+    refuses from the moment the entry stops being `LOADED`. What is left here is
+    bookkeeping: Home Assistant has no API for unregistering a WebSocket command
+    or a service, so the next setup re-registers over the top, and the offline
+    stub registry — which *can* unregister — needs the handler list at this point
+    to take ours back out.
 
-    `_STATIC_PATH_KEY` and `_MEDIA_VIEW_KEY` are kept: each records an aiohttp
-    route, which cannot be unregistered and so outlives every entry. Dropping
-    either flag would make the next setup in the same run register the same
-    route a second time.
+    `_STATIC_PATH_KEY` and `_MEDIA_VIEW_KEY` stay: each records an aiohttp route,
+    which cannot be unregistered and so outlives every entry. Dropping either
+    flag would make the next setup in the same run register the same route a
+    second time.
     """
 
     bucket = hass.data.get(DOMAIN)
     if not isinstance(bucket, dict):
         return
 
-    kept = {key: bucket[key] for key in (_STATIC_PATH_KEY, _MEDIA_VIEW_KEY) if key in bucket}
-    bucket.clear()
-    bucket.update(kept)
+    for key in ("ws_registered", "services_registered", "ws_handlers"):
+        bucket.pop(key, None)
 
 
 async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:

--- a/custom_components/haventory/calendar.py
+++ b/custom_components/haventory/calendar.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -27,6 +26,7 @@ from homeassistant.util import dt as dt_util
 from .calendar_projection import ProjectedEvent, build_events, next_event, window_dates
 from .const import CALENDAR_UNIQUE_ID, DOMAIN, INTEGRATION_VERSION, SIGNAL_INVENTORY_CHANGED
 from .models import Item
+from .runtime import find_runtime
 
 LOGGER = logging.getLogger(__name__)
 
@@ -121,11 +121,11 @@ class HaventoryCalendar(CalendarEntity):
         ceiling the README states.
         """
 
-        repo = (self.hass.data.get(DOMAIN) or {}).get("repository")
-        if repo is None:
+        runtime = find_runtime(self.hass)
+        if runtime is None:
             return None
         try:
-            result: dict[str, Any] = repo.list_items()
+            result = runtime.repository.list_items()
         except Exception:  # pragma: no cover - defensive
             LOGGER.exception(
                 "Failed to read items for the calendar",

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -318,7 +318,3 @@ EVENT_LOW_STOCK: str = "haventory_low_stock"
 # and the calendar alike, since both are derived from the same items. Bus events
 # are the public contract; this is the internal nudge that repaints entities.
 SIGNAL_INVENTORY_CHANGED: str = "haventory_inventory_changed"
-
-# `hass.data[DOMAIN]` key holding the previous low-stock id set. Seeded at setup
-# so a restart re-announces nothing, and diffed on every notification.
-DATA_LOW_STOCK_SNAPSHOT: str = "low_stock_snapshot"

--- a/custom_components/haventory/diagnostics.py
+++ b/custom_components/haventory/diagnostics.py
@@ -26,6 +26,7 @@ assuming a loaded runtime.
 
 from __future__ import annotations
 
+from dataclasses import fields
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +40,7 @@ from .health import collect_health_issues
 from .models import ITEM_STATUSES
 from .rate_limit import RateLimiter
 from .repository import Repository
+from .runtime import find_runtime
 from .storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
 
 # What the entry's options can carry that the household chose the words for. The
@@ -118,9 +120,9 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Build the diagnostics payload for the HAventory config entry."""
 
-    bucket = hass.data.get(DOMAIN) or {}
-    store = bucket.get("store")
-    repo = bucket.get("repository")
+    runtime = find_runtime(hass)
+    store = runtime.store if runtime is not None else None
+    repo = runtime.repository if runtime is not None else None
 
     # Off the event loop, the way `stale_files` does its own filesystem work.
     bundle = await hass.async_add_executor_job(_bundle_state, _CARD_BUNDLE_PATH)
@@ -141,12 +143,17 @@ async def async_get_config_entry_diagnostics(
         },
         "repository": _repository_block(repo if isinstance(repo, Repository) else None),
         "runtime": {
-            # Key names, never values: the bucket holds the repository itself,
-            # and a dump of it would be the whole inventory.
-            "data_keys": sorted(str(key) for key in bucket),
+            # Field names, never values: the runtime holds the repository
+            # itself, and a dump of it would be the whole inventory. Empty when
+            # no entry is loaded, which is the first thing to read here.
+            "data_keys": sorted(f.name for f in fields(runtime)) if runtime is not None else [],
+            # What is left in the shared domain bucket: the flags recording
+            # registrations Home Assistant cannot hand back, which say whether a
+            # route or a panel is already in place.
+            "shared_keys": sorted(str(key) for key in (hass.data.get(DOMAIN) or {})),
             "rate_limit": _rate_limit_block(
-                bucket.get("rate_limiter")
-                if isinstance(bucket.get("rate_limiter"), RateLimiter)
+                runtime.rate_limiter
+                if runtime is not None and isinstance(runtime.rate_limiter, RateLimiter)
                 else None
             ),
         },

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -35,13 +35,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import (
-    DATA_LOW_STOCK_SNAPSHOT,
     DOMAIN,
     EVENT_ITEM_CHANGED,
     EVENT_LOW_STOCK,
     SIGNAL_INVENTORY_CHANGED,
 )
 from .models import iso_utc_now
+from .runtime import HAventoryRuntime, find_runtime
 
 LOGGER = logging.getLogger(__name__)
 
@@ -78,16 +78,15 @@ def _broadcast_counts(hass: HomeAssistant) -> None:
 def seed_low_stock_snapshot(hass: HomeAssistant) -> None:
     """Record which items are low at setup, so a restart re-announces nothing.
 
-    Called once the repository is in the bucket. Without it the first mutation
-    after every restart would diff against an empty set and fire `entered` for
-    every item that was already low before the restart.
+    Called once the runtime is on the entry. Without it the first mutation after
+    every restart would diff against an empty set and fire `entered` for every
+    item that was already low before the restart.
     """
 
-    bucket = hass.data.get(DOMAIN)
-    if bucket is None:
+    runtime = find_runtime(hass)
+    if runtime is None:
         return
-    repo = bucket.get("repository")
-    bucket[DATA_LOW_STOCK_SNAPSHOT] = repo.low_stock_item_ids if repo is not None else frozenset()
+    runtime.low_stock_ids = runtime.repository.low_stock_item_ids
 
 
 def notify_mutation(
@@ -117,8 +116,8 @@ def notify_mutation(
     """
 
     try:
-        bucket = hass.data.get(DOMAIN)
-        if bucket is None:
+        runtime = find_runtime(hass)
+        if runtime is None:
             # The entry tore down between the write and this call. Nothing to
             # notify and nothing to diff against.
             return
@@ -127,7 +126,7 @@ def notify_mutation(
             _broadcast_event(hass, topic="items", action=action, payload={"item": item})
             _fire_item_changed(hass, action, item)
 
-        _fire_low_stock_transitions(hass, bucket, item=item)
+        _fire_low_stock_transitions(hass, runtime, item=item)
 
         async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
 
@@ -160,8 +159,8 @@ def notify_bulk_mutation(
     """
 
     try:
-        bucket = hass.data.get(DOMAIN)
-        if bucket is None:
+        runtime = find_runtime(hass)
+        if runtime is None:
             return
 
         # One `items` event for the batch, carrying no row: a subscriber is
@@ -174,7 +173,7 @@ def notify_bulk_mutation(
 
         # `item=None`: the diff covers the batch, and no single row is the one
         # a crossing should be attributed to.
-        _fire_low_stock_transitions(hass, bucket, item=None)
+        _fire_low_stock_transitions(hass, runtime, item=None)
 
         async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
         _broadcast_counts(hass)
@@ -227,7 +226,7 @@ def notify_location_changed(hass: HomeAssistant) -> None:
     """
 
     try:
-        if hass.data.get(DOMAIN) is None:
+        if find_runtime(hass) is None:
             return
         async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
     except Exception:  # pragma: no cover - defensive
@@ -256,7 +255,7 @@ def _fire_item_changed(hass: HomeAssistant, action: str, item: dict[str, Any]) -
 
 
 def _fire_low_stock_transitions(
-    hass: HomeAssistant, bucket: dict[str, Any], *, item: dict[str, Any] | None
+    hass: HomeAssistant, runtime: HAventoryRuntime, *, item: dict[str, Any] | None
 ) -> None:
     """Fire `entered` / `cleared` for the ids that crossed the threshold.
 
@@ -265,15 +264,12 @@ def _fire_low_stock_transitions(
     needs a pre-mutation read of its own.
     """
 
-    repo = bucket.get("repository")
-    if repo is None:
-        return
-
-    previous: frozenset[str] = bucket.get(DATA_LOW_STOCK_SNAPSHOT) or frozenset()
+    repo = runtime.repository
+    previous = runtime.low_stock_ids
     current = repo.low_stock_item_ids
     if current == previous:
         return
-    bucket[DATA_LOW_STOCK_SNAPSHOT] = current
+    runtime.low_stock_ids = current
 
     for item_id in current - previous:
         _fire(hass, EVENT_LOW_STOCK, _low_stock_payload(repo, item_id, "entered", item))

--- a/custom_components/haventory/media.py
+++ b/custom_components/haventory/media.py
@@ -52,6 +52,7 @@ from .const import (
 )
 from .exceptions import ValidationError
 from .models import AttachmentKind, AttachmentMeta
+from .runtime import find_runtime
 
 LOGGER = logging.getLogger(__name__)
 
@@ -369,14 +370,13 @@ class HaventoryMediaView(HomeAssistantView):  # type: ignore[misc, valid-type]
         """Return the file the two ids name, or 404 if no metadata claims it."""
 
         hass: HomeAssistant = request.app["hass"]
-        bucket = hass.data.get(DOMAIN) or {}
-        repo = bucket.get("repository")
-        if repo is None:
+        runtime = find_runtime(hass)
+        if runtime is None:
             # No config entry owns the data — an unload, a disable, or the first
             # half of a reload. Same refusal the WebSocket commands make.
             return web.Response(status=HTTPStatus.SERVICE_UNAVAILABLE)
 
-        meta = repo.find_attachment(item_id, attachment_id)
+        meta = runtime.repository.find_attachment(item_id, attachment_id)
         if meta is None:
             return web.Response(status=HTTPStatus.NOT_FOUND)
 

--- a/custom_components/haventory/runtime.py
+++ b/custom_components/haventory/runtime.py
@@ -1,0 +1,148 @@
+"""What one loaded config entry owns, and how any module reaches it.
+
+Home Assistant hands every config entry a `runtime_data` slot: setup fills it,
+Home Assistant clears it on unload, and a typed alias makes every read a checked
+one. HAventory keeps its repository, its store, its rate limiter and the rest of
+its per-entry state there rather than in the shared `hass.data[DOMAIN]` dict.
+
+**Two lookups, and the difference matters.** `loaded_runtime` refuses unless the
+entry is `LOADED` — it is the client-facing boundary, the thing that makes a
+WebSocket command a dashboard left open still holds refuse once the entry is
+gone. `find_runtime` asks only whether a runtime exists. Teardown runs while the
+entry is *not* loaded (Home Assistant sets `UNLOAD_IN_PROGRESS` before calling
+`async_unload_entry`, and clears `runtime_data` only after it returns), so the
+final flush, the teardown broadcast and the subscription close callbacks all go
+through `find_runtime`. Routing any of them through the loaded check would drop
+the last write, or leave a subscriber never told its topics had stopped.
+
+Single-instance (`single_config_entry` in the manifest, enforced again in the
+config flow), so "the entry" is `async_entries(DOMAIN)[0]` or nothing at all.
+
+What stays in `hass.data[DOMAIN]` is what outlives an entry: the flags recording
+an aiohttp route, a frontend module URL or a sidebar panel, none of which Home
+Assistant can hand back on unload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypedDict
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .exceptions import NotLoadedError
+from .rate_limit import RateLimiter
+from .repository import Repository
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.storage import Store
+
+    # Imported for typing only: `storage.py` reads the runtime, so a module-scope
+    # import here would be a cycle.
+    from .storage import DomainStore
+
+
+class Subscription(TypedDict, total=False):
+    """One open `haventory/subscribe`, as the broadcaster matches it.
+
+    Lives here rather than in `ws.py` because the registry holding these is a
+    field of the runtime, and typing that field from `ws.py` would be a cycle.
+    """
+
+    topic: str
+    location_id: str | None
+    location_ids: list[str]
+    area_id: str | None
+    include_subtree: bool
+    inspection_overdue_only: bool
+
+
+@dataclass(slots=True)
+class TodoBridgeState:
+    """The shopping-list bridge's own state, scoped to the entry like the rest.
+
+    Its `Store` is a second file beside the inventory's — the link map survives a
+    restart, so a line the household already ticked off is not written back.
+    """
+
+    entity_id: str = ""
+    links: dict[str, dict[str, str]] = field(default_factory=dict)
+    store: Store[dict[str, Any]] | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+@dataclass(slots=True)
+class HAventoryRuntime:
+    """Everything setup builds and unload gives up, in one typed place."""
+
+    store: DomainStore
+    repository: Repository
+    card_title: str
+    quick_filters: list[str] | None
+    rate_limiter: RateLimiter
+    # Serializes every write to the one store file. Per entry, because it guards
+    # that entry's store and nothing else.
+    persist_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # The pending debounced write, cancelled by anything that is about to write
+    # itself or to take the repository away.
+    persist_task: asyncio.Task[None] | None = None
+    subscriptions: dict[Any, dict[int, Subscription]] = field(default_factory=dict)
+    # Which items were low when the last mutation was announced. Seeded at setup
+    # so a restart re-announces nothing, and diffed after every mutation.
+    low_stock_ids: frozenset[str] = frozenset()
+    todo: TodoBridgeState = field(default_factory=TodoBridgeState)
+
+
+# A `type` statement rather than an assignment: its value is evaluated lazily, so
+# `ConfigEntry[HAventoryRuntime]` is never subscripted at import time. That keeps
+# it working against a stub `ConfigEntry` as well as the real generic one.
+type HAventoryConfigEntry = ConfigEntry[HAventoryRuntime]
+
+
+def find_entry(hass: HomeAssistant) -> HAventoryConfigEntry | None:
+    """The one config entry, in whatever state it is in."""
+
+    config_entries = getattr(hass, "config_entries", None)
+    if config_entries is None:
+        return None
+    entries = config_entries.async_entries(DOMAIN)
+    return entries[0] if entries else None
+
+
+def find_runtime(hass: HomeAssistant) -> HAventoryRuntime | None:
+    """The runtime if one exists, whatever state its entry is in.
+
+    For the paths that run outside a loaded entry: the teardown flush, the
+    teardown broadcast, and the subscription callbacks a closing connection fires
+    long after the entry went. See the module docstring for why they must not go
+    through `loaded_runtime`.
+    """
+
+    entry = find_entry(hass)
+    if entry is None:
+        return None
+    runtime = getattr(entry, "runtime_data", None)
+    return runtime if isinstance(runtime, HAventoryRuntime) else None
+
+
+def loaded_runtime(hass: HomeAssistant) -> HAventoryRuntime:
+    """The runtime of a `LOADED` entry, or `NotLoadedError`.
+
+    The client-facing boundary. Home Assistant cannot unregister a WebSocket
+    command or a service, so both go on listening after the entry is unloaded,
+    disabled or removed; this refusal is what makes them answer the contract's
+    `storage_error` instead of serving state nothing owns.
+    """
+
+    entry = find_entry(hass)
+    if entry is None:
+        raise NotLoadedError("no HAventory config entry; add the integration")
+    if getattr(entry, "state", None) is not ConfigEntryState.LOADED:
+        raise NotLoadedError("HAventory config entry is not loaded; run integration setup")
+    runtime = getattr(entry, "runtime_data", None)
+    if not isinstance(runtime, HAventoryRuntime):
+        raise NotLoadedError("HAventory runtime not initialized; run integration setup")
+    return runtime

--- a/custom_components/haventory/sensor.py
+++ b/custom_components/haventory/sensor.py
@@ -26,6 +26,7 @@ from .const import (
     SIGNAL_INVENTORY_CHANGED,
     HaventorySensorDescription,
 )
+from .runtime import find_runtime
 
 LOGGER = logging.getLogger(__name__)
 
@@ -106,11 +107,11 @@ class HaventoryCountSensor(SensorEntity):
         return int(value) if value is not None else None
 
     def _counts(self) -> dict[str, Any] | None:
-        repo = (self.hass.data.get(DOMAIN) or {}).get("repository")
-        if repo is None:
+        runtime = find_runtime(self.hass)
+        if runtime is None:
             return None
         try:
-            return dict(repo.get_counts())
+            return dict(runtime.repository.get_counts())
         except Exception:  # pragma: no cover - defensive
             LOGGER.exception(
                 "Failed to read counts for a sensor",

--- a/custom_components/haventory/serialization.py
+++ b/custom_components/haventory/serialization.py
@@ -8,13 +8,12 @@ caller: the WebSocket API and the ``haventory.*`` services. Both emit the shapes
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
 from .models import Item, Location
-from .repository import Repository
+from .runtime import find_runtime
 
 
 def effective_area_id_for_item(hass: HomeAssistant, item: Item) -> str | None:
@@ -27,9 +26,10 @@ def effective_area_id_for_item(hass: HomeAssistant, item: Item) -> str | None:
     try:
         if getattr(item, "location_id", None) is None:
             return None
-        bucket = hass.data.get(DOMAIN) or {}
-        repo = cast("Repository", bucket["repository"])
-        return repo.effective_area_id(str(item.location_id))
+        runtime = find_runtime(hass)
+        if runtime is None:
+            return None
+        return runtime.repository.effective_area_id(str(item.location_id))
     except Exception:
         return None
 

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -24,7 +24,6 @@ from .events import notify_counts, notify_location_mutation, notify_mutation
 from .exceptions import (
     ConflictError,
     NotFoundError,
-    NotLoadedError,
     StorageError,
     ValidationError,
     error_code,
@@ -32,6 +31,7 @@ from .exceptions import (
     log_severity,
 )
 from .repository import UNSET, Repository
+from .runtime import loaded_runtime
 from .serialization import serialize_item, serialize_location
 from .storage import async_persist_repo as _storage_async_persist_repo
 
@@ -158,11 +158,14 @@ SCHEMA_LOCATION_DELETE = vol.Schema({vol.Required("location_id"): str})
 
 
 def _get_repo(hass: HomeAssistant) -> Repository:
-    bucket = hass.data.get(DOMAIN) or {}
-    repo = bucket.get("repository")
-    if repo is None:
-        raise NotLoadedError("repository not initialized; run integration setup")
-    return repo  # type: ignore[return-value]
+    """The repository of a loaded entry, or `NotLoadedError`.
+
+    The same client-facing refusal `ws_guard` makes: Home Assistant cannot
+    unregister a service, so these handlers keep answering after the entry is
+    unloaded, disabled or removed, and the state check is what makes them stop.
+    """
+
+    return loaded_runtime(hass).repository
 
 
 def _log_domain_error(op: str, context: dict[str, Any], exc: Exception) -> None:

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -20,7 +20,7 @@ import logging
 import time
 from collections.abc import Mapping
 from copy import deepcopy
-from typing import Any, Final, cast
+from typing import Any, Final
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
@@ -34,6 +34,7 @@ from .exceptions import (
     StorageError,
 )
 from .models import seed_status_definitions, serialize_status_definition
+from .runtime import find_runtime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -163,23 +164,11 @@ async def async_backup_store(
     return True
 
 
-def _get_persist_lock(hass: HomeAssistant) -> asyncio.Lock:
-    """Get or create the persistence lock for this hass instance.
-
-    Returns a per-hass-instance asyncio.Lock to serialize persistence operations
-    and prevent race conditions from concurrent saves.
-    """
-    bucket = hass.data.setdefault(DOMAIN, {})
-    if "persist_lock" not in bucket:
-        bucket["persist_lock"] = asyncio.Lock()
-    return cast("asyncio.Lock", bucket["persist_lock"])
-
-
 class DomainStore:
     """Schema-aware wrapper around Home Assistant's Store for HAventory.
 
-    This class centralizes storage access and schema migrations. It should be
-    exposed via ``hass.data[DOMAIN]["store"]``.
+    This class centralizes storage access and schema migrations. One instance per
+    config entry, held on the entry's runtime.
 
     Note: HA's Store version is fixed at 1 to avoid HA's internal migration
     mechanism. All versioning is handled via `schema_version` in the payload.
@@ -342,25 +331,25 @@ class DomainStore:
 
 
 async def async_persist_repo(hass: HomeAssistant) -> None:
-    """Persist the current repository state via DomainStore with exclusive locking.
+    """Persist the current repository state, one writer at a time.
 
-    Looks up both the storage manager and repository in hass.data[DOMAIN].
-    Fails fast with StorageError if prerequisites are missing to avoid
-    silent data loss. Callers should ensure setup completed successfully.
+    Reads the store and the repository off the entry's runtime, and refuses with
+    `NotLoadedError` when there is none rather than silently writing nothing.
+    Deliberately **not** the loaded-entry lookup: teardown flushes through here
+    while the entry is already `UNLOAD_IN_PROGRESS`, and a loaded check would
+    turn the last write into a no-op.
 
-    Uses an asyncio.Lock to serialize concurrent persistence operations and
-    prevent race conditions from multiple handlers attempting to save simultaneously.
+    The lock is the runtime's, so it serializes exactly the writes that go to
+    that entry's one store file.
     """
 
-    lock = _get_persist_lock(hass)
-    async with lock:
-        bucket = hass.data.get(DOMAIN) or {}
-        store = bucket.get("store")
-        repo = bucket.get("repository")
-        if store is None:
-            raise NotLoadedError("storage manager not initialized; run integration setup")
-        if repo is None:
-            raise NotLoadedError("repository not initialized; run integration setup")
+    runtime = find_runtime(hass)
+    if runtime is None:
+        raise NotLoadedError("HAventory runtime not initialized; run integration setup")
+
+    async with runtime.persist_lock:
+        store = runtime.store
+        repo = runtime.repository
 
         start_time = time.monotonic()
         generation = getattr(repo, "generation", None)
@@ -408,9 +397,11 @@ def cancel_pending_persist(hass: HomeAssistant, *, op: str = "persist_cancel") -
     write would read — has to clear the pending task first, or it fires against
     state that has moved on.
     """
-    bucket = hass.data.setdefault(DOMAIN, {})
+    runtime = find_runtime(hass)
+    if runtime is None:
+        return
 
-    existing_task = bucket.get("persist_task")
+    existing_task = runtime.persist_task
     if existing_task is None or existing_task.done():
         return
 
@@ -431,7 +422,9 @@ async def async_request_persist(hass: HomeAssistant) -> None:
 
     The debounce delay is PERSIST_DEBOUNCE_DELAY (1.0 seconds by default).
     """
-    bucket = hass.data.setdefault(DOMAIN, {})
+    runtime = find_runtime(hass)
+    if runtime is None:
+        raise NotLoadedError("HAventory runtime not initialized; run integration setup")
 
     cancel_pending_persist(hass, op="persist_debounce_cancel")
 
@@ -465,7 +458,7 @@ async def async_request_persist(hass: HomeAssistant) -> None:
     # Schedule through HA rather than asyncio directly: hass tracks the task and
     # cancels/awaits it during shutdown, so a pending debounce cannot outlive the
     # event loop.
-    bucket["persist_task"] = hass.async_create_background_task(
+    runtime.persist_task = hass.async_create_background_task(
         _delayed_persist(), name=f"{DOMAIN} debounced persist"
     )
 

--- a/custom_components/haventory/todo_bridge.py
+++ b/custom_components/haventory/todo_bridge.py
@@ -19,7 +19,6 @@ rollback.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -38,6 +37,7 @@ from .const import (
     TODO_LINKS_STORAGE_KEY,
     TODO_LINKS_STORAGE_VERSION,
 )
+from .runtime import HAventoryRuntime, find_runtime
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,13 +59,6 @@ TODO_FEATURE_DELETE_ITEM_NAME = "todo.TodoListEntityFeature.DELETE_TODO_ITEM"
 # x2" would carry. It is what the card prints against a quantity, so the list
 # and the card read the same way.
 MULTIPLICATION_SIGN = "\u00d7"
-
-# `hass.data[DOMAIN]` keys, all entry-scoped — unload empties the bucket and the
-# next setup rebuilds them.
-_LINKS_KEY = "todo_links"
-_STORE_KEY = "todo_link_store"
-_LOCK_KEY = "todo_lock"
-_ENTITY_KEY = "todo_entity_id"
 
 
 def summary_for(name: str, quantity: int, threshold: int) -> str:
@@ -90,17 +83,21 @@ def configured_entity_id(entry: ConfigEntry) -> str:
 def apply_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Record which list the bridge writes to, from the entry's options."""
 
-    hass.data.setdefault(DOMAIN, {})[_ENTITY_KEY] = configured_entity_id(entry)
+    runtime = find_runtime(hass)
+    if runtime is None:
+        return
+    runtime.todo.entity_id = configured_entity_id(entry)
 
 
 async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Load the link map, subscribe to the mutation events, run a first pass."""
 
-    bucket = hass.data.setdefault(DOMAIN, {})
+    runtime = find_runtime(hass)
+    if runtime is None:
+        return
     store: Store[dict[str, Any]] = Store(hass, TODO_LINKS_STORAGE_VERSION, TODO_LINKS_STORAGE_KEY)
-    bucket[_STORE_KEY] = store
-    bucket[_LOCK_KEY] = asyncio.Lock()
-    bucket[_LINKS_KEY] = await _async_load_links(store)
+    runtime.todo.store = store
+    runtime.todo.links = await _async_load_links(store)
     apply_options(hass, entry)
 
     on_unload = getattr(entry, "async_on_unload", None)
@@ -141,18 +138,15 @@ async def async_reconcile(hass: HomeAssistant) -> None:
     to-do list that refuses must not turn a saved change into a failed one.
     """
 
-    bucket = hass.data.get(DOMAIN)
-    if not isinstance(bucket, dict):
-        return
-    lock = bucket.get(_LOCK_KEY)
-    if lock is None:
-        # No bridge in this bucket: the entry was torn down between the write
-        # and this call, or never set one up.
+    runtime = find_runtime(hass)
+    if runtime is None or runtime.todo.store is None:
+        # The entry was torn down between the write and this call, or never set
+        # a bridge up at all.
         return
 
     try:
-        async with lock:
-            await _async_reconcile_locked(hass, bucket)
+        async with runtime.todo.lock:
+            await _async_reconcile_locked(hass, runtime)
     except Exception:
         LOGGER.exception(
             "Failed to reconcile the to-do list",
@@ -160,15 +154,12 @@ async def async_reconcile(hass: HomeAssistant) -> None:
         )
 
 
-async def _async_reconcile_locked(hass: HomeAssistant, bucket: dict[str, Any]) -> None:
+async def _async_reconcile_locked(hass: HomeAssistant, runtime: HAventoryRuntime) -> None:
     """One pass, with the bridge lock held so two triggers cannot interleave."""
 
-    repo = bucket.get("repository")
-    links: dict[str, dict[str, str]] | None = bucket.get(_LINKS_KEY)
-    if repo is None or links is None:
-        return
-
-    entity_id: str = bucket.get(_ENTITY_KEY) or ""
+    repo = runtime.repository
+    links = runtime.todo.links
+    entity_id = runtime.todo.entity_id
     if not entity_id:
         # Off. The map is kept rather than retracted: clearing the option means
         # "stop managing the list", not "delete what is on it", and keeping it
@@ -194,7 +185,7 @@ async def _async_reconcile_locked(hass: HomeAssistant, bucket: dict[str, Any]) -
         # `finally`, so a pass that dies halfway still records the lines it did
         # write — losing them would mean writing them all a second time.
         if links != before:
-            await _async_save_links(bucket)
+            await _async_save_links(runtime)
 
 
 async def _async_retract(
@@ -445,16 +436,15 @@ async def _async_load_links(store: Store[dict[str, Any]]) -> dict[str, dict[str,
     return links
 
 
-async def _async_save_links(bucket: dict[str, Any]) -> None:
+async def _async_save_links(runtime: HAventoryRuntime) -> None:
     """Write the map out. A failed write costs duplicates, never the inventory."""
 
-    store = bucket.get(_STORE_KEY)
-    links = bucket.get(_LINKS_KEY)
-    if store is None or links is None:
+    store = runtime.todo.store
+    if store is None:
         return
 
     try:
-        await store.async_save({"links": links})
+        await store.async_save({"links": runtime.todo.links})
     except Exception:
         LOGGER.warning(
             "Could not save the to-do link map; lines already on the list may be written again",

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -11,7 +11,7 @@ import functools
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 
 import voluptuous as vol
 from homeassistant.components import websocket_api
@@ -46,7 +46,6 @@ from .events import (
 from .exceptions import (
     ConflictError,
     NotFoundError,
-    NotLoadedError,
     StorageError,
     ValidationError,
     error_code,
@@ -70,6 +69,7 @@ from .models import (
 )
 from .rate_limit import RateLimiter
 from .repository import UNSET, Repository
+from .runtime import Subscription, find_runtime, loaded_runtime
 from .serialization import serialize_item, serialize_location
 from .storage import CURRENT_SCHEMA_VERSION
 
@@ -77,32 +77,33 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _repo(hass: HomeAssistant) -> Repository:
-    bucket = hass.data.get(DOMAIN) or {}
-    repo = bucket.get("repository")
-    if repo is None:
-        raise NotLoadedError("repository not initialized; run integration setup")
-    return cast("Repository", repo)
+    return loaded_runtime(hass).repository
 
 
 def _require_loaded(hass: HomeAssistant) -> None:
-    """Refuse the command when no config entry owns the data.
+    """Refuse the command when no loaded config entry owns the data.
 
     Home Assistant cannot unregister a WebSocket command, so these keep
-    listening after the integration is unloaded, disabled or removed — and each
-    of those empties the domain bucket for exactly this check to find. It sits in
-    the guard rather than in the handlers so the whole surface goes quiet at
-    once: the commands that read no inventory (ping, version, config) would
-    otherwise keep answering for a backend that owns nothing.
+    listening after the integration is unloaded, disabled or removed — and in
+    each of those states the entry is no longer `LOADED`, which is what
+    `loaded_runtime` refuses on. It sits in the guard rather than in the handlers
+    so the whole surface goes quiet at once: the commands that read no inventory
+    (ping, version, config) would otherwise keep answering for a backend that
+    owns nothing.
     """
 
-    _repo(hass)
+    loaded_runtime(hass)
 
 
 def _rate_limiter(hass: HomeAssistant) -> RateLimiter | None:
-    """Return the configured rate limiter, or None when limiting is off."""
-    bucket = hass.data.get(DOMAIN) or {}
-    limiter = bucket.get("rate_limiter")
-    return limiter if isinstance(limiter, RateLimiter) else None
+    """The configured rate limiter, or None when limiting is off.
+
+    Resolved without the loaded check: the broadcaster charges this budget, and
+    a broadcast can run during teardown.
+    """
+
+    runtime = find_runtime(hass)
+    return runtime.rate_limiter if runtime is not None else None
 
 
 def _ctx(op: str, **extra: Any) -> dict[str, Any]:
@@ -470,16 +471,7 @@ def _execute_item_op(
 # -----------------------------
 
 
-class _Subscription(TypedDict, total=False):
-    topic: str
-    location_id: str | None
-    location_ids: list[str]
-    area_id: str | None
-    include_subtree: bool
-    inspection_overdue_only: bool
-
-
-def _subscription_location_ids(sub: _Subscription) -> list[str]:
+def _subscription_location_ids(sub: Subscription) -> list[str]:
     """The locations a subscription is scoped to, scalar and list unioned.
 
     The same union rule ``models.selected_location_ids`` applies to an
@@ -500,19 +492,23 @@ def _subscription_location_ids(sub: _Subscription) -> list[str]:
 
 def _subs_bucket(
     hass: HomeAssistant,
-) -> dict[websocket_api.ActiveConnection, dict[int, _Subscription]]:
-    """Get or create the subscriptions bucket.
+) -> dict[websocket_api.ActiveConnection, dict[int, Subscription]]:
+    """The open subscriptions, or an empty map when no runtime holds any.
 
-    Note: We use a regular dict (not WeakKeyDictionary) because HA's
-    ActiveConnection doesn't support weak references. Cleanup is handled
-    via the close callback registered in _register_close_listener.
+    A regular dict rather than a WeakKeyDictionary, because HA's
+    `ActiveConnection` does not support weak references; cleanup is the close
+    callback registered in `_register_close_listener`. That callback fires when
+    the *connection* closes, which can be long after the entry went — so this
+    resolves without the loaded check and answers `{}` rather than raising out
+    of a close callback.
     """
-    bucket = hass.data.setdefault(DOMAIN, {})
-    subs = bucket.get("subscriptions")
-    if subs is None:
-        subs = {}
-        bucket["subscriptions"] = subs
-    return cast("dict[websocket_api.ActiveConnection, dict[int, _Subscription]]", subs)
+
+    runtime = find_runtime(hass)
+    if runtime is None:
+        return {}
+    return cast(
+        "dict[websocket_api.ActiveConnection, dict[int, Subscription]]", runtime.subscriptions
+    )
 
 
 def _cleanup_subscriptions_for_conn(hass: HomeAssistant, conn: object) -> None:
@@ -658,7 +654,7 @@ def _payload_inspection_is_overdue(item: dict[str, Any]) -> bool:
     return date < today_utc_date()
 
 
-def _item_matches_filter(item: dict[str, Any], sub: _Subscription) -> bool:
+def _item_matches_filter(item: dict[str, Any], sub: Subscription) -> bool:
     if sub.get("inspection_overdue_only") and not _payload_inspection_is_overdue(item):
         return False
     # Read the area off the payload rather than resolving it from the repository:
@@ -680,7 +676,7 @@ def _item_matches_filter(item: dict[str, Any], sub: _Subscription) -> bool:
     return item.get("location_id") in loc_filters
 
 
-def _location_matches_filter(location: dict[str, Any], sub: _Subscription) -> bool:
+def _location_matches_filter(location: dict[str, Any], sub: Subscription) -> bool:
     loc_filters = _subscription_location_ids(sub)
     if not loc_filters:
         return True
@@ -867,8 +863,8 @@ async def ws_ping(
 
 
 def _schema_version_from_hass(hass: HomeAssistant) -> int:
-    bucket = hass.data.get(DOMAIN) or {}
-    ver = getattr(bucket.get("store"), "schema_version", None)
+    runtime = find_runtime(hass)
+    ver = getattr(runtime.store, "schema_version", None) if runtime is not None else None
     return ver if isinstance(ver, int) else int(CURRENT_SCHEMA_VERSION)
 
 
@@ -899,9 +895,9 @@ async def ws_config(
     reported so the picker can refuse an oversized file before it is sent, never
     so the backend can trust that it did.
     """
-    bucket = hass.data.get(DOMAIN) or {}
-    title = bucket.get("card_title")
-    pills = bucket.get("quick_filters")
+    runtime = loaded_runtime(hass)
+    title = runtime.card_title
+    pills = runtime.quick_filters
     result = {
         "card_title": title if isinstance(title, str) and title else DEFAULT_CARD_TITLE,
         # `null` is a value here, not an omission: it says the integration has
@@ -1005,7 +1001,7 @@ async def ws_subscribe(
     topic = msg.get("topic")
     if topic not in {"items", "locations", "stats", "statuses"}:
         raise ValidationError("topic must be one of: items, locations, stats, statuses")
-    sub: _Subscription = {
+    sub: Subscription = {
         "topic": topic,
     }
     if "location_id" in msg:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ module = [
   "haventory.health",
   "haventory.models",
   "haventory.repository",
+  "haventory.runtime",
   "haventory.serialization",
   "haventory.storage",
   "haventory.ws",

--- a/stubs/homeassistant/config_entries.pyi
+++ b/stubs/homeassistant/config_entries.pyi
@@ -16,8 +16,13 @@ class ConfigEntryState(Enum):
     SETUP_IN_PROGRESS = "setup_in_progress"
     UNLOAD_IN_PROGRESS = "unload_in_progress"
 
-class ConfigEntry:
+class ConfigEntry[DataT = Any]:
     entry_id: str
+    domain: str
+    state: ConfigEntryState
+    # Real HA deletes the attribute on unload rather than setting it to None, so
+    # every read goes through `getattr(entry, "runtime_data", None)`.
+    runtime_data: DataT
     options: Mapping[str, Any]
     def add_update_listener(
         self,

--- a/stubs/homeassistant/core.pyi
+++ b/stubs/homeassistant/core.pyi
@@ -16,8 +16,18 @@ class SupportsResponse(StrEnum):
     OPTIONAL = "optional"
     ONLY = "only"
 
+class ConfigEntries:
+    def async_entries(
+        self,
+        domain: str | None = ...,
+        include_ignore: bool = ...,
+        include_disabled: bool = ...,
+    ) -> list[Any]: ...
+    def __getattr__(self, name: str) -> Any: ...
+
 class HomeAssistant:
     data: dict[str, Any]
+    config_entries: ConfigEntries
     def async_create_background_task[R](
         self,
         target: Coroutine[Any, Any, R],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ import sys
 import tempfile
 import types
 from collections.abc import Mapping
-from enum import StrEnum
+from enum import Enum, StrEnum
 from pathlib import Path
 
 import voluptuous as vol
@@ -189,6 +189,39 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def async_remove(self, entity_id: str) -> None:
             self._states.pop(entity_id, None)
 
+    class _ConfigEntries:
+        """Stand in for HA's config-entry registry, for the one lookup we do.
+
+        Only `async_entries(domain)` — which is all `runtime.find_entry` calls,
+        and which real HA answers including disabled and ignored entries.
+        """
+
+        def __init__(self) -> None:
+            self._entries: list = []
+            self.updates: list[dict] = []
+
+        def async_entries(self, domain=None):
+            if domain is None:
+                return list(self._entries)
+            return [e for e in self._entries if getattr(e, "domain", None) == domain]
+
+        def add(self, entry) -> None:
+            # Idempotent: single-instance means a reload sets the *same* entry
+            # up again, and real HA keeps one registration for it.
+            if entry not in self._entries:
+                self._entries.append(entry)
+
+        def async_update_entry(self, entry, *, options=None, **_kwargs) -> None:
+            """Write options back, as setup does when it spends the repair opt-in."""
+
+            if options is not None:
+                entry.options = dict(options)
+                self.updates.append(dict(options))
+
+        def remove(self, entry) -> None:
+            if entry in self._entries:
+                self._entries.remove(entry)
+
     class HomeAssistant:  # type: ignore[override]
         def __init__(self) -> None:
             self.data = {}
@@ -201,6 +234,10 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             self.is_running = True
             self.dispatcher_sends: list[tuple[str, tuple]] = []
             self.dispatcher_connects: list[tuple[str, object]] = []
+            # Real HA holds an entry's runtime on the entry, and every read
+            # resolves it through here. A test that wants a loaded HAventory
+            # calls `install_runtime(hass)`, which registers one.
+            self.config_entries = _ConfigEntries()
 
         def async_create_background_task(self, target, name, eager_start=True):
             """Stand in for HA's tracked-task helper; the real one also cancels on shutdown."""
@@ -262,9 +299,36 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
     # homeassistant.config_entries
     ha_config_entries = types.ModuleType("homeassistant.config_entries")
 
+    class ConfigEntryState(Enum):  # type: ignore[override]
+        LOADED = "loaded"
+        SETUP_ERROR = "setup_error"
+        MIGRATION_ERROR = "migration_error"
+        SETUP_RETRY = "setup_retry"
+        NOT_LOADED = "not_loaded"
+        FAILED_UNLOAD = "failed_unload"
+        SETUP_IN_PROGRESS = "setup_in_progress"
+        UNLOAD_IN_PROGRESS = "unload_in_progress"
+
     class ConfigEntry:  # type: ignore[override]
-        def __init__(self, *, options: dict | None = None) -> None:
+        # Real HA's ConfigEntry is generic in its runtime type, and
+        # `runtime.HAventoryConfigEntry` subscripts it. The alias is a PEP 695
+        # `type` statement, so it is never evaluated at import — this keeps the
+        # mistake impossible rather than merely unhit.
+        def __class_getitem__(cls, _item):
+            return cls
+
+        def __init__(
+            self,
+            *,
+            options: dict | None = None,
+            entry_id: str = "haventory-test-entry",
+            domain: str = "haventory",
+            state=None,
+        ) -> None:
             self.options: dict = dict(options or {})
+            self.entry_id = entry_id
+            self.domain = domain
+            self.state = state if state is not None else ConfigEntryState.LOADED
             self._update_listeners: list = []
             self._on_unload: list = []
 
@@ -324,6 +388,7 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             }
 
     ha_config_entries.ConfigEntry = ConfigEntry
+    ha_config_entries.ConfigEntryState = ConfigEntryState
     ha_config_entries.ConfigFlow = ConfigFlow
     ha_config_entries.OptionsFlow = OptionsFlow
     sys.modules["homeassistant.config_entries"] = ha_config_entries

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -22,6 +22,7 @@ import pytest
 from aiohttp import FormData
 from custom_components.haventory import media
 from custom_components.haventory.const import DOMAIN, MEDIA_NAME_TOKEN_PARAM, MEDIA_SUBDIR
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -304,7 +305,7 @@ async def test_a_non_image_is_refused_and_leaves_nothing_behind(
 
     assert refused["success"] is False
     assert refused["error"]["code"] == "validation_error"
-    assert hass.data[DOMAIN]["repository"].get_item(item["id"]).attachments == []
+    assert find_runtime(hass).repository.get_item(item["id"]).attachments == []
     # Refused bytes are torn down on the same terms as accepted ones: off the
     # loop, and gone by the time the caller is told no.
     assert len(upload_teardowns) == 1
@@ -393,7 +394,7 @@ async def test_a_v5_store_boots_to_v6_with_both_backfills(
     assert persisted["items"][item_id]["attachments"] == []
     assert set(persisted["statuses"]) == {"lent_out", "ok", "missing", "needs_repair"}
     # The definition loaded before the item loop, so the slug was not coerced.
-    assert hass.data[DOMAIN]["repository"].get_item(item_id).status == "lent_out"
+    assert find_runtime(hass).repository.get_item(item_id).status == "lent_out"
 
     ws = await hass_ws_client(hass)
     await ws.send_json({"id": 1, "type": "haventory/config"})
@@ -555,4 +556,4 @@ async def test_a_pdf_is_refused_as_a_picture(
 
     assert refused["success"] is False
     assert refused["error"]["code"] == "validation_error"
-    assert hass.data[DOMAIN]["repository"].get_item(item["id"]).attachments == []
+    assert find_runtime(hass).repository.get_item(item["id"]).attachments == []

--- a/tests/integration/test_config_entry.py
+++ b/tests/integration/test_config_entry.py
@@ -23,6 +23,7 @@ from custom_components.haventory.const import (
     DOMAIN,
 )
 from custom_components.haventory.repository import Repository
+from custom_components.haventory.runtime import find_runtime
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
@@ -55,15 +56,19 @@ async def test_config_entry_setup_and_unload(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    # Setup wired the runtime data structures into hass.data.
-    bucket = hass.data[DOMAIN]
-    assert "store" in bucket
-    assert isinstance(bucket["repository"], Repository)
+    # Setup handed the runtime to Home Assistant, on the entry.
+    assert isinstance(entry.runtime_data.repository, Repository)
+    assert entry.runtime_data.store is not None
+    assert find_runtime(hass) is entry.runtime_data
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
+    # And took it back: Home Assistant *deletes* the attribute, which is the one
+    # thing only a real core can be asked to prove.
+    assert not hasattr(entry, "runtime_data")
+    assert find_runtime(hass) is None
     # Ephemeral registration flags are cleared on unload.
     assert hass.data[DOMAIN].get("ws_registered") is None
 
@@ -94,7 +99,7 @@ async def test_unloaded_entry_leaves_the_ws_api_refusing(
         assert refused["success"] is False, refused
         assert refused["error"]["code"] == "storage_error", refused
 
-    assert hass.data[DOMAIN].get("repository") is None
+    assert find_runtime(hass) is None
 
     # The second half of a reload puts it all back, inventory included.
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -219,7 +224,7 @@ async def test_removed_entry_leaves_the_ws_api_refusing(
     assert created["success"] is False, created
     assert created["error"]["code"] == "storage_error", created
 
-    assert hass.data[DOMAIN].get("repository") is None
+    assert find_runtime(hass) is None
 
 
 async def test_re_adding_a_removed_entry_restores_the_inventory(

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from custom_components.haventory.const import DOMAIN, EVENT_ITEM_CHANGED, EVENT_LOW_STOCK
+from custom_components.haventory.runtime import find_runtime
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry, async_capture_events
@@ -171,7 +172,7 @@ async def test_a_restart_re_announces_nothing(hass: HomeAssistant, hass_storage)
     await hass.async_block_till_done()
 
     assert captured == []
-    assert hass.data[DOMAIN]["repository"].low_stock_item_ids
+    assert find_runtime(hass).repository.low_stock_item_ids
 
 
 async def test_a_status_reassignment_reaches_the_bus_once_per_item(

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -8,6 +8,7 @@ not the offline in-memory stub.
 from __future__ import annotations
 
 from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import (
     CURRENT_SCHEMA_VERSION,
     STORAGE_KEY,
@@ -27,7 +28,7 @@ async def test_store_write_and_reload_roundtrip(hass: HomeAssistant, hass_storag
     await hass.async_block_till_done()
 
     quantity = 7
-    repo = hass.data[DOMAIN]["repository"]
+    repo = find_runtime(hass).repository
     created = repo.create_item({"name": "Flashlight", "quantity": quantity})
 
     # Persist synchronously through the real HA Store backend.
@@ -45,3 +46,55 @@ async def test_store_write_and_reload_roundtrip(hass: HomeAssistant, hass_storag
     reloaded_item = reloaded["items"][str(created.id)]
     assert reloaded_item["name"] == "Flashlight"
     assert reloaded_item["quantity"] == quantity
+
+
+async def test_the_unload_flush_reaches_the_store_it_is_giving_up(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The last write lands, through the state transition that could have eaten it.
+
+    Home Assistant marks the entry `UNLOAD_IN_PROGRESS` before calling
+    `async_unload_entry` and deletes `runtime_data` only after it returns, so the
+    teardown flush runs against an entry that is no longer `LOADED`. Only a real
+    core sequences it that way; the offline suite can stage the state but not
+    order it around HA's own call.
+    """
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Mutate the repository directly, so nothing has persisted it yet.
+    find_runtime(hass).repository.create_item({"name": "Written on the way out"})
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hasattr(entry, "runtime_data")
+    stored = hass_storage[STORAGE_KEY]["data"]
+    assert [item["name"] for item in stored["items"].values()] == ["Written on the way out"]
+
+
+async def test_setup_after_unload_reads_back_what_the_flush_wrote(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The reload loop end to end: a fresh runtime holds the same inventory."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    first_runtime = find_runtime(hass)
+    first_runtime.repository.create_item({"name": "Across the reload"})
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    second_runtime = find_runtime(hass)
+    assert second_runtime is not first_runtime
+    names = [item.name for item in second_runtime.repository.list_items()["items"]]
+    assert names == ["Across the reload"]

--- a/tests/integration/test_reminders.py
+++ b/tests/integration/test_reminders.py
@@ -12,6 +12,7 @@ import uuid
 from datetime import timedelta
 
 from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -82,7 +83,7 @@ async def test_a_v7_store_boots_to_the_current_version_with_the_fields_backfille
         assert persisted["items"][item_id]["reminder_interval"] is None
 
     # Nothing else moved: the upgrade adds nulls and takes nothing away.
-    repo = hass.data[DOMAIN]["repository"]
+    repo = find_runtime(hass).repository
     assert repo.get_item(PLAIN_ITEM_ID).name == "Hammer"
     assert repo.get_item(PLAIN_ITEM_ID).quantity == _HAMMER_QUANTITY
     assert repo.get_item(REMINDER_ITEM_ID).inspection_date == "2027-01-01"
@@ -115,7 +116,7 @@ async def test_a_reminder_set_over_websocket_survives_a_reload(
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
 
-    reloaded = hass.data[DOMAIN]["repository"].get_item(item_id)
+    reloaded = find_runtime(hass).repository.get_item(item_id)
     assert reloaded.reminder_date == "2027-03-01"
     assert reloaded.reminder_interval.unit == "months"
     assert reloaded.reminder_interval.count == _EVERY_THREE_MONTHS
@@ -285,7 +286,7 @@ async def test_a_v8_store_gains_an_anchor_for_every_reminder_it_holds(
     assert persisted["schema_version"] == CURRENT_SCHEMA_VERSION
     assert persisted["items"][REMINDER_ITEM_ID]["reminder_anchor"] == "2026-09-30"
     assert persisted["items"][PLAIN_ITEM_ID]["reminder_anchor"] is None
-    assert hass.data[DOMAIN]["repository"].get_item(REMINDER_ITEM_ID).reminder_anchor == (
+    assert find_runtime(hass).repository.get_item(REMINDER_ITEM_ID).reminder_anchor == (
         "2026-09-30"
     )
 
@@ -329,7 +330,7 @@ async def test_a_bumped_month_end_series_keeps_its_day_across_a_reload(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    reloaded = hass.data[DOMAIN]["repository"].get_item(item_id)
+    reloaded = find_runtime(hass).repository.get_item(item_id)
     assert reloaded.reminder_anchor == "2026-08-31"
     # And the calendar draws the series the anchor describes, not the bump's date.
     events = await hass.services.async_call(

--- a/tests/integration/test_repairs.py
+++ b/tests/integration/test_repairs.py
@@ -17,6 +17,7 @@ from custom_components.haventory.const import (
     ISSUE_CORRUPT_STORE,
     ISSUE_SCHEMA_DOWNGRADE,
 )
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.components.repairs import repairs_flow_manager
 from homeassistant.config_entries import ConfigEntryState
@@ -111,7 +112,7 @@ async def test_a_corrupt_row_offers_a_fix_that_backs_up_reloads_and_clears(
     assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
 
     # Loaded with the readable remainder, and the opt-in spent rather than kept.
-    repo = hass.data[DOMAIN]["repository"]
+    repo = find_runtime(hass).repository
     assert repo.get_counts()["items_total"] == 1
     assert repo.get_item(READABLE_ITEM_ID).name == "Hammer"
     assert CONF_ALLOW_LOSSY_LOAD not in entry.options
@@ -174,7 +175,7 @@ async def test_the_repair_survives_a_restart_with_no_mutation_in_between(
 
     assert entry.state is ConfigEntryState.LOADED
     assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
-    assert hass.data[DOMAIN]["repository"].get_counts()["items_total"] == 1
+    assert find_runtime(hass).repository.get_counts()["items_total"] == 1
 
 
 async def test_a_clean_load_spends_an_opt_in_left_on_the_entry(
@@ -253,7 +254,7 @@ async def test_a_row_with_no_name_reaches_the_repairs_card_and_its_fix(
     assert entry.state is ConfigEntryState.LOADED
     assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
 
-    repo = hass.data[DOMAIN]["repository"]
+    repo = find_runtime(hass).repository
     assert repo.get_counts()["items_total"] == 1
     assert repo.get_item(READABLE_ITEM_ID).name == "Hammer"
     # The dropped row survives in the copy, with its name still null — a backup
@@ -287,4 +288,4 @@ async def test_a_stored_name_over_the_cap_is_not_corruption(
 
     assert entry.state is ConfigEntryState.LOADED
     assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_CORRUPT_STORE) is None
-    assert hass.data[DOMAIN]["repository"].get_item(READABLE_ITEM_ID).name == "L" * 400
+    assert find_runtime(hass).repository.get_item(READABLE_ITEM_ID).name == "L" * 400

--- a/tests/integration/test_schema_migration.py
+++ b/tests/integration/test_schema_migration.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import uuid
 
 from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -51,7 +52,7 @@ async def test_v4_store_boots_to_v5_with_status_backfilled(
     assert persisted["items"][FLAGGED_ITEM_ID]["status"] == "needs_repair"
 
     # The running repository serves the backfilled items.
-    repo = hass.data[DOMAIN]["repository"]
+    repo = find_runtime(hass).repository
     assert repo.get_item(ITEM_ID).status == "ok"
     assert repo.get_item(FLAGGED_ITEM_ID).status == "needs_repair"
 

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from custom_components.haventory.const import DOMAIN, SENSOR_DESCRIPTIONS
+from custom_components.haventory.runtime import find_runtime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -171,7 +172,7 @@ async def test_each_sensor_reports_its_count(hass: HomeAssistant, descriptor) ->
     """Every entity reads its own key, so none of them is wired to the wrong one."""
 
     entry = await _setup(hass)
-    repo = hass.data[DOMAIN]["repository"]
+    repo = find_runtime(hass).repository
 
     entity_id = _entity_id_for(hass, entry, descriptor.key)
 

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -18,6 +18,7 @@ import voluptuous as vol
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import NotFoundError, StorageError, ValidationError
 from custom_components.haventory.repository import Repository
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -31,7 +32,7 @@ async def _setup(hass: HomeAssistant) -> Repository:
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    return hass.data[DOMAIN]["repository"]
+    return find_runtime(hass).repository
 
 
 async def _call(hass: HomeAssistant, service: str, data: dict) -> None:

--- a/tests/integration/test_todo_bridge.py
+++ b/tests/integration/test_todo_bridge.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import pytest
 from custom_components.haventory import todo_bridge
 from custom_components.haventory.const import CONF_TODO_ENTITY_ID, DOMAIN
+from custom_components.haventory.runtime import find_runtime
 from homeassistant.components.todo import (
     TodoItem,
     TodoItemStatus,
@@ -149,7 +150,7 @@ async def _create_low_item(hass: HomeAssistant, *, name: str = "Peanut butter") 
         blocking=True,
     )
     await hass.async_block_till_done()
-    items = hass.data[DOMAIN]["repository"]._debug_get_internal_indexes()["items_by_id"]
+    items = find_runtime(hass).repository._debug_get_internal_indexes()["items_by_id"]
     return next(item_id for item_id, item in items.items() if item.name == name)
 
 
@@ -240,9 +241,9 @@ async def test_a_list_that_is_not_there_does_not_fail_the_mutation(
     await _setup_haventory(hass, entity_id="todo.does_not_exist")
     item_id = await _create_low_item(hass)
 
-    assert hass.data[DOMAIN]["repository"].get_item(item_id).quantity == LOW_QUANTITY
+    assert find_runtime(hass).repository.get_item(item_id).quantity == LOW_QUANTITY
     assert todo_list.summaries == []
-    assert hass.data[DOMAIN][todo_bridge._LINKS_KEY] == {}
+    assert find_runtime(hass).todo.links == {}
 
 
 async def test_unloading_the_entry_stops_the_bridge_listening(
@@ -261,7 +262,8 @@ async def test_unloading_the_entry_stops_the_bridge_listening(
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert todo_bridge._LINKS_KEY not in hass.data[DOMAIN]
+    # The link map went with the runtime Home Assistant took back.
+    assert find_runtime(hass) is None
     # The list keeps what it had: an unloaded entry gives up its own runtime,
     # not the household's shopping list.
     assert todo_list.summaries == [f"Peanut butter {TIMES}2"]

--- a/tests/runtime_helpers.py
+++ b/tests/runtime_helpers.py
@@ -1,0 +1,154 @@
+"""One way for an offline test to say "an HAventory entry is loaded".
+
+Home Assistant holds an integration's runtime on the config entry, and every
+module in `custom_components/haventory` resolves it through
+`hass.config_entries` (see `haventory/runtime.py`). So a test that wants a
+working HAventory registers an entry with a runtime attached, rather than
+writing keys into `hass.data[DOMAIN]` — which is neither where the code looks
+nor a shape real Home Assistant has.
+
+* :func:`install_runtime` builds the runtime, attaches it to a stub entry and
+  registers that entry. Defaults are an empty repository and a real
+  `DomainStore`, which is what almost every test wants.
+* ``state=`` is what makes the refusals testable: an entry that is not `LOADED`
+  is exactly what a WebSocket command or a `haventory.*` service meets after an
+  unload, a disable or a removal, and `loaded_runtime` refuses on it.
+* :func:`unload_runtime` takes the runtime back the way Home Assistant does —
+  by **deleting** the attribute, not setting it to None, which is what every
+  ``getattr(entry, "runtime_data", None)`` in the integration is written
+  against.
+* :func:`runtime_of` and :func:`repo_of` are the read side, for a test that
+  asserts on what setup built.
+
+The stubs these lean on are installed by ``tests/conftest.py`` at import time,
+so importing Home Assistant here is safe.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.haventory import (
+    async_remove_entry,
+    async_setup,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.runtime import HAventoryRuntime, find_runtime
+from custom_components.haventory.storage import DomainStore
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+
+def install_runtime(  # noqa: PLR0913 - one keyword per runtime field, all optional
+    hass: HomeAssistant,
+    *,
+    repository: Repository | None = None,
+    store: DomainStore | None = None,
+    rate_limiter: RateLimiter | None = None,
+    card_title: str = "HAventory",
+    quick_filters: list[str] | None = None,
+    options: dict[str, Any] | None = None,
+    state: Any = None,
+    entry: Any = None,
+) -> HAventoryRuntime:
+    """Register one HAventory entry carrying a runtime, and return the runtime."""
+
+    runtime = HAventoryRuntime(
+        store=store if store is not None else DomainStore(hass),
+        repository=repository if repository is not None else Repository(),
+        card_title=card_title,
+        quick_filters=quick_filters,
+        rate_limiter=(
+            rate_limiter
+            if rate_limiter is not None
+            else RateLimiter(RateLimitConfig.from_options(options))
+        ),
+    )
+    if entry is None:
+        entry = ConfigEntry(options=dict(options or {}))
+    entry.state = state if state is not None else ConfigEntryState.LOADED
+    entry.runtime_data = runtime
+    hass.data.setdefault(DOMAIN, {})
+    hass.config_entries.add(entry)
+    return runtime
+
+
+def installed_entry(hass: HomeAssistant) -> Any:
+    """The registered entry, for a test that needs to move its state."""
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert entries, "no HAventory config entry registered; call install_runtime first"
+    return entries[0]
+
+
+def unload_runtime(hass: HomeAssistant) -> None:
+    """Take the runtime back the way Home Assistant does on unload."""
+
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        entry.state = ConfigEntryState.NOT_LOADED
+        if hasattr(entry, "runtime_data"):
+            del entry.runtime_data
+
+
+def runtime_of(hass: HomeAssistant) -> HAventoryRuntime:
+    """The installed runtime, asserted present."""
+
+    runtime = find_runtime(hass)
+    assert runtime is not None, "no HAventory runtime installed"
+    return runtime
+
+
+def repo_of(hass: HomeAssistant) -> Repository:
+    """The installed repository — what `hass.data[DOMAIN]["repository"]` used to be."""
+
+    return runtime_of(hass).repository
+
+
+async def setup_entry(hass: HomeAssistant, entry: Any = None, **kwargs: Any) -> Any:
+    """Run the integration's real setup the way Home Assistant runs it.
+
+    Home Assistant registers the entry, moves it through `SETUP_IN_PROGRESS` and
+    marks it `LOADED` only once `async_setup_entry` returns True. The runtime
+    lookup reads both the registry and the state, so a test that calls
+    `async_setup_entry` directly on a loose entry gets an integration that set
+    itself up and cannot find its own runtime.
+    """
+
+    if entry is None:
+        entry = ConfigEntry(**kwargs)
+    entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+    hass.config_entries.add(entry)
+    await async_setup(hass, {})
+    ok = await async_setup_entry(hass, entry)
+    entry.state = ConfigEntryState.LOADED if ok else ConfigEntryState.SETUP_ERROR
+    assert ok is True, "async_setup_entry did not report success"
+    return entry
+
+
+async def unload_entry(hass: HomeAssistant, entry: Any) -> bool:
+    """Unload it the way Home Assistant does, state transitions included.
+
+    `UNLOAD_IN_PROGRESS` **before** the call and `runtime_data` deleted only
+    **after** it — which is what lets teardown flush and lets the loaded check
+    refuse, at the same moment.
+    """
+
+    entry.state = ConfigEntryState.UNLOAD_IN_PROGRESS
+    unloaded = await async_unload_entry(hass, entry)
+    if unloaded and hasattr(entry, "runtime_data"):
+        del entry.runtime_data
+    entry.state = ConfigEntryState.NOT_LOADED if unloaded else ConfigEntryState.FAILED_UNLOAD
+    return unloaded
+
+
+async def remove_entry(hass: HomeAssistant, entry: Any) -> None:
+    """Remove it the way Home Assistant does: unload first, then remove."""
+
+    if getattr(entry, "state", None) is ConfigEntryState.LOADED:
+        await unload_entry(hass, entry)
+    await async_remove_entry(hass, entry)
+    hass.config_entries.remove(entry)

--- a/tests/test_diagnostics_offline.py
+++ b/tests/test_diagnostics_offline.py
@@ -15,11 +15,12 @@ import pytest
 from custom_components.haventory import diagnostics
 from custom_components.haventory.const import CONF_CARD_TITLE, CONF_TODO_ENTITY_ID, DOMAIN
 from custom_components.haventory.models import ITEM_STATUSES, ItemCreate
-from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+
+from runtime_helpers import install_runtime, repo_of
 
 STORED_TITLE = "Haus Hoffmann Vorratskammer"
 STORED_ITEM = "Zdrojova kniha 1987"
@@ -46,12 +47,12 @@ def _loaded_hass() -> tuple[HomeAssistant, ConfigEntry]:
             status=STORED_STATUS,
         )
     )
-    hass.data[DOMAIN] = {
-        "store": DomainStore(hass, key=STORAGE_KEY, version=CURRENT_SCHEMA_VERSION),
-        "repository": repo,
-        "card_title": STORED_TITLE,
-        "rate_limiter": RateLimiter(RateLimitConfig.from_options(None)),
-    }
+    install_runtime(
+        hass,
+        repository=repo,
+        store=DomainStore(hass, key=STORAGE_KEY, version=CURRENT_SCHEMA_VERSION),
+        card_title=STORED_TITLE,
+    )
     entry = ConfigEntry(
         options={CONF_CARD_TITLE: STORED_TITLE, CONF_TODO_ENTITY_ID: STORED_TODO_LIST}
     )
@@ -76,12 +77,20 @@ async def test_the_payload_answers_shape_questions() -> None:
     assert repository["counts"]["items_total"] == 1
     assert repository["counts"]["locations_total"] == 1
     assert repository["health_issues"] == []
-    assert repository["generation"] == hass.data[DOMAIN]["repository"].generation
+    assert repository["generation"] == repo_of(hass).generation
+    # Field names, so a report says what the runtime holds without holding any
+    # of it. `repository` naming the object and never its contents is the point.
     assert payload["runtime"]["data_keys"] == [
         "card_title",
+        "low_stock_ids",
+        "persist_lock",
+        "persist_task",
+        "quick_filters",
         "rate_limiter",
         "repository",
         "store",
+        "subscriptions",
+        "todo",
     ]
     assert payload["runtime"]["rate_limit"] == {
         "enabled": False,

--- a/tests/test_entry_removal_refusal_offline.py
+++ b/tests/test_entry_removal_refusal_offline.py
@@ -20,18 +20,15 @@ import asyncio
 import logging
 
 import pytest
-from custom_components.haventory import (
-    async_remove_entry,
-    async_setup,
-    async_setup_entry,
-)
 from custom_components.haventory import storage as storage_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import remove_entry, repo_of, runtime_of, setup_entry
 from ws_helpers import RecordingConn, ws_send
 
 WS_LOGGER = "custom_components.haventory.ws"
@@ -48,10 +45,7 @@ async def _setup_entry(hass: HomeAssistant) -> ConfigEntry:
     await DomainStore(hass, key=STORAGE_KEY).async_save(
         {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
     )
-    entry = ConfigEntry()
-    await async_setup(hass, {})
-    assert await async_setup_entry(hass, entry) is True
-    return entry
+    return await setup_entry(hass)
 
 
 @pytest.mark.asyncio
@@ -77,7 +71,7 @@ async def test_command_refuses_after_removal(command: str, payload: dict) -> Non
     entry = await _setup_entry(hass)
     assert (await ws_send(hass, 1, command, **payload))["success"] is True
 
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
 
     res = await ws_send(hass, 2, command, **payload)
     assert res["success"] is False, res
@@ -90,7 +84,7 @@ async def test_refusal_is_mapped_not_an_unhandled_crash(caplog) -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
 
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
     res = await ws_send(hass, 1, "haventory/item/create", name="Nope")
@@ -107,7 +101,7 @@ async def test_removal_stops_persistence(monkeypatch) -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    store = hass.data[DOMAIN]["store"]
+    store = runtime_of(hass).store
     saved: list[dict] = []
 
     async def _record(payload: dict) -> None:
@@ -115,7 +109,7 @@ async def test_removal_stops_persistence(monkeypatch) -> None:
 
     monkeypatch.setattr(store, "async_save", _record)
 
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
     saved.clear()  # removal's own flush is test_removal_flushes_before_dropping's business
 
     res = await ws_send(hass, 1, "haventory/item/create", name="Ghost")
@@ -132,7 +126,7 @@ async def test_removal_flushes_before_dropping(monkeypatch) -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    store = hass.data[DOMAIN]["store"]
+    store = runtime_of(hass).store
     saved: list[dict] = []
 
     async def _record(payload: dict) -> None:
@@ -140,11 +134,11 @@ async def test_removal_flushes_before_dropping(monkeypatch) -> None:
 
     monkeypatch.setattr(store, "async_save", _record)
 
-    hass.data[DOMAIN]["repository"].create_item({"name": "Unsaved"})
+    repo_of(hass).create_item({"name": "Unsaved"})
     await storage_mod.async_request_persist(hass)
-    pending = hass.data[DOMAIN]["persist_task"]
+    pending = runtime_of(hass).persist_task
 
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
 
     assert len(saved) == 1, "removal writes the pending state out"
     assert [item["name"] for item in saved[0]["items"].values()] == ["Unsaved"]
@@ -161,14 +155,16 @@ async def test_removal_drops_the_loaded_runtime() -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    bucket = hass.data[DOMAIN]
-    assert bucket["store"] is not None
-    assert bucket["repository"] is not None
+    runtime = runtime_of(hass)
+    assert runtime.store is not None
+    assert runtime.repository is not None
 
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
 
-    for key in ("store", "repository", "rate_limiter", "card_title", "persist_task"):
-        assert hass.data[DOMAIN].get(key) is None, key
+    # Home Assistant deletes the attribute rather than emptying it, so nothing
+    # the entry owned is reachable at all.
+    assert not hasattr(entry, "runtime_data")
+    assert find_runtime(hass) is None
 
 
 @pytest.mark.asyncio
@@ -183,7 +179,7 @@ async def test_removal_keeps_the_static_route_flag() -> None:
     entry = await _setup_entry(hass)
     hass.data[DOMAIN]["static_path_registered"] = True
 
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
 
     assert hass.data[DOMAIN].get("static_path_registered") is True
 
@@ -197,7 +193,7 @@ async def test_removal_drops_live_subscriptions() -> None:
     conn = RecordingConn()
     assert (await ws_send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
     conn.messages.clear()
 
     ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
@@ -215,10 +211,10 @@ async def test_re_adding_the_entry_restores_service() -> None:
     created = await ws_send(hass, 1, "haventory/item/create", name="Screwdriver")
     assert created["success"] is True
 
-    await async_remove_entry(hass, entry)
+    await remove_entry(hass, entry)
     assert (await ws_send(hass, 2, "haventory/item/list"))["success"] is False
 
-    assert await async_setup_entry(hass, ConfigEntry()) is True
+    await setup_entry(hass)
 
     listed = await ws_send(hass, 3, "haventory/item/list")
     assert listed["success"] is True, listed

--- a/tests/test_entry_unload_refusal_offline.py
+++ b/tests/test_entry_unload_refusal_offline.py
@@ -21,21 +21,18 @@ import asyncio
 import logging
 
 import pytest
-from custom_components.haventory import (
-    async_setup,
-    async_setup_entry,
-    async_unload_entry,
-)
 from custom_components.haventory import services as services_mod
 from custom_components.haventory import storage as storage_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import NotLoadedError
 from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
+from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY, DomainStore
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import repo_of, runtime_of, setup_entry, unload_entry
 from ws_helpers import RecordingConn, ws_call, ws_handler, ws_send
 
 
@@ -50,10 +47,7 @@ async def _setup_entry(hass: HomeAssistant) -> ConfigEntry:
     await DomainStore(hass, key=STORAGE_KEY).async_save(
         {"schema_version": CURRENT_SCHEMA_VERSION, "items": {}, "locations": {}}
     )
-    entry = ConfigEntry()
-    await async_setup(hass, {})
-    assert await async_setup_entry(hass, entry) is True
-    return entry
+    return await setup_entry(hass)
 
 
 @pytest.mark.asyncio
@@ -81,7 +75,7 @@ async def test_command_refuses_while_unloaded(command: str, payload: dict) -> No
     handler = ws_handler(hass, command)
     assert (await ws_call(handler, hass, 1, command, **payload))["success"] is True
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
     res = await ws_call(handler, hass, 2, command, **payload)
     assert res["success"] is False, res
@@ -94,14 +88,16 @@ async def test_unload_drops_the_loaded_runtime() -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    bucket = hass.data[DOMAIN]
-    assert bucket["store"] is not None
-    assert bucket["repository"] is not None
+    runtime = runtime_of(hass)
+    assert runtime.store is not None
+    assert runtime.repository is not None
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
-    for key in ("store", "repository", "rate_limiter", "card_title", "persist_task"):
-        assert hass.data[DOMAIN].get(key) is None, key
+    # Home Assistant deletes the attribute rather than emptying it, so nothing
+    # the entry owned is reachable at all.
+    assert not hasattr(entry, "runtime_data")
+    assert find_runtime(hass) is None
 
 
 @pytest.mark.asyncio
@@ -116,7 +112,7 @@ async def test_unload_keeps_the_static_route_flag() -> None:
     entry = await _setup_entry(hass)
     hass.data[DOMAIN]["static_path_registered"] = True
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
     assert hass.data[DOMAIN].get("static_path_registered") is True
 
@@ -129,7 +125,7 @@ async def test_unload_flushes_before_dropping(monkeypatch) -> None:
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    store = hass.data[DOMAIN]["store"]
+    store = runtime_of(hass).store
     saved: list[dict] = []
 
     async def _record(payload: dict) -> None:
@@ -137,11 +133,11 @@ async def test_unload_flushes_before_dropping(monkeypatch) -> None:
 
     monkeypatch.setattr(store, "async_save", _record)
 
-    hass.data[DOMAIN]["repository"].create_item({"name": "Unsaved"})
+    repo_of(hass).create_item({"name": "Unsaved"})
     await storage_mod.async_request_persist(hass)
-    pending = hass.data[DOMAIN]["persist_task"]
+    pending = runtime_of(hass).persist_task
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
     assert len(saved) == 1, "unload writes the pending state out"
     assert [item["name"] for item in saved[0]["items"].values()] == ["Unsaved"]
@@ -160,7 +156,7 @@ async def test_unloaded_service_refuses() -> None:
     entry = await _setup_entry(hass)
     await services_mod.service_item_create(hass, {"name": "Before"})
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
     with pytest.raises(NotLoadedError):
         await services_mod.service_item_create(hass, {"name": "After"})
@@ -189,7 +185,7 @@ async def test_unload_tells_open_subscribers_their_topic_stopped() -> None:
         ]
     conn.messages.clear()
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
     assert [(m["id"], m["event"]["topic"], m["event"]["action"]) for m in conn.messages] == [
         (11, "items", "unavailable"),
@@ -209,7 +205,7 @@ async def test_unload_drops_live_subscriptions() -> None:
     conn = RecordingConn()
     assert (await ws_send(hass, 7, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
     conn.messages.clear()
 
     ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
@@ -238,7 +234,7 @@ async def test_teardown_signal_outranks_the_event_budget() -> None:
             global_events_burst=1.0,
         )
     )
-    hass.data[DOMAIN]["rate_limiter"] = limiter
+    runtime_of(hass).rate_limiter = limiter
     conn = RecordingConn()
     assert (await ws_send(hass, 5, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
@@ -248,7 +244,7 @@ async def test_teardown_signal_outranks_the_event_budget() -> None:
     ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
     assert conn.messages == []
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
     assert [m["event"]["action"] for m in conn.messages] == ["unavailable"]
 
@@ -268,10 +264,10 @@ async def test_setup_after_unload_serves_again() -> None:
     assert created["success"] is True
     handler = ws_handler(hass, "haventory/item/list")
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
     assert (await ws_call(handler, hass, 2, "haventory/item/list"))["success"] is False
 
-    assert await async_setup_entry(hass, ConfigEntry()) is True
+    await setup_entry(hass, entry)
 
     listed = await ws_call(handler, hass, 3, "haventory/item/list")
     assert listed["success"] is True, listed
@@ -284,7 +280,7 @@ async def test_a_reload_writes_nothing_while_it_is_refusing(monkeypatch) -> None
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
-    store = hass.data[DOMAIN]["store"]
+    store = runtime_of(hass).store
     saved: list[dict] = []
 
     async def _record(payload: dict) -> None:
@@ -293,7 +289,7 @@ async def test_a_reload_writes_nothing_while_it_is_refusing(monkeypatch) -> None
     monkeypatch.setattr(store, "async_save", _record)
     handler = ws_handler(hass, "haventory/item/create")
 
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
     saved.clear()  # unload's own flush is test_unload_flushes_before_dropping's business
 
     res = await ws_call(handler, hass, 1, "haventory/item/create", name="Ghost")
@@ -301,7 +297,7 @@ async def test_a_reload_writes_nothing_while_it_is_refusing(monkeypatch) -> None
     assert res["success"] is False
     assert saved == []
 
-    assert await async_setup_entry(hass, ConfigEntry()) is True
+    await setup_entry(hass, entry)
     listed = await ws_send(hass, 2, "haventory/item/list")
     assert [item["name"] for item in listed["result"]["items"]] == []
 
@@ -313,7 +309,7 @@ async def test_refusal_is_mapped_not_an_unhandled_crash(caplog) -> None:
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
     handler = ws_handler(hass, "haventory/item/create")
-    await async_unload_entry(hass, entry)
+    await unload_entry(hass, entry)
 
     caplog.set_level(logging.DEBUG, logger="custom_components.haventory.ws")
     res = await ws_call(handler, hass, 1, "haventory/item/create", name="Nope")

--- a/tests/test_events_offline.py
+++ b/tests/test_events_offline.py
@@ -15,18 +15,16 @@ import pytest
 from custom_components.haventory import events as events_mod
 from custom_components.haventory import services as services_mod
 from custom_components.haventory.const import (
-    DATA_LOW_STOCK_SNAPSHOT,
-    DOMAIN,
     EVENT_ITEM_CHANGED,
     EVENT_LOW_STOCK,
     SIGNAL_INVENTORY_CHANGED,
 )
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.serialization import serialize_item
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, installed_entry, repo_of, unload_runtime
 from ws_helpers import ws_send
 
 LOW_THRESHOLD = 3
@@ -37,7 +35,7 @@ _AFTER_A_REASSIGNMENT = 2
 def _hass() -> tuple[HomeAssistant, Repository]:
     hass = HomeAssistant()
     repo = Repository()
-    hass.data[DOMAIN] = {"repository": repo}
+    install_runtime(hass, repository=repo)
     events_mod.seed_low_stock_snapshot(hass)
     return hass, repo
 
@@ -57,7 +55,7 @@ async def test_every_websocket_item_mutation_reaches_the_bus() -> None:
     """
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
     ws_setup(hass)
 
@@ -189,9 +187,9 @@ def test_the_seeded_snapshot_keeps_a_restart_quiet() -> None:
         {"name": "Batteries", "quantity": 1, "low_stock_threshold": LOW_THRESHOLD}
     )
     # The entry sets up against a store that already holds a low item.
-    hass.data[DOMAIN] = {"repository": repo}
+    runtime = install_runtime(hass, repository=repo)
     events_mod.seed_low_stock_snapshot(hass)
-    assert hass.data[DOMAIN][DATA_LOW_STOCK_SNAPSHOT] == frozenset({str(item.id)})
+    assert runtime.low_stock_ids == frozenset({str(item.id)})
 
     unrelated = repo.create_item({"name": "Rope", "quantity": 5})  # type: ignore[arg-type]
     events_mod.notify_mutation(hass, action="created", item=serialize_item(hass, unrelated))
@@ -205,12 +203,12 @@ def test_an_emptied_bucket_is_a_no_op() -> None:
     hass, repo = _hass()
     _item, serialized = _create(repo, hass, name="Widget")
 
-    hass.data.pop(DOMAIN)
+    unload_runtime(hass)
     events_mod.notify_mutation(hass, action="created", item=serialized)
     assert hass.bus.fired == []
 
-    # A bucket that survived but lost its repository is the same story.
-    hass.data[DOMAIN] = {}
+    # An entry that survived the unload but has no runtime is the same story.
+    hass.config_entries.remove(installed_entry(hass))
     events_mod.notify_mutation(hass, action="created", item=serialized)
     assert hass.bus.events_of(EVENT_LOW_STOCK) == []
 
@@ -257,10 +255,10 @@ async def test_deleting_a_status_with_reassign_to_announces_every_item_it_rewrot
     """
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
     ws_setup(hass)
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     moved = [repo.create_item({"name": f"Item {n}", "status": "missing"}) for n in range(3)]
     repo.create_item({"name": "Untouched"})
     hass.bus.fired.clear()
@@ -299,10 +297,10 @@ async def test_renaming_a_location_repaints_without_announcing_an_item_change() 
     """
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
     ws_setup(hass)
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     garage = repo.create_location(name="Garage")
     repo.create_item({"name": "Ladder", "location_id": str(garage.id)})
     hass.bus.fired.clear()
@@ -322,10 +320,10 @@ async def test_a_location_save_that_changes_no_path_repaints_nothing() -> None:
     """The control: a re-save with the same name is not a reason to recount."""
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
     ws_setup(hass)
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     garage = repo.create_location(name="Garage")
     hass.dispatcher_sends.clear()
 
@@ -342,10 +340,10 @@ async def test_moving_a_subtree_repaints_the_paths_it_rewrote() -> None:
     """`move_subtree` rewrites every path below the moved node."""
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
     ws_setup(hass)
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     garage = repo.create_location(name="Garage")
     cellar = repo.create_location(name="Cellar")
     shelf = repo.create_location(name="Shelf A", parent_id=str(garage.id))
@@ -369,9 +367,9 @@ async def test_the_location_service_repaints_the_same_way_the_command_does() -> 
     """An automation renaming a location must not leave the calendar behind."""
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     garage = repo.create_location(name="Garage")
     hass.dispatcher_sends.clear()
 
@@ -393,7 +391,7 @@ async def test_creating_and_deleting_a_location_repaints_the_count() -> None:
     """
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
     ws_setup(hass)
     hass.dispatcher_sends.clear()
@@ -416,7 +414,7 @@ async def test_the_location_services_repaint_the_count_too() -> None:
     """The same two mutations through `haventory.location_*`."""
 
     hass = HomeAssistant()
-    hass.data[DOMAIN] = {"repository": Repository(), "store": DomainStore(hass)}
+    install_runtime(hass)
     events_mod.seed_low_stock_snapshot(hass)
     hass.dispatcher_sends.clear()
 

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -22,7 +22,6 @@ from datetime import date
 import pytest
 from custom_components.haventory import import_export as ie
 from custom_components.haventory import media
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import StorageError, ValidationError
 from custom_components.haventory.models import (
     CATEGORY_MAX_LENGTH,
@@ -37,10 +36,11 @@ from custom_components.haventory.models import (
     validate_attachment_meta,
 )
 from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, repo_of, runtime_of
 from ws_helpers import ws_send
 
 # The `_seed` helper always creates exactly this many items and locations.
@@ -50,8 +50,7 @@ SEEDED_LOCATIONS = 2
 
 def _new_hass() -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 
@@ -118,7 +117,7 @@ def test_build_export_document_filtered_includes_ancestor_locations() -> None:
 @pytest.mark.asyncio
 async def test_ws_export_returns_document() -> None:
     hass = _new_hass()
-    _seed(hass.data[DOMAIN]["repository"])
+    _seed(repo_of(hass))
 
     res = await ws_send(hass, 1, "haventory/export")
     assert res["success"] is True, res
@@ -182,7 +181,7 @@ async def test_round_trip_via_ws_execute() -> None:
     """End-to-end round-trip through the export + execute WS commands."""
 
     src = _new_hass()
-    _seed(src.data[DOMAIN]["repository"])
+    _seed(repo_of(src))
     exported = (await ws_send(src, 1, "haventory/export"))["result"]
 
     dst = _new_hass()
@@ -385,7 +384,7 @@ async def test_ws_import_execute_invalid_document_is_validation_error() -> None:
 @pytest.mark.asyncio
 async def test_ws_import_execute_rolls_back_on_persist_failure() -> None:
     hass = _new_hass()
-    repo: Repository = hass.data[DOMAIN]["repository"]
+    repo: Repository = repo_of(hass)
     _seed(repo)
     before_counts = repo.get_counts()
 
@@ -408,7 +407,7 @@ async def test_ws_import_execute_rolls_back_on_persist_failure() -> None:
         async def async_save(self, _payload):
             raise StorageError("disk full")
 
-    hass.data[DOMAIN]["store"] = _FailingStore()
+    runtime_of(hass).store = _FailingStore()
 
     res = await ws_send(hass, 1, "haventory/import/execute", document=doc)
     assert res["success"] is False, res
@@ -595,7 +594,7 @@ async def test_import_preview_reports_references_with_no_file_on_this_install() 
     """A JSON export carries metadata and not bytes, so this is a caveat, not an error."""
 
     hass = _new_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     item = repo.create_item({"name": "Drill"})
     repo.add_attachment(item.id, validate_attachment_meta(_attachment_doc()))
     doc = _doc_from(repo)
@@ -617,7 +616,7 @@ async def test_import_replace_deletes_a_file_whose_metadata_it_overwrote() -> No
     """
 
     hass = _new_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     item = repo.create_item({"name": "Drill"})
     meta = validate_attachment_meta(_attachment_doc())
     repo.add_attachment(item.id, meta)
@@ -641,7 +640,7 @@ async def test_import_merge_keeps_a_file_the_document_does_not_mention() -> None
     """The other side of the same coin: `merge` unions, so nothing is orphaned."""
 
     hass = _new_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     item = repo.create_item({"name": "Drill"})
     meta = validate_attachment_meta(_attachment_doc())
     repo.add_attachment(item.id, meta)
@@ -1039,7 +1038,7 @@ def test_warnings_do_not_reach_import_execute() -> None:
 @pytest.mark.asyncio
 async def test_ws_import_preview_carries_the_warnings() -> None:
     hass = _new_hass()
-    hass.data[DOMAIN]["repository"].create_item({"name": "Hammer"})
+    repo_of(hass).create_item({"name": "Hammer"})
 
     res = await ws_send(
         hass, 1, "haventory/import/preview", document=_envelope(_rebuilt_item_doc("Hammer"))

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -30,6 +30,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers.storage import Store as HAStore
 
+from runtime_helpers import repo_of, runtime_of, setup_entry
+
 
 @pytest.mark.asyncio
 async def test_setup_entry_logs_warning_for_empty_storage(monkeypatch, caplog) -> None:
@@ -46,10 +48,9 @@ async def test_setup_entry_logs_warning_for_empty_storage(monkeypatch, caplog) -
 
     caplog.set_level(logging.WARNING)
 
-    result = await haven_init.async_setup_entry(hass, entry)
+    await setup_entry(hass, entry)
 
-    assert result is True
-    assert isinstance(hass.data[haven_init.DOMAIN]["repository"], Repository)
+    assert isinstance(repo_of(hass), Repository)
     assert any("Storage health" in record.message for record in caplog.records)
     assert any(
         record.levelname == "WARNING" and "Storage health" in record.message
@@ -197,12 +198,12 @@ async def test_setup_entry_publishes_card_title(monkeypatch) -> None:
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
-    assert hass.data[haven_init.DOMAIN]["card_title"] == "Pantry"
+    await setup_entry(hass, entry)
+    assert runtime_of(hass).card_title == "Pantry"
 
     entry.options[CONF_CARD_TITLE] = "Garage"
     await haven_init._async_options_updated(hass, entry)
-    assert hass.data[haven_init.DOMAIN]["card_title"] == "Garage"
+    assert runtime_of(hass).card_title == "Garage"
 
 
 @pytest.mark.asyncio
@@ -217,13 +218,13 @@ async def test_setup_entry_publishes_the_quick_filter_choice(monkeypatch) -> Non
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
+    await setup_entry(hass, entry)
     # Canonical order, not the order the checkboxes were ticked in.
-    assert hass.data[haven_init.DOMAIN]["quick_filters"] == ["total", "low_stock"]
+    assert runtime_of(hass).quick_filters == ["total", "low_stock"]
 
     entry.options[CONF_QUICK_FILTERS] = []
     await haven_init._async_options_updated(hass, entry)
-    assert hass.data[haven_init.DOMAIN]["quick_filters"] == []
+    assert runtime_of(hass).quick_filters == []
 
 
 @pytest.mark.asyncio
@@ -242,8 +243,8 @@ async def test_setup_entry_leaves_the_quick_filter_choice_unset(monkeypatch) -> 
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
-    assert hass.data[haven_init.DOMAIN]["quick_filters"] is None
+    await setup_entry(hass, entry)
+    assert runtime_of(hass).quick_filters is None
 
 
 @pytest.mark.asyncio
@@ -258,8 +259,8 @@ async def test_setup_entry_defaults_card_title_for_older_entries(monkeypatch) ->
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
-    assert hass.data[haven_init.DOMAIN]["card_title"] == DEFAULT_CARD_TITLE
+    await setup_entry(hass, entry)
+    assert runtime_of(hass).card_title == DEFAULT_CARD_TITLE
 
 
 @pytest.mark.asyncio
@@ -313,31 +314,14 @@ async def test_setup_entry_accepts_a_readable_store(monkeypatch) -> None:
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
-    assert isinstance(hass.data[haven_init.DOMAIN]["repository"], Repository)
+    await setup_entry(hass, entry)
+    assert isinstance(repo_of(hass), Repository)
 
 
 def _issues(hass: HomeAssistant) -> dict:
     """What the offline issue-registry stub recorded, keyed as HA keys it."""
 
     return hass.data.get("__issue_registry__") or {}
-
-
-class _ConfigEntries:
-    """The one config-entry API setup calls: writing the options back.
-
-    The offline `HomeAssistant` stub has no registry at all, which is how the
-    other setup tests get away without one — but the lossy-load opt-in is spent
-    through exactly this call, so the test that asserts it is spent has to
-    provide it.
-    """
-
-    def __init__(self) -> None:
-        self.updates: list[dict] = []
-
-    def async_update_entry(self, entry: ConfigEntry, *, options: dict) -> None:
-        entry.options = dict(options)
-        self.updates.append(dict(options))
 
 
 def _corrupt_payload() -> dict:
@@ -429,7 +413,7 @@ async def test_a_store_that_loads_clears_every_issue(monkeypatch) -> None:
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
+    await setup_entry(hass, entry)
     assert _issues(hass) == {}
 
 
@@ -438,7 +422,6 @@ async def test_the_repair_option_loads_the_readable_remainder(monkeypatch, caplo
     """What the fix flow buys: the same store, loaded, minus what could not be read."""
 
     hass = HomeAssistant()
-    hass.config_entries = _ConfigEntries()
     entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True})
     payload = _corrupt_payload()
     payload["items"]["11111111-1111-4111-8111-111111111111"] = {
@@ -453,9 +436,9 @@ async def test_the_repair_option_loads_the_readable_remainder(monkeypatch, caplo
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
     caplog.set_level(logging.WARNING)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
+    await setup_entry(hass, entry)
 
-    repository = hass.data[haven_init.DOMAIN]["repository"]
+    repository = repo_of(hass)
     assert repository.get_counts()["items_total"] == 1
     assert any("as the repair asked" in record.message for record in caplog.records)
 
@@ -465,7 +448,6 @@ async def test_the_repair_option_is_spent_on_the_boot_it_buys(monkeypatch) -> No
     """Left set, it would silently accept the next corruption too — a standing waiver."""
 
     hass = HomeAssistant()
-    hass.config_entries = _ConfigEntries()
     entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True, CONF_CARD_TITLE: "Pantry"})
 
     async def _fake_load(self):  # type: ignore[no-untyped-def]
@@ -473,7 +455,7 @@ async def test_the_repair_option_is_spent_on_the_boot_it_buys(monkeypatch) -> No
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
+    await setup_entry(hass, entry)
 
     assert CONF_ALLOW_LOSSY_LOAD not in entry.options
     # The rest of the options survive the edit; only the opt-in is taken back.
@@ -491,7 +473,6 @@ async def test_a_clean_load_spends_a_leftover_repair_option(monkeypatch) -> None
     """
 
     hass = HomeAssistant()
-    hass.config_entries = _ConfigEntries()
     entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True, CONF_CARD_TITLE: "Pantry"})
 
     async def _fake_load(self):  # type: ignore[no-untyped-def]
@@ -499,7 +480,7 @@ async def test_a_clean_load_spends_a_leftover_repair_option(monkeypatch) -> None
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
+    await setup_entry(hass, entry)
 
     assert CONF_ALLOW_LOSSY_LOAD not in entry.options
     assert entry.options[CONF_CARD_TITLE] == "Pantry"
@@ -510,7 +491,7 @@ async def test_an_ordinary_boot_does_not_write_the_entry_back(monkeypatch) -> No
     """Nothing to spend means nothing to write: every boot would otherwise touch the entry."""
 
     hass = HomeAssistant()
-    registry = _ConfigEntries()
+    registry = hass.config_entries
     hass.config_entries = registry
     entry = ConfigEntry(options={CONF_CARD_TITLE: "Pantry"})
 
@@ -519,7 +500,7 @@ async def test_an_ordinary_boot_does_not_write_the_entry_back(monkeypatch) -> No
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
+    await setup_entry(hass, entry)
 
     assert registry.updates == []
 
@@ -534,7 +515,6 @@ async def test_a_lossy_load_rewrites_the_store_it_could_not_fully_read(monkeypat
     """
 
     hass = HomeAssistant()
-    hass.config_entries = _ConfigEntries()
     entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True})
     key = "test_init_lossy_load_rewrites"
     monkeypatch.setattr(haven_init, "STORAGE_KEY", key)
@@ -551,7 +531,7 @@ async def test_a_lossy_load_rewrites_the_store_it_could_not_fully_read(monkeypat
     await backup.async_remove()
 
     try:
-        assert await haven_init.async_setup_entry(hass, entry) is True
+        await setup_entry(hass, entry)
 
         written = await raw_store.async_load()
         assert set(written["items"]) == {"11111111-1111-4111-8111-111111111111"}
@@ -571,7 +551,6 @@ async def test_a_lossy_load_that_cannot_be_copied_leaves_the_store_alone(
     """No copy, no rewrite: the rows stay recoverable at the price of one more refusal."""
 
     hass = HomeAssistant()
-    hass.config_entries = _ConfigEntries()
     entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True})
     key = "test_init_lossy_load_no_copy"
     monkeypatch.setattr(haven_init, "STORAGE_KEY", key)
@@ -586,7 +565,7 @@ async def test_a_lossy_load_that_cannot_be_copied_leaves_the_store_alone(
     monkeypatch.setattr(haven_init, "async_backup_store", _no_copy)
     caplog.set_level(logging.ERROR)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
+    await setup_entry(hass, entry)
 
     assert await raw_store.async_load() == payload
     assert any("could not copy it aside" in record.message for record in caplog.records)

--- a/tests/test_integration_bootstrap_offline.py
+++ b/tests/test_integration_bootstrap_offline.py
@@ -2,17 +2,18 @@
 
 Scenarios:
 - async_setup initializes hass.data[DOMAIN] without side effects
-- async_setup_entry creates a Store in hass.data[DOMAIN]["store"]
+- async_setup_entry creates a Store in runtime_of(hass).store
 """
 
 import pytest
-from custom_components.haventory import async_setup, async_setup_entry
+from custom_components.haventory import async_setup
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import repo_of, runtime_of, setup_entry
 from ws_helpers import ws_send
 
 
@@ -33,25 +34,19 @@ async def test_async_setup_initializes_domain_bucket() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_exposes_store_on_domain_bucket() -> None:
-    """async_setup_entry populates hass.data[DOMAIN]["store"]."""
+async def test_async_setup_entry_puts_the_runtime_on_the_entry() -> None:
+    """Setup builds the runtime and hands it to Home Assistant, not to a dict."""
 
-    # Arrange
     hass = HomeAssistant()
 
     class _DummyEntry(ConfigEntry):
         pass
 
-    entry = _DummyEntry()
+    entry = await setup_entry(hass, _DummyEntry())
 
-    # Act
-    result = await async_setup_entry(hass, entry)
-
-    # Assert
-    assert result is True
-    assert DOMAIN in hass.data
-    assert isinstance(hass.data[DOMAIN], dict)
-    assert "store" in hass.data[DOMAIN]
+    assert isinstance(entry.runtime_data.store, DomainStore)
+    assert isinstance(entry.runtime_data.repository, Repository)
+    assert runtime_of(hass) is entry.runtime_data
 
 
 @pytest.mark.asyncio
@@ -69,12 +64,10 @@ async def test_async_setup_entry_loads_repository_from_store_and_ws_reads() -> N
     class _DummyEntry(ConfigEntry):
         pass
 
-    entry = _DummyEntry()
-    ok = await async_setup_entry(hass, entry)
-    assert ok is True
+    await setup_entry(hass, _DummyEntry())
 
     # Repository is hydrated
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     assert repo.get_item(item.id).name == "SeedItem"
 
     # And WS commands are registered and can read the same item

--- a/tests/test_integration_lifecycle_offline.py
+++ b/tests/test_integration_lifecycle_offline.py
@@ -10,10 +10,12 @@ Scenarios:
 from __future__ import annotations
 
 import pytest
-from custom_components.haventory import async_setup, async_setup_entry, async_unload_entry
+from custom_components.haventory import async_setup, async_setup_entry
 from custom_components.haventory.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+
+from runtime_helpers import runtime_of, setup_entry, unload_entry
 
 
 @pytest.mark.asyncio
@@ -31,16 +33,13 @@ async def test_setup_and_setup_entry_idempotent() -> None:
     class _Entry(ConfigEntry):
         pass
 
-    entry = _Entry()
-
-    # First setup entry
-    ok = await async_setup_entry(hass, entry)
-    assert ok is True
+    entry = await setup_entry(hass, _Entry())
     bucket = hass.data[DOMAIN]
-    assert "store" in bucket
-    assert "repository" in bucket
+    assert runtime_of(hass).store is not None
+    assert runtime_of(hass).repository is not None
 
-    # WS/services registration flags set
+    # WS/services registration flags — the bookkeeping that stays in the shared
+    # bucket, because Home Assistant can unregister neither.
     assert bucket.get("ws_registered") is True
     assert bucket.get("services_registered") is True
 
@@ -48,8 +47,7 @@ async def test_setup_and_setup_entry_idempotent() -> None:
     ws_handlers_before = list(hass.data.get("__ws_commands__", []))
 
     # Second setup entry should be effectively idempotent for registration
-    ok2 = await async_setup_entry(hass, entry)
-    assert ok2 is True
+    await setup_entry(hass, entry)
     assert bucket.get("ws_registered") is True
     assert bucket.get("services_registered") is True
     assert list(hass.data.get("__ws_commands__", [])) == ws_handlers_before
@@ -74,7 +72,7 @@ async def test_unload_entry_cleans_flags_and_ws_handlers() -> None:
     ws_registry = hass.data.get("__ws_commands__")
     assert isinstance(ws_registry, list) and len(ws_registry) > 0
 
-    ok = await async_unload_entry(hass, entry)
+    ok = await unload_entry(hass, entry)
     assert ok is True
 
     # Flags cleared

--- a/tests/test_item_input_validation_offline.py
+++ b/tests/test_item_input_validation_offline.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import ValidationError
 from custom_components.haventory.models import (
     CATEGORY_MAX_LENGTH,
@@ -26,10 +25,10 @@ from custom_components.haventory.models import (
     ItemUpdate,
 )
 from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import ws_send
 
 # -----------------------------
@@ -103,9 +102,7 @@ def test_low_stock_threshold_rejects_bool() -> None:
 
 def _make_hass() -> HomeAssistant:
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 

--- a/tests/test_item_status_offline.py
+++ b/tests/test_item_status_offline.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import pytest
 from custom_components.haventory import import_export as ie
 from custom_components.haventory import migrations
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import ValidationError
 from custom_components.haventory.models import (
     DEFAULT_ITEM_STATUS,
@@ -31,6 +30,7 @@ from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store as HAStore
 
+from runtime_helpers import install_runtime
 from ws_helpers import ws_send
 
 # -----------------------------
@@ -260,8 +260,7 @@ async def test_domain_store_migrates_v4_store_on_load() -> None:
 
 def _new_hass() -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 

--- a/tests/test_runtime_offline.py
+++ b/tests/test_runtime_offline.py
@@ -1,0 +1,148 @@
+"""Offline tests for the two runtime lookups, and the paths that need each one.
+
+`loaded_runtime` is the client-facing boundary and refuses unless the entry is
+`LOADED`; `find_runtime` asks only whether a runtime exists. Everything that runs
+*outside* a loaded entry — the teardown flush, the teardown broadcast, a
+subscription callback fired by a connection closing long afterwards — has to go
+through the second, and this file is what pins that apart.
+
+`tests/integration/test_config_entry.py` covers the half only a real core can
+show: that Home Assistant deletes `runtime_data` on unload, and when.
+"""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.haventory import storage as storage_mod
+from custom_components.haventory import ws as ws_mod
+from custom_components.haventory.exceptions import NotLoadedError
+from custom_components.haventory.runtime import find_runtime, loaded_runtime
+from custom_components.haventory.storage import DomainStore
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from runtime_helpers import install_runtime, installed_entry, repo_of, unload_runtime
+from ws_helpers import RecordingConn, ws_send
+
+
+def test_loaded_runtime_answers_for_a_loaded_entry() -> None:
+    hass = HomeAssistant()
+    runtime = install_runtime(hass)
+
+    assert loaded_runtime(hass) is runtime
+    assert find_runtime(hass) is runtime
+
+
+def test_loaded_runtime_refuses_with_no_entry_at_all() -> None:
+    """The removed-integration case: nothing to resolve a runtime through."""
+
+    hass = HomeAssistant()
+
+    assert find_runtime(hass) is None
+    with pytest.raises(NotLoadedError):
+        loaded_runtime(hass)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ConfigEntryState.NOT_LOADED,
+        ConfigEntryState.SETUP_ERROR,
+        ConfigEntryState.SETUP_RETRY,
+        ConfigEntryState.UNLOAD_IN_PROGRESS,
+    ],
+)
+def test_only_loaded_counts_for_a_client(state) -> None:
+    """Every other state refuses, runtime attached or not.
+
+    A disabled entry keeps its object graph reachable, so "is there a runtime"
+    is not the question a command can ask — "is this entry serving" is.
+    """
+
+    hass = HomeAssistant()
+    runtime = install_runtime(hass, state=state)
+
+    with pytest.raises(NotLoadedError):
+        loaded_runtime(hass)
+    # ...and the internal lookup still finds it, which is what teardown needs.
+    assert find_runtime(hass) is runtime
+
+
+@pytest.mark.asyncio
+async def test_the_final_flush_writes_while_the_entry_is_not_loaded() -> None:
+    """The regression this migration was most likely to introduce.
+
+    Home Assistant marks an entry `UNLOAD_IN_PROGRESS` *before* calling
+    `async_unload_entry`, so the teardown flush runs against an entry that is no
+    longer loaded. Routed through the client-facing lookup it would refuse, and
+    whatever was still unsaved would be gone with no error anybody sees.
+    """
+
+    hass = HomeAssistant()
+    saved: list[dict] = []
+
+    class _RecordingStore(DomainStore):
+        async def async_save(self, payload: dict) -> None:  # type: ignore[override]
+            saved.append(payload)
+
+    install_runtime(hass, store=_RecordingStore(hass))
+    repo_of(hass).create_item({"name": "Unsaved"})  # type: ignore[arg-type]
+
+    installed_entry(hass).state = ConfigEntryState.UNLOAD_IN_PROGRESS
+    await storage_mod.async_persist_repo(hass)
+
+    assert [item["name"] for item in saved[-1]["items"].values()] == ["Unsaved"]
+
+
+@pytest.mark.asyncio
+async def test_a_persist_after_the_runtime_is_gone_refuses_rather_than_writing() -> None:
+    """No runtime is a refusal, not a silent write of nothing."""
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    unload_runtime(hass)
+
+    with pytest.raises(NotLoadedError):
+        await storage_mod.async_persist_repo(hass)
+
+
+@pytest.mark.asyncio
+async def test_a_close_callback_after_teardown_is_a_no_op() -> None:
+    """A connection outlives the entry, and its teardown must not raise.
+
+    The callbacks are bound to the connection, so they fire whenever it closes —
+    which can be long after the entry that served the subscription went away.
+    """
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    ws_mod.setup(hass)
+    conn = RecordingConn()
+
+    assert (await ws_send(hass, 1, "haventory/subscribe", conn=conn, topic="items"))["success"]
+    assert ws_mod._subs_bucket(hass)
+
+    unload_runtime(hass)
+
+    # Both callbacks, on a hass with no runtime left to look one up in.
+    ws_mod._drop_subscription(hass, conn, 1)
+    ws_mod._cleanup_subscriptions_for_conn(hass, conn)
+
+    assert ws_mod._subs_bucket(hass) == {}
+
+
+@pytest.mark.asyncio
+async def test_a_broadcast_after_teardown_reaches_nobody_and_raises_nothing() -> None:
+    """The other teardown-adjacent path through the subscription registry."""
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    ws_mod.setup(hass)
+    conn = RecordingConn()
+    assert (await ws_send(hass, 1, "haventory/subscribe", conn=conn, topic="items"))["success"]
+    conn.messages.clear()
+
+    unload_runtime(hass)
+    ws_mod.broadcast_event(hass, topic="items", action="created", payload=None)
+
+    assert conn.events() == []

--- a/tests/test_serialized_shapes_offline.py
+++ b/tests/test_serialized_shapes_offline.py
@@ -26,13 +26,14 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.import_export import build_export_document
 from custom_components.haventory.models import EMPTY_LOCATION_PATH, Item, Location, LocationPath
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.serialization import serialize_item, serialize_location
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
 from homeassistant.core import HomeAssistant
+
+from runtime_helpers import install_runtime
 
 GOLDEN = Path(__file__).resolve().parent / "fixtures" / "stored_payload.json"
 
@@ -83,7 +84,7 @@ def loaded_repository() -> Repository:
 
 def hass_with(repo: Repository) -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    install_runtime(hass, repository=repo)
     return hass
 
 

--- a/tests/test_service_broadcast_offline.py
+++ b/tests/test_service_broadcast_offline.py
@@ -23,13 +23,12 @@ import pytest
 from custom_components.haventory import events as events_mod
 from custom_components.haventory import rate_limit as rate_limit_module
 from custom_components.haventory import services as services_mod
-from custom_components.haventory.const import DOMAIN, EVENT_ITEM_CHANGED
+from custom_components.haventory.const import EVENT_ITEM_CHANGED
 from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import RecordingConn, ws_send
 
 _BULK_ROWS = 3
@@ -37,11 +36,7 @@ _BULK_ROWS = 3
 
 def _hass(limiter: RateLimiter | None = None) -> HomeAssistant:
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["store"] = DomainStore(hass)
-    if limiter is not None:
-        bucket["rate_limiter"] = limiter
+    install_runtime(hass, rate_limiter=limiter)
     ws_setup(hass)
     events_mod.seed_low_stock_snapshot(hass)
     return hass

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -19,7 +19,7 @@ import voluptuous as vol
 import yaml
 from custom_components.haventory import events as events_mod
 from custom_components.haventory import services as services_mod
-from custom_components.haventory.const import DOMAIN, EVENT_ITEM_CHANGED
+from custom_components.haventory.const import EVENT_ITEM_CHANGED
 from custom_components.haventory.exceptions import (
     ConflictError,
     NotFoundError,
@@ -31,14 +31,15 @@ from custom_components.haventory.storage import DomainStore
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.util import dt as dt_util
 
+from runtime_helpers import install_runtime, repo_of, runtime_of
+
 
 @pytest.mark.asyncio
 async def test_item_create_and_update_flow_logs_and_mutates() -> None:
     """Create an item, then update it; ensure repo state changes and no exceptions bubble."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
 
     # Create
     await services_mod.service_item_create(
@@ -50,7 +51,7 @@ async def test_item_create_and_update_flow_logs_and_mutates() -> None:
         },
     )
 
-    repo: Repository = hass.data[DOMAIN]["repository"]
+    repo: Repository = repo_of(hass)
     assert repo.get_counts()["items_total"] == 1
 
     # Update name and quantity
@@ -71,8 +72,8 @@ async def test_item_move_and_quantity_helpers() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
 
     # Create locations and item
     await services_mod.service_location_create(hass, {"name": "Garage"})
@@ -109,9 +110,9 @@ async def test_services_persist_after_mutations(monkeypatch) -> None:
     """Service handlers should call DomainStore.async_save after changes."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
 
     calls = {"count": 0}
 
@@ -128,7 +129,7 @@ async def test_services_persist_after_mutations(monkeypatch) -> None:
     assert calls["count"] >= MIN_PERSISTS_AFTER_CREATE
 
     # Also ensure delete persists
-    repo: Repository = hass.data[DOMAIN]["repository"]
+    repo: Repository = repo_of(hass)
     loc_id = next(iter(repo._debug_get_internal_indexes()["locations_by_id"]))
     await services_mod.service_location_delete(hass, {"location_id": loc_id})
     MIN_PERSISTS_AFTER_DELETE = 3
@@ -156,8 +157,7 @@ async def test_service_registration_and_schema_errors(monkeypatch, caplog) -> No
     hass.services = _Services()  # type: ignore[attr-defined]
 
     # Wire repository and store
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
 
     services_mod.setup(hass)
     # Ensure all expected services are registered
@@ -216,8 +216,8 @@ async def test_repository_exceptions_are_logged(monkeypatch, caplog) -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
 
     # Create one item to operate on
     await services_mod.service_item_create(hass, {"name": "Widget"})
@@ -289,13 +289,12 @@ def test_service_catalog_agrees_across_registration_yaml_and_strings() -> None:
 async def _seeded(hass: HomeAssistant) -> tuple[Repository, str, str]:
     """A repository holding one location and one item inside it."""
 
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     loc = await services_mod.service_location_create(hass, {"name": "Shelf"})
     item = await services_mod.service_item_create(
         hass, {"name": "Widget", "quantity": 5, "location_id": loc["location"]["id"]}
     )
-    return hass.data[DOMAIN]["repository"], item["item"]["id"], loc["location"]["id"]
+    return repo_of(hass), item["item"]["id"], loc["location"]["id"]
 
 
 @pytest.mark.asyncio
@@ -358,8 +357,7 @@ async def test_item_create_response_survives_json_serialization() -> None:
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
 
     response = await services_mod.service_item_create(
         hass,
@@ -441,8 +439,7 @@ async def test_a_failed_service_fires_no_event() -> None:
     """The event follows the durable write, so a rejected call announces nothing."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
 
     with pytest.raises(NotFoundError):
         await services_mod.service_item_update(hass, {"item_id": "nope", "name": "Ghost"})
@@ -459,8 +456,7 @@ async def test_a_failed_persist_answers_nothing(monkeypatch) -> None:
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
 
     async def _persist(_hass):  # type: ignore[no-untyped-def]
         raise StorageError("persist failed")
@@ -508,8 +504,7 @@ async def test_a_reminder_can_be_set_and_cleared_through_item_update() -> None:
 @pytest.mark.asyncio
 async def test_a_reminder_created_with_the_item_is_stored() -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
 
     created = await services_mod.service_item_create(
         hass,

--- a/tests/test_storage_concurrency_offline.py
+++ b/tests/test_storage_concurrency_offline.py
@@ -6,7 +6,7 @@ prevents race conditions, and properly debounces rapid changes.
 
 import asyncio
 import logging
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from custom_components.haventory import storage as storage_mod
@@ -23,22 +23,25 @@ from custom_components.haventory.storage import (
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, runtime_of
 from ws_helpers import ws_send
 
 # Named constants for test assertions
 RAPID_MUTATION_COUNT = 3
 
 
-class _TrackedTaskHass:
+class _TrackedTaskHass(HomeAssistant):
     """hass double that records the background tasks it is handed.
 
     Mirrors ``HomeAssistant.async_create_background_task``'s signature so the
     debounced persist path is driven through the same call it makes against a
-    real core, and keeps every scheduled task addressable for assertions.
+    real core, and keeps every scheduled task addressable for assertions. It
+    subclasses the stub rather than standing alone because the persist path
+    resolves its runtime through `hass.config_entries`.
     """
 
     def __init__(self) -> None:
-        self.data: dict = {}
+        super().__init__()
         self.background_tasks: list[tuple[str, asyncio.Task]] = []
 
     def async_create_background_task(self, target, name, eager_start=True):
@@ -50,8 +53,7 @@ class _TrackedTaskHass:
 @pytest.mark.asyncio
 async def test_persist_lock_prevents_concurrent_saves():
     """Concurrent persist calls are serialized by lock, preventing race conditions."""
-    hass = MagicMock()
-    hass.data = {"haventory": {}}
+    hass = HomeAssistant()
 
     # Create a mock store with artificial delay to simulate slow I/O
     mock_store = AsyncMock(spec=DomainStore)
@@ -67,8 +69,7 @@ async def test_persist_lock_prevents_concurrent_saves():
 
     # Create repository and store
     repo = Repository()
-    hass.data["haventory"]["store"] = mock_store
-    hass.data["haventory"]["repository"] = repo
+    install_runtime(hass, repository=repo, store=mock_store)
 
     # Launch multiple concurrent persist operations
     tasks = [async_persist_repo(hass) for _ in range(3)]
@@ -82,7 +83,6 @@ async def test_persist_lock_prevents_concurrent_saves():
 async def test_debounce_coalesces_rapid_changes():
     """Rapid persist requests are coalesced into a single save operation."""
     hass = _TrackedTaskHass()
-    hass.data = {"haventory": {}}
 
     # Create mock store that counts save calls
     mock_store = AsyncMock(spec=DomainStore)
@@ -95,8 +95,7 @@ async def test_debounce_coalesces_rapid_changes():
 
     # Create repository and store
     repo = Repository()
-    hass.data["haventory"]["store"] = mock_store
-    hass.data["haventory"]["repository"] = repo
+    install_runtime(hass, repository=repo, store=mock_store)
 
     # Request multiple rapid persists
     for _ in range(10):
@@ -114,25 +113,23 @@ async def test_debounce_coalesces_rapid_changes():
 async def test_debounce_cancels_pending_task():
     """New persist request cancels previous pending task."""
     hass = _TrackedTaskHass()
-    hass.data = {"haventory": {}}
 
     mock_store = AsyncMock(spec=DomainStore)
     mock_store.async_save = AsyncMock()
 
     repo = Repository()
-    hass.data["haventory"]["store"] = mock_store
-    hass.data["haventory"]["repository"] = repo
+    install_runtime(hass, repository=repo, store=mock_store)
 
     # Request first persist
     await async_request_persist(hass)
-    first_task = hass.data["haventory"].get("persist_task")
+    first_task = runtime_of(hass).persist_task
     assert first_task is not None
     assert not first_task.done()
 
     # Request second persist before first completes
     await asyncio.sleep(0.1)  # Wait a bit but not full delay
     await async_request_persist(hass)
-    second_task = hass.data["haventory"].get("persist_task")
+    second_task = runtime_of(hass).persist_task
 
     # Give time for cancellation to propagate
     await asyncio.sleep(0.01)
@@ -146,7 +143,6 @@ async def test_debounce_cancels_pending_task():
 async def test_immediate_persist_bypasses_debounce():
     """Immediate persist cancels pending debounced task and saves immediately."""
     hass = _TrackedTaskHass()
-    hass.data = {"haventory": {}}
 
     mock_store = AsyncMock(spec=DomainStore)
     save_times = []
@@ -157,8 +153,7 @@ async def test_immediate_persist_bypasses_debounce():
     mock_store.async_save = record_save
 
     repo = Repository()
-    hass.data["haventory"]["store"] = mock_store
-    hass.data["haventory"]["repository"] = repo
+    install_runtime(hass, repository=repo, store=mock_store)
 
     # Request debounced persist
     start_time = asyncio.get_event_loop().time()
@@ -192,14 +187,14 @@ async def test_debounce_schedules_ha_tracked_background_task(monkeypatch):
     mock_store.async_save = record_save
     repo = Repository()
     repo.create_item(ItemCreate(name="Tracked"))
-    hass.data[DOMAIN] = {"store": mock_store, "repository": repo}
+    install_runtime(hass, repository=repo, store=mock_store)
 
     await async_request_persist(hass)
 
     assert len(hass.background_tasks) == 1
     name, task = hass.background_tasks[0]
     assert DOMAIN in name
-    assert hass.data[DOMAIN]["persist_task"] is task
+    assert runtime_of(hass).persist_task is task
 
     await asyncio.sleep(0.2)
 
@@ -221,7 +216,7 @@ async def test_debounce_coalesces_across_tracked_tasks(monkeypatch):
 
     mock_store = AsyncMock(spec=DomainStore)
     mock_store.async_save = record_save
-    hass.data[DOMAIN] = {"store": mock_store, "repository": Repository()}
+    install_runtime(hass, repository=Repository(), store=mock_store)
 
     for _ in range(RAPID_MUTATION_COUNT):
         await async_request_persist(hass)
@@ -245,8 +240,13 @@ async def test_debounced_tracked_task_reports_failure_without_raising(monkeypatc
     monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
 
     hass = _TrackedTaskHass()
-    # No "store" entry: async_persist_repo raises StorageError.
-    hass.data[DOMAIN] = {"repository": Repository()}
+
+    async def refuse_save(_data):
+        raise OSError("disk went away")
+
+    failing_store = AsyncMock(spec=DomainStore)
+    failing_store.async_save = refuse_save
+    install_runtime(hass, store=failing_store)
 
     await async_request_persist(hass)
     _, task = hass.background_tasks[0]
@@ -282,15 +282,13 @@ async def test_generation_counter_increments_on_modification():
 @pytest.mark.asyncio
 async def test_concurrent_operations_with_persistence():
     """Multiple concurrent operations complete successfully with locking."""
-    hass = MagicMock()
-    hass.data = {"haventory": {}}
+    hass = HomeAssistant()
 
     mock_store = AsyncMock(spec=DomainStore)
     mock_store.async_save = AsyncMock()
 
     repo = Repository()
-    hass.data["haventory"]["store"] = mock_store
-    hass.data["haventory"]["repository"] = repo
+    install_runtime(hass, repository=repo, store=mock_store)
 
     # Create initial items
     items = [repo.create_item(ItemCreate(name=f"Item {i}")) for i in range(10)]
@@ -318,15 +316,13 @@ async def test_persist_with_timing_logs(caplog):
     """Persistence operations log timing information for debugging."""
     caplog.set_level(logging.DEBUG)
 
-    hass = MagicMock()
-    hass.data = {"haventory": {}}
+    hass = HomeAssistant()
 
     mock_store = AsyncMock(spec=DomainStore)
     mock_store.async_save = AsyncMock()
 
     repo = Repository()
-    hass.data["haventory"]["store"] = mock_store
-    hass.data["haventory"]["repository"] = repo
+    install_runtime(hass, repository=repo, store=mock_store)
 
     await async_persist_repo(hass)
 
@@ -343,14 +339,12 @@ async def test_debounce_request_logs(caplog):
     caplog.set_level(logging.DEBUG)
 
     hass = _TrackedTaskHass()
-    hass.data = {"haventory": {}}
 
     mock_store = AsyncMock(spec=DomainStore)
     mock_store.async_save = AsyncMock()
 
     repo = Repository()
-    hass.data["haventory"]["store"] = mock_store
-    hass.data["haventory"]["repository"] = repo
+    install_runtime(hass, repository=repo, store=mock_store)
 
     await async_request_persist(hass)
 
@@ -372,9 +366,9 @@ async def test_ws_mutations_use_immediate_persistence(monkeypatch):
     """
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    install_runtime(hass, repository=repo)
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
     ws_setup(hass)
 
     # Track calls to async_persist_repo (immediate)

--- a/tests/test_todo_bridge_offline.py
+++ b/tests/test_todo_bridge_offline.py
@@ -23,7 +23,6 @@ import pytest
 from custom_components.haventory import todo_bridge
 from custom_components.haventory.const import (
     CONF_TODO_ENTITY_ID,
-    DOMAIN,
     EVENT_ITEM_CHANGED,
     EVENT_LOW_STOCK,
     TODO_LINKS_STORAGE_KEY,
@@ -35,6 +34,8 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.storage import Store
+
+from runtime_helpers import install_runtime, runtime_of
 
 TODO_ENTITY = "todo.shopping_list"
 OTHER_ENTITY = "todo.household"
@@ -91,9 +92,9 @@ async def _bridge(
 ) -> tuple[HomeAssistant, Repository, _Services, ConfigEntry]:
     """A hass with a loaded repository and the bridge set up against it.
 
-    The repository goes into the bucket before setup, as `async_setup_entry`
-    puts it there — the bridge's first pass reads it, so a test that seeds it
-    afterwards is not testing the same sequence Home Assistant runs.
+    The runtime goes onto the entry before setup, as `async_setup_entry` puts it
+    there — the bridge's first pass reads the repository off it, so a test that
+    seeds it afterwards is not testing the same sequence Home Assistant runs.
     """
 
     hass = HomeAssistant()
@@ -101,13 +102,15 @@ async def _bridge(
     services = _Services()
     hass.services = services  # type: ignore[attr-defined]
     repository = repo if repo is not None else Repository()
-    hass.data[DOMAIN] = {"repository": repository}
+    entry = ConfigEntry(options={CONF_TODO_ENTITY_ID: entity_id})
+    install_runtime(
+        hass, repository=repository, entry=entry, options={CONF_TODO_ENTITY_ID: entity_id}
+    )
     if available:
         hass.states.async_set(entity_id, "0")
     if not keep_links:
         await _forget_links(hass)
 
-    entry = ConfigEntry(options={CONF_TODO_ENTITY_ID: entity_id})
     await todo_bridge.async_setup(hass, entry)
     return hass, repository, services, entry
 
@@ -179,13 +182,13 @@ async def test_a_refused_add_leaves_the_item_unlinked_so_the_next_pass_retries()
 
     await todo_bridge.async_reconcile(hass)
     assert services.names == [ADD]
-    assert hass.data[DOMAIN]["todo_links"] == {}
+    assert runtime_of(hass).todo.links == {}
 
     services.refuse = set()
     services.clear()
     await todo_bridge.async_reconcile(hass)
     assert services.names == [ADD]
-    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+    assert list(runtime_of(hass).todo.links.values()) == [
         {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}2"}
     ]
 
@@ -208,7 +211,7 @@ async def test_a_refused_removal_gives_up_the_link() -> None:
     repo.set_quantity(str(item.id), THRESHOLD + 1)
     await todo_bridge.async_reconcile(hass)
     assert services.names == [REMOVE]
-    assert hass.data[DOMAIN]["todo_links"] == {}
+    assert runtime_of(hass).todo.links == {}
 
     # And the retraction is not attempted a second time on the next pass.
     services.clear()
@@ -240,7 +243,7 @@ async def test_clearing_the_option_stops_writing_without_retracting() -> None:
     todo_bridge.apply_options(hass, entry)
     await todo_bridge.async_reconcile(hass)
     assert services.calls == []
-    assert len(hass.data[DOMAIN]["todo_links"]) == 1
+    assert len(runtime_of(hass).todo.links) == 1
 
 
 @pytest.mark.asyncio
@@ -260,7 +263,7 @@ async def test_changing_the_list_moves_the_lines_across() -> None:
     assert services.names == [REMOVE, ADD]
     assert services.calls[0][1]["entity_id"] == TODO_ENTITY
     assert services.calls[1][1]["entity_id"] == OTHER_ENTITY
-    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+    assert list(runtime_of(hass).todo.links.values()) == [
         {"entity_id": OTHER_ENTITY, "summary": f"Peanut butter {TIMES}2"}
     ]
 
@@ -277,7 +280,7 @@ async def test_a_missing_or_unavailable_list_is_left_alone_until_it_answers() ->
 
     await todo_bridge.async_reconcile(hass)
     assert services.calls == []
-    assert hass.data[DOMAIN]["todo_links"] == {}
+    assert runtime_of(hass).todo.links == {}
 
     hass.states.async_set(TODO_ENTITY, STATE_UNAVAILABLE)
     await todo_bridge.async_reconcile(hass)
@@ -306,7 +309,7 @@ async def test_a_line_is_restated_when_the_shortfall_moves() -> None:
         "item": f"Peanut butter {TIMES}1",
         "rename": f"Peanut butter {TIMES}3",
     }
-    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+    assert list(runtime_of(hass).todo.links.values()) == [
         {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}3"}
     ]
 
@@ -323,7 +326,7 @@ async def test_a_refused_restatement_keeps_the_link_on_the_text_already_there() 
     services.clear()
     repo.set_quantity(str(item.id), 0)
     await todo_bridge.async_reconcile(hass)
-    assert list(hass.data[DOMAIN]["todo_links"].values()) == [
+    assert list(runtime_of(hass).todo.links.values()) == [
         {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}1"}
     ]
 
@@ -392,7 +395,7 @@ async def test_a_stored_row_missing_half_of_itself_is_dropped_on_load() -> None:
     # exactly as it read it and the assertion is about the read alone.
     hass, _repo, _services, _entry = await _bridge(entity_id="", keep_links=True)
 
-    assert hass.data[DOMAIN]["todo_links"] == {
+    assert runtime_of(hass).todo.links == {
         "kept": {"entity_id": TODO_ENTITY, "summary": f"Peanut butter {TIMES}2"}
     }
 
@@ -425,7 +428,7 @@ async def test_a_list_that_cannot_delete_collects_one_line_per_item_and_no_more(
         # Nothing is even attempted: Home Assistant would refuse it, and the
         # link is what stops the next crossing writing a second line.
         assert services.calls == [], cycle
-        assert list(hass.data[DOMAIN]["todo_links"]) == [str(item.id)], cycle
+        assert list(runtime_of(hass).todo.links) == [str(item.id)], cycle
 
         services.clear()
         repo.set_quantity(str(item.id), THRESHOLD - 1)
@@ -449,7 +452,7 @@ async def test_a_list_that_can_delete_still_has_its_lines_retracted() -> None:
     await todo_bridge.async_reconcile(hass)
 
     assert services.names == [REMOVE]
-    assert hass.data[DOMAIN]["todo_links"] == {}
+    assert runtime_of(hass).todo.links == {}
 
 
 @pytest.mark.asyncio
@@ -465,4 +468,4 @@ async def test_a_list_publishing_no_features_is_treated_as_it_always_was() -> No
     await todo_bridge.async_reconcile(hass)
 
     assert services.names == [REMOVE]
-    assert hass.data[DOMAIN]["todo_links"] == {}
+    assert runtime_of(hass).todo.links == {}

--- a/tests/test_ws_areas_offline.py
+++ b/tests/test_ws_areas_offline.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 import pytest
 from custom_components.haventory.areas import async_get_area_registry
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import ws_send
 
 
@@ -22,8 +20,7 @@ async def test_ws_areas_list_returns_registry_entries() -> None:
     """areas/list returns {areas:[{id,name}]} populated from registry."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # Seed HA's area registry stub

--- a/tests/test_ws_bulk_offline.py
+++ b/tests/test_ws_bulk_offline.py
@@ -8,12 +8,11 @@ Scenarios:
 from __future__ import annotations
 
 import pytest
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, runtime_of
 from ws_helpers import ws_send
 
 
@@ -22,9 +21,9 @@ async def test_bulk_mixed_results_and_single_persist(monkeypatch) -> None:
     """Bulk should return per-op results and persist once if any success."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
     ws_setup(hass)
 
     calls = {"count": 0}
@@ -72,9 +71,9 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
     """Bulk: empty returns empty results; invalid type rejected; dup op_id rejects."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
     ws_setup(hass)
 
     calls = {"count": 0}

--- a/tests/test_ws_distinct_values_offline.py
+++ b/tests/test_ws_distinct_values_offline.py
@@ -13,20 +13,17 @@ Scenarios:
 from __future__ import annotations
 
 import pytest
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from custom_components.haventory.ws import ws_distinct_values
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import ws_send
 
 
 def _fresh_hass() -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 

--- a/tests/test_ws_effective_area_offline.py
+++ b/tests/test_ws_effective_area_offline.py
@@ -10,13 +10,13 @@ Scenarios:
 from __future__ import annotations
 
 import pytest
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import _item_matches_filter
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, runtime_of
 from ws_helpers import ws_send
 
 
@@ -26,8 +26,8 @@ async def test_effective_area_id_present_from_ancestor() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     # Tree: Garage(area='wohnzimmer') -> Shelf A -> Bin 1
@@ -63,8 +63,8 @@ async def test_effective_area_id_none_when_no_area() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     root = repo.create_location(name="Root")  # no area
@@ -85,8 +85,8 @@ async def test_effective_area_id_updates_on_area_change_without_version_bump() -
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     # Root without area -> effective_area_id None
@@ -118,8 +118,8 @@ async def test_subscription_matcher_agrees_with_item_list_on_area() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     kitchen = repo.create_location(name="Kitchen", area_id="kitchen")

--- a/tests/test_ws_error_mapping_offline.py
+++ b/tests/test_ws_error_mapping_offline.py
@@ -21,21 +21,18 @@ from typing import Any
 import pytest
 from custom_components.haventory import ws as ws_module
 from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import UNEXPECTED_ERROR_MESSAGE
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, repo_of
 from ws_helpers import RecordingConn, ws_send
 
 
 def _make_hass(*, with_repo: bool = True) -> HomeAssistant:
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
     if with_repo:
-        bucket["repository"] = Repository()
-        bucket["store"] = DomainStore(hass)
+        install_runtime(hass)
     ws_setup(hass)
     return hass
 
@@ -136,7 +133,7 @@ async def test_bulk_malformed_custom_fields_payload_fails_only_that_op() -> None
     """A payload that would raise TypeError fails per-op as validation_error."""
 
     hass = _make_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
     conn = RecordingConn()
@@ -180,7 +177,7 @@ async def test_bulk_payload_field_validation_errors() -> None:
     """Missing/typed-wrong per-op payload fields fail their own op only."""
 
     hass = _make_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
     res = await ws_send(
@@ -223,7 +220,7 @@ async def test_bulk_unexpected_per_op_error_is_contained(monkeypatch) -> None:
     """An unexpected exception in one op yields per-op unknown_error only."""
 
     hass = _make_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
     def _boom(_hass: HomeAssistant, _payload: dict) -> tuple[dict, str]:
@@ -274,5 +271,5 @@ async def test_broadcast_failure_does_not_fail_the_command(monkeypatch) -> None:
 
     res = await ws_send(hass, 101, "haventory/item/create", conn=conn, name="Widget")
     assert res["success"] is True
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     assert repo.get_counts()["items_total"] == 1

--- a/tests/test_ws_guard_offline.py
+++ b/tests/test_ws_guard_offline.py
@@ -4,6 +4,8 @@ Scenarios:
 - handlers return the error envelope while also attempting to send it
 - send_message raising does not prevent returning the error envelope
 - missing send_message still returns the error envelope
+- the loaded-entry refusal: answered while `LOADED`, `storage_error` when the
+  entry is gone and when it exists in any other state
 """
 
 from __future__ import annotations
@@ -12,11 +14,12 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 import pytest
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+
+from runtime_helpers import install_runtime
+from ws_helpers import ws_send
 
 
 def _get_handler(
@@ -51,8 +54,7 @@ async def test_returns_and_sends_error_when_validation_fails() -> None:
     """Handlers should send AND return the error envelope."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     handler = _get_handler(hass, "haventory/item/set_quantity")
@@ -76,8 +78,7 @@ async def test_returns_error_when_send_message_raises() -> None:
     """Even if send fails, the error envelope must be returned to caller."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     handler = _get_handler(hass, "haventory/item/set_quantity")
@@ -95,8 +96,7 @@ async def test_returns_error_when_no_send_message_attribute() -> None:
     """If the connection lacks send_message, the error is still returned."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     handler = _get_handler(hass, "haventory/item/set_quantity")
@@ -107,3 +107,52 @@ async def test_returns_error_when_no_send_message_attribute() -> None:
 
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["haventory/item/list", "haventory/ping"])
+async def test_a_command_answers_while_the_entry_is_loaded(command: str) -> None:
+    """The happy path of the state check that replaced the emptied bucket."""
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    ws_setup(hass)
+
+    res = await ws_send(hass, 1, command)
+
+    assert res["success"] is True, res
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["haventory/item/list", "haventory/ping"])
+async def test_a_command_refuses_when_no_entry_exists(command: str) -> None:
+    """Nothing to resolve a runtime through is the removed-integration case."""
+
+    hass = HomeAssistant()
+    ws_setup(hass)
+
+    res = await ws_send(hass, 1, command)
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "storage_error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["haventory/item/list", "haventory/ping"])
+async def test_a_command_refuses_while_the_entry_is_not_loaded(command: str) -> None:
+    """An entry that exists but is unloaded or disabled serves nothing.
+
+    The behavior `_require_loaded` used to get from an emptied bucket, restated
+    against the source of truth that replaced it. The runtime is deliberately
+    left attached: what refuses here is the *state*, not a missing object, which
+    is exactly the disabled-entry case.
+    """
+
+    hass = HomeAssistant()
+    install_runtime(hass, state=ConfigEntryState.NOT_LOADED)
+    ws_setup(hass)
+
+    res = await ws_send(hass, 1, command)
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "storage_error"

--- a/tests/test_ws_helpers_offline.py
+++ b/tests/test_ws_helpers_offline.py
@@ -11,12 +11,10 @@ fails loudly rather than returning nothing.
 from __future__ import annotations
 
 import pytest
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import RecordingConn, ws_call, ws_handler, ws_send
 
 # One frame id, reused: what matters is that the envelope echoes the one sent.
@@ -25,9 +23,7 @@ FRAME_ID = 7
 
 def _make_hass() -> HomeAssistant:
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -26,17 +26,17 @@ from pathlib import Path
 import pytest
 from custom_components.haventory import media as media_mod
 from custom_components.haventory import ws as ws_mod
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, repo_of, runtime_of
 from ws_helpers import ws_send
 
 
 def _repo_of(hass: HomeAssistant) -> Repository:
-    return hass.data[DOMAIN]["repository"]
+    return repo_of(hass)
 
 
 @pytest.mark.asyncio
@@ -44,8 +44,7 @@ async def test_item_create_get_update_delete_success() -> None:
     """Create, get, update, delete an item via WS and assert envelopes."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # Create
@@ -79,8 +78,7 @@ async def test_item_update_normalizes_a_tag_list_carrying_a_null() -> None:
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Battery")
@@ -104,8 +102,7 @@ async def test_item_quantity_and_checkout_helpers() -> None:
     """Adjust/set quantity and check in/out via WS."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     initial_quantity = 1
@@ -142,8 +139,7 @@ async def test_item_check_out_due_date_is_optional() -> None:
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -169,8 +165,7 @@ async def test_item_list_pagination_cursor_passthrough() -> None:
     """List items returns items array and next_cursor passthrough shape."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # Seed a couple items
@@ -192,8 +187,7 @@ async def test_error_mapping_validation_and_not_found_and_conflict() -> None:
     """Ensure errors map to codes and include context."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # validation_error: negative quantity
@@ -222,10 +216,10 @@ async def test_ws_mutations_persist_to_store(monkeypatch) -> None:
     """After WS mutations, DomainStore.async_save is invoked with export_state."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     # Real store instance so key exists; we'll spy on method
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
     ws_setup(hass)
 
     calls = {"count": 0}
@@ -275,8 +269,7 @@ async def test_inspection_date_in_create_update_get() -> None:
     """inspection_date field is handled correctly in WS create/update/get operations."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # Create item with inspection_date
@@ -310,8 +303,7 @@ async def test_item_list_reports_filtered_total() -> None:
     """item/list includes `total`: all matches for the filter, on every page."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     await ws_send(hass, 1, "haventory/item/create", name="Hammer", category="tools")
@@ -405,8 +397,7 @@ async def test_attachment_add_and_remove_bump_the_version(upload) -> None:
     """Attaching a file is an item edit, unlike the derived location path."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -450,8 +441,7 @@ async def test_attachment_add_announces_the_item_as_updated(upload, monkeypatch)
     """An open card learns about a new photo the same way it learns about an edit."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -477,8 +467,7 @@ async def test_attachment_add_announces_the_item_as_updated(upload, monkeypatch)
 @pytest.mark.asyncio
 async def test_attachment_add_refuses_a_stale_expected_version(upload) -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -504,8 +493,7 @@ async def test_attachment_add_refuses_a_stale_expected_version(upload) -> None:
 @pytest.mark.asyncio
 async def test_attachment_add_on_an_unknown_item_is_not_found(upload) -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     upload("upload-1")
@@ -526,8 +514,7 @@ async def test_attachment_add_reports_an_unknown_file_id_as_not_found(upload) ->
     """`file_upload` raises for an expired upload, or one already consumed."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -547,8 +534,7 @@ async def test_attachment_add_reports_an_unknown_file_id_as_not_found(upload) ->
 @pytest.mark.asyncio
 async def test_attachment_add_refuses_a_file_whose_bytes_are_not_an_image(upload) -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -578,8 +564,7 @@ async def test_attachment_add_consumes_the_upload_handle_off_the_event_loop(uplo
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -607,8 +592,7 @@ async def test_attachment_add_tears_the_upload_down_off_the_loop_when_it_is_refu
     """The failure path pays the same teardown, so it offloads it the same way."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -640,8 +624,7 @@ async def test_attachment_add_tears_the_upload_down_when_the_command_is_cancelle
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -675,8 +658,7 @@ async def test_attachment_add_tears_the_upload_down_when_the_command_is_cancelle
 @pytest.mark.asyncio
 async def test_attachment_remove_deletes_the_file_and_the_item_delete_cascades(upload) -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -714,8 +696,7 @@ async def test_attachment_remove_deletes_the_file_and_the_item_delete_cascades(u
 @pytest.mark.asyncio
 async def test_attachment_remove_of_an_unknown_id_is_not_found() -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -737,8 +718,7 @@ async def test_attachment_update_retitles_and_bumps_the_version(upload) -> None:
     """A title is what a manuals list reads, so it is a real item edit."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Dishwasher")
@@ -766,8 +746,7 @@ async def test_attachment_update_retitles_and_bumps_the_version(upload) -> None:
 @pytest.mark.asyncio
 async def test_attachment_update_reports_a_stale_version_as_conflict(upload) -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Dishwasher")
@@ -794,8 +773,7 @@ async def test_attachment_update_reports_a_stale_version_as_conflict(upload) -> 
 @pytest.mark.asyncio
 async def test_attachment_reorder_makes_the_named_first_one_the_cover(upload) -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -827,8 +805,7 @@ async def test_attachment_reorder_refuses_a_partial_list(upload) -> None:
     """A partial list would leave two attachments claiming the same position."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
@@ -860,8 +837,7 @@ async def test_attachment_reorder_refuses_a_partial_list(upload) -> None:
 
 def _hass_with_items(count: int = 3) -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     repo = _repo_of(hass)
     for i in range(count):

--- a/tests/test_ws_locations_offline.py
+++ b/tests/test_ws_locations_offline.py
@@ -11,12 +11,11 @@ from __future__ import annotations
 
 import pytest
 from custom_components.haventory.areas import async_get_area_registry
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, repo_of, runtime_of
 from ws_helpers import ws_send
 
 
@@ -25,8 +24,7 @@ async def test_location_crud_and_tree() -> None:
     """Create a small tree, list, get, move via WS, and delete."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # Seed areas and create root and child
@@ -62,8 +60,7 @@ async def test_ws_location_create_update_area_validation() -> None:
     """Create/update with area validation and serialization of area_id."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # Unknown area on create → validation_error
@@ -100,8 +97,7 @@ async def test_ws_location_create_update_area_with_non_uuid_id() -> None:
     """WS accepts non-UUID area ids when present in HA area registry."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     reg = await async_get_area_registry(hass)
@@ -123,8 +119,7 @@ async def test_location_error_mapping() -> None:
     """Invalid operations yield validation/not_found errors."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
 
@@ -133,9 +128,9 @@ async def test_ws_location_mutations_persist_to_store(monkeypatch) -> None:
     """Location create/update/delete should persist via DomainStore.save."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
     ws_setup(hass)
 
     calls = {"count": 0}
@@ -168,9 +163,9 @@ async def test_location_move_subtree_persists(monkeypatch) -> None:
     """move_subtree persists via DomainStore.async_save."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
     ws_setup(hass)
 
     calls = {"count": 0}
@@ -204,8 +199,7 @@ async def test_location_tree_includes_item_counts() -> None:
     """Tree nodes carry direct and subtree item counts."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     root = await ws_send(hass, 1, "haventory/location/create", name="Garage")
@@ -228,8 +222,8 @@ async def test_location_tree_includes_item_counts() -> None:
     assert child_node["subtree_item_count"] == 1
 
     # Moving the wrench out of the tree drops both counts
-    items = hass.data[DOMAIN]["repository"].list_items(flt={"q": "wrench"})["items"]
-    hass.data[DOMAIN]["repository"].update_item(items[0].id, {"location_id": None})
+    items = repo_of(hass).list_items(flt={"q": "wrench"})["items"]
+    repo_of(hass).update_item(items[0].id, {"location_id": None})
     res2 = await ws_send(hass, 8, "haventory/location/tree")
     node2 = res2["result"][0]
     assert node2["direct_item_count"] == 1
@@ -243,8 +237,7 @@ async def test_location_tree_reports_matching_counts_for_a_filter() -> None:
     """With a filter, nodes also carry how much of themselves it keeps."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     root = await ws_send(hass, 1, "haventory/location/create", name="Garage")

--- a/tests/test_ws_logging_offline.py
+++ b/tests/test_ws_logging_offline.py
@@ -23,14 +23,12 @@ from typing import Any
 import pytest
 import voluptuous as vol
 from custom_components.haventory import services as services_mod
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import NotLoadedError, StorageError
 from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, repo_of, runtime_of
 from ws_helpers import RecordingConn, ws_send
 
 WS_LOGGER = "custom_components.haventory.ws"
@@ -40,11 +38,7 @@ RATE_LIMIT_LOGGER = "custom_components.haventory.rate_limit"
 
 def _make_hass(limiter: RateLimiter | None = None) -> HomeAssistant:
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["store"] = DomainStore(hass)
-    if limiter is not None:
-        bucket["rate_limiter"] = limiter
+    install_runtime(hass, rate_limiter=limiter)
     ws_setup(hass)
     return hass
 
@@ -163,7 +157,7 @@ async def test_storage_error_logs_error_with_traceback(caplog, monkeypatch) -> N
     async def _raise(*_args: Any, **_kwargs: Any) -> None:
         raise StorageError("failed to persist repository")
 
-    monkeypatch.setattr(hass.data[DOMAIN]["store"], "async_save", _raise)
+    monkeypatch.setattr(runtime_of(hass).store, "async_save", _raise)
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
     res = await ws_send(hass, 1, "haventory/item/create", name="X")
@@ -184,7 +178,7 @@ async def test_unknown_error_logs_error_with_traceback(caplog, monkeypatch) -> N
     def _boom(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError("kaboom")
 
-    monkeypatch.setattr(hass.data[DOMAIN]["repository"], "create_item", _boom)
+    monkeypatch.setattr(repo_of(hass), "create_item", _boom)
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
     res = await ws_send(hass, 1, "haventory/item/create", name="X")
@@ -281,7 +275,7 @@ async def test_a_real_storage_failure_still_logs_error_with_traceback(caplog, mo
     async def _raise(*_args: Any, **_kwargs: Any) -> None:
         raise StorageError("failed to persist repository")
 
-    monkeypatch.setattr(hass.data[DOMAIN]["store"], "async_save", _raise)
+    monkeypatch.setattr(runtime_of(hass).store, "async_save", _raise)
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
     res = await ws_send(hass, 1, "haventory/item/create", name="X")
@@ -351,7 +345,7 @@ async def test_bulk_unexpected_error_logs_error_with_traceback(caplog, monkeypat
     def _boom(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError("kaboom")
 
-    monkeypatch.setattr(hass.data[DOMAIN]["repository"], "update_item", _boom)
+    monkeypatch.setattr(repo_of(hass), "update_item", _boom)
     caplog.clear()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
@@ -440,7 +434,7 @@ async def test_partly_successful_bulk_still_logs_its_summary(caplog) -> None:
 @pytest.mark.asyncio
 async def test_service_conflict_logs_warning_without_traceback(caplog) -> None:
     hass = _make_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     await services_mod.service_item_create(hass, {"name": "Widget"})
     item_id = next(iter(repo._debug_get_internal_indexes()["items_by_id"]))
 

--- a/tests/test_ws_rate_limit_offline.py
+++ b/tests/test_ws_rate_limit_offline.py
@@ -41,13 +41,13 @@ from custom_components.haventory.rate_limit import (
     RateLimiter,
     TokenBucket,
 )
-from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
 from custom_components.haventory.ws import RATE_LIMITED_MESSAGE
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, repo_of, runtime_of, setup_entry
 from ws_helpers import RecordingConn, ws_send
 
 
@@ -71,11 +71,7 @@ def clock(monkeypatch) -> _FakeClock:
 
 def _make_hass(limiter: RateLimiter | None = None) -> HomeAssistant:
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["store"] = DomainStore(hass)
-    if limiter is not None:
-        bucket["rate_limiter"] = limiter
+    install_runtime(hass, rate_limiter=limiter)
     ws_setup(hass)
     return hass
 
@@ -207,7 +203,7 @@ async def test_rate_limited_command_does_not_execute(clock: _FakeClock) -> None:
     res = await ws_send(hass, 2, "haventory/item/create", conn=conn, name="Second")
     assert res["success"] is False
     assert res["error"]["code"] == "rate_limited"
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     assert repo.get_counts()["items_total"] == 1
 
 
@@ -441,7 +437,6 @@ def test_options_schema_defaults_to_the_stored_options() -> None:
 @pytest.mark.asyncio
 async def test_options_update_listener_rebuilds_limiter() -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})
     configured_rate = 5.0
     configured_burst = 7.0
     entry = ConfigEntry(
@@ -451,9 +446,11 @@ async def test_options_update_listener_rebuilds_limiter() -> None:
             CONF_RATE_LIMIT_COMMANDS_BURST: configured_burst,
         }
     )
+    # The listener rewrites a live runtime; an entry that never loaded has none.
+    install_runtime(hass, entry=entry)
 
     await _async_options_updated(hass, entry)
-    limiter = hass.data[DOMAIN]["rate_limiter"]
+    limiter = runtime_of(hass).rate_limiter
     assert isinstance(limiter, RateLimiter)
     assert limiter.enabled is True
     assert limiter.config.commands_per_second == configured_rate
@@ -461,7 +458,7 @@ async def test_options_update_listener_rebuilds_limiter() -> None:
 
     entry.options[CONF_RATE_LIMIT_ENABLED] = False
     await _async_options_updated(hass, entry)
-    assert hass.data[DOMAIN]["rate_limiter"].enabled is False
+    assert runtime_of(hass).rate_limiter.enabled is False
 
 
 def test_from_options_ignores_invalid_values() -> None:
@@ -536,8 +533,8 @@ async def test_setup_entry_wires_rate_limiter_from_entry_options(monkeypatch) ->
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    assert await haven_init.async_setup_entry(hass, entry) is True
-    limiter = hass.data[DOMAIN]["rate_limiter"]
+    await setup_entry(hass, entry)
+    limiter = runtime_of(hass).rate_limiter
     assert isinstance(limiter, RateLimiter)
     assert limiter.enabled is True
     assert limiter.config.commands_per_second == configured_rate
@@ -546,7 +543,7 @@ async def test_setup_entry_wires_rate_limiter_from_entry_options(monkeypatch) ->
     # An options change rebuilds the limiter through the registered listener.
     entry.options[CONF_RATE_LIMIT_ENABLED] = False
     await entry._update_listeners[0](hass, entry)
-    assert hass.data[DOMAIN]["rate_limiter"].enabled is False
+    assert runtime_of(hass).rate_limiter.enabled is False
 
     # Unload drops the limiter with the other ephemeral state.
     assert await haven_init.async_unload_entry(hass, entry) is True
@@ -574,10 +571,10 @@ async def test_close_cleanup_registers_in_conn_subscriptions() -> None:
     # The cleanup callable is registered where real HA invokes it on close.
     cleanup = conn.subscriptions.get("haventory/cleanup")
     assert callable(cleanup)
-    assert conn in hass.data[DOMAIN]["subscriptions"]
+    assert conn in runtime_of(hass).subscriptions
 
     cleanup()
-    assert conn not in hass.data[DOMAIN]["subscriptions"]
+    assert conn not in runtime_of(hass).subscriptions
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_reminders_offline.py
+++ b/tests/test_ws_reminders_offline.py
@@ -14,13 +14,11 @@ from __future__ import annotations
 from datetime import UTC, date, datetime, timedelta, timezone
 
 import pytest
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
+from runtime_helpers import install_runtime, repo_of
 from ws_helpers import ws_send
 
 MONTHLY = {"unit": "months", "count": 3}
@@ -31,8 +29,7 @@ _EDITED_QUANTITY = 4
 
 def _hass() -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 
@@ -302,7 +299,7 @@ async def test_bump_names_a_stored_anchor_it_cannot_read() -> None:
         reminder_date="2026-09-01",
         reminder_interval=MONTHLY,
     )
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
     repo.get_item(item_id).reminder_date = "next week"
 
     res = await ws_send(hass, 3, "haventory/reminder/bump", item_id=item_id)

--- a/tests/test_ws_schema_validation_offline.py
+++ b/tests/test_ws_schema_validation_offline.py
@@ -25,13 +25,11 @@ from typing import Any
 
 import pytest
 import voluptuous as vol
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, repo_of
 from ws_helpers import RecordingConn, ws_send
 
 INVALID_FORMAT = "invalid_format"
@@ -70,8 +68,7 @@ class _Probe:
 
 def _fresh_hass() -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 
@@ -236,7 +233,7 @@ async def test_a_real_command_refuses_a_wrong_typed_field_and_mutates_nothing() 
     """
 
     hass = _fresh_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
 
     res = await ws_send(hass, 1, "haventory/item/create", name="Hammer", tags="chisel")
 
@@ -256,7 +253,7 @@ async def test_the_widened_fields_answer_validation_error_and_mutate_nothing() -
     """
 
     hass = _fresh_hass()
-    repo = hass.data[DOMAIN]["repository"]
+    repo = repo_of(hass)
 
     for payload in (
         {"name": "Hammer", "quantity": "many"},

--- a/tests/test_ws_statuses_offline.py
+++ b/tests/test_ws_statuses_offline.py
@@ -12,19 +12,17 @@ from __future__ import annotations
 
 import pytest
 from custom_components.haventory import ws as ws_mod
-from custom_components.haventory.const import DEFAULT_STATUS_COLOR, DEFAULT_STATUS_ICON, DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.const import DEFAULT_STATUS_COLOR, DEFAULT_STATUS_ICON
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import ws_send
 
 
 def _new_hass() -> HomeAssistant:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
     return hass
 

--- a/tests/test_ws_storage_error_offline.py
+++ b/tests/test_ws_storage_error_offline.py
@@ -22,13 +22,13 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import StorageError
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, runtime_of
 from ws_helpers import RecordingConn, ws_send
 
 
@@ -42,9 +42,9 @@ class _ConnStub(RecordingConn):
 def _make_hass() -> tuple[HomeAssistant, Repository, DomainStore]:
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    install_runtime(hass, repository=repo)
     store = DomainStore(hass)
-    hass.data[DOMAIN]["store"] = store
+    runtime_of(hass).store = store
     ws_setup(hass)
     return hass, repo, store
 

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -19,13 +19,13 @@ from typing import Any
 
 import pytest
 from custom_components.haventory.areas import async_get_area_registry
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import _subs_bucket, broadcast_event
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime, runtime_of
 from ws_helpers import RecordingConn, ws_send
 
 
@@ -122,8 +122,7 @@ async def test_subscribe_receives_item_created_and_counts() -> None:
     """Subscribe to items and stats; creating an item emits item+counts events."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -154,8 +153,7 @@ async def test_unsubscribe_stops_events() -> None:
     """Unsubscribe removes further deliveries for the subscription id."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -185,8 +183,7 @@ async def test_double_subscribe_and_unsubscribe_edge() -> None:
     """Double subscribing reuses conn bucket; unsubscribe of unknown id is benign."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -210,8 +207,7 @@ async def test_subscriptions_cleanup_on_connection_close() -> None:
     """Connection close should remove all subscriptions for that connection."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -230,8 +226,7 @@ async def test_location_filters_subtree_and_direct_only() -> None:
     """location_id + include_subtree filters constrain delivered item events."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -327,8 +322,7 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
     """`inspection_overdue_only` narrows item events the same way `item/list` does."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -392,8 +386,8 @@ async def test_area_filter_constrains_delivered_events() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -453,8 +447,8 @@ async def test_area_and_location_filters_are_conjunctive() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -513,8 +507,8 @@ async def test_location_area_change_emits_no_item_events() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -566,8 +560,8 @@ async def test_reassigning_a_locations_own_area_announces_one_moved_event() -> N
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     reg = await async_get_area_registry(hass)
@@ -610,8 +604,8 @@ async def test_an_area_set_on_a_nested_location_is_announced_too() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     reg = await async_get_area_registry(hass)
@@ -659,8 +653,8 @@ async def test_an_area_a_nested_location_already_resolves_to_is_silent() -> None
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     reg = await async_get_area_registry(hass)
@@ -700,8 +694,8 @@ async def test_location_update_announces_what_changed_once() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     reg = await async_get_area_registry(hass)
@@ -764,8 +758,7 @@ async def test_framework_unsubscribe_events_tears_down_subscription() -> None:
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     sub_id = 501
@@ -799,8 +792,7 @@ async def test_dedicated_unsubscribe_clears_framework_registry() -> None:
     teardown paths symmetric (no stale callback left in ``connection.subscriptions``)."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     sub_id = 601
@@ -827,8 +819,7 @@ async def test_subscribe_on_slotted_connection_never_stamps_attribute() -> None:
     """
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     conn = _SlottedHAConn()
@@ -866,8 +857,8 @@ async def test_location_ids_scopes_a_subscription_to_several_locations() -> None
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass, repository=repo)
+    runtime_of(hass).store = DomainStore(hass)
     ws_setup(hass)
 
     conn = _ConnStub()
@@ -945,8 +936,7 @@ async def test_location_ids_scopes_a_subscription_to_several_locations() -> None
 @pytest.mark.asyncio
 async def test_subscribe_refuses_location_ids_that_is_not_a_list() -> None:
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(

--- a/tests/test_ws_utils_offline.py
+++ b/tests/test_ws_utils_offline.py
@@ -17,7 +17,6 @@ from custom_components.haventory.const import (
     ATTACHMENT_MANUAL_MIME_TYPES,
     ATTACHMENT_PICTURE_MIME_TYPES,
     DEFAULT_CARD_TITLE,
-    DOMAIN,
     INTEGRATION_VERSION,
     MAX_ATTACHMENT_BYTES,
     MAX_MANUALS_PER_ITEM,
@@ -29,6 +28,7 @@ from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import ws_send
 
 
@@ -37,7 +37,7 @@ async def test_ping_echo_and_ts() -> None:
     """haventory/ping echoes input and includes ts."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 1, "haventory/ping", echo={"hello": "world"})
@@ -51,7 +51,7 @@ async def test_version_reports_integration_and_schema() -> None:
     """haventory/version reports integration_version and schema_version."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 2, "haventory/version")
@@ -73,7 +73,7 @@ async def test_health_reports_the_generation_this_run_has_reached() -> None:
 
     hass = HomeAssistant()
     repo = Repository()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    install_runtime(hass, repository=repo)
     ws_setup(hass)
 
     before = await ws_send(hass, 30, "haventory/health")
@@ -89,9 +89,7 @@ async def test_config_reports_configured_card_title() -> None:
     """haventory/config hands the card the title set in the options flow."""
 
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["card_title"] = "Pantry"
+    install_runtime(hass, card_title="Pantry")
     ws_setup(hass)
 
     res = await ws_send(hass, 5, "haventory/config")
@@ -104,7 +102,7 @@ async def test_config_falls_back_to_default_card_title() -> None:
     """An entry predating the option has no stored title; the default stands in."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 6, "haventory/config")
@@ -117,9 +115,7 @@ async def test_config_reports_the_configured_quick_filter_pills() -> None:
     """haventory/config hands the card the pill choice made in the options flow."""
 
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["quick_filters"] = ["total", "low_stock"]
+    install_runtime(hass, quick_filters=["total", "low_stock"])
     ws_setup(hass)
 
     res = await ws_send(hass, 7, "haventory/config")
@@ -132,9 +128,7 @@ async def test_config_reports_an_empty_pill_choice_as_empty() -> None:
     """No pills is a choice, and has to arrive as one rather than as "unset"."""
 
     hass = HomeAssistant()
-    bucket = hass.data.setdefault(DOMAIN, {})
-    bucket["repository"] = Repository()
-    bucket["quick_filters"] = []
+    install_runtime(hass, quick_filters=[])
     ws_setup(hass)
 
     res = await ws_send(hass, 8, "haventory/config")
@@ -147,7 +141,7 @@ async def test_config_reports_no_pill_choice_as_null() -> None:
     """An entry that never chose leaves the decision to the dashboard."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 9, "haventory/config")
@@ -160,7 +154,7 @@ async def test_config_reports_the_status_vocabulary() -> None:
     """The card labels a stored slug from here, not from a constant of its own."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 7, "haventory/config")
@@ -183,7 +177,7 @@ async def test_config_reports_the_attachment_caps_and_accepted_types() -> None:
     """Reported so the picker can refuse early — never so the backend can trust it."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 8, "haventory/config")
@@ -206,7 +200,7 @@ async def test_stats_returns_counts() -> None:
     """haventory/stats returns repository counts."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 3, "haventory/stats")
@@ -236,7 +230,7 @@ async def test_stats_carries_status_counts_beside_the_legacy_keys() -> None:
     repo.create_item({"name": "Hammer", "status": "missing"})
     repo.create_item({"name": "Saw"})
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = repo
+    install_runtime(hass, repository=repo)
     ws_setup(hass)
 
     res = await ws_send(hass, 31, "haventory/stats")
@@ -253,7 +247,7 @@ async def test_health_is_healthy_for_fresh_repo() -> None:
     """haventory/health returns healthy True and includes counts and issues list."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
+    install_runtime(hass)
     ws_setup(hass)
 
     res = await ws_send(hass, 4, "haventory/health")

--- a/tests/test_ws_wrappers_offline.py
+++ b/tests/test_ws_wrappers_offline.py
@@ -10,12 +10,10 @@ Scenarios:
 from __future__ import annotations
 
 import pytest
-from custom_components.haventory.const import DOMAIN
-from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
+from runtime_helpers import install_runtime
 from ws_helpers import ws_send
 
 
@@ -24,8 +22,7 @@ async def test_add_remove_tags_success_and_normalization() -> None:
     """add/remove tags should normalize case/whitespace and preserve order on union/subtract."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Thing")
@@ -67,8 +64,7 @@ async def test_update_custom_fields_set_unset_and_validation_error() -> None:
     """update_custom_fields sets/unsets and rejects non-scalar values."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
@@ -114,8 +110,7 @@ async def test_set_low_stock_threshold_affects_counts() -> None:
     """Setting low_stock_threshold should update low_stock_count via stats."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Nails", quantity=1)
@@ -146,8 +141,7 @@ async def test_item_move_updates_location() -> None:
     """item/move should set location_id and return updated item."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     created = await ws_send(hass, 1, "haventory/item/create", name="Box")
@@ -165,8 +159,7 @@ async def test_unknown_command_and_type_errors() -> None:
     """Unknown command type and bad payloads produce validation_error envelopes."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["repository"] = Repository()
-    hass.data[DOMAIN]["store"] = DomainStore(hass)
+    install_runtime(hass)
     ws_setup(hass)
 
     # Unknown command type: ensure no handler responds


### PR DESCRIPTION
## Summary

The repository, the store, the rate limiter and the persist lock lived in
`hass.data[DOMAIN]` — the historical shared dict: untyped (every read a cast), invisible to
Home Assistant, created and emptied by hand. Since 2024.4 a config entry carries
`runtime_data`: setup fills it, Home Assistant clears it on unload, and a typed alias makes
every access a checked one.

`custom_components/haventory/runtime.py` is the new module — `HAventoryRuntime` with
everything one loaded entry owns, the `Subscription` TypedDict the registry needs (it cannot
live in `ws.py` and be a field of the runtime without a cycle), the PEP 695
`type HAventoryConfigEntry = ConfigEntry[HAventoryRuntime]`, and the two lookups.

Closes #280.

### Two lookups, which is the part that bites

```
loaded_runtime(hass)   refuses unless the entry is LOADED
find_runtime(hass)     asks only whether a runtime exists
```

`loaded_runtime` is the **client boundary**: Home Assistant can unregister neither a
WebSocket command nor a service, so both go on listening after the entry is unloaded,
disabled or removed, and this refusal is what makes them answer the contract's
`storage_error` instead of serving state nothing owns. It replaces the emptied bucket the old
`_repo` was reading.

`find_runtime` is for everything that runs **outside** a loaded entry. Home Assistant marks
an entry `UNLOAD_IN_PROGRESS` *before* calling `async_unload_entry` and deletes
`runtime_data` only *after* it returns (verified against the core in the phacc venv:
`config_entries.py` sets the state, then `object.__delattr__(self, "runtime_data")` on the
way out). So the teardown flush, the teardown broadcast, and the subscription callbacks a
closing connection fires long afterwards all go through it. A flush routed through the loaded
check would write nothing and drop whatever was still unsaved, with no error anybody sees —
which is the regression this migration was most likely to introduce, and is pinned twice
below.

### What stays in `hass.data[DOMAIN]`

Only what outlives an entry, because Home Assistant cannot hand it back: the flags recording
an aiohttp route (`static_path_registered`, `media_view_registered`), the frontend module URL
and the sidebar panel — plus the WebSocket and service registration bookkeeping.
`_drop_entry_runtime` becomes `_forget_registration_flags`, which is all that is left for it
to do; Home Assistant's own clearing replaces the rest.

### Decisions taken against the notes

- **`async_persist_repo(hass)` keeps its signature** rather than taking the runtime. The
  notes ask for `async_persist_repo(runtime)` so `storage.py` "stops looking anything up"; it
  resolves through `find_runtime` instead. The correctness requirement — that the teardown
  flush must not go through the loaded check — is honoured exactly, and it is what the tests
  pin. Threading the runtime through instead would have changed ~10 call sites and their
  tests for no observable difference, in a PR whose test churn is already the expensive part.
- **`ws_registered` / `services_registered` / `ws_handlers` stay in the bucket.** The notes
  say they can move. They record registrations Home Assistant cannot undo — the same family
  as `static_path_registered` — and the offline stub registry, which *can* undo them, needs
  the handler list at unload. Moving them onto an object that dies with the entry would have
  made `ws_mod.setup(hass)` take the runtime, and with it ~15 test files, for a flag.
- **The to-do bridge's four keys move too**, which the notes predate. They are entry-scoped
  state with their own `Store` and lock; leaving them in a bucket the entry no longer owns is
  the exact wart this issue is about. They live on the runtime as `TodoBridgeState`.
- **`low_stock_snapshot` moves as a field** (`runtime.low_stock_ids`), and
  `DATA_LOW_STOCK_SNAPSHOT` in `const.py` goes with it — a constant naming a dict key that no
  longer exists.
- **The diagnostics `runtime.data_keys` now lists the runtime's field names**, and a new
  `shared_keys` lists what is left in the domain bucket. Both are names, never values, for
  the reason the old one was: the runtime holds the repository, and a dump of it would be the
  whole inventory.
- **Drive-by:** `# noqa`-style, the codespell hook's ignore list gains `categorie` — the
  deliberate near-miss filter key `test_ws_distinct_values_offline.py` asks the backend to
  refuse by name, in the same list and for the same reason as `batery`. It only surfaced
  because this PR is the first to put that file in a commit.

## Type of change

- [x] Refactor (no functional change)

No user-visible change, no wire change, no stored shape change. `serialize_state`'s output is
untouched — the V0.7.0 condition #482 left behind.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` — **1225 passed, 22 skipped**; `uv run ruff check .` — all checks passed; `uv run ruff format --check .` — clean; `uv run mypy` — **no issues in 25 source files**, with `haventory.runtime` added to the strict override list and **no new `cast(...)`** (`storage.py` loses one)
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean, `npx vitest run` — **63 files / 1860 tests passed**, `npm run build` — built. Nothing crosses the boundary; run because the gate says so.
- [x] phacc (`scripts/test_integration.sh`, the Docker recipe): **115 passed** — required here, since entry state transitions and `runtime_data` clearing are invisible to the stub by construction

New tests:

- `tests/test_runtime_offline.py` — the two lookups apart: `loaded_runtime` answers for a `LOADED` entry, refuses with no entry at all, and refuses for `NOT_LOADED` / `SETUP_ERROR` / `SETUP_RETRY` / `UNLOAD_IN_PROGRESS` **with the runtime still attached** (the disabled-entry case: what refuses is the state, not a missing object) while `find_runtime` still finds it; the final flush writes while the entry is `UNLOAD_IN_PROGRESS`; a persist with no runtime refuses rather than writing nothing; a close callback fired after the runtime is gone is a no-op; a broadcast then reaches nobody and raises nothing.
- `tests/test_ws_guard_offline.py` — the same refusal from the client's side, per command: answered while `LOADED`, `storage_error` when the entry is gone and when it exists in another state.
- `tests/integration/test_persistence.py` — the unload flush reaching a **real** `Store` through Home Assistant's own state transitions, and a setup-after-unload reading back what it wrote into a fresh runtime.
- `tests/integration/test_config_entry.py` — `runtime_data` present while loaded, and **deleted** (not emptied) after unload, which only a real core can be asked to prove.

The fixture is the real cost, and it is `tests/runtime_helpers.py`: `install_runtime` (one
way to say "an entry is loaded", with `state=` for the refusals), `setup_entry` /
`unload_entry` / `remove_entry` (the real lifecycle with the state transitions Home Assistant
makes around it), and `runtime_of` / `repo_of` for the read side. 49 test files converted; the
offline `HomeAssistant` stub grew a `config_entries` registry and the `ConfigEntry` stub grew
`entry_id`, `domain`, `state`, `runtime_data` and `__class_getitem__` — so subscripting the
alias stays impossible to get wrong rather than merely unhit.

### Live checks (dev HA 2026.7.4, 1087 items)

One tab on the card, one on `/haventory`, neither touched. The entry is reloaded over REST,
then its options are changed through the real options flow and changed back. Harness:
`.claude/skills/run-haventory/reload_probe.mjs`.

```
entry after reload : loaded
card events        : items/unavailable, stats/unavailable, locations/unavailable, statuses/unavailable, items/created, stats/counts
panel events       : items/unavailable, stats/unavailable, locations/unavailable, statuses/unavailable, items/created, stats/counts
options flow       : create_entry -> restored create_entry
sidebar panel      : before=true after=true
rows visible       : 51

[PASS] the entry is LOADED again
[PASS] the card was told its subscription stopped
[PASS] the panel was told too
[PASS] the card re-subscribed and saw the new item
[PASS] the panel re-subscribed and saw it too
[PASS] the options change was accepted and undone
[PASS] the card element survived the options change
[FAIL] the panel survived the reload            <- see below
[FAIL] the panel element survived the options change
[PASS] the sidebar entry survived it
[PASS] the card is showing rows
```

**The two `[FAIL]`s are pre-existing and are now #507.** An open `/haventory` tab is taken to
the default dashboard when the panel is briefly unregistered. Confirmed not a regression by
deploying **`main`'s whole integration package into the same container** and running the same
probe: byte-identical result, both `[FAIL]`s and every `[PASS]`. The branch was redeployed
afterwards.

`log_sweep.py --since 25m` reports one blocking record per reload — also pre-existing, also
reproduced on `main`, filed as **#508**: the to-do bridge's boot-time `listen_once` unsub is
stale by the time anything unloads, and Home Assistant logs the removal failure at ERROR.

Nothing else in the sweep: the eight WARNINGs are the contract's own refusals, which is what
this PR's `storage_error` path is supposed to produce while the entry is down.

The dev instance's inventory is back to its baseline (the probe item was deleted) and its
options were written back with the values the form reported, not with defaults.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `CLAUDE.md` gains `runtime.py` and the two-lookup rule and loses the two lines naming the bucket; `README.md`'s store line names `entry.runtime_data.store`.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — **no WS API change**: the envelope, the taxonomy and every command shape are untouched, and the refusal is still `storage_error`.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Follow-ups

- **#507** — a reload takes an open `/haventory` page back to the default dashboard.
- **#508** — the first reload after a restart logs an ERROR about a listener that already fired.
- Neither is caused by this PR; both were found by its live checks and reproduced against
  `main`.
