### PR TITLE
fix(skills): make stress.py honour the worktree's .env and name its target

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -22,12 +22,21 @@ Docker and filesystem through Git Bash instead; nothing else here depends on the
   It was provisioned once by hand (image run + HA onboarding in the browser); if it's
   ever gone, that one-time onboarding has to be redone in a browser — not scripted.
 - `uv` (Python 3.14 env) and Node 22.13+ (or ≥ 24, per the card's `engines`) on PATH.
-- Repo-root **`.env`** (gitignored) with the credentials both drivers auto-read:
+- A **`.env`** (gitignored) at the root of the checkout you are standing in, with the
+  credentials every driver and harness auto-reads:
 
   ```
   HA_BASE_URL=http://localhost:8123
   HA_TOKEN=<long-lived access token>
   ```
+
+  It **wins over an inherited export**: a worktree carrying its own `.env` names the
+  instance that worktree is for, whatever a shell profile exported.
+  `HAVENTORY_IGNORE_ENV_FILE=1` hands the decision back to the environment for one run.
+  Every driver and harness prints the resolved target on stderr before it acts
+  (`[target] HA_BASE_URL=…`), and the Python ones print the store's counts with it — so
+  a run against the wrong inventory shows up in the first line instead of in a number
+  that looks off later.
 
   Do **not** put `HA_CONTAINER` in `.env` — `scripts/smoke_online.sh` purges the
   HAventory store from that container whenever it's set (see Gotchas).

--- a/.claude/skills/run-haventory/card_views.mjs
+++ b/.claude/skills/run-haventory/card_views.mjs
@@ -46,21 +46,80 @@ const WS_TIMEOUT_MS = 10000;
 
 let cachedConfig = null;
 
-/** HA base URL + long-lived token: real env vars win, the repo-root .env fills the gaps. */
+const IGNORE_FLAG = "HAVENTORY_IGNORE_ENV_FILE";
+const DEFAULT_BASE = "http://localhost:8123";
+
+/**
+ * Which instance a harness resolved, and what to say about it — the pure half of
+ * `haConfig`, so `node --test` can hold the precedence rule without a filesystem.
+ *
+ * `envText` is the `.env` beside the checkout, or null when there is none.
+ */
+export function resolveTarget({ envText, env, envFile }) {
+  const ignored = !["", "0", "false", "no"].includes(
+    (env[IGNORE_FLAG] ?? "").trim().toLowerCase(),
+  );
+  const values = {};
+  const overrode = [];
+
+  if (envText != null && !ignored) {
+    for (const line of envText.split(/\r?\n/)) {
+      const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
+      if (!m) continue;
+      const [, key, value] = m;
+      // The displaced base URL is the whole point of the report — it is the
+      // instance the run would have gone to. No other displaced value is named:
+      // one of them is the token.
+      if (key in env && env[key] !== value) {
+        overrode.push(key === "HA_BASE_URL" ? `${key}=${env[key]}` : key);
+      }
+      values[key] = value;
+    }
+  }
+
+  let source;
+  if (envText == null) source = "the environment; no .env beside the checkout";
+  else if (ignored) source = `the environment; ${envFile} ignored via ${IGNORE_FLAG}`;
+  else source = envFile;
+
+  const merged = { ...env, ...values };
+  return {
+    base: (merged.HA_BASE_URL || DEFAULT_BASE).replace(/\/$/, ""),
+    token: merged.HA_TOKEN,
+    source,
+    overrode,
+    values,
+  };
+}
+
+/**
+ * HA base URL + long-lived token, and the target named out loud.
+ *
+ * The `.env` beside this checkout wins over an inherited export: a worktree
+ * carrying its own `.env` names the instance that worktree is for, and a shell
+ * profile exporting `HA_BASE_URL` for a different one must not silently outrank
+ * it. `HAVENTORY_IGNORE_ENV_FILE=1` hands the decision back to the environment
+ * for one run. The resolved target goes to stderr, which every harness keeps
+ * free of its own output.
+ */
 export function haConfig() {
   if (cachedConfig) return cachedConfig;
+  const envFile = path.join(repoRoot, ".env");
+  let envText = null;
   try {
-    for (const line of readFileSync(path.join(repoRoot, ".env"), "utf8").split(/\r?\n/)) {
-      const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*)\s*$/);
-      if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
-    }
+    envText = readFileSync(envFile, "utf8");
   } catch {
     /* no .env — rely on real env vars */
   }
-  cachedConfig = {
-    base: (process.env.HA_BASE_URL ?? "http://localhost:8123").replace(/\/$/, ""),
-    token: process.env.HA_TOKEN,
-  };
+
+  const target = resolveTarget({ envText, env: process.env, envFile });
+  Object.assign(process.env, target.values);
+  cachedConfig = { base: target.base, token: target.token };
+
+  console.error(`[target] HA_BASE_URL=${target.base} (from ${target.source})`);
+  if (target.overrode.length) {
+    console.error(`[target] the .env overrode the environment's ${target.overrode.join(", ")}`);
+  }
   return cachedConfig;
 }
 

--- a/.claude/skills/run-haventory/card_views.test.mjs
+++ b/.claude/skills/run-haventory/card_views.test.mjs
@@ -13,7 +13,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import { cardViewsOf, holdsCard, parsePathOverrides, pickView } from "./card_views.mjs";
+import { cardViewsOf, holdsCard, parsePathOverrides, pickView, resolveTarget } from "./card_views.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -161,3 +161,62 @@ for (const file of HARNESSES.filter((f) => codeOf(f).includes("page.goto("))) {
     assert.doesNotMatch(code, /["'`][^"'`]*\/(lovelace|dashboard-)[^"'`]*["'`]/);
   });
 }
+
+// --- which instance a harness is pointed at -------------------------------
+//
+// A shell profile exporting HA_BASE_URL for one instance must not outrank the
+// .env in the worktree the harness was started from: the harnesses that import
+// data or drive two tabs write, and writing into someone else's inventory is
+// the failure this precedence exists to remove.
+
+const ENV_A = "HA_BASE_URL=http://instance-a:8123\nHA_TOKEN=token-a\n";
+
+test("the .env beside the checkout beats an inherited export", () => {
+  const target = resolveTarget({
+    envText: ENV_A,
+    env: { HA_BASE_URL: "http://instance-b:8123", HA_TOKEN: "token-b" },
+    envFile: "/wt/.env",
+  });
+
+  assert.equal(target.base, "http://instance-a:8123");
+  assert.equal(target.token, "token-a");
+  assert.equal(target.source, "/wt/.env");
+  assert.deepEqual(target.overrode, ["HA_BASE_URL=http://instance-b:8123", "HA_TOKEN"]);
+});
+
+test("the displaced token is named but never printed", () => {
+  const target = resolveTarget({ envText: ENV_A, env: { HA_TOKEN: "token-b" }, envFile: "/wt/.env" });
+
+  assert.deepEqual(target.overrode, ["HA_TOKEN"]);
+});
+
+test("HAVENTORY_IGNORE_ENV_FILE hands the decision back to the environment", () => {
+  const target = resolveTarget({
+    envText: ENV_A,
+    env: { HA_BASE_URL: "http://release-host:8123", HAVENTORY_IGNORE_ENV_FILE: "1" },
+    envFile: "/wt/.env",
+  });
+
+  assert.equal(target.base, "http://release-host:8123");
+  assert.deepEqual(target.overrode, []);
+  assert.match(target.source, /HAVENTORY_IGNORE_ENV_FILE/);
+});
+
+test("no .env leaves the environment alone, and no HA_BASE_URL falls back to localhost", () => {
+  const exported = resolveTarget({ envText: null, env: { HA_BASE_URL: "http://b:8123/" }, envFile: "/wt/.env" });
+  assert.equal(exported.base, "http://b:8123");
+  assert.deepEqual(exported.values, {});
+
+  const bare = resolveTarget({ envText: null, env: {}, envFile: "/wt/.env" });
+  assert.equal(bare.base, "http://localhost:8123");
+});
+
+test("a value the environment already agrees with is not reported as overridden", () => {
+  const target = resolveTarget({
+    envText: ENV_A,
+    env: { HA_BASE_URL: "http://instance-a:8123" },
+    envFile: "/wt/.env",
+  });
+
+  assert.deepEqual(target.overrode, []);
+});

