### PR TITLE
ci: print the card smoke's Home Assistant version into the log, not only the summary

### DIFF
--- a/.github/workflows/card-smoke.yml
+++ b/.github/workflows/card-smoke.yml
@@ -86,6 +86,9 @@ jobs:
           version=$(curl -fsS -H "Authorization: Bearer ${{ steps.provision.outputs.token }}" \
             http://localhost:8123/api/config | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          # Into the log as well as the summary: a job summary is only readable in
+          # the browser, and the log is what a failing month gets grepped for.
+          echo "Home Assistant ${version} (channel ${{ matrix.channel }})"
           {
             echo "### Card smoke against Home Assistant ${{ matrix.channel }}"
             echo


### PR DESCRIPTION
## Summary

The card smoke writes the Home Assistant version it drove into `$GITHUB_STEP_SUMMARY`, which is only readable in the browser — nothing in the REST API returns a job summary. So the one fact the run exists to establish could not be read back from a script, and the log, which is what a failing month gets grepped for, did not carry it.

One `echo` beside the summary write. Caught by dispatching the workflow: both channels passed, and confirming *which* Home Assistant each drove meant opening the run page.

Refs #366

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1279 passed, 22 skipped; `ruff check`, `ruff format --check`, `mypy` → clean.
- [x] Frontend: `npx eslint .`, `npm run typecheck`, `npx vitest run` → 1868 passed, `npm run build`.
- [x] `actionlint` (the digest-pinned image CI uses) → clean.
- [x] Re-dispatched after merge; the versions are in the handover.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — none: the existing guard tests already hold this workflow's triggers, contexts, label and `RUN_ONLINE` flag, and a log line is not a behaviour any of them should pin.
- [x] Docs updated — no behaviour change.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

---

## Handover

### 1. Merged / left open

All four merged and their branches deleted; nothing is left open for the owner.

- **#527** — `test(integration): cover the debounced persist, the downgrade refusal, the error envelope and the retired-files sweep against real HA` (closes **#208**)
- **#528** — `ci: run the integration suite against the newest Home Assistant monthly` (closes **#227**)
- **#529** — `ci: drive the card's live smoke against Home Assistant stable and beta on a schedule` (refs **#366** item 4)
- **#530** — this one: the card smoke's Home Assistant version into the log as well as the summary (refs **#366**)

**#366 stays open on items 1 and 3**, which are S7's. Item 4 is done and green — the recorded
cut line was not reached, so no comment was left on the issue and nothing was re-filed to V0.8.0.

### 2. Test this by hand

**Nothing by hand.** Everything this session shipped is machine-checked, and both scheduled
workflows were dispatched and are green:

- `ha-latest` — [run 32474151557](https://github.com/chrreiter/HAventory/actions/runs/32474151557):
  resolved **Home Assistant 2026.8.2** (phacc unpinned), derived frontend wheel
  `home-assistant-frontend==20260729.7`, **135 passed**. The floor run in `ci.yml` is still
  green at 2026.6.0, also 135.
- `card-smoke` — [run 32475250376](https://github.com/chrreiter/HAventory/actions/runs/32475250376):
  both legs green. `stable` → **Home Assistant 2026.8.2**, `beta` → **Home Assistant 2026.8.2**,
  each reporting *created item appeared live / rename reflected live / deletion reflected live*
  with no card console errors. (Both channels point at the same release today — no beta cycle
  is open. The beta leg starts saying something different the moment one is.)
- Neither notifier opened an issue, which is the correct behaviour on a green run with nothing
  outstanding; the branching of both was rehearsed against a stub `gh` across all five paths.

### 3. Decisions taken against drifted notes

- **#208, the "no `data` key" control case.** Unreachable as written — `_context_from_msg`
  always returns at least `{"op": …}`, so every `ws_guard` refusal carries `data`. The control
  is Home Assistant's *own* pre-handler refusal (`invalid_format`), which carries none.
- **#208, the retired-files probe.** `_PACKAGE_DIR` is redirected at `tmp_path` rather than
  writing probe files into the checkout being tested; the executor, the setup ordering and the
  escape guard are exercised either way.
- **#208, "no 'Task was destroyed but it is pending' in caplog".** That message comes from
  asyncio's `Task.__del__` at GC and cannot be asserted in a test body; phacc's `verify_cleanup`
  already fails a leaking test. Asserted instead: the task is finished with no exception after
  an unload inside a five-minute debounce, and the cancel line names what ended it.
- **#208, `ERR_ID_REUSE` / `ERR_UNKNOWN_COMMAND`.** A case each was cheap, so both are covered
  rather than named in Follow-ups.
- **#227, an existing test failed against latest.** `panel_custom` gained a `handle_safe_area`
  default in 2026.8 and `test_the_sidebar_panel_lands_in_the_real_panel_registry` asserted the
  `_panel_custom` block by equality. Relaxed to a subset in the same PR: what the test is about
  is the block *this integration asked for*, and failing a monthly run on a key HA chose for
  itself would train the reader to ignore it.
- **#227, the step-summary wording.** It does not name `requirements-integration.txt`, because
  the guard test greps every `run:` block for that filename and keeping the guard blunt is worth
  more than the sentence.
- **#366 item 4, a second workflow rather than a second job.** The *pattern* is reused verbatim;
  folding a card smoke into a file named `ha-latest` would make its name a lie and force its
  `notify` job to work out which half failed. It gets its own `ci:card-smoke` label for the same
  reason — one shared label would have each workflow closing the other's report — and its own
  cron slot an hour later so the two do not contend for runners.

### 4. Follow-ups

None filed. Two named and deliberately not filed:

- **A Firefox leg for the card smoke.** Card *registration* is only proven in Firefox (HA swaps
  `window.customElements` during boot and Chromium wins that race); the smoke asserts live
  updates in an already-registered card, which is a stable Chromium path. No real install has
  reported a registration failure, and this would be a new job rather than a change to the
  existing one — below CLAUDE.md's real-world bar.
- **Stale `.git/worktrees` entries in this clone** (`wt-s11`, `wt432`) make every `git fetch`
  print `Permission denied`. A local host wart from earlier sessions; it affects no install and
  no CI run.

### 5. State left behind

- **Dev Home Assistant (`localhost:8123`): untouched.** Nothing this session ran pointed at it —
  the rehearsals used a separate container on **8124** with `HAVENTORY_IGNORE_ENV_FILE=1`
  throughout. Verified afterwards: `items_total=1087 locations_total=89`, container still up,
  profile language unchanged.
- **Containers removed**: the rehearsal HA (`hav-ci-ha`) and the phacc harness (`hav-int`). The
  `hav-int-venv` Docker volume is kept, so the next session's first
  `scripts/test_integration.sh` re-provisions in about a minute rather than three.
- **Branches**: all four deleted on merge. `main` is at `507281b`, working tree clean.
- **Two new labels exist on the repository**: `ci:ha-latest` and `ci:card-smoke`, both synced by
  the `labels` workflow when `.github/labels.yml` landed. `gh issue create` refuses an unknown
  label, so a workflow naming one that is missing fails rather than opening an unlabelled issue —
  which is what `test_every_notification_label_is_declared_as_code` now prevents.
- **The scheduled dates.** Both workflows next fire automatically on **2026-09-08**, `ha-latest`
  at 05:00 UTC and `card-smoke` at 06:00 UTC. A failure on the 8th is **drift against a newer
  Home Assistant, not a regression in whatever pull request is open that day** — each opens or
  updates its own pinned issue and says so in the body.
