### PR TITLE
ci: drive the card's live smoke against Home Assistant stable and beta on a schedule

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -33,6 +33,9 @@
 - name: "ci:ha-latest"
   color: "fbca04"
   description: "Drift against current Home Assistant, found by the scheduled ha-latest run"
+- name: "ci:card-smoke"
+  color: "fbca04"
+  description: "The scheduled card smoke fails against current Home Assistant"
 
 # --- Housekeeping ---
 - name: "good first issue"

--- a/.github/workflows/card-smoke.yml
+++ b/.github/workflows/card-smoke.yml
@@ -1,0 +1,150 @@
+name: card-smoke
+
+# The card, driven in a real browser against a real Home Assistant, once a month.
+#
+# The card's contact surface with Home Assistant is small and named — `callWS`,
+# `subscribeMessage`, `window.customCards`, the theme variables — and the reason
+# it survives HA upgrades is that it renders no `ha-*` element. Nothing in the
+# unit suite can check that: a mock is only as truthful as its author's model of
+# the contract, and `e2e/live-updates.smoke.mjs` exists because one once was not.
+# That smoke drives the real card against a real HA, and until now it never ran
+# unattended.
+#
+# Two channels. `stable` says what users have; `beta` says what they will have in
+# a few weeks, which is the whole point of running it early.
+#
+# Scheduled only, like `ha-latest.yml`: no `pull_request` trigger, so it reports
+# no check and can never become a gate a pull request waits on.
+on:
+  schedule:
+    # Same slot as `ha-latest.yml`, an hour later so the two do not contend for
+    # runners. The 8th is after Home Assistant's monthly minor, which lands on the
+    # first Wednesday.
+    - cron: "0 6 8 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [stable, beta]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        with:
+          enable-cache: true
+      - name: Install Python 3.14
+        run: uv python install 3.14
+      - name: Sync dev environment
+        # `scripts/ci_provision_ha.py` and `scripts/ws_init_haventory.py` both
+        # talk to Home Assistant over aiohttp, which the dev group carries.
+        run: uv sync --python 3.14
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: cards/haventory-card/package-lock.json
+      - name: Build the card
+        # Into `custom_components/haventory/www/`, which is inside the directory
+        # the container mounts below — so the bundle Home Assistant serves is the
+        # one this commit produces.
+        run: npm ci --no-audit --no-fund && npm run build
+        working-directory: cards/haventory-card
+      - name: Install the browser the smoke drives
+        run: npx playwright install --with-deps chromium
+        working-directory: cards/haventory-card
+      - name: Boot Home Assistant (${{ matrix.channel }})
+        # Read-only mount: Home Assistant reads the integration out of the
+        # checkout, and nothing it does can write back into the workspace.
+        run: |
+          docker run -d --name ha-smoke -e TZ=UTC -p 8123:8123 \
+            -v "${{ github.workspace }}/custom_components/haventory:/config/custom_components/haventory:ro" \
+            "ghcr.io/home-assistant/home-assistant:${{ matrix.channel }}"
+      - name: Onboard it and put the card on a dashboard
+        id: provision
+        # A blank instance needs everything a dev instance was set up with by
+        # hand: an owner, a token, and a view holding the card. All of it is REST
+        # and WebSocket — no browser, and nothing interactive.
+        run: uv run python scripts/ci_provision_ha.py --base-url http://localhost:8123
+      - name: Add the HAventory config entry
+        env:
+          HA_BASE_URL: http://localhost:8123
+          HA_TOKEN: ${{ steps.provision.outputs.token }}
+          # There is no `.env` on a runner, but the helper prefers one when there
+          # is; saying so here means a stray file could never redirect the run.
+          HAVENTORY_IGNORE_ENV_FILE: "1"
+        run: uv run python scripts/ws_init_haventory.py
+      - name: Report the Home Assistant this ran against
+        id: version
+        run: |
+          version=$(curl -fsS -H "Authorization: Bearer ${{ steps.provision.outputs.token }}" \
+            http://localhost:8123/api/config | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Card smoke against Home Assistant ${{ matrix.channel }}"
+            echo
+            echo "- Home Assistant \`${version}\` (channel \`${{ matrix.channel }}\`)"
+            echo "- Dashboard view: \`${{ steps.provision.outputs.card-path }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Live-update smoke
+        env:
+          # Without this the smoke prints SKIP and exits 0 — a green job that
+          # tested nothing. `tests/test_repo_hardening_offline.py` holds it.
+          RUN_ONLINE: "1"
+          HA_BASE_URL: http://localhost:8123
+          HA_TOKEN: ${{ steps.provision.outputs.token }}
+          HAVENTORY_IGNORE_ENV_FILE: "1"
+        run: node e2e/live-updates.smoke.mjs --path "${{ steps.provision.outputs.card-path }}"
+        working-directory: cards/haventory-card
+      - name: Home Assistant log
+        # The card failing and Home Assistant failing look identical from the
+        # browser, and only this tells them apart.
+        if: failure()
+        run: docker logs ha-smoke
+
+  notify:
+    # Its own label rather than `ha-latest.yml`'s: two workflows sharing one
+    # pinned issue would have each closing the other's report.
+    needs: [smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open, update or close the drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          FAILED: ${{ needs.smoke.result != 'success' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label ci:card-smoke --state open --limit 1 --json number --jq '.[0].number // empty')
+
+          if [ "${FAILED}" = "true" ]; then
+            # printf rather than a multi-line string: a shell string indented to
+            # match this block would carry its leading spaces into the issue, and
+            # Markdown reads an indented line as a code block.
+            body=$(printf '%s\n\n%s\n' \
+              "The scheduled card smoke failed: ${RUN_URL}" \
+              "The run page says which channel — a \`beta\` failure is a warning about the next release, a \`stable\` one is affecting users now. The step summary of each leg names the Home Assistant version it drove.")
+            if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" --body "${body}"
+            else
+              gh issue create \
+                --title "Card smoke fails against current Home Assistant" \
+                --label ci:card-smoke \
+                --body "${body}"
+            fi
+          elif [ -n "${existing}" ]; then
+            gh issue comment "${existing}" \
+              --body "The scheduled card smoke passes again on both channels: ${RUN_URL}"
+            gh issue close "${existing}" --reason completed
+          fi

--- a/README.md
+++ b/README.md
@@ -960,6 +960,14 @@ Leave both unset — a fresh install, or any dashboard written before either opt
   pull request is open that day — and it opens or updates one issue labelled
   `ci:ha-latest`, which a later passing run closes again. It reports no check on a pull
   request and can never block one.
+- **`card-smoke`** is the frontend counterpart, on the same schedule: it boots Home
+  Assistant `stable` and `beta` in the runner, onboards them over REST
+  (`scripts/ci_provision_ha.py`), installs the integration and the built card, and drives
+  `cards/haventory-card/e2e/live-updates.smoke.mjs` against each. Nothing in the unit
+  suite renders the card against a real Home Assistant, so this is what would catch the
+  card's contact surface breaking; a `beta` failure arrives before users upgrade rather
+  than after. Same handling: one issue labelled `ci:card-smoke`, closed again by a later
+  passing run, and no check on a pull request.
 - PR hygiene: Conventional-Commit PR-title check, path-based auto-labeling
   (`.github/labeler.yml`), labels-as-code (`.github/labels.yml`), CODEOWNERS review
   requests, and issue/PR templates.

--- a/scripts/ci_provision_ha.py
+++ b/scripts/ci_provision_ha.py
@@ -1,0 +1,269 @@
+r"""Onboard a blank Home Assistant and put the HAventory card on a dashboard.
+
+For the scheduled card smoke, which boots
+``ghcr.io/home-assistant/home-assistant:{stable,beta}`` in the CI runner and then
+needs everything a browser harness normally gets from a dev instance somebody set
+up by hand: an owner account, a long-lived token, and a dashboard view holding a
+``custom:haventory-card``.
+
+None of it needs a browser. Onboarding is plain REST — create the owner, trade
+the returned code for a token, tick the three remaining steps — and the rest is
+the WebSocket API. The one thing this script does **not** do is create the config
+entry: ``scripts/ws_init_haventory.py`` already answers that flow from its own
+schema, so it runs afterwards with the token printed here.
+
+Writes ``HA_TOKEN=<token>`` to the file named by ``GITHUB_OUTPUT`` when that is
+set, and prints the token on stdout otherwise. Everything else goes to stderr, so
+the token is the only thing a caller has to parse.
+
+Usage:
+  uv run python scripts/ci_provision_ha.py --base-url http://localhost:8123
+
+Deliberately for a **blank** instance: onboarding answers once and refuses
+afterwards, so pointing this at an instance somebody uses would fail rather than
+change it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import secrets
+import sys
+import time
+from typing import Any
+
+import aiohttp
+
+# Home Assistant's own frontend uses its origin as the OAuth client id, and the
+# token endpoint checks the two agree.
+CLIENT_ID_SUFFIX = "/"
+
+OWNER_USERNAME = "ci"
+OWNER_NAME = "CI Runner"
+
+# The dashboard the smoke drives. A plain masonry view, never `type: panel`: the
+# card picks its layout from its own rendered width, and the smoke asserts on
+# `hv-list-row` — the narrow branch, which is what a normal column produces and a
+# panel view does not.
+DASHBOARD_URL_PATH = "haventory-smoke"
+CARD_VIEW_PATH = "cards"
+
+CLIENT_NAME = "HAventory card smoke"
+TOKEN_LIFESPAN_DAYS = 1
+
+BOOT_TIMEOUT_S = 300.0
+BOOT_POLL_INTERVAL_S = 3.0
+HTTP_OK = 200
+
+
+def log(message: str) -> None:
+    """Progress goes to stderr; stdout carries the token and nothing else."""
+    print(message, file=sys.stderr, flush=True)
+
+
+async def wait_for_http(session: aiohttp.ClientSession, base_url: str) -> None:
+    """Block until Home Assistant answers, or give up with what it last said.
+
+    A cold container takes a minute or two to reach this point, and the port is
+    open well before the app behind it is.
+    """
+    deadline = time.monotonic() + BOOT_TIMEOUT_S
+    last = "no response yet"
+    while time.monotonic() < deadline:
+        try:
+            async with session.get(f"{base_url}/manifest.json") as response:
+                if response.status == HTTP_OK:
+                    log(f"Home Assistant is answering at {base_url}")
+                    return
+                last = f"HTTP {response.status}"
+        except aiohttp.ClientError as exc:
+            last = type(exc).__name__
+        await asyncio.sleep(BOOT_POLL_INTERVAL_S)
+    raise RuntimeError(f"Home Assistant did not come up within {BOOT_TIMEOUT_S:.0f}s ({last})")
+
+
+async def _post_json(
+    session: aiohttp.ClientSession, url: str, payload: dict[str, Any], **kwargs: Any
+) -> dict[str, Any]:
+    async with session.post(url, json=payload, **kwargs) as response:
+        body = await response.text()
+        if response.status != HTTP_OK:
+            raise RuntimeError(f"POST {url} answered HTTP {response.status}: {body}")
+        return json.loads(body)
+
+
+async def onboard(session: aiohttp.ClientSession, base_url: str) -> str:
+    """Walk Home Assistant's onboarding steps, returning an access token.
+
+    The first step is what mints the owner; the code it hands back is traded for
+    a bearer at the token endpoint, and the three remaining steps only flip their
+    own done-flags — but an instance with any of them outstanding shows the
+    onboarding screen instead of a dashboard, so all of them are answered.
+    """
+    client_id = base_url + CLIENT_ID_SUFFIX
+    # The account lives as long as the container does and nobody ever signs in to
+    # it, but a fresh secret costs one call and leaves nothing quotable behind.
+    password = secrets.token_urlsafe(24)
+
+    created = await _post_json(
+        session,
+        f"{base_url}/api/onboarding/users",
+        {
+            "client_id": client_id,
+            "name": OWNER_NAME,
+            "username": OWNER_USERNAME,
+            "password": password,
+            "language": "en",
+        },
+    )
+    log("Owner account created")
+
+    # Form-encoded, not JSON: this is the OAuth token endpoint, not an HA API.
+    async with session.post(
+        f"{base_url}/auth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": created["auth_code"],
+            "client_id": client_id,
+        },
+    ) as response:
+        body = await response.text()
+        if response.status != HTTP_OK:
+            raise RuntimeError(f"token exchange answered HTTP {response.status}: {body}")
+        access_token = json.loads(body)["access_token"]
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    for step, payload in (
+        ("core_config", {}),
+        ("analytics", {}),
+        ("integration", {"client_id": client_id, "redirect_uri": base_url}),
+    ):
+        await _post_json(session, f"{base_url}/api/onboarding/{step}", payload, headers=headers)
+    log("Onboarding steps answered")
+
+    return str(access_token)
+
+
+class WSClient:
+    """A minimal authenticated WebSocket caller, since only a few commands are needed."""
+
+    def __init__(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        self._ws = ws
+        self._next_id = 0
+
+    async def call(self, command: dict[str, Any]) -> Any:
+        self._next_id += 1
+        message_id = self._next_id
+        await self._ws.send_json({"id": message_id, **command})
+        while True:
+            message = await self._ws.receive_json()
+            if message.get("id") != message_id or message.get("type") != "result":
+                continue
+            if not message.get("success"):
+                raise RuntimeError(f"{command['type']} failed: {message.get('error')}")
+            return message.get("result")
+
+
+async def _connect(
+    session: aiohttp.ClientSession, base_url: str, access_token: str
+) -> tuple[aiohttp.ClientWebSocketResponse, WSClient]:
+    ws = await session.ws_connect(base_url.replace("http", "ws", 1) + "/api/websocket")
+    while True:
+        message = await ws.receive_json()
+        if message.get("type") == "auth_required":
+            await ws.send_json({"type": "auth", "access_token": access_token})
+        elif message.get("type") == "auth_ok":
+            return ws, WSClient(ws)
+        elif message.get("type") == "auth_invalid":
+            raise RuntimeError(f"WebSocket auth refused: {message.get('message')}")
+
+
+async def mint_long_lived_token(client: WSClient) -> str:
+    """A refresh token that outlives the session the onboarding bearer belongs to."""
+    token = await client.call(
+        {
+            "type": "auth/long_lived_access_token",
+            "client_name": CLIENT_NAME,
+            "lifespan": TOKEN_LIFESPAN_DAYS,
+        }
+    )
+    log("Long-lived token minted")
+    return str(token)
+
+
+async def create_dashboard(client: WSClient) -> str:
+    """A dashboard holding one HAventory card, and the path the smoke is pointed at.
+
+    Storage-mode dashboards are two commands: register the dashboard, then save a
+    config into it. The view carries nothing else — an empty column is what the
+    card's narrow branch renders in.
+    """
+    await client.call(
+        {
+            "type": "lovelace/dashboards/create",
+            "url_path": DASHBOARD_URL_PATH,
+            "title": "HAventory smoke",
+            "require_admin": False,
+            "show_in_sidebar": True,
+        }
+    )
+    await client.call(
+        {
+            "type": "lovelace/config/save",
+            "url_path": DASHBOARD_URL_PATH,
+            "config": {
+                "views": [
+                    {
+                        "title": "Cards",
+                        "path": CARD_VIEW_PATH,
+                        "cards": [{"type": "custom:haventory-card"}],
+                    }
+                ]
+            },
+        }
+    )
+    path = f"/{DASHBOARD_URL_PATH}/{CARD_VIEW_PATH}"
+    log(f"Dashboard created, card at {path}")
+    return path
+
+
+def emit(token: str, card_path: str) -> None:
+    """Hand the results back the way the caller asked for them."""
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"token={token}\n")
+            handle.write(f"card-path={card_path}\n")
+    else:
+        print(token)
+
+
+async def run(base_url: str) -> None:
+    async with aiohttp.ClientSession() as session:
+        await wait_for_http(session, base_url)
+        access_token = await onboard(session, base_url)
+        ws, client = await _connect(session, base_url, access_token)
+        try:
+            token = await mint_long_lived_token(client)
+            card_path = await create_dashboard(client)
+        finally:
+            await ws.close()
+    emit(token, card_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("HA_BASE_URL", "http://localhost:8123"),
+        help="the blank Home Assistant to onboard",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(args.base_url.rstrip("/")))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_repo_hardening_offline.py
+++ b/tests/test_repo_hardening_offline.py
@@ -11,10 +11,11 @@ third-party action it calls is pinned to an immutable revision, and that
 Dependabot is configured to keep ``requirements-integration.txt`` patched
 without fighting the pins that file carries deliberately.
 
-Last, the scheduled ``ha-latest`` run, which is worthless in two specific ways
-that a green run of its own would not reveal: reporting a check that a pull
-request then waits on, and installing the pinned floor instead of the newest
-core — which would make it a second, slower copy of ``ci.yml``'s integration job.
+Last, the two scheduled runs — ``ha-latest`` and ``card-smoke`` — each of which
+can be worthless in ways a green run of its own would not reveal: reporting a
+check that a pull request then waits on, installing the pinned floor instead of
+the newest core, or driving a smoke that skips itself because its opt-in flag is
+missing.
 """
 
 from __future__ import annotations
@@ -33,6 +34,11 @@ RULESET_PATH = REPO_ROOT / ".github" / "rulesets" / "main.json"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 DEPENDABOT_PATH = REPO_ROOT / ".github" / "dependabot.yml"
 HA_LATEST_PATH = WORKFLOWS_DIR / "ha-latest.yml"
+CARD_SMOKE_PATH = WORKFLOWS_DIR / "card-smoke.yml"
+
+# Every workflow that only ever runs on a timer, and the slot each one claims.
+# Two crons in the same minute would have them contending for runners.
+SCHEDULED_WORKFLOWS = ((HA_LATEST_PATH, "0 5 8 * *"), (CARD_SMOKE_PATH, "0 6 8 * *"))
 
 # `actions/*` is GitHub's own namespace, and this repository pins it by tag on
 # purpose; everything else names an immutable revision, because a tag can be
@@ -315,19 +321,30 @@ def test_a_blanket_ignore_is_told_from_a_scoped_one() -> None:
     assert ignored_update_types(scoped) == {"homeassistant": set(VERSION_UPDATE_TYPES)}
 
 
+def load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
 @pytest.fixture
 def ha_latest() -> dict[str, Any]:
-    return yaml.safe_load(HA_LATEST_PATH.read_text(encoding="utf-8"))
+    return load(HA_LATEST_PATH)
 
 
-def test_scheduled_ha_latest_reports_no_required_contexts(ha_latest: dict[str, Any]) -> None:
+@pytest.fixture
+def card_smoke() -> dict[str, Any]:
+    return load(CARD_SMOKE_PATH)
+
+
+@pytest.mark.parametrize("path", [path for path, _ in SCHEDULED_WORKFLOWS])
+def test_a_scheduled_workflow_reports_no_required_contexts(path: Path) -> None:
     """A monthly run must never become a check a pull request waits on.
 
-    It has no pull-request trigger, so it reports nothing on one and the ruleset
-    needs no edit. Adding that trigger later would put two check names into
-    ``available_contexts()`` that no pull request can satisfy quickly.
+    Neither has a pull-request trigger, so neither reports on one and the ruleset
+    needs no edit. Adding that trigger to either would put check names into
+    ``available_contexts()`` that no pull request can satisfy quickly — the card
+    smoke's worst, since it boots Home Assistant twice.
     """
-    assert workflow_contexts(ha_latest) == set()
+    assert workflow_contexts(load(path)) == set()
 
 
 def test_ha_latest_installs_no_pinned_home_assistant(ha_latest: dict[str, Any]) -> None:
@@ -349,9 +366,79 @@ def test_ha_latest_installs_no_pinned_home_assistant(ha_latest: dict[str, Any]) 
     assert "pytest-homeassistant-custom-component" in commands
 
 
-def test_ha_latest_is_dispatchable_and_scheduled(ha_latest: dict[str, Any]) -> None:
+@pytest.mark.parametrize(("path", "cron"), SCHEDULED_WORKFLOWS)
+def test_a_scheduled_workflow_is_dispatchable_and_on_its_own_slot(path: Path, cron: str) -> None:
     """Both triggers: the cron is the point, and dispatch is how it is proved."""
-    triggers = workflow_triggers(ha_latest)
+    triggers = workflow_triggers(load(path))
 
     assert "workflow_dispatch" in triggers
-    assert [entry["cron"] for entry in triggers["schedule"]] == ["0 5 8 * *"]
+    assert [entry["cron"] for entry in triggers["schedule"]] == [cron]
+
+
+def test_the_card_smoke_opts_into_the_online_test(card_smoke: dict[str, Any]) -> None:
+    """Its own green-and-worthless mode.
+
+    `e2e/live-updates.smoke.mjs` is opt-in: without ``RUN_ONLINE`` it prints SKIP
+    and exits 0, so the job would boot Home Assistant twice, drive nothing and
+    pass. The flag has to be on the step that runs it, not merely somewhere in
+    the file.
+    """
+    steps = [
+        step
+        for job in card_smoke["jobs"].values()
+        for step in job.get("steps", [])
+        if "live-updates.smoke.mjs" in str(step.get("run", ""))
+    ]
+
+    assert steps, "no step runs the live-update smoke"
+    for step in steps:
+        assert str(step.get("env", {}).get("RUN_ONLINE", "")) == "1"
+
+
+def test_the_scheduled_runs_do_not_share_a_notification_label(
+    ha_latest: dict[str, Any], card_smoke: dict[str, Any]
+) -> None:
+    """One label between them would have each closing the other's report."""
+
+    def labels(workflow: dict[str, Any]) -> set[str]:
+        commands = "\n".join(
+            str(step["run"])
+            for job in workflow["jobs"].values()
+            for step in job.get("steps", [])
+            if "run" in step
+        )
+        return set(re.findall(r"ci:[a-z-]+", commands))
+
+    ha_latest_labels, card_smoke_labels = labels(ha_latest), labels(card_smoke)
+
+    assert ha_latest_labels and card_smoke_labels
+    assert ha_latest_labels.isdisjoint(card_smoke_labels)
+
+
+def test_every_notification_label_is_declared_as_code(
+    ha_latest: dict[str, Any], card_smoke: dict[str, Any]
+) -> None:
+    """`gh issue create` refuses a label the repository does not have.
+
+    So a label named in a workflow and missing from `.github/labels.yml` is not a
+    cosmetic gap — it is the notification failing on the month it is needed.
+    """
+    declared = {
+        entry["name"]
+        for entry in yaml.safe_load((REPO_ROOT / ".github" / "labels.yml").read_text("utf-8"))
+    }
+    used = set(
+        re.findall(
+            r"ci:[a-z-]+",
+            "\n".join(
+                str(step["run"])
+                for workflow in (ha_latest, card_smoke)
+                for job in workflow["jobs"].values()
+                for step in job.get("steps", [])
+                if "run" in step
+            ),
+        )
+    )
+
+    assert used, "no notification label is named by either scheduled workflow"
+    assert used <= declared, f"undeclared: {sorted(used - declared)}"

--- a/tests/test_toolchain_pins.py
+++ b/tests/test_toolchain_pins.py
@@ -98,6 +98,7 @@ PYTHON_FLOOR_SITES: tuple[tuple[str, int, int], ...] = (
     (".github/workflows/ci.yml", 5, 0),
     (".github/workflows/codeql.yml", 1, 0),
     (".github/workflows/ha-latest.yml", 3, 0),
+    (".github/workflows/card-smoke.yml", 3, 0),
     ("README.md", 10, 0),
     ("CONTRIBUTING.md", 1, 0),
     ("docs/backend_api_contract.md", 1, 0),


### PR DESCRIPTION
## Summary

Nothing in CI renders the card against a real Home Assistant. The unit suite mocks the
WebSocket layer, and `e2e/live-updates.smoke.mjs` exists because a mock once delivered the
wrong frame shape to the subscription callback: the card silently stopped reflecting live
inventory changes and every unit test stayed green. That smoke drives the real card against
a real HA — it just never ran unattended.

New `.github/workflows/card-smoke.yml` runs it monthly against **`stable`** and **`beta`**.
Each matrix leg boots `ghcr.io/home-assistant/home-assistant:<channel>` in the runner with
the checkout's `custom_components/haventory` mounted read-only (so the bundle HA serves is
the one this commit built), provisions the instance, and drives the smoke at a dashboard
view the provisioning created. A `beta` failure arrives before users upgrade rather than
after — which is the half of #366 item 2 that a `stable`-only run would not give.

**`scripts/ci_provision_ha.py` is what makes it unattended.** Home Assistant's onboarding is
plain REST — create the owner, trade the returned code for a bearer at `/auth/token`, answer
`core_config` / `analytics` / `integration` — and the long-lived token and the dashboard are
WebSocket commands. No browser and nothing interactive. It deliberately handles a *blank*
instance only: onboarding answers once and refuses afterwards, so pointing it at an instance
somebody uses fails rather than changes it. The config entry is left to
`scripts/ws_init_haventory.py`, which already answers that flow from its own returned schema.

Refs #366 (item 4). Items 1 and 3 are S7's.

## Guard tests

Generalised over both scheduled workflows, since they now share a pattern:

- **`test_a_scheduled_workflow_reports_no_required_contexts`** — neither has a
  `pull_request` trigger, so neither reports a check the ruleset would have to name. Worse
  here than for `ha-latest`: this one boots Home Assistant twice.
- **`test_a_scheduled_workflow_is_dispatchable_and_on_its_own_slot`** — both triggers, and
  a cron slot each (05:00 and 06:00 on the 8th) so the two do not contend for runners.
- **`test_the_scheduled_runs_do_not_share_a_notification_label`** — one label between them
  would have each workflow closing the other's report.
- **`test_the_card_smoke_opts_into_the_online_test`** — this job's own green-and-worthless
  mode. Without `RUN_ONLINE` the smoke prints SKIP and exits 0, so the job would boot Home
  Assistant twice, drive nothing and pass. The flag has to be on the step that runs the
  smoke, not merely somewhere in the file.
- **`test_every_notification_label_is_declared_as_code`** — `gh issue create` refuses a
  label the repository does not have (verified: it validates before opening, and opens
  nothing). A label named in a workflow and missing from `.github/labels.yml` is the
  notification failing on the month it is needed.

## Decisions taken against the issue's wording

1. **A second workflow, not a second job in `ha-latest.yml`.** #366 says "the same cron,
   the same 'open or update a pinned issue on failure' handling … reuse whatever that issue
   builds". The *pattern* is reused verbatim; the file is not. Folding a card smoke into a
   workflow named `ha-latest` would make its name a lie, and its `notify` job would have to
   distinguish which half failed before it could pick a label.
2. **Its own `ci:card-smoke` label.** Sharing `ci:ha-latest` would make each workflow's
   success close the other's open report. That is what
   `test_the_scheduled_runs_do_not_share_a_notification_label` now prevents.
3. **An hour after `ha-latest`, not the same minute.** "Same cron" is about the day, and two
   simultaneous scheduled workflows contend for the same runner pool.
4. **The channel that failed is named on the run page, not in the issue title.** A matrix
   job's outputs collide (last leg wins), so a title claiming a version could name the wrong
   channel's. Each leg writes its own resolved Home Assistant version into its step summary
   instead, and the issue links the run.

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1279 passed, 22
      skipped**; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` → clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` → **1868 passed**, `npm run build`.
- [x] `actionlint` (the digest-pinned image CI uses) over the whole workflow tree → clean.
- [x] **The whole chain rehearsed locally, end to end, against a container booted exactly
      the way the workflow boots one** (`ghcr.io/home-assistant/home-assistant:stable`, the
      checkout's integration directory mounted read-only):
      1. `uv run python scripts/ci_provision_ha.py --base-url http://localhost:8124` →
         owner created, onboarding answered, long-lived token minted, dashboard created,
         card at `/haventory-smoke/cards`.
      2. `uv run python scripts/ws_init_haventory.py` → `{"ok": true, "integration_version":
         "0.6.0", "schema_version": 9}`.
      3. `RUN_ONLINE=1 node e2e/live-updates.smoke.mjs --path /haventory-smoke/cards` →
         **PASS**: created item appeared live, rename reflected live, deletion reflected
         live, no card console errors.
      Re-running the provisioning against the now-onboarded instance fails, as intended.

The dispatch itself, on both channels, is the live check after merge — its step summaries
go in the handover.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — five guard tests, each covering a way the job could be green and
      worthless or actively harmful.
- [x] Docs updated — one README bullet under CI/CD & Ops beside `ha-latest`'s.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Follow-ups

- The `ci:card-smoke` label is created by the `labels` workflow when this lands on `main`,
  the same way `ci:ha-latest` was.
- The smoke's Chromium is deliberate. Card *registration* is only proven in Firefox — HA
  swaps `window.customElements` during boot and Chromium wins that race — but this job
  asserts live updates in an already-registered card, which is a stable Chromium path.
  Adding a Firefox registration leg is a separate question and is not filed: no real install
  has reported it, and it would be a new job rather than a change to this one.