--- a/.claude/skills/run-haventory/driver.py
+++ b/.claude/skills/run-haventory/driver.py
@@ -5,8 +5,11 @@ haventory integration loaded. Complements scripts/ws_probe.py (single message)
 by holding ONE authenticated connection for a whole command sequence, so ids
 and item versions can flow between steps.
 
-Config: reads HA_BASE_URL / HA_TOKEN from the environment, falling back to a
-`.env` file at the repo root (KEY=VALUE lines; see SKILL.md).
+Config: HA_BASE_URL / HA_TOKEN come from the `.env` beside this checkout, which
+wins over an inherited export -- a worktree's .env names the instance that worktree
+is for. HAVENTORY_IGNORE_ENV_FILE=1 hands the decision back to the environment for
+one run. Every command prints the resolved target and the store's counts on stderr
+before it acts, and `smoke` (which creates and deletes) says that it writes.
 
 Usage (from repo root):
   uv run python .claude/skills/run-haventory/driver.py status
@@ -20,13 +23,12 @@ It only touches objects it creates (unique suffix), so it is safe on a dev
 instance holding existing data.
 """
 # Dev/agent harness script — magic numbers in assertions are fine here.
-# ruff: noqa: PLR2004, PLW2901
+# ruff: noqa: PLR2004
 
 from __future__ import annotations
 
 import asyncio
 import json
-import os
 import sys
 import time
 from pathlib import Path
@@ -36,26 +38,12 @@ import aiohttp
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RECV_TIMEOUT_S = 20.0
+# One definition of "which instance is this?" for every helper in the repo. This
+# file's committed location names the checkout it belongs to, so the import
+# follows the same tree the .env is read from.
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-
-def load_env() -> None:
-    """Populate os.environ from repo-root .env (existing env vars win)."""
-    env_file = REPO_ROOT / ".env"
-    if not env_file.is_file():
-        return
-    for line in env_file.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        os.environ.setdefault(key.strip(), value.strip())
-
-
-def ws_url(base_url: str) -> str:
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    return f"ws://{base_url.removeprefix('http://')}/api/websocket"
+import dev_env  # noqa: E402
 
 
 class HaWs:
@@ -83,7 +71,9 @@ class HaWs:
 
 
 async def connect(session: aiohttp.ClientSession, base: str, token: str) -> HaWs:
-    ws = await session.ws_connect(ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=15))
+    ws = await session.ws_connect(
+        dev_env.ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=15)
+    )
     await asyncio.wait_for(ws.receive_json(), timeout=RECV_TIMEOUT_S)  # hello
     await ws.send_json({"type": "auth", "access_token": token})
     auth = await asyncio.wait_for(ws.receive_json(), timeout=RECV_TIMEOUT_S)
@@ -238,15 +228,18 @@ async def cmd_smoke(base: str, token: str) -> int:
 
 
 def main() -> None:
-    load_env()
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
     args = sys.argv[1:]
     if not args or args[0] not in {"status", "send", "smoke"}:
         print(__doc__, file=sys.stderr)
         sys.exit(2)
+    target = dev_env.load_env(REPO_ROOT)
+    base = target.base_url
+    token = target.token
+    # `send` carries whatever frames the caller hands it, so only `smoke` is known
+    # to write here; the base URL and counts are what name the target either way.
+    asyncio.run(dev_env.announce_store(target, action="smoke" if args[0] == "smoke" else None))
     if not token:
-        print("Missing HA_TOKEN (env or repo-root .env)", file=sys.stderr)
+        print(f"Missing HA_TOKEN (looked in {target.source})", file=sys.stderr)
         sys.exit(2)
     try:
         if args[0] == "status":

--- a/.claude/skills/run-haventory/lifecycle_probe.py
+++ b/.claude/skills/run-haventory/lifecycle_probe.py
@@ -30,13 +30,17 @@ Usage (from the repo root):
   uv run python .claude/skills/run-haventory/lifecycle_probe.py entry --yes
   uv run python .claude/skills/run-haventory/lifecycle_probe.py all --yes
 
-Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root `.env`, and
-HA_CONTAINER (default "home-assistant") for the docker exec calls.
+HA_BASE_URL / HA_TOKEN come from the `.env` beside this checkout, which wins over
+an inherited export -- a worktree's .env names the instance that worktree is for.
+HAVENTORY_IGNORE_ENV_FILE=1 hands the decision back to the environment for one run.
+The target and the store's counts print on stderr before anything is restarted or
+rewritten. HA_CONTAINER (default "home-assistant") names the container the docker
+exec calls go to.
 """
 # Dev/agent harness script. Driving the container means shelling out to `docker`
 # on PATH (S603/S607), and the restart has to block the loop while it runs
-# (ASYNC221). The .env loader is copied from driver.py verbatim (PLW2901).
-# ruff: noqa: S603, S607, ASYNC221, PLW2901
+# (ASYNC221).
+# ruff: noqa: S603, S607, ASYNC221
 
 from __future__ import annotations
 
@@ -59,26 +63,12 @@ RECV_TIMEOUT_S = 30.0
 # polled on the WS command the integration itself registers.
 READY_TIMEOUT_S = 120.0
 HTTP_OK = 200
+# One definition of "which instance is this?" for every helper in the repo. This
+# file's committed location names the checkout it belongs to, so the import
+# follows the same tree the .env is read from.
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-
-def load_env() -> None:
-    """Populate os.environ from repo-root .env (existing env vars win)."""
-    env_file = REPO_ROOT / ".env"
-    if not env_file.is_file():
-        return
-    for line in env_file.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        os.environ.setdefault(key.strip(), value.strip())
-
-
-def ws_url(base_url: str) -> str:
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    return f"ws://{base_url.removeprefix('http://')}/api/websocket"
+import dev_env  # noqa: E402
 
 
 def container() -> str:
@@ -132,7 +122,7 @@ async def connect(session: aiohttp.ClientSession) -> Ws:
     base = os.environ["HA_BASE_URL"]
     token = os.environ["HA_TOKEN"]
     ws = await session.ws_connect(
-        ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=RECV_TIMEOUT_S)
+        dev_env.ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=RECV_TIMEOUT_S)
     )
     await asyncio.wait_for(ws.receive_json(), timeout=RECV_TIMEOUT_S)
     await ws.send_json({"type": "auth", "access_token": token})
@@ -407,7 +397,6 @@ async def run(names: list[str]) -> int:
 
 
 def main() -> int:
-    load_env()
     argv = sys.argv[1:]
     names = [a for a in argv if not a.startswith("-")]
     if not names or (names[0] != "all" and any(n not in CHECKS for n in names)):
@@ -415,14 +404,21 @@ def main() -> int:
         return 2
     if names[0] == "all":
         names = list(CHECKS)
-    if "--yes" not in argv:
+    target = dev_env.load_env(REPO_ROOT)
+    os.environ["HA_BASE_URL"] = target.base_url
+    # Before the --yes gate, not after: the instance about to be restarted is what
+    # the operator needs on screen while deciding whether to pass --yes.
+    confirmed = "--yes" in argv
+    action = f"{' '.join(names)} (container restart, store edit)" if confirmed else None
+    asyncio.run(dev_env.announce_store(target, action=action))
+    if not confirmed:
         print(
             f"This restarts container '{container()}' and edits {STORE_PATH}. Re-run with --yes.",
             file=sys.stderr,
         )
         return 2
-    if not os.environ.get("HA_TOKEN"):
-        print("Missing HA_TOKEN (env or repo-root .env)", file=sys.stderr)
+    if not target.token:
+        print(f"Missing HA_TOKEN (looked in {target.source})", file=sys.stderr)
         return 2
     return asyncio.run(run(names))
 

--- a/.claude/skills/test-haventory/SKILL.md
+++ b/.claude/skills/test-haventory/SKILL.md
@@ -25,8 +25,13 @@ clean-Linux/CI commands live in the README ("The gate").
   not parse on ≤3.13), **Node 22.13+**, **Docker** (for the online surfaces). [Windows/Git
   Bash] **Git Bash** for the `.sh`/`.py` helpers.
 - `pre-commit` on PATH (the git hook needs it): `uv tool install pre-commit`.
