### PR TITLE
test(skills): branch-discriminating desktop surfaces and `--dashboard` selection

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -185,8 +185,24 @@ sections column measures ~500px even in a 1440px window, so it gets the narrow b
 | `column` | any other view — sections, masonry — the column a card normally sits in | `screenshot.mjs`, `visual_pass.mjs` mobile, `import_policies.mjs`, `rl_banner.mjs` |
 
 A view without a `path` is addressed by **index**, which is why the dev instance's sections
-view is `/dashboard-dev/0`. Each harness prints the view it resolved and why, so a run says
-where it went:
+view is `/dashboard-dev/0`.
+
+**Choosing between dashboards.** Discovery searches every dashboard and takes the first
+matching view in `lovelace/dashboards/list` order, which is the right answer on an instance
+with one card-bearing dashboard and an arbitrary one on an instance with two. Every harness
+takes `--dashboard <url path or title>` (matched case-insensitively against either) to
+narrow discovery before the shape is picked:
+
+```bash
+node visual_pass.mjs --dashboard household        # or --dashboard lovelace-household
+node screenshot.mjs --dashboard "Family kitchen" --out kitchen.png
+```
+
+A `--dashboard` naming nothing is an **error**, not a fallback — quietly opening another
+dashboard's card is the exact failure the flag exists to remove, and the message lists what
+discovery did find. A `--path` names a URL outright and still wins for the pass it targets.
+
+Each harness prints the view it resolved and why, so a run says where it went:
 
 ```
 view (desktop): /dashboard-dev/wide  ← dev › wide (panel)
@@ -205,7 +221,16 @@ Three things discovery does when it cannot give a clean answer, all of them out 
 - **The shape was wrong anyway** — `visual_pass.mjs`'s two card passes assert the branch
   the card actually took (`d-layout`, `m-layout`) before running a single recipe. Enough
   testids are shared between the branches that a wrong-shape run would otherwise pass while
-  photographing the other layout.
+  photographing the other layout. Two desktop surfaces carry that check themselves, because
+  they drive components the narrow branch also mounts: `d-02-filter-panel` asserts the
+  filter sheet's Apply button is **absent** (both branches mount the same `hv-filter-panel`,
+  but the desktop one applies each change live and renders no footer), and `d-11-full-view`
+  asserts the shell's **`open-full-view` footer link** is present — `hv-card-shell` renders
+  it only when it is not in its narrow branch, and the shell stays in the DOM under the
+  modal. The full view itself cannot carry that check: it is a modal at any width and sizes
+  its sidebar off the *window*, so a narrow card opening it in a wide window still shows the
+  sidebar. The sidebar is asserted beside the link as the mirror of `pm-01-page`, which
+  asserts the same element hidden at 375px.
 
 The sidebar panel at `/haventory` needs none of this — HA routes it from the integration's
 own registration, so it is the one surface that survives any dashboard edit, and both
@@ -404,6 +429,7 @@ node visual_pass.mjs --only panel         # sidebar panel, desktop width
 node visual_pass.mjs --only panel-mobile  # sidebar panel, 375x812
 node visual_pass.mjs --list               # surface names
 node visual_pass.mjs --path desktop=/other/wide --path mobile=/other/0
+node visual_pass.mjs --dashboard household   # an instance with two card dashboards
 ```
 
 Four passes — 14 card surfaces at desktop width, 8 at phone width, and the sidebar panel
@@ -412,7 +438,9 @@ at both (10 wide, 8 narrow) — each a recipe of clicks against the card's own
 captured only if its root element exists afterwards, so a renamed testid fails loudly
 instead of silently photographing the wrong screen. The two card passes additionally
 assert the layout branch the card took (`d-layout`, `m-layout`), which is what makes 42
-rows out of 40 surfaces. Exit is non-zero if any of them failed, or the browser logged a
+rows out of 40 surfaces; the desktop filter-panel and full-view surfaces each carry that
+check for themselves as well, so they fail on the narrow branch on their own rather than
+relying on the pass-level one. Exit is non-zero if any of them failed, or the browser logged a
 console error. Files are prefixed `d-`, `m-`, `p-` and `pm-`.
 
 The four passes open **three** URLs — two discovered dashboard views and `/haventory` — so
@@ -423,6 +451,10 @@ The four passes open **three** URLs — two discovered dashboard views and `/hav
 ```bash
 node visual_pass.mjs --only desktop --path /dashboard-dev/wide
 ```
+
+`--dashboard` is the other half: it narrows *discovery* for the whole run rather than naming
+a URL, so both card passes stay on the dashboard you meant and keep choosing their own view
+shape within it. See "Where the card lives".
 
 The card's narrow layout is a **different component tree** (sheets, not panels), which is
 why the two card lists differ rather than sharing one. The panel's is not: `hv-full-view`
@@ -543,9 +575,12 @@ counts only grow — a *smaller* one than the last release's means collection br
 tests were removed — so treat them as a floor, and re-pin them when a release moves them.
 The full gate, with the numbers kept next to it, is the sibling `/test-haventory` skill.
 
-The harness has its own unit cover for the parts of `card_views.mjs` that decide where a
-run looks — which views hold the card, which URL addresses them, what `--path` asked for.
-No HA and no dependency beyond Node:
+The harness has its own unit cover for the parts that decide where a run looks and which
+instance it looks at: `card_views.mjs` (which views hold the card, which URL addresses them,
+what `--path` and `--dashboard` asked for, which `.env` wins) and `surfaces.mjs`, whose
+tables are checked about themselves — every selector a desktop surface asserts **absent** has
+to be one a narrow surface asserts present, so a typo cannot leave a `hidden` check passing
+vacuously. No HA and no dependency beyond Node:
 
 ```bash
 cd .claude/skills/run-haventory && node --test

--- a/.claude/skills/run-haventory/card_views.mjs
+++ b/.claude/skills/run-haventory/card_views.mjs
@@ -160,10 +160,30 @@ export function cardViewsOf(config, dashPath, dashTitle = dashPath) {
       urlPath: `/${dashPath}/${view.path ?? index}`,
       shape: viewType === "panel" ? "wide" : "column",
       viewType,
+      // Both names the dashboard answers to, as fields rather than only inside
+      // `label`: --dashboard matches on them, and matching by sniffing a
+      // composed string would break the moment the label's shape changes.
+      dashPath,
+      dashTitle,
       label: `${dashTitle} › ${view.title ?? view.path ?? `view ${index}`}`,
     });
   });
   return found;
+}
+
+/**
+ * The discovered views belonging to one dashboard, named by its URL path or its
+ * title, case-insensitively.
+ *
+ * An instance with the card on more than one dashboard otherwise gives a pass
+ * whichever `lovelace/dashboards/list` returned first, and no way to say which
+ * one it meant short of a per-pass `--path`.
+ */
+export function filterByDashboard(found, name) {
+  const wanted = String(name).trim().toLowerCase();
+  return found.filter(
+    (v) => v.dashPath?.toLowerCase() === wanted || v.dashTitle?.toLowerCase() === wanted,
+  );
 }
 
 /**
@@ -291,19 +311,35 @@ let notesPrinted = false;
  * so a run says which view it chose and why. `label` names the caller's own
  * notion of the pass when it has one; the shape is the sensible default.
  *
+ * `dashboard` narrows discovery to one dashboard before the shape is picked, so
+ * two passes in one run can name different ones — discovery itself stays
+ * memoized and unfiltered. `override` still wins outright: a `--path` names a
+ * URL, and there is nothing left to select.
+ *
  * @param {string} shape
- * @param {{ override?: string | null, label?: string }} [options]
+ * @param {{ override?: string | null, label?: string, dashboard?: string | null }} [options]
  * @returns {Promise<string>}
  */
