### PR TITLE
test(integration): cover the debounced persist, the downgrade refusal, the error envelope and the retired-files sweep against real HA

### DIFF
--- a/tests/integration/test_config_entry.py
+++ b/tests/integration/test_config_entry.py
@@ -11,6 +11,14 @@ The reload tests are the reason this file talks to a real WebSocket rather than
 calling handlers: unload, setup and the subscription registry all move under one
 connection that outlives them, and that interleaving is exactly what the stubs
 cannot reproduce.
+
+The refusal tests at the bottom are here for the same kind of reason. Setup
+raises ``ConfigEntryError`` rather than ``ConfigEntryNotReady`` for a store this
+build cannot read, and the whole point of that choice is the state Home
+Assistant then lands the entry in — ``SETUP_ERROR``, which stays put and shows
+its message, against ``SETUP_RETRY``, which backs off behind a generic one. A
+stub raising a stub exception can show which class was raised; only a real core
+shows what it costs.
 """
 
 from __future__ import annotations
@@ -24,6 +32,7 @@ from custom_components.haventory.const import (
 )
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.runtime import find_runtime
+from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
@@ -309,3 +318,71 @@ async def test_the_options_flow_refuses_a_pill_it_does_not_offer(hass: HomeAssis
         )
 
     assert CONF_QUICK_FILTERS not in entry.options
+
+
+def _seed_store(hass_storage: dict, data: object) -> None:
+    """Put ``data`` on disk under HAventory's key, exactly as written."""
+
+    hass_storage[STORAGE_KEY] = {"version": 1, "key": STORAGE_KEY, "data": data}
+
+
+async def _setup_expecting_failure(hass: HomeAssistant) -> MockConfigEntry:
+    """Set the entry up knowing it will not load, and hand it back to be read."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is False
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_a_store_from_a_newer_build_stops_the_entry_rather_than_retrying(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The refusal reaches the user as an error state carrying both versions."""
+
+    newer = CURRENT_SCHEMA_VERSION + 1
+    _seed_store(hass_storage, {"schema_version": newer, "items": {}, "locations": {}})
+
+    entry = await _setup_expecting_failure(hass)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert str(newer) in entry.reason
+    assert str(CURRENT_SCHEMA_VERSION) in entry.reason
+    assert find_runtime(hass) is None
+    # And the file it refused to read is still the file it was handed.
+    assert hass_storage[STORAGE_KEY]["data"]["schema_version"] == newer
+
+
+async def test_an_unreadable_schema_version_stops_the_entry_with_its_own_message(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """A hand-edited store says nothing about its schema; guessing is the bug."""
+
+    _seed_store(hass_storage, {"schema_version": None, "items": {}, "locations": {}})
+
+    entry = await _setup_expecting_failure(hass)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert "corrupt schema_version" in entry.reason
+    assert find_runtime(hass) is None
+    assert hass_storage[STORAGE_KEY]["data"]["schema_version"] is None
+
+
+async def test_a_store_that_cannot_be_read_right_now_is_retried_instead(
+    hass: HomeAssistant, hass_storage: dict
+) -> None:
+    """The counter-case that gives the two above their meaning.
+
+    A payload that is not a mapping at all is a plain storage failure, not a
+    verdict about which schema wrote it, so it takes the retry path. Without
+    this case "raises ConfigEntryError" and "raises ConfigEntryNotReady" would
+    be indistinguishable from the outside.
+    """
+
+    _seed_store(hass_storage, ["not", "a", "mapping"])
+
+    entry = await _setup_expecting_failure(hass)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert find_runtime(hass) is None

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -3,10 +3,20 @@
 Confirms a mutation is written through Home Assistant's ``Store`` backend and can
 be read back by a fresh store instance — the real serialize/deserialize path,
 not the offline in-memory stub.
+
+The debounced write is here for a sharper reason. ``async_request_persist``
+schedules through ``hass.async_create_background_task`` precisely so Home
+Assistant holds the task and cancels it at shutdown; the offline stub forwards
+that call to a plain ``asyncio`` task, which nothing tracks, so the property the
+scheduling exists for is the one offline tests cannot see.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
+
+from custom_components.haventory import storage as storage_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import (
@@ -14,9 +24,20 @@ from custom_components.haventory.storage import (
     STORAGE_KEY,
     DomainStore,
     async_persist_immediate,
+    async_request_persist,
 )
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+# Short enough that a test can wait it out, long enough that the assertion
+# taken before it elapses is not a race. The debounce rides ``asyncio.sleep``
+# rather than Home Assistant's clock helpers, so ``async_fire_time_changed``
+# would not move it — a real, shortened delay is the honest way to drive it.
+SHORT_DEBOUNCE = 0.05
+
+# Longer than any of these tests take, so a debounce scheduled with it can only
+# end by being cancelled — never by firing on its own.
+UNREACHABLE_DEBOUNCE = 300.0
 
 
 async def test_store_write_and_reload_roundtrip(hass: HomeAssistant, hass_storage: dict) -> None:
@@ -98,3 +119,76 @@ async def test_setup_after_unload_reads_back_what_the_flush_wrote(
     assert second_runtime is not first_runtime
     names = [item.name for item in second_runtime.repository.list_items()["items"]]
     assert names == ["Across the reload"]
+
+
+async def test_a_debounced_persist_lands_in_the_store_only_after_its_window(
+    hass: HomeAssistant, hass_storage: dict, monkeypatch
+) -> None:
+    """The window is a window: nothing is written until it elapses, then it is.
+
+    A debounce that wrote immediately would pass every "the data is on disk"
+    assertion while coalescing nothing, so both halves are asserted here.
+    """
+
+    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", SHORT_DEBOUNCE)
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Straight onto the repository, so only the debounce can carry it to disk.
+    find_runtime(hass).repository.create_item({"name": "Debounced"})
+    await async_request_persist(hass)
+
+    pending = find_runtime(hass).persist_task
+    assert pending is not None
+    # Home Assistant is holding it. That is what makes shutdown cancel and await
+    # the task instead of destroying it while pending, and it is exactly what
+    # the offline stub's untracked `asyncio.create_task` cannot show.
+    assert pending in hass._background_tasks
+
+    assert STORAGE_KEY not in hass_storage
+
+    await asyncio.sleep(SHORT_DEBOUNCE * 4)
+
+    assert pending.done()
+    stored = hass_storage[STORAGE_KEY]["data"]
+    assert [item["name"] for item in stored["items"].values()] == ["Debounced"]
+
+
+async def test_the_unload_flush_beats_a_debounce_that_has_not_fired(
+    hass: HomeAssistant, hass_storage: dict, monkeypatch, caplog
+) -> None:
+    """Teardown writes the mutation and leaves no task behind to write it again.
+
+    With a debounce this long the only way the item reaches the store is the
+    teardown flush, and the only way the task can be finished afterwards is
+    cancellation — so a green run says both happened, in that order.
+    """
+
+    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", UNREACHABLE_DEBOUNCE)
+    caplog.set_level(logging.DEBUG, logger="custom_components.haventory.storage")
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    find_runtime(hass).repository.create_item({"name": "Flushed past the debounce"})
+    await async_request_persist(hass)
+    pending = find_runtime(hass).persist_task
+    assert pending is not None
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Finished, without having reached the end of a five-minute sleep. The task
+    # swallows its own cancellation and returns normally, so the log line is
+    # what names the way it ended.
+    assert pending.done()
+    assert pending.exception() is None
+    assert any("op=persist_immediate_cancel" in record.getMessage() for record in caplog.records)
+
+    stored = hass_storage[STORAGE_KEY]["data"]
+    assert [item["name"] for item in stored["items"].values()] == ["Flushed past the debounce"]

--- a/tests/integration/test_stale_files.py
+++ b/tests/integration/test_stale_files.py
@@ -1,0 +1,80 @@
+"""Integration: the retired-files sweep runs on Home Assistant's own executor.
+
+Setup deletes files out of the installed integration directory, and it does so
+through `hass.async_add_executor_job` — on HA's thread pool in production, and
+on a bare loop executor offline. What only a real core can show is that the
+deletion is complete by the time the rest of setup runs: the sweep is awaited
+inside `async_setup_entry`, ahead of the step that serves the card directory,
+so a retired bundle is gone before anything can be served from beside it.
+
+`_PACKAGE_DIR` is redirected at a throwaway directory the same way the offline
+tests do it. The directory it normally names is this checkout's own
+`custom_components/haventory/`, and a test that wrote probe files into the tree
+it is testing would leave them behind on any failure — the executor, the
+setup ordering and the escape guard are all exercised either way.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from custom_components.haventory import stale_files
+from custom_components.haventory.const import DOMAIN
+from custom_components.haventory.runtime import find_runtime
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+RETIRED_MODULE = "reminders.py"
+
+
+@pytest.fixture
+def install_dir(tmp_path: Path, monkeypatch) -> Path:
+    """A stand-in for the installed integration directory, safe to delete from."""
+
+    directory = tmp_path / "custom_components" / "haventory"
+    directory.mkdir(parents=True)
+    monkeypatch.setattr(stale_files, "_PACKAGE_DIR", directory)
+    return directory
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_setup_sweeps_a_retired_file_through_the_real_executor(
+    hass: HomeAssistant, install_dir: Path, monkeypatch
+) -> None:
+    """The upgrade case, end to end: the file is gone and the entry is loaded."""
+
+    monkeypatch.setattr(stale_files, "RETIRED_PATHS", (RETIRED_MODULE,))
+    left_behind = install_dir / RETIRED_MODULE
+    left_behind.write_text("LEGACY = True\n", encoding="utf-8")
+
+    entry = await _setup(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert not left_behind.exists()
+    # Setup carried on past the sweep rather than the sweep being all that ran.
+    assert find_runtime(hass) is not None
+
+
+async def test_a_swept_path_that_escapes_the_package_is_refused_on_the_executor(
+    hass: HomeAssistant, install_dir: Path, monkeypatch, caplog
+) -> None:
+    """A typo in the list points into the operator's config tree; setup must not follow it."""
+
+    monkeypatch.setattr(stale_files, "RETIRED_PATHS", ("../secrets.yaml",))
+    outside = (install_dir / "../secrets.yaml").resolve()
+    outside.write_text("token: secret\n", encoding="utf-8")
+
+    entry = await _setup(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert outside.read_text(encoding="utf-8") == "token: secret\n"
+    assert any("outside the integration directory" in record.message for record in caplog.records)

--- a/tests/integration/test_ws_errors.py
+++ b/tests/integration/test_ws_errors.py
@@ -1,0 +1,144 @@
+"""Integration: what a real client actually receives when a command fails.
+
+The contract's error frame carries a `data` object that Home Assistant's own
+`websocket_api.error_message` has no parameter for, so `ws.py` builds the
+envelope by hand. Offline, both sides of that distinction are our own code —
+the stub sends what the guard returns — and nothing proves the extra key
+survives a real connection's serialization out to a real client.
+
+The refusals Home Assistant makes on its own behalf are here for the same
+reason. They happen inside `ActiveConnection`, before any handler runs: an id
+that does not increase and a command this build does not have are both refused
+by state the offline helpers keep no equivalent of, so what a client sees in
+either case is asserted here or nowhere.
+"""
+
+from __future__ import annotations
+
+from custom_components.haventory.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_the_error_context_reaches_the_client_intact(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """`data` arrives with the request fields the taxonomy promised, not just `op`."""
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/get", "item_id": "does-not-exist"})
+    resp = await client.receive_json()
+
+    assert resp["success"] is False, resp
+    assert resp["error"]["code"] == "not_found"
+    assert resp["error"]["data"] == {"op": "item_get", "item_id": "does-not-exist"}
+
+
+async def test_a_nested_error_payload_survives_the_wire(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """The richest `data` there is: a list of objects, not a flat string map.
+
+    An import document is rejected with one entry per problem, and the card
+    shows them field by field — so anything that flattened or dropped the
+    nesting on the way out would cost the whole message.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "haventory/import/execute",
+            "document": {"haventory_export_version": "one", "items": "nope"},
+        }
+    )
+    resp = await client.receive_json()
+
+    assert resp["success"] is False, resp
+    assert resp["error"]["code"] == "validation_error"
+    errors = resp["error"]["data"]["errors"]
+    assert errors, resp
+    assert all(isinstance(entry, dict) and "path" in entry for entry in errors), errors
+    assert {entry["path"] for entry in errors} == {
+        "haventory_export_version",
+        "schema_version",
+        "items",
+    }
+
+
+async def test_home_assistants_own_refusal_carries_no_data_key(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """The counter-case: `data` is ours, not something every frame arrives with.
+
+    A frame the command schema rejects is answered by Home Assistant before
+    `ws_guard` runs, and its envelope has no `data` at all. Without this the
+    assertions above would also pass if a real connection simply added the key
+    to everything.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/get"})
+    resp = await client.receive_json()
+
+    assert resp["success"] is False, resp
+    assert resp["error"]["code"] == "invalid_format", resp
+    assert "data" not in resp["error"], resp
+
+
+async def test_a_reused_frame_id_is_refused_before_the_command_runs(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """Real connections track `last_id`; the offline helpers dispatch each frame alone.
+
+    So an offline test can reuse an id — or send ids out of order — in a way no
+    real client gets away with, and a card that did it would find out here.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 7, "type": "haventory/item/create", "name": "First"})
+    assert (await client.receive_json())["success"] is True
+
+    await client.send_json({"id": 7, "type": "haventory/item/create", "name": "Second"})
+    refused = await client.receive_json()
+    assert refused["success"] is False, refused
+    assert refused["error"]["code"] == "id_reuse", refused
+
+    # Refused by the connection, so the handler never ran and nothing was created.
+    await client.send_json({"id": 8, "type": "haventory/item/list"})
+    listed = await client.receive_json()
+    assert [item["name"] for item in listed["result"]["items"]] == ["First"]
+
+
+async def test_a_command_this_build_does_not_have_is_answered_not_ignored(
+    hass: HomeAssistant, hass_ws_client
+) -> None:
+    """What a newer card meets on an older backend: an answer it can branch on.
+
+    Offline the helpers raise `AssertionError("No handler responded")`, which is
+    a fine test failure and no description at all of what a client receives.
+    """
+
+    await _setup(hass)
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "haventory/item/teleport"})
+    resp = await client.receive_json()
+
+    assert resp["success"] is False, resp
+    assert resp["error"]["code"] == "unknown_command", resp


### PR DESCRIPTION
## Summary

Four paths the offline suite can stage but not observe, asserted against a real Home
Assistant core. No production code changes — every gap here was a missing assertion.

**The debounced persist (#123).** `async_request_persist` schedules through
`hass.async_create_background_task` precisely so Home Assistant holds the task; the offline
stub forwards that call to a plain `asyncio` task, which nothing tracks. Two cases in
`tests/integration/test_persistence.py`:

- the window is a window — with the delay shortened to 50 ms, nothing is on disk when the
  request returns, the task is in HA's own `_background_tasks` set, and the payload lands
  after the window elapses;
- with the delay set to five minutes, unloading the entry writes the mutation anyway and
  leaves the task finished — it cannot have slept its way there, so the flush cancelled it.

**The `ConfigEntryError` downgrade refusal (#120).** The reason for raising
`ConfigEntryError` rather than `ConfigEntryNotReady` is the state Home Assistant lands the
entry in, and state is what a stub raising a stub exception cannot show. Three cases in
`tests/integration/test_config_entry.py`: a store one schema version ahead and a store with
an unreadable `schema_version` both stop at `SETUP_ERROR` with their own message and leave
the file untouched; a payload that is not a mapping at all takes `SETUP_RETRY`. The third
is the control — without it, "raises `ConfigEntryError`" and "raises `ConfigEntryNotReady`"
are indistinguishable from outside.

**The WS error envelope.** `ws.py` builds the contract's frame by hand because HA's
`websocket_api.error_message` has no `data` parameter. New
`tests/integration/test_ws_errors.py` proves the context reaches a real client
(`data == {"op": "item_get", "item_id": …}`), that a nested payload survives the wire (the
import rejection's list of `{path, message}` objects, intact), and — as the control — that
Home Assistant's *own* pre-handler refusal carries no `data` key at all, so the key is ours
rather than something every frame arrives with.

The same file covers the two divergences the 2026-08-05 comment left open, since a case
each turned out to be cheap: a **reused frame id** answers `id_reuse` and the handler never
runs (asserted: the second item was not created), and an **unknown command** answers
`unknown_command` rather than the offline helpers' `AssertionError("No handler responded")`
— which is what a newer card meets on an older backend.

**The retired-files sweep.** New `tests/integration/test_stale_files.py`: through a real
setup on HA's own executor, a retired file is deleted and the entry still reaches `LOADED`;
and a listed path escaping the package directory is refused, with the operator's file
intact.

Closes #208

## Decisions taken against the 2026-08-05 implementation notes

The notes' line references were taken against a much older tree and were resolved by symbol
throughout. Four substantive departures:

1. **"A command whose failure carries no context returns an error frame with no `data` key
   at all."** Not reachable: `_context_from_msg` always returns at least `{"op": …}`, so
   every `ws_guard` refusal carries `data`. The honest control is Home Assistant's own
   refusal, made inside `ActiveConnection` before any handler runs — a frame the command
   schema rejects answers `invalid_format` with no `data`. That is what
   `test_home_assistants_own_refusal_carries_no_data_key` asserts.
2. **"Create the probe file inside the integration package directory."**
   `stale_files._PACKAGE_DIR` is redirected at a `tmp_path` directory instead, the way
   `tests/test_stale_files_offline.py` already does it. That directory is this checkout's
   own `custom_components/haventory/`, and a test writing probe files into the tree it is
   testing leaves them behind on any failure. The three things this file exists for — the
   real executor, the setup ordering, the escape guard — are exercised either way.
3. **"`hass.async_stop()` must finish with no 'Task was destroyed but it is pending' record
   in `caplog`."** That message is emitted by asyncio's `Task.__del__` at garbage-collection
   time and cannot be asserted from inside the test body; phacc's autouse `verify_cleanup`
   fixture already fails any test that leaks a task or a timer. Asserted instead: the task
   is finished with no exception after an unload that happened well inside a five-minute
   debounce, and the `op=persist_immediate_cancel` line names what ended it.
4. **The envelope assertion went into a new `test_ws_errors.py`** rather than
   `test_ws_items.py` — the notes offered either, and the file now carries five cases,
   two of them about Home Assistant's own refusals rather than about items.

Also worth recording: `RETIRED_PATHS` is still `()` in this release, so the sweep tests
monkeypatch it. Nothing was appended to it here.

## Type of change

- [x] Documentation / tooling / CI  *(tests only)*

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1269 passed, 22
      skipped**; `uv run ruff check .` → all checks passed; `uv run ruff format --check .` →
      184 files already formatted; `uv run mypy` → no issues in 26 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` → **1868 passed (63 files)**, `npm run build` → 610.11 kB.
- [x] phacc (`scripts/test_integration.sh`, in the Docker harness the V0.7.0 plan
      documents): **135 passed** at the declared floor, up from 123 before this PR.
      The offline suite never collects `tests/integration/`, and its count is unchanged.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case) — each of the four
      additions carries its own control case.
- [x] Docs updated where behavior changed — no behavior changed; the contract already
      documents the `data` context these tests pin.
- [x] WebSocket API changes keep `ws.py` and the docs in sync — no API change.
- [x] Essential invariants preserved.

## Follow-ups

None. The two stub divergences the issue's 2026-08-05 comment left open (`ERR_ID_REUSE`,
`ERR_UNKNOWN_COMMAND`) are covered here rather than deferred.