-- A `.env` at the repo root with `HA_BASE_URL` + `HA_TOKEN` (a long-lived token; per session,
-  never committed). The online surfaces read it directly.
+- A `.env` at the root of **the checkout you are standing in** with `HA_BASE_URL` +
+  `HA_TOKEN` (a long-lived token; per session, never committed). The online surfaces read
+  it directly, and it **wins over an inherited export** — a worktree carrying its own
+  `.env` names the instance that worktree is for, whatever a shell profile exported.
+  `HAVENTORY_IGNORE_ENV_FILE=1` hands the decision back to the environment for one run
+  (that is how a recipe points a helper at a remote instance while a dev `.env` sits in
+  the tree).
 - For the browser smoke: Chromium for Playwright — `npx playwright install chromium`. It
   caches under `~/.cache/ms-playwright`; [Windows/Git Bash] `~/AppData/Local/ms-playwright`.
 
@@ -98,7 +103,22 @@ for i in $(seq 1 45); do \
 `stress.py` is the adversarial online driver. Each subcommand runs one layer, prefixes its
 data with `stress_test_` (so `cleanup` sweeps it), and polls `haventory/health` as the pass
 gate (`healthy: true`, `issues: []`). Run **one at a time, non-destructive first, `restart`
-last**. Reads `HA_BASE_URL`/`HA_TOKEN` from `.env`.
+last**.
+
+Every command prints its target before it acts, and stops if it cannot read the store —
+so "wrong instance" is the first line of output rather than a count that looks off later:
+
+```
+[target] HA_BASE_URL=http://localhost:8123 (from /repo/.env)
+[target] store: items_total=1087 locations_total=89
+[target] 'bulk' writes to this instance; proceeding
+```
+
+The second line is the tell: an empty store where 1 000 items were expected (or the
+reverse) means the `.env`, the export or the container is not the one you meant. A
+destructive command names its target and proceeds — nothing prompts. When the `.env`
+displaced an exported `HA_BASE_URL`, a middle line says which instance the run would
+otherwise have gone to.
 
 ```bash
 export PYTHONIOENCODING=utf-8   # [Windows/Git Bash] only; a Linux terminal is UTF-8 already
@@ -212,5 +232,8 @@ not re-verified here.
   the tar-pipe deploy above instead.
 - **`stress.py` baseline errors / `unknown command`** — check `.env` has `HA_BASE_URL`/`HA_TOKEN`
   and the container is up; run `baseline` first to confirm the integration imported.
+- **`cannot read the store at …`** — the `[target]` line above it names the instance that
+  was resolved. Either it is the wrong one (fix the `.env`, or re-run with
+  `HAVENTORY_IGNORE_ENV_FILE=1` to use the export) or the integration is not loaded there.
 - **E2E redirected to `/auth/authorize`** — `HA_TOKEN` is missing/expired.
 - **`pre-commit` not found on commit** — `uv tool install pre-commit`.

--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -21,9 +21,13 @@ Subcommands (run one at a time; non-destructive first, `restart` last):
   restart      DESTRUCTIVE: mid-load storm + docker restart + on-disk store cross-check
   cleanup      delete everything with the stress_test_ prefix
 
-Config from env or repo-root .env: HA_BASE_URL, HA_TOKEN. HA_CONTAINER (default
-"home-assistant") is only needed by `restart`. Set HAVENTORY_REPO to override the
-repo root that .env is read from (otherwise derived from this file's location).
+Config from the .env beside this checkout (HA_BASE_URL, HA_TOKEN), which wins over
+an inherited export -- a worktree's .env names the instance that worktree is for.
+HAVENTORY_IGNORE_ENV_FILE=1 hands the decision back to the environment for one run.
+Every command prints the resolved target and the store's counts before it acts, and
+a command that writes says so and proceeds without prompting. HA_CONTAINER (default
+"home-assistant") is only needed by `restart`. Set HAVENTORY_REPO to override which
+checkout's .env is read (otherwise derived from this file's location).
 
 Run:  uv run --no-project --with aiohttp python .claude/skills/test-haventory/stress.py <cmd> [args]
 """
@@ -44,29 +48,22 @@ from typing import Any
 import aiohttp
 
 PREFIX = "stress_test_"
-# Repo root holds the .env this harness reads. Prefer an explicit override, else
-# derive it from this file's committed location (<repo>/.claude/skills/test-haventory/).
+# This file's committed location is <repo>/.claude/skills/test-haventory/, so it
+# always knows its own checkout -- that is where the shared target resolution
+# lives, and it is read from there even when HAVENTORY_REPO points the .env
+# lookup at a different tree.
+CHECKOUT = Path(__file__).resolve().parents[3]
 _env_repo = os.environ.get("HAVENTORY_REPO")
-REPO_ROOT = Path(_env_repo) if _env_repo else Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(_env_repo) if _env_repo else CHECKOUT
+sys.path.insert(0, str(CHECKOUT / "scripts"))
 
+import dev_env
 
-def load_env() -> None:
-    env_file = REPO_ROOT / ".env"
-    if not env_file.is_file():
-        return
-    for line in env_file.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, _, v = line.partition("=")
-        os.environ.setdefault(k.strip(), v.strip())
-
-
-def ws_url(base: str) -> str:
-    base = base.rstrip("/")
-    if base.startswith("https://"):
-        return f"wss://{base[len('https://') :]}/api/websocket"
-    return f"ws://{base.removeprefix('http://')}/api/websocket"
+# Every command mutates the instance except these two: `baseline` reads health and
+# version, `subteardown` only subscribes and unsubscribes. The rest create or delete
+# stress_test_-prefixed fixtures, rewrite the rate-limit options through the config
+# flow, or restart the container.
+READ_ONLY_COMMANDS = frozenset({"baseline", "subteardown"})
 
 
 class WSConn:
@@ -139,7 +136,9 @@ async def connect() -> WSConn:
     # abandoned session there surfaces as an "Unclosed client session" warning — and
     # the log sweep is an oracle whose value is that a clean run is silent.
     try:
-        ws = await session.ws_connect(ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=20))
+        ws = await session.ws_connect(
+            dev_env.ws_url(base), timeout=aiohttp.ClientWSTimeout(ws_receive=20)
+        )
         await asyncio.wait_for(ws.receive_json(), timeout=20)  # hello
         await ws.send_json({"type": "auth", "access_token": token})
         auth = await asyncio.wait_for(ws.receive_json(), timeout=20)
@@ -1512,17 +1511,52 @@ async def cmd_cleanup() -> None:
         await conn.close()
 
 
-def main() -> None:
-    load_env()
-    if not os.environ.get("HA_TOKEN"):
+COMMANDS = READ_ONLY_COMMANDS | {
+    "fuzz",
+    "bulkfuzz",
+    "ratelimit",
+    "bulk",
+    "races",
+    "hammer",
+    "restart",
+    "statsprobe",
+    "cleanup",
+}
+
+
+def announce_target(cmd: str) -> None:
+    """Name the instance -- and what is in it -- before the command touches it."""
+    target = dev_env.load_env(REPO_ROOT)
+    if not target.token:
         print("Missing HA_TOKEN", file=sys.stderr)
         sys.exit(2)
-    os.environ.setdefault("HA_BASE_URL", "http://localhost:8123")
+    os.environ["HA_BASE_URL"] = target.base_url
+    counts, why = asyncio.run(dev_env.probe_counts(target.base_url, target.token))
+    writes = counts is not None and cmd not in READ_ONLY_COMMANDS
+    dev_env.announce(
+        target,
+        counts=counts,
+        unavailable=why,
+        action=f"'{cmd}'" if writes else None,
+        stream=sys.stdout,
+    )
+    if counts is None:
+        # Every layer needs a loaded integration; failing here beats failing three
+        # minutes into a bulk run against an instance that was never the target.
+        print(f"cannot read the store at {target.base_url}: {why}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> None:
     args = sys.argv[1:]
     if not args:
         print(__doc__)
         sys.exit(2)
     cmd = args[0]
+    if cmd not in COMMANDS:
+        print(f"unknown command: {cmd}", file=sys.stderr)
+        sys.exit(2)
+    announce_target(cmd)
     if cmd == "baseline":
         asyncio.run(cmd_baseline())
     elif cmd == "fuzz":
@@ -1547,9 +1581,6 @@ def main() -> None:
         asyncio.run(cmd_subteardown())
     elif cmd == "cleanup":
         asyncio.run(cmd_cleanup())
-    else:
-        print(f"unknown command: {cmd}", file=sys.stderr)
-        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -1058,10 +1058,14 @@ scripts/reload_addon.sh --container <your_container> --tail-logs
 
 Quick probes/subscriptions without writing test code. Run via `uv run python scripts/<name>.py`.
 
+They take `HA_BASE_URL`/`HA_TOKEN` from a `.env` at the root of the checkout they are run
+from, which **wins over an inherited export** (`HAVENTORY_IGNORE_ENV_FILE=1` hands the
+decision back to the environment), and each prints the instance it resolved — plus the
+store's item and location totals — on stderr before it acts.
+
 `scripts/ws_probe.py` — send a single WS command and print the first reply:
 
 ```bash