-export async function cardPath(shape, { override = null, label = shape } = {}) {
+export async function cardPath(shape, { override = null, label = shape, dashboard = null } = {}) {
   if (override) {
     console.log(`view (${label}): ${override}  ← --path override`);
     return override;
   }
-  const { found, notes } = await discoverCardViews();
+  const { found: all, notes } = await discoverCardViews();
   if (!notesPrinted) {
     notesPrinted = true;
     for (const note of notes) console.log(`  (${note})`);
+  }
+  const found = dashboard ? filterByDashboard(all, dashboard) : all;
+  if (dashboard && found.length === 0) {
+    // Falling back here would open some other dashboard's card, which is the
+    // exact failure the flag exists to remove — so it stops the run instead.
+    const offered = all.map((v) => `${v.dashPath} (${v.dashTitle})`);
+    const seen = offered.length ? [...new Set(offered)].join(", ") : "nothing";
+    throw new Error(
+      `--dashboard ${dashboard}: no dashboard by that url path or title holds a ${CARD_TYPE}. ` +
+        `Discovery found: ${seen}.${notes.length ? ` (${notes.join("; ")})` : ""}`,
+    );
   }
   const { view, exact } = pickView(found, shape);
   if (!view) {

--- a/.claude/skills/run-haventory/card_views.test.mjs
+++ b/.claude/skills/run-haventory/card_views.test.mjs
@@ -13,7 +13,19 @@ import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import { cardViewsOf, holdsCard, parsePathOverrides, pickView, resolveTarget } from "./card_views.mjs";
+import {
+  cardViewsOf,
+  filterByDashboard,
+  holdsCard,
+  parsePathOverrides,
+  pickView,
+  resolveTarget,
+} from "./card_views.mjs";
+import {
+  DESKTOP_SURFACES,
+  MOBILE_SURFACES,
+  PANEL_MOBILE_SURFACES,
+} from "./surfaces.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -49,8 +61,22 @@ test("holdsCard says no to a view of other cards and to a strategy dashboard", (
 
 test("cardViewsOf reads both dev-dashboard views with their shapes", () => {
   assert.deepEqual(cardViewsOf(DEV_DASHBOARD, "dashboard-dev", "dev"), [
-    { urlPath: "/dashboard-dev/0", shape: "column", viewType: "sections", label: "dev › view 0" },
-    { urlPath: "/dashboard-dev/wide", shape: "wide", viewType: "panel", label: "dev › wide" },
+    {
+      urlPath: "/dashboard-dev/0",
+      shape: "column",
+      viewType: "sections",
+      dashPath: "dashboard-dev",
+      dashTitle: "dev",
+      label: "dev › view 0",
+    },
+    {
+      urlPath: "/dashboard-dev/wide",
+      shape: "wide",
+      viewType: "panel",
+      dashPath: "dashboard-dev",
+      dashTitle: "dev",
+      label: "dev › wide",
+    },
   ]);
 });
 
@@ -75,10 +101,61 @@ test("cardViewsOf treats a view with no type as a column and a strategy config a
     urlPath: "/d/0",
     shape: "column",
     viewType: "masonry",
+    // With no title given, the url path is the dashboard's only name.
+    dashPath: "d",
+    dashTitle: "d",
     label: "d › view 0",
   });
   assert.deepEqual(cardViewsOf({ strategy: { type: "map" } }, "map"), []);
   assert.deepEqual(cardViewsOf(undefined, "d"), []);
+});
+
+// --- choosing between dashboards -------------------------------------------
+//
+// Discovery returns every view on the instance that holds the card, in
+// `lovelace/dashboards/list` order. On an instance with the card on two
+// dashboards that order is the only thing deciding which one a pass opens, and
+// nothing about it says which was meant.
+
+const SECOND_DASHBOARD = {
+  views: [{ title: "Household", path: "wide", type: "panel", cards: [{ type: "custom:haventory-card" }] }],
+};
+const TWO_DASHBOARDS = [
+  ...cardViewsOf(DEV_DASHBOARD, "dashboard-dev", "dev"),
+  ...cardViewsOf(SECOND_DASHBOARD, "lovelace-home", "Home"),
+];
+
+test("filterByDashboard picks by url path or by title, case-insensitively", () => {
+  assert.deepEqual(
+    filterByDashboard(TWO_DASHBOARDS, "dashboard-dev").map((v) => v.urlPath),
+    ["/dashboard-dev/0", "/dashboard-dev/wide"],
+  );
+  assert.deepEqual(
+    filterByDashboard(TWO_DASHBOARDS, "DEV").map((v) => v.urlPath),
+    ["/dashboard-dev/0", "/dashboard-dev/wide"],
+  );
+  assert.deepEqual(
+    filterByDashboard(TWO_DASHBOARDS, "home").map((v) => v.urlPath),
+    ["/lovelace-home/wide"],
+  );
+});
+
+test("filterByDashboard returns nothing for a name no dashboard answers to", () => {
+  // The caller turns this into an error rather than falling through to
+  // pickView: opening some other dashboard's card is the failure the flag
+  // exists to remove.
+  assert.deepEqual(filterByDashboard(TWO_DASHBOARDS, "dashboard-dev-2"), []);
+  assert.deepEqual(filterByDashboard([], "dev"), []);
+});
+
+test("filtering first stops a shape reaching across dashboards", () => {
+  // Unfiltered, the dev dashboard's panel view answers "wide" — so a pass that
+  // named the other dashboard would silently open this one.
+  assert.equal(pickView(TWO_DASHBOARDS, "wide").view.urlPath, "/dashboard-dev/wide");
+  assert.equal(
+    pickView(filterByDashboard(TWO_DASHBOARDS, "Home"), "wide").view.urlPath,
+    "/lovelace-home/wide",
+  );
 });
 
 test("pickView prefers the asked-for shape wherever it sits", () => {
@@ -219,4 +296,74 @@ test("a value the environment already agrees with is not reported as overridden"
   });
 
   assert.deepEqual(target.overrode, []);
+});
+
+// --- the desktop surfaces tell the two layout branches apart ---------------
+//
+// The card picks its layout from its own width, so a desktop pass that lands in
+// a normal dashboard column runs the narrow branch — and a recipe whose
+// selectors exist on both branches passes there without noticing. #178's
+// `d-layout` check covers the pass as a whole; these two surfaces are the ones
+// that reuse a component the narrow branch also mounts, so each carries its own
+// discriminator.
+
+const selectorsOf = (surface) => [
+  ...[surface.expect ?? []].flat(),
+  ...[surface.hidden ?? []].flat(),
+];
+const surfaceById = (table, id) => table.find((s) => s.id === id);
+
+test("the desktop filter panel asserts the sheet's Apply button is absent", () => {
+  const desktop = surfaceById(DESKTOP_SURFACES, "02-filter-panel");
+  assert.match(desktop.hidden, /sheet-apply/);
+  // Both branches mount the same hv-filter-panel, which is why `filter-panel`
+  // alone could not tell them apart.
+  assert.match([desktop.expect].flat().join(" "), /filter-panel/);
+});
+
+test("the desktop full view asserts what the card's own branch decides", () => {
+  const desktop = surfaceById(DESKTOP_SURFACES, "11-full-view");
+  const expected = [desktop.expect].flat().join(" ");
+  // The full view is a modal at any width and sizes its sidebar off the window,
+  // so neither `full-view` nor `full-sidebar` can tell a narrow card in a wide
+  // window from a wide one. The shell's footer link is rendered only on the
+  // desktop branch, and the shell stays in the DOM under the modal.
+  assert.match(expected, /open-full-view/);
+  assert.match(expected, /full-sidebar/);
+});
+
+test("every selector a desktop surface hides is one a narrow surface expects", () => {
+  // A `hidden` selector that matches nothing anywhere passes forever — a typo in
+  // one is invisible. Anchoring each to a narrow-branch surface that asserts the
+  // same element visible is what keeps it from going vacuous.
+  const narrow = new Set(
+    [...MOBILE_SURFACES, ...PANEL_MOBILE_SURFACES]
+      .flatMap((s) => [s.expect ?? []].flat())
+      .map((sel) => sel.replace(/^\S+\s/, "")),
+  );
+  const hiddens = DESKTOP_SURFACES.flatMap((s) => [s.hidden ?? []].flat());
+  assert.ok(hiddens.length > 0, "no desktop surface discriminates by absence");
+  for (const sel of hiddens) {
+    assert.ok(narrow.has(sel.replace(/^\S+\s/, "")), `nothing narrow expects ${sel}`);
+  }
+});
+
+test("every selector the panel-mobile surfaces hide is one a wide surface expects", () => {
+  const wide = new Set(
+    DESKTOP_SURFACES.flatMap((s) => [s.expect ?? []].flat()).map((sel) => sel.replace(/^\S+\s/, "")),
+  );
+  const hiddens = PANEL_MOBILE_SURFACES.flatMap((s) => [s.hidden ?? []].flat());
+  assert.ok(hiddens.length > 0, "no panel-mobile surface discriminates by absence");
+  for (const sel of hiddens) {
+    assert.ok(wide.has(sel.replace(/^\S+\s/, "")), `nothing wide expects ${sel}`);
+  }
+});
+
+test("no surface asserts the same selector both visible and hidden", () => {
+  for (const table of [DESKTOP_SURFACES, MOBILE_SURFACES, PANEL_MOBILE_SURFACES]) {
+    for (const surface of table) {
+      const all = selectorsOf(surface);
+      assert.equal(new Set(all).size, all.length, `${surface.id} repeats a selector`);
+    }
+  }
 });

