### PR TITLE
docs: one declared floor, and a guard against a second README version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,12 @@ hook can no longer run a different version than CI.
 When raising the HA floor, three constraints stack and the binding one is not always the
 same: the HA APIs the integration touches, the Python floor those releases carry, and
 **security** — a declared floor is a recommendation about what to run, so it must not point
-at a release with a known unpatched advisory. That last one moves with new advisories, so
-"the oldest release with no known advisory" is not a fixed number; re-derive it rather than
-assuming the current floor is still the right one. `dependency-review` fails CI if
-`requirements-integration.txt` is pinned below it.
+at a release carrying a known unpatched **high or critical** advisory. Lower severities do
+not move it: "any advisory at all" is what turns a floor into a treadmill, and it is not how
+the current one was derived. The high/critical set still moves with new advisories, so that
+number is not fixed either; re-derive it rather than assuming the current floor is still the
+right one. `dependency-review` fails CI if `requirements-integration.txt` is pinned below
+it.
 
 Toolchain: **uv** (env + lockfile + dependency groups), ruff, mypy, ESLint (no separate
 formatter), TypeScript, Vite, Vitest. Pins live in `pyproject.toml` and
@@ -287,6 +289,16 @@ See the README "Developer Checklist" for the full backend/frontend/CI checklist.
 - **Areas are HA's, not ours.** The integration reads the area registry and never creates
   areas. An item's area is inherited from its location tree's root, exposed as
   `effective_area_id`, and shown with one chip vocabulary wherever the card marks an area.
