### PR TITLE
feat(card): show the row thumbnail in the full view and the sidebar panel

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -1,6 +1,15 @@
 import './hv-data-table';
-import { all, componentCss, makeItem, mountComponent, q } from '../test.utils';
+import {
+  all,
+  componentCss,
+  makeAttachment,
+  makeItem,
+  makeMediaBindings,
+  mountComponent,
+  q,
+} from '../test.utils';
 import { ACTIONS_COLUMN_WIDTH } from '../store/columns';
+import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { toIsoDate } from '../ui/relative-time';
 import { rowMenuEntries } from './hv-list-row';
 import type { HVDataTable } from './hv-data-table';
@@ -303,6 +312,65 @@ describe('hv-data-table: the name cell picks one chip', () => {
     expect(q(el, '.name-cell')?.textContent).toContain('Checked out');
   });
 
+});
+
+describe('hv-data-table: row thumbnail', () => {
+  it('shows the first picture beside the name, at the card list row’s own box', async () => {
+    const media = makeMediaBindings();
+    const el = await mount(
+      [{ id: 'i-thumb', name: 'Cordless drill', attachments: [makeAttachment({ id: 'att-1' })] }],
+      { media },
+    );
+    // One more frame: the signed URL arrives from a resolved promise.
+    await el.updateComplete;
+    await el.updateComplete;
+
+    const img = q(el, '[data-testid="row-thumb"]') as HTMLImageElement | null;
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute('src')).toBe(
+      `/api/haventory/media/i-thumb/att-1?${MEDIA_NAME_TOKEN_PARAM}=`
+        + `${attachmentNameToken(makeAttachment({ id: 'att-1' }))}&authSig=test`,
+    );
+    expect(img?.getAttribute('alt')).toBe('Photo of Cordless drill');
+    // Nothing is thumbnailed server-side, so the browser must be told not to
+    // fetch and decode every row's full-size photo at once.
+    expect(img?.getAttribute('loading')).toBe('lazy');
+    expect(img?.getAttribute('decoding')).toBe('async');
+    // It leads the cell: a picture after the name would be a second column of
+    // ragged marks rather than the thing the eye lands on first.
+    expect(q(el, '.name-cell')?.firstElementChild).toBe(img);
+  });
+
+  // A placeholder here would add a column of empty squares to a mostly
+  // photo-less inventory — and would spend the name's floor on every row.
+  it('renders no image element at all for a row without a picture', async () => {
+    const el = await mount([{ id: '1', name: 'Screws' }], { media: makeMediaBindings() });
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="row-thumb"]')).toBeNull();
+    expect(el.shadowRoot?.querySelector('img')).toBeNull();
+  });
+
+  // The panel and the card are two hosts of the same table; one that was never
+  // handed the signer must not render broken images.
+  it('shows nothing rather than a broken image without a signer', async () => {
+    const el = await mount([{ id: '1', attachments: [makeAttachment()] }]);
+    await el.updateComplete;
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="row-thumb"]')).toBeNull();
+  });
+
+  it('ignores a non-picture attachment', async () => {
+    const el = await mount(
+      [{ id: '1', attachments: [makeAttachment({ kind: 'manual', mime: 'application/pdf' })] }],
+      { media: makeMediaBindings() },
+    );
+    await el.updateComplete;
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="row-thumb"]')).toBeNull();
+  });
 });
 
 describe('hv-data-table: sorting', () => {

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -12,6 +12,8 @@ import {
   normalizeColumns,
   tableTemplateFor,
 } from '../store/columns';
+import { MediaUrls, ROW_THUMB_SIZE, attachmentNameToken, pictureAlt, pictures } from '../ui/media';
+import type { MediaBindings } from '../ui/media';
 import { getDefaultOrderFor } from '../store/sort';
 import type { AreaRef, StatusDefinition } from '../store/types';
 import type { ColumnKey } from '../store/columns';
@@ -167,6 +169,22 @@ export class HVDataTable extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+      /* The same box the card's list rows draw, so one item is the same size
+         and shape whichever surface it is browsed on. Fixed, so a portrait
+         photo and a landscape one leave the row the same height; and rendered
+         only where there is a picture, so a mostly photo-less inventory does
+         not grow a column of empty squares — and so the name keeps its whole
+         floor on every row that has no photo to spend it on. What the picture
+         costs the name on the rows that do have one, and why the column's floor
+         does not grow to cover it, is on NAME_COLUMN_SIZE. */
+      .thumb {
+        flex: none;
+        width: ${unsafeCSS(ROW_THUMB_SIZE)}px;
+        height: ${unsafeCSS(ROW_THUMB_SIZE)}px;
+        border-radius: 6px;
+        object-fit: cover;
+        background: var(--hv-surface-raised);
       }
       /*
        * A phone shows about a quarter of this table — the template's floor is
@@ -402,6 +420,36 @@ export class HVDataTable extends LitElement {
   /** HA areas, to name the one each item's location resolves to. */
   @property({ attribute: false }) areas: AreaRef[] = [];
   @property({ attribute: false }) selection: Set<string> = new Set();
+  /** Picture access; null means the rows show no thumbnails. */
+  @property({ attribute: false }) media: MediaBindings | null = null;
+
+  private readonly _urls = new MediaUrls(this);
+
+  protected willUpdate() {
+    this._urls.configure(this.media?.sign ?? null);
+  }
+
+  /**
+   * A row's leading thumbnail: the item's first picture, or nothing.
+   *
+   * The full-size file is what loads — nothing is thumbnailed server-side — so
+   * `loading="lazy"` and `decoding="async"` are what keep a long table from
+   * fetching and decoding every row's photo at once.
+   */
+  private _renderThumb(item: Item) {
+    const first = pictures(item.attachments)[0];
+    if (!first) return null;
+    const src = this._urls.get(item.id, first.id, attachmentNameToken(first));
+    if (!src) return null;
+    return html`<img
+      class="thumb"
+      data-testid="row-thumb"
+      src=${src}
+      alt=${pictureAlt(item.name, 0, 1)}
+      loading="lazy"
+      decoding="async"
+    />`;
+  }
 
   /**
    * `row`, `columnheader` and `cell` are only meaningful under a table, grid or
@@ -651,6 +699,7 @@ export class HVDataTable extends LitElement {
                       >`
                     : null}
                   <span class="name-cell" role="cell">
+                    ${this._renderThumb(item)}
                     <span class="name" data-testid="table-name" title=${item.name}>${item.name}</span>
                     ${isLowStock(item) && !item.checked_out
                       ? html`<span

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -2098,6 +2098,7 @@ export class HVFullView extends LitElement {
             <hv-data-table
               .statuses=${this.st?.statuses ?? null}
               .areas=${st?.areasCache?.areas ?? []}
+              .media=${this.media}
               data-testid="full-table"
               .items=${(st?.items ?? []) as Item[]}
               .columns=${this.columns}

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -1,4 +1,4 @@
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
@@ -6,7 +6,15 @@ import { areaMarkName, itemPathParts, pathTitle, renderAreaChip } from '../ui/lo
 import { icon } from '../ui/icons';
 import { formatDate, isDue, isOverdue } from '../ui/relative-time';
 import { itemStatus, renderStatusChip, statusLabel } from '../ui/status';
-import { MediaUrls, attachmentNameToken, manuals, pictureAlt, pictures } from '../ui/media';
+import {
+  MediaUrls,
+  ROW_THUMB_SIZE,
+  ROW_THUMB_SIZE_TOUCH,
+  attachmentNameToken,
+  manuals,
+  pictureAlt,
+  pictures,
+} from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import type { AreaRef, Item, StatusDefinition } from '../store/types';
 import './hv-overflow-menu';
@@ -153,15 +161,15 @@ export class HVListRow extends LitElement {
          inventory would otherwise grow a column of empty squares. */
       .thumb {
         flex: none;
-        width: 34px;
-        height: 34px;
+        width: ${unsafeCSS(ROW_THUMB_SIZE)}px;
+        height: ${unsafeCSS(ROW_THUMB_SIZE)}px;
         border-radius: 6px;
         object-fit: cover;
         background: var(--hv-surface-raised);
       }
       :host([mobile]) .thumb {
-        width: 40px;
-        height: 40px;
+        width: ${unsafeCSS(ROW_THUMB_SIZE_TOUCH)}px;
+        height: ${unsafeCSS(ROW_THUMB_SIZE_TOUCH)}px;
       }
       /* A mark, not a chip: that an item has a manual is a fact about it, not
          a state anyone has to act on, so it stays out of the hue vocabulary the

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -12,6 +12,7 @@ import {
   tableTemplateFor,
 } from './columns';
 import type { ColumnKey } from './columns';
+import { ROW_THUMB_SIZE } from '../ui/media';
 
 describe('columns model', () => {
   beforeEach(() => {
@@ -305,6 +306,22 @@ describe('table column widths', () => {
   // an Updated column holding nothing but "—".
   it('renders an ordinary name whole at the width the sidebar panel gets', () => {
     expect(nameWidthOf(PANEL_GRID_AT_1920)).toBeGreaterThanOrEqual(ORDINARY_NAME_WIDTH);
+  });
+
+  // The panel is also where the whole default set has to fit, and it does, with
+  // room over — which is what keeps Location and Tags off their floors and the
+  // table free of a sideways scroll at the width it is most often read at.
+  //
+  // That room is smaller than a row's leading thumbnail, which is why the name
+  // column's floor is not widened to hold one: the picture comes out of the
+  // name's own floor on the rows that have a picture, rather than out of every
+  // row's Location and Tags. See NAME_COLUMN_SIZE.
+  it('fits the whole default set inside the box the sidebar panel gives it', () => {
+    const template = tableTemplateFor([...DEFAULT_COLUMNS], { selectable: false });
+    const gaps = 8 * (template.split(/\s+(?![^(]*\))/).length - 1);
+    const slack = PANEL_GRID_AT_1920 - (minWidthOf(template) + gaps);
+    expect(slack).toBeGreaterThan(0);
+    expect(slack).toBeLessThan(ROW_THUMB_SIZE + 8);
   });
 
   // The name is fed from Category, the flexible column carrying one word, and

--- a/cards/haventory-card/src/store/columns.ts
+++ b/cards/haventory-card/src/store/columns.ts
@@ -167,6 +167,18 @@ const COLUMN_TABLE_SIZE: Record<ColumnKey, string> = Object.fromEntries(
  * whether a name ends or elides: it holds an ordinary one of about 35
  * characters, which is 245px at the row's 13.5px text.
  *
+ * A row carrying a picture spends 42px of that floor on the leading thumbnail
+ * — the `ROW_THUMB_SIZE` box and the cell's gap — and the floor is deliberately
+ * *not* widened to hold both. Widening it by that much is what the panel cannot
+ * afford: at the 1360px content box the docked HA sidebar leaves it, the
+ * default column set has 34px of slack, so a 42px reserve puts the table into a
+ * sideways scroll at the width it is most often read at and drops Location and
+ * Tags from 152px each onto their floors — on every row, including the ones
+ * with no picture at all. Against that, the reserve would buy the guarantee
+ * back from ~31 characters to ~35, on the rows that have a photo, where the
+ * photo is itself what makes the row recognisable. Measured on a 1093-item
+ * inventory: 0.4% of names run past 31 characters.
+ *
  * The growth factor does not outrank the others, and that is the point. A name
  * is one line of text with an end to it; a path and a tag set are not. Past the
  * floors every extra pixel goes to Location and Tags, whose cells wrap — which

--- a/cards/haventory-card/src/ui/media.ts
+++ b/cards/haventory-card/src/ui/media.ts
@@ -47,6 +47,21 @@ export const MEDIA_NAME_TOKEN_PARAM = 'v';
  */
 export const SIGNED_URL_TTL_SECONDS = 1800;
 
+/**
+ * The box a row's leading thumbnail draws in, on every surface that shows one.
+ *
+ * One number rather than one per component: the full view's table has to
+ * reserve this much inside its name column, and a box that outgrew the reserve
+ * would take the width back out of the name.
+ */
+export const ROW_THUMB_SIZE = 34;
+
+/**
+ * The same box where a finger is the pointer. A phone shows one column of rows
+ * and can spend the extra six pixels on making the picture legible.
+ */
+export const ROW_THUMB_SIZE_TOUCH = 40;
+
 /** Re-sign this long before expiry, so an in-flight request never lands late. */
 const REFRESH_MARGIN_MS = 60_000;
 


### PR DESCRIPTION
## Summary

The card's compact list shows an item's first picture beside its name — the thing that
makes a row recognisable at a glance. The full view and the sidebar panel, the two surfaces
most people browse in, showed nothing of the kind: `hv-data-table`'s name cell was text only
and the component never imported `ui/media` at all.

It does now, on the same path the list row uses:

- The same `MediaBindings` / `MediaUrls` pair — `hv-full-view` already builds the bindings
  for its editor and detail sheet, so the table is handed the one that exists rather than a
  second one.
- The same fixed box and radius, `loading="lazy"`, `decoding="async"`, and the signed URL
  the media route requires.
- **Nothing at all for a row without a picture** — no placeholder, so a mostly photo-less
  inventory does not grow a column of empty squares, and a row with no photo keeps the whole
  name column.

The box is one exported constant now (`ROW_THUMB_SIZE`), read by the card's list rows and by
the table, so the two cannot drift apart on the number the column budget is reasoned about.

Closes #490

## The measurement the issue asked for, and the decision it forced

> a thumbnail that costs the name its last word on a common width is the wrong trade

Taken on the dev instance at `/haventory`, **full column set** (all nine, forced through the
picker's own stored record), at the three widths §6.7 names. The name column resolves to its
250px floor at every one of them — with the full set the fixed columns take enough that each
flexible track freezes on its minimum, so the floor is the whole answer.

| | table box | name track before | name track after | name **text** after |
| --- | --- | --- | --- | --- |
| HA sidebar docked, 1920 | 1400px | 250px | 250px | 208px |
| HA sidebar hidden, 1920 | 1656px | 250px | 250px | 208px |
| narrow branch | 375px | 250px | 250px | 208px |

No track moves. What moves is the text inside the cell on the rows that carry a picture:
42px of the floor (a 34px box and the cell's 8px gap) goes to the photo. Graded probe names,
measured at the docked width (`shown` / `needed`, in px):

| name | before | after |
| --- | --- | --- |
| 20 chars | 143 / 143 | 143 / 143 |
| 25 chars | 186 / 186 | 186 / 186 |
| 30 chars | 210 / 210 | 208 / 210 — 2px short |
| 35 chars | 233 / 233 | 208 / 233 — 25px short |
| 40 chars | 250 / 264 — already 14px short | 208 / 264 |
| 45 chars | 250 / 298 — already 48px short | 208 / 298 |

So the guarantee narrows from about 37 characters to about 31, **on rows that have a
picture**. Measured against the instance's 1093 real items: median name 17 characters, p90
20, and **0.4% run past 31**.

### Where it does cost a word

The name cell also holds the inline chip — Low, or Checked out, or the status when that
column is off — and that chip takes its width before the name does. On a row carrying both a
picture and a "Checked out" chip, the ceiling drops to about 18 characters. Nine photo-bearing
rows, before and after:

![a checked-out row with a photo](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/490-chip-rows.png)

`QA-08 Label Printer` (−1px), `QA-04 Torque Wrench` (−14px) and `QA-03 Extension Ladder`
(−28px) elide where they did not before; `QA-02 Circular Saw` still fits. All three carry the
"Checked out" chip. The full name stays in the cell's `title`.

### Why the column template did not move

§6.7 says that if the name loses its last word, "the column template moves, not the
thumbnail". It was tried, measured, and **rejected** — both sizes cost more than they buy:

| reserve | what it does |
| --- | --- |
| **+42px** (box + gap, floor 292px) | The default set's minimum goes 1254 → 1296px. With the nine 8px gaps that is 1368px against the 1360px content box the docked HA sidebar leaves — so the panel's *default* table starts scrolling sideways at the width it is most often read at, and Location and Tags drop from 152px each onto their 140/130 floors. On every row, including the ones with no picture. |
| **+34px** (box only, floor 284px) | Fits exactly, no scroll — but Location and Tags land on their floors just the same, and `QA-03 Extension Ladder` still elides: 142px of text for a name needing 146. It buys nothing and costs every row. |

Neither price is worth a guarantee that reaches 0.4% of names, and the rows that pay are the
ones the picture itself identifies. The reasoning is recorded on `NAME_COLUMN_SIZE`, where
the next reader will look for it, and a new test pins the budget that forbids the reserve —
the default set fits the panel's box with less slack than a thumbnail.

## Before / after

Same rows, same column set, same widths. Rows with no picture are unchanged and grow no
placeholder:

**Docked HA sidebar, 1400px table**

![docked](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/490-docked.png)

**Hidden HA sidebar, 1656px table**

![hidden](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/490-hidden.png)

**375px**

![375px](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/490-narrow.png)

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1261 passed, 22 skipped;
      `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → 1733 passed across 62 files, `npm run build` clean.

phacc: not involved — nothing here crosses into `custom_components/`.

### New tests

`hv-data-table`, four cases: a row with a picture renders `row-thumb` with the signed URL,
the item's alt text, `loading="lazy"` and `decoding="async"`, and leads the cell; a row
without one renders no `<img>` at all; a table given no signer renders nothing rather than a
broken image; a manual is not a picture.

`columns`: the default set fits the box the sidebar panel gives it, with less slack than a
thumbnail — which is the budget that decides the section above, and what fails if someone
widens the floor to reserve one.

### Live checks

Dev HA `2026.7.4`, 1093 items / 89 locations, branch built and deployed, served bundle hash
verified against the local build.

- **Registration, in Firefox** — the only browser where it is a real test:
  `haventory-card` and `haventory-panel` in the registry, `window.customCards` carrying the
  card, the `haventory` icon set registered, 50 rows on the card and 50 in the panel's table,
  no console or page error from the card bundle.
- **Live-update smoke** — `RUN_ONLINE=1 node e2e/live-updates.smoke.mjs`: create, rename and
  delete out of band all reflected live. PASS.
- **Thumbnail attributes, read off the live DOM** — 34×34px box, `loading="lazy"`,
  `decoding="async"`, `src` carrying `authSig`, on all 15 photo-bearing rows of the probe set
  and on all three widths.
- **Whole-surface regression** — `visual_pass.mjs` against `main` and against this branch on
  the same data, 42/42 surfaces each, pixel-diffed: **all 40 shots byte-identical**. None of
  the rows those surfaces happen to show carries a picture, which makes the run the control
  this change most needed — across every card, full-view and panel surface at desktop and
  phone width, a photo-less row is pixel-for-pixel what it was. No placeholder, no shifted
  name, no changed row height.
- **The card's own list rows are unchanged** — its 34/40px boxes became reads of the shared
  constant, and the mobile list still draws them: 9 thumbnails on the probe search, 0 broken,
  no failed response.

  ![the card's list rows, unchanged](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/490-card-list-unchanged.png)

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated.
- [x] Docs: `docs/frontend_architecture.md` describes components, not per-cell contents; no
      documented behaviour changed.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Decisions taken against drifted notes

- **The column template does not move**, against §6.7's instruction — measured, with both
  candidate reserves priced, in the section above. This is the one judgment §6.7 said to take
  here.
- **The thumbnail's box is now a constant** rather than a literal in each row component. The
  issue asks for "the same fixed box"; two literals in two files is how that stops being true,
  and the column budget is reasoned about in terms of that number.
- **`hv-full-view` hands the table the `MediaBindings` it already builds** — the issue notes
  the view "already receives the bindings for its detail sheet and editor", and it does; no
  second builder was added.
- **No drifted file references.** `hv-list-row._renderThumb`, `hv-data-table`'s
  `data-testid="table-name"` cell and `NAME_COLUMN_SIZE` are all where the issue says.

## Follow-ups

Named, deliberately not filed: **a row carrying both a picture and an inline chip elides
names past about 18 characters** at the panel's docked width, as the section above shows.
It is the trade this PR takes rather than a defect — the full name is in the cell's `title`,
the card's own list rows have always behaved this way, and the alternatives are priced above
— but it is the thing to look at first if the shortening reads as too aggressive in use. It
is in the handover's hand-test list for exactly that reason.

## Handover

**1. Merged / left open**

All three merged by the session, branches deleted; nothing is waiting on the owner.

- [#533](https://github.com/chrreiter/HAventory/pull/533) — `fix(card): keep the location tree's tally whole when an area name is long` (closes [#426](https://github.com/chrreiter/HAventory/issues/426))
- [#534](https://github.com/chrreiter/HAventory/pull/534) — `feat(card): show the row thumbnail in the full view and the sidebar panel` (closes [#490](https://github.com/chrreiter/HAventory/issues/490))
- [#535](https://github.com/chrreiter/HAventory/pull/535) — `refactor(card): name the Home Assistant contact surface in one module and hold `ha-*` at zero` (closes [#366](https://github.com/chrreiter/HAventory/issues/366))

**2. Test this by hand**

1. `[desktop]` Open the full view (or `/haventory`) and read the location tree's
   `Ground Floor Utility Room` band. **Expect:** the tally on the right is whole — the name
   is what shortens, ending in an ellipsis, with the full name on hover. Narrow the window
   until other bands shorten too; no number should ever be clipped.
2. `[phone]` The same band on a phone. The sidebar is hidden at 375px, so reach it through
   the full view's location rail. **Expect:** the same — name shortens, number whole.
3. `[desktop]` Browse the panel and the full view. **Expect:** rows with a photo carry the
   same small picture the card's list rows show, at the same size; rows without a photo
   look exactly as before, with no empty square and no shifted name.
4. `[desktop]` **The one judgment worth your eye:** find a row that is *checked out* **and**
   has a photo, with a name over about 18 characters. **Expect:** the name now ends in an
   ellipsis where it did not before — the picture and the "Checked out" chip share the name
   column with it. The full name is still on hover. The PR body prices the two ways of
   buying it back (both cost every row's Location and Tags, one of them adds a sideways
   scroll at the panel's most common width) — tell me if the shortening reads as too
   aggressive and it becomes an issue.
5. `[phone]` The same rows at phone width, where the table pins the name column and scrolls
   the rest sideways. **Expect:** the picture rides with the pinned name and nothing else
   moved.
6. `[desktop]` Dashboard → edit → the HAventory card → **Configure**. **Expect:** a `TITLE`
   field that types normally, updates the preview heading live, and saves; emptying it hands
   the heading back to the integration option. This field is the card's own control now
   rather than HA's `ha-form`, so it is worth one look — including in your dark theme.

Everything else the harness proved: both gates green on each PR
([#533](https://github.com/chrreiter/HAventory/pull/533),
[#534](https://github.com/chrreiter/HAventory/pull/534),
[#535](https://github.com/chrreiter/HAventory/pull/535) each carry their numbers), CI green
including hassfest and the integration job, card registration checked **in Firefox** on
each PR, the live-update smoke green on each, and `visual_pass.mjs` diffed pixel-for-pixel
across all 40 surfaces per PR.

**3. Decisions taken against drifted notes**

- **#426 is fixed in the chip vocabulary, not in the tree** — the same chip is drawn by six
  other components, and capping it there means a long area name elides wherever it is
  printed. The band also gained a `title`, which the issue did not ask for; eliding without
  one would have made the full name unreachable.
- **#490's column template did **not** move**, against §6.7's instruction. Measured: the
  42px reserve pushes the panel's *default* table into a sideways scroll at the 1360px
  content box the docked HA sidebar leaves, and a 34px one puts Location and Tags on their
  floors while still eliding the same names. Both prices land on every row, including the
  98% with no photo. Full numbers in [#534](https://github.com/chrreiter/HAventory/pull/534).
- **#366's `ha-*` row was not zero** — the card editor had rendered `ha-form` since 0.4.1,
  added in #374 the day after the audit that recorded the row as `none`. Removed rather than
  allowed by name, which is what the issue's own reasoning asks for.
- **#366's counts are stale in the card's favour** — `callWS` is already down to one module
  (43 sites, all in `store/ws.ts`, none in a component), and the theme surface is 15
  variables rather than 8. Both are recorded in the contract module and swept by its test.
- **#366 item 4 landed in S5** (#529, #530), so PR 3 closes the issue rather than referencing
  it.

**4. Follow-ups**

None filed. Two named and deliberately not filed, both in
[#534](https://github.com/chrreiter/HAventory/pull/534) and
[#535](https://github.com/chrreiter/HAventory/pull/535):

- A row with **both** a picture and an inline chip elides names past about 18 characters at
  the panel's docked width. It is the trade #490 takes rather than a defect, the full name
  is in the cell's `title`, and the alternatives are priced — but it is hand-test 4 above,
  because it is the one thing here a person should judge rather than a measurement.
- The card editor's `Title` label is uppercased by the card's own `.hv-label`, where HA's
  form drew it in sentence case. One label in one dialog; a one-line change if you would
  rather it matched HA's.

**5. State left behind**

- **Dev HA** — restored. Six probe items with pictures were created to measure the name
  column and deleted again; the store is back at **1087 items / 89 locations** with no
  `S7NAME` or `e2e_smoke` rows. The `dashboard-dev` config is byte-identical (the editor
  probe typed a title but never saved). Rate limiting untouched, language untouched. The
  container currently serves the **PR 3 branch build**, which is `main` as of #535 — redeploy
  from `main` if anything else has landed since.
- **Branches** — all three feature branches deleted on merge. One orphan branch survives on
  purpose: **`claude-assets-v0-7-0-s7`**, holding the screenshots the three PR bodies link
  to. It is never merged; delete it only if those bodies stop mattering.
- **Next session** — S8 (#190, German) starts from `main`. Its 52-file sweep now also has
  `cards/haventory-card/src/ha-contract.ts` and `CONTRIBUTING.md`'s no-`ha-*` rule in the
  tree; neither carries user-facing strings. The card editor's `Title` label is a new
  user-facing string that S8 will want to translate, and it is the card's own text now
  rather than HA's form label.
