### PR TITLE
fix(logging): put the context a bug report needs into the message text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,9 @@ and the two must move together, which `tests/test_toolchain_pins.py` now enforce
 - `rate_limit.py` — opt-in token-bucket rate limiting (per-connection + global, for
   commands and broadcasts). Off by default; configured via the options flow
   (`config_flow.py`); limiter instance lives on the runtime (`entry.runtime_data.rate_limiter`).
+- `logs.py` — `context_logger`, the `LoggerAdapter` every module's logger comes from: it
+  renders `extra=` into the message so `op`, `elapsed_ms`, the schema versions and
+  `storage_key` are greppable in a user's log.
 - `import_export.py` — JSON import/export with `merge` / `replace` / `skip` policies and a
   read-only preview. **Import identity is the id, never the name.**
 - `stale_files.py` — `RETIRED_PATHS`, the explicit list of files earlier releases shipped
@@ -226,8 +229,14 @@ Offline tests stub HA via `tests/conftest.py`.
 - **Deleting or renaming a file inside `custom_components/haventory/`** means appending its
   old path to `RETIRED_PATHS` in the same PR — a HACS upgrade leaves it behind otherwise.
   The rule is stated in `CONTRIBUTING.md`.
-- **Logging**: avoid reserved `LogRecord` keys in `extra=` — use `item_name` / `location_name`,
-  not `name`.
+- **Logging**: take the module logger from `logs.context_logger(__name__)` — never
+  `logging.getLogger` directly, which `tests/test_logs_offline.py` sweeps for. It folds the
+  `extra=` context into the message text as `key=value` pairs (`op` first, `domain` left out
+  because the logger name says it) and hands the mapping on unchanged, so a structured
+  handler still reads the fields. Home Assistant's formatter renders the message and drops
+  everything else, so a field left only in `extra=` is invisible in the one log a bug report
+  carries. Keep attaching context through `extra=`; that is still the call-site shape. Avoid
+  reserved `LogRecord` keys there — `item_name` / `location_name`, not `name`.
 - **Comments explain constraints, not history.** A comment earns its place by encoding
   something the code cannot say itself: a browser or platform quirk, an API contract, a
   required ordering, an accessibility requirement, a deliberate tradeoff whose alternative

--- a/README.md
+++ b/README.md
@@ -1124,7 +1124,11 @@ through [private reporting](SECURITY.md), never a public issue.
   built assets `custom_components/haventory/www/`, served at `/haventory_static/`;
   calendar entity `calendar.haventory`, whose `unique_id` is the constant
   `haventory_calendar`.
-- Logging: avoid reserved `LogRecord` keys in logger extras — use `item_name` /
+- Logging: every module takes its logger from `logs.context_logger`, which writes the
+  `extra=` context into the message text as `key=value` pairs and passes the mapping on for
+  any structured handler. Home Assistant's formatter renders the message and drops
+  everything else, so a field that stayed in `extra=` was invisible in exactly the log a bug
+  report carries. Avoid reserved `LogRecord` keys in the extras — use `item_name` /
   `location_name`, not `name`.
 
 ## Developer docs

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -1301,12 +1301,11 @@ def _log_storage_health(payload: dict[str, Any], *, schema_version: int) -> None
     location_count = len(locations) if isinstance(locations, dict) else 0
 
     level = logging.WARNING if item_count == 0 and location_count == 0 else logging.DEBUG