+- **One declared Home Assistant floor, and `hacs.json` is it.** There is no second,
+  lower "runs on" number beside a higher "recommended" one. `requirements-integration.txt`
+  pins the in-process suite to the declared floor, which is the only reason "minimum
+  supported" is a tested claim rather than an assertion — and a lower API floor could not
+  be pinned there, because the releases below the current floor carry the advisory
+  `dependency-review` rejects. So the older releases the integration also works on live in
+  git history and in
+  [#235](https://github.com/chrreiter/HAventory/issues/235), not in a second
+  version-shaped string in the README that nothing would keep true;
+  `tests/test_min_ha_version.py` fails when one appears.
 - **Reminders/calendar ride HA-native primitives** — `calendar.haventory` is a
   `CalendarEntity`, and notifications are the household's own automations calling
   `notify.notify`. Occurrences are **derived on read**, never scheduled and never stored:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ GitHub release, which already contains the built card. Installing from the defau
 is deliberately not offered — the card bundle is a build artifact and is not in git, so a
 branch install would come up without a card and report success.
 
-Minimum Home Assistant version: **2026.6.0** — the oldest release that both runs the
-integration and carries no known security advisory. Developers: see the Developer
-Checklist below and [CONTRIBUTING.md](CONTRIBUTING.md).
+Minimum Home Assistant version: **2026.6.0** — one declared floor, and this is it: the
+oldest release that both runs the integration and carries no known unpatched high or
+critical security advisory. The integration is verified against older releases as well,
+but a declared minimum is also a recommendation about what to run, and this project will
+not point it at a release with a known hole. Developers: see the Developer Checklist
+below and [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Finding HAventory after install
 

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -26,6 +26,13 @@
 # when the declared minimum moves; `tests/test_min_ha_version.py` fails if the two
 # drift apart.
 #
+# This pin is also what makes the declared floor testable, and therefore why the
+# floor cannot be split into a lower "runs on" number and a higher "recommended"
+# one: the suite runs at exactly what is pinned here, so a declared floor this
+# file did not pin would be the one version CI never exercises. A second file
+# pinned lower does not rescue it — it re-introduces the advisory below, which
+# `dependency-review` fails outright.
+#
 # 2026.6.0 rather than 2026.3.x, which the API touch points would also allow:
 # every release below 2026.6.0 is affected by GHSA-x84v-g949-293w (high, fixed in
 # 2026.6.0), and the dependency-review check fails the pin outright.

--- a/tests/test_min_ha_version.py
+++ b/tests/test_min_ha_version.py
@@ -9,6 +9,13 @@ and unrelated pins.
 ``requirements-integration.txt`` is the one that makes the claim testable: the
 in-process HA suite runs against exactly that pin, so pinning it to the floor is
 what turns "minimum supported" from an assertion into something CI defends.
+
+That is also why there is one floor and not two. A lower "runs on" number beside
+a higher "recommended" one could not be pinned here — the releases below the
+current floor carry the advisory ``dependency-review`` rejects — so the declared
+minimum would become the one version CI never runs at. The README is therefore
+held to a single Home Assistant version, by a guard that reads the shape rather
+than the two registered sentences.
 """
 
 from __future__ import annotations
@@ -43,6 +50,24 @@ DECLARATION_SITES: tuple[tuple[str, str, int], ...] = (
 )
 
 
+# A Home Assistant version as the README writes one. Prose wraps, so the mention
+# and the number often land on different lines; whitespace is flattened before
+# the window in front of a number decides whether it is Home Assistant's.
+BOLD_VERSION = re.compile(rf"\*\*({VERSION})\*\*")
+HOME_ASSISTANT = re.compile(r"\b(?:Home Assistant|HA)\b")
+CONTEXT_CHARS = 120
+
+
+def home_assistant_versions_in(text: str) -> list[str]:
+    """Every bold three-component version the text states about Home Assistant."""
+    flattened = re.sub(r"\s+", " ", text)
+    return [
+        match.group(1)
+        for match in BOLD_VERSION.finditer(flattened)
+        if HOME_ASSISTANT.search(flattened[max(0, match.start() - CONTEXT_CHARS) : match.start()])
+    ]
+
+
 def declared_floor() -> str:
     """The minimum supported HA version as HACS reads it."""
     return json.loads((REPO_ROOT / "hacs.json").read_text(encoding="utf-8"))["homeassistant"]
@@ -73,3 +98,36 @@ def test_declaration_sites_match_hacs_json(
     assert set(found) == {declared_floor()}, (
         f"{relative_path} declares {sorted(set(found))}, hacs.json declares {declared_floor()!r}"
     )
+
+
+def test_readme_names_one_home_assistant_version() -> None:
+    """A second version in the README would be a floor nothing keeps true.
+
+    ``DECLARATION_SITES`` pins the two sentences that state the floor today, by
+    the wording they use. A "recommended version" written anywhere else, in any
+    wording, is the copy that goes stale — and this project decided there is one
+    number, so the guard reads the shape instead of a sentence.
+    """
+    stated = home_assistant_versions_in((REPO_ROOT / "README.md").read_text(encoding="utf-8"))
+
+    assert set(stated) == {declared_floor()}, (
+        f"README.md states Home Assistant {sorted(set(stated))}; hacs.json declares "
+        f"{declared_floor()!r}, and there is one floor — anchor a second number in "
+        f"DECLARATION_SITES or drop it"
+    )
+
+
+def test_a_second_home_assistant_version_is_reported() -> None:
+    """The guard sees the number that was added, not only the declared one."""
+    sample = (
+        "Minimum Home Assistant version: **2026.3.1** is the oldest release that\n"
+        "runs the integration. For Home Assistant itself we recommend\n"
+        "**2026.6.0** or newer.\n"
+    )
+
+    assert home_assistant_versions_in(sample) == ["2026.3.1", "2026.6.0"]
+
+
+def test_a_version_that_is_not_home_assistants_is_left_alone() -> None:
+    """The card and the integration carry their own versions, in the same shape."""
+    assert home_assistant_versions_in("The store listing lands with **1.0.0**.") == []


### PR DESCRIPTION
## Summary

The decision #235 asks for, taken the way its implementation notes recommend: **one
declared Home Assistant floor**, `hacs.json` is it, and no second "recommended" number.

The argument that settles it is mechanical. `requirements-integration.txt` pins the
in-process suite to the declared floor, and that pin is the only reason "minimum
supported" is a tested claim rather than an assertion. Under a runs-on/recommended split
the pin could not follow the lower API floor — every release below the current one carries
GHSA-x84v-g949-293w, which `dependency-review` fails outright — so the declared floor
would become the one version CI never runs at.

So this is documentation plus a guard, not a renumbering. `hacs.json`, `manifest.json`,
`CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `pyproject.toml` and
`.github/workflows/ci.yml` are deliberately untouched — under the other option every one of
them would have moved.

- `CLAUDE.md` — a new bullet under "Scope decisions that stay true" records the decision
  and why the integration pin is what makes it work. The floor-raising paragraph's security
  clause is now bounded to **high or critical** advisories: "any advisory at all" is what
  makes the policy read as a treadmill, and it is not how the current floor was derived.
- `README.md` — the minimum-version sentence states the policy: one floor, the severity
  bound, and that the integration is verified against older releases while a declared
  minimum is also a recommendation about what to run. No second version-shaped string —
  the verified API floor stays in git history and in #235, where nothing has to keep it
  true.
- `requirements-integration.txt` — the version-policy comment says why this pin cannot be
  split from `hacs.json`.
- `tests/test_min_ha_version.py` — the guard that makes the decision enforceable rather
  than conventional.

Closes #235

## The guard

`DECLARATION_SITES` pins the two README sentences *by their wording*, so a "recommended
version" written in any other wording is invisible to it. The new
`home_assistant_versions_in()` reads the **shape** instead: every bold three-component
version whose flattened 120-character run-up mentions Home Assistant. All of them must
equal `hacs.json`'s floor.

Non-vacuous by construction (an empty result fails the set comparison), and it bites — a
line appended to the real README:

```
E   AssertionError: README.md states Home Assistant ['2026.6.0', '2026.9.1']; hacs.json
    declares '2026.6.0', and there is one floor — anchor a second number in
    DECLARATION_SITES or drop it
```

Edge cases: a two-version sample reports **both** numbers (the failure above is the
guard working, not an artefact of the README's current text), and a bold version with no
Home Assistant mention in front of it — the project's own release version, written in the
same shape — is left alone.

## Decisions taken against drifted notes

- The notes cite `README.md:34` for the minimum-version sentence; it is line 41 today.
  Same sentence, decided against the file.
- The notes' "deferred to live verification" item — that HACS evaluates `hacs.json` at the
  ref it installs, which is what makes "raising the floor does not retract published
  releases" true — is **verified**, against the HACS 2.0.5 running in the dev Home
  Assistant rather than by a README claim:
  `HacsRepository._ensure_download_capabilities(ref)` fetches
  `raw.githubusercontent.com/<repo>/<ref>/hacs.json` through `get_hacs_json(version=ref)`
  and raises only when `hacs.core.ha_version < target_manifest.homeassistant`. An older
  tag is checked against its own `hacs.json`, so a raise gates the release carrying it.
  The claim is not printed in the README anyway — it is the reasoning behind the decision,
  and it now sits on evidence.
- The second deferred item — whether the current floor still carries no unpatched
  high/critical advisory — is not re-derived here; nothing in this PR moves the number,
  and `dependency-review` is what fails the pin if it ever should move.

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1250 passed, 22
      skipped**; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` (**63 files, 1864 tests**), `npm run build`.
- phacc not required: nothing here changes integration behavior, and the HA pin does not
  move. (It ran green on this branch's parent commit.)

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + two edge cases).
- [x] Docs updated where behavior changed (`README.md`, `CLAUDE.md`,
      `requirements-integration.txt`).
- [x] No WebSocket API change.
- [x] Essential invariants untouched.

## Follow-ups

None filed. One thing the next floor raise should know: the README sentence no longer
carries a severity-free "no known security advisory" claim, so re-deriving the floor means
asking specifically whether a candidate release has an unpatched **high or critical**
advisory — CLAUDE.md now says so in both places that describe the policy.