--- a/.claude/skills/run-haventory/drive_import.mjs
+++ b/.claude/skills/run-haventory/drive_import.mjs
@@ -40,7 +40,7 @@ if (!token) {
 }
 
 // --- args ----------------------------------------------------------------
-const VALUE_FLAGS = new Set(["--policy", "--out", "--path"]);
+const VALUE_FLAGS = new Set(["--policy", "--out", "--path", "--dashboard"]);
 const flag = (name, dflt) => {
   const i = args.indexOf(name);
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
@@ -58,6 +58,7 @@ const docPath = positionals[0];
 if (!docPath) {
   console.error("Usage: node drive_import.mjs <document.json> [--policy merge|replace|skip]");
   console.error("                             [--apply] [--out <prefix>] [--path <ha-url-path>]");
+  console.error("                             [--dashboard <url path or title>]");
   process.exit(2);
 }
 
@@ -71,6 +72,9 @@ const outPrefix = flag("--out", "import");
 // The import sheet is a wide surface: with no --path, ask the instance for a
 // panel-mode view so the sheet gets the room its preview table needs.
 const urlPathArg = flag("--path", null);
+// `--dashboard <url path or title>` narrows discovery when the instance holds
+// the card on more than one dashboard; `--path` still wins outright.
+const dashboard = flag("--dashboard", null);
 const apply = args.includes("--apply");
 const shot = (suffix) => path.resolve(skillDir, `${outPrefix}-${suffix}.png`);
 
@@ -86,7 +90,7 @@ console.log(
     (apply ? " · APPLY (this writes)" : " · preview only"),
 );
 
-const urlPath = urlPathArg ?? (await cardPath("wide"));
+const urlPath = urlPathArg ?? (await cardPath("wide", { dashboard }));
 
 // --- drive ---------------------------------------------------------------
 const browser = await chromium.launch();

--- a/.claude/skills/run-haventory/import_policies.mjs
+++ b/.claude/skills/run-haventory/import_policies.mjs
@@ -50,7 +50,10 @@ if (!token) {
   process.exit(2);
 }
 
-const urlPath = flag("--path", null) ?? (await cardPath("column"));
+// `--dashboard <url path or title>` narrows discovery when the instance holds
+// the card on more than one dashboard; `--path` still wins outright.
+const dashboard = flag("--dashboard", null);
+const urlPath = flag("--path", null) ?? (await cardPath("column", { dashboard }));
 const outPrefix = flag("--out", "policies");
 const sampleSize = Number(flag("--items", "6"));
 const docPath = flag("--doc", null);

--- a/.claude/skills/run-haventory/reload_probe.mjs
+++ b/.claude/skills/run-haventory/reload_probe.mjs
@@ -25,6 +25,9 @@ const flag = (name, dflt) => {
 };
 
 const { base, token } = haConfig();
+// `--dashboard <url path or title>` narrows discovery when the instance holds
+// the card on more than one dashboard; `--path` still wins outright.
+const dashboard = flag("--dashboard", null);
 const outPrefix = flag("--out", "reload");
 const PROBE = `reload probe ${Math.floor(Date.now() / 1000)}`;
 
@@ -119,7 +122,7 @@ async function openTab(urlPath, root) {
   return { page, events, root };
 }
 
-const card = await openTab(await cardPath("wide"), "haventory-card");
+const card = await openTab(await cardPath("wide", { dashboard }), "haventory-card");
 const panel = await openTab("/haventory", "haventory-panel");
 
 const entries = await rest("GET", "/api/config/config_entries/entry");

--- a/.claude/skills/run-haventory/rl_banner.mjs
+++ b/.claude/skills/run-haventory/rl_banner.mjs
@@ -57,7 +57,10 @@ const flag = (name, dflt) => {
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
 };
 
-const urlPath = flag("--path", null) ?? (await cardPath("column"));
+// `--dashboard <url path or title>` narrows discovery when the instance holds
+// the card on more than one dashboard; `--path` still wins outright.
+const dashboard = flag("--dashboard", null);
+const urlPath = flag("--path", null) ?? (await cardPath("column", { dashboard }));
 const outPrefix = flag("--out", "rl");
 const observeSecs = args.includes("--observe") ? Number(flag("--observe", "30")) : null;
 const scenarioArg = flag("--scenario", null);

--- a/.claude/skills/run-haventory/screenshot.mjs
+++ b/.claude/skills/run-haventory/screenshot.mjs
@@ -72,7 +72,10 @@ const outFile = path.resolve(skillDir, flag("--out", "screenshot.png"));
 // With no --path, ask the instance which dashboard view holds the card in a
 // normal column — the shape a single screenshot is normally after. The sidebar
 // panel is not a dashboard view and is reached with an explicit --path.
-const urlPath = flag("--path", null) ?? (await cardPath("column"));
+// `--dashboard <url path or title>` narrows discovery when the instance holds
+// the card on more than one dashboard; `--path` still wins outright.
+const dashboard = flag("--dashboard", null);
+const urlPath = flag("--path", null) ?? (await cardPath("column", { dashboard }));
 const rootElement = flag("--element", "haventory-card");
 const fullPage = has("--full");
 const haDark = has("--dark");

--- a/.claude/skills/run-haventory/surfaces.mjs
+++ b/.claude/skills/run-haventory/surfaces.mjs
@@ -1,0 +1,375 @@
+// The surfaces a visual pass walks: named recipes of clicks against the card's
+// and the panel's own `data-testid`s, one table per layout branch.
+//
+// They live apart from the runner because they are data, and because a test can
+// then check the tables about themselves — `card_views.test.mjs` asserts that
+// every desktop surface says something the narrow branch cannot, which is the
+// property that makes a desktop pass fail when it lands on the wrong layout.
+
+// --- surface recipes ------------------------------------------------------
+// `open` is a list of steps run in order against the pass's root element:
+//   ["click", <sel>]  ["hover", <sel>]  ["fill", <sel>, <text>]  ["key", <key>]  ["wait", <ms>]
+// `expect` is the selector — or list of selectors — that must be visible once the
+// recipe has run; `hidden` is the optional counterpart, for a layout whose point
+// is that something is gone. Selectors pierce shadow DOM, so nested components
+// address directly.
+//
+// Every recipe starts from a freshly loaded page. Chaining them instead would be
+// faster, but a modal left standing puts a scrim over everything that follows
+// and one failure then cascades into a dozen — which reads as a broken card
+// rather than a broken recipe. That is why the full-view surfaces each re-open
+// the full view rather than assuming the previous surface left it up.
+//
+// Surfaces are named after what a reader would call the screen, and prefixed
+// d-/m-/p-/pm- in the file name so the desktop, mobile and the two panel
+// captures of the same surface sort next to each other.
+//
+// The card chooses its layout from ITS OWN width, not the viewport's, so the
+// desktop pass runs on a panel-mode view: in a normal dashboard column even a
+// 1440px window gets the narrow branch, where the filter panel is a modal sheet
+// and the full-view link is absent entirely. Which view that is, on this
+// instance, is discovered — see card_views.mjs.
+//
+// Each pass names the root element it waits for and scopes its selectors to:
+// the sidebar panel at /haventory is a different custom element and renders no
+// card at all, so waiting for `haventory-card` there only ever times out.
+export const CARD = "haventory-card";
+export const PANEL = "haventory-panel";
+const OVERFLOW = `${CARD} [data-testid="card-overflow"] button`;
+const menu = (id) => `${CARD} [data-testid="overflow-item"][data-id="${id}"]`;
+
+// Opening the full view is a shared prefix, not a surface the later ones inherit.
+const OPEN_FULL = [
+  ["click", `${CARD} [data-testid="expand-toggle"]`],
+  ["wait", 1500],
+];
+
+export const DESKTOP_SURFACES = [
+  { id: "01-list", open: [], expect: `${CARD} [data-testid="card-list"]` },
+  {
+    id: "02-filter-panel",
+    open: [["click", `${CARD} [data-testid="filter-toggle"]`]],
+    expect: `${CARD} [data-testid="filter-panel"]`,
+    // The narrow branch mounts this same `hv-filter-panel` inside the filter
+    // sheet, so `filter-panel` alone would pass on either layout. The desktop
+    // panel applies each change as it is made and renders no footer; the
+    // sheet's Apply button is therefore precisely "this is not the sheet".
+    hidden: `${CARD} [data-testid="sheet-apply"]`,
+  },
+  {
+    id: "03-search",
+    open: [
+      ["fill", `${CARD} [data-testid="search-input"]`, "box"],
+      ["wait", 1500],
+    ],
+    expect: `${CARD} [data-testid="card-list"]`,
+  },
+  {
+    id: "04-add-editor",
+    open: [["click", `${CARD} [data-testid="add-item"]`]],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "05-row-editor",
+    // The row's edit button lives in `.hover-actions` and is transparent until
+    // the row is hovered, so it has to be revealed before it can be clicked.
+    open: [
+      ["hover", `${CARD} [data-testid="list-row"]`],
+      ["click", `${CARD} [data-testid="list-row"] [data-testid="row-edit"]`],
+    ],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "06-overflow",
+    open: [["click", OVERFLOW]],
+    expect: `${CARD} [data-testid="overflow-menu"]`,
+  },
+  {
+    id: "07-organize",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("organize")],
+      ["wait", 800],
+    ],
+    expect: `${CARD} [data-testid="organize-dialog"]`,
+  },
+  {
+    id: "08-diagnostics",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("diagnostics")],
+      ["wait", 800],
+    ],
+    // The panel host is a zero-size wrapper; its status line is what proves the
+    // panel is actually open.
+    expect: `${CARD} [data-testid="diagnostics-status"]`,
+  },
+  {
+    id: "09-import",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("import")],
+    ],
+    expect: `${CARD} [data-testid="import-text"]`,
+  },
+  {
+    id: "10-selection",
+    // Selection mode is entered from the menu; the per-row checkboxes do not
+    // exist until it is on.
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("select-items")],
+      ["wait", 700],
+    ],
+    expect: `${CARD} [data-testid="selection-bar"], ${CARD} [data-testid="bulk-bar"]`,
+  },
+  {
+    id: "11-full-view",
+    // `expand-toggle` is the app-bar control and exists at every width;
+    // `open-full-view` is a footer link the narrow branch does not render.
+    open: OPEN_FULL,
+    // `full-view` alone opens on either layout: it is a modal at any width, and
+    // `hv-full-view` sizes its own sidebar off the window rather than off the
+    // card, so even the sidebar is present when a narrow card opens it in a
+    // wide window. The footer link is the one thing here that the card's own
+    // branch decides — `hv-card-shell` renders it only when it is not mobile —
+    // and the shell stays in the DOM under the modal. The sidebar is asserted
+    // beside it as the mirror of the panel-mobile page surface, which asserts
+    // that same element hidden.
+    expect: [
+      `${CARD} [data-testid="full-view"]`,
+      `${CARD} [data-testid="full-sidebar"]`,
+      `${CARD} [data-testid="open-full-view"]`,
+    ],
+  },
+  {
+    id: "12-full-filters",
+    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="full-filters-toggle"]`], ["wait", 500]],
+    expect: `${CARD} [data-testid="full-filter-panel"]`,
+  },
+  {
+    id: "13-full-editor",
+    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="full-add-item"]`], ["wait", 600]],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "14-full-columns",
+    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="columns-expanded"]`], ["wait", 600]],
+    expect: `${CARD} [data-testid="column-options"]`,
+  },
+];
+
+// The narrow layout is a different component tree, not a reflow: the filter
+// panel becomes a sheet, the row opens a detail sheet, and the editor arrives as
+// a bottom sheet. Recipes that only exist here live in their own list.
+export const MOBILE_SURFACES = [
+  { id: "01-list", open: [], expect: `${CARD} [data-testid="card-list"]` },
+  {
+    id: "02-filter-sheet",
+    open: [
+      ["click", `${CARD} [data-testid="filter-toggle"]`],
+      ["wait", 600],
+    ],
+    // `filter-sheet` is the bottom-sheet host and has no box of its own, so the
+    // sheet's own footer buttons are what prove it came up — and they are what
+    // the desktop filter-panel surface asserts are absent.
+    expect: [`${CARD} [data-testid="sheet-cancel"]`, `${CARD} [data-testid="sheet-apply"]`],
+    // A modal sheet is not dismissed by pressing its opener again — leaving it
+    // up would put a scrim over every surface that follows.
+  },
+  {
+    id: "03-detail-sheet",
+    open: [
+      ["click", `${CARD} [data-testid="list-row"] [data-testid="row-name"]`],
+      ["wait", 700],
+    ],
+    expect: `${CARD} [data-testid="sheet-name"]`,
+  },
+  {
+    id: "04-add-sheet",
+    open: [
+      ["click", `${CARD} [data-testid="add-item"]`],
+      ["wait", 700],
+    ],
+    expect: `${CARD} [data-testid="item-editor"]`,
+  },
+  {
+    id: "05-overflow",
+    open: [["click", OVERFLOW]],
+    expect: `${CARD} [data-testid="overflow-menu"]`,
+  },
+  {
+    id: "06-organize",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("organize")],
+      ["wait", 900],
+    ],
+    expect: `${CARD} [data-testid="organize-dialog"]`,
+  },
+  {
+    id: "07-diagnostics",
+    open: [
+      ["click", OVERFLOW],
+      ["click", menu("diagnostics")],
+      ["wait", 800],
+    ],
+    expect: `${CARD} [data-testid="diagnostics-status"]`,
+  },
+  {
+    id: "08-full-view",
+    open: [
+      ["click", `${CARD} [data-testid="expand-toggle"]`],
+      ["wait", 1500],
+    ],
+    expect: `${CARD} [data-testid="full-view"]`,
+  },
+];
+
+// The sidebar panel embeds the same full view the card opens in a modal, so its
+// inner testids are the full view's — but the surrounding host is `haventory-panel`
+// with its own dialog set, which is exactly what these recipes prove. The panel's
+// overflow lives on the full view's app bar, not behind the card's `card-overflow`.
+const PANEL_OVERFLOW = `${PANEL} [data-testid="full-overflow"] [data-testid="overflow-trigger"]`;
+const panelMenu = (id) => `${PANEL} [data-testid="overflow-item"][data-id="${id}"]`;
+
+export const PANEL_SURFACES = [
+  { id: "01-page", open: [], expect: `${PANEL} [data-testid="full-table"]` },
+  {
+    id: "02-filters",
+    open: [["click", `${PANEL} [data-testid="full-filters-toggle"]`], ["wait", 500]],
+    expect: `${PANEL} [data-testid="full-filter-panel"]`,
+  },
+  {
+    id: "03-search",
+    open: [
+      ["fill", `${PANEL} [data-testid="full-search"]`, "box"],
+      ["wait", 1500],
+    ],
+    expect: `${PANEL} [data-testid="full-table"]`,
+  },
+  {
+    id: "04-add-editor",
+    open: [["click", `${PANEL} [data-testid="full-add-item"]`], ["wait", 600]],
+    expect: `${PANEL} [data-testid="item-editor"]`,
+  },
+  {
+    id: "05-row-editor",
+    // The table's row actions are `visibility: hidden` until the row is
+    // hovered, so the edit button has to be revealed before it can be clicked.
+    open: [
+      ["hover", `${PANEL} [data-testid="table-row"]`],
+      ["click", `${PANEL} [data-testid="table-edit"]`],
+      ["wait", 600],
+    ],
+    expect: `${PANEL} [data-testid="item-editor"]`,
+  },
+  {
+    id: "06-overflow",
+    open: [["click", PANEL_OVERFLOW]],
+    expect: `${PANEL} [data-testid="overflow-menu"]`,
+  },
+  {
+    id: "07-organize",
+    open: [
+      ["click", PANEL_OVERFLOW],
+      ["click", panelMenu("organize")],
+      ["wait", 800],
+    ],
+    expect: `${PANEL} [data-testid="organize-dialog"]`,
+  },
+  {
+    id: "08-columns",
+    open: [["click", `${PANEL} [data-testid="columns-expanded"]`], ["wait", 600]],
+    expect: `${PANEL} [data-testid="column-options"]`,
+  },
+  {
+    id: "09-diagnostics",
+    open: [
+      ["click", PANEL_OVERFLOW],
+      ["click", panelMenu("diagnostics")],
+      ["wait", 800],
+    ],
+    expect: `${PANEL} [data-testid="diagnostics-status"]`,
+  },
+  {
+    id: "10-import",
+    open: [
+      ["click", PANEL_OVERFLOW],
+      ["click", panelMenu("import")],
+    ],
+    expect: `${PANEL} [data-testid="import-text"]`,
+  },
+];
+
+// The panel on a phone. Unlike the card, whose narrow layout is a different
+// component tree, `hv-full-view` keeps one tree and switches on a media query at
+// 700px — so these are the panel recipes again, at a width where that branch is
+// live, plus the three assertions that only hold there: the sidebar is gone, the
+// filter panel grows a staged apply/cancel footer, and the app bar trades the
+// close button for the button that reopens Home Assistant's own drawer (which a
+// panel must offer itself once HA has collapsed it).
+export const PANEL_MOBILE_SURFACES = [
+  {
+    id: "01-page",
+    open: [],
+    expect: [`${PANEL} [data-testid="full-table"]`, `${PANEL} [data-testid="panel-menu"]`],
+    hidden: `${PANEL} [data-testid="full-sidebar"]`,
+  },
+  {
+    id: "02-filters",
+    open: [["click", `${PANEL} [data-testid="full-filters-toggle"]`], ["wait", 500]],
+    // The footer is the narrow branch's own: the wide panel applies each change
+    // as it is made, this one stages them behind Apply.
+    expect: [`${PANEL} [data-testid="full-filter-panel"]`, `${PANEL} [data-testid="full-panel-foot"]`],
+  },
+  {
+    id: "03-search",
+    open: [
+      ["fill", `${PANEL} [data-testid="full-search"]`, "box"],
+      ["wait", 1500],
+    ],
+    expect: `${PANEL} [data-testid="full-table"]`,
+  },
+  {
+    id: "04-add-editor",
+    open: [["click", `${PANEL} [data-testid="full-add-item"]`], ["wait", 600]],
+    expect: `${PANEL} [data-testid="item-editor"]`,
+  },
+  {
+    id: "05-row-editor",
+    // At this width the table is off the side of the screen, so it cannot be
+    // the read view: opening a row lands on the detail sheet, and the form is
+    // one tap deeper inside it. The pencil goes the same way as the row itself,
+    // which is the point of the one method that decides.
+    open: [
+      ["hover", `${PANEL} [data-testid="table-row"]`],
+      ["click", `${PANEL} [data-testid="table-edit"]`],
+      ["wait", 800],
+      ["click", `${PANEL} [data-testid="sheet-edit-details"]`],
+      ["wait", 600],
+    ],
+    // The sheet's own back arrow, not its host element: `hv-bottom-sheet` draws
+    // its panel in its shadow root and the host itself has no box to wait for.
+    expect: [`${PANEL} [data-testid="sheet-back"]`, `${PANEL} [data-testid="item-editor"]`],
+  },
+  {
+    id: "06-overflow",
+    open: [["click", PANEL_OVERFLOW]],
+    expect: `${PANEL} [data-testid="overflow-menu"]`,
+  },
+  {
+    id: "07-organize",
+    open: [
+      ["click", PANEL_OVERFLOW],
+      ["click", panelMenu("organize")],
+      ["wait", 800],
+    ],
+    expect: `${PANEL} [data-testid="organize-dialog"]`,
+  },
+  {
+    id: "08-columns",
+    open: [["click", `${PANEL} [data-testid="columns-expanded"]`], ["wait", 600]],
+    expect: `${PANEL} [data-testid="column-options"]`,
+  },
+];

--- a/.claude/skills/run-haventory/two_tab.mjs
+++ b/.claude/skills/run-haventory/two_tab.mjs
@@ -27,7 +27,10 @@ const flag = (name, dflt) => {
 };
 
 const { base, token } = haConfig();
-const urlPath = flag("--path", null) ?? (await cardPath("wide"));
+// `--dashboard <url path or title>` narrows discovery when the instance holds
+// the card on more than one dashboard; `--path` still wins outright.
+const dashboard = flag("--dashboard", null);
+const urlPath = flag("--path", null) ?? (await cardPath("wide", { dashboard }));
 const outPrefix = flag("--out", "two-tab");
 const PROBE = `two-tab probe ${Math.floor(Date.now() / 1000)}`;
 

--- a/.claude/skills/run-haventory/visual_pass.mjs
+++ b/.claude/skills/run-haventory/visual_pass.mjs
@@ -18,10 +18,15 @@
 //   node visual_pass.mjs --dark                # HA dark theme + dark OS scheme
 //   node visual_pass.mjs --list                # print the surface names and exit
 //   node visual_pass.mjs --path desktop=/other/wide   # one pass onto another view
+//   node visual_pass.mjs --dashboard household          # on an instance with two
 //
 // The four passes open three different URLs, so `--path` names the pass it
 // applies to and may be repeated. A bare `--path <url>` is taken only alongside
 // `--only`, where there is exactly one pass for it to mean.
+//
+// `--dashboard <url path or title>` narrows discovery to one dashboard for the
+// whole run, for an instance holding the card on more than one; a `--path` names
+// a URL outright and still wins for the pass it targets.
 //
 // Everything it drives is read-only: it opens panels, sheets and editors but
 // never saves, imports or deletes. The one exception is the search box, which is
@@ -35,6 +40,14 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 import { cardPath, haConfig, parsePathOverrides } from "./card_views.mjs";
+import {
+  CARD,
+  DESKTOP_SURFACES,
+  MOBILE_SURFACES,
+  PANEL,
+  PANEL_MOBILE_SURFACES,
+  PANEL_SURFACES,
+} from "./surfaces.mjs";
 
 const skillDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -43,356 +56,6 @@ const flag = (name, dflt) => {
   const i = args.indexOf(name);
   return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
 };
-
-// --- surface recipes ------------------------------------------------------
-// `open` is a list of steps run in order against the pass's root element:
-//   ["click", <sel>]  ["hover", <sel>]  ["fill", <sel>, <text>]  ["key", <key>]  ["wait", <ms>]
-// `expect` is the selector — or list of selectors — that must be visible once the
-// recipe has run; `hidden` is the optional counterpart, for a layout whose point
-// is that something is gone. Selectors pierce shadow DOM, so nested components
-// address directly.
-//
-// Every recipe starts from a freshly loaded page. Chaining them instead would be
-// faster, but a modal left standing puts a scrim over everything that follows
-// and one failure then cascades into a dozen — which reads as a broken card
-// rather than a broken recipe. That is why the full-view surfaces each re-open
-// the full view rather than assuming the previous surface left it up.
-//
-// Surfaces are named after what a reader would call the screen, and prefixed
-// d-/m-/p-/pm- in the file name so the desktop, mobile and the two panel
-// captures of the same surface sort next to each other.
-//
-// The card chooses its layout from ITS OWN width, not the viewport's, so the
-// desktop pass runs on a panel-mode view: in a normal dashboard column even a
-// 1440px window gets the narrow branch, where the filter panel is a modal sheet
-// and the full-view link is absent entirely. Which view that is, on this
-// instance, is discovered — see card_views.mjs.
-//
-// Each pass names the root element it waits for and scopes its selectors to:
-// the sidebar panel at /haventory is a different custom element and renders no
-// card at all, so waiting for `haventory-card` there only ever times out.
-const CARD = "haventory-card";
-const PANEL = "haventory-panel";
-const OVERFLOW = `${CARD} [data-testid="card-overflow"] button`;
-const menu = (id) => `${CARD} [data-testid="overflow-item"][data-id="${id}"]`;
-
-// Opening the full view is a shared prefix, not a surface the later ones inherit.
-const OPEN_FULL = [
-  ["click", `${CARD} [data-testid="expand-toggle"]`],
-  ["wait", 1500],
-];
-
-const DESKTOP_SURFACES = [
-  { id: "01-list", open: [], expect: `${CARD} [data-testid="card-list"]` },
-  {
-    id: "02-filter-panel",
-    open: [["click", `${CARD} [data-testid="filter-toggle"]`]],
-    expect: `${CARD} [data-testid="filter-panel"]`,
-  },
-  {
-    id: "03-search",
-    open: [
-      ["fill", `${CARD} [data-testid="search-input"]`, "box"],
-      ["wait", 1500],
-    ],
-    expect: `${CARD} [data-testid="card-list"]`,
-  },
-  {
-    id: "04-add-editor",
-    open: [["click", `${CARD} [data-testid="add-item"]`]],
-    expect: `${CARD} [data-testid="item-editor"]`,
-  },
-  {
-    id: "05-row-editor",
-    // The row's edit button lives in `.hover-actions` and is transparent until
-    // the row is hovered, so it has to be revealed before it can be clicked.
-    open: [
-      ["hover", `${CARD} [data-testid="list-row"]`],
-      ["click", `${CARD} [data-testid="list-row"] [data-testid="row-edit"]`],
-    ],
-    expect: `${CARD} [data-testid="item-editor"]`,
-  },
-  {
-    id: "06-overflow",
-    open: [["click", OVERFLOW]],
-    expect: `${CARD} [data-testid="overflow-menu"]`,
-  },
-  {
-    id: "07-organize",
-    open: [
-      ["click", OVERFLOW],
-      ["click", menu("organize")],
-      ["wait", 800],
-    ],
-    expect: `${CARD} [data-testid="organize-dialog"]`,
-  },
-  {
-    id: "08-diagnostics",
-    open: [
-      ["click", OVERFLOW],
-      ["click", menu("diagnostics")],
-      ["wait", 800],
-    ],
-    // The panel host is a zero-size wrapper; its status line is what proves the
-    // panel is actually open.
-    expect: `${CARD} [data-testid="diagnostics-status"]`,
-  },
-  {
-    id: "09-import",
-    open: [
-      ["click", OVERFLOW],
-      ["click", menu("import")],
-    ],
-    expect: `${CARD} [data-testid="import-text"]`,
-  },
-  {
-    id: "10-selection",
-    // Selection mode is entered from the menu; the per-row checkboxes do not
-    // exist until it is on.
-    open: [
-      ["click", OVERFLOW],
-      ["click", menu("select-items")],
-      ["wait", 700],
-    ],
-    expect: `${CARD} [data-testid="selection-bar"], ${CARD} [data-testid="bulk-bar"]`,
-  },
-  {
-    id: "11-full-view",
-    // `expand-toggle` is the app-bar control and exists at every width;
-    // `open-full-view` is a footer link the narrow branch does not render.
-    open: OPEN_FULL,
-    expect: `${CARD} [data-testid="full-view"]`,
-  },
-  {
-    id: "12-full-filters",
-    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="full-filters-toggle"]`], ["wait", 500]],
-    expect: `${CARD} [data-testid="full-filter-panel"]`,
-  },
-  {
-    id: "13-full-editor",
-    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="full-add-item"]`], ["wait", 600]],
-    expect: `${CARD} [data-testid="item-editor"]`,
-  },
-  {
-    id: "14-full-columns",
-    open: [...OPEN_FULL, ["click", `${CARD} [data-testid="columns-expanded"]`], ["wait", 600]],
-    expect: `${CARD} [data-testid="column-options"]`,
-  },
-];
-
-// The narrow layout is a different component tree, not a reflow: the filter
-// panel becomes a sheet, the row opens a detail sheet, and the editor arrives as
-// a bottom sheet. Recipes that only exist here live in their own list.
-const MOBILE_SURFACES = [
-  { id: "01-list", open: [], expect: `${CARD} [data-testid="card-list"]` },
-  {
-    id: "02-filter-sheet",
-    open: [
-      ["click", `${CARD} [data-testid="filter-toggle"]`],
-      ["wait", 600],
-    ],
-    // `filter-sheet` is the bottom-sheet host and has no box of its own, so the
-    // sheet's own footer button is what proves it came up.
-    expect: `${CARD} [data-testid="sheet-cancel"]`,
-    // A modal sheet is not dismissed by pressing its opener again — leaving it
-    // up would put a scrim over every surface that follows.
-  },
-  {
-    id: "03-detail-sheet",
-    open: [
-      ["click", `${CARD} [data-testid="list-row"] [data-testid="row-name"]`],
-      ["wait", 700],
-    ],
-    expect: `${CARD} [data-testid="sheet-name"]`,
-  },
-  {
-    id: "04-add-sheet",
-    open: [
-      ["click", `${CARD} [data-testid="add-item"]`],
-      ["wait", 700],
-    ],
-    expect: `${CARD} [data-testid="item-editor"]`,
-  },
-  {
-    id: "05-overflow",
-    open: [["click", OVERFLOW]],
-    expect: `${CARD} [data-testid="overflow-menu"]`,
-  },
-  {
-    id: "06-organize",
-    open: [
-      ["click", OVERFLOW],
-      ["click", menu("organize")],
-      ["wait", 900],
-    ],
-    expect: `${CARD} [data-testid="organize-dialog"]`,
-  },
-  {
-    id: "07-diagnostics",
-    open: [
-      ["click", OVERFLOW],
-      ["click", menu("diagnostics")],
-      ["wait", 800],
-    ],
-    expect: `${CARD} [data-testid="diagnostics-status"]`,
-  },
-  {
-    id: "08-full-view",
-    open: [
-      ["click", `${CARD} [data-testid="expand-toggle"]`],
-      ["wait", 1500],
-    ],
-    expect: `${CARD} [data-testid="full-view"]`,
-  },
-];
-
-// The sidebar panel embeds the same full view the card opens in a modal, so its
-// inner testids are the full view's — but the surrounding host is `haventory-panel`
-// with its own dialog set, which is exactly what these recipes prove. The panel's
-// overflow lives on the full view's app bar, not behind the card's `card-overflow`.
-const PANEL_OVERFLOW = `${PANEL} [data-testid="full-overflow"] [data-testid="overflow-trigger"]`;
-const panelMenu = (id) => `${PANEL} [data-testid="overflow-item"][data-id="${id}"]`;
-
-const PANEL_SURFACES = [
-  { id: "01-page", open: [], expect: `${PANEL} [data-testid="full-table"]` },
-  {
-    id: "02-filters",
-    open: [["click", `${PANEL} [data-testid="full-filters-toggle"]`], ["wait", 500]],
-    expect: `${PANEL} [data-testid="full-filter-panel"]`,
-  },
-  {
-    id: "03-search",
-    open: [
-      ["fill", `${PANEL} [data-testid="full-search"]`, "box"],
-      ["wait", 1500],
-    ],
-    expect: `${PANEL} [data-testid="full-table"]`,
-  },
-  {
-    id: "04-add-editor",
-    open: [["click", `${PANEL} [data-testid="full-add-item"]`], ["wait", 600]],
-    expect: `${PANEL} [data-testid="item-editor"]`,
-  },
-  {
-    id: "05-row-editor",
-    // The table's row actions are `visibility: hidden` until the row is
-    // hovered, so the edit button has to be revealed before it can be clicked.
-    open: [
-      ["hover", `${PANEL} [data-testid="table-row"]`],
-      ["click", `${PANEL} [data-testid="table-edit"]`],
-      ["wait", 600],
-    ],
-    expect: `${PANEL} [data-testid="item-editor"]`,
-  },
-  {
-    id: "06-overflow",
-    open: [["click", PANEL_OVERFLOW]],
-    expect: `${PANEL} [data-testid="overflow-menu"]`,
-  },
-  {
-    id: "07-organize",
-    open: [
-      ["click", PANEL_OVERFLOW],
-      ["click", panelMenu("organize")],
-      ["wait", 800],
-    ],
-    expect: `${PANEL} [data-testid="organize-dialog"]`,
-  },
-  {
-    id: "08-columns",
-    open: [["click", `${PANEL} [data-testid="columns-expanded"]`], ["wait", 600]],
-    expect: `${PANEL} [data-testid="column-options"]`,
-  },
-  {
-    id: "09-diagnostics",
-    open: [
-      ["click", PANEL_OVERFLOW],
-      ["click", panelMenu("diagnostics")],
-      ["wait", 800],
-    ],
-    expect: `${PANEL} [data-testid="diagnostics-status"]`,
-  },
-  {
-    id: "10-import",
-    open: [
-      ["click", PANEL_OVERFLOW],
-      ["click", panelMenu("import")],
-    ],
-    expect: `${PANEL} [data-testid="import-text"]`,
-  },
-];
-
-// The panel on a phone. Unlike the card, whose narrow layout is a different
-// component tree, `hv-full-view` keeps one tree and switches on a media query at
-// 700px — so these are the panel recipes again, at a width where that branch is
-// live, plus the three assertions that only hold there: the sidebar is gone, the
-// filter panel grows a staged apply/cancel footer, and the app bar trades the
-// close button for the button that reopens Home Assistant's own drawer (which a
-// panel must offer itself once HA has collapsed it).
-const PANEL_MOBILE_SURFACES = [
-  {
-    id: "01-page",
-    open: [],
-    expect: [`${PANEL} [data-testid="full-table"]`, `${PANEL} [data-testid="panel-menu"]`],
-    hidden: `${PANEL} [data-testid="full-sidebar"]`,
-  },
-  {
-    id: "02-filters",
-    open: [["click", `${PANEL} [data-testid="full-filters-toggle"]`], ["wait", 500]],
-    // The footer is the narrow branch's own: the wide panel applies each change
-    // as it is made, this one stages them behind Apply.
-    expect: [`${PANEL} [data-testid="full-filter-panel"]`, `${PANEL} [data-testid="full-panel-foot"]`],
-  },
-  {
-    id: "03-search",
-    open: [
-      ["fill", `${PANEL} [data-testid="full-search"]`, "box"],
-      ["wait", 1500],
-    ],
-    expect: `${PANEL} [data-testid="full-table"]`,
-  },
-  {
-    id: "04-add-editor",
-    open: [["click", `${PANEL} [data-testid="full-add-item"]`], ["wait", 600]],
-    expect: `${PANEL} [data-testid="item-editor"]`,
-  },
-  {
-    id: "05-row-editor",
-    // At this width the table is off the side of the screen, so it cannot be
-    // the read view: opening a row lands on the detail sheet, and the form is
-    // one tap deeper inside it. The pencil goes the same way as the row itself,
-    // which is the point of the one method that decides.
-    open: [
-      ["hover", `${PANEL} [data-testid="table-row"]`],
-      ["click", `${PANEL} [data-testid="table-edit"]`],
-      ["wait", 800],
-      ["click", `${PANEL} [data-testid="sheet-edit-details"]`],
-      ["wait", 600],
-    ],
-    // The sheet's own back arrow, not its host element: `hv-bottom-sheet` draws
-    // its panel in its shadow root and the host itself has no box to wait for.
-    expect: [`${PANEL} [data-testid="sheet-back"]`, `${PANEL} [data-testid="item-editor"]`],
-  },
-  {
-    id: "06-overflow",
-    open: [["click", PANEL_OVERFLOW]],
-    expect: `${PANEL} [data-testid="overflow-menu"]`,
-  },
-  {
-    id: "07-organize",
-    open: [
-      ["click", PANEL_OVERFLOW],
-      ["click", panelMenu("organize")],
-      ["wait", 800],
-    ],
-    expect: `${PANEL} [data-testid="organize-dialog"]`,
-  },
-  {
-    id: "08-columns",
-    open: [["click", `${PANEL} [data-testid="columns-expanded"]`], ["wait", 600]],
-    expect: `${PANEL} [data-testid="column-options"]`,
-  },
-];
 
 if (args.includes("--list")) {
   console.log("desktop:     ", DESKTOP_SURFACES.map((s) => s.id).join(", "));
@@ -411,6 +74,7 @@ if (!token) {
 const outDir = path.resolve(skillDir, flag("--out", "visual"));
 const haDark = args.includes("--dark");
 const only = flag("--only", null);
+const dashboard = flag("--dashboard", null);
 const wanted = flag("--surfaces", null)?.split(",").map((s) => s.trim());
 mkdirSync(outDir, { recursive: true });
 
@@ -481,14 +145,21 @@ if (error) {
 }
 
 const PASSES = ALL_PASSES.filter((p) => !only || p.key === only);
-for (const pass of PASSES) {
-  const override = overrides[pass.key] ?? null;
-  if (pass.route && !override) {
-    pass.urlPath = pass.route;
-    console.log(`view (${pass.key}): ${pass.route}  ← the integration's own panel route`);
-  } else {
-    pass.urlPath = await cardPath(pass.shape, { override, label: pass.key });
+try {
+  for (const pass of PASSES) {
+    const override = overrides[pass.key] ?? null;
+    if (pass.route && !override) {
+      pass.urlPath = pass.route;
+      console.log(`view (${pass.key}): ${pass.route}  ← the integration's own panel route`);
+    } else {
+      pass.urlPath = await cardPath(pass.shape, { override, label: pass.key, dashboard });
+    }
   }
+} catch (err) {
+  // A --dashboard that names nothing belongs with the other rejected flags
+  // above, as one line — not as an uncaught rejection with a stack.
+  console.error(err.message);
+  process.exit(2);
 }
 
 const results = [];


### PR DESCRIPTION
## Summary

Two `visual_pass.mjs` gaps from #212, plus the discovery module's dashboard blind spot.

**The desktop surfaces that were not branch-discriminating.** The card picks its layout
from its own rendered width, so a desktop pass that lands in a dashboard *column* runs the
narrow branch — and `d-02-filter-panel` and `d-11-full-view` passed there too, because the
narrow branch mounts the same `hv-filter-panel` inside its sheet and the full view is a
modal at any width. Each now asserts something the narrow branch does not have:

- `d-02-filter-panel` waits for the sheet's **Apply button to be absent**. The desktop panel
  applies each change as it is made and renders no footer, so `sheet-apply` hidden is
  exactly "this is not the sheet". The mobile filter-sheet surface now expects both footer
  buttons, so the element the desktop surface asserts absent is one a narrow surface asserts
  present.
- `d-11-full-view` expects the shell's **`open-full-view` footer link**, which
  `hv-card-shell` renders only when it is not in its narrow branch, and which stays in the
  DOM under the modal.

**`--dashboard <url path or title>`.** `card_views.mjs` took the first matching view in
`lovelace/dashboards/list` order, which is right on an instance with one card-bearing
dashboard and arbitrary on an instance with two. Records now carry `dashPath`/`dashTitle`
as fields, `filterByDashboard` matches either case-insensitively, and `cardPath` applies the
filter after discovery — so discovery stays memoized and unfiltered, and two passes in one
run can name different dashboards. A `--dashboard` that matches nothing is an **error**
listing what discovery did find; `--path` names a URL outright and still wins. All seven
harnesses take the flag.

**`surfaces.mjs`.** The four surface tables move out of the runner so `node --test` can
check them about themselves — see "Decisions" for why the rule the notes proposed is not the
rule that landed.

Closes #212

## Decisions taken against drifted notes

- **`d-11-full-view`: `full-sidebar` alone does not discriminate.** The notes proposed
  asserting the full view's sidebar, on the grounds that `hv-full-view` drops it under a
  700px media query. Driving it proved otherwise: the full view is a modal sized off the
  *window*, so a narrow card opening it in a 1440px window still shows the sidebar. The
  control run below has `d-11` **passing** on the wrong layout with only the sidebar
  asserted. `open-full-view` — a shell footer link rendered only on the desktop branch — is
  what actually fails there, and is what the surface now asserts. The sidebar is kept beside
  it as the mirror of `pm-01-page`'s `hidden` check, which is still worth having.
- **The structural rule the notes suggested is not true of this file.** "Every
  `DESKTOP_SURFACES` entry carries either a `hidden` selector or an `expect` selector that
  `MOBILE_SURFACES` does not use" fails for most surfaces today (`d-01-list`, `d-03-search`,
  `d-04`/`d-05` and others assert only selectors the mobile table also uses), and making it
  true would mean inventing discriminators for ten surfaces that #178's pass-level
  `d-layout` check already covers. What landed instead is a pair of rules that *are* true
  and catch a real failure mode: **every selector a desktop surface asserts hidden must be
  one a narrow surface asserts visible**, and the mirror for `PANEL_MOBILE_SURFACES`. A
  `hidden` selector that matches nothing passes forever, so a typo in one is otherwise
  invisible — verified by breaking `sheet-apply` to `sheet-applyX` and watching the test
  fail with `nothing narrow expects …`. Two further cases pin the two surfaces #212 names,
  by name.
