### PR TITLE
ci: Dependabot pip block, wider tsc gate, frontend pre-commit hooks, moderate audit level, digest-pinned actionlint

### DIFF
--- a/.claude/skills/run-haventory/card_views.mjs
+++ b/.claude/skills/run-haventory/card_views.mjs
@@ -231,6 +231,10 @@ let notesPrinted = false;
  * The URL path a harness should open for the given shape, announced on stdout
  * so a run says which view it chose and why. `label` names the caller's own
  * notion of the pass when it has one; the shape is the sensible default.
+ *
+ * @param {string} shape
+ * @param {{ override?: string | null, label?: string }} [options]
+ * @returns {Promise<string>}
  */
 export async function cardPath(shape, { override = null, label = shape } = {}) {
   if (override) {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,20 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
+    groups:
+      python-dev:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # Integration test harness (pip): `requirements-integration.txt` at the root.
+  # The dependency graph already scans that file, so an advisory in it alerts;
+  # what was missing is the pull request that fixes it.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
     ignore:
       # Not dependencies to keep current. `requirements-integration.txt` pins the
       # Home Assistant core to the floor `hacs.json` declares, so the in-process
@@ -39,9 +53,16 @@ updates:
       # tests/test_min_ha_version.py and tests/integration/test_frontend.py — so
       # a bump arrives as a red pull request that reopens every week. Both move
       # together, by hand, when the declared floor moves.
+      #
+      # Scoped to version updates rather than ignored outright: a security update
+      # for either must still be able to open a pull request.
       - dependency-name: "homeassistant"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
       - dependency-name: "home-assistant-frontend"
-    groups:
-      python-dev:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,16 @@ jobs:
           cache-dependency-path: cards/haventory-card/package-lock.json
       - name: Install
         run: npm ci --no-audit --no-fund
-      - name: Audit (npm advisories, high+)
+      - name: Audit (npm advisories, moderate+)
         # The repository's Dependabot auto-triage rule dismisses development-scope
         # alerts, so the alert dashboard cannot be trusted to surface a vulnerable
         # dev dependency — this blocking step is where the lockfile is checked.
-        # Kept explicit rather than folded into the install above, whose
-        # `--no-audit` keeps install output free of advisory noise.
-        run: npm audit --audit-level=high
+        # Moderate rather than high: a moderate development-scope advisory is
+        # dismissed on the dashboard and would otherwise clear the gate here too,
+        # so it would surface nowhere. Kept explicit rather than folded into the
+        # install above, whose `--no-audit` keeps install output free of advisory
+        # noise.
+        run: npm audit --audit-level=moderate
       - name: Lint
         run: npx eslint .
       - name: Types (tsc --noEmit)
@@ -160,7 +163,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: actionlint
-        uses: docker://rhysd/actionlint:1.7.12
+        # Digest-pinned: a tag can be moved, and Scorecard's pinned-dependencies
+        # check reads a tag pin as unpinned. The trailing comment is where the
+        # version lives, and `tests/test_toolchain_pins.py` ties it to the
+        # `.pre-commit-config.yaml` rev so the hook and the job stay one release.
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667  # v1.7.12
         with:
           args: -color
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,27 @@ repos:
             cards/haventory-card/package-lock\.json
           )
         additional_dependencies: ["tomli"]
+  # The card's half of the gate, run from the card package because that is where
+  # its node_modules and config live. `pass_filenames: false` because both tools
+  # take the package, not a file list; `language: system` because the hooks run
+  # the npm binaries this checkout already installed rather than an environment
+  # pre-commit builds. Vitest deliberately stays out: a full card suite on every
+  # commit is what makes people reach for `--no-verify`, and CI plus
+  # `scripts/ci_local.sh` already run it.
+  - repo: local
+    hooks:
+      - id: card-eslint
+        name: eslint (card)
+        entry: bash -c 'cd cards/haventory-card && npx eslint .'
+        language: system
+        pass_filenames: false
+        files: ^cards/haventory-card/
+      - id: card-typecheck
+        name: tsc --noEmit (card)
+        entry: bash -c 'cd cards/haventory-card && npm run typecheck'
+        language: system
+        pass_filenames: false
+        files: ^cards/haventory-card/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/cards/haventory-card/e2e/live-updates.smoke.mjs
+++ b/cards/haventory-card/e2e/live-updates.smoke.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 // End-to-end *live-update* smoke test for the HAventory Lovelace card.
 //
 // WHY THIS EXISTS
@@ -49,6 +50,7 @@ if (!token) {
 }
 
 const args = process.argv.slice(2);
+/** @type {(name: string, dflt: string | null) => string | null} */
 const flag = (name, dflt) => {
   const i = args.indexOf(name);
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
@@ -81,12 +83,17 @@ const nameB = `e2e_smoke_${stamp}_b`; // renamed to this out-of-band to prove li
 // WebSocket, performs the auth handshake, sends exactly one command, resolves with
 // {result} or {error}, then closes. Deliberately NOT the card's connection: the card
 // must learn of the change purely through its own subscription.
+/**
+ * @param {import('playwright').Page} page
+ * @param {Record<string, unknown>} command
+ * @returns {Promise<{ result?: any, error?: { code: string, message: string } }>}
+ */
 async function wsCommand(page, command) {
   return page.evaluate(
     ([wsUrl, accessToken, cmd]) =>
       new Promise((resolve, reject) => {
         const ws = new WebSocket(wsUrl);
-        const done = (v) => {
+        const done = (/** @type {any} */ v) => {
           try { ws.close(); } catch { /* ignore */ }
           resolve(v);
         };
@@ -112,10 +119,18 @@ async function wsCommand(page, command) {
 }
 
 // --- small polling helper (no @playwright/test expect here) --------------
+/**
+ * The predicate is handed the page it polls rather than closing over it, so
+ * every caller polls the page `waitFor` is waiting on.
+ *
+ * @param {import('playwright').Page} page
+ * @param {(page: import('playwright').Page) => Promise<boolean>} predicate
+ * @param {{ timeout?: number, interval?: number, label?: string }} [options]
+ */
 async function waitFor(page, predicate, { timeout = 12000, interval = 250, label = 'condition' } = {}) {
   const deadline = Date.now() + timeout;
   for (;;) {
-    if (await predicate()) return true;
+    if (await predicate(page)) return true;
     if (Date.now() > deadline) throw new Error(`timed out waiting for ${label} (${timeout}ms)`);
     await page.waitForTimeout(interval);
   }
@@ -126,14 +141,19 @@ async function waitFor(page, predicate, { timeout = 12000, interval = 250, label
 // hv-list-row). The item name is always rendered (unlike the optional columns the
 // full view can hide), so it is the reliable signal that a live event reached the
 // card's list.
+/** @type {(page: import('playwright').Page, name: string) => import('playwright').Locator} */
 const rowByName = (page, name) => page.locator('haventory-card hv-list-row', { hasText: name });
 
 // --- drive ---------------------------------------------------------------
+/** @type {string[]} */
 const consoleErrors = [];
+/** @type {string[]} */
 const pageErrors = [];
 const browser = await chromium.launch();
 let createdId = null;
+/** @type {Error | null} */
 let failure = null;
+/** @type {import('playwright').Page | null} */
 let page = null;
 
 try {
@@ -176,7 +196,7 @@ try {
   if (created.error) throw new Error(`create failed: ${JSON.stringify(created.error)}`);
   createdId = created.result?.id;
   if (!createdId) throw new Error('create returned no id');
-  await waitFor(page, async () => (await rowByName(page, nameA).count()) > 0, {
+  await waitFor(page, async (p) => (await rowByName(p, nameA).count()) > 0, {
     label: 'created row to appear live',
   });
   console.log('  ok: created item appeared live (no manual re-list)');
@@ -192,7 +212,7 @@ try {
   if (upd.error) throw new Error(`update failed: ${JSON.stringify(upd.error)}`);
   await waitFor(
     page,
-    async () => (await rowByName(page, nameB).count()) > 0 && (await rowByName(page, nameA).count()) === 0,
+    async (p) => (await rowByName(p, nameB).count()) > 0 && (await rowByName(p, nameA).count()) === 0,
     { label: 'rename to reflect live (in-place replace)' },
   );
   console.log('  ok: rename reflected live (in-place replace)');
@@ -205,12 +225,12 @@ try {
   });
   if (del.error) throw new Error(`delete failed: ${JSON.stringify(del.error)}`);
   createdId = null; // deleted; nothing to clean up
-  await waitFor(page, async () => (await rowByName(page, nameB).count()) === 0, {
+  await waitFor(page, async (p) => (await rowByName(p, nameB).count()) === 0, {
     label: 'deleted row to disappear live',
   });
   console.log('  ok: deletion reflected live');
 } catch (e) {
-  failure = e;
+  failure = /** @type {Error} */ (e);
 } finally {
   // Best-effort cleanup so a mid-run failure never leaves e2e_smoke_ junk behind.
   if (createdId && page) {

--- a/cards/haventory-card/eslint.config.js
+++ b/cards/haventory-card/eslint.config.js
@@ -1,3 +1,4 @@
+// @ts-check
 import js from '@eslint/js';
 import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';

--- a/cards/haventory-card/package-lock.json
+++ b/cards/haventory-card/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/node": "^22.20.1",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "@vitest/coverage-v8": "^4.1.10",
@@ -747,6 +748,16 @@
       "version": "7.0.15",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -2595,6 +2606,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/cards/haventory-card/package.json
+++ b/cards/haventory-card/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/node": "^22.20.1",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
     "@vitest/coverage-v8": "^4.1.10",

--- a/cards/haventory-card/tsconfig.json
+++ b/cards/haventory-card/tsconfig.json
@@ -10,7 +10,14 @@
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["vitest/globals"]
+    // The JavaScript in this package opts in per file with `// @ts-check`, so
+    // `checkJs` stays off: `e2e/live-updates.smoke.mjs` imports a module from
+    // `.claude/skills/`, which enters the program and would otherwise be blamed
+    // for errors under a gate it is not part of. The Node globals the driver
+    // uses come from @types/node.
+    "allowJs": true,
+    "checkJs": false,
+    "types": ["vitest/globals", "node"]
   },
-  "include": ["src"]
+  "include": ["src", "vite.config.ts", "eslint.config.js", "e2e"]
 }

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -36,7 +36,7 @@ fi
 
 if command -v npm >/dev/null 2>&1; then
   info 'Frontend: install, audit, lint, types, test, build...'
-  (cd "$CARD_DIR" && npm ci --no-audit --no-fund && npm audit --audit-level=high \
+  (cd "$CARD_DIR" && npm ci --no-audit --no-fund && npm audit --audit-level=moderate \
     && npm run lint && npm run typecheck && npm test -- --coverage && npm run build)
 else
   err 'npm not found; skipping frontend tasks.'

--- a/tests/test_frontend_toolchain_offline.py
+++ b/tests/test_frontend_toolchain_offline.py
@@ -1,0 +1,101 @@
+"""The card's typecheck covers the package, not only ``src/``.
+
+``tsc`` reads whatever ``include`` names and nothing else, so a config file or a
+driver added beside the source is un-typechecked until someone notices — and
+nothing notices, because the gate stays green. The files outside ``src/`` are
+the ones that drift hardest: they are edited rarely, run outside the bundle, and
+`e2e/live-updates.smoke.mjs` talks to both Node and a browser.
+
+``checkJs`` stays off deliberately. That driver imports a module from
+``.claude/skills/run-haventory/``, which enters the compiler's program; with
+``checkJs`` on, a file belonging to another gate would be blamed for errors
+here. Each JavaScript file this package owns opts in with ``// @ts-check``
+instead, and this module is what keeps a new one from forgetting.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CARD = REPO_ROOT / "cards" / "haventory-card"
+TSCONFIG = CARD / "tsconfig.json"
+
+# Built output, vendored packages and coverage reports are not sources.
+SKIPPED_DIRS = frozenset({"node_modules", "coverage", "dist", "www"})
+SOURCE_SUFFIXES = frozenset({".ts", ".js", ".mjs", ".cjs"})
+JAVASCRIPT_SUFFIXES = frozenset({".js", ".mjs", ".cjs"})
+OPT_IN = "// @ts-check"
+
+
+def tsconfig() -> dict[str, Any]:
+    """The card's compiler configuration.
+
+    ``tsconfig.json`` is JSONC — TypeScript accepts comments there and the file
+    uses them, so the whole-line ones are dropped before parsing.
+    """
+    return json.loads(re.sub(r"(?m)^\s*//.*$", "", TSCONFIG.read_text(encoding="utf-8")))
+
+
+def package_sources() -> list[Path]:
+    """Every source file the card package owns, relative to the package root.
+
+    The skipped directories are pruned as the walk goes rather than filtered
+    afterwards: ``node_modules`` alone holds tens of thousands of files.
+    """
+    found: list[Path] = []
+    for directory, subdirectories, filenames in CARD.walk():
+        subdirectories[:] = [name for name in subdirectories if name not in SKIPPED_DIRS]
+        for filename in filenames:
+            path = directory / filename
+            if path.suffix in SOURCE_SUFFIXES:
+                found.append(path.relative_to(CARD))
+    return sorted(found)
+
+
+def is_included(relative: Path, include: list[str]) -> bool:
+    """Whether ``include`` names the file, or a directory it sits under."""
+    return any(relative == Path(entry) or Path(entry) in relative.parents for entry in include)
+
+
+def test_every_source_in_the_package_is_typechecked() -> None:
+    """A config file added beside the source cannot slip past the gate."""
+    include = tsconfig()["include"]
+
+    missed = [str(path) for path in package_sources() if not is_included(path, include)]
+
+    assert missed == [], f"not named by tsconfig `include`: {missed}"
+
+
+def test_the_gate_reaches_past_the_source_directory() -> None:
+    """The three files the widening was for, named rather than implied."""
+    include = set(tsconfig()["include"])
+
+    assert {"src", "vite.config.ts", "eslint.config.js", "e2e"} <= include
+
+
+def test_javascript_is_parsed_and_opts_in_to_checking() -> None:
+    """``allowJs`` lets the JavaScript in; ``// @ts-check`` is what checks it."""
+    options = tsconfig()["compilerOptions"]
+    assert options["allowJs"] is True
+    assert options["checkJs"] is False
+
+    unmarked = [
+        str(path)
+        for path in package_sources()
+        if path.suffix in JAVASCRIPT_SUFFIXES
+        and not (CARD / path).read_text(encoding="utf-8").startswith(OPT_IN)
+    ]
+
+    assert unmarked == [], f"JavaScript without a `{OPT_IN}` line: {unmarked}"
+
+
+def test_an_uncovered_file_is_reported() -> None:
+    """The error case: `include` naming only the source directory."""
+    assert is_included(Path("src/index.ts"), ["src"])
+    assert is_included(Path("vite.config.ts"), ["src", "vite.config.ts"])
+    assert not is_included(Path("eslint.config.js"), ["src"])
+    assert not is_included(Path("e2e/live-updates.smoke.mjs"), ["src", "vite.config.ts"])

--- a/tests/test_repo_hardening_offline.py
+++ b/tests/test_repo_hardening_offline.py
@@ -1,15 +1,22 @@
-"""Tests for the committed branch ruleset in ``.github/rulesets/``.
+"""Tests for the repository configuration that CI itself cannot report on.
 
-A required status check that never reports blocks every pull request forever, so
-the checks named in the ruleset are validated against the workflows that are
-supposed to produce them: the context has to be a job that runs on pull requests
-to ``main`` through an unfiltered trigger.
+The committed branch ruleset in ``.github/rulesets/`` comes first: a required
+status check that never reports blocks every pull request forever, so the checks
+it names are validated against the workflows that are supposed to produce them —
+the context has to be a job that runs on pull requests to ``main`` through an
+unfiltered trigger.
+
+Then two things a workflow run cannot tell you about itself: that every
+third-party action it calls is pinned to an immutable revision, and that
+Dependabot is configured to keep ``requirements-integration.txt`` patched
+without fighting the pins that file carries deliberately.
 """
 
 from __future__ import annotations
 
 import itertools
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +26,25 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RULESET_PATH = REPO_ROOT / ".github" / "rulesets" / "main.json"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+DEPENDABOT_PATH = REPO_ROOT / ".github" / "dependabot.yml"
+
+# `actions/*` is GitHub's own namespace, and this repository pins it by tag on
+# purpose; everything else names an immutable revision, because a tag can be
+# repointed by whoever owns it and Scorecard's pinned-dependencies check reads a
+# tag as unpinned. A `docker://` image counts as third party too.
+FIRST_PARTY_ACTION = re.compile(r"^actions/")
+IMMUTABLE_REVISION = re.compile(r"@(?:[0-9a-f]{40}|sha256:[0-9a-f]{64})$")
+
+# The two pins `requirements-integration.txt` carries as derived numbers rather
+# than as dependencies to keep current.
+HA_PINS = ("homeassistant", "home-assistant-frontend")
+VERSION_UPDATE_TYPES = frozenset(
+    {
+        "version-update:semver-major",
+        "version-update:semver-minor",
+        "version-update:semver-patch",
+    }
+)
 
 # App id of GitHub Actions. Pinning it on a required check means a status posted
 # by any other app cannot satisfy the requirement.
@@ -167,3 +193,117 @@ def test_path_filtered_workflow_reports_no_required_contexts() -> None:
 
 def test_unknown_required_check_is_not_satisfied_by_the_workflows() -> None:
     assert "backend (3.13)" not in available_contexts()
+
+
+def uses_values(node: Any) -> list[str]:
+    """Every ``uses:`` value anywhere in a parsed workflow."""
+    if isinstance(node, dict):
+        return [
+            *([str(node["uses"])] if "uses" in node else []),
+            *(value for child in node.values() for value in uses_values(child)),
+        ]
+    if isinstance(node, list):
+        return [value for child in node for value in uses_values(child)]
+    return []
+
+
+def unpinned_actions(workflow: dict[str, Any]) -> list[str]:
+    """Third-party references a workflow calls without naming a revision."""
+    return [
+        reference
+        for reference in uses_values(workflow)
+        if not FIRST_PARTY_ACTION.match(reference) and not IMMUTABLE_REVISION.search(reference)
+    ]
+
+
+def dependabot_block(ecosystem: str, directory: str) -> dict[str, Any] | None:
+    """The update block for one ecosystem and directory, if it is configured."""
+    config = yaml.safe_load(DEPENDABOT_PATH.read_text(encoding="utf-8"))
+    for update in config["updates"]:
+        if update["package-ecosystem"] == ecosystem and update["directory"] == directory:
+            return dict(update)
+    return None
+
+
+def ignored_update_types(block: dict[str, Any]) -> dict[str, set[str]]:
+    """What each ignored dependency is ignored for; an empty set means everything."""
+    return {
+        entry["dependency-name"]: set(entry.get("update-types", []))
+        for entry in block.get("ignore", [])
+    }
+
+
+def test_third_party_actions_are_pinned_by_digest() -> None:
+    """A tag can be moved under the workflow that calls it; a digest cannot."""
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+        assert unpinned_actions(workflow) == [], f"{path.name} calls an unpinned action"
+
+
+def test_a_tag_pinned_reference_is_reported() -> None:
+    """The error case, in the shape a new workflow arrives in."""
+    workflow = yaml.safe_load(
+        """
+        name: new
+        on: [push]
+        jobs:
+          check:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v7
+              - uses: astral-sh/setup-uv@v10
+              - uses: docker://rhysd/actionlint:1.7.12
+        """
+    )
+
+    assert unpinned_actions(workflow) == [
+        "astral-sh/setup-uv@v10",
+        "docker://rhysd/actionlint:1.7.12",
+    ]
+
+
+def test_dependabot_updates_the_integration_requirements() -> None:
+    """Without a pip block nothing opens the fix for an advisory in that file.
+
+    The dependency graph scans ``requirements-integration.txt`` either way, so
+    the alert arrives; the pull request that closes it does not.
+    """
+    assert dependabot_block("pip", "/") is not None
+
+
+def test_dependabot_leaves_the_ha_pins_alone() -> None:
+    """Both pins are derived numbers: a version bump of either is a red build.
+
+    ``homeassistant`` is the floor ``hacs.json`` declares, and
+    ``home-assistant-frontend`` must equal what that release's own manifest asks
+    for — so an automated bump is not an upgrade. Ignoring them outright would
+    also swallow the security update this block exists to receive, so the ignore
+    names version updates and nothing else.
+    """
+    block = dependabot_block("pip", "/")
+    assert block is not None
+    ignored = ignored_update_types(block)
+
+    assert set(HA_PINS) <= set(ignored), f"pip block ignores {sorted(ignored)}"
+    for name in HA_PINS:
+        assert ignored[name] == VERSION_UPDATE_TYPES, (
+            f"{name} is ignored for {sorted(ignored[name]) or 'every update'} — a blanket "
+            f"ignore also mutes the security channel"
+        )
+
+
+def test_a_blanket_ignore_is_told_from_a_scoped_one() -> None:
+    """The two are one line apart in the file and opposite in effect."""
+    blanket = {"ignore": [{"dependency-name": "homeassistant"}]}
+    scoped = {
+        "ignore": [
+            {
+                "dependency-name": "homeassistant",
+                "update-types": sorted(VERSION_UPDATE_TYPES),
+            }
+        ]
+    }
+
+    assert ignored_update_types(blanket) == {"homeassistant": set()}
+    assert ignored_update_types(scoped) == {"homeassistant": set(VERSION_UPDATE_TYPES)}

--- a/tests/test_toolchain_pins.py
+++ b/tests/test_toolchain_pins.py
@@ -413,9 +413,15 @@ def test_the_documented_ruff_command_runs_the_pinned_ruff() -> None:
 
 
 def test_pre_commit_runs_the_actionlint_ci_runs() -> None:
-    """Same split as ruff: the hook and the CI job are pinned independently."""
+    """Same split as ruff: the hook and the CI job are pinned independently.
+
+    The job pins the image by digest, which names no version — so the trailing
+    comment is where the version lives, and the tie to the hook's ``rev`` is
+    only readable if the two are written together.
+    """
     ci_image = re.search(
-        r"docker://rhysd/actionlint:(\S+)", CI_WORKFLOW.read_text(encoding="utf-8")
+        r"docker://rhysd/actionlint@sha256:[0-9a-f]{64} +# v(\S+)",
+        CI_WORKFLOW.read_text(encoding="utf-8"),
     )
-    assert ci_image is not None
+    assert ci_image is not None, "the actionlint job names no digest-pinned image with a version"
     assert pre_commit_rev("https://github.com/rhysd/actionlint") == ci_image.group(1)


### PR DESCRIPTION
## Summary

Five of the six toolchain gaps #210 collects. **The coverage upload is not among them:**
the repository has no secrets at all (`gh secret list` is empty;
`GET /repos/chrreiter/HAventory/actions/secrets` reports `total_count: 0`), and Codecov
needs `CODECOV_TOKEN` while the repository is private. Per the V0.7.0 plan's owner
pre-flight item 2 that bullet is dropped, and #514 carries it with everything the notes had
worked out — including the SHA-pin shape the new guard test here now enforces.

- **Dependabot pip block.** `.github/dependabot.yml` gains a `pip` ecosystem at `/`, which
  is where Dependabot looks for `requirements*.txt`. The dependency graph already scanned
  that file, so an advisory in it alerted; nothing opened the fix. `homeassistant` and
  `home-assistant-frontend` are ignored for `version-update:semver-{major,minor,patch}`
  only — a blanket ignore would also mute the security update the block exists to receive.
- **tsc gate scope.** `include` reaches `vite.config.ts`, `eslint.config.js` and `e2e/`;
  `allowJs` lets the JavaScript in, `@types/node` supplies the driver's Node globals.
- **pre-commit frontend hooks.** Two `repo: local`, `language: system`,
  `pass_filenames: false` hooks scoped to `^cards/haventory-card/` run the card's eslint and
  typecheck. Vitest stays out: a full card suite on every commit is what makes people reach
  for `--no-verify`, and CI plus `scripts/ci_local.sh` already run it.
- **npm audit level.** `--audit-level=moderate` in both places that spell it. A moderate
  development-scope advisory is auto-dismissed on the alert dashboard and cleared the old
  threshold here, so it surfaced nowhere. The lockfile is clean at the tighter level today.
- **actionlint digest.** `docker://rhysd/actionlint@sha256:b1934ee5…  # v1.7.12` — the
  multi-arch index digest for that tag. The trailing comment is where the version lives, and
  `tests/test_toolchain_pins.py` now reads it there, so the hook `rev` and the job still have
  to name one release.

Closes #210

## Decisions taken against the notes

- **`checkJs` stays off; the JavaScript opts in per file with `// @ts-check`.** The notes say
  to turn `checkJs` on. Doing that pulls `.claude/skills/run-haventory/card_views.mjs` into
  the program — `e2e/live-updates.smoke.mjs` imports it — and blames it for **28**
  implicit-any errors under this package's `strict`, in a file that belongs to a different
  gate (`node --test` in the skill directory) and that S4 is about to rewrite for #212.
  Per-file opt-in checks everything this package owns at full strictness and leaves the
  imported module to its own gate. `tests/test_frontend_toolchain_offline.py` keeps a new
  `.js`/`.mjs` file from forgetting the marker, so the opt-in cannot rot into "nothing is
  checked".
- **The e2e driver is typed, not merely included.** Making it pass under `strict` meant
  JSDoc: `import('playwright').Page` on the helpers, `string[]` on the two error collectors,
  `Error | null` on the failure, and `waitFor` now hands its predicate the page it polls
  instead of the predicate closing over a nullable binding. `cardPath` in `card_views.mjs`
  gained the JSDoc signature it was already documented to have, so the driver's call
  typechecks.
- **`@types/node` is pinned to `^22`, the `engines` floor**, not the newest LTS — the driver
  is then typed against the oldest Node the card claims to run on.
- **The two Home Assistant ignores moved out of the `uv` block.** They were written there
  with a comment about `requirements-integration.txt`, but the uv ecosystem reads
  `pyproject.toml` and `uv.lock`, which name neither dependency: the rules could never fire.
  They now sit in the pip block that actually sees that file.
- **The typecheck and the audit stay on both Node legs** (the notes' own call): ~5 s each,
  and a `matrix.node-version ==` condition is one more thing that can quietly stop running.
- The notes' adjacent finding — `cards/haventory-card/.eslintrc.cjs` being inert under
  ESLint 10 — has gone stale: the file is no longer in the tree.
- `tsconfig.json` is now JSONC (TypeScript accepts comments; the two additions needed
  explaining). The new test strips whole-line comments before parsing it.

## Tests

- `tests/test_repo_hardening_offline.py` — `test_third_party_actions_are_pinned_by_digest`
  walks every `uses:` in every workflow: `actions/*` may stay on tags (the repository's
  convention), everything else must carry a 40-hex SHA or an `@sha256:` digest. Error case:
  a synthetic workflow mixing `actions/checkout@v7`, `astral-sh/setup-uv@v10` and
  `docker://rhysd/actionlint:1.7.12` reports exactly the last two. This lands here rather
  than with #227 so S5's new workflow meets a guard that already tells it how to pin.
  `test_dependabot_leaves_the_ha_pins_alone` holds the pip block's ignores to version
  updates, and a companion case shows a blanket ignore reading as "every update" so the two
  cannot be confused.
- `tests/test_frontend_toolchain_offline.py` (new) — every `.ts`/`.js`/`.mjs` the card
  package owns is named by an `include` entry (so a new config file cannot slip past the
  gate), the three widened entries are present, and every JavaScript file under the gate
  carries `// @ts-check`.
- `tests/test_toolchain_pins.py` — the actionlint tie now reads the digest form.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1259 passed, 22
      skipped**; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck` (now over the
      wider set), `npx vitest run` (**63 files, 1864 tests**), `npm run build`.
- [x] `uv run pre-commit run card-eslint --all-files` and `… card-typecheck --all-files` —
      both **Passed**, and both ran again for real in this branch's commit.
- phacc not required (nothing here changes integration behavior); it was green on this
  branch's parent.

**The hooks bite.** A deliberate `const broken: number = "not a number"` in `src/index.ts`,
run through the hook the way a commit would:

```
$ uv run pre-commit run card-typecheck --files cards/haventory-card/src/index.ts
src/index.ts(223,7): error TS2322: Type 'string' is not assignable to type 'number'.
```

**The widened gate is not cosmetic.** Deliberate errors in two files that were outside it
until now:

```
e2e/live-updates.smoke.mjs(261,15): error TS2345: Argument of type 'null' is not assignable to parameter of type 'Page'.
eslint.config.js(81,21): error TS2304: Cannot find name 'missingGlobalThing'.
```

**The retyped driver still drives.** Against the dev Home Assistant, `RUN_ONLINE=1 node
e2e/live-updates.smoke.mjs`:

```
view (column): /dashboard-dev/0  ← Dev › view 0 (sections)
  ok: created item appeared live (no manual re-list)
  ok: rename reflected live (in-place replace)
  ok: deletion reflected live

PASS: card reflects live create / rename / delete over the WS subscription.
```

It creates and deletes its own rows, so the dev instance is left as it was found.

## Type of change

- [x] Documentation / tooling / CI

## Checklist

- [x] PR title follows Conventional Commits (the plan's title minus the coverage bullet,
      which is not in this PR).
- [x] Tests added/updated (happy path + error/edge case for each new guard).
- [x] Docs updated where behavior changed — no user-facing behavior moved; the README badge
      belonged to the dropped bullet.
- [x] No WebSocket API change.
- [x] Essential invariants untouched.

## Follow-ups

- #514 — the coverage upload and badge, blocked on a `CODECOV_TOKEN` secret. Filed
  unmilestoned; staging it is the owner's call.
- Not filed: the Dependabot pip block and the actionlint digest can only be observed on the
  default branch (the next weekly Dependabot run, and Scorecard's pinned-dependencies score
  on its next scheduled run). Both are configuration this PR's tests already assert
  statically; watching them is a note, not an issue.

## Handover

**1. Merged / left open**

| PR | Issue | State |
| --- | --- | --- |
| [#512](https://github.com/chrreiter/HAventory/pull/512) — build: raise the Python floor to the one Home Assistant requires | #433 | squash-merged, branch deleted |
| [#513](https://github.com/chrreiter/HAventory/pull/513) — docs: one declared floor, and a guard against a second README version | #235 | squash-merged, branch deleted |
| this PR | #210 | self-merged once CI is green |

Nothing is left open for the owner. No release-please PR was touched (#491 is untouched).

**2. Test this by hand**

Nothing that changes the product — no runtime code moved in any of the three PRs, and the
card bundle is byte-identical. Two things only the default branch can show, when you next
pass through GitHub:

1. `[desktop]` **Insights → Dependency graph → Dependabot**: after the next weekly run a
   `pip` job for `/` appears beside `github-actions`, `npm` and `uv`. Expect no version-bump
   PR for `homeassistant` or `home-assistant-frontend` — and a security PR for either would
   still be allowed to open, which is the point of the scoped ignore.
2. `[desktop]` **Scorecard's pinned-dependencies score** on its next scheduled run: the
   actionlint job no longer counts as an unpinned dependency.

What the harness proved instead: the raised floor is enforced by uv
(`uv sync --python 3.14.1` → *"incompatible with the project's Python requirement:
`>=3.14.2`"*) and by the phacc suite against Home Assistant's own metadata; the README guard
reports a second Home Assistant version; both new pre-commit hooks fail on a real type
error; the widened typecheck catches errors in `e2e/` and `eslint.config.js`; and the
retyped live-update driver passes against the dev Home Assistant.

**3. Decisions taken against drifted notes**

- #433: the HA-metadata comparison lives in `tests/integration/test_python_floor.py` (only
  there does `Requires-Python` exist); the offline half in `tests/test_toolchain_pins.py`
  registers each file's copies as *series* (`3.14`) or *floor* (`3.14.2`) counts.
- #433: `scripts/test_integration.sh` keeps requesting the series — with the floor raised,
  `uv sync` stops a stale interpreter one step earlier, and pinning the script to an exact
  patch would make every fresh container download it.
- #235: the notes' `README.md:34` is line 41 today; and HACS reading `hacs.json` **per ref**
  is now verified against the HACS 2.0.5 in the dev HA rather than assumed.
- #210: `checkJs` off with per-file `// @ts-check`; `@types/node` at the `engines` floor; the
  two HA ignores moved from the `uv` block (which cannot see them) to the new pip block.
  Full reasoning in the sections above.

**4. Follow-ups**

- #514 (coverage upload, needs `CODECOV_TOKEN`) — filed, unmilestoned.
- Nothing else filed. The two observation-only items above did not clear the bar.

**5. State left behind**

- **Dev Home Assistant** — data as found. The one live run (the e2e smoke) creates a row and
  deletes it; no `e2e_smoke_*` items remain, no options or profile were changed.
- **Branches** — `claude/v0-7-0-s3-python-floor` and `claude/v0-7-0-s3-floor-policy` deleted
  on merge; `claude/v0-7-0-s3-ci-polish` goes the same way.
- **Machine** — the phacc container `hav-int` is removed, so the plan's Docker recipe runs
  verbatim next time; its `hav-int-venv` volume is kept, which is what makes a re-run about
  thirty seconds instead of three minutes. Python 3.14.1, downloaded to prove the floor
  rejects it, was uninstalled again.
- **For S4** — `.claude/skills/run-haventory/card_views.mjs` gained a JSDoc signature on
  `cardPath`, and `cards/haventory-card/e2e/live-updates.smoke.mjs` is now typechecked:
  #212's work on that skill has to keep `npm run typecheck` in the card package green, and a
  new `.mjs` there needs `// @ts-check` only if it lives inside the card package.
