### PR TITLE
build: raise the Python floor to the one Home Assistant requires

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,17 @@ Three floors constrain everything, none of them written down here:
   enumerates the copies and fails when one drifts. Add a new copy to that test or don't
   write it. `requirements-integration.txt` pins the in-process suite to the floor, so CI
   runs the integration *at* it rather than at whatever is current.
-- **Python** — `requires-python` in `pyproject.toml`; ruff's `target-version` and mypy's
-  `python_version` follow it, and CI installs it. It cannot go lower than HA's own floor,
-  and the source uses PEP 758 unparenthesized `except A, B:`, which does not parse on
-  older interpreters — so an older HA could not import the integration at all. uv
-  provisions the interpreter automatically on `uv sync`; an environment with restricted
-  egress must preinstall it or allow the python-build-standalone download, otherwise the
-  offline suite cannot run there.
+- **Python** — `requires-python` in `pyproject.toml`, stated at patch level because Home
+  Assistant states its own that way; ruff's `target-version` and mypy's `python_version`
+  follow it as a series (neither accepts a patch), and CI installs it. It cannot go lower
+  than HA's own floor, and the source uses PEP 758 unparenthesized `except A, B:`, which
+  does not parse on older interpreters — so an older HA could not import the integration
+  at all. `tests/test_toolchain_pins.py` holds every copy to the declaration and tells the
+  two spellings apart; `tests/integration/test_python_floor.py` holds the declaration to
+  the `Requires-Python` of the HA release `requirements-integration.txt` pins, which is
+  the only place both numbers exist. uv provisions the interpreter automatically on
+  `uv sync`; an environment with restricted egress must preinstall it or allow the
+  python-build-standalone download, otherwise the offline suite cannot run there.
 - **Node** — `engines` in `cards/haventory-card/package.json`; CI runs a matrix across the
   supported majors, and every `node-version:` a workflow pins has to be one of them.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,12 @@ description = "Home Assistant custom integration for household inventory trackin
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "chrreiter" }]
-# Matches the declared HA runtime (min HA 2026.6.0 => Python 3.14). uv provisions
-# the interpreter automatically (`uv sync` / `uv python install 3.14`); dev
-# environments must allow that download or preinstall Python 3.14.
-requires-python = ">=3.14"
+# Matches the declared HA runtime (min HA 2026.6.0 => Python 3.14.2), patch level
+# included: that is the floor Home Assistant's own metadata states, so an
+# interpreter this project accepts can install it. uv provisions the interpreter
+# automatically (`uv sync` / `uv python install 3.14`); dev environments must
+# allow that download or preinstall Python 3.14.
+requires-python = ">=3.14.2"
 
 [project.urls]
 Homepage = "https://github.com/chrreiter/HAventory#readme"