- **The tables moved to `surfaces.mjs`.** `visual_pass.mjs` launches a browser at module
  top level, so a test cannot import it to read the tables; the alternative was regex-
  scraping the runner's source. The tables are data, and this is the smallest change that
  makes the assertion real rather than approximate. `visual_pass.mjs` imports them back and
  its behaviour is unchanged (`--list` prints the same four lines).
- **Seven callers, not five.** The notes list `visual_pass`, `screenshot`, `rl_banner`,
  `drive_import`, `import_policies`; `two_tab.mjs` and `reload_probe.mjs` have been added
  since and call `cardPath` too. Both take `--dashboard`.
- **An unmatched `--dashboard` throws** from `cardPath` rather than calling `process.exit`
  in a library; `visual_pass.mjs` catches it and prints the one line beside its other
  rejected-flag messages (exit 2). The six single-URL harnesses surface the same message as
  an uncaught error and exit non-zero.

## Type of change

- [x] Documentation / tooling / CI
- [x] Refactor (no functional change) — the surface tables' move

## How was this tested?

- [x] `node --test` in `.claude/skills/run-haventory/` → **34 pass** (26 before). New:
      `filterByDashboard` by path and by title (case-insensitively), the empty result for a
      name nothing answers to, that filtering first stops a shape reaching across
      dashboards, the two `dashPath`/`dashTitle` fields folded into the existing
      `deepEqual`s, the two sharpened surfaces by name, the two hidden-selector anchoring
      rules, and that no surface asserts one selector both visible and hidden.
- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1269 passed, 22
      skipped**; `ruff check` / `ruff format --check` / `mypy` clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck` (which has
      `.claude/skills/run-haventory/` in its program, so `surfaces.mjs` is checked),
      `npx vitest run` (**1864 passed**), `npm run build` → all clean.
- phacc: not involved.

### Live checks (dev HA @ localhost:8123)

1. **The desktop pass still passes on the right layout** —
   `node visual_pass.mjs --only desktop`: `view (desktop): /dashboard-dev/wide ← Dev › wide
   (panel)`, **15/15 surfaces captured**, `d-02-filter-panel` and `d-11-full-view` among
   them.
2. **The control — the same recipes on the wrong layout.**
   `--only desktop --path /dashboard-dev/0 --surfaces filter-panel,full-view,list` (the
   sections column, where a 1440px window still gets the narrow branch):
   ```
   FAIL  d-layout: card took its narrow branch on /dashboard-dev/0, but this pass needs the desktop one
   PASS  d-01-list
   FAIL  d-02-filter-panel: page.waitForSelector: Timeout 10000ms exceeded.
   FAIL  d-11-full-view: page.waitForSelector: Timeout 10000ms exceeded.
   ```
   Both now fail on their own. `d-01-list` still passes there, which is the honest state of
   the rest of the table and why `d-layout` stays the pass-level check. An intermediate run
   with only `full-sidebar` added had `d-11` **passing** here — that is the evidence behind
   the first decision above.
3. **The narrow branch is untouched** — `--only mobile --surfaces filter-sheet`:
   `m-layout` and `m-02-filter-sheet` both pass with the sheet's two footer buttons
   asserted (2/2 captured).
4. **`--dashboard` end to end on a two-dashboard instance.** A temporary
   `s4-second` / "Household" dashboard was created over WS with a panel view holding the
   card, and deleted again afterwards. With both present, `node card_views.mjs` listed
   **3 views across 2 dashboards** and unfiltered `wide` resolved to `/dashboard-dev/wide`:
   ```
   by title  : /s4-second/wide      (--dashboard household)
   by path   : /s4-second/wide      (--dashboard s4-second)
   dev       : /dashboard-dev/wide  (--dashboard DEV)
   unmatched : --dashboard nope: no dashboard by that url path or title holds a
               custom:haventory-card. Discovery found: dashboard-dev (Dev), s4-second (Household).
   ```
   Through the harness: `--only desktop --surfaces list,filter-panel --dashboard Household`
   opened `/s4-second/wide` and captured 3/3; `--dashboard nope` printed the one-line error
   and exited **2**.
5. **State restored** — the temporary dashboard was deleted and `node card_views.mjs` is
   back to the two dev views; no inventory data was touched (the pass is read-only and
   clears its search box).

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + the edge case the flag exists for).
- [x] Docs updated: `SKILL.md` — "Where the card lives" gains the dashboard filter and what
      the two surfaces now assert; the visual-pass section gains `--dashboard`; the unit-cover
      paragraph names `surfaces.mjs`.
- [x] No WebSocket API change, no `custom_components/` change.

## Follow-ups

- `d-01-list`, `d-03-search` and the editor/overflow/organize surfaces assert only selectors
  the narrow branch also has. Giving each its own discriminator would mean ten more
  assertions to cover what one `d-layout` check already catches — named here, not filed.

## Handover

**1. Merged / left open**

All three merged and their branches deleted; nothing is left open for you.

- #524 — `fix(skills): make stress.py honour the worktree's .env and name its target`
  (closes #432)
- #525 — `test(skills): branch-discriminating desktop surfaces and --dashboard selection`
  (closes #212)
- this PR — `test(card): fake-timer the remaining wall-clock waits; sweep pending timeouts in
  teardown` (closes #209)

**2. Test this by hand**

Nothing by hand. Everything in this session is harness and suite work, and each half was
driven against the real dev HA rather than asserted offline:

1. `[log]` The near-miss #432 describes was reproduced and refused: from a worktree whose
   `.env` named an unreachable instance, with the shell exporting the dev one, `stress.py
   bulk 5` printed the target, named the displaced URL and exited **before creating
   anything**; the dev store stayed at 1087 items. `HAVENTORY_IGNORE_ENV_FILE=1` from the
   same worktree reached the dev instance and read its counts. Evidence in #524.
2. `[desktop]` The two sharpened surfaces were driven both ways: 15/15 on
   `/dashboard-dev/wide`, and `d-02` + `d-11` failing on `/dashboard-dev/0` where they used
   to pass. `--dashboard` was proven on a temporary second card-bearing dashboard, by title
   and by url path, with the unmatched name exiting 2. Evidence in #525.
3. `[optional]` If you want one thing on screen: run
   `uv run --no-project --with aiohttp python .claude/skills/test-haventory/stress.py baseline`
   and read the first two lines. They are what every helper now prints before it acts, and
   whether that wording is useful to you is the one judgement a harness cannot make.

**3. Decisions taken against drifted notes**

- #432's four named scripts never read `.env` at all; the same-`setdefault` bug was in
  `driver.py`, `lifecycle_probe.py` and `card_views.mjs`'s `haConfig()`. All are fixed, and
  the escape hatch `HAVENTORY_IGNORE_ENV_FILE=1` exists because
  `dev/release_testing_plan.md` documents a probe aimed at a remote host inline.
- #212's `d-11` discriminator is `open-full-view`, not `full-sidebar`: driving it showed the
  full view sizes its sidebar off the window, so a narrow card in a wide window still shows
  it. The structural rule the notes proposed is not true of the current table; what landed
  instead is "every selector a desktop surface asserts absent must be one a narrow surface
  asserts present", which is true, catches a typo'd `hidden`, and was verified by breaking
  one on purpose.
- #209's table had drifted and was short by three waits, the largest of them 618 ms per run.

**4. Follow-ups**

- Named and deliberately not filed (they clear no real-world bar): the ten `vi.waitUntil` /
  `vi.waitFor` polls in the card suite; `log_sweep.py` having no base URL to name; the
  desktop surfaces beyond `d-02`/`d-11` that assert only selectors the narrow branch also
  has (`d-layout` covers them, and ten more assertions would not).
- No new issues were filed this session.

**5. State left behind**

- **Dev HA (`home-assistant`, localhost:8123):** data unchanged — 1087 items / 89 locations
  before and after. A temporary dashboard `s4-second` ("Household") was created over WS to
  prove `--dashboard` and **deleted again**; `node card_views.mjs` is back to the two
  `dashboard-dev` views. No `.storage` edits, no restarts, rate limiting untouched, language
  untouched.
- **Branches:** `claude/v0-7-0-s4-stress-env`, `claude/v0-7-0-s4-visual-pass` and
  `claude/v0-7-0-s4-fake-timers` are merged and deleted on the remote.
- **New files the next session should know about:** `scripts/dev_env.py` (one place that
  decides which instance a helper talks to — reuse it rather than reading `.env` again) and
  `.claude/skills/run-haventory/surfaces.mjs` (the visual-pass tables, now importable by
  tests).
- **Host quirk, pre-existing:** every `git` command in this checkout prints
  `error: failed to delete '.git/worktrees/<name>': Permission denied` for ~20 stale worktree
  entries left by earlier sessions. It is noise, not a failure; the worktree this session
  created for the #432 proof is gone from `git worktree list` and its directory is removed.
- **Open PRs left alone:** release-please's #491 (`chore(main): release 0.7.0`) — never
  touched by a session, and per the plan it waits for S11 — and Dependabot's #516–#523.