-export HA_TOKEN=<token>            # HA_BASE_URL defaults to http://localhost:8123
 export HAV_MSG='{"id":1,"type":"haventory/ping","echo":"hi"}'
 uv run python scripts/ws_probe.py
 ```
@@ -1071,7 +1075,6 @@ print events. Optional: `HAV_LOCATION_ID`, `HAV_INCLUDE_SUBTREE`, `HAV_MAX_EVENT
 `HAV_MUTATIONS` (JSON array of WS messages to send after subscribing):
 
 ```bash
-export HA_TOKEN=<token>
 export HAV_TOPIC=items HAV_MAX_EVENTS=3
 uv run python scripts/ws_subscribe.py
 ```

--- a/dev/release_testing_plan.md
+++ b/dev/release_testing_plan.md
@@ -88,11 +88,16 @@ therefore validates what was rehydrated from disk, which makes it the corruption
 this plan. Prefer it over eyeballing the JSON:
 
 ```bash
-HA_BASE_URL=http://<host>:8123 HA_TOKEN=<token> \
+HAVENTORY_IGNORE_ENV_FILE=1 HA_BASE_URL=http://<host>:8123 HA_TOKEN=<token> \
   HAV_MSG='{"id":1,"type":"haventory/health"}' uv run python scripts/ws_probe.py
 ```
 
 Pass = `{"healthy": true, "issues": []}` and `counts` matching what the card shows.