@@ -45,8 +47,9 @@ probes = [
 # `custom_components/haventory` directly. Don't build/install the project itself.
 package = false
 
-# py314 matches requires-python. Note: the 2026 formatter emits PEP 758
-# unparenthesized `except A, B:` at this target — the source is 3.14-only.
+# py314 is the floor's series; ruff's target carries no patch level. Note: the
+# 2026 formatter emits PEP 758 unparenthesized `except A, B:` at this target —
+# the source is 3.14-only.
 [tool.ruff]
 target-version = "py314"
 line-length = 100
@@ -85,7 +88,8 @@ quote-style = "preserve"
 "scripts/**" = ["ASYNC240", "ASYNC250"]
 
 [tool.mypy]
-# python_version matches requires-python / ruff target (HA 2026.6.0 => Python 3.14).
+# python_version follows requires-python; mypy takes the series only
+# (HA 2026.6.0 => Python 3.14).
 python_version = "3.14"
 files = ["custom_components/haventory"]
 namespace_packages = true

--- a/tests/integration/test_python_floor.py
+++ b/tests/integration/test_python_floor.py
@@ -1,0 +1,62 @@
+"""Integration: the declared Python floor is one this Home Assistant installs on.
+
+``pyproject.toml`` declares the interpreter this project needs, and the Home
+Assistant release ``requirements-integration.txt`` pins declares its own. The
+second number exists only where Home Assistant is installed, which is here —
+offline there is nothing to compare against, so ``tests/test_toolchain_pins.py``
+holds every copy of the floor to the declaration and this holds the declaration
+to Home Assistant.
+
+A floor below HA's own is not a lax declaration but a misleading one: uv is free
+to hand such an environment an interpreter that then cannot resolve Home
+Assistant at all, and the failure reads as an unsatisfiable dependency rather
+than as an interpreter too old.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from importlib.metadata import metadata
+from pathlib import Path
+
+import pytest
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def lowest_admitted(requires_python: str) -> tuple[int, ...]:
+    """The oldest interpreter a ``Requires-Python`` specifier set admits."""
+    lower_bounds = re.findall(r">=\s*(\d+(?:\.\d+)*)", requires_python)
+    assert len(lower_bounds) == 1, f"{requires_python!r} states no single lower bound"
+    return tuple(int(part) for part in lower_bounds[0].split("."))
+
+
+def declared_floor() -> tuple[int, ...]:
+    """The floor ``requires-python`` declares."""
+    requires_python = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["project"][
+        "requires-python"
+    ]
+    return lowest_admitted(requires_python)
+
+
+def test_the_declared_floor_is_not_below_what_this_ha_release_demands() -> None:
+    """`requires-python` admits no interpreter Home Assistant would refuse."""
+    home_assistant = lowest_admitted(str(metadata("homeassistant")["Requires-Python"]))
+
+    assert declared_floor() >= home_assistant, (
+        f"pyproject.toml declares Python {declared_floor()}, Home Assistant "
+        f"{metadata('homeassistant')['Version']} demands {home_assistant}"
+    )
+
+
+def test_a_lower_bound_is_read_out_of_a_compound_specifier() -> None:
+    """Home Assistant may bound the top as well; only the bottom is the floor."""
+    assert lowest_admitted(">=3.14.2,<3.16") == (3, 14, 2)
+    assert lowest_admitted(">= 3.14") == (3, 14)
+
+
+def test_a_specifier_without_a_lower_bound_is_refused() -> None:
+    """An unbounded specifier compares as no floor at all, so it must not pass."""
+    with pytest.raises(AssertionError):
+        lowest_admitted("<3.16")

--- a/tests/test_toolchain_pins.py
+++ b/tests/test_toolchain_pins.py
@@ -12,6 +12,14 @@ committed file is then swept for the same spellings, so a copy in an
 unregistered file fails too. Adding a copy means registering it here or not
 writing it.
 
+The floor is declared at patch level because Home Assistant declares its own
+that way; most copies name only the series an interpreter belongs to — ruff's
+target, mypy's ``python_version``, the CI matrix. Both spellings are registered
+per file, so relaxing a patch-level copy to the series fails as loudly as
+changing the number does. Whether the declared patch is the one the pinned Home
+Assistant release demands cannot be read without HA installed, and is asserted
+in ``tests/integration/test_python_floor.py``.
+
 Two Python copies are shaped so no interpreter-version pattern can see them, and
 neither is unguarded: ``.github/rulesets/main.json`` names the required check
 ``backend (3.14)``, which ``tests/test_repo_hardening_offline.py`` ties to the
@@ -26,6 +34,7 @@ import json
 import re
 import subprocess
 import tomllib
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -60,7 +69,7 @@ def collapse(text: str) -> str:
 # The Python floor
 # --------------------------------------------------------------------------
 
-_PY = r"3\.\d+"
+_PY = r"3\.\d+(?:\.\d+)?"
 
 # Every spelling of an interpreter version this repository uses. Anchored on
 # "python" or on the "3.14-only" phrase so that release versions which merely
@@ -82,22 +91,23 @@ PYTHON_VERSION_FORMS = re.compile(
 # ruff spells the same number without the dot.
 RUFF_TARGET_VERSION = re.compile(r"target-version *= *\"py3(\d\d)\"")
 
-# (path relative to the repository root, number of copies in it).
-PYTHON_FLOOR_SITES: tuple[tuple[str, int], ...] = (
-    ("pyproject.toml", 8),
-    (".github/workflows/ci.yml", 5),
-    (".github/workflows/codeql.yml", 1),
-    ("README.md", 10),
-    ("CONTRIBUTING.md", 1),
-    ("docs/backend_api_contract.md", 1),
-    ("requirements-integration.txt", 2),
-    ("scripts/test_integration.sh", 4),
-    (".devcontainer/Dockerfile", 1),
-    (".devcontainer/develop.sh", 2),
-    (".devcontainer/post-create.sh", 1),
-    (".claude/hooks/session-start.sh", 8),
-    (".claude/skills/run-haventory/SKILL.md", 2),
-    (".claude/skills/test-haventory/SKILL.md", 7),
+# (path relative to the repository root, copies naming the series, copies
+# naming the patch-level floor).
+PYTHON_FLOOR_SITES: tuple[tuple[str, int, int], ...] = (
+    ("pyproject.toml", 6, 2),
+    (".github/workflows/ci.yml", 5, 0),
+    (".github/workflows/codeql.yml", 1, 0),
+    ("README.md", 10, 0),
+    ("CONTRIBUTING.md", 1, 0),
+    ("docs/backend_api_contract.md", 1, 0),
+    ("requirements-integration.txt", 2, 0),
+    ("scripts/test_integration.sh", 4, 0),
+    (".devcontainer/Dockerfile", 1, 0),
+    (".devcontainer/develop.sh", 2, 0),
+    (".devcontainer/post-create.sh", 1, 0),
+    (".claude/hooks/session-start.sh", 8, 0),
+    (".claude/skills/run-haventory/SKILL.md", 2, 0),
+    (".claude/skills/test-haventory/SKILL.md", 7, 0),
 )
 
 # `dev/` holds design documents that quote configuration verbatim to describe
@@ -138,8 +148,14 @@ SWEPT_NAMES = frozenset({"Dockerfile"})
 
 
 def declared_python_floor() -> str:
-    """The interpreter version ``requires-python`` demands."""
+    """The interpreter version ``requires-python`` demands, patch level and all."""
     return read_toml(PYPROJECT)["project"]["requires-python"].removeprefix(">=")
+
+
+def declared_python_series() -> str:
+    """The floor's ``major.minor`` — the spelling a runtime target is written in."""
+    major, minor, *_ = declared_python_floor().split(".")
+    return f"{major}.{minor}"
 
 
 def python_versions_in(text: str) -> list[str]:
@@ -188,22 +204,45 @@ def test_the_floor_cannot_drop_below_the_syntax_the_source_uses() -> None:
     older interpreter parses — an environment below the floor cannot import the
     package at all, so lowering the declaration would not merely widen support.
     """
-    major, minor = (int(part) for part in declared_python_floor().split("."))
+    major, minor = (int(part) for part in declared_python_series().split("."))
     assert (major, minor) >= (3, 14)
 
 
-@pytest.mark.parametrize(("relative_path", "occurrences"), PYTHON_FLOOR_SITES)
-def test_python_floor_sites_match_pyproject(relative_path: str, occurrences: int) -> None:
-    """Every registered copy of the floor agrees with ``requires-python``."""
-    found = python_versions_in((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+def test_the_floor_is_declared_at_patch_level() -> None:
+    """A series-only declaration admits interpreters Home Assistant refuses.
 
-    assert len(found) == occurrences, (
-        f"{relative_path}: expected {occurrences} interpreter version(s), found {len(found)} "
-        f"({found}) — register the new copy here or drop it"
+    Home Assistant states its own floor at patch level — ``>=3.14.2`` for the
+    release ``requirements-integration.txt`` installs — so a declaration of
+    ``>=3.14`` here is satisfied by interpreters that cannot install Home
+    Assistant at all. The failure then surfaces as an unsatisfiable dependency
+    resolution rather than as an interpreter a couple of patch releases too old.
+    """
+    assert re.fullmatch(r"\d+\.\d+\.\d+", declared_python_floor()), (
+        f"requires-python declares {declared_python_floor()!r}, which names no patch release"
     )
-    assert set(found) == {declared_python_floor()}, (
-        f"{relative_path} states {sorted(set(found))}, "
-        f"pyproject.toml declares {declared_python_floor()!r}"
+
+
+@pytest.mark.parametrize(("relative_path", "series_copies", "floor_copies"), PYTHON_FLOOR_SITES)
+def test_python_floor_sites_match_pyproject(
+    relative_path: str, series_copies: int, floor_copies: int
+) -> None:
+    """Every registered copy names the floor, in the spelling registered for it."""
+    found = Counter(python_versions_in((REPO_ROOT / relative_path).read_text(encoding="utf-8")))
+    expected = Counter(
+        {
+            version: count
+            for version, count in (
+                (declared_python_series(), series_copies),
+                (declared_python_floor(), floor_copies),
+            )
+            if count
+        }
+    )
+
+    assert found == expected, (
+        f"{relative_path} states {dict(found)}; registered here are {series_copies} copy/copies "
+        f"of the {declared_python_series()} series and {floor_copies} of the "
+        f"{declared_python_floor()} floor — register the new copy here or drop it"
     )
 
 
@@ -224,7 +263,7 @@ def test_a_local_only_file_is_not_swept() -> None:
 
 def test_no_unregistered_file_states_an_interpreter_version() -> None:
     """A copy in a file this test does not know about fails the same way."""
-    registered = {path for path, _ in PYTHON_FLOOR_SITES}
+    registered = {path for path, *_ in PYTHON_FLOOR_SITES}
     carrying = {
         path.relative_to(REPO_ROOT).as_posix()
         for path in swept_files()
@@ -248,6 +287,7 @@ def test_both_spellings_of_a_version_are_found() -> None:
     assert python_versions_in('target-version = "py315"') == ["3.15"]
     assert python_versions_in("needs Python\n**3.15** to run") == ["3.15"]
     assert python_versions_in("uv venv --python 3.15 .venv") == ["3.15"]
+    assert python_versions_in('requires-python = ">=3.15.2"') == ["3.15.2"]
 
 
 # --------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.14"
+requires-python = ">=3.14.2"
 resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version < '3.15'",


### PR DESCRIPTION
## Summary

`requires-python` declared `>=3.14`; the Home Assistant release
`requirements-integration.txt` pins declares `>=3.14.2`. So an interpreter that satisfied
this project could fail to install the one dependency the integration mode exists to load,
and the failure read as an unsatisfiable dependency resolution rather than "your
interpreter is two patch releases too old" — invisible in CI, which provisions a current
uv, and expensive for a contributor whose uv still resolves `3.14` to `3.14.0rc2`.

The issue's **option 1**: the declaration names the patch release, and two guards keep it
true.

- `pyproject.toml` — `requires-python = ">=3.14.2"`, and the comments above it, ruff's
  `target-version` and mypy's `python_version` now say why those two carry only the
  series (neither setting accepts a patch level). `uv.lock` re-locked.
- `tests/test_toolchain_pins.py` — the floor register gains a column: each file is
  registered with how many copies name the **series** (`3.14`) and how many name the
  **floor** (`3.14.2`). The version pattern learned the patch-level spelling, so the
  declaration itself is seen rather than read as `3.14`. A copy that names another series
  or another patch still fails, and relaxing a patch-level copy to the series now fails
  too.
- `tests/integration/test_python_floor.py` (new) — the declaration is not below the
  `Requires-Python` of the Home Assistant release installed in that environment, read
  through `importlib.metadata`. Plus the helper's edge cases: the lower bound is taken out
  of a compound specifier, and a specifier with no lower bound is refused rather than
  read as "no floor".
- `CLAUDE.md` — the Python floor bullet records the split: patch-level declaration,
  series-level copies, which test holds which half.

Closes #433

## Decisions taken against the issue's notes

- **Which file holds which half** (§6.3 asks for this to be decided and recorded). The
  comparison against Home Assistant's own metadata lives in
  `tests/integration/test_python_floor.py`, because `Requires-Python` only exists where HA
  is installed and the offline suite stubs HA away. The offline half —
  `tests/test_toolchain_pins.py` — keeps every copy in step with the declaration and
  additionally asserts the declaration names a patch release, so a revert to `>=3.14`
  fails the fast gate too rather than only in the phacc job.
- **The issue's second shape (pin `scripts/test_integration.sh`) is not folded in.** The
  script keeps asking uv for the series. With the floor raised, an environment whose uv
  can only reach `3.14.0rc2` is stopped at `uv sync` — the bootstrap `scripts/setup.sh`,
  the devcontainer post-create hook and CLAUDE.md all run first — and told exactly which
  requirement the interpreter misses (evidence below). Pinning the script to the exact
  floor patch instead would make every fresh container download `3.14.2` while CI keeps
  provisioning the series, for a diagnosis that has already been given one step earlier.
- **Prose copies stay at the series.** `README.md`, `CONTRIBUTING.md`,
  `docs/backend_api_contract.md`, the devcontainer scripts, the session-start hook and the
  two skills all say "Python 3.14", which is the runtime series they mean; only
  `pyproject.toml` states a patch level, and it is what uv enforces. The register now
  encodes that rather than tolerating it.

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1247 passed, 22
      skipped**; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all
      clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` (**63 files, 1864 tests**), `npm run build` — untouched by this PR,
      run because the repo gate says both.
- [x] phacc (`scripts/test_integration.sh` in the plan's Docker recipe, Python 3.14.3):
      **123 passed**, the three new cases included.

**The new integration guard bites.** With `requires-python` temporarily back at `>=3.14`:

```
E   AssertionError: pyproject.toml declares Python (3, 14), Home Assistant 2026.6.0 demands (3, 14, 2)
E   assert (3, 14) >= (3, 14, 2)
```

**`uv sync` refuses an interpreter below the floor**, naming it — the diagnosis the issue
asks for, one patch below the floor rather than the rc build this machine cannot reach:

```
$ uv sync --python 3.14.1
Using CPython 3.14.1
error: The requested interpreter resolved to Python 3.14.1, which is incompatible with the
project's Python requirement: `>=3.14.2` (from `project.requires-python`)
```

A fresh `uv sync` at the raised floor resolves and installs normally (Python 3.14.6 here).

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`CLAUDE.md`; no user-facing behavior moved).
- [x] No WebSocket API change.
- [x] Essential invariants untouched.

## Follow-ups

None. The one thing worth saying out loud: this floor moves whenever the pinned Home
Assistant release does, and the phacc guard is what will say so — a raise of the HA pin
whose `Requires-Python` has moved now fails the `integration` job until `pyproject.toml`
follows.