+    # The three numbers are the context's, not the message's: it is rendered into
+    # the line either way, and formatting them here as well printed each twice.
     LOGGER.log(
         level,
-        "Storage health: schema_version=%s items=%s locations=%s",
-        schema_version,
-        item_count,
-        location_count,
+        "Storage health",
         extra={
             "domain": DOMAIN,
             "op": "setup_storage_health",

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -73,6 +73,7 @@ from .const import (
     REPAIR_ISSUE_IDS,
 )
 from .exceptions import CorruptSchemaVersionError, SchemaDowngradeError, StorageError
+from .logs import context_logger
 from .rate_limit import RateLimitConfig, RateLimiter
 from .repository import LoadReport, Repository
 from .runtime import HAventoryConfigEntry, HAventoryRuntime, find_runtime
@@ -87,7 +88,7 @@ from .storage import (
     schema_downgrade_message,
 )
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 _MANIFEST_PATH = Path(__file__).with_name("manifest.json")
 

--- a/custom_components/haventory/calendar.py
+++ b/custom_components/haventory/calendar.py
@@ -11,7 +11,6 @@ over on a day nobody touched the inventory.
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
@@ -25,10 +24,11 @@ from homeassistant.util import dt as dt_util
 
 from .calendar_projection import ProjectedEvent, build_events, next_event, window_dates
 from .const import CALENDAR_UNIQUE_ID, DOMAIN, INTEGRATION_VERSION, SIGNAL_INVENTORY_CHANGED
+from .logs import context_logger
 from .models import Item
 from .runtime import find_runtime
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 
 async def async_setup_entry(

--- a/custom_components/haventory/calendar_projection.py
+++ b/custom_components/haventory/calendar_projection.py
@@ -14,15 +14,15 @@ occurrences the window covers, and none of them is written anywhere.
 
 from __future__ import annotations
 
-import logging
 from calendar import monthrange
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 
+from .logs import context_logger
 from .models import Item, ReminderInterval
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 # Which unreadable stored dates have already been reported, as
 # ``(item_id, field, value)``. The projection runs on every calendar read, so an

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -27,7 +27,6 @@ same call.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Sequence
 from typing import Any
 
@@ -40,10 +39,11 @@ from .const import (
     EVENT_LOW_STOCK,
     SIGNAL_INVENTORY_CHANGED,
 )
+from .logs import context_logger
 from .models import iso_utc_now
 from .runtime import HAventoryRuntime, find_runtime
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 # The WebSocket items vocabulary, reused verbatim: an automation and a card
 # client describe the same mutation with the same word.

--- a/custom_components/haventory/logs.py
+++ b/custom_components/haventory/logs.py
@@ -1,0 +1,82 @@
+"""Making the context a log line carries reach the log.
+
+Every module attaches structured context to its records — `op`, `elapsed_ms`,
+the schema versions, `storage_key` — through `extra=`. Home Assistant's log
+formatter renders the message and its `%`-args and drops everything else, so all
+of it was invisible in the one place it is wanted: a log pasted into a bug
+report. `grep persist_complete home-assistant.log` found nothing, because the
+string only existed in a field nothing rendered.
+
+`context_logger` is what every module takes its logger from. It is a
+`LoggerAdapter` whose `process` folds the `extra=` mapping into the message text
+and hands the same mapping on untouched, so a structured handler still sees the
+fields and a plain reader finally does too. Nothing at the call sites changes:
+they keep writing `_LOGGER.warning("...", extra={...})`.
+
+The rendering is `key=value`, space separated, appended to the message — a shape
+`grep` and `awk` both take apart:
+
+    Repository persisted successfully op=persist_complete generation=7 elapsed_ms=12
+
+`domain` is the one field left out of the text: every record already carries the
+logger name it would repeat.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import MutableMapping
+from typing import Any
+
+# Long enough for a path, a URL or a store key; short enough that one field
+# cannot push the message itself off the readable part of a line.
+_MAX_VALUE_CHARS = 160
+
+# Rendered from the logger name on every record already.
+_SKIPPED_FIELDS = frozenset({"domain"})
+
+# What a value has to contain before it needs quoting: anything that would break
+# a reader splitting the tail on spaces and then on the first `=`.
+_NEEDS_QUOTING = (" ", "\t", "\n", "=", '"')
+
+
+def _render_value(value: Any) -> str:
+    text = str(value)
+    if len(text) > _MAX_VALUE_CHARS:
+        text = text[: _MAX_VALUE_CHARS - 1] + "…"
+    if any(char in text for char in _NEEDS_QUOTING) or text == "":
+        return '"' + text.replace('"', "'").replace("\n", " ") + '"'
+    return text
+
+
+def render_context(context: MutableMapping[str, Any]) -> str:
+    """The `key=value` tail for one record's context, `op` first.
+
+    `op` leads because it is the field a maintainer greps for and the one that
+    says which operation the rest of the line is about.
+    """
+
+    fields = [(key, value) for key, value in context.items() if key not in _SKIPPED_FIELDS]
+    fields.sort(key=lambda pair: pair[0] != "op")
+    return " ".join(f"{key}={_render_value(value)}" for key, value in fields)
+
+
+class ContextLogger(logging.LoggerAdapter):  # type: ignore[type-arg]
+    """A logger whose `extra=` context is also written into the message."""
+
+    def process(
+        self, msg: Any, kwargs: MutableMapping[str, Any]
+    ) -> tuple[Any, MutableMapping[str, Any]]:
+        """Append the context to the message, and pass `extra=` on unchanged."""
+
+        context = kwargs.get("extra")
+        if not isinstance(context, MutableMapping):
+            return msg, kwargs
+        tail = render_context(context)
+        return (f"{msg} {tail}" if tail else msg), kwargs
+
+
+def context_logger(name: str) -> ContextLogger:
+    """The logger a module should use. Same underlying logger, same name."""
+
+    return ContextLogger(logging.getLogger(name), {})

--- a/custom_components/haventory/media.py
+++ b/custom_components/haventory/media.py
@@ -19,7 +19,6 @@ Three rules hold everything here together:
 
 from __future__ import annotations
 
-import logging
 import shutil
 from collections.abc import Iterable
 from http import HTTPStatus
@@ -51,10 +50,11 @@ from .const import (
     MEDIA_URL_TEMPLATE,
 )
 from .exceptions import ValidationError
+from .logs import context_logger
 from .models import AttachmentKind, AttachmentMeta
 from .runtime import find_runtime
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 # Accepted types and the per-item cap, by attachment kind.
 MIME_TYPES_BY_KIND: dict[str, tuple[str, ...]] = {

--- a/custom_components/haventory/rate_limit.py
+++ b/custom_components/haventory/rate_limit.py
@@ -15,7 +15,6 @@ loop access is needed. Tests monkeypatch ``_monotonic`` for determinism.
 from __future__ import annotations
 
 import functools
-import logging
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -42,8 +41,9 @@ from .const import (
     DEFAULT_RATE_LIMIT_GLOBAL_EVENTS_PER_SECOND,
     DOMAIN,
 )
+from .logs import context_logger
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 # Module-level clock indirection so tests can monkeypatch time deterministically.
 _monotonic = time.monotonic

--- a/custom_components/haventory/repairs.py
+++ b/custom_components/haventory/repairs.py
@@ -12,8 +12,6 @@ is what makes going past it reversible — the load itself destroys nothing.
 
 from __future__ import annotations
 
-import logging
-
 import voluptuous as vol
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow, RepairsFlowResult
 from homeassistant.config_entries import ConfigEntryState
@@ -21,9 +19,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 from .const import CONF_ALLOW_LOSSY_LOAD, DOMAIN, ISSUE_CORRUPT_STORE
+from .logs import context_logger
 from .storage import async_backup_store
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 
 class LossyLoadRepairFlow(RepairsFlow):

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -14,7 +14,6 @@ import base64
 import binascii
 import copy
 import json
-import logging
 import re
 import uuid
 from collections import deque
@@ -25,6 +24,7 @@ from typing import Any, NamedTuple, TypedDict
 
 from .calendar_projection import next_occurrence_after
 from .exceptions import ConflictError, NotFoundError, ValidationError
+from .logs import context_logger
 from .models import (
     DEFAULT_ITEM_STATUS,
     EMPTY_LOCATION_PATH,
@@ -73,7 +73,7 @@ from .models import (
     validate_status_slug,
 )
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 
 class _TextTokens(NamedTuple):

--- a/custom_components/haventory/sensor.py
+++ b/custom_components/haventory/sensor.py
@@ -8,7 +8,6 @@ at all. `const.SENSOR_DESCRIPTIONS` is the catalog; nothing here is per-count.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
@@ -26,9 +25,10 @@ from .const import (
     SIGNAL_INVENTORY_CHANGED,
     HaventorySensorDescription,
 )
+from .logs import context_logger
 from .runtime import find_runtime
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 
 async def async_setup_entry(

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -11,7 +11,6 @@ surfaces them to the caller.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable, Coroutine
 from typing import Any, NoReturn
 
@@ -30,12 +29,13 @@ from .exceptions import (
     log_exc_info,
     log_severity,
 )
+from .logs import context_logger
 from .repository import UNSET, Repository
 from .runtime import loaded_runtime
 from .serialization import serialize_item, serialize_location
 from .storage import async_persist_repo as _storage_async_persist_repo
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 
 # -----------------------------

--- a/custom_components/haventory/stale_files.py
+++ b/custom_components/haventory/stale_files.py
@@ -17,15 +17,15 @@ there, and a wildcard would take those too.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Sequence
 from pathlib import Path
 
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
+from .logs import context_logger
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 _PACKAGE_DIR = Path(__file__).parent
 

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -16,7 +16,6 @@ forward-only migrations when an older schema payload is encountered.
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 from collections.abc import Mapping
 from copy import deepcopy
@@ -33,10 +32,11 @@ from .exceptions import (
     SchemaDowngradeError,
     StorageError,
 )
+from .logs import context_logger
 from .models import seed_status_definitions, serialize_status_definition
 from .runtime import find_runtime
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = context_logger(__name__)
 
 # Current schema version for persisted payloads
 CURRENT_SCHEMA_VERSION: Final[int] = 9

--- a/custom_components/haventory/todo_bridge.py
+++ b/custom_components/haventory/todo_bridge.py
@@ -19,7 +19,6 @@ rollback.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -37,9 +36,10 @@ from .const import (
     TODO_LINKS_STORAGE_KEY,
     TODO_LINKS_STORAGE_VERSION,
 )
+from .logs import context_logger
 from .runtime import HAventoryRuntime, find_runtime
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 TODO_DOMAIN = "todo"
 SERVICE_ADD_ITEM = "add_item"

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -54,6 +53,7 @@ from .exceptions import (
 )
 from .health import collect_health_issues
 from .import_export import POLICIES, Policy
+from .logs import context_logger
 from .models import (
     ATTACHMENT_KINDS,
     AttachmentMeta,
@@ -73,7 +73,7 @@ from .runtime import Subscription, find_runtime, loaded_runtime
 from .serialization import serialize_item, serialize_location
 from .storage import CURRENT_SCHEMA_VERSION
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = context_logger(__name__)
 
 
 def _repo(hass: HomeAssistant) -> Repository:

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -69,15 +69,10 @@ async def test_a_refusal_logs_the_operation_it_refused(
     assert "item_id=nope" in refusals[-1]
 
 
-async def test_the_setup_line_carries_its_op_beside_its_own_percent_args(
+async def test_the_setup_line_carries_the_numbers_a_boot_is_diagnosed_from(
     hass: HomeAssistant, caplog
 ) -> None:
-    """A record with `%`-args keeps them, and gains the context behind them.
-
-    "Storage health" is the one line in the integration that formats its own
-    numbers into the message, so it is where a rendering that clobbered the
-    `%`-args would show first.
-    """
+    """The line an operator reads first after a start-up that looks wrong."""
 
     caplog.set_level(logging.DEBUG, logger="custom_components.haventory")
     await _setup(hass)
@@ -85,5 +80,8 @@ async def test_the_setup_line_carries_its_op_beside_its_own_percent_args(
     health = [r.getMessage() for r in caplog.records if "Storage health" in r.getMessage()]
 
     assert health, [r.getMessage() for r in caplog.records][-10:]
-    assert "schema_version=" in health[-1]
     assert "op=setup_storage_health" in health[-1]
+    assert "schema_version=" in health[-1]
+    assert "items_count=" in health[-1]
+    # Once each: the numbers used to be formatted into the message as well.
+    assert health[-1].count("schema_version=") == 1

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -1,0 +1,89 @@
+"""Integration: the context survives a real Home Assistant log record.
+
+The offline suite reads `record.getMessage()` off a stub-driven call. What only a
+real core shows is that the fields are still there after Home Assistant's own
+logging setup has had the record — that nothing in its handler chain, its
+formatter or its filters puts them back where they were.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from custom_components.haventory.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_a_service_mutation_logs_a_greppable_persist_line(
+    hass: HomeAssistant, caplog
+) -> None:
+    """`grep persist_complete` on a user's log finds the line, and its timing."""
+
+    caplog.set_level(logging.DEBUG, logger="custom_components.haventory.storage")
+    await _setup(hass)
+
+    await hass.services.async_call(DOMAIN, "item_create", {"name": "Torch"}, blocking=True)
+    await hass.async_block_till_done()
+
+    formatter = logging.Formatter("%(levelname)s [%(name)s] %(message)s")
+    rendered = [formatter.format(record) for record in caplog.records]
+    complete = [line for line in rendered if "op=persist_complete" in line]
+
+    assert complete, rendered[-10:]
+    assert "elapsed_ms=" in complete[-1]
+    # The name is what a user filters on, and it is still the module's own.
+    assert "[custom_components.haventory.storage]" in complete[-1]
+
+
+async def test_a_refusal_logs_the_operation_it_refused(
+    hass: HomeAssistant, hass_ws_client, caplog
+) -> None:
+    """The other half: a rejection says which command it was, in the message.
+
+    The taxonomy already logs every rejection once with the same structured
+    context the envelope carries; this is that context arriving where somebody
+    reading the log can see it.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+    caplog.clear()
+    caplog.set_level(logging.WARNING, logger="custom_components.haventory.ws")
+
+    await client.send_json({"id": 1, "type": "haventory/item/get", "item_id": "nope"})
+    result = await client.receive_json()
+    assert result["success"] is False
+    assert result["error"]["code"] == "not_found"
+
+    refusals = [r.getMessage() for r in caplog.records if "op=item_get" in r.getMessage()]
+    assert refusals, [r.getMessage() for r in caplog.records]
+    assert "item_id=nope" in refusals[-1]
+
+
+async def test_the_setup_line_carries_its_op_beside_its_own_percent_args(
+    hass: HomeAssistant, caplog
+) -> None:
+    """A record with `%`-args keeps them, and gains the context behind them.
+
+    "Storage health" is the one line in the integration that formats its own
+    numbers into the message, so it is where a rendering that clobbered the
+    `%`-args would show first.
+    """
+
+    caplog.set_level(logging.DEBUG, logger="custom_components.haventory")
+    await _setup(hass)
+
+    health = [r.getMessage() for r in caplog.records if "Storage health" in r.getMessage()]
+
+    assert health, [r.getMessage() for r in caplog.records][-10:]
+    assert "schema_version=" in health[-1]
+    assert "op=setup_storage_health" in health[-1]

--- a/tests/test_logs_offline.py
+++ b/tests/test_logs_offline.py
@@ -105,8 +105,8 @@ async def test_a_real_persist_writes_its_op_and_elapsed_ms_into_the_message(capl
     assert any("op=persist_start" in message for message in messages)
 
 
-def test_every_module_logger_goes_through_the_adapter() -> None:
-    """A module taking `logging.getLogger` directly loses its context silently.
+def test_no_module_takes_a_logger_around_the_adapter() -> None:
+    """`logging.getLogger` anywhere but `logs.py` loses that module's context.
 
     Read from the source rather than by importing: several modules pull in Home
     Assistant packages the offline stubs deliberately do not provide.
@@ -114,12 +114,25 @@ def test_every_module_logger_goes_through_the_adapter() -> None:
 
     offenders = []
     for path in sorted(PACKAGE.glob("*.py")):
-        source = path.read_text(encoding="utf-8")
-        for line in source.splitlines():
-            if line.startswith(("LOGGER = ", "_LOGGER = ")) and "context_logger" not in line:
-                offenders.append(f"{path.name}: {line.strip()}")
+        if path.name == "logs.py":
+            continue
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if "logging.getLogger(" in line:
+                offenders.append(f"{path.name}:{number}: {line.strip()}")
 
-    assert offenders == []
+    assert offenders == [], "take the logger from logs.context_logger(__name__) instead"
+
+
+def test_every_module_that_logs_has_a_logger_from_the_adapter() -> None:
+    """The other half: a module that logs at all takes its logger from here."""
+
+    for path in sorted(PACKAGE.glob("*.py")):
+        if path.name == "logs.py":
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "LOGGER." not in source:
+            continue
+        assert "context_logger(__name__)" in source, path.name
 
 
 def test_the_logger_keeps_the_module_name_it_was_asked_for() -> None:

--- a/tests/test_logs_offline.py
+++ b/tests/test_logs_offline.py
@@ -1,0 +1,138 @@
+"""Offline tests: the context a record carries reaches the rendered message.
+
+Home Assistant's formatter renders the message and drops `extra=`, so every
+field this integration attached was invisible in the one place it is wanted — a
+log pasted into a bug report. These cover the rendering, the fields that have to
+survive it, and the sweep that keeps a new module from quietly opting out.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from custom_components.haventory import storage as storage_mod
+from custom_components.haventory.logs import ContextLogger, context_logger, render_context
+from homeassistant.core import HomeAssistant
+
+from runtime_helpers import install_runtime, repo_of
+
+PACKAGE = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
+
+# The fields a maintainer asks a bug report for, per #430.
+GREPPABLE = ("op", "elapsed_ms", "storage_key", "schema_version", "from_version")
+
+
+def test_the_context_becomes_key_value_pairs_after_the_message() -> None:
+    rendered = render_context({"domain": "haventory", "op": "persist_complete", "elapsed_ms": 12})
+
+    assert rendered == "op=persist_complete elapsed_ms=12"
+
+
+def test_op_leads_wherever_it_was_written() -> None:
+    """It is the field a maintainer greps for, and it says what the rest is about."""
+
+    rendered = render_context({"generation": 7, "op": "persist_start", "domain": "haventory"})
+
+    assert rendered.startswith("op=persist_start")
+
+
+def test_the_domain_is_left_out_because_the_logger_name_already_says_it() -> None:
+    assert render_context({"domain": "haventory"}) == ""
+
+
+def test_a_value_that_would_break_the_scan_is_quoted() -> None:
+    """A reader splits the tail on spaces and then on the first `=`."""
+
+    rendered = render_context({"item_name": "Photo Album #0318", "note": "", "key": "a=b"})
+
+    assert 'item_name="Photo Album #0318"' in rendered
+    assert 'note=""' in rendered
+    assert 'key="a=b"' in rendered
+
+
+def test_a_long_value_cannot_push_the_message_off_the_line() -> None:
+    rendered = render_context({"path": "x" * 500})
+
+    value = rendered.split("=", 1)[1]
+    assert len(value) < len("x" * 500)
+    assert value.endswith("…")
+
+
+def test_a_record_with_no_context_is_left_alone(caplog) -> None:
+    caplog.set_level(logging.DEBUG)
+    logger = context_logger("custom_components.haventory.test")
+
+    logger.debug("Nothing attached")
+
+    assert [record.getMessage() for record in caplog.records] == ["Nothing attached"]
+
+
+def test_the_extra_mapping_is_handed_on_untouched(caplog) -> None:
+    """A structured handler still gets the fields; the text is the addition."""
+
+    caplog.set_level(logging.DEBUG)
+    logger = context_logger("custom_components.haventory.test")
+
+    logger.debug("Persisted", extra={"domain": "haventory", "op": "persist_complete", "ms": 3})
+
+    record = caplog.records[-1]
+    assert record.getMessage() == "Persisted op=persist_complete ms=3"
+    assert record.op == "persist_complete"
+    assert record.domain == "haventory"
+
+
+@pytest.mark.asyncio
+async def test_a_real_persist_writes_its_op_and_elapsed_ms_into_the_message(caplog) -> None:
+    """#430's acceptance: `grep persist_complete` finds a line, with the timing on it.
+
+    The measurement this was found by needed the median of `elapsed_ms`, and
+    getting it meant editing `storage.py` inside a running container.
+    """
+
+    caplog.set_level(logging.DEBUG)
+    hass = HomeAssistant()
+    install_runtime(hass)
+    repo_of(hass).create_item({"name": "Torch"})  # type: ignore[arg-type]
+
+    await storage_mod.async_persist_repo(hass)
+
+    messages = [record.getMessage() for record in caplog.records]
+    complete = [message for message in messages if "op=persist_complete" in message]
+    assert complete, messages
+    assert "elapsed_ms=" in complete[0]
+    assert any("op=persist_start" in message for message in messages)
+
+
+def test_every_module_logger_goes_through_the_adapter() -> None:
+    """A module taking `logging.getLogger` directly loses its context silently.
+
+    Read from the source rather than by importing: several modules pull in Home
+    Assistant packages the offline stubs deliberately do not provide.
+    """
+
+    offenders = []
+    for path in sorted(PACKAGE.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        for line in source.splitlines():
+            if line.startswith(("LOGGER = ", "_LOGGER = ")) and "context_logger" not in line:
+                offenders.append(f"{path.name}: {line.strip()}")
+
+    assert offenders == []
+
+
+def test_the_logger_keeps_the_module_name_it_was_asked_for() -> None:
+    """The name is what a user filters on in Settings → System → Logs."""
+
+    logger = context_logger("custom_components.haventory.storage")
+
+    assert isinstance(logger, ContextLogger)
+    assert logger.logger.name == "custom_components.haventory.storage"
+
+
+@pytest.mark.parametrize("field", GREPPABLE)
+def test_the_fields_a_bug_report_is_asked_for_render(field: str) -> None:
+    """Named one by one, so dropping one from the rendering is a failure."""
+
+    assert f"{field}=" in render_context({"domain": "haventory", field: "value"})


### PR DESCRIPTION
## Summary

Every module attached structured context to its records — `op`, `elapsed_ms`, the schema
versions, `storage_key`, `item_name` — through `extra=`. Home Assistant's log formatter
renders the message and its `%`-args and drops everything else, so **none of it reached the
log**. From the dev instance's own log stream, the same line before and after this PR:

```
2026-08-04 11:36:53 DEBUG [custom_components.haventory.storage] Repository persisted successfully
2026-08-21 02:43:58 DEBUG [custom_components.haventory.storage] Repository persisted successfully op=persist_complete generation=1178 elapsed_ms=34
```

`grep persist_complete home-assistant.log` used to find nothing at all — the string only
existed in a field nothing rendered. That is how this was found: measuring #200 needed the
median of `elapsed_ms`, and getting it meant editing `storage.py` inside the running
container.

Closes #430.

### How it is said once

`custom_components/haventory/logs.py` — `context_logger`, a `LoggerAdapter` whose `process`
folds the `extra=` mapping into the message and hands the same mapping on untouched, so a
structured handler still reads the fields and a plain reader finally does too.

**Nothing at the ~109 call sites changes.** They keep writing
`_LOGGER.warning("...", extra={...})`, which is exactly what keeps the message and the
context from drifting apart — there is no second thing to remember. What changes is one line
per module: the logger comes from `context_logger(__name__)`.

The rendering: `key=value`, space separated, appended to the message.

- **`op` leads.** It is the field a maintainer greps for and the one that says what the rest
  of the line is about.
- **`domain` is left out of the text.** Every record already carries the logger name it would
  repeat (`custom_components.haventory.storage`), and it stays in `extra=`.
- **A value carrying a space, an `=` or a quote is quoted**, and one over 160 characters is
  truncated — so the tail stays something `grep` and `awk` can take apart, and one long path
  cannot push the message off the readable part of a line.

A second commit drops the three numbers "Storage health" formatted into its own message: it
attached the same three as context, so with the context rendered each appeared twice.

### Decisions taken against the issue's notes

- **A `LoggerAdapter`, not a helper each call site wraps its message in.** The issue asks for
  "a small helper that folds a context dict into the message (and keeps `extra=`)". Every
  shape where the call site does the folding either repeats the fields (once for the text,
  once for `extra=`) or rewrites all 109 sites into a new idiom. `LoggerAdapter.process` is
  the stdlib hook for exactly this, and it leaves the call sites — and their diff — alone.
- **Every field renders, rather than a chosen list.** The issue's first question is which
  fields are for a human. A curated list is a second thing to keep in step with the call
  sites, and the fields that are not worth reading are already short. Truncation and quoting
  handle the ones that could be awkward. The five §6.2 names (`op`, `elapsed_ms`,
  `storage_key`, `schema_version`, `from_version`) are pinned one by one anyway, so dropping
  one from the rendering is a failure rather than a silent loss.
- **`extra=` stays.** The issue's third question. It costs nothing, a custom handler can read
  it, and it is now not the *only* home for a value — which is what created this.
- **The rule lives in `CLAUDE.md` and `README.md`, not `CONTRIBUTING.md`.** The issue says
  both `CONTRIBUTING.md` and `CLAUDE.md` carry it; `CONTRIBUTING.md` has never mentioned
  logging. Both places that do say it now describe what happens, and `CLAUDE.md` names the
  sweep that enforces it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

No API, no stored shape, no behavior a client can see. What changes is what a log line says.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` — **1241 passed, 22 skipped**; `uv run ruff check .` — all checks passed; `uv run ruff format --check .` — clean; `uv run mypy` — no issues in 26 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean, `npx vitest run` — **63 files / 1860 tests passed**, `npm run build` — built
- [x] phacc (`scripts/test_integration.sh`, the Docker recipe): **118 passed**

New tests:

- `tests/test_logs_offline.py` — the rendering (`op` first, `domain` skipped, quoting for a value that would break the scan, truncation), a record with no context left alone, `extra=` handed on untouched (`record.op` still reads), and #430's own acceptance: a **real** `async_persist_repo` whose `record.getMessage()` carries `op=persist_complete` and `elapsed_ms=`. Plus the sweep in both directions — no `logging.getLogger(` anywhere in the package but `logs.py`, and every module that logs takes its logger from here — and the five greppable fields named one at a time.
- `tests/integration/test_logging.py` — the same through a real core: a service mutation's persist line survives Home Assistant's own handler chain and formatter with its `op` and `elapsed_ms` and its module name intact; a refused command logs `op=item_get item_id=nope`; and the setup line carries its numbers exactly once.

### Live checks (dev HA 2026.7.4, 1087 items)

The §6.2 check, inside the container, after deploying this branch:

```
$ grep 'persist_complete' /config/home-assistant.log | tail -1
2026-08-21 02:43:58.085 DEBUG (MainThread) [custom_components.haventory.storage] \
  Repository persisted successfully op=persist_complete generation=1178 elapsed_ms=34

$ grep 'Storage health' /config/home-assistant.log | tail -1
2026-08-21 02:43:34.865 DEBUG (MainThread) [custom_components.haventory] \
  Storage health op=setup_storage_health schema_version=9 items_count=1087 locations_count=89
```

The before/after at the top of this PR is the same container's log stream, so it is one
instance changing rather than two set-ups being compared.

`log_sweep.py --since 10m`: **PASS (blocking=0)**, and nothing in EXPECTED or KNOWN either.

The probe item was deleted; the instance is back to 1087 items / 89 locations.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`CLAUDE.md`, `README.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change. `docs/backend_api_contract.md` → "Logging" describes the level policy, which this does not touch.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Follow-ups

- Some messages now end in context that partly restates them — "Failed to persist during
  teardown op=unload" reads fine, but a few older messages were written to carry their own
  nouns. Nothing is wrong or duplicated except the "Storage health" line this PR fixed; a
  sweep for the rest is a wording pass, not a bug, and is not filed.
- The three issues this session filed from its live checks: **#505** (a filtered list reads
  "Showing 1 of 0 matching items" after an event-inserted row), **#507** (a reload takes an
  open `/haventory` page back to the default dashboard), **#508** (the first reload after a
  restart logs an ERROR about a listener that already fired). None is caused by this session's
  work; #507 and #508 were reproduced against `main`.

## Handover

### 1. Merged / left open

All four merged by this session, in the planned order; nothing left open.

1. **#504** — `feat(sensor): checked-out, locations and inspection-due counts` (closes #493)
2. **#506** — `fix(services): broadcast service mutations to WebSocket subscribers` (closes #450)
3. **#509** — `refactor: move the runtime onto `entry.runtime_data`` (closes #280)
4. **this PR** — `fix(logging): put the context a bug report needs into the message text` (closes #430)

Each ran both gates before every commit, `scripts/test_integration.sh` through the Docker
recipe before merge, CI green including hassfest, and its own live checks on the dev
instance.

### 2. Test this by hand

1. `[HA settings]` Settings → Devices & services → HAventory → the device page. **Seven
   sensors**, named *Item count*, *Low stock count*, *Checked out count*, *Checked out
   overdue count*, *Inspection overdue count*, *Inspection due count*, *Location count*.
   Expected: the values match the card's own count pills. The harness read them over REST and
   photographed the page; a human eye on the names in the entity picker is what it cannot do.
2. `[phone]` Open the card on a phone, leave it alone, and run an automation or script that
   calls any `haventory.*` service (`haventory.item_create` is enough). Expected: the list and
   the counts update with nothing touched. Proven with two desktop tabs and a service call
   from a third connection; a real phone, over the LAN or the Companion app, is what the
   harness cannot be.
3. `[log]` Settings → System → Logs, filter `haventory`, and set
   `custom_components.haventory` to Debug first. Expected: every line ends in `op=…` and the
   operation names read sensibly in the UI's own rendering. Proven by grepping the file
   inside the container; the UI's line wrapping and truncation are what a human sees.
4. `[HA settings]` Save the options (Settings → Devices & services → HAventory →
   **Configure**) while an `/haventory` tab is open in another window. Expected — and this is
   the known defect **#507** — that tab is taken to the default dashboard. Worth seeing once
   so the issue is judged on how it feels, not on a log line.

### 3. Decisions taken against drifted notes

- **#493:** "Locations count" → **"Location count"**, following #492's singular-noun
  vocabulary (`items_total` is *Item count*), and "four of the nine keys" → "seven of the
  twelve" — the comment was already stale in the other direction.
- **#493:** no `item/list` filter for `inspection_due_count`; the gap is documented in the
  contract instead of widening the wire for a count nothing filters on.
- **#450:** **locations are in scope.** The issue's table names item services only, but its
  title and symptom are about `haventory.*`, and the location services reached no subscriber
  either.
- **#450:** `events.py` imports `ws.py` **inside the function** with a reasoned
  `# noqa: PLC0415`; moving the broadcaster to a third module would have dragged
  `_subs_bucket`, `_rate_limiter` and `_repo` with it, which #280 was about to move anyway.
- **#280:** `async_persist_repo(hass)` **keeps its signature** and resolves through
  `find_runtime`, rather than taking the runtime as the notes ask. The two-lookup rule — the
  part the notes call "the part that bites" — is honoured exactly and pinned twice.
- **#280:** `ws_registered` / `services_registered` / `ws_handlers` **stay** in
  `hass.data[DOMAIN]`; the notes say they can move, but they record registrations Home
  Assistant cannot undo, like the route flags beside them. The to-do bridge's four keys, which
  the notes predate, **do** move.
- **#430:** a `LoggerAdapter` rather than a helper each call site wraps its message in, so the
  109 call sites keep their shape; and the rule lives in `CLAUDE.md`/`README.md`, not
  `CONTRIBUTING.md`, which never carried it.
- **Plan drift:** §4 points at "the assets-branch recipe the `run-haventory` skill documents";
  the skill documented no such recipe, and §6.2 points at "the `two-tab` recipe in the
  `run-haventory` skill", which did not exist either. Screenshots are hosted on the orphan
  branch `claude-assets-v0-7-0-s2`, and the two-tab recipe is now a real harness
  (`two_tab.mjs`) documented in the skill, along with `reload_probe.mjs`.

### 4. Follow-ups

Filed:

- **#505** — with a search active, a row arriving through an event is added to the list but
  not counted into the footer, which then reads "Showing 1 of 0 matching items". Card-side and
  pre-existing (reproduced with a WebSocket mutation as the mutator).
- **#507** — a reload, or an options save, takes an open `/haventory` page back to the default
  dashboard and does not bring it back. Reproduced against `main` in the same container.
- **#508** — the first reload after a restart logs an ERROR naming
  `custom_components.haventory.todo_bridge` about a one-time listener that already fired.
  Reproduced against `main`.

Named and deliberately not filed:

- **PR 1 found and fixed its own defect before merge:** promoting `locations_total` exposed
  that a location create or delete repainted nothing, so the new sensor sat at the old figure.
  Fixed in #504's second commit rather than filed.
- **The card's `inspection_due` quick-filter pill** is named *due* and behaves as *overdue*
  (it reads `inspection_overdue_count` and filters with `inspection_overdue_only`). Now
  nameable, but changing it moves a user-visible filter and belongs with the card sessions
  (S7's territory) — worth filing there rather than here, with the pill's own screenshots.
- **A wording pass over log messages** that partly restate their new context tail. Nothing is
  duplicated after this PR's "Storage health" fix; the rest is taste.

### 5. State left behind

- **Dev HA** (container `home-assistant`, HA 2026.7.4): running **this branch's** build, which
  is `main` once this merges. Inventory restored to its baseline — **1087 items, 89
  locations** — every probe item deleted. Options written back through the real flow with the
  values the form reported (`card_title: HAventory`, `sidebar_panel_enabled: true`,
  `quick_filters: [total, low_stock, overdue, inspection_due, checked_out]`); no defaults were
  guessed. Profile language untouched (German, as it was). `log_sweep.py`: PASS, blocking=0.
- **The UTC date rolled over mid-session** (2026-08-20 → 21), and one real item — *Photo Album
  #0318* — has an inspection date of exactly 2026-08-21. So the dev instance currently shows
  `inspection_due_count` 34 against `inspection_overdue_count` 33, which is the new sensor
  being right rather than something to chase.
- **Branches:** all four PR branches deleted on merge. The orphan branch
  **`claude-assets-v0-7-0-s2`** holds the screenshots the PR bodies link to; it is merged into
  nothing and can be deleted once these PRs are closed for good.
- **Harnesses added** under `.claude/skills/run-haventory/`, both listed in the skill's
  verification table: `two_tab.mjs` (a mutation from neither tab repaints both; `--ws` is its
  control) and `reload_probe.mjs` (a reload and an options change with the card and the panel
  open). Neither runs in CI.
- **Not touched:** the release-please PR, `dev/V0_7_0_implementation.md`, and the four issues'
  text — decisions were recorded in PR bodies, as §4 asks.
- **For S3:** `main` now carries `custom_components/haventory/runtime.py` and
  `custom_components/haventory/logs.py`, and `tests/runtime_helpers.py` is how an offline test
  says "an entry is loaded" — a new test that hand-wires `hass.data[DOMAIN]` will not work.
  `pyproject.toml`'s strict-mypy list gained `haventory.runtime`, and the codespell hook's
  ignore list gained `categorie`.