+
+`HAVENTORY_IGNORE_ENV_FILE=1` is what makes the two variables beside it win: without it
+the `.env` in the checkout takes precedence, and the probe would answer for the local dev
+instance instead of the release-test host. The probe prints the target it resolved on
+stderr — read that line before reading the result.
 
 **3. Store snapshots.** Before and after every destructive scenario:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ line-length = 100
 respect-gitignore = true
 src = [
   "custom_components/haventory",
+  "scripts",
   "tests",
 ]
 exclude = [

--- a/scripts/create_test_items.py
+++ b/scripts/create_test_items.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Create random test items with all fields populated via HA WebSocket API.
 
+HA_BASE_URL / HA_TOKEN come from the .env beside this checkout, which wins over an
+inherited export; HAVENTORY_IGNORE_ENV_FILE=1 hands the decision back to the
+environment. The target and the store's counts print on stderr before the first
+item is created -- this script writes, and writing into the wrong inventory is the
+failure it has to make visible.
+
 This is a dev/test utility script - security linting rules are relaxed:
 - S311: Uses standard random (not crypto) - fine for test data generation
 - S603: subprocess call is trusted (pip install)
@@ -13,9 +19,14 @@ import os
 import random
 import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import dev_env
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 try:
     import aiohttp
@@ -197,22 +208,23 @@ def generate_random_item(index):
 
 async def main():
     """Run the test item creation script."""
-    base_url = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
+    target = dev_env.load_env(REPO_ROOT)
+    base_url = target.base_url
+    token = target.token
+
+    start_index = int(os.environ.get("START_INDEX", "0"))
+    count = int(os.environ.get("ITEM_COUNT", "30"))
+    await dev_env.announce_store(target, action=f"creating {count} items")
 
     if not token:
         print("Error: HA_TOKEN environment variable not set")
         sys.exit(1)
 
-    print(f"Connecting to Home Assistant at {base_url}")
     print("Creating random items with all bells and whistles...")
     print("-" * 60)
 
     created = 0
     failed = 0
-
-    start_index = int(os.environ.get("START_INDEX", "0"))
-    count = int(os.environ.get("ITEM_COUNT", "30"))
 
     async with aiohttp.ClientSession() as session:
         for i in range(start_index, start_index + count):

--- a/scripts/dev_env.py
+++ b/scripts/dev_env.py
@@ -1,0 +1,220 @@
+"""Which Home Assistant a dev helper is about to talk to, and saying so out loud.
+
+The helpers in ``scripts/`` and in ``.claude/skills/`` are run from whichever
+checkout the operator is standing in, while ``HA_BASE_URL`` / ``HA_TOKEN`` are
+commonly exported once by a shell profile. Two rules keep a run from answering
+for an instance nobody meant to touch:
+
+1. **The ``.env`` beside the checkout wins over an inherited export.** It is the
+   more specific statement of intent: a worktree carrying its own ``.env`` names
+   the instance that worktree is for. Set ``HAVENTORY_IGNORE_ENV_FILE=1`` to hand
+   the decision back to the environment for one run -- that is how a recipe
+   points a helper at a remote instance while a dev ``.env`` sits in the tree.
+2. **Every helper names its target before it acts** -- the base URL, where that
+   value came from, and the store's counts. A run against the wrong inventory is
+   then visible in the first line of output instead of being inferred later from
+   a number that looks off.
+
+Parsing matches what ``set -a; source .env; set +a`` does with the same file:
+``KEY=VALUE`` per line, ``#`` comments and blanks skipped, no quote stripping.
+
+The banner is ASCII only: it prints on consoles that are not UTF-8.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from collections.abc import MutableMapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+import aiohttp
+
+DEFAULT_BASE_URL = "http://localhost:8123"
+IGNORE_FLAG = "HAVENTORY_IGNORE_ENV_FILE"
+BANNER_PREFIX = "[target]"
+# The banner answers "which inventory is this?", so it carries the two totals that
+# tell one instance from another and leaves the rest of `haventory/health` to the
+# commands that assert on it.
+HEADLINE_COUNTS = ("items_total", "locations_total")
+
+
+@dataclass(frozen=True)
+class Target:
+    """The instance a helper resolved, and how it got there."""
+
+    base_url: str
+    token: str | None
+    source: str
+    env_file: Path | None
+    overrode: tuple[str, ...]
+    displaced_base_url: str | None
+    ignored: bool
+
+
+def parse_env_file(text: str) -> dict[str, str]:
+    """Read ``KEY=VALUE`` lines the way ``source`` would, minus shell expansion."""
+    values: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip()
+    return values
+
+
+def load_env(root: Path, environ: MutableMapping[str, str] | None = None) -> Target:
+    """Apply ``<root>/.env`` over ``environ`` and report the resolved target.
+
+    Keys the file declares replace what the environment carried; keys it does not
+    declare are left alone, so a per-command ``HA_CONTAINER=...`` still reaches
+    the helper.
+    """
+    env = os.environ if environ is None else environ
+    env_file = root / ".env"
+    present = env_file.is_file()
+    ignored = env.get(IGNORE_FLAG, "").strip().lower() not in {"", "0", "false", "no"}
+    overrode: list[str] = []
+    displaced_base_url: str | None = None
+
+    if present and not ignored:
+        for key, value in parse_env_file(env_file.read_text(encoding="utf-8")).items():
+            if key in env and env[key] != value:
+                overrode.append(key)
+                if key == "HA_BASE_URL":
+                    displaced_base_url = env[key]
+            env[key] = value
+
+    if present and not ignored:
+        source = str(env_file)
+    elif present:
+        source = f"the environment; {env_file} ignored via {IGNORE_FLAG}"
+    elif "HA_BASE_URL" in env:
+        source = "the environment; no .env beside the checkout"
+    else:
+        source = "the built-in default; nothing set HA_BASE_URL"
+
+    return Target(
+        base_url=env.get("HA_BASE_URL") or DEFAULT_BASE_URL,
+        token=env.get("HA_TOKEN") or None,
+        source=source,
+        env_file=env_file if present else None,
+        overrode=tuple(overrode),
+        displaced_base_url=displaced_base_url,
+        ignored=ignored,
+    )
+
+
+def target_lines(
+    target: Target,
+    *,
+    counts: dict[str, Any] | None = None,
+    unavailable: str | None = None,
+    action: str | None = None,
+) -> list[str]:
+    """The banner every helper prints before it acts."""
+    lines = [f"{BANNER_PREFIX} HA_BASE_URL={target.base_url} (from {target.source})"]
+
+    if target.overrode:
+        # The displaced URL is the whole point of the line -- it is the instance
+        # the run would have gone to. No other displaced value is printed: one of
+        # them is the token.
+        displaced = ", ".join(
+            f"{key}={target.displaced_base_url}" if key == "HA_BASE_URL" else key
+            for key in sorted(target.overrode)
+        )
+        lines.append(f"{BANNER_PREFIX} the .env overrode the environment's {displaced}")
+
+    if counts is None:
+        lines.append(f"{BANNER_PREFIX} store: unavailable ({unavailable or 'not probed'})")
+    else:
+        totals = " ".join(f"{k}={counts[k]}" for k in HEADLINE_COUNTS if k in counts)
+        totals = totals or "reachable, but reported no totals"
+        lines.append(f"{BANNER_PREFIX} store: {totals}")
+
+    if action:
+        lines.append(f"{BANNER_PREFIX} {action} writes to this instance; proceeding")
+    return lines
+
+
+def announce(
+    target: Target,
+    *,
+    counts: dict[str, Any] | None = None,
+    unavailable: str | None = None,
+    action: str | None = None,
+    stream: TextIO = sys.stderr,
+) -> None:
+    """Print the banner. Defaults to stderr, which the JSON-printing helpers need."""
+    for line in target_lines(target, counts=counts, unavailable=unavailable, action=action):
+        print(line, file=stream, flush=True)
+
+
+async def announce_store(
+    target: Target,
+    *,
+    action: str | None = None,
+    stream: TextIO = sys.stderr,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Probe the resolved instance and print the banner -- one call per helper."""
+    if target.token is None:
+        counts, why = None, f"HA_TOKEN is unset (looked in {target.source})"
+    else:
+        counts, why = await probe_counts(target.base_url, target.token)
+    announce(target, counts=counts, unavailable=why, action=action, stream=stream)
+    return counts, why
+
+
+def ws_url(base_url: str) -> str:
+    """Convert an HTTP(S) base URL to the Home Assistant WebSocket endpoint."""
+    base = base_url.rstrip("/")
+    if base.startswith("https://"):
+        return f"wss://{base[len('https://') :]}/api/websocket"
+    if base.startswith("http://"):
+        return f"ws://{base[len('http://') :]}/api/websocket"
+    return f"ws://{base}/api/websocket"
+
+
+async def probe_counts(
+    base_url: str, token: str, *, timeout_s: float = 10.0
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Ask ``haventory/health`` for the store's counts.
+
+    Returns ``(counts, None)`` or ``(None, reason)``. Every failure is a reason
+    rather than an exception: the banner is a courtesy, and a helper that can
+    still do its job -- ``ws_init_haventory.py`` runs before the integration is
+    loaded -- must not be stopped by it.
+    """
+    try:
+        async with aiohttp.ClientSession() as session:
+            ws = await asyncio.wait_for(
+                session.ws_connect(
+                    ws_url(base_url), timeout=aiohttp.ClientWSTimeout(ws_receive=timeout_s)
+                ),
+                timeout=timeout_s,
+            )
+            async with ws:
+                await asyncio.wait_for(ws.receive_json(), timeout=timeout_s)  # hello
+                await ws.send_json({"type": "auth", "access_token": token})
+                auth = await asyncio.wait_for(ws.receive_json(), timeout=timeout_s)
+                if auth.get("type") != "auth_ok":
+                    return None, f"auth refused ({auth.get('message') or auth.get('type')})"
+                await ws.send_json({"id": 1, "type": "haventory/health"})
+                while True:
+                    frame = await asyncio.wait_for(ws.receive_json(), timeout=timeout_s)
+                    if not isinstance(frame, dict) or frame.get("id") != 1:
+                        continue
+                    if not frame.get("success"):
+                        err = frame.get("error") or {}
+                        code = err.get("code", "error")
+                        return None, f"{code}: {err.get('message', '')}".strip()
+                    result = frame.get("result") or {}
+                    return dict(result.get("counts") or {}), None
+    except Exception as err:
+        # A banner failure must not mask the helper's own error handling, so every
+        # exception becomes a printed reason.
+        return None, f"{type(err).__name__}: {err}"

--- a/scripts/probe_attachments.py
+++ b/scripts/probe_attachments.py
@@ -2,8 +2,6 @@ r"""Online probes for the HAventory attachment path, against a live dev instance
 
 Usage:
   export RUN_ONLINE=1
-  export HA_BASE_URL='http://localhost:8123'
-  export HA_TOKEN='<your-long-lived-token>'
   export HA_CONTAINER='home-assistant'          # or HA_CONFIG_DIR, see below
   uv sync --group probes
   uv run --group probes python scripts/probe_attachments.py
@@ -16,8 +14,10 @@ Options:
 Environment variables:
 - RUN_ONLINE: must be `1`. Nothing here mocks anything and it writes to a real
   inventory, so it never runs by accident.
-- HA_BASE_URL: Home Assistant base URL. Default: http://localhost:8123
-- HA_TOKEN: long-lived access token (required)
+- HA_BASE_URL / HA_TOKEN: taken from the `.env` beside this checkout, which wins
+  over an inherited export; HAVENTORY_IGNORE_ENV_FILE=1 hands the decision back
+  to the environment. The resolved target and the store's counts print on stderr
+  before the first upload. A token is required.
 - HA_CONFIG_DIR: the Home Assistant config directory as this host sees it. Set
   it when the config lives on a bind mount; leave it unset to read the stored
   bytes through `docker exec`.
@@ -78,7 +78,10 @@ except ImportError:  # pragma: no cover - the group is opt-in
 
 # Both helpers live in `scripts/`, which is the interpreter's own directory when
 # this file is run as a script.
+import dev_env
 from probe_fixtures import generate as generate_fixtures
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # -----------------------------------------------------------------------------
 # Mirrors of what the card decides before an upload starts.
@@ -670,11 +673,13 @@ async def run_probes(args: argparse.Namespace) -> int:
     if os.environ.get("RUN_ONLINE") != "1":
         print("Set RUN_ONLINE=1: this writes to a real inventory.", file=sys.stderr)
         return 2
-    token = os.environ.get("HA_TOKEN")
+    target = dev_env.load_env(REPO_ROOT)
+    token = target.token
+    base = target.base_url
+    await dev_env.announce_store(target, action="the attachment probes")
     if not token:
-        print("Missing HA_TOKEN in environment", file=sys.stderr)
+        print(f"Missing HA_TOKEN (looked in {target.source})", file=sys.stderr)
         return 2
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
 
     temporary = args.fixtures_dir is None
     fixtures = (

--- a/scripts/stress_test.py
+++ b/scripts/stress_test.py
@@ -38,9 +38,14 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import count
+from pathlib import Path
 from typing import Any
 
 import aiohttp
+
+import dev_env
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # -----------------------------------------------------------------------------
 # Constants
@@ -1412,10 +1417,12 @@ async def main() -> int:  # noqa: PLR0911, PLR0912, PLR0915
     parser.add_argument("--skip-confirm", action="store_true", help="Skip user confirmation")
     args = parser.parse_args()
 
-    # Get environment variables
+    # The .env beside the checkout names the instance; HA_CONTAINER stays an export
+    # (a container named in .env arms scripts/smoke_online.sh to purge that store).
+    target = dev_env.load_env(REPO_ROOT)
     container_name = os.environ.get("HA_CONTAINER")
-    base_url = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
+    base_url = target.base_url
+    token = target.token
 
     if not container_name:
         print_status("Missing HA_CONTAINER environment variable", "fail")
@@ -1426,7 +1433,7 @@ async def main() -> int:  # noqa: PLR0911, PLR0912, PLR0915
 
     print_status("HAventory Backend Stress Test", "header")
     print_status(f"Container: {container_name}", "info")
-    print_status(f"Base URL: {base_url}", "info")
+    print_status(f"Base URL: {base_url} (from {target.source})", "info")
 
     # Step 1: Deploy code
     if not args.skip_deploy:

--- a/scripts/ws_init_haventory.py
+++ b/scripts/ws_init_haventory.py
@@ -1,9 +1,13 @@
 r"""Initialize HAventory config entry via Home Assistant WebSocket API.
 
 Usage:
-  export HA_BASE_URL='http://localhost:8123'
-  export HA_TOKEN='<your-long-lived-token>'
   uv run python scripts/ws_init_haventory.py
+
+Target:
+  HA_BASE_URL / HA_TOKEN come from the .env beside this checkout, which wins over an
+  inherited export -- a worktree's .env names the instance that worktree is for. Set
+  HAVENTORY_IGNORE_ENV_FILE=1 to hand the decision back to the environment for one
+  run. The resolved base URL prints on stderr before anything is written.
 
 Behavior:
 - Starts the HAventory config flow (domain "haventory").
@@ -17,20 +21,15 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import sys
+from pathlib import Path
 from typing import Any
 
 import aiohttp
 
+import dev_env
 
-def _ws_url_from_base(base_url: str) -> str:
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    if base_url.startswith("http://"):
-        return f"ws://{base_url[len('http://') :]}/api/websocket"
-    return f"ws://{base_url}/api/websocket"
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 async def _recv_json(ws: aiohttp.ClientWebSocketResponse) -> dict[str, Any]:
@@ -121,13 +120,17 @@ def build_user_input(data_schema: object) -> dict[str, Any]:
 
 
 async def run() -> int:  # noqa: PLR0912, PLR0915
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
+    target = dev_env.load_env(REPO_ROOT)
+    base = target.base_url
+    token = target.token
+    # The config entry this creates is what loads the integration, so the store is
+    # routinely unreadable here -- the banner says so and the run continues.
+    await dev_env.announce_store(target, action="creating the haventory config entry")
     if not token:
         print("Missing HA_TOKEN in environment", file=sys.stderr)
         return 2
 
-    ws_url = _ws_url_from_base(base)
+    ws_url = dev_env.ws_url(base)
 
     async with aiohttp.ClientSession() as session:
         async with session.ws_connect(ws_url) as ws:

--- a/scripts/ws_probe.py
+++ b/scripts/ws_probe.py
@@ -1,14 +1,17 @@
 r"""WebSocket probe for HAventory commands.
 
 Usage:
-  export HA_BASE_URL='http://localhost:8123'
-  export HA_TOKEN='<your-long-lived-token>'
   export HAV_MSG='{"id":1, "type":"haventory/ping", "echo":"hi"}'
   uv run python scripts/ws_probe.py
 
+Target:
+  HA_BASE_URL / HA_TOKEN come from the .env beside this checkout, which wins over an
+  inherited export -- a worktree's .env names the instance that worktree is for. Set
+  HAVENTORY_IGNORE_ENV_FILE=1 to hand the decision back to the environment for one
+  run. The resolved base URL and the store's counts print on stderr before anything
+  is sent.
+
 Environment variables:
-- HA_BASE_URL: Home Assistant base URL (http/https). Default: http://localhost:8123
-- HA_TOKEN: Long-lived access token (required)
 - HAV_MSG: JSON message to send (required). Example: {"id":1, "type":"haventory/version"}
 
 Notes:
@@ -21,25 +24,20 @@ import asyncio
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 import aiohttp
 
+import dev_env
 
-def _ws_url_from_base(base_url: str) -> str:
-    """Convert an HTTP(S) base URL to a WS(S) endpoint."""
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    if base_url.startswith("http://"):
-        return f"ws://{base_url[len('http://') :]}/api/websocket"
-    # Fallback: assume it's a bare host:port
-    return f"ws://{base_url}/api/websocket"
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 async def run_probe() -> int:
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
+    target = dev_env.load_env(REPO_ROOT)
+    base = target.base_url
+    token = target.token
     raw_msg = os.environ.get("HAV_MSG")
     connect_timeout_s = float(os.environ.get("HAV_CONNECT_TIMEOUT", "10"))
     recv_timeout_s = float(os.environ.get("HAV_RECV_TIMEOUT", "20"))
@@ -57,7 +55,9 @@ async def run_probe() -> int:
         print(f"HAV_MSG is not valid JSON: {err}", file=sys.stderr)
         return 2
 
-    ws_url = _ws_url_from_base(base)
+    await dev_env.announce_store(target)
+
+    ws_url = dev_env.ws_url(base)
 
     async with aiohttp.ClientSession() as session:
         # Bound the websocket upgrade with connect_timeout_s (asyncio.wait_for); the

--- a/scripts/ws_subscribe.py
+++ b/scripts/ws_subscribe.py
@@ -1,8 +1,6 @@
 r"""WebSocket subscription helper for HAventory topics.
 
 Environment variables:
-  export HA_BASE_URL='http://localhost:8123'
-  export HA_TOKEN='<your-long-lived-token>'
   export HAV_TOPIC='items'            # or 'locations' or 'stats'
   export HAV_LOCATION_ID=''           # for topic 'locations' (optional)
   export HAV_INCLUDE_SUBTREE='true'   # for topic 'locations' (optional)
@@ -13,6 +11,13 @@ Optional mutations after subscribe:
 
 Run:
   uv run python scripts/ws_subscribe.py
+
+Target:
+  HA_BASE_URL / HA_TOKEN come from the .env beside this checkout, which wins over an
+  inherited export -- a worktree's .env names the instance that worktree is for. Set
+  HAVENTORY_IGNORE_ENV_FILE=1 to hand the decision back to the environment for one
+  run. The resolved base URL and the store's counts print on stderr before anything
+  is sent.
 
 Notes:
 - Converts http(s) base URL into ws(s) automatically.
@@ -26,18 +31,14 @@ import json
 import os
 import sys
 from itertools import count
+from pathlib import Path
 from typing import Any
 
 import aiohttp
 
+import dev_env
 
-def _ws_url_from_base(base_url: str) -> str:
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    if base_url.startswith("http://"):
-        return f"ws://{base_url[len('http://') :]}/api/websocket"
-    return f"ws://{base_url}/api/websocket"
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -70,8 +71,9 @@ async def _drain_until(ws: aiohttp.ClientWebSocketResponse, predicate, limit: in
 
 
 async def run_subscriber() -> int:
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
+    target = dev_env.load_env(REPO_ROOT)
+    base = target.base_url
+    token = target.token
     topic = os.environ.get("HAV_TOPIC", "items").strip().lower()
     location_id = os.environ.get("HAV_LOCATION_ID")
     include_subtree = _env_bool("HAV_INCLUDE_SUBTREE", True)
@@ -98,7 +100,9 @@ async def run_subscriber() -> int:
             subscribe_payload["location_id"] = location_id
         subscribe_payload["include_subtree"] = include_subtree
 
-    ws_url = _ws_url_from_base(base)
+    await dev_env.announce_store(target, action="HAV_MUTATIONS" if mutations else None)
+
+    ws_url = dev_env.ws_url(base)
 
     async with aiohttp.ClientSession() as session:
         # Bound the websocket upgrade with connect_timeout_s (asyncio.wait_for); the

--- a/tests/test_dev_env_target_offline.py
+++ b/tests/test_dev_env_target_offline.py
@@ -1,0 +1,144 @@
+"""The dev helpers resolve one instance, and say which one before they act.
+
+``scripts/dev_env.py`` is the single answer to "which Home Assistant is this
+run about to touch". A shell profile that exports ``HA_BASE_URL``/``HA_TOKEN``
+for one instance must not silently outrank the ``.env`` sitting in the checkout
+the helper was started from, and the resolved target has to be printed rather
+than inferred from a count that looks off.
+"""
+
+# The tokens below are fixtures; S105 cannot tell a fake one from a real one.
+# ruff: noqa: S105
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from dev_env import (  # noqa: E402
+    DEFAULT_BASE_URL,
+    IGNORE_FLAG,
+    load_env,
+    parse_env_file,
+    target_lines,
+)
+
+ENV_A = "HA_BASE_URL=http://instance-a:8123\nHA_TOKEN=token-a\n"
+
+
+def test_env_file_beats_an_inherited_export(tmp_path: Path) -> None:
+    """The worktree's .env names the instance that worktree is for."""
+    (tmp_path / ".env").write_text(ENV_A, encoding="utf-8")
+    env = {"HA_BASE_URL": "http://instance-b:8123", "HA_TOKEN": "token-b"}
+
+    target = load_env(tmp_path, env)
+
+    assert env["HA_BASE_URL"] == "http://instance-a:8123"
+    assert env["HA_TOKEN"] == "token-a"
+    assert target.base_url == "http://instance-a:8123"
+    assert target.token == "token-a"
+    assert target.overrode == ("HA_BASE_URL", "HA_TOKEN")
+    assert target.source == str(tmp_path / ".env")
+
+
+def test_keys_the_file_does_not_declare_survive(tmp_path: Path) -> None:
+    """A per-command HA_CONTAINER=... still reaches the helper.
+
+    The .env deliberately declares no container (setting one there arms
+    ``scripts/smoke_online.sh`` to purge that container's store), so overriding
+    the whole environment rather than the declared keys would break the one way
+    the container is named.
+    """
+    (tmp_path / ".env").write_text(ENV_A, encoding="utf-8")
+    env = {"HA_CONTAINER": "throwaway-ha"}
+
+    load_env(tmp_path, env)
+
+    assert env["HA_CONTAINER"] == "throwaway-ha"
+
+
+def test_the_ignore_flag_hands_the_decision_back(tmp_path: Path) -> None:
+    """A recipe pointing a helper at a remote instance says so out loud."""
+    (tmp_path / ".env").write_text(ENV_A, encoding="utf-8")
+    env = {
+        "HA_BASE_URL": "http://release-host:8123",
+        "HA_TOKEN": "token-b",
+        IGNORE_FLAG: "1",
+    }
+
+    target = load_env(tmp_path, env)
+
+    assert target.base_url == "http://release-host:8123"
+    assert target.token == "token-b"
+    assert target.overrode == ()
+    assert IGNORE_FLAG in target.source
+    assert IGNORE_FLAG in target_lines(target)[0]
+
+
+def test_no_env_file_leaves_the_environment_alone(tmp_path: Path) -> None:
+    """Nothing to be more specific than: the export is the only statement there is."""
+    env = {"HA_BASE_URL": "http://instance-b:8123"}
+
+    target = load_env(tmp_path, env)
+
+    assert target.base_url == "http://instance-b:8123"
+    assert target.env_file is None
+    assert target.overrode == ()
+
+
+def test_an_unset_base_url_falls_back_to_the_local_default(tmp_path: Path) -> None:
+    target = load_env(tmp_path, {})
+
+    assert target.base_url == DEFAULT_BASE_URL
+    assert target.token is None
+
+
+def test_a_value_the_environment_already_agrees_with_is_not_reported(tmp_path: Path) -> None:
+    """ "Overrode" means the target moved; repeating a value is not a warning."""
+    (tmp_path / ".env").write_text(ENV_A, encoding="utf-8")
+    env = {"HA_BASE_URL": "http://instance-a:8123"}
+
+    assert load_env(tmp_path, env).overrode == ()
+
+
+def test_parse_skips_comments_and_blanks() -> None:
+    parsed = parse_env_file("# a comment\n\nHA_BASE_URL=http://x:8123\nnot-a-pair\nHA_TOKEN=t\n")
+
+    assert parsed == {"HA_BASE_URL": "http://x:8123", "HA_TOKEN": "t"}
+
+
+def test_the_banner_names_the_url_the_counts_and_the_write(tmp_path: Path) -> None:
+    """What the operator reads before a destructive command starts."""
+    (tmp_path / ".env").write_text(ENV_A, encoding="utf-8")
+    target = load_env(tmp_path, {"HA_BASE_URL": "http://instance-b:8123"})
+
+    counts = {"items_total": 1079, "locations_total": 48, "status_counts": {"ok": 1079}}
+    lines = target_lines(target, counts=counts, action="bulk")
+
+    assert "HA_BASE_URL=http://instance-a:8123" in lines[0]
+    assert "HA_BASE_URL=http://instance-b:8123" in lines[1]
+    assert lines[2].endswith("items_total=1079 locations_total=48")  # and nothing else
+    assert "bulk writes to this instance" in lines[3]
+    assert all(line.isascii() for line in lines)
+
+
+def test_the_banner_never_prints_a_displaced_token(tmp_path: Path) -> None:
+    """The displaced base URL is the tell; the displaced token is a secret."""
+    (tmp_path / ".env").write_text(ENV_A, encoding="utf-8")
+    target = load_env(tmp_path, {"HA_TOKEN": "token-b"})
+
+    lines = target_lines(target, counts={"items_total": 0})
+
+    assert any("HA_TOKEN" in line for line in lines)
+    assert not any("token-b" in line for line in lines)
+
+
+def test_the_banner_says_why_the_counts_are_missing(tmp_path: Path) -> None:
+    """An unreachable or unloaded instance still gets its URL named."""
+    lines = target_lines(load_env(tmp_path, {}), unavailable="unknown_command: haventory/health")
+
+    assert "unavailable (unknown_command: haventory/health)" in lines[1]
+    assert not any("writes to this instance" in line for line in lines)


### PR DESCRIPTION
## Summary

`load_env()` in `.claude/skills/test-haventory/stress.py` filled `os.environ` with
`setdefault`, so a shell profile exporting `HA_BASE_URL`/`HA_TOKEN` for one instance
outranked the `.env` in the checkout the harness was started from — and nothing printed
which instance had answered. That is the near-miss #432 records: a worktree pointed at a
throwaway HA had its `baseline` answered by the shared dev container, and the next command
in that handover was `bulk 1000`.

Two rules now hold for every helper in the repo that talks to a running Home Assistant:

1. **The `.env` beside the checkout wins over an inherited export** — it is the more
   specific statement of intent. `HAVENTORY_IGNORE_ENV_FILE=1` hands the decision back to
   the environment for one run, which is what a recipe pointing a helper at a remote
   instance needs (see "Decisions" below).
2. **Every helper names its target before it acts** — the base URL, where that value came
   from, the store's `items_total`/`locations_total`, and, when the `.env` displaced an
   exported `HA_BASE_URL`, the instance the run would otherwise have gone to. A command
   that writes says so and proceeds; nothing prompts. `stress.py` additionally stops when
   it cannot read the store, rather than failing three minutes into a `bulk` run.

```
[target] HA_BASE_URL=http://127.0.0.1:8199 (from …/scratchpad/wt432/.env)
[target] the .env overrode the environment's HA_BASE_URL=http://localhost:8123
[target] store: unavailable (ClientConnectorError: Cannot connect to host 127.0.0.1:8199 …)
[target] 'bulk' writes to this instance; proceeding
cannot read the store at http://127.0.0.1:8199: ClientConnectorError: …
```

`scripts/dev_env.py` is the single place that decides this for the Python helpers;
`resolveTarget` in `card_views.mjs` is its counterpart for the eight browser harnesses
(they all reach it through `haConfig()`). Both halves are pure and unit-tested. Three
duplicate `ws_url` / `_ws_url_from_base` copies fold into `dev_env.ws_url`, and two
duplicate `.env` loaders (`driver.py`, `lifecycle_probe.py` — whose comment said it was
copied "verbatim") fold into `dev_env.load_env`.

Closes #432

## Decisions taken against drifted notes

- **Precedence: the `.env` wins** — fixed by the V0.7.0 plan §6.4. The escape hatch the
  issue's own wording asks for ("if the ambient environment is meant to win, the script has
  to say so out loud") is `HAVENTORY_IGNORE_ENV_FILE=1`, and it is not optional polish:
  `dev/release_testing_plan.md` documents a `ws_probe.py` invocation naming a **remote**
  release-test host inline, and without the flag the dev `.env` would silently answer for
  it. That recipe now carries the flag.
- **The four scripts the issue names do not read `.env` at all.** `ws_probe.py`,
  `ws_subscribe.py`, `ws_init_haventory.py` and `create_test_items.py` read `os.environ`
  only, so "the same pattern" was not there to fix — a worktree's `.env` was ignored
  outright rather than merely outranked. They now resolve through `dev_env` like the rest.
- **The actual same-bug files were elsewhere**, found by grepping for `setdefault` rather
  than by the issue's file list: `.claude/skills/run-haventory/driver.py` and
  `lifecycle_probe.py` (identical `setdefault` loaders; `lifecycle_probe` restarts the
  container and rewrites the store) and `card_views.mjs`'s `haConfig()`
  (`!(m[1] in process.env)`, which every browser harness inherits — including the two that
  import data). Fixing only the files the issue listed would have left the destructive ones
  broken.
- **`scripts/stress_test.py` and `scripts/probe_attachments.py`** are the remaining Python
  helpers that write to a live instance; both now resolve the same way.
  `scripts/stress_test.py` already printed base URL and counts, so it gained the precedence
  fix plus the source of the value.
- **Banner on stderr for the `scripts/` helpers, stdout for `stress.py`.** `ws_probe.py`,
  `ws_subscribe.py` and `ws_init_haventory.py` print JSON that callers parse; `stress.py`
  prints prose. The banner is ASCII so it survives a non-UTF-8 console.
- **Counts on the Python side only.** `haConfig()` is synchronous and shared by all eight
  `.mjs` harnesses, so they print the resolved base URL but not the store totals; each
  prints the dashboard discovery found immediately afterwards, which names the instance
  again.
- **`HA_CONTAINER` is untouched** — the `.env` overrides only the keys it declares, so a
  per-command `HA_CONTAINER=…` still reaches the helper. (Putting it in `.env` arms
  `scripts/smoke_online.sh` to purge that container's store; a test pins that the override
  is per-key.)
- **Shell helpers are deliberately out of scope**: `scripts/*.sh` read the environment and
  never a `.env`, so `set -a; source .env; set +a` is an explicit act with no silent
  precedence to get wrong.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1269 passed, 22
      skipped**; `uv run ruff check .` → clean; `uv run ruff format --check .` → clean;
      `uv run mypy` → clean (26 files).
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` (**1864 passed / 63 files**), `npm run build` → all clean.
- [x] `node --test` in `.claude/skills/run-haventory/` → **26 pass** (21 before; 5 new
      `resolveTarget` cases).
- New offline cases: `tests/test_dev_env_target_offline.py` (10) — the `.env` beating an
  inherited export, keys it does not declare surviving, the ignore flag, no `.env` at all,
  the built-in default, a value the environment already agrees with, comment/blank parsing,
  the banner's three lines, and that a displaced **token** is named but never printed.
- phacc: not involved (no `custom_components/` or `tests/integration/` change).

### Live checks (dev HA, `home-assistant` @ localhost:8123, 1087 items / 89 locations)

1. **`stress.py baseline` from the main checkout** names that checkout's `.env` and prints
   the store:
   ```
   [target] HA_BASE_URL=http://localhost:8123 (from C:\…\HAventory\.env)
   [target] store: items_total=1087 locations_total=89
   version: {'integration_version': '0.6.0', 'schema_version': 9}
     [oracle PASS] baseline: healthy=True issues=[] gen=1185
   ```
2. **The §6.4 check — a worktree carrying its own `.env`.** A detached worktree whose
   `.env` named `http://127.0.0.1:8199` (nothing listening), while the shell exported
   `HA_BASE_URL=http://localhost:8123`. `baseline` and `bulk 5` both named
   `127.0.0.1:8199`, reported the displaced `localhost:8123`, and exited 2 **before
   creating anything**. `items_total` on the shared instance was 1087 before and after —
   the near-miss the issue describes, refused.
3. **The escape hatch, same worktree:** `HAVENTORY_IGNORE_ENV_FILE=1 … baseline` →
   `HA_BASE_URL=http://localhost:8123 (from the environment; …\wt432\.env ignored via
   HAVENTORY_IGNORE_ENV_FILE)` and `store: items_total=1087 locations_total=89`.
4. **stdout stays a data channel:** `HAV_MSG='{"id":1,"type":"haventory/version"}'
   ws_probe.py` printed only its JSON result on stdout, with both `[target]` lines on
   stderr. Same for `ws_subscribe.py` (`HAV_TOPIC=stats HAV_MAX_EVENTS=0`) and
   `ws_init_haventory.py` (which prints `{"ok": true, …}`; the entry already exists, so it
   took the already-configured path).
5. `create_test_items.py` with `ITEM_COUNT=0` printed the banner plus `creating 0 items
   writes to this instance; proceeding` and wrote nothing.
6. `driver.py status` and `card_views.mjs` both printed `[target]` on stderr with their own
   output unchanged; `lifecycle_probe.py resources` (no `--yes`) printed the target
   **before** its refusal, so the instance is on screen while deciding whether to pass
   `--yes`, and claims "proceeding" only when it will.
7. Dev HA data unchanged (1087 items / 89 locations throughout); the temporary worktree was
   removed.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases, in both languages).
- [x] Docs updated: both `SKILL.md`s, `README.md`'s helper-script section,
      `dev/release_testing_plan.md`'s remote-host recipe.
- [x] No WebSocket API change.
- [x] Essential invariants untouched (no `custom_components/` change).

## Follow-ups

- `scripts/dev_env.py` is imported by the two `.claude/skills/` harnesses through a
  `sys.path` insert anchored on each file's own committed location — the same anchor
  `stress.py` already used for its `.env`. It fails loudly (ImportError) if the layout
  moves rather than silently falling back to the old behaviour. Not filed.
- `log_sweep.py` resolves only `HA_CONTAINER` and never a base URL, so it has no target to
  name. Not filed.

## Handover

**1. Merged / left open**

All three merged and their branches deleted; nothing is left open for you.

- #524 — `fix(skills): make stress.py honour the worktree's .env and name its target`
  (closes #432)
- #525 — `test(skills): branch-discriminating desktop surfaces and --dashboard selection`
  (closes #212)
- this PR — `test(card): fake-timer the remaining wall-clock waits; sweep pending timeouts in
  teardown` (closes #209)

**2. Test this by hand**

Nothing by hand. Everything in this session is harness and suite work, and each half was
driven against the real dev HA rather than asserted offline:

1. `[log]` The near-miss #432 describes was reproduced and refused: from a worktree whose
   `.env` named an unreachable instance, with the shell exporting the dev one, `stress.py
   bulk 5` printed the target, named the displaced URL and exited **before creating
   anything**; the dev store stayed at 1087 items. `HAVENTORY_IGNORE_ENV_FILE=1` from the
   same worktree reached the dev instance and read its counts. Evidence in #524.
2. `[desktop]` The two sharpened surfaces were driven both ways: 15/15 on
   `/dashboard-dev/wide`, and `d-02` + `d-11` failing on `/dashboard-dev/0` where they used
   to pass. `--dashboard` was proven on a temporary second card-bearing dashboard, by title
   and by url path, with the unmatched name exiting 2. Evidence in #525.
3. `[optional]` If you want one thing on screen: run
   `uv run --no-project --with aiohttp python .claude/skills/test-haventory/stress.py baseline`
   and read the first two lines. They are what every helper now prints before it acts, and
   whether that wording is useful to you is the one judgement a harness cannot make.

**3. Decisions taken against drifted notes**

- #432's four named scripts never read `.env` at all; the same-`setdefault` bug was in
  `driver.py`, `lifecycle_probe.py` and `card_views.mjs`'s `haConfig()`. All are fixed, and
  the escape hatch `HAVENTORY_IGNORE_ENV_FILE=1` exists because
  `dev/release_testing_plan.md` documents a probe aimed at a remote host inline.
- #212's `d-11` discriminator is `open-full-view`, not `full-sidebar`: driving it showed the
  full view sizes its sidebar off the window, so a narrow card in a wide window still shows
  it. The structural rule the notes proposed is not true of the current table; what landed
  instead is "every selector a desktop surface asserts absent must be one a narrow surface
  asserts present", which is true, catches a typo'd `hidden`, and was verified by breaking
  one on purpose.
- #209's table had drifted and was short by three waits, the largest of them 618 ms per run.

**4. Follow-ups**

- Named and deliberately not filed (they clear no real-world bar): the ten `vi.waitUntil` /
  `vi.waitFor` polls in the card suite; `log_sweep.py` having no base URL to name; the
  desktop surfaces beyond `d-02`/`d-11` that assert only selectors the narrow branch also
  has (`d-layout` covers them, and ten more assertions would not).
- No new issues were filed this session.

**5. State left behind**

- **Dev HA (`home-assistant`, localhost:8123):** data unchanged — 1087 items / 89 locations
  before and after. A temporary dashboard `s4-second` ("Household") was created over WS to
  prove `--dashboard` and **deleted again**; `node card_views.mjs` is back to the two
  `dashboard-dev` views. No `.storage` edits, no restarts, rate limiting untouched, language
  untouched.
- **Branches:** `claude/v0-7-0-s4-stress-env`, `claude/v0-7-0-s4-visual-pass` and
  `claude/v0-7-0-s4-fake-timers` are merged and deleted on the remote.
- **New files the next session should know about:** `scripts/dev_env.py` (one place that
  decides which instance a helper talks to — reuse it rather than reading `.env` again) and
  `.claude/skills/run-haventory/surfaces.mjs` (the visual-pass tables, now importable by
  tests).
- **Host quirk, pre-existing:** every `git` command in this checkout prints
  `error: failed to delete '.git/worktrees/<name>': Permission denied` for ~20 stale worktree
  entries left by earlier sessions. It is noise, not a failure; the worktree this session
  created for the #432 proof is gone from `git worktree list` and its directory is removed.
- **Open PRs left alone:** release-please's #491 (`chore(main): release 0.7.0`) — never
  touched by a session, and per the plan it waits for S11 — and Dependabot's #516–#523.
