### PR TITLE
test(card): fake-timer the remaining wall-clock waits; sweep pending timeouts in teardown

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -385,12 +385,22 @@ describe('hv-card-shell: search and filters', () => {
     const { store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Wood Glue' })] });
     const input = sr.querySelector('[data-testid="search-input"]') as HTMLInputElement;
 
-    input.value = 'glue';
-    input.dispatchEvent(new Event('input'));
-    expect(store.state.value.filters.q).toBe('');
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      input.value = 'glue';
+      input.dispatchEvent(new Event('input'));
+      expect(store.state.value.filters.q).toBe('');
 
-    await new Promise((r) => setTimeout(r, 250));
-    expect(store.state.value.filters.q).toBe('glue');
+      // Still nothing on the last millisecond of the 200 ms window...
+      await vi.advanceTimersByTimeAsync(199);
+      expect(store.state.value.filters.q).toBe('');
+
+      // ...and the store hears it on the next one.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(store.state.value.filters.q).toBe('glue');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // The full view and the panel word it this way, and the card searches the same
@@ -1049,26 +1059,42 @@ describe('hv-card-shell: mobile', () => {
       makeItem({ id: '3', category: 'Hardware' }),
     ];
     const { el, store, sr } = await mountShell({ items, mobile: true });
-    (sr.querySelector('[data-testid="filter-toggle"]') as HTMLButtonElement).click();
-    await settle(el);
 
-    const panel = sr.querySelector('hv-filter-panel') as HTMLElement;
-    (panel.shadowRoot?.querySelector('[data-value="Hardware"]') as HTMLButtonElement).click();
-    await settle(el);
+    // The staged count rides a 150 ms debounce that the clicks below schedule,
+    // so the clock is taken over before them — installed here, after the mount,
+    // so the setup keeps running on real timers.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      (sr.querySelector('[data-testid="filter-toggle"]') as HTMLButtonElement).click();
+      await settle(el);
 
-    // Staged only — the list has not moved.
-    expect(store.state.value.filters.categories).toEqual([]);
-    expect(store.state.value.items).toHaveLength(3);
+      const panel = sr.querySelector('hv-filter-panel') as HTMLElement;
+      (panel.shadowRoot?.querySelector('[data-value="Hardware"]') as HTMLButtonElement).click();
+      await settle(el);
 
-    // ...and the apply button reports what committing would do.
-    await new Promise((r) => setTimeout(r, 250));
-    await el.updateComplete;
-    const apply = sr.querySelector('[data-testid="sheet-apply"]') as HTMLButtonElement;
-    expect(apply.textContent?.trim()).toBe('Show 2 items');
+      // Staged only — the list has not moved.
+      expect(store.state.value.filters.categories).toEqual([]);
+      expect(store.state.value.items).toHaveLength(3);
 
-    apply.click();
-    await settle(el);
-    expect(store.state.value.filters.categories).toEqual(['Hardware']);
+      // ...and the apply button reports what committing would do, but not
+      // before the window is up.
+      const apply = sr.querySelector('[data-testid="sheet-apply"]') as HTMLButtonElement;
+      await vi.advanceTimersByTimeAsync(149);
+      await settle(el);
+      expect(apply.textContent?.trim()).toBe('Show items');
+
+      // The debounce fires into an async count, so the render lands one settle
+      // past the millisecond — `settle` drives this same clock.
+      await vi.advanceTimersByTimeAsync(1);
+      await settle(el);
+      expect(apply.textContent?.trim()).toBe('Show 2 items');
+
+      apply.click();
+      await settle(el);
+      expect(store.state.value.filters.categories).toEqual(['Hardware']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // "Clear all" went straight to the store: the list behind the sheet reloaded

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1906,12 +1906,22 @@ describe('hv-full-view: app bar filters', () => {
   it('debounces the app bar search', async () => {
     const { store, sr } = await mount({ items: [makeItem({ id: '1' })] });
     const input = q(sr, '[data-testid="full-search"]') as HTMLInputElement;
-    input.value = 'glue';
-    input.dispatchEvent(new Event('input'));
-    expect(store.state.value.filters.q).toBe('');
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      input.value = 'glue';
+      input.dispatchEvent(new Event('input'));
+      expect(store.state.value.filters.q).toBe('');
 
-    await new Promise((r) => setTimeout(r, 250));
-    expect(store.state.value.filters.q).toBe('glue');
+      // Still nothing on the last millisecond of the 200 ms window...
+      await vi.advanceTimersByTimeAsync(199);
+      expect(store.state.value.filters.q).toBe('');
+
+      // ...and the store hears it on the next one.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(store.state.value.filters.q).toBe('glue');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -1402,13 +1402,31 @@ describe('Store: location tree and diagnostics data', () => {
       makeItem({ id: '4', location_id: 'kitchen', category: 'Tools' }),
       makeItem({ id: '5', category: 'Tools' }),
     ];
-    const store = new Store(makeMockHass({ items, locations }), fast);
+    const hass = makeMockHass({ items, locations });
+    const store = new Store(hass, fast);
     await store.init();
+    const treeCalls = () => hass.__calls.filter((c) => c === 'haventory/location/tree').length;
+    const before = treeCalls();
 
-    // Narrow by category *and* location: the sidebar still has to show where the
-    // other matches are, or picking a different branch becomes guesswork.
-    store.setFilters({ categories: ['Tools'], locationIds: ['kitchen'] });
-    await new Promise((r) => setTimeout(r, 400));
+    // The refresh rides a 250 ms debounce, so the test drives that clock rather
+    // than out-waiting it: installed here, after init, so the setup above keeps
+    // running on real timers.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      // Narrow by category *and* location: the sidebar still has to show where
+      // the other matches are, or picking a different branch becomes guesswork.
+      store.setFilters({ categories: ['Tools'], locationIds: ['kitchen'] });
+
+      // Nothing on the last millisecond before the window closes...
+      await vi.advanceTimersByTimeAsync(249);
+      expect(treeCalls()).toBe(before);
+
+      // ...and exactly one walk when it does.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(treeCalls()).toBe(before + 1);
+    } finally {
+      vi.useRealTimers();
+    }
 
     const tree = store.state.value.locationTreeCache!;
     const garage = tree.find((n) => n.id === 'garage')!;
@@ -1427,8 +1445,15 @@ describe('Store: location tree and diagnostics data', () => {
     await store.init();
 
     const before = hass.__calls.filter((c) => c === 'haventory/location/tree').length;
-    store.setFilters({ sort: { field: 'name', order: 'asc' } });
-    await new Promise((r) => setTimeout(r, 400));
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      store.setFilters({ sort: { field: 'name', order: 'asc' } });
+      // Well past the 250 ms debounce: the claim is that nothing was scheduled
+      // at all, not that it had not fired yet.
+      await vi.advanceTimersByTimeAsync(400);
+    } finally {
+      vi.useRealTimers();
+    }
     expect(hass.__calls.filter((c) => c === 'haventory/location/tree').length).toBe(before);
   });
 
@@ -1544,7 +1569,9 @@ describe('Store: import reload signalling', () => {
     store.state.onChange(() => seen.push(store.state.value.degraded.reloading));
 
     hass.__emit('items', 'reloaded', {});
-    await new Promise((r) => setTimeout(r, 5));
+    // The re-list is a promise chain, not a debounce: draining the queue is the
+    // whole wait, and 5 ms of real time was only ever a hedge on the scheduler.
+    await flush(2);
 
     // It went up and came back down; nothing is left stuck.
     expect(seen).toContain(true);
@@ -1564,7 +1591,7 @@ describe('Store: import reload signalling', () => {
     store.state.onChange(() => seen.push(store.state.value.degraded.reloading));
 
     hass.__emit('items', 'updated', {});
-    await new Promise((r) => setTimeout(r, 5));
+    await flush(2);
 
     expect(seen).toContain(true);
     expect(store.state.value.degraded.reloading).toBe(false);

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -2,6 +2,17 @@ import { describe, it, expect, vi } from 'vitest';
 import { Store } from './store';
 import { makeMockHass, makeItem } from '../test.utils';
 
+/**
+ * Let queued microtasks and any zero-delay timers run.
+ *
+ * What the waits below are actually waiting for is a promise chain — a list or a
+ * facet call answered by the mock — so draining the queue is the whole wait, and
+ * a real delay was only ever a hedge on the scheduler.
+ */
+async function flush(rounds = 2): Promise<void> {
+  for (let i = 0; i < rounds; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('Store', () => {
   it('initializes with stats, areas, locations, and first page of items', async () => {
     const items = Array.from({ length: 30 }, (_, i) => makeItem({ id: `${i}`, name: `Item ${i}` }));
@@ -214,7 +225,7 @@ describe('Store', () => {
     expect(store.state.value.total).toBe(total);
     expect(store.state.value.loading).toBe(true);
 
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(store.state.value.loading).toBe(false);
     expect(store.state.value.items.map((i) => i.name)).toEqual(['Item 1']);
   });
@@ -239,7 +250,7 @@ describe('Store', () => {
       await store.init();
 
       store.setFilters({ q: 'Alpha' });
-      await new Promise((r) => setTimeout(r, 10));
+      await flush();
       expect(store.state.value.items.map((i) => i.id)).toEqual(['a']);
       expect(store.wasRemoved('b')).toBe(false);
     });
@@ -335,12 +346,12 @@ describe('Store', () => {
     };
 
     store.setFilters({ orphansOnly: true });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(listFilters.length).toBeGreaterThan(0);
     expect(listFilters[listFilters.length - 1]?.orphaned_only).toBe(true);
 
     store.setFilters({ orphansOnly: false });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(listFilters[listFilters.length - 1]?.orphaned_only).toBeUndefined();
   });
 
@@ -356,11 +367,11 @@ describe('Store', () => {
     expect(store.state.value.items.length).toBe(2);
 
     store.setFilters({ orphansOnly: true });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(store.state.value.items.map((i) => i.id)).toEqual(['o1']);
 
     store.setFilters({ orphansOnly: false });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(store.state.value.items.length).toBe(2);
   });
 
@@ -372,12 +383,12 @@ describe('Store', () => {
     await store.init();
 
     store.setFilters({ q: 'saw' });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(store.state.value.items.map((i) => i.name)).toEqual(['Electric Saw']);
 
     // Tags are searchable too
     store.setFilters({ q: 'adhesive' });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(store.state.value.items.map((i) => i.name)).toEqual(['Glue']);
   });
 
@@ -390,11 +401,11 @@ describe('Store', () => {
     await store.init();
 
     store.setFilters({ sort: { field: 'due_date', order: 'asc' } });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(store.state.value.items.map((i) => i.name)).toEqual(['Early', 'Late', 'Undated']);
 
     store.setFilters({ sort: { field: 'due_date', order: 'desc' } });
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
     expect(store.state.value.items.map((i) => i.name)).toEqual(['Late', 'Early', 'Undated']);
   });
 
@@ -780,16 +791,30 @@ describe('Store', () => {
     const before = hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length;
 
     // What a filter panel does: several keys in a row, one answer wanted.
-    store.setFilters({ checkedOutOnly: true });
-    store.setFilters({ lowStockOnly: true });
-    store.setFilters({ q: 'drill' });
-    await vi.waitUntil(
-      () => hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length > before,
-    );
-    await new Promise((r) => setTimeout(r, 300));
+    // The coalescing window is a 250 ms debounce, so the test drives that clock
+    // rather than out-waiting it: installed here, after init, so the setup above
+    // keeps running on real timers.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      store.setFilters({ checkedOutOnly: true });
+      store.setFilters({ lowStockOnly: true });
+      store.setFilters({ q: 'drill' });
 
-    const after = hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length;
-    expect(after).toBe(before + 1);
+      // Nothing has been asked yet on the last millisecond of the window...
+      await vi.advanceTimersByTimeAsync(249);
+      const facetCalls = () =>
+        hass.__messages.filter((m) => m.type === 'haventory/distinct_values').length;
+      expect(facetCalls()).toBe(before);
+
+      // ...and the three patches then produce exactly one answer, with nothing
+      // trailing behind it.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(facetCalls()).toBe(before + 1);
+      await vi.advanceTimersByTimeAsync(300);
+      expect(facetCalls()).toBe(before + 1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // Issue #440: not every facet refetch is debounced — an item event lands

--- a/cards/haventory-card/src/test.setup.test.ts
+++ b/cards/haventory-card/src/test.setup.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { pendingIntervalCount, stopPendingIntervals } from './test.setup';
+import {
+  pendingIntervalCount,
+  pendingTimeoutCount,
+  stopPendingIntervals,
+  stopPendingTimeouts,
+} from './test.setup';
 import { defineCardElement } from './register';
 
 // The suite's own guard rail: an interval that survives its spec file ticks
@@ -34,5 +39,50 @@ describe('the pending-interval sweep', () => {
     window.clearInterval(timer);
 
     expect(pendingIntervalCount()).toBe(0);
+  });
+});
+
+// A `setTimeout` pending at teardown fails the same way an interval does, and
+// unlike an interval it also has to leave the set on its own when it fires.
+describe('the pending-timeout sweep', () => {
+  it('stops a swept timeout from firing', async () => {
+    const tick = vi.fn();
+    window.setTimeout(tick, 1);
+
+    stopPendingTimeouts();
+    // Scheduled after the sweep, so this wait is not the one being cancelled.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(tick).not.toHaveBeenCalled();
+  });
+
+  it('forgets a timeout that already fired, without anyone clearing it', async () => {
+    stopPendingTimeouts();
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+
+    // The wait above scheduled one timeout and it has run: only the timeout
+    // that is still pending — none — may be counted. Left to the id alone, the
+    // set would grow by one for every zero-delay wait a spec file makes.
+    expect(pendingTimeoutCount()).toBe(0);
+  });
+
+  it('forgets a timeout its owner cleared', () => {
+    stopPendingTimeouts();
+
+    const timer = window.setTimeout(() => {}, 1000);
+    expect(pendingTimeoutCount()).toBe(1);
+    window.clearTimeout(timer);
+
+    expect(pendingTimeoutCount()).toBe(0);
+  });
+
+  it('hands the handler the arguments it was scheduled with', () => {
+    // The wrapper calls the handler itself, so the extra arguments only survive
+    // if it passes them on.
+    const seen: unknown[] = [];
+    window.setTimeout((...args: unknown[]) => seen.push(...args), 1, 'a', 2);
+
+    return vi.waitFor(() => expect(seen).toEqual(['a', 2]));
   });
 });

--- a/cards/haventory-card/src/test.setup.ts
+++ b/cards/haventory-card/src/test.setup.ts
@@ -46,9 +46,55 @@ export function pendingIntervalCount(): number {
   return liveIntervals.size;
 }
 
+/*
+ * A `setTimeout` still pending when the environment goes away fails exactly the
+ * same way an interval does, so it is swept the same way. One difference decides
+ * the shape: a timeout fires once and is then gone, and nothing tells the set
+ * that. The wrapper therefore wraps the handler and drops the id as it runs —
+ * without that, every zero-delay wait a spec file makes stays in the set and the
+ * count reports garbage.
+ */
+const liveTimeouts = new Set<number>();
+const scheduleTimeout = window.setTimeout.bind(window);
+const cancelTimeout = window.clearTimeout.bind(window);
+
+window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+  // A string handler would have to be wrapped through `eval` to learn when it
+  // fired; nothing here schedules one, so it is passed straight through.
+  if (typeof handler !== 'function') return scheduleTimeout(handler, timeout, ...args);
+  let id = 0;
+  id = scheduleTimeout(
+    (...fired: unknown[]) => {
+      liveTimeouts.delete(id);
+      handler(...fired);
+    },
+    timeout,
+    ...args,
+  );
+  liveTimeouts.add(id);
+  return id;
+}) as typeof window.setTimeout;
+
+window.clearTimeout = ((id?: number) => {
+  if (id !== undefined) liveTimeouts.delete(id);
+  cancelTimeout(id);
+}) as typeof window.clearTimeout;
+
+/** Cancel every timeout still pending in this spec file's window. */
+export function stopPendingTimeouts(): void {
+  for (const id of liveTimeouts) cancelTimeout(id);
+  liveTimeouts.clear();
+}
+
+/** How many timeouts the sweep is currently holding. */
+export function pendingTimeoutCount(): number {
+  return liveTimeouts.size;
+}
+
 // Per spec file, immediately before the environment goes away. Fake timers
-// install their own `setInterval` over the wrapper above and clean up after
+// install their own timer functions over the wrappers above and clean up after
 // themselves, so what reaches here is the real-timer work only.
 afterAll(() => {
   stopPendingIntervals();
+  stopPendingTimeouts();
 });

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -1,4 +1,5 @@
 import type { CSSResult } from 'lit';
+import { vi } from 'vitest';
 
 import { Store } from './store/store';
 import type {
@@ -1146,9 +1147,14 @@ function queryRoot(root: Element | DocumentFragment): ParentNode {
  * The macrotask boundary is what separates this from awaiting `updateComplete`
  * alone: it drains the microtask queue first, so a render that another render
  * queued has already been scheduled by the time the element is awaited.
+ *
+ * Under fake timers that boundary has to be driven rather than waited on —
+ * nothing advances a fake clock on its own, so a real zero-delay wait there
+ * never resolves and the test hangs until vitest kills it.
  */
 export async function settle(el: HTMLElement): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  if (vi.isFakeTimers()) await vi.advanceTimersByTimeAsync(0);
+  else await new Promise((resolve) => setTimeout(resolve, 0));
   await (el as Renderable).updateComplete;
 }
 

--- a/cards/haventory-card/src/utils/debounce.test.ts
+++ b/cards/haventory-card/src/utils/debounce.test.ts
@@ -1,51 +1,65 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { debounce } from './debounce';
 
+// The unit under test *is* a timer, so every case here drives a fake clock:
+// waiting out a real 50 ms window can only ever assert "by now", while advancing
+// to the millisecond before and the millisecond itself asserts the delay. There
+// is no async setup in this file for the fake clock to interfere with, so it is
+// installed for the whole describe rather than per test.
 describe('debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('delays function execution by specified ms', async () => {
-    // Function should not be called until delay has passed
     const fn = vi.fn();
     const debounced = debounce(fn, 50);
 
     debounced();
+    await vi.advanceTimersByTimeAsync(49);
     expect(fn).not.toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 60));
+    await vi.advanceTimersByTimeAsync(1);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
   it('resets timer on subsequent calls', async () => {
-    // Multiple rapid calls should only result in one execution
+    // Multiple rapid calls should only result in one execution, and each call
+    // starts the window again rather than shortening it.
     const fn = vi.fn();
     const debounced = debounce(fn, 50);
 
     debounced();
-    await new Promise((r) => setTimeout(r, 30));
+    await vi.advanceTimersByTimeAsync(30);
     debounced(); // Reset timer
-    await new Promise((r) => setTimeout(r, 30));
+    await vi.advanceTimersByTimeAsync(30);
     debounced(); // Reset timer again
 
-    // Should not have been called yet
+    // 60 ms of calls, and nothing has fired: the window is measured from the
+    // last one.
+    await vi.advanceTimersByTimeAsync(49);
     expect(fn).not.toHaveBeenCalled();
 
-    // Wait for final debounce to complete
-    await new Promise((r) => setTimeout(r, 60));
+    await vi.advanceTimersByTimeAsync(1);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
   it('passes arguments to wrapped function', async () => {
-    // Arguments should be preserved and passed to the original function
     const fn = vi.fn();
     const debounced = debounce(fn, 50);
 
     debounced('arg1', 42, { key: 'value' });
-    await new Promise((r) => setTimeout(r, 60));
+    await vi.advanceTimersByTimeAsync(50);
 
     expect(fn).toHaveBeenCalledWith('arg1', 42, { key: 'value' });
   });
 
   it('uses arguments from last call when debouncing', async () => {
-    // When multiple calls happen, only the last arguments should be used
+    // When multiple calls happen, only the last arguments should be used.
     const fn = vi.fn();
     const debounced = debounce(fn, 50);
 
@@ -53,7 +67,7 @@ describe('debounce', () => {
     debounced('second');
     debounced('third');
 
-    await new Promise((r) => setTimeout(r, 60));
+    await vi.advanceTimersByTimeAsync(50);
     expect(fn).toHaveBeenCalledTimes(1);
     expect(fn).toHaveBeenCalledWith('third');
   });


### PR DESCRIPTION
## Summary

Two suite improvements from #209.

**The wall-clock waits are gone.** Every remaining `await new Promise(r => setTimeout(r, N))`
with a non-zero `N` either drove a debounce or hedged on a promise chain. The debounce ones
move onto a fake clock, which also sharpens them: advance to `delay - 1` and assert nothing
has moved, then the last millisecond and assert it has — a two-sided claim about the delay
where the wait could only ever say "by now". The promise-chain ones become queue drains,
which is what the real delay was standing in for. Per-test, measured on the same host:

| test | before | after |
|---|---|---|
| `store.revamp` counts each location against the filter | 409 ms | 2 ms |
| `store.revamp` does not re-walk the tree for a re-order | 405 ms | 1 ms |
| `store.test` coalesces the facet refetch across a burst | 618 ms | 4 ms |
| `hv-card-shell` debounces the search before touching the store | 276 ms | 29 ms |
| `hv-card-shell` stages filters in the sheet | 319 ms | 44 ms |
| `hv-full-view` debounces the app bar search | 273 ms | 24 ms |
| `debounce.test.ts` (four cases, file total) | ~260 ms | 22 ms |

`settle()` in `test.utils.ts` learns to drive a fake clock: a real zero-delay wait never
resolves under one, so a converted test would hang until vitest killed it.

**The teardown sweep covers `setTimeout` too.** #164 tracks intervals and cancels the
survivors in an `afterAll`; a timeout still pending when jsdom goes away fails identically —
vitest counts the ReferenceError as an uncaught exception and exits 1 with every test
passing. The wrapper has one thing the interval wrapper does not need: a timeout fires once
and nothing tells the set, so it wraps the *handler* and drops the id as it runs. Without
that the set accumulates every zero-delay wait a spec file makes and `pendingTimeoutCount()`
reports garbage — which is a test, not a comment (see below).

Closes #209

## Decisions taken against drifted notes

- **The table's line numbers had moved and the list was short.** The notes' six waits are
  now at `store.revamp.test.ts:1411/1431/1547` (plus a second 5 ms wait at `:1567` the notes
  did not have), `hv-card-shell.test.ts:392` and `:1064`, `hv-full-view.test.ts:1913`.
  Grepping the whole suite rather than following the list found three more: a **300 ms** wait
  in `store.test.ts` (the facet-coalescing case, 618 ms per run), ten 10 ms waits in the same
  file, and five 30–60 ms waits in `debounce.test.ts`. All are converted — the PR title says
  *the remaining* waits, and leaving the biggest one behind would have made that false. What
  is left is zero-delay drains, plus two real waits in `test.setup.test.ts` that are testing
  the real-timer sweep and have to be real.
- **The two 5 ms waits are not debounces**, so they did not get a fake clock: they wait for
  the reload flag to go up and back down across a promise chain the mock answers
  immediately. `flush(2)` — the file's own helper — is what they were hedging for, and it
  says so. Same for the ten 10 ms waits in `store.test.ts`, which needed the helper added
  there.
- **`settle()` is shared, not local.** The notes describe a local `settle()` in
  `hv-card-shell.test.ts` and "its twin" in `hv-full-view.test.ts`; both import it from
  `src/test.utils.ts`, so the fake-timer awareness lands once for every caller.
- **`hv-card-shell`'s staged-filter case installs the clock before the clicks, not before
  the wait.** The debounce is scheduled by the click that stages a category, so installing
  fake timers afterwards leaves that timer on the real clock and advancing does nothing —
  the first attempt failed exactly that way. Both fake-timer blocks in the components now
  open right after the mount, which still keeps `mountShell`/`store.init()` on real timers as
  the notes require.
- **`debounce.test.ts` uses `beforeEach`, not per-test installs.** The notes' reason for
  per-test installs is that the surrounding `store.init()`/mount helpers must keep real
  timers; that file has no async setup at all, and the unit under test *is* a timer.
- **`window.setTimeout` returns an object here, not a number.** In vitest's jsdom the id is a
  Node `Timeout`, which is why the sweep stores whatever it was handed and hands the same
  value back — matching the existing interval wrapper. A string handler is passed straight
  through untracked: wrapping it would need `eval`, and nothing here schedules one.

## Type of change

- [x] Documentation / tooling / CI (test-suite only; no production code changed)

## How was this tested?

- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run`, `npm run build` → all clean. **1868 passed / 63 files** (1864 + 4 new).
- [x] `npx vitest run` **twice**, exit code checked both times — the teardown sweep's failure
      mode is an uncaught exception at environment teardown, which shows up as exit 1 with
      every test passing, so the exit code is the assertion. Both runs: `exit=0`.
- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1269 passed, 22 skipped;
      `ruff check` / `ruff format --check` / `mypy` clean. `node --test` in
      `.claude/skills/run-haventory/` → 26 pass.
- New cases in `src/test.setup.test.ts` (4): a pending timeout is cancelled by
  `stopPendingTimeouts()` and never fires; a timeout that already fired is no longer counted
  **without anyone clearing it**; `window.clearTimeout(id)` drops it from the set; and the
  handler still receives the arguments it was scheduled with.
- **Controls, because a guard that cannot fail proves nothing.** Deleting the
  `liveTimeouts.delete(id)` line from the wrapper fails exactly the already-fired case
  (`× forgets a timeout that already fired`) and nothing else — that is the case the notes
  call "the reason that detail is not an optimization". Each converted debounce keeps its
  `delay - 1` assertion, which fails if the debounce is shortened or removed.
- phacc: not involved.

### On the timing claim

The per-test numbers above are the measurement: they were taken back to back on this host by
stashing and unstashing the diff, and they are repeatable. The **full-suite wall time is
not** — two back-to-back pairs on the same host gave 45.9 s → 43.5 s and 37.2 s → 49.1 s,
with the reported `environment` figure swinging by 30% between runs. A 2-second change does
not survive that, so the honest claim is the per-test one: ~2.2 s of waiting removed, and no
test that still waits on a real clock except the two that are testing the real clock.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + the two edge cases the wrapper exists for).
- [x] No docs change: no behaviour outside the suite changed.
- [x] No WebSocket API change, no `custom_components/` change.
- [x] Essential invariants untouched.

## Follow-ups

- `vi.waitUntil` / `vi.waitFor` appear ten times across the suite and poll a real clock. They
  are bounded by what they are waiting for rather than by a fixed delay, so they cost nothing
  when the condition is already true. Named here, not filed.

## Handover

**1. Merged / left open**

All three merged and their branches deleted; nothing is left open for you.

- #524 — `fix(skills): make stress.py honour the worktree's .env and name its target`
  (closes #432)
- #525 — `test(skills): branch-discriminating desktop surfaces and --dashboard selection`
  (closes #212)
- this PR — `test(card): fake-timer the remaining wall-clock waits; sweep pending timeouts in
  teardown` (closes #209)

**2. Test this by hand**

Nothing by hand. Everything in this session is harness and suite work, and each half was
driven against the real dev HA rather than asserted offline:

1. `[log]` The near-miss #432 describes was reproduced and refused: from a worktree whose
   `.env` named an unreachable instance, with the shell exporting the dev one, `stress.py
   bulk 5` printed the target, named the displaced URL and exited **before creating
   anything**; the dev store stayed at 1087 items. `HAVENTORY_IGNORE_ENV_FILE=1` from the
   same worktree reached the dev instance and read its counts. Evidence in #524.
2. `[desktop]` The two sharpened surfaces were driven both ways: 15/15 on
   `/dashboard-dev/wide`, and `d-02` + `d-11` failing on `/dashboard-dev/0` where they used
   to pass. `--dashboard` was proven on a temporary second card-bearing dashboard, by title
   and by url path, with the unmatched name exiting 2. Evidence in #525.
3. `[optional]` If you want one thing on screen: run
   `uv run --no-project --with aiohttp python .claude/skills/test-haventory/stress.py baseline`
   and read the first two lines. They are what every helper now prints before it acts, and
   whether that wording is useful to you is the one judgement a harness cannot make.

**3. Decisions taken against drifted notes**

- #432's four named scripts never read `.env` at all; the same-`setdefault` bug was in
  `driver.py`, `lifecycle_probe.py` and `card_views.mjs`'s `haConfig()`. All are fixed, and
  the escape hatch `HAVENTORY_IGNORE_ENV_FILE=1` exists because
  `dev/release_testing_plan.md` documents a probe aimed at a remote host inline.
- #212's `d-11` discriminator is `open-full-view`, not `full-sidebar`: driving it showed the
  full view sizes its sidebar off the window, so a narrow card in a wide window still shows
  it. The structural rule the notes proposed is not true of the current table; what landed
  instead is "every selector a desktop surface asserts absent must be one a narrow surface
  asserts present", which is true, catches a typo'd `hidden`, and was verified by breaking
  one on purpose.
- #209's table had drifted and was short by three waits, the largest of them 618 ms per run.

**4. Follow-ups**

- Named and deliberately not filed (they clear no real-world bar): the ten `vi.waitUntil` /
  `vi.waitFor` polls in the card suite; `log_sweep.py` having no base URL to name; the
  desktop surfaces beyond `d-02`/`d-11` that assert only selectors the narrow branch also
  has (`d-layout` covers them, and ten more assertions would not).
- No new issues were filed this session.

**5. State left behind**

- **Dev HA (`home-assistant`, localhost:8123):** data unchanged — 1087 items / 89 locations
  before and after. A temporary dashboard `s4-second` ("Household") was created over WS to
  prove `--dashboard` and **deleted again**; `node card_views.mjs` is back to the two
  `dashboard-dev` views. No `.storage` edits, no restarts, rate limiting untouched, language
  untouched.
- **Branches:** `claude/v0-7-0-s4-stress-env`, `claude/v0-7-0-s4-visual-pass` and
  `claude/v0-7-0-s4-fake-timers` are merged and deleted on the remote.
- **New files the next session should know about:** `scripts/dev_env.py` (one place that
  decides which instance a helper talks to — reuse it rather than reading `.env` again) and
  `.claude/skills/run-haventory/surfaces.mjs` (the visual-pass tables, now importable by
  tests).
- **Host quirk, pre-existing:** every `git` command in this checkout prints
  `error: failed to delete '.git/worktrees/<name>': Permission denied` for ~20 stale worktree
  entries left by earlier sessions. It is noise, not a failure; the worktree this session
  created for the #432 proof is gone from `git worktree list` and its directory is removed.
- **Open PRs left alone:** release-please's #491 (`chore(main): release 0.7.0`) — never
  touched by a session, and per the plan it waits for S11 — and Dependabot's #516–#523.
