### PR TITLE
refactor(card): name the Home Assistant contact surface in one module and hold `ha-*` at zero

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,17 @@ plus `actionlint`, `hassfest`, HACS validation, CodeQL, and dependency review.
   goes in one of the two, and neither is a tracker: work lives in GitHub issues.
 - **Preserve the core invariants**: case-insensitive search, denormalized
   `location_path` on items, and optimistic concurrency via the item `version`.
+- **The card renders no `ha-*` element.** Home Assistant's frontend components
+  — `ha-form`, `ha-dialog`, `ha-selector`, `ha-data-table` — are registered
+  lazily inside HA's own bundle, are not published for card authors to import,
+  and are not versioned, so a card that renders one depends on an internal that
+  moves. None of them exists in jsdom either, which means the break arrives as a
+  user report after an upgrade rather than as a red test. Build the control out
+  of the card's own elements and `--hv-*` tokens instead; the glyphs are inlined
+  in `ui/icons` for the same reason.
+  `cards/haventory-card/src/ha-contract.ts` names everything the card *does* ask
+  of Home Assistant, and its test holds this rule — and that file's list of
+  theme variables and WebSocket calls — to the sources.
 - **Deleting or renaming a file inside `custom_components/haventory/`?** Add its
   old path to `RETIRED_PATHS` in `custom_components/haventory/stale_files.py` in
   the same PR — an upgrade extracts the release asset over the install directory

