### PR TITLE
fix(card): keep the location tree's tally whole when an area name is long

### DIFF
--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -423,6 +423,24 @@ describe('hv-location-tree: area grouping', () => {
     expect(heads(el)[0].querySelector('[data-icon="home"]')).toBeTruthy();
   });
 
+  // The band's name is the thing that shortens when it outgrows the column —
+  // the tally beside it has to stay whole, because a clipped number reads as a
+  // smaller one and nothing says it was cut. What elision takes, the title
+  // gives back, the way the sidebar's category and tag rows do it.
+  it('keeps the full area name reachable when the band has to shorten it', async () => {
+    const el = await mountAreas({
+      areas: [{ id: 'area-kitchen', name: 'Ground Floor Utility Room' }, AREAS[1]],
+    });
+    const kitchen = heads(el).find((h) => h.dataset.area === 'area-kitchen');
+    const holder = kitchen?.querySelector('.area-name');
+    expect(holder?.getAttribute('title')).toBe('Ground Floor Utility Room');
+    expect(holder?.querySelector('.hv-chip-text')?.textContent).toBe('Ground Floor Utility Room');
+    // The band for the locations no area claims is a heading like any other,
+    // and names itself rather than reading `null` out of a missing group.
+    const none = heads(el).find((h) => h.dataset.area === 'no-area');
+    expect(none?.querySelector('.area-name')?.getAttribute('title')).toBe('No area');
+  });
+
   it('leaves an inventory that assigns no areas exactly as it was', async () => {
     const el = await mount();
     expect(heads(el)).toEqual([]);

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -615,9 +615,12 @@ export class HVLocationTree extends LitElement {
     const pickable = this.areaSelectable && group !== null;
     const selected =
       pickable && this.selectedAreaId === group.id && !this._anySelected() && !this.orphansSelected;
+    const name = group?.name ?? 'No area';
     const label = group
       ? renderAreaChip(group.name)
-      : html`<span class="hv-area-chip quiet area-none">No area</span>`;
+      : html`<span class="hv-area-chip quiet area-none"
+          ><span class="hv-chip-text">${name}</span></span
+        >`;
 
     return html`<div
       class="row hv-browse-row area-head ${selected ? 'selected' : ''} ${pickable ? 'selectable' : ''}"
@@ -635,9 +638,7 @@ export class HVLocationTree extends LitElement {
             class="twisty hv-browse-row-lead"
             data-testid="tree-area-twisty"
             data-area=${group?.id ?? NO_AREA_KEY}
-            aria-label=${open
-              ? `Collapse ${group?.name ?? 'No area'}`
-              : `Expand ${group?.name ?? 'No area'}`}
+            aria-label=${open ? `Collapse ${name}` : `Expand ${name}`}
             @click=${(e: Event) => {
               e.stopPropagation();
               this._toggleArea(key);
@@ -650,11 +651,12 @@ export class HVLocationTree extends LitElement {
             class="area-name"
             data-testid="tree-area-select"
             data-area=${group.id}
+            title=${name}
             @click=${() => this._emit('select-area', { areaId: group.id })}
           >
             ${label}
           </button>`
-        : html`<span class="area-name">${label}</span>`}
+        : html`<span class="area-name" title=${name}>${label}</span>`}
       ${this.showCounts ? this._renderAreaCount(roots) : null}
     </div>`;
   }

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -59,6 +59,35 @@ export const chip = css`
   }
 
   /*
+   * The two chips whose label a household writes — a status it named, an HA
+   * area it named — and which therefore have no length this card can rely on.
+   *
+   * Both have to be allowed to shrink for their label to elide at all: the
+   * metrics above hold every chip at flex: none, which is right beside other
+   * chips and wrong inside a box narrower than the chip. Left unshrunk they do
+   * not merely spill — the location tree's area band painted its name over the
+   * tally beside it, and a clipped number reads as a smaller one with nothing
+   * to say it was cut.
+   *
+   * The elision belongs on the label, not on the box around it: the chip is an
+   * inline-flex container, so text-overflow on an ancestor cannot reach into it
+   * and text-overflow on the chip itself does nothing. As a flex item the label
+   * is a block container already, so only the shrink and the overflow are
+   * needed. The glyph and the screen-reader word stay outside the label, which
+   * is why every caller renders the name in its own element.
+   */
+  .hv-area-chip,
+  .hv-status-chip {
+    max-width: 100%;
+  }
+  .hv-area-chip > .hv-chip-text,
+  .hv-status-chip > .hv-chip-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /*
    * Pressable. Reads as an empty outline until it carries a hue or is applied,
    * so a row of them says "these are choices" rather than "these are facts".
    *
@@ -196,20 +225,6 @@ export const chip = css`
     gap: 4px;
     background: var(--hv-status-bg, var(--hv-tone-neutral-bg));
     color: var(--hv-status-fg, var(--hv-tone-neutral-fg));
-    /* A household names its own statuses, so a label can outrun the column it
-       sits in. The chip must be allowed to shrink for the label to elide at
-       all — the metrics above hold every chip at flex: none, which is right
-       beside other chips and wrong inside a cell narrower than this one. */
-    max-width: 100%;
-  }
-  /* Elision has to happen on the label, not on the cell around it: the chip is
-     an inline-flex box, and text-overflow on an ancestor cannot reach into one
-     — the label was hard-cut mid-word instead. As a flex item the label is a
-     block container already, so only the shrink and the overflow are needed. */
-  .hv-status-chip > .hv-chip-text {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
   /* Selected, it keeps its own colour — the hue is what says which status was
      picked, so painting it primary blue erases the answer at the moment it is

--- a/cards/haventory-card/src/ui/location-path.test.ts
+++ b/cards/haventory-card/src/ui/location-path.test.ts
@@ -181,6 +181,19 @@ describe('renderAreaChip', () => {
     expect(chipOf('Kitchen')?.querySelector('.hv-sr-only')?.textContent).toContain('Area');
   });
 
+  // A household names its areas in Home Assistant, so the name can outrun the
+  // box the chip lands in. The wrapper is what the shared rule in ui/chip.ts
+  // elides — without it text-overflow has nothing to act on inside an
+  // inline-flex chip, and the name paints over whatever sits to its right.
+  it('wraps the name so it can elide inside a narrow box', () => {
+    const label = chipOf('Ground Floor Utility Room')?.querySelector('.hv-chip-text');
+    expect(label?.textContent).toBe('Ground Floor Utility Room');
+    // The glyph and the screen-reader word stay outside it: eliding those
+    // would drop the half of the chip that costs nothing to keep.
+    expect(label?.querySelector('svg')).toBe(null);
+    expect(label?.querySelector('.hv-sr-only')).toBe(null);
+  });
+
   it('renders nothing when the location resolves to no area', () => {
     expect(chipOf(null)).toBe(null);
   });

--- a/cards/haventory-card/src/ui/location-path.ts
+++ b/cards/haventory-card/src/ui/location-path.ts
@@ -141,10 +141,15 @@ export function areaMarkName(areaName: string | null, path: string): string | nu
  *
  * The glyph carries that distinction visually and is decorative, so the word
  * "Area" is spelled out for anyone who cannot see it.
+ *
+ * The name sits in its own element because a household writes it and it can
+ * outrun the box the chip lands in: that element is what the shared rule in
+ * `ui/chip` elides, and text-overflow has nothing to act on without it.
  */
 export function renderAreaChip(areaName: string | null): TemplateResult | null {
   if (!areaName) return null;
   return html`<span class="hv-area-chip" data-testid="area-chip"
-    >${icon('home', 12)}<span class="hv-sr-only">Area: </span>${areaName}</span
+    >${icon('home', 12)}<span class="hv-sr-only">Area: </span
+    ><span class="hv-chip-text">${areaName}</span></span
   >`;
 }


### PR DESCRIPTION
## Summary

In the full view's sidebar location tree, an area chip could not shrink, so a long area
name ran past its row and painted over the tally to its right. Measured live on the dev
instance at the default 264px sidebar: `Area: Ground Floor Utility Room` is a 189.3px chip
in a 170.6px slot and overran the tally by **12.8px**, covering the leading digit — `41 / 41`
read as `1 / 41`. A wrong number, not a cosmetic clip: nothing on screen says the figure
was cut.

The area chip now elides its name the way the status chip already does, and for the same
reason — a household writes both labels, so neither has a length the card can rely on:

- `renderAreaChip` puts the name in its own element (`.hv-chip-text`). `text-overflow` has
  no effect on an inline-flex container and cannot reach into one, so without that element
  there is nothing for the ellipsis to act on.
- The shrink-and-elide rule in `ui/chip.ts` moves up out of the status-chip block and now
  covers both chips. No new CSS — the same four declarations, one selector wider.
- The location tree's area band carries the full name as a `title`, so what elision takes
  stays reachable, the way the sidebar's category and tag rows do it.

The tally is `flex: none` already and needed no change; it now draws in full and the name
is what shortens.

Closes #426

## Before / after

Dev instance, `/haventory`, 1920px viewport, 264px sidebar, a search active so the band
shows a `matching / total` pair:

![the area band before and after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/426-sidebar.png)

The whole sidebar column, [before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/426-before-full.png)
and [after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/426-after-full.png).

Measured in the DOM, same page, same data (chip right edge minus tally left edge; positive
means the chip is over the number):

| band | chip | slot | overlap before | overlap after |
| --- | --- | --- | --- | --- |
| `Ground Floor Utility Room` | 189.3px → 170.6px | 170.6px | **+12.8px** | **−6.0px** (the row's own gap) |
| `Bedroom` | 89.0px | 157.5px | −74.5px | −74.5px |
| `Kitchen` | 79.8px | 157.5px | −83.7px | −83.7px |
| `Küche` | 71.7px | 183.6px | −118.0px | −118.0px |
| `Living Room` | 109.0px | 157.5px | −54.5px | −54.5px |
| `No area` | 65.1px | 157.5px | −98.4px | −98.4px |

Only the band that overran moved. Every other band is unchanged to the tenth of a pixel.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1261 passed, 22 skipped;
      `uv run ruff check .` → all checks passed; `uv run ruff format --check .` → 183 files
      already formatted; `uv run mypy` → no issues in 26 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → 1728 passed across 62 files, `npm run build` clean.

phacc: not involved — nothing here crosses into `custom_components/`.

### New tests

- `renderAreaChip` wraps the name so it can elide, and keeps the glyph and the
  screen-reader word out of the wrapper (the half that costs nothing to keep).
- The location tree's area band exposes the full name as a `title`, and the band for
  locations no area claims names itself rather than reading `null` out of a missing group.

Layout itself is not assertable in jsdom, so the pixel proof is the live measurement above.

### Live checks

Dev HA (`2026.7.4`, 1087 items / 89 locations), branch built and deployed, served bundle
hash verified against the local build:

- **Registration, in Firefox** — the browser where it is a real test, since Chromium wins
  HA's `customElements` swap race: `haventory-card` and `haventory-panel` both in the
  registry, `window.customCards` carries the card, the `haventory` icon set is registered,
  50 rows rendered on the card and 50 in the panel's table. No console or page error from
  the card bundle (HA's own `app.*.js` throws twice in Firefox on its own — the stacks are
  entirely inside HA's bundle).
- **Live-update smoke** — `RUN_ONLINE=1 node e2e/live-updates.smoke.mjs`: create, rename and
  delete out of band all reflected live. PASS.
- **Whole-surface regression** — `visual_pass.mjs` before and after, 42/42 surfaces captured
  each time, pixel-diffed. Of the 40 shots: **25 byte-identical**, **14** differing by 6–7
  antialiased pixels on the chip's right edge (the label gaining its own box changes the
  text measurement by a fraction of a pixel), and **one** — `p-03-search`, the panel's own
  filtered state — showing the fix, `0 / 41` covered before and whole after. Every mobile
  (`m-*`) and panel-mobile (`pm-*`) surface is byte-identical.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated.
- [x] Docs: no behaviour a doc describes changed.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Decisions taken against drifted notes

- **The fix is in the chip vocabulary, not in the tree.** The issue describes the tree's
  area row, and the same chip is rendered by `hv-data-table`, `hv-detail-sheet`,
  `hv-full-view`, `hv-item-editor`, `hv-list-row` and `hv-organize-dialog`. Capping the
  chip there rather than in one component's stylesheet means a long area name elides
  wherever it is printed instead of overflowing whatever sits beside it; the surface pass
  above is what checks that this costs the other six nothing.
- **`title` on the band is beyond what the issue asks for.** The issue asks only that the
  tally stay whole. Eliding without a tooltip would make the full name unreachable on that
  surface, and the rows the issue holds up as the model — the sidebar's category and tag
  rows — carry one. Added, and stated here rather than in the issue.
- **No drifted file references.** `hv-location-tree.ts`, `ui/chip.ts` and
  `ui/location-path.ts` are all where the issue's prose implies.

## Follow-ups

None.

## Handover

**1. Merged / left open**

All three merged by the session, branches deleted; nothing is waiting on the owner.

- [#533](https://github.com/chrreiter/HAventory/pull/533) — `fix(card): keep the location tree's tally whole when an area name is long` (closes [#426](https://github.com/chrreiter/HAventory/issues/426))
- [#534](https://github.com/chrreiter/HAventory/pull/534) — `feat(card): show the row thumbnail in the full view and the sidebar panel` (closes [#490](https://github.com/chrreiter/HAventory/issues/490))
- [#535](https://github.com/chrreiter/HAventory/pull/535) — `refactor(card): name the Home Assistant contact surface in one module and hold `ha-*` at zero` (closes [#366](https://github.com/chrreiter/HAventory/issues/366))

**2. Test this by hand**

1. `[desktop]` Open the full view (or `/haventory`) and read the location tree's
   `Ground Floor Utility Room` band. **Expect:** the tally on the right is whole — the name
   is what shortens, ending in an ellipsis, with the full name on hover. Narrow the window
   until other bands shorten too; no number should ever be clipped.
2. `[phone]` The same band on a phone. The sidebar is hidden at 375px, so reach it through
   the full view's location rail. **Expect:** the same — name shortens, number whole.
3. `[desktop]` Browse the panel and the full view. **Expect:** rows with a photo carry the
   same small picture the card's list rows show, at the same size; rows without a photo
   look exactly as before, with no empty square and no shifted name.
4. `[desktop]` **The one judgment worth your eye:** find a row that is *checked out* **and**
   has a photo, with a name over about 18 characters. **Expect:** the name now ends in an
   ellipsis where it did not before — the picture and the "Checked out" chip share the name
   column with it. The full name is still on hover. The PR body prices the two ways of
   buying it back (both cost every row's Location and Tags, one of them adds a sideways
   scroll at the panel's most common width) — tell me if the shortening reads as too
   aggressive and it becomes an issue.
5. `[phone]` The same rows at phone width, where the table pins the name column and scrolls
   the rest sideways. **Expect:** the picture rides with the pinned name and nothing else
   moved.
6. `[desktop]` Dashboard → edit → the HAventory card → **Configure**. **Expect:** a `TITLE`
   field that types normally, updates the preview heading live, and saves; emptying it hands
   the heading back to the integration option. This field is the card's own control now
   rather than HA's `ha-form`, so it is worth one look — including in your dark theme.

Everything else the harness proved: both gates green on each PR
([#533](https://github.com/chrreiter/HAventory/pull/533),
[#534](https://github.com/chrreiter/HAventory/pull/534),
[#535](https://github.com/chrreiter/HAventory/pull/535) each carry their numbers), CI green
including hassfest and the integration job, card registration checked **in Firefox** on
each PR, the live-update smoke green on each, and `visual_pass.mjs` diffed pixel-for-pixel
across all 40 surfaces per PR.

**3. Decisions taken against drifted notes**

- **#426 is fixed in the chip vocabulary, not in the tree** — the same chip is drawn by six
  other components, and capping it there means a long area name elides wherever it is
  printed. The band also gained a `title`, which the issue did not ask for; eliding without
  one would have made the full name unreachable.
- **#490's column template did **not** move**, against §6.7's instruction. Measured: the
  42px reserve pushes the panel's *default* table into a sideways scroll at the 1360px
  content box the docked HA sidebar leaves, and a 34px one puts Location and Tags on their
  floors while still eliding the same names. Both prices land on every row, including the
  98% with no photo. Full numbers in [#534](https://github.com/chrreiter/HAventory/pull/534).
- **#366's `ha-*` row was not zero** — the card editor had rendered `ha-form` since 0.4.1,
  added in #374 the day after the audit that recorded the row as `none`. Removed rather than
  allowed by name, which is what the issue's own reasoning asks for.
- **#366's counts are stale in the card's favour** — `callWS` is already down to one module
  (43 sites, all in `store/ws.ts`, none in a component), and the theme surface is 15
  variables rather than 8. Both are recorded in the contract module and swept by its test.
- **#366 item 4 landed in S5** (#529, #530), so PR 3 closes the issue rather than referencing
  it.

**4. Follow-ups**

None filed. Two named and deliberately not filed, both in
[#534](https://github.com/chrreiter/HAventory/pull/534) and
[#535](https://github.com/chrreiter/HAventory/pull/535):

- A row with **both** a picture and an inline chip elides names past about 18 characters at
  the panel's docked width. It is the trade #490 takes rather than a defect, the full name
  is in the cell's `title`, and the alternatives are priced — but it is hand-test 4 above,
  because it is the one thing here a person should judge rather than a measurement.
- The card editor's `Title` label is uppercased by the card's own `.hv-label`, where HA's
  form drew it in sentence case. One label in one dialog; a one-line change if you would
  rather it matched HA's.

**5. State left behind**

- **Dev HA** — restored. Six probe items with pictures were created to measure the name
  column and deleted again; the store is back at **1087 items / 89 locations** with no
  `S7NAME` or `e2e_smoke` rows. The `dashboard-dev` config is byte-identical (the editor
  probe typed a title but never saved). Rate limiting untouched, language untouched. The
  container currently serves the **PR 3 branch build**, which is `main` as of #535 — redeploy
  from `main` if anything else has landed since.
- **Branches** — all three feature branches deleted on merge. One orphan branch survives on
  purpose: **`claude-assets-v0-7-0-s7`**, holding the screenshots the three PR bodies link
  to. It is never merged; delete it only if those bodies stop mattering.
- **Next session** — S8 (#190, German) starts from `main`. Its 52-file sweep now also has
  `cards/haventory-card/src/ha-contract.ts` and `CONTRIBUTING.md`'s no-`ha-*` rule in the
  tree; neither carries user-facing strings. The card editor's `Title` label is a new
  user-facing string that S8 will want to translate, and it is the card's own text now
  rather than HA's form label.
