### PR TITLE
ci: run the integration suite against the newest Home Assistant monthly

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -29,6 +29,11 @@
   color: "bfd4f2"
   description: "Documentation and READMEs"
 
+# --- CI ---
+- name: "ci:ha-latest"
+  color: "fbca04"
+  description: "Drift against current Home Assistant, found by the scheduled ha-latest run"
+
 # --- Housekeeping ---
 - name: "good first issue"
   color: "7057ff"

--- a/.github/workflows/ha-latest.yml
+++ b/.github/workflows/ha-latest.yml
@@ -1,0 +1,151 @@
+name: ha-latest
+
+# The integration suite against the NEWEST Home Assistant, once a month.
+#
+# `ci.yml`'s `integration` job pins Home Assistant to the declared floor, which is
+# what makes "minimum supported" a tested claim — and means nothing in CI ever
+# runs against current HA. Home Assistant ships breaking changes monthly, so this
+# job is the early warning: a failure here is drift against a newer core, never a
+# regression in whatever pull request happens to be open that day.
+#
+# Deliberately scheduled only. With no `pull_request` trigger it reports no check
+# on a pull request, so it can never become a gate one waits on — see
+# `tests/test_repo_hardening_offline.py`.
+on:
+  schedule:
+    # 05:00 UTC on the 8th. Home Assistant's monthly minor lands on the first
+    # Wednesday, so the 8th is always after it and after phacc has published the
+    # build that pins it.
+    - cron: "0 5 8 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-latest:
+    runs-on: ubuntu-latest
+    outputs:
+      ha-version: ${{ steps.resolved.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        with:
+          enable-cache: true
+      - name: Install Python 3.14
+        # Pinned, unlike the Home Assistant version. If a future HA raises its own
+        # Python floor, this job is where that surfaces first — as a resolution
+        # failure with a legible message, which is the warning the job is for.
+        run: uv python install 3.14
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: cards/haventory-card/package-lock.json
+      - name: Build the card the integration serves
+        # Same reason as in `ci.yml`: the bundle is git-ignored and the
+        # integration skips its frontend registration when it is absent, so
+        # without this step the frontend tests skip rather than run.
+        run: npm ci --no-audit --no-fund && npm run build
+        working-directory: cards/haventory-card
+      - name: Create integration environment (newest phacc, newest HA core)
+        # phacc ALONE, unpinned, and `homeassistant` is never named: each phacc
+        # release pins one exact Home Assistant version, so asking for phacc is
+        # the only way to ask for "the newest core there is a harness for".
+        # Naming `homeassistant` here would just be overridden by that pin, and
+        # `requirements-integration.txt` would pin the floor — the two mistakes
+        # that would silently turn this into a second copy of the floor run.
+        run: |
+          uv venv --python 3.14 .venv-integration
+          uv pip install --python .venv-integration/bin/python pytest-homeassistant-custom-component
+      - name: Install the frontend wheel this core asks for
+        # `requirements-integration.txt` hand-carries this pin because the harness
+        # does not install component requirements, and `frontend` fails to set up
+        # without it. A hand-carried pin is exactly what a "latest" job cannot
+        # have, so it is derived from the resolved core's own manifest — which
+        # satisfies `test_the_frontend_wheel_matches_what_this_ha_release_asks_for`
+        # by construction, at whatever version that core asks for.
+        run: |
+          wheel=$(.venv-integration/bin/python -c "
+          import json, pathlib
+          from homeassistant.components import frontend
+          manifest = pathlib.Path(frontend.__file__).with_name('manifest.json')
+          print(json.loads(manifest.read_text(encoding='utf-8'))['requirements'][0])
+          ")
+          echo "Derived frontend wheel: ${wheel}"
+          uv pip install --python .venv-integration/bin/python "${wheel}"
+      - name: Report what "latest" resolved to
+        id: resolved
+        # A passing run has to say what it proved, or it proves nothing legible.
+        run: |
+          version=$(.venv-integration/bin/python -c "from homeassistant.const import __version__; print(__version__)")
+          harness=$(.venv-integration/bin/python -c "from importlib.metadata import version; print(version('pytest-homeassistant-custom-component'))")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Integration suite against current Home Assistant"
+            echo
+            echo "- Home Assistant \`${version}\` (phacc \`${harness}\`)"
+            echo "- The declared floor is tested separately, by the integration job in \`ci.yml\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Integration tests (in-process HA via phacc)
+        # Autoload ON so phacc and its pytest-asyncio/aiohttp/socket stack load;
+        # phacc requires pytest-asyncio's auto mode.
+        run: >
+          .venv-integration/bin/python -m pytest -q
+          -o asyncio_mode=auto
+          tests/integration
+          --junitxml=integration-latest-junit.xml
+      - name: Upload integration artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-latest-artifacts
+          path: integration-latest-junit.xml
+
+  notify:
+    # One pinned issue, opened on the first failing month and closed again when a
+    # later run passes — so the tracker never carries a stale drift report, and a
+    # month that stays broken gets a comment rather than a second issue.
+    needs: [integration-latest]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open, update or close the drift issue
+        # The preinstalled `gh` CLI rather than a third-party action: no new
+        # dependency to digest-pin, which keeps Scorecard's pinned-dependencies
+        # check where it is.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          FAILED: ${{ needs.integration-latest.result != 'success' }}
+          HA_VERSION: ${{ needs.integration-latest.outputs.ha-version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          version="${HA_VERSION:-unknown}"
+          existing=$(gh issue list --label ci:ha-latest --state open --limit 1 --json number --jq '.[0].number // empty')
+
+          if [ "${FAILED}" = "true" ]; then
+            # printf rather than a multi-line string: a shell string indented to
+            # match this block would carry its leading spaces into the issue, and
+            # Markdown reads an indented line as a code block.
+            body=$(printf '%s\n\n%s\n' \
+              "The scheduled integration run against current Home Assistant (\`${version}\`) failed: ${RUN_URL}" \
+              "This is drift against a newer Home Assistant, not a regression in whatever pull request is open today. The floor run in \`ci.yml\` is unaffected.")
+            if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" --body "${body}"
+            else
+              gh issue create \
+                --title "Integration suite fails against Home Assistant ${version}" \
+                --label ci:ha-latest \
+                --body "${body}"
+            fi
+          elif [ -n "${existing}" ]; then
+            gh issue comment "${existing}" \
+              --body "The scheduled integration run passes again, against Home Assistant \`${version}\`: ${RUN_URL}"
+            gh issue close "${existing}" --reason completed
+          fi

--- a/README.md
+++ b/README.md
@@ -953,6 +953,13 @@ Leave both unset — a fresh install, or any dashboard written before either opt
   frontend (npm audit + eslint + tsc + vitest + build, Node 22/24 matrix), actionlint,
   hassfest + HACS validation, CodeQL, OpenSSF Scorecard, and dependency review.
   Third-party actions are SHA-pinned; first-party `actions/*` use `@v7`.
+- **`ha-latest`** runs the same integration suite against the *newest* Home Assistant on
+  the 8th of each month (and on demand via *Run workflow*). The `integration` job above
+  pins the declared floor, so this is the only thing in CI that meets a current core. A
+  failure here is drift against that newer Home Assistant — not a regression in whatever
+  pull request is open that day — and it opens or updates one issue labelled
+  `ci:ha-latest`, which a later passing run closes again. It reports no check on a pull
+  request and can never block one.
 - PR hygiene: Conventional-Commit PR-title check, path-based auto-labeling
   (`.github/labeler.yml`), labels-as-code (`.github/labels.yml`), CODEOWNERS review
   requests, and issue/PR templates.

--- a/tests/integration/test_frontend.py
+++ b/tests/integration/test_frontend.py
@@ -176,6 +176,12 @@ async def test_the_sidebar_panel_lands_in_the_real_panel_registry(hass: HomeAssi
     The offline suite asserts this against a stub of `async_register_panel`;
     only the real helper proves the `_panel_custom` block HA's frontend reads is
     the one we asked for, module URL and element name included.
+
+    A subset rather than an equality: `panel_custom` fills the block with its own
+    defaults too, and Home Assistant adds one from time to time (`2026.8`
+    introduced `handle_safe_area`). What matters is what this integration asked
+    for; a key HA chose for itself is not drift and must not fail the scheduled
+    run against a newer core.
     """
     await _setup(hass)
 
@@ -186,12 +192,15 @@ async def test_the_sidebar_panel_lands_in_the_real_panel_registry(hass: HomeAssi
     assert panel.sidebar_icon == PANEL_ICON
     assert panel.require_admin is False
     assert panel.config["title"] == DEFAULT_CARD_TITLE
-    assert panel.config["_panel_custom"] == {
-        "name": PANEL_ELEMENT_NAME,
-        "embed_iframe": False,
-        "trust_external": False,
-        "module_url": next(iter(hass.data[frontend.DATA_EXTRA_MODULE_URL].urls)),
-    }
+    assert (
+        panel.config["_panel_custom"].items()
+        >= {
+            "name": PANEL_ELEMENT_NAME,
+            "embed_iframe": False,
+            "trust_external": False,
+            "module_url": next(iter(hass.data[frontend.DATA_EXTRA_MODULE_URL].urls)),
+        }.items()
+    )
 
 
 @needs_bundle

--- a/tests/test_repo_hardening_offline.py
+++ b/tests/test_repo_hardening_offline.py
@@ -10,6 +10,11 @@ Then two things a workflow run cannot tell you about itself: that every
 third-party action it calls is pinned to an immutable revision, and that
 Dependabot is configured to keep ``requirements-integration.txt`` patched
 without fighting the pins that file carries deliberately.
+
+Last, the scheduled ``ha-latest`` run, which is worthless in two specific ways
+that a green run of its own would not reveal: reporting a check that a pull
+request then waits on, and installing the pinned floor instead of the newest
+core — which would make it a second, slower copy of ``ci.yml``'s integration job.
 """
 
 from __future__ import annotations
@@ -27,6 +32,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 RULESET_PATH = REPO_ROOT / ".github" / "rulesets" / "main.json"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 DEPENDABOT_PATH = REPO_ROOT / ".github" / "dependabot.yml"
+HA_LATEST_PATH = WORKFLOWS_DIR / "ha-latest.yml"
 
 # `actions/*` is GitHub's own namespace, and this repository pins it by tag on
 # purpose; everything else names an immutable revision, because a tag can be
@@ -307,3 +313,45 @@ def test_a_blanket_ignore_is_told_from_a_scoped_one() -> None:
 
     assert ignored_update_types(blanket) == {"homeassistant": set()}
     assert ignored_update_types(scoped) == {"homeassistant": set(VERSION_UPDATE_TYPES)}
+
+
+@pytest.fixture
+def ha_latest() -> dict[str, Any]:
+    return yaml.safe_load(HA_LATEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_scheduled_ha_latest_reports_no_required_contexts(ha_latest: dict[str, Any]) -> None:
+    """A monthly run must never become a check a pull request waits on.
+
+    It has no pull-request trigger, so it reports nothing on one and the ruleset
+    needs no edit. Adding that trigger later would put two check names into
+    ``available_contexts()`` that no pull request can satisfy quickly.
+    """
+    assert workflow_contexts(ha_latest) == set()
+
+
+def test_ha_latest_installs_no_pinned_home_assistant(ha_latest: dict[str, Any]) -> None:
+    """The failure mode that would leave it green and worthless.
+
+    Either naming ``homeassistant`` on the command line or installing
+    ``requirements-integration.txt`` would pull the declared floor, and the job
+    would quietly re-test what ``ci.yml`` already tests.
+    """
+    commands = "\n".join(
+        str(step["run"])
+        for job in ha_latest["jobs"].values()
+        for step in job.get("steps", [])
+        if "run" in step
+    )
+
+    assert "requirements-integration.txt" not in commands
+    assert "homeassistant==" not in commands
+    assert "pytest-homeassistant-custom-component" in commands
+
+
+def test_ha_latest_is_dispatchable_and_scheduled(ha_latest: dict[str, Any]) -> None:
+    """Both triggers: the cron is the point, and dispatch is how it is proved."""
+    triggers = workflow_triggers(ha_latest)
+
+    assert "workflow_dispatch" in triggers
+    assert [entry["cron"] for entry in triggers["schedule"]] == ["0 5 8 * *"]

--- a/tests/test_toolchain_pins.py
+++ b/tests/test_toolchain_pins.py
@@ -97,6 +97,7 @@ PYTHON_FLOOR_SITES: tuple[tuple[str, int, int], ...] = (
     ("pyproject.toml", 6, 2),
     (".github/workflows/ci.yml", 5, 0),
     (".github/workflows/codeql.yml", 1, 0),
+    (".github/workflows/ha-latest.yml", 3, 0),
     ("README.md", 10, 0),
     ("CONTRIBUTING.md", 1, 0),
     ("docs/backend_api_contract.md", 1, 0),


### PR DESCRIPTION
## Summary

`ci.yml`'s `integration` job pins Home Assistant to the declared floor — which is what
makes "minimum supported" a tested claim, and also means nothing in CI ever meets a current
core. New `.github/workflows/ha-latest.yml` runs the same suite against the newest Home
Assistant there is a phacc harness for, at 05:00 UTC on the 8th of each month and on demand
via *Run workflow*.

**What "latest" resolves to.** phacc alone, unpinned; `homeassistant` is never named on a
command line. Each phacc release pins one exact core, so asking for phacc *is* asking for
the newest core there is a harness for — and naming `homeassistant`, or installing
`requirements-integration.txt`, would pull the declared floor and leave a job that is green
and worthless. That is the failure mode
`test_ha_latest_installs_no_pinned_home_assistant` exists for.

**The frontend wheel.** `requirements-integration.txt` hand-carries this pin because the
harness does not install component requirements. A hand-carried pin is exactly what a
"latest" job cannot have, so the job reads `requirements[0]` out of the resolved core's own
`homeassistant/components/frontend/manifest.json` and installs that — which satisfies
`test_the_frontend_wheel_matches_what_this_ha_release_asks_for` by construction, at whatever
version that core asks for.

**Reporting.** The resolved Home Assistant and phacc versions go into
`$GITHUB_STEP_SUMMARY`, so a passing month still says what it proved.

**Notification.** A `notify` job (`needs: [integration-latest]`, `if: always()`,
`issues: write`) drives the preinstalled `gh` rather than a third-party action — no new
dependency to digest-pin, so Scorecard's pinned-dependencies check stays where it is. On
failure it comments on the open `ci:ha-latest` issue or opens one titled with the resolved
version; on success it comments and closes any that is open, so a fixed month leaves no
stale pinned issue behind.

**Not a gate.** No `pull_request` trigger, so the workflow reports no check name, the
ruleset needs no edit, and no pull request can ever wait on it.

Closes #227

## The drift it found before it had run once

Rehearsing the install steps by hand (below) resolved to Home Assistant **2026.8.2** against
the floor's 2026.6.0 — and the suite failed one case:
`test_the_sidebar_panel_lands_in_the_real_panel_registry`. `panel_custom` gained a
`handle_safe_area` default in 2026.8, and the test asserted the whole `_panel_custom` block
by equality.

That test is about the block *this integration asked for* — element name, module URL,
`embed_iframe`, `trust_external` — so it now asserts a subset. A key Home Assistant chose
for itself is not drift, and failing the monthly run on one would train the reader to
ignore it. The floor run is unaffected; both now pass at 135.

## Decisions taken against the 2026-08-05 implementation notes

1. **The notes did not anticipate an existing test failing against latest.** Fixed here
   rather than deferred: shipping a scheduled job whose first dispatch opens a pinned issue
   about our own over-strict assertion would be a poor first impression of the signal.
2. **The step-summary text does not name `requirements-integration.txt`.** The blunt guard
   test greps every `run:` block for that filename, and a prose mention inside the summary
   would trip it. Keeping the guard blunt is worth more than the sentence — the summary
   says "the declared floor is tested separately, by the integration job in `ci.yml`".
3. **Everything else is as the notes describe**: `cron: "0 5 8 * *"` plus
   `workflow_dispatch`, the `gh`-driven notifier, the `ci:ha-latest` label in
   `.github/labels.yml`, the README line, and the three guard tests in
   `tests/test_repo_hardening_offline.py`. `requirements-integration.txt` is untouched.

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1272 passed, 22
      skipped** (three new guard tests); `uv run ruff check .`, `uv run ruff format --check .`,
      `uv run mypy` → all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` → **1868 passed**, `npm run build`.
- [x] `actionlint` (the digest-pinned image CI uses) over the whole workflow tree → clean.
- [x] phacc at the declared floor (`scripts/test_integration.sh`, Docker harness):
      **135 passed** — the new job does not disturb the floor run.
- [x] **The two novel install steps rehearsed by hand**, exactly as the notes ask, in a
      scratch venv: `uv venv --python 3.14`, `uv pip install
      pytest-homeassistant-custom-component` → resolved `homeassistant 2026.8.2` /
      `pytest-homeassistant-custom-component 0.13.356`; the manifest derivation produced
      `home-assistant-frontend==20260729.7`; the full suite then ran green at **135 passed**
      against that core (after the `_panel_custom` fix above).
- [x] **The notifier's branching rehearsed** with a stub `gh` on the workflow's own `run`
      block, since only a real failing month would otherwise exercise it. All five paths
      behave: failure with no open issue → `issue create` with the label and the resolved
      version in the title; failure with an open issue → `issue comment`; success with an
      open issue → `issue comment` then `issue close --reason completed`; success with none
      → no call at all; and a failure before the version step → title says `unknown`. The
      body is built with `printf` so no leading indentation reaches the issue (Markdown
      would read an indented line as a code block).

Deferred to live verification: the dispatch itself, after merge — the step summary goes in
the handover.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — three guard tests, each covering a way the job could be green
      and worthless or green and harmful.
- [x] Docs updated — one README bullet under CI/CD & Ops naming the job, its schedule, and
      what a failure means.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Follow-ups

- The `ci:ha-latest` label does not exist on the repository yet; the `labels` workflow
  creates it when `.github/labels.yml` lands on `main`, before the first dispatch. Worth
  knowing: `gh issue create` validates a label before opening, so an unlabelled repository
  would have made the notifier fail rather than open an unlabelled issue.