--- a/cards/haventory-card/src/ha-contract.test.ts
+++ b/cards/haventory-card/src/ha-contract.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { HA_THEME_VARS, SURFACE_VARS, registerCustomCard } from './ha-contract';
+
+/**
+ * The contract in `ha-contract.ts` is only worth writing if it stays true, and
+ * the only thing that can keep it true is a sweep of the sources. These read
+ * the tree the way `tests/test_min_ha_version.py` reads it for the Home
+ * Assistant floor: enumerate what may name a thing, and fail when something
+ * else does.
+ */
+
+const SRC = join(__dirname);
+
+function sourceFiles(dir: string = SRC): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (!entry.name.endsWith('.ts')) return [];
+    if (entry.name.endsWith('.test.ts')) return [];
+    if (entry.name.startsWith('test.')) return [];
+    return [path];
+  });
+}
+
+const read = (path: string) => readFileSync(path, 'utf8');
+const relative = (path: string) => path.slice(SRC.length + 1).replace(/\\/g, '/');
+
+/**
+ * The sweeps below are about what the card *renders*, and a comment renders
+ * nothing — `ui/icons` names `<ha-icon>` to explain why the glyphs are inlined
+ * instead, which is the rule being kept rather than broken. The `[^:]` guard
+ * keeps a `https://` inside a string from swallowing the rest of its line.
+ */
+const code = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+
+describe('the Home Assistant contact surface', () => {
+  // The value of this row of the contract is that it is empty. HA's frontend
+  // components are registered lazily inside its own bundle, are not published
+  // for card authors, and are not versioned — and none of them exists in jsdom,
+  // so one rendered here would break after a user's upgrade rather than in CI.
+  // It did happen: the card editor rendered `ha-form` for one text field for a
+  // release, which is the shape of regression this exists to catch.
+  it('renders no ha-* element anywhere in the card', () => {
+    const offenders: string[] = [];
+    for (const path of sourceFiles()) {
+      const source = code(read(path));
+      // A tag being opened, not a word: `<ha-form`, `</ha-dialog>`,
+      // `document.createElement('ha-selector')`.
+      const matches = [
+        ...source.matchAll(/<\/?ha-[a-z0-9-]+/g),
+        ...source.matchAll(/createElement\(\s*['"`]ha-[a-z0-9-]+/g),
+      ];
+      for (const match of matches) offenders.push(`${relative(path)}: ${match[0]}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // Every one of these is read with a fallback of its own, which is what makes
+  // a renamed Home Assistant variable cost the binding and not the card. A
+  // binding added without a line in the contract would be a dependency nobody
+  // had recorded — so this sweeps every source file, not only `ui/tokens`.
+  it('binds no Home Assistant theme variable the contract does not name', () => {
+    const bound = new Set<string>();
+    for (const path of sourceFiles()) {
+      for (const match of code(read(path)).matchAll(/var\((--[a-z0-9_-]+)/gi)) {
+        // The card's own tokens are not Home Assistant's.
+        if (!match[1].startsWith('--hv-')) bound.add(match[1]);
+      }
+    }
+    expect([...bound].sort()).toEqual([...HA_THEME_VARS].sort());
+  });
+
+  it('probes the surface with variables the contract names', () => {
+    for (const name of SURFACE_VARS) expect(HA_THEME_VARS).toContain(name);
+  });
+
+  // `callWS` and `subscribeMessage` are Home Assistant's, so the card names
+  // them in one place and every caller goes through the wrappers there. A
+  // second call site is a second thing to find when an upgrade breaks one.
+  it('reaches Home Assistant through the contract and nowhere else', () => {
+    const offenders: string[] = [];
+    for (const path of sourceFiles()) {
+      if (relative(path) === 'ha-contract.ts') continue;
+      const source = code(read(path));
+      for (const match of source.matchAll(/\.callWS\b|\.connection\.subscribeMessage\b|window\.customCards/g)) {
+        offenders.push(`${relative(path)}: ${match[0]}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('registerCustomCard', () => {
+  beforeEach(() => {
+    delete window.customCards;
+  });
+
+  it("adds the entry Home Assistant's picker reads", () => {
+    registerCustomCard({ type: 'haventory-card', name: 'HAventory', description: 'x' });
+    expect(window.customCards).toEqual([
+      { type: 'haventory-card', name: 'HAventory', description: 'x' },
+    ]);
+  });
+
+  // The bundle can be evaluated twice on one page — a Lovelace resource and an
+  // extra module URL are the same file loaded two ways — and a second entry
+  // would show the card twice in the picker.
+  it('does not add the same card twice', () => {
+    registerCustomCard({ type: 'haventory-card', name: 'HAventory', description: 'x' });
+    registerCustomCard({ type: 'haventory-card', name: 'HAventory', description: 'x' });
+    expect(window.customCards).toHaveLength(1);
+  });
+
+  // The list belongs to the instance, not to this card.
+  it("leaves another card's entry alone", () => {
+    const other = { type: 'other-card', name: 'Other', description: 'y' };
+    window.customCards = [other];
+    registerCustomCard({ type: 'haventory-card', name: 'HAventory', description: 'x' });
+    expect(window.customCards[0]).toBe(other);
+    expect(window.customCards).toHaveLength(2);
+  });
+});

--- a/cards/haventory-card/src/ha-contract.ts
+++ b/cards/haventory-card/src/ha-contract.ts
@@ -1,0 +1,180 @@
+/**
+ * Everything this card asks of Home Assistant, in one file.
+ *
+ * The rest of the card does not talk to Home Assistant. It renders its own
+ * elements, styles them from its own `--hv-*` tokens, and reaches the backend
+ * through the client in `store/ws`, which reaches Home Assistant through the
+ * two functions below. So when an upgrade breaks the card, this is the file to
+ * open: whatever moved is named here or the card was not using it.
+ *
+ * The whole surface:
+ *
+ * | what | why it is safe to depend on |
+ * | --- | --- |
+ * | `hass.callWS` | the frontend's own command channel, unchanged for years |
+ * | `hass.connection.subscribeMessage` | the same channel's subscription half |
+ * | `hass.fetchWithAuth` | the only way to POST attachment bytes to core's `/api/file_upload` |
+ * | `window.customCards` | how every custom card has advertised itself to the picker |
+ * | `setConfig` / the `hass` setter | the Lovelace card lifecycle itself |
+ * | the theme variables below | read with a fallback each, so a rename costs the binding and not the card |
+ *
+ * And one row that is deliberately empty:
+ *
+ * **The card renders no `ha-*` element.** Home Assistant's frontend components
+ * — `ha-form`, `ha-dialog`, `ha-selector`, `ha-data-table` — are registered
+ * lazily inside HA's own bundle, are not published for card authors to import,
+ * and are not versioned. A card that renders one depends on an internal that
+ * moves, and it breaks after an upgrade rather than in CI: `ha-form` does not
+ * exist in jsdom, so the unit suite would stay green while the card was broken
+ * in the browser. Every glyph the card draws is inlined in `ui/icons` and
+ * `ui/brand-icon` for the same reason, which also makes icons assertable in
+ * Vitest. `ha-contract.test.ts` sweeps the sources and fails on a match, and
+ * `CONTRIBUTING.md` carries the rule.
+ */
+
+import type { AnyEventPayload, Unsubscribe } from './store/types';
+
+export type { Unsubscribe };
+
+/**
+ * The part of the `hass` object this card uses, structurally.
+ *
+ * Structural rather than an import of Home Assistant's own type: the frontend
+ * publishes no package a card can depend on, and naming only what is used means
+ * a field the card never reads cannot break it.
+ */
+export interface HassLike {
+  /** Home Assistant's `callWS` returns the `result` part of the message. */
+  callWS<T>(msg: Record<string, unknown>): Promise<T>;
+  /**
+   * `fetch` with the user's auth header attached — the only way to POST to
+   * core's `/api/file_upload`, which is how attachment bytes reach the server
+   * without crossing the WebSocket. Optional because this interface is
+   * structural: a caller that never uploads need not provide it.
+   */
+  fetchWithAuth?(path: string, init?: RequestInit): Promise<Response>;
+  connection: {
+    /**
+     * Home Assistant delivers the *inner* event payload to the callback (the
+     * `event` field of the `{id, type:'event', event}` wire frame), not the
+     * whole envelope. A mock that delivered the envelope once kept the unit
+     * suite green while the card had stopped reflecting live changes, which is
+     * why `e2e/live-updates.smoke.mjs` exists.
+     */
+    subscribeMessage(
+      cb: (event: AnyEventPayload) => void,
+      msg: Record<string, unknown>,
+    ): Unsubscribe | Promise<Unsubscribe>;
+    /**
+     * Connection lifecycle. `disconnected` fires when the socket closes, before
+     * Home Assistant starts reconnecting; `ready` fires once it is back and HA
+     * has re-issued the subscriptions it was holding, so a listener runs with
+     * the watches already live again. Optional because the interface is
+     * structural: a caller may pass a connection that only sends messages.
+     */
+    addEventListener?(event: 'ready' | 'disconnected', cb: () => void): void;
+    removeEventListener?(event: 'ready' | 'disconnected', cb: () => void): void;
+  };
+}
+
+/** Send one command over Home Assistant's WebSocket and take its `result`. */
+export function callWS<T>(hass: HassLike, msg: Record<string, unknown>): Promise<T> {
+  return hass.callWS<T>(msg);
+}
+
+/**
+ * Open one subscription over the same socket.
+ *
+ * Home Assistant returns either the unsubscribe function or a promise of one,
+ * depending on how far the connection has got, so the caller has to handle both
+ * — this hands back exactly what HA gave rather than papering over it, since a
+ * component that awaited unconditionally would leak a subscription it never
+ * managed to close.
+ */
+export function subscribeMessage(
+  hass: HassLike,
+  cb: (event: AnyEventPayload) => void,
+  msg: Record<string, unknown>,
+): Unsubscribe | Promise<Unsubscribe> {
+  return hass.connection.subscribeMessage(cb, msg);
+}
+
+/** One entry in Home Assistant's card picker. */
+export interface CustomCardMeta {
+  type: string;
+  name: string;
+  description: string;
+  preview?: boolean;
+  /** The picker entry's "documentation" link. */
+  documentationURL?: string;
+}
+
+declare global {
+  interface Window {
+    customCards?: CustomCardMeta[];
+  }
+}
+
+/**
+ * Advertise a card to Home Assistant's picker.
+ *
+ * The list is shared with every other custom card on the instance, so it is
+ * appended to rather than replaced, and an entry is added only once — the
+ * bundle can be evaluated twice on one page, and a second entry would show the
+ * card twice in the picker.
+ *
+ * Does nothing outside a browser, so importing the bundle in a test or a build
+ * step is not a registration.
+ */
+export function registerCustomCard(meta: CustomCardMeta): void {
+  if (typeof window === 'undefined') return;
+  window.customCards = window.customCards || [];
+  if (window.customCards.some((c) => c?.type === meta.type)) return;
+  window.customCards.push(meta);
+}
+
+/**
+ * The Home Assistant theme variables the card binds, and the only ones.
+ *
+ * Every one is read with a fallback of its own, so a variable Home Assistant
+ * renames costs that binding and not the card — the token falls back to its
+ * literal and the card keeps its own palette. That is the whole reason this
+ * list can be a note rather than a worry.
+ *
+ * `ha-contract.test.ts` sweeps every source file for a `var(--…)` that is not
+ * one of the card's own `--hv-*`, so a binding added anywhere without a line
+ * here fails rather than going unrecorded.
+ */
+export const HA_THEME_VARS = [
+  // Surfaces, text, lines and the accent — bound in `ui/tokens`, one `--hv-*`
+  // token each.
+  '--card-background-color',
+  '--ha-card-background',
+  '--primary-background-color',
+  '--primary-text-color',
+  '--secondary-text-color',
+  '--text-primary-color',
+  '--divider-color',
+  '--primary-color',
+  '--error-color',
+  '--input-fill-color',
+  // Shape and type, so the card sits in a theme's own card geometry.
+  '--ha-card-border-radius',
+  '--ha-card-font-family',
+  '--paper-font-body1_-_font-family',
+  // The two the card and the sidebar panel set their own body type from, so a
+  // host page's text metrics do not decide the card's.
+  '--mdc-typography-body2-font-size',
+  '--mdc-typography-body2-line-height',
+] as const;
+
+/**
+ * The subset that describes the surface the card is drawn on, most specific
+ * first — the ones `--hv-surface` binds to, and the ones `ui/theme` reads back
+ * to decide which `color-scheme` the card is living in.
+ */
+export const SURFACE_VARS = [
+  '--card-background-color',
+  '--ha-card-background',
+  '--primary-background-color',
+] as const;

--- a/cards/haventory-card/src/haventory-card-editor.test.ts
+++ b/cards/haventory-card/src/haventory-card-editor.test.ts
@@ -1,16 +1,7 @@
 import './haventory-card-editor';
 import type { HAventoryCardEditor, HAventoryCardConfig } from './haventory-card-editor';
+import { DEFAULT_CARD_TITLE } from './ui/card-title';
 import { mountComponent } from './test.utils';
-
-// jsdom does not define `ha-form` — Home Assistant does, at runtime — so the
-// node stays an unknown element. That is exactly the seam worth testing: what
-// Lit sets on it going in, and what this element makes of the event HA's own
-// control dispatches coming back.
-type Form = HTMLElement & {
-  schema?: { name: string }[];
-  data?: HAventoryCardConfig;
-  computeLabel?: () => string;
-};
 
 async function mount(config: HAventoryCardConfig) {
   const { el } = await mountComponent<
@@ -21,14 +12,14 @@ async function mount(config: HAventoryCardConfig) {
   return el;
 }
 
-const formOf = (el: { shadowRoot: ShadowRoot }) =>
-  el.shadowRoot.querySelector('[data-testid="card-editor-form"]') as Form;
+const titleOf = (el: { shadowRoot: ShadowRoot }) =>
+  el.shadowRoot.querySelector('[data-testid="card-editor-title"]') as HTMLInputElement;
 
-/** What HA's own `ha-form` raises when a field is edited. */
-const edit = (form: Form, value: Record<string, unknown>) =>
-  form.dispatchEvent(
-    new CustomEvent('value-changed', { detail: { value }, bubbles: true, composed: true }),
-  );
+/** Type into the field the way a person editing the card does. */
+const edit = (input: HTMLInputElement, value: string) => {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+};
 
 function captured(el: HTMLElement) {
   const seen: HAventoryCardConfig[] = [];
@@ -43,19 +34,31 @@ afterEach(() => {
 });
 
 describe('haventory-card-editor', () => {
-  it('puts the title into the form HA renders', async () => {
+  // The card's own input rather than HA's `ha-form`: that control is lazily
+  // registered inside HA's bundle and does not exist in jsdom, so a break would
+  // arrive as a user report after an upgrade rather than as a red test here.
+  it("edits the title with the card's own labelled field", async () => {
     const el = await mount({ type: 'custom:haventory-card', title: 'Pantry' });
-    const form = formOf(el);
-    expect(form.schema?.map((f) => f.name)).toEqual(['title']);
-    expect(form.data?.title).toBe('Pantry');
-    expect(form.computeLabel?.()).toBe('Title');
+    const input = titleOf(el);
+
+    expect(input.value).toBe('Pantry');
+    expect(el.shadowRoot.querySelector('label')?.textContent?.trim()).toBe('Title');
+    expect(el.shadowRoot.querySelector('label')?.getAttribute('for')).toBe(input.id);
+  });
+
+  // The heading a card with no title of its own shows, so the empty field says
+  // what leaving it empty means rather than only that it is empty.
+  it('shows the heading an untitled card falls back to', async () => {
+    const el = await mount({ type: 'custom:haventory-card' });
+    expect(titleOf(el).value).toBe('');
+    expect(titleOf(el).placeholder).toBe(DEFAULT_CARD_TITLE);
   });
 
   it('raises exactly one config-changed, keeping the card type', async () => {
     const el = await mount({ type: 'custom:haventory-card', title: 'Pantry' });
     const seen = captured(el);
 
-    edit(formOf(el), { title: 'Garage shelf' });
+    edit(titleOf(el), 'Garage shelf');
 
     expect(seen).toHaveLength(1);
     expect(seen[0]).toEqual({ type: 'custom:haventory-card', title: 'Garage shelf' });
@@ -73,7 +76,7 @@ describe('haventory-card-editor', () => {
     });
     const seen = captured(el);
 
-    edit(formOf(el), { title: 'Garage shelf' });
+    edit(titleOf(el), 'Garage shelf');
 
     expect(seen[0]).toEqual({
       type: 'custom:haventory-card',
@@ -89,20 +92,9 @@ describe('haventory-card-editor', () => {
     const el = await mount({ type: 'custom:haventory-card', title: 'Pantry' });
     const seen = captured(el);
 
-    edit(formOf(el), { title: '   ' });
+    edit(titleOf(el), '   ');
 
     expect(seen[0]).toEqual({ type: 'custom:haventory-card' });
     expect('title' in seen[0]).toBe(false);
-  });
-
-  it('does not let the form event escape as well as the config change', async () => {
-    const el = await mount({ type: 'custom:haventory-card' });
-    const escaped: Event[] = [];
-    document.addEventListener('value-changed', (e) => escaped.push(e));
-
-    edit(formOf(el), { title: 'Garage shelf' });
-
-    expect(escaped).toHaveLength(0);
-    document.removeEventListener('value-changed', (e) => escaped.push(e));
   });
 });

--- a/cards/haventory-card/src/haventory-card-editor.ts
+++ b/cards/haventory-card/src/haventory-card-editor.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { tokens, base } from './ui/tokens';
+import { DEFAULT_CARD_TITLE } from './ui/card-title';
 import { defineCardElement } from './register';
 import type { HassLike } from './store/types';
 
@@ -12,19 +13,20 @@ export interface HAventoryCardConfig {
 }
 
 /**
+ * The visual editor Home Assistant opens from the card picker.
+ *
  * One field. `setConfig` on the card reads `title` and `quick_filters`, and the
  * pill choice belongs to the integration's options flow instead — the sidebar
  * panel has no dashboard config at all, so a card editor could never reach it.
- */
-const SCHEMA = [{ name: 'title', selector: { text: {} } }];
-
-/**
- * The visual editor Home Assistant opens from the card picker.
  *
- * `ha-form` rather than a local input: it is the frontend's own control, so it
- * takes the dashboard's theming and its layout without this card re-deriving
- * either. The element is not defined here — HA defines it — so nothing in this
- * module may depend on it existing.
+ * The field is the card's own input rather than Home Assistant's `ha-form`.
+ * That control is registered lazily inside HA's bundle, is not published for
+ * card authors and is not versioned, so a card that renders it depends on an
+ * internal that moves — and does not exist in jsdom, which means the break
+ * would arrive as a user report after an upgrade rather than as a red test.
+ * `ha-contract` states that rule for the whole card and `ha-contract.test.ts`
+ * holds it at zero. The card's own tokens bind the dashboard's theme variables,
+ * so a local field still takes the theme it is opened inside.
  *
  * Registered through `defineCardElement` rather than the decorator the `hv-*`
  * components use, because HA instantiates this element by tag name after the
@@ -37,6 +39,13 @@ export class HAventoryCardEditor extends LitElement {
     css`
       :host {
         display: block;
+      }
+      /* HA's own editor dialog stacks its rows with this much between them, so
+         a card editor that grows a second field sits in the same rhythm. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
       }
     `,
   ];
@@ -51,18 +60,18 @@ export class HAventoryCardEditor extends LitElement {
   }
 
   render() {
-    return html`<ha-form
-      data-testid="card-editor-form"
-      .hass=${this.hass}
-      .data=${this._config}
-      .schema=${SCHEMA}
-      .computeLabel=${this._label}
-      @value-changed=${this._onValueChanged}
-    ></ha-form>`;
-  }
-
-  private _label(): string {
-    return 'Title';
+    return html`<div class="field" data-testid="card-editor-form">
+      <label class="hv-label" for="card-editor-title">Title</label>
+      <input
+        id="card-editor-title"
+        class="hv-input"
+        type="text"
+        data-testid="card-editor-title"
+        .value=${typeof this._config.title === 'string' ? this._config.title : ''}
+        placeholder=${DEFAULT_CARD_TITLE}
+        @input=${this._onInput}
+      />
+    </div>`;
   }
 
   /**
@@ -74,9 +83,8 @@ export class HAventoryCardEditor extends LitElement {
    * An emptied title is dropped rather than written as "", which is what hands
    * the heading back to the integration-wide option.
    */
-  private _onValueChanged(event: CustomEvent<{ value?: { title?: unknown } }>): void {
-    event.stopPropagation();
-    const title = event.detail?.value?.title;
+  private _onInput(event: Event): void {
+    const title = (event.target as HTMLInputElement).value;
     const config: HAventoryCardConfig = { ...this._config };
     if (typeof title === 'string' && title.trim() !== '') config.title = title;
     else delete config.title;

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from 'lit';
+import { registerCustomCard } from './ha-contract';
 import type { HassLike } from './store/types';
 import { Store } from './store/store';
 import { resolveColorScheme } from './ui/theme';
@@ -190,32 +191,12 @@ defineCardElement('haventory-card', HAventoryCard);
 // page — including the ones no card is on.
 registerBrandIcon();
 
-// Auto-register with Lovelace card picker when loaded via /local
-interface CustomCardMeta {
-  type: string;
-  name: string;
-  description: string;
-  preview?: boolean;
-  /** The picker entry's "documentation" link. */
-  documentationURL?: string;
-}
-
-declare global {
-  interface Window {
-    customCards?: CustomCardMeta[];
-  }
-}
-
-if (typeof window !== 'undefined') {
-  window.customCards = window.customCards || [];
-  const already = window.customCards.some((c) => c?.type === 'haventory-card');
-  if (!already) {
-    window.customCards.push({
-      type: 'haventory-card',
-      name: 'HAventory',
-      description: 'HAventory inventory card',
-      preview: true,
-      documentationURL: 'https://github.com/chrreiter/HAventory#readme',
-    });
-  }
-}
+// The picker entry, so the card can be added by name rather than by typing
+// `custom:haventory-card` into a YAML editor.
+registerCustomCard({
+  type: 'haventory-card',
+  name: 'HAventory',
+  description: 'HAventory inventory card',
+  preview: true,
+  documentationURL: 'https://github.com/chrreiter/HAventory#readme',
+});

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -615,34 +615,14 @@ export type AnyEventPayload = ItemsEventPayload | LocationsEventPayload | StatsE
 
 export type Unsubscribe = () => void;
 
-/** Minimal Home Assistant-like interface used by the WS client. */
-export interface HassLike {
-  // Home Assistant's callWS returns the `result` part of the message.
-  callWS<T>(msg: Record<string, unknown>): Promise<T>;
-  /**
-   * `fetch` with the user's auth header attached — the only way to POST to
-   * core's `/api/file_upload`, which is how attachment bytes reach the server
-   * without crossing the WebSocket. Optional because this interface is
-   * structural: a caller that never uploads need not provide it.
-   */
-  fetchWithAuth?(path: string, init?: RequestInit): Promise<Response>;
-  // WebSocket connection with subscribeMessage to receive event messages; returns unsubscribe.
-  // Home Assistant delivers the *inner* event payload to the callback (the `event`
-  // field of the `{id, type:'event', event}` wire frame), not the whole envelope.
-  connection: {
-    subscribeMessage(
-      cb: (event: AnyEventPayload) => void,
-      msg: Record<string, unknown>,
-    ): Unsubscribe | Promise<Unsubscribe>;
-    // Connection lifecycle. `disconnected` fires when the socket closes, before
-    // Home Assistant starts reconnecting; `ready` fires once it is back and HA
-    // has re-issued the subscriptions it was holding, so a listener runs with
-    // the watches already live again. Optional because the interface is
-    // structural: a caller may pass a connection that only sends messages.
-    addEventListener?(event: 'ready' | 'disconnected', cb: () => void): void;
-    removeEventListener?(event: 'ready' | 'disconnected', cb: () => void): void;
-  };
-}
+/**
+ * The `hass` object, as much of it as this card uses.
+ *
+ * Defined in `ha-contract`, with every other thing the card asks of Home
+ * Assistant, and re-exported here because this is where the shapes it carries
+ * are declared.
+ */
+export type { HassLike } from '../ha-contract';
 
 /** How a tag selection is combined: any of them, or all of them. */
 export type TagMatchMode = 'any' | 'all';

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -1,3 +1,4 @@
+import { callWS, subscribeMessage } from '../ha-contract';
 import type {
   AnyEventPayload,
   AreasListResult,
@@ -39,23 +40,23 @@ export class WSClient {
 
   // ---------- Utility ----------
   ping(echo?: unknown) {
-    return this.hass.callWS<{ echo: unknown; ts: string }>({ type: 'haventory/ping', echo });
+    return callWS<{ echo: unknown; ts: string }>(this.hass, { type: 'haventory/ping', echo });
   }
 
   version() {
-    return this.hass.callWS<VersionInfo>({ type: 'haventory/version' });
+    return callWS<VersionInfo>(this.hass, { type: 'haventory/version' });
   }
 
   config() {
-    return this.hass.callWS<IntegrationConfig>({ type: 'haventory/config' });
+    return callWS<IntegrationConfig>(this.hass, { type: 'haventory/config' });
   }
 
   stats() {
-    return this.hass.callWS<StatsCounts>({ type: 'haventory/stats' });
+    return callWS<StatsCounts>(this.hass, { type: 'haventory/stats' });
   }
 
   health() {
-    return this.hass.callWS<HealthResult>({ type: 'haventory/health' });
+    return callWS<HealthResult>(this.hass, { type: 'haventory/health' });
   }
 
   /**
@@ -66,12 +67,12 @@ export class WSClient {
   distinctValues(filter?: ItemFilter) {
     const msg: Record<string, unknown> = { type: 'haventory/distinct_values' };
     if (filter) msg.filter = filter;
-    return this.hass.callWS<DistinctValues>(msg);
+    return callWS<DistinctValues>(this.hass, msg);
   }
 
   // ---------- Items ----------
   getItem(itemId: string) {
-    return this.hass.callWS<Item>({ type: 'haventory/item/get', item_id: itemId });
+    return callWS<Item>(this.hass, { type: 'haventory/item/get', item_id: itemId });
   }
   listItems(filter?: ItemFilter, sort?: Sort, limit?: number, cursor?: string) {
     const msg: Record<string, unknown> = { type: 'haventory/item/list' };
@@ -79,48 +80,48 @@ export class WSClient {
     if (sort) msg.sort = sort;
     if (typeof limit === 'number') msg.limit = limit;
     if (cursor) msg.cursor = cursor;
-    return this.hass.callWS<ListItemsResult>(msg);
+    return callWS<ListItemsResult>(this.hass, msg);
   }
 
   createItem(input: ItemCreate) {
-    return this.hass.callWS<Item>({ type: 'haventory/item/create', ...input });
+    return callWS<Item>(this.hass, { type: 'haventory/item/create', ...input });
   }
 
   updateItem(itemId: string, changes: ItemUpdate, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/update', item_id: itemId, ...changes };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   deleteItem(itemId: string, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/delete', item_id: itemId };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<null>(payload);
+    return callWS<null>(this.hass, payload);
   }
 
   adjustQuantity(itemId: string, delta: number, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/adjust_quantity', item_id: itemId, delta };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   setQuantity(itemId: string, quantity: number, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/set_quantity', item_id: itemId, quantity };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   checkOut(itemId: string, dueDate?: string | null, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/check_out', item_id: itemId };
     if (dueDate !== undefined) payload.due_date = dueDate;
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   markCheckedIn(itemId: string, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/check_in', item_id: itemId };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   /**
@@ -136,7 +137,7 @@ export class WSClient {
       item_id: itemId,
     };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   setLowStockThreshold(itemId: string, threshold: number | null, expectedVersion?: number) {
@@ -146,13 +147,13 @@ export class WSClient {
       low_stock_threshold: threshold,
     };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   moveItem(itemId: string, locationId: string | null, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/move', item_id: itemId, location_id: locationId };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   /**
@@ -162,13 +163,13 @@ export class WSClient {
   addTags(itemId: string, tags: string[], expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/add_tags', item_id: itemId, tags };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   removeTags(itemId: string, tags: string[], expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/remove_tags', item_id: itemId, tags };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   updateCustomFields(
@@ -184,7 +185,7 @@ export class WSClient {
     if (set) payload.set = set;
     if (unset) payload.unset = unset;
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   /**
@@ -193,7 +194,7 @@ export class WSClient {
    * no rollback — earlier successes stand.
    */
   bulk(operations: BulkOperation[]) {
-    return this.hass.callWS<BulkResults>({ type: 'haventory/items/bulk', operations });
+    return callWS<BulkResults>(this.hass, { type: 'haventory/items/bulk', operations });
   }
 
   // ---------- Attachments ----------
@@ -239,7 +240,7 @@ export class WSClient {
       filename: file.name,
     };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   /**
@@ -261,7 +262,7 @@ export class WSClient {
       title,
     };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   /**
@@ -284,7 +285,7 @@ export class WSClient {
       attachment_ids: attachmentIds,
     };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   /** Detach one file from an item; the backend deletes the bytes with it. */
@@ -295,7 +296,7 @@ export class WSClient {
       attachment_id: attachmentId,
     };
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return this.hass.callWS<Item>(payload);
+    return callWS<Item>(this.hass, payload);
   }
 
   /**
@@ -309,7 +310,7 @@ export class WSClient {
    * lets the browser cache and evict it normally.
    */
   async signPath(path: string, expires: number): Promise<string> {
-    const signed = await this.hass.callWS<{ path: string }>({
+    const signed = await callWS<{ path: string }>(this.hass, {
       type: 'auth/sign_path',
       path,
       expires,
@@ -319,18 +320,18 @@ export class WSClient {
 
   // ---------- Locations / Areas ----------
   listLocations() {
-    return this.hass.callWS<Location[]>({ type: 'haventory/location/list' });
+    return callWS<Location[]>(this.hass, { type: 'haventory/location/list' });
   }
 
   createLocation(name: string, parentId?: string | null, areaId?: string | null) {
     const msg: Record<string, unknown> = { type: 'haventory/location/create', name };
     if (parentId !== undefined) msg.parent_id = parentId;
     if (areaId !== undefined) msg.area_id = areaId;
-    return this.hass.callWS<Location>(msg);
+    return callWS<Location>(this.hass, msg);
   }
 
   getLocation(locationId: string) {
-    return this.hass.callWS<Location>({ type: 'haventory/location/get', location_id: locationId });
+    return callWS<Location>(this.hass, { type: 'haventory/location/get', location_id: locationId });
   }
 
   /**
@@ -346,15 +347,15 @@ export class WSClient {
     if (changes.name !== undefined) msg.name = changes.name;
     if (changes.areaId !== undefined) msg.area_id = changes.areaId;
     if (changes.newParentId !== undefined) msg.new_parent_id = changes.newParentId;
-    return this.hass.callWS<Location>(msg);
+    return callWS<Location>(this.hass, msg);
   }
 
   deleteLocation(locationId: string) {
-    return this.hass.callWS<null>({ type: 'haventory/location/delete', location_id: locationId });
+    return callWS<null>(this.hass, { type: 'haventory/location/delete', location_id: locationId });
   }
 
   moveLocationSubtree(locationId: string, newParentId: string | null) {
-    return this.hass.callWS<Location>({
+    return callWS<Location>(this.hass, {
       type: 'haventory/location/move_subtree',
       location_id: locationId,
       new_parent_id: newParentId,
@@ -369,11 +370,11 @@ export class WSClient {
   getLocationTree(filter?: ItemFilter) {
     const msg: Record<string, unknown> = { type: 'haventory/location/tree' };
     if (filter) msg.filter = filter;
-    return this.hass.callWS<LocationTreeNode[]>(msg);
+    return callWS<LocationTreeNode[]>(this.hass, msg);
   }
 
   listAreas() {
-    return this.hass.callWS<AreasListResult>({ type: 'haventory/areas/list' });
+    return callWS<AreasListResult>(this.hass, { type: 'haventory/areas/list' });
   }
 
   // ---------- Import / export (data safety) ----------
@@ -381,24 +382,24 @@ export class WSClient {
   exportDocument(filter?: ItemFilter) {
     const msg: Record<string, unknown> = { type: 'haventory/export' };
     if (filter) msg.filter = filter;
-    return this.hass.callWS<ExportDocument>(msg);
+    return callWS<ExportDocument>(this.hass, msg);
   }
 
   /** Validate + classify a document without mutating state. */
   importPreview(document: unknown, policy: ImportPolicy) {
-    return this.hass.callWS<ImportPreview>({ type: 'haventory/import/preview', document, policy });
+    return callWS<ImportPreview>(this.hass, { type: 'haventory/import/preview', document, policy });
   }
 
   /** Apply a document with the chosen conflict policy (rolls back on failure). */
   importExecute(document: unknown, policy: ImportPolicy) {
-    return this.hass.callWS<ImportSummary>({ type: 'haventory/import/execute', document, policy });
+    return callWS<ImportSummary>(this.hass, { type: 'haventory/import/execute', document, policy });
   }
 
   // ---------- Status definitions ----------
 
   /** The status vocabulary in display order. */
   listStatuses() {
-    return this.hass.callWS<StatusDefinition[]>({ type: 'haventory/status/list' });
+    return callWS<StatusDefinition[]>(this.hass, { type: 'haventory/status/list' });
   }
 
   createStatus(status: {
@@ -408,7 +409,7 @@ export class WSClient {
     icon?: string;
     order?: number;
   }) {
-    return this.hass.callWS<StatusDefinition>({ type: 'haventory/status/create', ...status });
+    return callWS<StatusDefinition>(this.hass, { type: 'haventory/status/create', ...status });
   }
 
   /** Edit presentation only — the slug is what items store and cannot change. */
@@ -416,7 +417,7 @@ export class WSClient {
     slug: string,
     changes: { label?: string; color?: StatusColorValue; icon?: string; order?: number },
   ) {
-    return this.hass.callWS<StatusDefinition>({
+    return callWS<StatusDefinition>(this.hass, {
       type: 'haventory/status/update',
       slug,
       ...changes,
@@ -425,7 +426,7 @@ export class WSClient {
 
   /** Rewrite display order. `slugs` must name every status exactly once. */
   reorderStatuses(slugs: string[]) {
-    return this.hass.callWS<StatusDefinition[]>({ type: 'haventory/status/reorder', slugs });
+    return callWS<StatusDefinition[]>(this.hass, { type: 'haventory/status/reorder', slugs });
   }
 
   /**
@@ -436,7 +437,7 @@ export class WSClient {
    * item naming a status that no longer exists.
    */
   deleteStatus(slug: string, reassignTo?: string) {
-    return this.hass.callWS<{ status: StatusDefinition; reassigned: number }>({
+    return callWS<{ status: StatusDefinition; reassigned: number }>(this.hass, {
       type: 'haventory/status/delete',
       slug,
       ...(reassignTo ? { reassign_to: reassignTo } : {}),
@@ -477,7 +478,7 @@ export class WSClient {
     if (opts && 'area_id' in opts) msg.area_id = opts.area_id ?? null;
     if (opts && 'include_subtree' in opts) msg.include_subtree = !!opts.include_subtree;
 
-    const unsubOrPromise = this.hass.connection.subscribeMessage((event) => {
+    const unsubOrPromise = subscribeMessage(this.hass, (event) => {
       // Home Assistant's `subscribeMessage` delivers the *inner* event payload
       // (the `event` field of the `{id, type:'event', event}` wire frame) to the
       // callback — NOT the whole envelope. Guard only against a nullish payload.
@@ -581,7 +582,7 @@ export class WSClient {
     cb: () => void,
     opts?: { onOpen?: () => void; onError?: (err: unknown) => void },
   ): Unsubscribe {
-    const unsubOrPromise = this.hass.connection.subscribeMessage(() => cb(), {
+    const unsubOrPromise = subscribeMessage(this.hass, () => cb(), {
       type: 'subscribe_events',
       event_type: 'area_registry_updated',
     });

--- a/cards/haventory-card/src/ui/theme.ts
+++ b/cards/haventory-card/src/ui/theme.ts
@@ -17,6 +17,8 @@
  * every `hv-*` component without threading anything through them.
  */
 
+import { SURFACE_VARS } from '../ha-contract';
+
 /** Alpha below this reads as "nothing painted here" rather than a real colour. */
 const MIN_OPAQUE_ALPHA = 0.1;
 
@@ -74,13 +76,10 @@ export function schemeForSurface(cssColor: string): 'light' | 'dark' | null {
 
 /**
  * The theme variables that describe the surface the card sits on, most specific
- * first. These are the same ones `--hv-surface` binds to.
+ * first. These are the same ones `--hv-surface` binds to, and they are declared
+ * with the rest of the card's Home Assistant contact surface in `ha-contract`.
  */
-export const SURFACE_VARS = [
-  '--card-background-color',
-  '--ha-card-background',
-  '--primary-background-color',
-] as const;
+export { SURFACE_VARS };
 
 /**
  * The scheme implied by an element's resolved theme variables, or `null` when

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -50,9 +50,10 @@ which HA's custom-panel loader instantiates for the sidebar page. It mirrors the
 store lifecycle and renders `<hv-full-view embedded open>`.
 
 `src/haventory-card-editor.ts` defines `haventory-card-editor` — the bundle's third
-HA-facing element, which `getConfigElement` creates by tag. It renders one `ha-form` field
-for `title`, HA's own control rather than a local input, and turns the form's
-`value-changed` into a `config-changed` carrying `{ ...config, title }`. The spread is the
+HA-facing element, which `getConfigElement` creates by tag. It renders one field for
+`title`, built from the card's own input and `--hv-*` tokens rather than HA's `ha-form`
+(see "The Home Assistant contact surface" below), and turns its `input` event into a
+`config-changed` carrying `{ ...config, title }`. The spread is the
 point: the card ignores unknown keys instead of rejecting them, so `quick_filters` and
 anything a future version writes survive an edit untouched. An emptied title is dropped
 from the config rather than written as `""`, which hands the heading back to the
@@ -79,6 +80,25 @@ Host differences enter as constructor hooks (`onItemDeleted`, `onBrowse`). The p
 those dialogs is not one of them: the instance watches the viewport itself (`NARROW_QUERY`,
 started and stopped from each host's connected/disconnected callbacks) and hands the same
 answer to all five, so the card and the panel cannot disagree about what a phone is.
+
+---
+
+## The Home Assistant contact surface
+
+`src/ha-contract.ts` is the one module that names what the card asks of Home Assistant,
+and the file to open when an upgrade breaks something: the `HassLike` shape, thin wrappers
+for `callWS` and `connection.subscribeMessage`, the `window.customCards` picker
+registration, and the theme variables the card binds. `store/ws.ts` is the only caller of
+the two WebSocket wrappers; `index.ts` is the only caller of the registration; `ui/theme.ts`
+reads `SURFACE_VARS` from here to classify the surface the card is painted on.
+
+The row that matters most is empty: **the card renders no `ha-*` element.** HA's frontend
+components are registered lazily inside its own bundle, are not published for card authors
+and are not versioned, and none of them exists in jsdom — so one rendered here would break
+after a user's upgrade rather than in CI. Every glyph is inlined in `ui/icons` for the same
+reason. `src/ha-contract.test.ts` sweeps the sources and fails on an `ha-*` tag, on a
+`callWS` / `subscribeMessage` / `window.customCards` reached outside the contract, and on a
+Home Assistant theme variable bound without a line in `HA_THEME_VARS`.
 
 ---
 


### PR DESCRIPTION
## Summary

The card reaches into Home Assistant in a handful of places, all of them stable for years.
Nothing in the repository said which places, and nothing checked that the list stayed short.

**`src/ha-contract.ts` is that list** — the `HassLike` shape, thin wrappers for `callWS` and
`connection.subscribeMessage`, the `window.customCards` picker registration, and the theme
variables the card binds, with a header stating what each is and why depending on it is
safe. `store/ws.ts` is the only caller of the two WebSocket wrappers, `index.ts` of the
registration, `ui/theme.ts` of `SURFACE_VARS`. One file to open when an upgrade breaks
something.

**The row that carries the value is the empty one, and it was not empty.** The card editor
had been rendering `ha-form` for a single text field since 0.4.1 — added in #374 on
2026-08-11, the day after the audit that produced this issue recorded the row as `none`.
That is exactly the regression item 3 exists to catch: HA's frontend components are
registered lazily inside its own bundle, are not published for card authors and are not
versioned, and none of them exists in jsdom — so the break would have arrived as a user
report after an upgrade rather than as a red test here. The editor now draws its field from
the card's own input and `--hv-*` tokens, which bind the dashboard's theme either way.

**`ha-contract.test.ts` holds all of it to the sources**, the way
`tests/test_min_ha_version.py` holds the Home Assistant floor: it fails on an `ha-*` tag
anywhere in `src/`, on a `callWS` / `subscribeMessage` / `window.customCards` reached
outside the contract, and on a Home Assistant theme variable bound without a line in
`HA_THEME_VARS`. Comments are stripped before each sweep — `ui/icons` names `<ha-icon>` to
explain why the glyphs are inlined, which is the rule being kept rather than broken.

`CONTRIBUTING.md` carries the rule and its reason;
[`docs/frontend_architecture.md`](docs/frontend_architecture.md) gains a section naming the
module and the sweep.

Closes #366

Item 4 of this issue — the scheduled `stable`/`beta` card smoke — landed in S5 as #529 and
#530, so this closes the issue rather than referencing it.

## The card editor, without `ha-form`

Driven through Home Assistant's own "edit card" dialog on the dev instance — HA opens the
editor, the field is the card's `<input>`, it carries the `Title` label HA's form used to
draw, the live preview follows the typing, and no `ha-form` exists in the dialog:

![the card editor, light](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/366-editor-light.png)

![the card editor, HA dark theme](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s7/366-editor-dark.png)

The field reads the dashboard's own theme through the card's tokens: `rgb(255,255,255)` on
`rgb(20,20,20)` in the light theme, `rgb(28,28,28)` on `rgb(225,225,225)` in the dark one,
in HA's own Roboto — which is the thing `ha-form` was there for.

## Type of change

- [x] Refactor (no functional change)
- [x] New feature (the guard tests, and the editor field is rebuilt)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1261 passed, 22
      skipped; `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → **1740 passed across 63 files**, `npm run build` clean.

phacc: not involved — nothing here crosses into `custom_components/`.

### New tests

`ha-contract.test.ts`, seven cases: the three source sweeps above, that every `SURFACE_VARS`
entry is also a contract entry, and three on `registerCustomCard` — it adds the picker
entry, it does not add the same card twice (the bundle can be evaluated twice on one page),
and it leaves another card's entry in the shared list alone.

`haventory-card-editor.test.ts` is rewritten around the real control rather than around a
`value-changed` event from an element jsdom never defines: the field carries its label and
the card's current title, an untitled card shows the fallback heading as the placeholder,
typing raises exactly one `config-changed`, unknown config keys survive the round trip, and
an emptied title is dropped rather than written as `""`.

### Live checks

Dev HA `2026.7.4`, branch built and deployed, served bundle hash verified against the local
build.

- **The card editor, through HA's own dialog** — light and dark, above. Every assertion
  green, no console or page error.
- **Registration, in Firefox** — the only browser where it is a real test, and the one this
  PR could plausibly break, since it moves the `window.customCards` registration:
  `haventory-card` and `haventory-panel` in the registry, `window.customCards` carrying
  exactly one entry, the `haventory` icon set registered, 50 rows on the card and 50 in the
  panel's table, no error from the card bundle.
- **Live-update smoke** — `RUN_ONLINE=1 node e2e/live-updates.smoke.mjs`, which drives the
  `subscribeMessage` path this PR routes through the contract: create, rename and delete out
  of band all reflected live. PASS.
- **Whole-surface regression** — `visual_pass.mjs` before and after, 42/42 surfaces each,
  pixel-diffed: seven surfaces differ, every one of them in the Updated column where a row's
  relative time crossed from "6 d ago" to "1 w ago" between the two runs. No layout change
  anywhere.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated.
- [x] Docs updated: `CONTRIBUTING.md` and `docs/frontend_architecture.md`.
- [x] No WebSocket API change — the wrappers pass the same frames to the same methods.
- [x] Essential invariants preserved.

## Decisions taken against drifted notes

- **`ha-form` is removed rather than allowed as an exception.** The issue's table records
  the `ha-*` row as `none`; the tree acquired one the day after it was written. Allowing it
  by name would have made the guard describe the tree instead of holding it, and the issue's
  own words are that "one `ha-*` element added later for a single control re-introduces the
  whole lazy-registration problem". The editor's benefit from #374 — a visual editor instead
  of the YAML fallback — is untouched.
- **`callWS` is already down to one module.** The issue counts "~50 call sites across
  `store/` and components"; today all 43 are inside `store/ws.ts` and no component calls it
  at all. So this PR routes one module through the wrappers rather than fifty-odd call
  sites, and the sweep is what keeps it that way.
- **The theme surface is 15 variables, not the 8 the issue lists.** The sweep found
  `--error-color` and `--input-fill-color` in `ui/tokens`, `--ha-card-border-radius`,
  `--ha-card-font-family` and `--paper-font-body1_-_font-family` for shape and type, and
  `--mdc-typography-body2-font-size` / `--mdc-typography-body2-line-height` set on the card
  and the panel hosts. All 15 are read with a fallback, so the issue's conclusion holds; the
  count did not.
- **`HassLike` moves into the contract and `store/types.ts` re-exports it.** The interface
  is where `callWS` and `subscribeMessage` are *named*, so leaving it behind would have left
  the contract incomplete on its own terms. Every existing importer is unchanged.
- **`SURFACE_VARS` moves too, and `ui/theme.ts` re-exports it.** The issue says `ui/theme.ts`
  "already does exactly this for the theme variables"; with one contract module the
  definition belongs there and the probe stays where it is.
- **No drifted file references otherwise.** `ui/theme.ts`, `ui/tokens.ts`, `index.ts` and
  `store/ws.ts` are all where the issue's prose implies.

## Follow-ups

Named, deliberately not filed: **the editor's `Title` label is uppercased by the card's own
`.hv-label`**, where HA's form drew it in sentence case. It is one label in one dialog and
reads as a field label either way; if the owner would rather it matched HA's, it is a
one-line change to that rule's use here.
## Handover

**1. Merged / left open**

All three merged by the session, branches deleted; nothing is waiting on the owner.

- [#533](https://github.com/chrreiter/HAventory/pull/533) — `fix(card): keep the location tree's tally whole when an area name is long` (closes [#426](https://github.com/chrreiter/HAventory/issues/426))
- [#534](https://github.com/chrreiter/HAventory/pull/534) — `feat(card): show the row thumbnail in the full view and the sidebar panel` (closes [#490](https://github.com/chrreiter/HAventory/issues/490))
- [#535](https://github.com/chrreiter/HAventory/pull/535) — `refactor(card): name the Home Assistant contact surface in one module and hold `ha-*` at zero` (closes [#366](https://github.com/chrreiter/HAventory/issues/366))

**2. Test this by hand**

1. `[desktop]` Open the full view (or `/haventory`) and read the location tree's
   `Ground Floor Utility Room` band. **Expect:** the tally on the right is whole — the name
   is what shortens, ending in an ellipsis, with the full name on hover. Narrow the window
   until other bands shorten too; no number should ever be clipped.
2. `[phone]` The same band on a phone. The sidebar is hidden at 375px, so reach it through
   the full view's location rail. **Expect:** the same — name shortens, number whole.
3. `[desktop]` Browse the panel and the full view. **Expect:** rows with a photo carry the
   same small picture the card's list rows show, at the same size; rows without a photo
   look exactly as before, with no empty square and no shifted name.
4. `[desktop]` **The one judgment worth your eye:** find a row that is *checked out* **and**
   has a photo, with a name over about 18 characters. **Expect:** the name now ends in an
   ellipsis where it did not before — the picture and the "Checked out" chip share the name
   column with it. The full name is still on hover. The PR body prices the two ways of
   buying it back (both cost every row's Location and Tags, one of them adds a sideways
   scroll at the panel's most common width) — tell me if the shortening reads as too
   aggressive and it becomes an issue.
5. `[phone]` The same rows at phone width, where the table pins the name column and scrolls
   the rest sideways. **Expect:** the picture rides with the pinned name and nothing else
   moved.
6. `[desktop]` Dashboard → edit → the HAventory card → **Configure**. **Expect:** a `TITLE`
   field that types normally, updates the preview heading live, and saves; emptying it hands
   the heading back to the integration option. This field is the card's own control now
   rather than HA's `ha-form`, so it is worth one look — including in your dark theme.

Everything else the harness proved: both gates green on each PR
([#533](https://github.com/chrreiter/HAventory/pull/533),
[#534](https://github.com/chrreiter/HAventory/pull/534),
[#535](https://github.com/chrreiter/HAventory/pull/535) each carry their numbers), CI green
including hassfest and the integration job, card registration checked **in Firefox** on
each PR, the live-update smoke green on each, and `visual_pass.mjs` diffed pixel-for-pixel
across all 40 surfaces per PR.

**3. Decisions taken against drifted notes**

- **#426 is fixed in the chip vocabulary, not in the tree** — the same chip is drawn by six
  other components, and capping it there means a long area name elides wherever it is
  printed. The band also gained a `title`, which the issue did not ask for; eliding without
  one would have made the full name unreachable.
- **#490's column template did **not** move**, against §6.7's instruction. Measured: the
  42px reserve pushes the panel's *default* table into a sideways scroll at the 1360px
  content box the docked HA sidebar leaves, and a 34px one puts Location and Tags on their
  floors while still eliding the same names. Both prices land on every row, including the
  98% with no photo. Full numbers in [#534](https://github.com/chrreiter/HAventory/pull/534).
- **#366's `ha-*` row was not zero** — the card editor had rendered `ha-form` since 0.4.1,
  added in #374 the day after the audit that recorded the row as `none`. Removed rather than
  allowed by name, which is what the issue's own reasoning asks for.
- **#366's counts are stale in the card's favour** — `callWS` is already down to one module
  (43 sites, all in `store/ws.ts`, none in a component), and the theme surface is 15
  variables rather than 8. Both are recorded in the contract module and swept by its test.
- **#366 item 4 landed in S5** (#529, #530), so PR 3 closes the issue rather than referencing
  it.

**4. Follow-ups**

None filed. Two named and deliberately not filed, both in
[#534](https://github.com/chrreiter/HAventory/pull/534) and
[#535](https://github.com/chrreiter/HAventory/pull/535):

- A row with **both** a picture and an inline chip elides names past about 18 characters at
  the panel's docked width. It is the trade #490 takes rather than a defect, the full name
  is in the cell's `title`, and the alternatives are priced — but it is hand-test 4 above,
  because it is the one thing here a person should judge rather than a measurement.
- The card editor's `Title` label is uppercased by the card's own `.hv-label`, where HA's
  form drew it in sentence case. One label in one dialog; a one-line change if you would
  rather it matched HA's.

**5. State left behind**

- **Dev HA** — restored. Six probe items with pictures were created to measure the name
  column and deleted again; the store is back at **1087 items / 89 locations** with no
  `S7NAME` or `e2e_smoke` rows. The `dashboard-dev` config is byte-identical (the editor
  probe typed a title but never saved). Rate limiting untouched, language untouched. The
  container currently serves the **PR 3 branch build**, which is `main` as of #535 — redeploy
  from `main` if anything else has landed since.
- **Branches** — all three feature branches deleted on merge. One orphan branch survives on
  purpose: **`claude-assets-v0-7-0-s7`**, holding the screenshots the three PR bodies link
  to. It is never merged; delete it only if those bodies stop mattering.
- **Next session** — S8 (#190, German) starts from `main`. Its 52-file sweep now also has
  `cards/haventory-card/src/ha-contract.ts` and `CONTRIBUTING.md`'s no-`ha-*` rule in the
  tree; neither carries user-facing strings. The card editor's `Title` label is a new
  user-facing string that S8 will want to translate, and it is the card's own text now
  rather than HA's form label.
