### PR TITLE
feat(i18n): translation mechanism, German backend translations and the shared copy modules

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -381,6 +381,41 @@ nothing, which is only visible by reading the sheet next to the counts it produc
 (`"C:/Users/you/backup.json"`) and prefix the command with `MSYS_NO_PATHCONV=1` if you
 override `--path` — see the path-conversion gotcha below.
 
+### Screenshot the setup and options screens
+
+Neither dialog has a URL of its own, so both are opened by clicking through HA's own UI:
+
+```bash
+cd .claude/skills/run-haventory
+node shot_options.mjs --out de            # de-entry.png, de-options.png + the step text
+node shot_config_flow.mjs --out de-setup  # de-setup-step.png
+node shot_config_flow.mjs --out de-setup --submit   # CREATES the config entry
+```
+
+`shot_options.mjs` opens the integration page and presses Configure, so it works whatever
+language the profile is in — it matches the button on either spelling. `shot_config_flow.mjs`
+goes through HA's own `/_my_redirect/config_flow_start?domain=haventory`, which **only starts
+when no entry exists**: HAventory is single-instance, so the caller has to remove the entry
+first and `--submit` is how it is put back.
+
+The language is the Home Assistant *profile's*, not a flag. Set and restore it over WS —
+`value: null` is what the profile looks like before anyone chose:
+
+```bash
+D=.claude/skills/run-haventory/driver.py
+uv run python $D send '{"type":"frontend/set_user_data","key":"language","value":{"language":"de"}}'
+uv run python $D send '{"type":"frontend/set_user_data","key":"language","value":null}'
+uv run python $D send '{"type":"frontend/get_user_data","key":"language"}'   # confirm
+```
+
+Removing the entry keeps the store (`.storage/haventory_store` is not touched) but **drops
+the entry's options**, so read them out first and put them back through the options flow
+afterwards — every section key is required in that POST, `todo` and `rate_limit` included:
+
+```bash
+docker exec home-assistant python -c "import json; d = json.load(open('/config/.storage/core.config_entries')); print([e['options'] for e in d['data']['entries'] if e['domain'] == 'haventory'])"
+```
+
 ## Verification harnesses
 
 Four checks that need a real instance and a real browser, each with its own oracle so a

--- a/.claude/skills/run-haventory/shot_config_flow.mjs
+++ b/.claude/skills/run-haventory/shot_config_flow.mjs
@@ -1,0 +1,89 @@
+// Screenshot HAventory's *setup* dialog in whatever language the Home Assistant
+// profile is set to, and optionally submit it.
+//
+// The config flow has no URL of its own, but HA's own `my` redirect opens it:
+// /_my_redirect/config_flow_start?domain=haventory. It only starts when no
+// entry exists — the integration is single-instance — so the caller has to
+// remove the entry first and put it back afterwards.
+//
+// Usage (from the skill dir):
+//   node shot_config_flow.mjs [--out <prefix>] [--submit]
+//
+// --submit presses the form's submit button and shoots the "created" screen too.
+
+import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { haConfig } from "./card_views.mjs";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+
+const { base, token } = haConfig();
+if (!token) {
+  console.error("Missing HA_TOKEN (env or repo-root .env)");
+  process.exit(2);
+}
+const prefix = flag("--out", "config-flow");
+const submit = args.includes("--submit");
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 1280, height: 1000 },
+  serviceWorkers: "block",
+});
+const page = await context.newPage();
+page.on("console", (m) => {
+  if (m.type() === "error") console.error(`console: ${m.text()}`);
+});
+
+await page.addInitScript(
+  ([hassUrl, accessToken]) => {
+    localStorage.setItem(
+      "hassTokens",
+      JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "unused-long-lived",
+        expires_in: 1800,
+        expires: Date.now() + 365 * 24 * 3600 * 1000,
+        hassUrl,
+        clientId: hassUrl + "/",
+      }),
+    );
+  },
+  [base, token],
+);
+
+await page.goto(base + "/_my_redirect/config_flow_start?domain=haventory", {
+  waitUntil: "domcontentloaded",
+});
+if (page.url().includes("/auth/authorize")) {
+  console.error("Redirected to the login page — is HA_TOKEN valid?");
+  await browser.close();
+  process.exit(1);
+}
+await page.waitForTimeout(4000);
+// HA asks "Do you want to set up <integration>?" first; that is its own
+// dialog, not the integration's step.
+const confirm = page.getByRole("button", { name: /^(OK|Ja|Yes)$/ }).first();
+if (await confirm.count()) {
+  await confirm.click();
+  await page.waitForTimeout(4000);
+}
+await page.screenshot({ path: path.join(skillDir, `${prefix}-step.png`) });
+
+if (submit) {
+  const button = page.getByRole("button", { name: /^(Absenden|Submit|Bestätigen|OK|Weiter|Next)$/i }).first();
+  await button.click();
+  await page.waitForTimeout(4000);
+  await page.screenshot({ path: path.join(skillDir, `${prefix}-created.png`) });
+}
+
+await browser.close();
+console.log(`wrote ${prefix}-step.png${submit ? ` and ${prefix}-created.png` : ""}`);

--- a/.claude/skills/run-haventory/shot_options.mjs
+++ b/.claude/skills/run-haventory/shot_options.mjs
@@ -1,0 +1,111 @@
+// Screenshot HAventory's options screen (and, with --config, a fresh config
+// flow) in whatever language the Home Assistant profile is set to.
+//
+// Both dialogs are opened by clicking through HA's own UI, because neither has
+// a URL of its own — the options flow is a dialog on the integration page and
+// the config flow is one on the integrations list.
+//
+// Usage (from the skill dir):
+//   node shot_options.mjs [--out <prefix>] [--dark] [--scheme light|dark]
+//
+// Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
+
+import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { haConfig } from "./card_views.mjs";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+const has = (name) => args.includes(name);
+
+const { base, token } = haConfig();
+if (!token) {
+  console.error("Missing HA_TOKEN (env or repo-root .env)");
+  process.exit(2);
+}
+
+const prefix = flag("--out", "options");
+const haDark = has("--dark");
+const colorScheme = flag("--scheme", haDark ? "dark" : "light");
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 1280, height: 1000 },
+  serviceWorkers: "block",
+  colorScheme,
+});
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on("console", (msg) => {
+  if (msg.type() === "error") consoleErrors.push(msg.text());
+});
+
+await page.addInitScript(
+  ([hassUrl, accessToken, dark]) => {
+    localStorage.setItem(
+      "hassTokens",
+      JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "unused-long-lived",
+        expires_in: 1800,
+        expires: Date.now() + 365 * 24 * 3600 * 1000,
+        hassUrl,
+        clientId: hassUrl + "/",
+      }),
+    );
+    if (dark) localStorage.setItem("selectedTheme", JSON.stringify({ dark: true }));
+  },
+  [base, token, haDark],
+);
+
+await page.goto(base + "/config/integrations/integration/haventory", {
+  waitUntil: "domcontentloaded",
+});
+if (page.url().includes("/auth/authorize")) {
+  console.error("Redirected to the login page — is HA_TOKEN valid?");
+  await browser.close();
+  process.exit(1);
+}
+await page.waitForTimeout(3000);
+await page.screenshot({ path: path.join(skillDir, `${prefix}-entry.png`) });
+
+// The entry card's "Configure" / "Konfigurieren" link. Role selectors pierce
+// shadow DOM, and the label is whatever language the profile is in — so match
+// on either spelling rather than on one.
+const configure = page.getByRole("link", { name: /Konfigurieren|Configure/i }).first();
+const configureButton = page.getByRole("button", { name: /Konfigurieren|Configure/i }).first();
+const target = (await configure.count()) ? configure : configureButton;
+await target.click();
+await page.waitForTimeout(2500);
+await page.screenshot({ path: path.join(skillDir, `${prefix}-options.png`) });
+
+// The full step text lives inside a scrolling dialog, so grab what it rendered
+// as well — a screenshot cuts off the long section descriptions.
+const text = await page.evaluate(() => {
+  const seen = new Set();
+  const out = [];
+  const walk = (root) => {
+    for (const el of root.querySelectorAll("*")) {
+      if (seen.has(el)) continue;
+      seen.add(el);
+      if (el.shadowRoot) walk(el.shadowRoot);
+    }
+    const dialog = root.querySelector?.("ha-dialog, dialog");
+    if (dialog) out.push(dialog.textContent);
+  };
+  walk(document);
+  return out.join("\n----\n");
+});
+console.log(text.replace(/\n{3,}/g, "\n\n").slice(0, 6000));
+
+for (const e of consoleErrors.slice(0, 10)) console.error(`console: ${e}`);
+await browser.close();
+console.log(`\nwrote ${prefix}-entry.png and ${prefix}-options.png`);

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,14 @@ repos:
         exclude: |
           (?x)^(
             custom_components/haventory/www/|
-            cards/haventory-card/package-lock\.json
+            cards/haventory-card/package-lock\.json|
+            # A dictionary for a language other than English is not English
+            # prose, and every word in it is a false positive — "ist", "sie",
+            # "oder" and "alle" are all real English typos and all ordinary
+            # German. The English originals they are written against stay in
+            # scope: `strings.json` and `i18n/en.ts` are still read.
+            custom_components/haventory/translations/(?!en\.json)|
+            cards/haventory-card/src/i18n/(?!en\.ts)
           )
         additional_dependencies: ["tomli"]
   # The card's half of the gate, run from the card package because that is where

--- a/cards/haventory-card/src/components/hv-bulk-bar.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.ts
@@ -2,7 +2,8 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { icon } from '../ui/icons';
-import { counted, plural } from '../ui/plural';
+import { tn } from '../i18n';
+import { counted } from '../ui/plural';
 import type { IconName } from '../ui/icons';
 import type { AreaRef, BulkFailure, DistinctValues, Item, LocationTreeNode } from '../store/types';
 import './hv-chip-input';
@@ -403,7 +404,7 @@ export class HVBulkBar extends LitElement {
           </div>
           <div class="sub" data-testid="bulk-result-summary">
             ${result.succeeded} of ${result.succeeded + failedCount} succeeded.
-            ${clean ? '' : `${failedCount} failed and ${plural(failedCount, 'was', 'were')} left unchanged.`}
+            ${clean ? '' : tn('hv.bulk.result.failed', failedCount)}
           </div>
         </div>
       </div>
@@ -422,7 +423,7 @@ export class HVBulkBar extends LitElement {
         : null}
       <div class="result-foot">
         <span class="hint">
-          ${failedCount ? `Selection kept to the ${counted(failedCount, 'failed row')}` : ''}
+          ${failedCount ? `Selection kept to the ${counted(failedCount, 'failedRow')}` : ''}
         </span>
         <button
           class="hv-text-button"

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -10,7 +10,7 @@ import {
   settle,
   stubViewport,
 } from '../test.utils';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { addDays, toIsoDate } from '../ui/relative-time';
 import type { HVCardShell } from './hv-card-shell';
 import type { Item, Location } from '../store/types';
@@ -952,13 +952,13 @@ describe('hv-card-shell: adding an item on a phone', () => {
 
       const panel = hostGuard(sr).shadowRoot as ShadowRoot;
       expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
-        DISCARD_PROMPT.heading,
+        discardPrompt().heading,
       );
       expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
-        DISCARD_PROMPT.message,
+        discardPrompt().message,
       );
       expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
-        DISCARD_PROMPT.confirmLabel,
+        discardPrompt().confirmLabel,
       );
     });
   });

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -12,7 +12,7 @@ import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
 import { HostSurfaces } from '../host-surfaces';
@@ -587,7 +587,7 @@ export class HVCardShell extends LitElement {
     if (this._editing === next) return;
     if (this._editing !== null && this._editor?.dirty) {
       this.surfaces.confirm({
-        ...DISCARD_PROMPT,
+        ...discardPrompt(),
         onConfirm: () => {
           this._editorError = null;
           this._editing = next;

--- a/cards/haventory-card/src/components/hv-checkout-popover.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.ts
@@ -5,7 +5,7 @@ import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
 import {
   DEFAULT_CUSTOM_DAYS,
-  QUICK_DAY_OFFSETS,
+  quickDayOffsets,
   addDays,
   formatDate,
 } from '../ui/relative-time';
@@ -321,7 +321,7 @@ export class HVCheckoutPopover extends LitElement {
         </div>
         <div class="body">
           <div class="offsets">
-            ${QUICK_DAY_OFFSETS.map((offset) => {
+            ${quickDayOffsets().map((offset) => {
               const value = addDays(offset.days);
               return html`<button
                 class="offset ${!this._customOpen && this._due === value ? 'on' : ''}"

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -9,7 +9,7 @@ import {
   q,
   settle as settleEl,
 } from '../test.utils';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVDetailSheet } from './hv-detail-sheet';
@@ -567,13 +567,13 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
 
     const panel = guard(el).shadowRoot as ShadowRoot;
     expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
-      DISCARD_PROMPT.heading,
+      discardPrompt().heading,
     );
     expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
-      DISCARD_PROMPT.message,
+      discardPrompt().message,
     );
     expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
-      DISCARD_PROMPT.confirmLabel,
+      discardPrompt().confirmLabel,
     );
   });
 

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -20,7 +20,7 @@ import {
   pictures,
 } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { ViewportNarrow } from '../ui/responsive';
 import type { AreaRef, Item, Location, LocationTreeNode, MediaConfig, ScalarValue, StatusDefinition } from '../store/types';
 import './hv-bottom-sheet';
@@ -921,9 +921,9 @@ export class HVDetailSheet extends LitElement {
         data-testid="sheet-discard-confirm"
         ?open=${this._pendingDiscard !== null}
         ?mobile=${this._viewport.narrow}
-        .heading=${DISCARD_PROMPT.heading}
-        .message=${DISCARD_PROMPT.message}
-        .confirmLabel=${DISCARD_PROMPT.confirmLabel}
+        .heading=${discardPrompt().heading}
+        .message=${discardPrompt().message}
+        .confirmLabel=${discardPrompt().confirmLabel}
         destructive
         @confirm=${(e: Event) => {
           e.stopPropagation();

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
@@ -101,7 +101,7 @@ describe('hv-diagnostics-panel: integrity issues', () => {
     const issues = all(el, '[data-testid="diagnostics-issue"]');
     expect(issues).toHaveLength(2);
     expect(issues[0].dataset.code).toBe('item_references_missing_location');
-    expect(issues[0].textContent).toContain('3 item(s) reference a location that no longer exists');
+    expect(issues[0].textContent).toContain('3 items reference a location that no longer exists');
     expect(q(el, '[data-testid="diagnostics-status"]')?.textContent).toContain('Issues found');
   });
 });

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,7 +1,7 @@
 import './hv-full-view';
 import { componentCss, makeItem, mountComponent, mountStore, q, settle, stubViewport } from '../test.utils';
 import { deepActiveElement } from '../ui/dialog-focus';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVFullView } from './hv-full-view';
 import type { Item, Location, StatusDefinition } from '../store/types';
@@ -1410,13 +1410,13 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
 
     const panel = guard(sr).shadowRoot as ShadowRoot;
     expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
-      DISCARD_PROMPT.heading,
+      discardPrompt().heading,
     );
     expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
-      DISCARD_PROMPT.message,
+      discardPrompt().message,
     );
     expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
-      DISCARD_PROMPT.confirmLabel,
+      discardPrompt().confirmLabel,
     );
   });
 });

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -6,7 +6,8 @@ import { chip } from '../ui/chip';
 import { browseRow } from '../ui/browse-row';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
-import { counted, plural, showingCount } from '../ui/plural';
+import { tn } from '../i18n';
+import { counted, showingCount } from '../ui/plural';
 import { nextZBase } from '../utils/zindex';
 import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters, soleLocationId } from '../store/store';
@@ -24,7 +25,7 @@ import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
 import { NARROW_QUERY } from '../ui/responsive';
@@ -2280,9 +2281,9 @@ export class HVFullView extends LitElement {
           data-testid="full-discard-confirm"
           ?open=${this._pendingDiscard !== null}
           ?mobile=${this._narrow}
-          .heading=${DISCARD_PROMPT.heading}
-          .message=${DISCARD_PROMPT.message}
-          .confirmLabel=${DISCARD_PROMPT.confirmLabel}
+          .heading=${discardPrompt().heading}
+          .message=${discardPrompt().message}
+          .confirmLabel=${discardPrompt().confirmLabel}
           destructive
           @confirm=${() => {
             const to = this._pendingDiscard;
@@ -2300,7 +2301,7 @@ export class HVFullView extends LitElement {
   private get _checkedOutWarning(): string | null {
     const out = this._selectedItems.filter((i) => i.checked_out).length;
     if (!out) return null;
-    return `${out} of them ${plural(out, 'is', 'are')} checked out`;
+    return tn('hv.fullView.checkedOutWarning', out);
   }
 }
 

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -630,7 +630,7 @@ export class HVImportSheet extends LitElement {
           ? html`<div class="alert warn" data-testid="import-warnings">
               <span class="glyph">${icon('alert', 18)}</span>
               <span>
-                ${counted(warnings.length, 'name clash', 'name clashes')} — the file would add
+                ${counted(warnings.length, 'nameClash')} — the file would add
                 ${warnings.length === 1 ? 'an entry' : 'entries'} under a name something here already uses,
                 under a different id. Import matches on the id alone, so
                 ${warnings.length === 1 ? 'this becomes a duplicate' : 'these become duplicates'} rather than

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -11,7 +11,7 @@ import {
   settle,
   stubViewport,
 } from '../test.utils';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { addDays } from '../ui/relative-time';
 import type { HVItemEditor } from './hv-item-editor';
@@ -1170,7 +1170,7 @@ describe('hv-item-editor: every close this form owns asks the same question', ()
     const guard = await dialog(el, 'editor-discard-confirm');
     expect(guard.open).toBe(true);
     expect(guard.shadowRoot?.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
-      DISCARD_PROMPT.message,
+      discardPrompt().message,
     );
     expect(cancels).toBe(0);
 

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -6,7 +6,7 @@ import { areaMarkName, locationPathParts, pathTitle, renderAreaChip } from '../u
 import { icon } from '../ui/icons';
 import {
   DEFAULT_CUSTOM_DAYS,
-  QUICK_DAY_OFFSETS,
+  quickDayOffsets,
   addDays,
   formatDate,
   isOverdue,
@@ -14,7 +14,7 @@ import {
 } from '../ui/relative-time';
 import { saveShortcutLabel } from '../ui/keyboard';
 import { counted } from '../ui/plural';
-import { DISCARD_PROMPT } from '../ui/discard';
+import { discardPrompt } from '../ui/discard';
 import { ViewportNarrow } from '../ui/responsive';
 import { nextZBase } from '../utils/zindex';
 import {
@@ -1912,7 +1912,7 @@ export class HVItemEditor extends LitElement {
   private _renderInspectionOffsets(current: string) {
     return html`
       <div class="offsets" data-testid="editor-inspection-offsets">
-        ${QUICK_DAY_OFFSETS.map((offset) => {
+        ${quickDayOffsets().map((offset) => {
           const value = addDays(offset.days);
           return html`<button
             class="offset ${!this._inspectionCustomOpen && current === value ? 'on' : ''}"
@@ -2846,9 +2846,9 @@ export class HVItemEditor extends LitElement {
         data-testid="editor-discard-confirm"
         ?open=${this._confirmDiscard}
         ?mobile=${this._viewport.narrow}
-        .heading=${DISCARD_PROMPT.heading}
-        .message=${DISCARD_PROMPT.message}
-        .confirmLabel=${DISCARD_PROMPT.confirmLabel}
+        .heading=${discardPrompt().heading}
+        .message=${discardPrompt().message}
+        .confirmLabel=${discardPrompt().confirmLabel}
         destructive
         @confirm=${(e: Event) => {
           e.stopPropagation();

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -936,7 +936,7 @@ export class HVOrganizeDialog extends LitElement {
       // saying why up front beats surfacing a validation error after the fact.
       const parts: string[] = [];
       if (items) parts.push(counted(items, 'item'));
-      if (children) parts.push(counted(children, 'sub-location'));
+      if (children) parts.push(counted(children, 'subLocation'));
       this._guard = {
         locationId: node.id,
         message: `"${node.name}" still contains ${parts.join(' and ')}. Move or delete them first.`,
@@ -1367,7 +1367,7 @@ export class HVOrganizeDialog extends LitElement {
     const items = source.direct_item_count ?? 0;
     const children = source.children?.length ?? 0;
     const parts = [counted(items, 'item')];
-    if (children) parts.push(counted(children, 'sub-location'));
+    if (children) parts.push(counted(children, 'subLocation'));
 
     return html`<div class="expander" data-testid="location-merge">
       <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap">
@@ -1813,7 +1813,7 @@ export class HVOrganizeDialog extends LitElement {
     return html`
       <div class="toolbar">
         <span class="toolbar-count" data-testid="organize-status-count"
-          >${counted(defs.length, 'status', 'statuses')}</span
+          >${counted(defs.length, 'status')}</span
         >
         <button
           class="hv-pill"
@@ -2086,7 +2086,7 @@ export class HVOrganizeDialog extends LitElement {
             }}
           />
         </label>
-        <span class="toolbar-count" data-testid="organize-value-count">${counted(values.length, this._noun, noun)}</span>
+        <span class="toolbar-count" data-testid="organize-value-count">${counted(values.length, this.tab === 'tags' ? 'tag' : 'category')}</span>
         <button
           class="hv-pill"
           data-testid="organize-new-value"

--- a/cards/haventory-card/src/ha-contract.ts
+++ b/cards/haventory-card/src/ha-contract.ts
@@ -12,6 +12,7 @@
  * | what | why it is safe to depend on |
  * | --- | --- |
  * | `hass.callWS` | the frontend's own command channel, unchanged for years |
+ * | `hass.language` | the user's profile language, read once to pick a dictionary |
  * | `hass.connection.subscribeMessage` | the same channel's subscription half |
  * | `hass.fetchWithAuth` | the only way to POST attachment bytes to core's `/api/file_upload` |
  * | `window.customCards` | how every custom card has advertised itself to the picker |
@@ -46,6 +47,13 @@ export type { Unsubscribe };
 export interface HassLike {
   /** Home Assistant's `callWS` returns the `result` part of the message. */
   callWS<T>(msg: Record<string, unknown>): Promise<T>;
+  /**
+   * The language the user reads Home Assistant in, as a BCP-47 tag (`de`,
+   * `de-CH`, `en-GB`). Optional because this interface is structural and
+   * because a `hass` object handed over before the profile has loaded may not
+   * carry one yet; the card resolves anything it cannot answer to English.
+   */
+  language?: string;
   /**
    * `fetch` with the user's auth header attached — the only way to POST to
    * core's `/api/file_upload`, which is how attachment bytes reach the server

--- a/cards/haventory-card/src/haventory-card-editor.ts
+++ b/cards/haventory-card/src/haventory-card-editor.ts
@@ -1,5 +1,7 @@
 import { LitElement, css, html } from 'lit';
+import type { PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { setLanguage } from './i18n';
 import { tokens, base } from './ui/tokens';
 import { DEFAULT_CARD_TITLE } from './ui/card-title';
 import { defineCardElement } from './register';
@@ -57,6 +59,15 @@ export class HAventoryCardEditor extends LitElement {
   /** Lovelace hands the whole card config in, including keys the card ignores. */
   public setConfig(config: HAventoryCardConfig): void {
     this._config = { ...config };
+  }
+
+  /**
+   * Home Assistant sets `hass` as a plain property here rather than through the
+   * setter the card and the panel have, so the language is picked up on the
+   * update it arrives on.
+   */
+  protected willUpdate(changed: PropertyValues<this>): void {
+    if (changed.has('hass')) setLanguage(this.hass?.language);
   }
 
   render() {

--- a/cards/haventory-card/src/haventory-panel.ts
+++ b/cards/haventory-card/src/haventory-panel.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { setLanguage } from './i18n';
 import type { HassLike } from './store/types';
 import { Store } from './store/store';
 import { resolveColorScheme } from './ui/theme';
@@ -71,6 +72,8 @@ export class HAventoryPanel extends LitElement {
 
   set hass(h: HassLike | undefined) {
     this._hass = h;
+    // Ahead of the store, for the same reason the card does it there.
+    if (setLanguage(h?.language)) this.requestUpdate();
     if (h && !this.store) {
       this.store = new Store(h);
       this._storeUnsub = this.store.state.onChange(() => {

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -5,7 +5,8 @@ import { loadColumnPrefs, saveColumnPrefs } from './store/columns';
 import { activeFilterCount, defaultFilters } from './store/store';
 import type { Store } from './store/store';
 import type { ImportPolicy, ImportPreview, ImportSummary } from './store/types';
-import { counted, plural } from './ui/plural';
+import { tn } from './i18n';
+import { counted } from './ui/plural';
 import { NARROW_QUERY } from './ui/responsive';
 import type { OrganizeTab } from './components/hv-organize-dialog';
 import type { OverflowMenuEntry } from './components/hv-overflow-menu';
@@ -250,7 +251,7 @@ export class HostSurfaces {
               sub:
                 filtered === null
                   ? 'Active filter · Keeps location paths'
-                  : `${filtered} filtered ${plural(filtered, 'item')} · Keeps location paths`,
+                  : tn('hv.surfaces.exportView.filtered', filtered),
             },
           ]
         : []),

--- a/cards/haventory-card/src/i18n/catalog.test.ts
+++ b/cards/haventory-card/src/i18n/catalog.test.ts
@@ -1,0 +1,65 @@
+import { DICTIONARIES } from './index';
+import { en } from './en';
+import { de } from './de';
+
+const enKeys = new Set(Object.keys(en));
+const PLACEHOLDER = /\{(\w+)\}/g;
+
+function placeholders(value: string): Set<string> {
+  return new Set([...value.matchAll(PLACEHOLDER)].map((m) => m[1]));
+}
+
+describe('the key universe', () => {
+  it('pairs every counted key', () => {
+    // `tn` builds `<key>.one` / `<key>.other` at the call site, so a pair with
+    // one half missing is a string that renders as nothing at the count nobody
+    // tested with.
+    for (const key of enKeys) {
+      if (key.endsWith('.one')) expect(enKeys).toContain(`${key.slice(0, -4)}.other`);
+      if (key.endsWith('.other')) expect(enKeys).toContain(`${key.slice(0, -6)}.one`);
+    }
+  });
+});
+
+describe.each(Object.entries(DICTIONARIES).filter(([tag]) => tag !== 'en'))(
+  'the %s dictionary',
+  (_tag, dictionary) => {
+    it('carries no key English has dropped', () => {
+      // A rename leaves the old key behind in every other dictionary, where it
+      // is dead weight nothing reads and nothing else notices.
+      expect(Object.keys(dictionary).filter((key) => !enKeys.has(key))).toEqual([]);
+    });
+
+    it('repeats the placeholders of the English it replaces', () => {
+      // A typo'd placeholder renders literally in the middle of a sentence,
+      // and a dropped one silently loses the number the sentence is about.
+      for (const [key, value] of Object.entries(dictionary)) {
+        const english = en[key as keyof typeof en];
+        expect([key, [...placeholders(value as string)].sort()]).toEqual([
+          key,
+          [...placeholders(english)].sort(),
+        ]);
+      }
+    });
+  },
+);
+
+describe('the German dictionary', () => {
+  it('is complete', () => {
+    // Not implied by the type: `Record<TranslationKey, string>` is what makes
+    // an omission a compile error, and this is what makes it a red test for
+    // anyone reading the suite rather than the compiler output.
+    expect(Object.keys(de).sort()).toEqual([...enKeys].sort());
+  });
+
+  it('translates every string rather than copying the English', () => {
+    // Some words are the same in both languages — a product name, a borrowed
+    // term, a symbol — and those are listed here so that being identical is a
+    // decision somebody took rather than a key pasted across and forgotten.
+    const SAME_IN_BOTH: string[] = [];
+    const untranslated = Object.entries(de)
+      .filter(([key, value]) => value === en[key as keyof typeof en])
+      .map(([key]) => key);
+    expect(untranslated.sort()).toEqual(SAME_IN_BOTH.sort());
+  });
+});

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -1,0 +1,232 @@
+/**
+ * German.
+ *
+ * Register and vocabulary follow Home Assistant's own German, which is what
+ * surrounds the card on every screen it renders on: informal address ("du"),
+ * `Bereich` for an area, `Kategorie`, `Label`, a space before an ellipsis, an
+ * en dash where the English writes an em dash, and German quotation marks
+ * („…“) where the English writes straight ones.
+ *
+ * Three words the card had to choose for itself, because Home Assistant has no
+ * equivalent:
+ *
+ * - an item is a **Gegenstand** — a physical thing a household owns, not an
+ *   `Eintrag` (which is what Home Assistant calls a to-do line, and HAventory
+ *   writes those onto a shopping list beside its own items) and not an
+ *   `Artikel` (which is stock in a shop);
+ * - a location is an **Ort**, short enough to carry a nesting level in front of
+ *   it in the tree and not tied to geography the way `Standort` is;
+ * - checking out is **Ausleihen**, checking in **Zurückgeben** — what a
+ *   household actually does when someone takes a drill away.
+ *
+ * Typed as a complete record rather than a `Dictionary`, so an English string
+ * added without a German one fails to compile instead of quietly falling back.
+ */
+
+import type { TranslationKey } from './en';
+
+export const de: Record<TranslationKey, string> = {
+  'hv.action.refresh': 'Aktualisieren',
+  'hv.action.retry': 'Erneut versuchen',
+  'hv.action.dismiss': 'Schließen',
+  'hv.action.discard': 'Verwerfen',
+
+  'hv.empty.loading.headline': 'Gegenstände werden geladen',
+  'hv.empty.connectionLost.headline': 'Home Assistant ist nicht erreichbar',
+  'hv.empty.connectionLost.detail': 'Die Liste füllt sich, sobald die Verbindung wieder steht.',
+  'hv.empty.noMatches.headline': 'Keine Gegenstände passen zu diesen Filtern',
+  'hv.empty.noMatches.clearAction': 'Alle zurücksetzen',
+  'hv.empty.emptyLocation.headline': 'Nichts in {location}',
+  'hv.empty.emptyLocation.headlineUnnamed': 'Nichts an diesem Ort',
+  'hv.empty.emptyLocation.addAction': 'Hier hinzufügen',
+  'hv.empty.emptyLocation.clearAction': 'Alles anzeigen',
+  'hv.empty.noItems.headline': 'Noch keine Gegenstände',
+  'hv.empty.noItems.detail':
+    'Füge deinen ersten Gegenstand hinzu oder stelle ein Backup wieder her.',
+  'hv.empty.noItems.addAction': 'Ersten Gegenstand hinzufügen',
+  'hv.empty.noItems.importAction': 'Backup importieren',
+
+  'hv.banner.connectionLost.heading': 'Verbindung unterbrochen',
+  'hv.banner.connectionLost.message':
+    ' · es werden die bereits geladenen Daten angezeigt. Änderungen werden möglicherweise nicht gespeichert.',
+  'hv.banner.connectionLost.action': 'Neu verbinden',
+  'hv.banner.liveUpdates.heading': 'Live-Aktualisierungen pausiert',
+  'hv.banner.liveUpdates.cause.unavailable': 'HAventory ist nicht verfügbar',
+  'hv.banner.liveUpdates.cause.rateLimited': 'Ratenbegrenzung aktiv',
+  'hv.banner.liveUpdates.retrying':
+    ' · {cause}. Es wird automatisch erneut versucht; bis dahin kann diese Liste veraltet sein.',
+  'hv.banner.liveUpdates.stalled':
+    ' · {cause}. Diese Liste kann veraltet sein, bis du aktualisierst.',
+  'hv.banner.retrying.heading': 'Beschäftigt – wird wiederholt',
+  'hv.banner.retrying.message.one': ' · {count} Änderung in der Warteschlange',
+  'hv.banner.retrying.message.other': ' · {count} Änderungen in der Warteschlange',
+  'hv.banner.rateLimited.heading': 'Ratenbegrenzung aktiv',
+  'hv.banner.rateLimited.message':
+    ' · einige Live-Aktualisierungen wurden möglicherweise verworfen, daher kann diese Liste veraltet sein.',
+  'hv.banner.reloading.heading': 'Das Inventar wurde durch einen Import ersetzt',
+  'hv.banner.reloading.message': ' · wird neu geladen …',
+  'hv.banner.conflict.heading': 'Jemand anderes hat diesen Gegenstand geändert.',
+  'hv.banner.conflict.viewLatest': 'Aktuellen Stand ansehen',
+  'hv.banner.conflict.reapply': 'Meine Änderung erneut anwenden',
+
+  'hv.discard.heading': 'Änderungen verwerfen?',
+  'hv.discard.message': 'Alles, was du seit dem letzten Speichern eingegeben hast, geht verloren.',
+
+  'hv.health.itemIdKeyMismatch.one':
+    '{count} Gegenstand ist unter einem Schlüssel gespeichert, der nicht zu seiner ID passt.',
+  'hv.health.itemIdKeyMismatch.other':
+    '{count} Gegenstände sind unter Schlüsseln gespeichert, die nicht zu ihren IDs passen.',
+  'hv.health.itemReferencesMissingLocation.one':
+    '{count} Gegenstand verweist auf einen Ort, den es nicht mehr gibt – er erscheint unter „Kein Ort“.',
+  'hv.health.itemReferencesMissingLocation.other':
+    '{count} Gegenstände verweisen auf einen Ort, den es nicht mehr gibt – sie erscheinen unter „Kein Ort“.',
+  'hv.health.itemMissingFromLocationIndex.one': '{count} Gegenstand fehlt im Ortsindex.',
+  'hv.health.itemMissingFromLocationIndex.other': '{count} Gegenstände fehlen im Ortsindex.',
+  'hv.health.checkedOutItemMissingFromIndex.one':
+    '{count} ausgeliehener Gegenstand fehlt im Ausleih-Index.',
+  'hv.health.checkedOutItemMissingFromIndex.other':
+    '{count} ausgeliehene Gegenstände fehlen im Ausleih-Index.',
+  'hv.health.nonCheckedOutItemInIndex.one':
+    '{count} Gegenstand steht im Ausleih-Index, ist aber nicht ausgeliehen.',
+  'hv.health.nonCheckedOutItemInIndex.other':
+    '{count} Gegenstände stehen im Ausleih-Index, sind aber nicht ausgeliehen.',
+  'hv.health.lowStockItemMissingFromIndex.one':
+    '{count} Gegenstand mit niedrigem Bestand fehlt im Bestandsindex.',
+  'hv.health.lowStockItemMissingFromIndex.other':
+    '{count} Gegenstände mit niedrigem Bestand fehlen im Bestandsindex.',
+  'hv.health.nonLowStockItemInIndex.one':
+    '{count} Gegenstand steht im Bestandsindex, hat aber keinen niedrigen Bestand.',
+  'hv.health.nonLowStockItemInIndex.other':
+    '{count} Gegenstände stehen im Bestandsindex, haben aber keinen niedrigen Bestand.',
+  'hv.health.tagsIndexUnknownItems.one':
+    'Der Label-Index verweist auf {count} Gegenstand, den es nicht mehr gibt.',
+  'hv.health.tagsIndexUnknownItems.other':
+    'Der Label-Index verweist auf {count} Gegenstände, die es nicht mehr gibt.',
+  'hv.health.categoryIndexUnknownItems.one':
+    'Der Kategorie-Index verweist auf {count} Gegenstand, den es nicht mehr gibt.',
+  'hv.health.categoryIndexUnknownItems.other':
+    'Der Kategorie-Index verweist auf {count} Gegenstände, die es nicht mehr gibt.',
+  'hv.health.checkedOutIndexUnknownItems.one':
+    'Der Ausleih-Index verweist auf {count} Gegenstand, den es nicht mehr gibt.',
+  'hv.health.checkedOutIndexUnknownItems.other':
+    'Der Ausleih-Index verweist auf {count} Gegenstände, die es nicht mehr gibt.',
+  'hv.health.lowStockIndexUnknownItems.one':
+    'Der Bestandsindex verweist auf {count} Gegenstand, den es nicht mehr gibt.',
+  'hv.health.lowStockIndexUnknownItems.other':
+    'Der Bestandsindex verweist auf {count} Gegenstände, die es nicht mehr gibt.',
+  'hv.health.locationIndexUnknownItems.one':
+    'Der Ortsindex verweist auf {count} Gegenstand, den es nicht mehr gibt.',
+  'hv.health.locationIndexUnknownItems.other':
+    'Der Ortsindex verweist auf {count} Gegenstände, die es nicht mehr gibt.',
+  'hv.health.locationIndexMissingLocation.one':
+    'Der Ortsindex führt {count} Fach für einen Ort, den es nicht mehr gibt.',
+  'hv.health.locationIndexMissingLocation.other':
+    'Der Ortsindex führt {count} Fächer für Orte, die es nicht mehr gibt.',
+  'hv.health.locationBucketMismatch.one':
+    '{count} Fach im Ortsindex stimmt nicht mit den Gegenständen überein, die es führt.',
+  'hv.health.locationBucketMismatch.other':
+    '{count} Fächer im Ortsindex stimmen nicht mit den Gegenständen überein, die sie führen.',
+  'hv.health.locationIdKeyMismatch.one':
+    '{count} Ort ist unter einem Schlüssel gespeichert, der nicht zu seiner ID passt.',
+  'hv.health.locationIdKeyMismatch.other':
+    '{count} Orte sind unter Schlüsseln gespeichert, die nicht zu ihren IDs passen.',
+  'hv.health.itemsTotalMismatch.one':
+    'Die zwischengespeicherte Gesamtzahl der Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein.',
+  'hv.health.itemsTotalMismatch.other':
+    'Die zwischengespeicherte Gesamtzahl der Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein.',
+  'hv.health.locationsTotalMismatch.one':
+    'Die zwischengespeicherte Gesamtzahl der Orte stimmt nicht mit den gespeicherten Orten überein.',
+  'hv.health.locationsTotalMismatch.other':
+    'Die zwischengespeicherte Gesamtzahl der Orte stimmt nicht mit den gespeicherten Orten überein.',
+  'hv.health.checkedOutCountMismatch.one':
+    'Die zwischengespeicherte Zahl der ausgeliehenen Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein.',
+  'hv.health.checkedOutCountMismatch.other':
+    'Die zwischengespeicherte Zahl der ausgeliehenen Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein.',
+  'hv.health.lowStockCountMismatch.one':
+    'Die zwischengespeicherte Zahl der Gegenstände mit niedrigem Bestand stimmt nicht mit den gespeicherten Gegenständen überein.',
+  'hv.health.lowStockCountMismatch.other':
+    'Die zwischengespeicherte Zahl der Gegenstände mit niedrigem Bestand stimmt nicht mit den gespeicherten Gegenständen überein.',
+
+  'hv.count.item.one': '{count} Gegenstand',
+  'hv.count.item.other': '{count} Gegenstände',
+  'hv.count.location.one': '{count} Ort',
+  'hv.count.location.other': '{count} Orte',
+  'hv.count.subLocation.one': '{count} Unterort',
+  'hv.count.subLocation.other': '{count} Unterorte',
+  'hv.count.tag.one': '{count} Label',
+  'hv.count.tag.other': '{count} Labels',
+  'hv.count.category.one': '{count} Kategorie',
+  'hv.count.category.other': '{count} Kategorien',
+  'hv.count.status.one': '{count} Status',
+  'hv.count.status.other': '{count} Status',
+  'hv.count.field.one': '{count} Feld',
+  'hv.count.field.other': '{count} Felder',
+  'hv.count.filter.one': '{count} Filter',
+  'hv.count.filter.other': '{count} Filter',
+  'hv.count.issue.one': '{count} Problem',
+  'hv.count.issue.other': '{count} Probleme',
+  'hv.count.problem.one': '{count} Problem',
+  'hv.count.problem.other': '{count} Probleme',
+  'hv.count.conflict.one': '{count} Konflikt',
+  'hv.count.conflict.other': '{count} Konflikte',
+  'hv.count.nameClash.one': '{count} Namenskonflikt',
+  'hv.count.nameClash.other': '{count} Namenskonflikte',
+  'hv.count.failedRow.one': '{count} fehlgeschlagene Zeile',
+  'hv.count.failedRow.other': '{count} fehlgeschlagene Zeilen',
+
+  'hv.list.showingAll.one': '{count} Gegenstand wird angezeigt',
+  'hv.list.showingAll.other': '{count} Gegenstände werden angezeigt',
+  'hv.list.showingOf.one': '{loaded} von {count} Gegenstand wird angezeigt',
+  'hv.list.showingOf.other': '{loaded} von {count} Gegenständen werden angezeigt',
+  'hv.list.showingOfMatching.one': '{loaded} von {count} passendem Gegenstand wird angezeigt',
+  'hv.list.showingOfMatching.other': '{loaded} von {count} passenden Gegenständen werden angezeigt',
+
+  'hv.rewrite.tag.remove.one': 'Entfernt „{from}“ von {count} Gegenstand.',
+  'hv.rewrite.tag.remove.other': 'Entfernt „{from}“ von {count} Gegenständen.',
+  'hv.rewrite.tag.retag.one': 'Ändert das Label bei {count} Gegenstand und entfernt „{from}“.',
+  'hv.rewrite.tag.retag.other': 'Ändert das Label bei {count} Gegenständen und entfernt „{from}“.',
+  'hv.rewrite.category.clear.one': 'Entfernt die Kategorie bei {count} Gegenstand.',
+  'hv.rewrite.category.clear.other': 'Entfernt die Kategorie bei {count} Gegenständen.',
+  'hv.rewrite.category.set.one': 'Ordnet {count} Gegenstand der Kategorie „{to}“ zu.',
+  'hv.rewrite.category.set.other': 'Ordnet {count} Gegenstände der Kategorie „{to}“ zu.',
+
+  'hv.bulk.result.failed.one': '{count} ist fehlgeschlagen und blieb unverändert.',
+  'hv.bulk.result.failed.other': '{count} sind fehlgeschlagen und blieben unverändert.',
+  'hv.fullView.checkedOutWarning.one': '{count} davon ist ausgeliehen',
+  'hv.fullView.checkedOutWarning.other': '{count} davon sind ausgeliehen',
+  'hv.surfaces.exportView.filtered.one': '{count} gefilterter Gegenstand · behält Ortspfade',
+  'hv.surfaces.exportView.filtered.other': '{count} gefilterte Gegenstände · behält Ortspfade',
+
+  'hv.time.justNow': 'gerade eben',
+  'hv.date.offsetDays': '+{days} Tage',
+
+  'hv.reminder.every.days.one': 'täglich',
+  'hv.reminder.every.days.other': 'alle {count} Tage',
+  'hv.reminder.every.weeks.one': 'wöchentlich',
+  'hv.reminder.every.weeks.other': 'alle {count} Wochen',
+  'hv.reminder.every.months.one': 'monatlich',
+  'hv.reminder.every.months.other': 'alle {count} Monate',
+
+  'hv.area.prefix': 'Bereich: {name}',
+  'hv.area.srPrefix': 'Bereich: ',
+
+  'hv.shortcut.ctrlEnter': 'Strg+Enter',
+
+  'hv.form.error.nameRequired': 'Name ist erforderlich.',
+  'hv.form.error.nameTooLong': 'Der Name darf höchstens {max} Zeichen lang sein.',
+  'hv.form.error.descriptionTooLong': 'Die Beschreibung darf höchstens {max} Zeichen lang sein.',
+  'hv.form.error.categoryTooLong': 'Die Kategorie darf höchstens {max} Zeichen lang sein.',
+  'hv.form.error.quantityNegative': 'Die Menge darf nicht negativ sein.',
+  'hv.form.error.lowStockRange':
+    'Die Bestandsschwelle muss 0 oder größer sein – oder leer bleiben.',
+  'hv.form.error.tooManyTags': 'Ein Gegenstand kann höchstens {max} Labels tragen.',
+  'hv.form.error.tagTooLong': 'Jedes Label darf höchstens {max} Zeichen lang sein.',
+  'hv.form.error.reminderRange':
+    'Wiederholung von 1 bis {max}, oder leer lassen für einen einmaligen Termin.',
+  'hv.form.error.customFieldDuplicate': '„{key}“ kommt zweimal vor.',
+  'hv.form.error.customFieldKeyTooLong': 'Feldnamen dürfen höchstens {max} Zeichen lang sein.',
+  'hv.form.error.customFieldNotNumber': '„{key}“ muss eine Zahl sein.',
+  'hv.form.error.customFieldNotDate': '„{key}“ muss ein Datum sein.',
+  'hv.form.error.customFieldValueTooLong': '„{key}“ darf höchstens {max} Zeichen lang sein.',
+  'hv.form.error.tooManyCustomFields': 'Ein Gegenstand kann höchstens {max} eigene Felder tragen.',
+};

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -207,6 +207,9 @@ export const de: Record<TranslationKey, string> = {
   'hv.reminder.every.months.one': 'monatlich',
   'hv.reminder.every.months.other': 'alle {count} Monate',
 
+  'hv.media.photoAlt': '{name} – Foto {index} von {total}',
+  'hv.media.photoAltOnly': 'Foto von {name}',
+
   'hv.area.prefix': 'Bereich: {name}',
   'hv.area.srPrefix': 'Bereich: ',
 

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -1,0 +1,267 @@
+/**
+ * The key universe.
+ *
+ * Every string the card can say is here, and `TranslationKey` is derived from
+ * it — so a key that exists in no dictionary is a compile error at the call
+ * site, and a dictionary carrying a key this file has dropped is one at its
+ * own. English is also the fallback every other dictionary degrades to, which
+ * is why this one is the complete one by construction.
+ *
+ * Conventions:
+ *
+ * - Keys are `hv.<area>.<thing>`, lower camel inside a segment.
+ * - `{name}` placeholders are filled by `t(key, params)`; a placeholder with no
+ *   parameter renders literally, so a typo shows up rather than blanking a word.
+ * - A counted string is a pair, `<key>.one` and `<key>.other`, reached through
+ *   `tn(key, count)`; `{count}` is passed in for both forms. A form may leave
+ *   the number out — German writes "täglich" where English writes "every day".
+ * - Whole sentences, not fragments glued at the call site: word order is a
+ *   language's own, and a sentence assembled from three keys can only ever be
+ *   English word order with foreign words in it.
+ */
+
+export const en = {
+  // Shared verbs. One key each, because German has one word each and thirty
+  // copies of "Aktualisieren" is thirty chances to drift.
+  'hv.action.refresh': 'Refresh',
+  'hv.action.retry': 'Try again',
+  'hv.action.dismiss': 'Dismiss',
+  'hv.action.discard': 'Discard',
+
+  // ui/empty-state — the ways a list can have no rows.
+  'hv.empty.loading.headline': 'Loading items',
+  'hv.empty.connectionLost.headline': "Can't reach Home Assistant",
+  'hv.empty.connectionLost.detail': 'The list will fill in once the connection is back.',
+  'hv.empty.noMatches.headline': 'No items match these filters',
+  'hv.empty.noMatches.clearAction': 'Clear all',
+  'hv.empty.emptyLocation.headline': 'Nothing in {location}',
+  // A separate sentence rather than a "this location" filler in the one above:
+  // German takes a different preposition for a named place than for an unnamed
+  // one, and a language that inflects the name cannot borrow either.
+  'hv.empty.emptyLocation.headlineUnnamed': 'Nothing in this location',
+  'hv.empty.emptyLocation.addAction': 'Add item here',
+  'hv.empty.emptyLocation.clearAction': 'Show everything',
+  'hv.empty.noItems.headline': 'No items yet',
+  'hv.empty.noItems.detail': 'Add your first item, or restore a backup.',
+  'hv.empty.noItems.addAction': 'Add your first item',
+  'hv.empty.noItems.importAction': 'Import backup',
+
+  // ui/banners — the two stacks that say something is wrong.
+  'hv.banner.connectionLost.heading': 'Connection lost',
+  'hv.banner.connectionLost.message': ' · showing the data already loaded. Changes may not save.',
+  'hv.banner.connectionLost.action': 'Reconnect',
+  'hv.banner.liveUpdates.heading': 'Live updates paused',
+  'hv.banner.liveUpdates.cause.unavailable': 'HAventory is not available',
+  'hv.banner.liveUpdates.cause.rateLimited': 'rate limited',
+  'hv.banner.liveUpdates.retrying':
+    ' · {cause}. Retrying automatically; this list may be out of date until then.',
+  'hv.banner.liveUpdates.stalled': ' · {cause}. This list may be out of date until you refresh.',
+  'hv.banner.retrying.heading': 'Busy — retrying',
+  'hv.banner.retrying.message.one': ' · {count} change queued',
+  'hv.banner.retrying.message.other': ' · {count} changes queued',
+  'hv.banner.rateLimited.heading': 'Rate limited',
+  'hv.banner.rateLimited.message':
+    ' · some live updates may have been dropped, so this list can be out of date.',
+  'hv.banner.reloading.heading': 'Inventory was replaced by an import',
+  'hv.banner.reloading.message': ' · reloading…',
+  // Also what an open editor says about a rejected save — one sentence for one
+  // event, wherever the card reports it.
+  'hv.banner.conflict.heading': 'Someone else changed this item.',
+  'hv.banner.conflict.viewLatest': 'View latest',
+  'hv.banner.conflict.reapply': 'Re-apply my change',
+
+  // ui/discard — the one question asked before typed edits are thrown away.
+  'hv.discard.heading': 'Discard your changes?',
+  'hv.discard.message': 'What you have typed since the last save is lost.',
+
+  // ui/health-codes — `haventory/health` issue codes, said in words. Counted,
+  // because the backend repeats a code once per offending entity.
+  'hv.health.itemIdKeyMismatch.one':
+    '{count} item is stored under a key that does not match its id.',
+  'hv.health.itemIdKeyMismatch.other':
+    '{count} items are stored under a key that does not match their id.',
+  'hv.health.itemReferencesMissingLocation.one':
+    '{count} item references a location that no longer exists — it appears under "No location".',
+  'hv.health.itemReferencesMissingLocation.other':
+    '{count} items reference a location that no longer exists — they appear under "No location".',
+  'hv.health.itemMissingFromLocationIndex.one': '{count} item is missing from the location index.',
+  'hv.health.itemMissingFromLocationIndex.other':
+    '{count} items are missing from the location index.',
+  'hv.health.checkedOutItemMissingFromIndex.one':
+    '{count} checked-out item is missing from the checked-out index.',
+  'hv.health.checkedOutItemMissingFromIndex.other':
+    '{count} checked-out items are missing from the checked-out index.',
+  'hv.health.nonCheckedOutItemInIndex.one':
+    '{count} item is in the checked-out index but is not checked out.',
+  'hv.health.nonCheckedOutItemInIndex.other':
+    '{count} items are in the checked-out index but are not checked out.',
+  'hv.health.lowStockItemMissingFromIndex.one':
+    '{count} low-stock item is missing from the low-stock index.',
+  'hv.health.lowStockItemMissingFromIndex.other':
+    '{count} low-stock items are missing from the low-stock index.',
+  'hv.health.nonLowStockItemInIndex.one':
+    '{count} item is in the low-stock index but is not low on stock.',
+  'hv.health.nonLowStockItemInIndex.other':
+    '{count} items are in the low-stock index but are not low on stock.',
+  'hv.health.tagsIndexUnknownItems.one': 'The tag index references {count} item that no longer exists.',
+  'hv.health.tagsIndexUnknownItems.other':
+    'The tag index references {count} items that no longer exist.',
+  'hv.health.categoryIndexUnknownItems.one':
+    'The category index references {count} item that no longer exists.',
+  'hv.health.categoryIndexUnknownItems.other':
+    'The category index references {count} items that no longer exist.',
+  'hv.health.checkedOutIndexUnknownItems.one':
+    'The checked-out index references {count} item that no longer exists.',
+  'hv.health.checkedOutIndexUnknownItems.other':
+    'The checked-out index references {count} items that no longer exist.',
+  'hv.health.lowStockIndexUnknownItems.one':
+    'The low-stock index references {count} item that no longer exists.',
+  'hv.health.lowStockIndexUnknownItems.other':
+    'The low-stock index references {count} items that no longer exist.',
+  'hv.health.locationIndexUnknownItems.one':
+    'The location index references {count} item that no longer exists.',
+  'hv.health.locationIndexUnknownItems.other':
+    'The location index references {count} items that no longer exist.',
+  'hv.health.locationIndexMissingLocation.one':
+    'The location index has {count} bucket for a missing location.',
+  'hv.health.locationIndexMissingLocation.other':
+    'The location index has {count} buckets for missing locations.',
+  'hv.health.locationBucketMismatch.one':
+    '{count} location bucket disagrees with the items it holds.',
+  'hv.health.locationBucketMismatch.other':
+    '{count} location buckets disagree with the items they hold.',
+  'hv.health.locationIdKeyMismatch.one':
+    '{count} location is stored under a key that does not match its id.',
+  'hv.health.locationIdKeyMismatch.other':
+    '{count} locations are stored under a key that does not match their id.',
+  // Four whole-store tallies. One entity each, so both forms say the same thing.
+  'hv.health.itemsTotalMismatch.one': 'The cached item total disagrees with the stored items.',
+  'hv.health.itemsTotalMismatch.other': 'The cached item total disagrees with the stored items.',
+  'hv.health.locationsTotalMismatch.one':
+    'The cached location total disagrees with the stored locations.',
+  'hv.health.locationsTotalMismatch.other':
+    'The cached location total disagrees with the stored locations.',
+  'hv.health.checkedOutCountMismatch.one':
+    'The cached checked-out count disagrees with the stored items.',
+  'hv.health.checkedOutCountMismatch.other':
+    'The cached checked-out count disagrees with the stored items.',
+  'hv.health.lowStockCountMismatch.one':
+    'The cached low-stock count disagrees with the stored items.',
+  'hv.health.lowStockCountMismatch.other':
+    'The cached low-stock count disagrees with the stored items.',
+
+  // ui/plural — a count and the noun it counts, for a tally that stands alone.
+  // A count inside a sentence gets a key for the whole sentence instead.
+  'hv.count.item.one': '{count} item',
+  'hv.count.item.other': '{count} items',
+  'hv.count.location.one': '{count} location',
+  'hv.count.location.other': '{count} locations',
+  'hv.count.subLocation.one': '{count} sub-location',
+  'hv.count.subLocation.other': '{count} sub-locations',
+  'hv.count.tag.one': '{count} tag',
+  'hv.count.tag.other': '{count} tags',
+  'hv.count.category.one': '{count} category',
+  'hv.count.category.other': '{count} categories',
+  'hv.count.status.one': '{count} status',
+  'hv.count.status.other': '{count} statuses',
+  'hv.count.field.one': '{count} field',
+  'hv.count.field.other': '{count} fields',
+  'hv.count.filter.one': '{count} filter',
+  'hv.count.filter.other': '{count} filters',
+  'hv.count.issue.one': '{count} issue',
+  'hv.count.issue.other': '{count} issues',
+  'hv.count.problem.one': '{count} problem',
+  'hv.count.problem.other': '{count} problems',
+  'hv.count.conflict.one': '{count} conflict',
+  'hv.count.conflict.other': '{count} conflicts',
+  'hv.count.nameClash.one': '{count} name clash',
+  'hv.count.nameClash.other': '{count} name clashes',
+  'hv.count.failedRow.one': '{count} failed row',
+  'hv.count.failedRow.other': '{count} failed rows',
+
+  // ui/plural — the line under a list saying how much of the set is on screen.
+  'hv.list.showingAll.one': 'Showing {count} item',
+  'hv.list.showingAll.other': 'Showing {count} items',
+  'hv.list.showingOf.one': 'Showing {loaded} of {count} item',
+  'hv.list.showingOf.other': 'Showing {loaded} of {count} items',
+  'hv.list.showingOfMatching.one': 'Showing {loaded} of {count} matching item',
+  'hv.list.showingOfMatching.other': 'Showing {loaded} of {count} matching items',
+
+  // ui/value-rewrite — what renaming a tag or a category is about to do.
+  'hv.rewrite.tag.remove.one': 'Removes "{from}" from {count} item.',
+  'hv.rewrite.tag.remove.other': 'Removes "{from}" from {count} items.',
+  'hv.rewrite.tag.retag.one': 'Retags {count} item, then removes "{from}".',
+  'hv.rewrite.tag.retag.other': 'Retags {count} items, then removes "{from}".',
+  'hv.rewrite.category.clear.one': 'Clears the category on {count} item.',
+  'hv.rewrite.category.clear.other': 'Clears the category on {count} items.',
+  'hv.rewrite.category.set.one': 'Recategorises {count} item as "{to}".',
+  'hv.rewrite.category.set.other': 'Recategorises {count} items as "{to}".',
+
+  // ui/relative-time — everything `Intl` does not already say in the user's
+  // language. The spans themselves come from `Intl.RelativeTimeFormat`.
+  'hv.time.justNow': 'just now',
+  'hv.date.offsetDays': '+{days} days',
+
+  // ui/reminder — how a repeat is written. `every 1 days` is not a sentence in
+  // any language, so the singular form is its own wording in each.
+  'hv.reminder.every.days.one': 'every day',
+  'hv.reminder.every.days.other': 'every {count} days',
+  'hv.reminder.every.weeks.one': 'every week',
+  'hv.reminder.every.weeks.other': 'every {count} weeks',
+  'hv.reminder.every.months.one': 'every month',
+  'hv.reminder.every.months.other': 'every {count} months',
+
+  // ui/location-path — the area beside a path.
+  'hv.area.prefix': 'Area: {name}',
+  // Read out before the chip's name, for anyone who cannot see the glyph that
+  // says the same thing. The trailing space is part of the announcement.
+  'hv.area.srPrefix': 'Area: ',
+
+  // ui/keyboard — the save chord, on a keyboard without a Command key.
+  'hv.shortcut.ctrlEnter': 'Ctrl+Enter',
+
+  // Three counted sentences whose components are translated in a later batch;
+  // they land here because `ui/plural` no longer derives an English plural for
+  // anyone, and these were its last three callers outside `src/ui`.
+  'hv.bulk.result.failed.one': '{count} failed and was left unchanged.',
+  'hv.bulk.result.failed.other': '{count} failed and were left unchanged.',
+  'hv.fullView.checkedOutWarning.one': '{count} of them is checked out',
+  'hv.fullView.checkedOutWarning.other': '{count} of them are checked out',
+  'hv.surfaces.exportView.filtered.one': '{count} filtered item · Keeps location paths',
+  'hv.surfaces.exportView.filtered.other': '{count} filtered items · Keeps location paths',
+
+  // ui/item-form — what the editor refuses to save, and why.
+  'hv.form.error.nameRequired': 'Name is required.',
+  'hv.form.error.nameTooLong': 'Name is limited to {max} characters.',
+  'hv.form.error.descriptionTooLong': 'Description is limited to {max} characters.',
+  'hv.form.error.categoryTooLong': 'Category is limited to {max} characters.',
+  'hv.form.error.quantityNegative': "Quantity can't be negative.",
+  'hv.form.error.lowStockRange': 'Low-stock threshold must be 0 or more, or empty.',
+  'hv.form.error.tooManyTags': 'An item can carry at most {max} tags.',
+  'hv.form.error.tagTooLong': 'Each tag is limited to {max} characters.',
+  'hv.form.error.reminderRange': 'Repeat every 1 to {max}, or leave it empty for a one-off.',
+  'hv.form.error.customFieldDuplicate': '"{key}" is used twice.',
+  'hv.form.error.customFieldKeyTooLong': 'Field names are limited to {max} characters.',
+  'hv.form.error.customFieldNotNumber': '"{key}" must be a number.',
+  'hv.form.error.customFieldNotDate': '"{key}" must be a date.',
+  'hv.form.error.customFieldValueTooLong': '"{key}" is limited to {max} characters.',
+  'hv.form.error.tooManyCustomFields': 'An item can carry at most {max} custom fields.',
+} as const;
+
+/** Every string the card can say, as a type. */
+export type TranslationKey = keyof typeof en;
+
+/**
+ * A dictionary for one language.
+ *
+ * Partial on purpose: a community dictionary is incomplete on the day it
+ * arrives, and `t` falls through to English for whatever it has not reached
+ * yet. `de` is declared complete separately, which is what makes TypeScript
+ * itself refuse a German string left behind by a new English one.
+ */
+export type Dictionary = Partial<Record<TranslationKey, string>>;
+
+/** The base of a counted pair — everything `tn` may be called with. */
+export type PluralKey = {
+  [K in TranslationKey]: K extends `${infer Base}.one` ? Base : never;
+}[TranslationKey];

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -211,6 +211,10 @@ export const en = {
   'hv.reminder.every.months.one': 'every month',
   'hv.reminder.every.months.other': 'every {count} months',
 
+  // ui/media — what a screen reader says about an item's photo.
+  'hv.media.photoAlt': '{name} — photo {index} of {total}',
+  'hv.media.photoAltOnly': 'Photo of {name}',
+
   // ui/location-path — the area beside a path.
   'hv.area.prefix': 'Area: {name}',
   // Read out before the chip's name, for anyone who cannot see the glyph that

--- a/cards/haventory-card/src/i18n/index.test.ts
+++ b/cards/haventory-card/src/i18n/index.test.ts
@@ -1,0 +1,91 @@
+import { DICTIONARIES, language, resolveLanguage, setLanguage, t, tn } from './index';
+import type { Dictionary } from './index';
+
+describe('resolveLanguage', () => {
+  it('takes an exact tag', () => {
+    expect(resolveLanguage('de')).toBe('de');
+    expect(resolveLanguage('DE')).toBe('de');
+  });
+
+  it('falls back through the primary subtag', () => {
+    // Home Assistant reports a regional profile as `de-CH`; nothing here
+    // carries one, and Swiss German readers get German rather than English.
+    expect(resolveLanguage('de-CH')).toBe('de');
+  });
+
+  it('falls back to English for anything else', () => {
+    expect(resolveLanguage('sv')).toBe('en');
+    expect(resolveLanguage('')).toBe('en');
+    expect(resolveLanguage(null)).toBe('en');
+    expect(resolveLanguage(undefined)).toBe('en');
+  });
+});
+
+describe('setLanguage', () => {
+  it('reports only the changes, so a host re-renders once and not on every hass', () => {
+    expect(setLanguage('de')).toBe(true);
+    expect(setLanguage('de')).toBe(false);
+    // Two tags that resolve to the same dictionary are not a change either.
+    expect(setLanguage('de-AT')).toBe(false);
+    expect(setLanguage('en')).toBe(true);
+  });
+
+  it('reports what it resolved to, never the tag it was handed', () => {
+    setLanguage('de-CH');
+    expect(language()).toBe('de');
+  });
+});
+
+describe('t', () => {
+  it('answers in the language in force', () => {
+    expect(t('hv.action.refresh')).toBe('Refresh');
+    setLanguage('de');
+    expect(t('hv.action.refresh')).toBe('Aktualisieren');
+  });
+
+  it('fills placeholders', () => {
+    expect(t('hv.empty.emptyLocation.headline', { location: 'Garage' })).toBe('Nothing in Garage');
+    expect(t('hv.form.error.nameTooLong', { max: 200 })).toBe('Name is limited to 200 characters.');
+  });
+
+  it('leaves a placeholder standing when nothing fills it', () => {
+    // Visible in the UI on purpose: a sentence quietly missing its number
+    // reads as finished copy that says the wrong thing.
+    expect(t('hv.empty.emptyLocation.headline')).toBe('Nothing in {location}');
+  });
+
+  it('falls back to English for a key a dictionary has not reached yet', () => {
+    // What a community dictionary looks like on the day it arrives: a handful
+    // of keys, and everything else still English rather than `hv.action.retry`
+    // printed on a button.
+    const partial: Dictionary = { 'hv.action.refresh': 'Rafraîchir' };
+    (DICTIONARIES as Record<string, Dictionary>).fr = partial;
+    try {
+      setLanguage('fr');
+      expect(t('hv.action.refresh')).toBe('Rafraîchir');
+      expect(t('hv.action.retry')).toBe('Try again');
+    } finally {
+      delete (DICTIONARIES as Record<string, Dictionary>).fr;
+    }
+  });
+});
+
+describe('tn', () => {
+  it('picks the form the count asks for', () => {
+    expect(tn('hv.count.item', 1)).toBe('1 item');
+    expect(tn('hv.count.item', 0)).toBe('0 items');
+    expect(tn('hv.count.item', 2)).toBe('2 items');
+  });
+
+  it('lets a form place the number where its language puts it, or leave it out', () => {
+    setLanguage('de');
+    expect(tn('hv.reminder.every.days', 1)).toBe('täglich');
+    expect(tn('hv.reminder.every.days', 3)).toBe('alle 3 Tage');
+  });
+
+  it('carries extra parameters into the chosen form', () => {
+    expect(tn('hv.rewrite.tag.remove', 2, { from: 'winter' })).toBe(
+      'Removes "winter" from 2 items.',
+    );
+  });
+});

--- a/cards/haventory-card/src/i18n/index.ts
+++ b/cards/haventory-card/src/i18n/index.ts
@@ -1,0 +1,124 @@
+/**
+ * The card's copy, in one place per language.
+ *
+ * Home Assistant tells a card which language the user reads in `hass.language`,
+ * and that is the only input: there is no per-card language option, because a
+ * dashboard is read by the same person who set the profile.
+ *
+ * A module singleton rather than a Lit context or a threaded property. Half the
+ * card's copy lives in plain functions with no host element — `ui/empty-state`,
+ * `ui/health-codes`, `ui/plural`, `describeFailure` in `hv-bulk-bar` — and a
+ * context cannot reach any of them without a signature change at every call
+ * site. The language is fixed for the lifetime of a page, so a singleton gives
+ * up nothing: `setLanguage` reports whether the value actually moved, and the
+ * two hosts call `requestUpdate()` when it did.
+ *
+ * Adding a language is one file here and one `translations/<tag>.json` for the
+ * backend; `CONTRIBUTING.md` carries the recipe.
+ */
+
+import { en } from './en';
+import type { Dictionary, PluralKey, TranslationKey } from './en';
+import { de } from './de';
+
+export type { Dictionary, PluralKey, TranslationKey };
+
+/** What a placeholder may be filled with. */
+export type TranslationParams = Readonly<Record<string, string | number>>;
+
+/**
+ * Every dictionary this bundle carries, keyed by lower-case BCP-47 tag.
+ *
+ * Lower-case because `resolveLanguage` compares against a lower-cased tag: Home
+ * Assistant sends `de-CH` and a registry keyed `de-ch` is what lets a regional
+ * dictionary be found by an exact match rather than only through its primary
+ * subtag.
+ */
+export const DICTIONARIES: Readonly<Record<string, Dictionary>> = { en, de };
+
+/** The language every dictionary is complete for, and the fallback for the rest. */
+export const FALLBACK_LANGUAGE = 'en';
+
+/**
+ * The dictionary a Home Assistant language tag resolves to.
+ *
+ * Exact tag first, then the primary subtag, then English: a user reading
+ * `de-CH` gets the German dictionary rather than falling all the way back, and
+ * a tag nothing here carries degrades to a language that is complete instead of
+ * to a screen of keys.
+ */
+export function resolveLanguage(tag: string | null | undefined): string {
+  if (!tag) return FALLBACK_LANGUAGE;
+  const exact = tag.toLowerCase();
+  if (exact in DICTIONARIES) return exact;
+  const primary = exact.split('-')[0];
+  if (primary && primary in DICTIONARIES) return primary;
+  return FALLBACK_LANGUAGE;
+}
+
+let current = FALLBACK_LANGUAGE;
+let active: Dictionary = en;
+
+/**
+ * Point the card at a language.
+ *
+ * Returns whether the resolved language changed, so a host can re-render on the
+ * one `set hass` that moves it and not on the hundreds that do not.
+ */
+export function setLanguage(tag: string | null | undefined): boolean {
+  const next = resolveLanguage(tag);
+  if (next === current) return false;
+  current = next;
+  active = DICTIONARIES[next] ?? en;
+  return true;
+}
+
+/** The resolved language in force, never a tag no dictionary answers to. */
+export function language(): string {
+  return current;
+}
+
+const PLACEHOLDER = /\{(\w+)\}/g;
+
+/**
+ * Fill `{name}` placeholders from `params`.
+ *
+ * A placeholder with no parameter is left standing rather than blanked: a
+ * sentence with a visible `{count}` in it names the bug, where a sentence
+ * quietly missing its number reads as finished copy that says the wrong thing.
+ */
+function interpolate(template: string, params: TranslationParams): string {
+  return template.replace(PLACEHOLDER, (whole, name: string) =>
+    name in params ? String(params[name]) : whole,
+  );
+}
+
+/**
+ * One string, in the language in force.
+ *
+ * A key the active dictionary has not translated falls through to English
+ * rather than rendering the key itself: a partial dictionary — which is what a
+ * community contribution is on the day it arrives — then shows a mixed screen
+ * instead of `hv.item.save`.
+ */
+export function t(key: TranslationKey, params?: TranslationParams): string {
+  const template = active[key] ?? en[key];
+  return params ? interpolate(template, params) : template;
+}
+
+/**
+ * One counted string, in the language in force.
+ *
+ * Two forms, `<key>.one` and `<key>.other`, because that is the split English
+ * and German share for every noun the card counts. `Intl.PluralRules` would add
+ * a category axis every dictionary has to fill and answer a question neither of
+ * these two languages asks.
+ *
+ * `count` is passed through as a parameter, so a form can place the number
+ * wherever its language puts it — or leave it out, which is what "täglich" for
+ * "every 1 days" does.
+ */
+export function tn(key: PluralKey, count: number, params?: TranslationParams): string {
+  const form = `${key}.${count === 1 ? 'one' : 'other'}` as TranslationKey;
+  return t(form, { count, ...params });
+}

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from 'lit';
 import { registerCustomCard } from './ha-contract';
+import { setLanguage } from './i18n';
 import type { HassLike } from './store/types';
 import { Store } from './store/store';
 import { resolveColorScheme } from './ui/theme';
@@ -96,6 +97,9 @@ export class HAventoryCard extends LitElement {
 
   set hass(h: HassLike | undefined) {
     this._hass = h;
+    // Ahead of the store, so the first render of every surface it feeds is
+    // already in the user's language rather than flashing English first.
+    if (setLanguage(h?.language)) this.requestUpdate();
     if (h && !this.store) {
       this.store = new Store(h);
       this._storeUnsub = this.store.state.onChange(() => {

--- a/cards/haventory-card/src/test.setup.ts
+++ b/cards/haventory-card/src/test.setup.ts
@@ -1,4 +1,15 @@
-import { afterAll } from 'vitest';
+import { afterAll, beforeEach } from 'vitest';
+import { setLanguage } from './i18n';
+
+/*
+ * The card's language is a module singleton, and a spec file shares one module
+ * registry across its tests — so a test that switches to German leaves every
+ * test after it in German. Reset before each, which also means a spec need only
+ * say `setLanguage('de')` and not clean up after itself.
+ */
+beforeEach(() => {
+  setLanguage('en');
+});
 
 // Minimal polyfills for jsdom environment used in Vitest.
 // `ui/responsive.ts` observes the card element's own width, so jsdom needs a

--- a/cards/haventory-card/src/ui/banners.ts
+++ b/cards/haventory-card/src/ui/banners.ts
@@ -1,7 +1,7 @@
 import { css, html } from 'lit';
 import type { TemplateResult } from 'lit';
+import { t, tn } from '../i18n';
 import { icon } from './icons';
-import { counted } from './plural';
 import type { Store } from '../store/store';
 import type { StoreState } from '../store/types';
 // Registers the element this file emits. Kept here rather than left to each
@@ -60,26 +60,29 @@ export function renderDegradedBanners(st: StoreState | null, hooks: BannerHooks)
     banners.push(html`<hv-banner
       kind="error"
       glyph="wifiOff"
-      heading="Connection lost"
-      message=" · showing the data already loaded. Changes may not save."
+      heading=${t('hv.banner.connectionLost.heading')}
+      message=${t('hv.banner.connectionLost.message')}
       data-testid="degraded-offline"
     >
       <button slot="actions" class="hv-pill outline" data-testid="degraded-reconnect" @click=${hooks.onRefresh}>
-        Reconnect
+        ${t('hv.banner.connectionLost.action')}
       </button>
     </hv-banner>`);
   } else if (degraded.liveUpdates !== 'live') {
     // Ranked above the generic rate-limit warning below: that one says events
     // *may* have been dropped, this one says there are no events at all.
     const retrying = degraded.liveUpdates === 'retrying';
-    const cause = degraded.liveUpdatesReason === 'unavailable' ? 'HAventory is not available' : 'rate limited';
+    const cause =
+      degraded.liveUpdatesReason === 'unavailable'
+        ? t('hv.banner.liveUpdates.cause.unavailable')
+        : t('hv.banner.liveUpdates.cause.rateLimited');
     banners.push(html`<hv-banner
       kind="warning"
       glyph="clock"
-      heading="Live updates paused"
+      heading=${t('hv.banner.liveUpdates.heading')}
       message=${retrying
-        ? ` · ${cause}. Retrying automatically; this list may be out of date until then.`
-        : ` · ${cause}. This list may be out of date until you refresh.`}
+        ? t('hv.banner.liveUpdates.retrying', { cause })
+        : t('hv.banner.liveUpdates.stalled', { cause })}
       data-testid="degraded-live-updates"
     >
       ${retrying
@@ -90,27 +93,27 @@ export function renderDegradedBanners(st: StoreState | null, hooks: BannerHooks)
             data-testid="degraded-live-refresh"
             @click=${hooks.onRefresh}
           >
-            Refresh
+            ${t('hv.action.refresh')}
           </button>`}
     </hv-banner>`);
   } else if (degraded.retrying > 0) {
     banners.push(html`<hv-banner
       kind="warning"
       glyph="clock"
-      heading="Busy — retrying"
-      message=${` · ${counted(degraded.retrying, 'change')} queued`}
+      heading=${t('hv.banner.retrying.heading')}
+      message=${tn('hv.banner.retrying.message', degraded.retrying)}
       data-testid="degraded-retrying"
     ></hv-banner>`);
   } else if (degraded.rateLimited) {
     banners.push(html`<hv-banner
       kind="warning"
       glyph="clock"
-      heading="Rate limited"
-      message=" · some live updates may have been dropped, so this list can be out of date."
+      heading=${t('hv.banner.rateLimited.heading')}
+      message=${t('hv.banner.rateLimited.message')}
       data-testid="degraded-rate-limited"
     >
       <button slot="actions" class="hv-pill outline" data-testid="degraded-refresh" @click=${hooks.onRefresh}>
-        Refresh
+        ${t('hv.action.refresh')}
       </button>
     </hv-banner>`);
   }
@@ -119,8 +122,8 @@ export function renderDegradedBanners(st: StoreState | null, hooks: BannerHooks)
     banners.push(html`<hv-banner
       kind="info"
       glyph="refresh"
-      heading="Inventory was replaced by an import"
-      message=" · reloading…"
+      heading=${t('hv.banner.reloading.heading')}
+      message=${t('hv.banner.reloading.message')}
       data-testid="degraded-reloading"
     ></hv-banner>`);
   }
@@ -139,7 +142,7 @@ export function renderErrorBanners(st: StoreState | null, hooks: BannerHooks): T
         const conflict = e.kind === 'conflict' && e.itemId;
         return html`<hv-banner
           kind=${conflict ? 'warning' : 'error'}
-          .heading=${conflict ? 'Someone else changed this item.' : null}
+          .heading=${conflict ? t('hv.banner.conflict.heading') : null}
           .message=${e.message}
           data-testid="banner-entry"
           data-code=${e.code}
@@ -154,7 +157,7 @@ export function renderErrorBanners(st: StoreState | null, hooks: BannerHooks): T
                     store?.dismissError(e.id);
                   }}
                 >
-                  View latest
+                  ${t('hv.banner.conflict.viewLatest')}
                 </button>
                 ${e.changes
                   ? html`<button
@@ -165,7 +168,7 @@ export function renderErrorBanners(st: StoreState | null, hooks: BannerHooks): T
                         store?.dismissError(e.id);
                       }}
                     >
-                      Re-apply my change
+                      ${t('hv.banner.conflict.reapply')}
                     </button>`
                   : null}
               </span>`
@@ -174,7 +177,7 @@ export function renderErrorBanners(st: StoreState | null, hooks: BannerHooks): T
             slot="actions"
             class="hv-icon-button"
             data-testid="banner-dismiss"
-            aria-label="Dismiss"
+            aria-label=${t('hv.action.dismiss')}
             @click=${() => store?.dismissError(e.id)}
           >
             ${icon('close', 16)}

--- a/cards/haventory-card/src/ui/discard.ts
+++ b/cards/haventory-card/src/ui/discard.ts
@@ -1,3 +1,5 @@
+import { t } from '../i18n';
+
 /**
  * The one question asked before typed edits are thrown away.
  *
@@ -7,12 +9,24 @@
  * never reads as a different question depending on which control the user
  * reached for.
  *
+ * A function rather than a constant: the language is not known when this module
+ * is evaluated — Home Assistant hands it over in `set hass`, which is long
+ * after — so a constant here would freeze the English strings into every
+ * surface that spreads it.
+ *
  * Spread into `HostSurfaces.confirm()` alongside an `onConfirm`, or bound field
  * by field onto an `hv-confirm`.
  */
-export const DISCARD_PROMPT = {
-  heading: 'Discard your changes?',
-  message: 'What you have typed since the last save is lost.',
-  confirmLabel: 'Discard',
-  destructive: true,
-} as const;
+export function discardPrompt(): {
+  heading: string;
+  message: string;
+  confirmLabel: string;
+  destructive: true;
+} {
+  return {
+    heading: t('hv.discard.heading'),
+    message: t('hv.discard.message'),
+    confirmLabel: t('hv.action.discard'),
+    destructive: true,
+  };
+}

--- a/cards/haventory-card/src/ui/editor-error.ts
+++ b/cards/haventory-card/src/ui/editor-error.ts
@@ -1,3 +1,4 @@
+import { t } from '../i18n';
 import type { ErrorEntry } from '../store/types';
 
 /**
@@ -13,5 +14,5 @@ import type { ErrorEntry } from '../store/types';
  * would be describing the surface, not the failure.
  */
 export function editorErrorText(entry: ErrorEntry): string {
-  return entry.kind === 'conflict' ? 'Someone else changed this item.' : entry.message;
+  return entry.kind === 'conflict' ? t('hv.banner.conflict.heading') : entry.message;
 }

--- a/cards/haventory-card/src/ui/empty-state.ts
+++ b/cards/haventory-card/src/ui/empty-state.ts
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import type { TemplateResult } from 'lit';
+import { t } from '../i18n';
 import { activeFilterCount, defaultFilters, soleLocationId } from '../store/store';
 import type { StoreFilters } from '../store/types';
 
@@ -72,33 +73,35 @@ export function emptyStateCopy(kind: EmptyKind, locationName?: string | null): E
     // action the other kinds offer would be an answer to a question that has
     // not been asked yet.
     case 'loading':
-      return { headline: 'Loading items', offers: [] };
+      return { headline: t('hv.empty.loading.headline'), offers: [] };
     case 'connection-lost':
       return {
-        headline: "Can't reach Home Assistant",
-        detail: 'The list will fill in once the connection is back.',
-        offers: [{ id: 'refresh', label: 'Try again' }],
+        headline: t('hv.empty.connectionLost.headline'),
+        detail: t('hv.empty.connectionLost.detail'),
+        offers: [{ id: 'refresh', label: t('hv.action.retry') }],
       };
     case 'no-matches':
       return {
-        headline: 'No items match these filters',
-        offers: [{ id: 'clear-filters', label: 'Clear all' }],
+        headline: t('hv.empty.noMatches.headline'),
+        offers: [{ id: 'clear-filters', label: t('hv.empty.noMatches.clearAction') }],
       };
     case 'empty-location':
       return {
-        headline: `Nothing in ${locationName ?? 'this location'}`,
+        headline: locationName
+          ? t('hv.empty.emptyLocation.headline', { location: locationName })
+          : t('hv.empty.emptyLocation.headlineUnnamed'),
         offers: [
-          { id: 'add-item', label: 'Add item here' },
-          { id: 'clear-filters', label: 'Show everything' },
+          { id: 'add-item', label: t('hv.empty.emptyLocation.addAction') },
+          { id: 'clear-filters', label: t('hv.empty.emptyLocation.clearAction') },
         ],
       };
     default:
       return {
-        headline: 'No items yet',
-        detail: 'Add your first item, or restore a backup.',
+        headline: t('hv.empty.noItems.headline'),
+        detail: t('hv.empty.noItems.detail'),
         offers: [
-          { id: 'add-item', label: 'Add your first item' },
-          { id: 'import', label: 'Import backup' },
+          { id: 'add-item', label: t('hv.empty.noItems.addAction') },
+          { id: 'import', label: t('hv.empty.noItems.importAction') },
         ],
       };
   }

--- a/cards/haventory-card/src/ui/health-codes.test.ts
+++ b/cards/haventory-card/src/ui/health-codes.test.ts
@@ -1,3 +1,4 @@
+import { setLanguage } from '../i18n';
 import { summarizeIssues } from './health-codes';
 
 describe('summarizeIssues', () => {
@@ -17,7 +18,17 @@ describe('summarizeIssues', () => {
     expect(out).toHaveLength(1);
     expect(out[0].code).toBe('item_references_missing_location');
     expect(out[0].count).toBe(3);
-    expect(out[0].message).toContain('3 item(s) reference a location that no longer exists');
+    expect(out[0].message).toContain('3 items reference a location that no longer exists');
+  });
+
+  it('agrees with its own count, and says so in the language in force', () => {
+    expect(summarizeIssues(['location_id_key_mismatch'])[0].message).toBe(
+      '1 location is stored under a key that does not match its id.',
+    );
+    setLanguage('de');
+    expect(
+      summarizeIssues(['location_id_key_mismatch', 'location_id_key_mismatch'])[0].message,
+    ).toMatch(/^2 Orte sind /);
   });
 
   it('keeps distinct codes in first-seen order', () => {

--- a/cards/haventory-card/src/ui/health-codes.ts
+++ b/cards/haventory-card/src/ui/health-codes.ts
@@ -7,6 +7,9 @@
  * needs one card per distinct problem with a count, so dedupe and count here.
  */
 
+import { tn } from '../i18n';
+import type { PluralKey } from '../i18n';
+
 export interface HealthIssueSummary {
   /** The raw backend code, kept so the panel can still show it verbatim. */
   code: string;
@@ -17,34 +20,34 @@ export interface HealthIssueSummary {
 }
 
 /**
- * Known codes from `_collect_item_issues` / `_collect_index_issues` in `ws.py`.
- * `{n}` is replaced with the occurrence count. Unknown codes are surfaced as-is
- * rather than swallowed — a new backend check should still be visible.
+ * Known codes from `_collect_item_issues` / `_collect_index_issues` in `ws.py`,
+ * each mapped to the counted pair that says it in words.
+ *
+ * A code with no entry here is surfaced as-is rather than swallowed — a new
+ * backend check should still be visible, in whatever language, before anyone
+ * has got round to writing a sentence for it.
  */
-const MESSAGES: Record<string, string> = {
-  item_id_key_mismatch: '{n} item(s) are stored under a key that does not match their id.',
-  item_references_missing_location:
-    '{n} item(s) reference a location that no longer exists — they appear under "No location".',
-  item_missing_from_items_by_location_index: '{n} item(s) are missing from the location index.',
-  checked_out_item_missing_from_index: '{n} checked-out item(s) are missing from the checked-out index.',
-  non_checked_out_item_present_in_index: '{n} item(s) are in the checked-out index but are not checked out.',
-  low_stock_item_missing_from_index: '{n} low-stock item(s) are missing from the low-stock index.',
-  non_low_stock_item_present_in_index: '{n} item(s) are in the low-stock index but are not low on stock.',
-  tags_index_references_unknown_item_ids: 'The tag index references {n} item(s) that no longer exist.',
-  category_index_references_unknown_item_ids: 'The category index references {n} item(s) that no longer exist.',
-  checked_out_index_references_unknown_item_ids:
-    'The checked-out index references {n} item(s) that no longer exist.',
-  low_stock_index_references_unknown_item_ids: 'The low-stock index references {n} item(s) that no longer exist.',
-  items_by_location_index_references_unknown_item_ids:
-    'The location index references {n} item(s) that no longer exist.',
-  items_by_location_references_missing_location: 'The location index has {n} bucket(s) for missing locations.',
-  items_by_location_bucket_mismatch: '{n} location bucket(s) disagree with the items they hold.',
-  location_id_key_mismatch: '{n} location(s) are stored under a key that does not match their id.',
-  items_total_count_mismatch: 'The cached item total disagrees with the stored items.',
-  locations_total_count_mismatch: 'The cached location total disagrees with the stored locations.',
-  checked_out_count_mismatch: 'The cached checked-out count disagrees with the stored items.',
-  low_stock_count_mismatch: 'The cached low-stock count disagrees with the stored items.',
-};
+const MESSAGE_KEYS = {
+  item_id_key_mismatch: 'hv.health.itemIdKeyMismatch',
+  item_references_missing_location: 'hv.health.itemReferencesMissingLocation',
+  item_missing_from_items_by_location_index: 'hv.health.itemMissingFromLocationIndex',
+  checked_out_item_missing_from_index: 'hv.health.checkedOutItemMissingFromIndex',
+  non_checked_out_item_present_in_index: 'hv.health.nonCheckedOutItemInIndex',
+  low_stock_item_missing_from_index: 'hv.health.lowStockItemMissingFromIndex',
+  non_low_stock_item_present_in_index: 'hv.health.nonLowStockItemInIndex',
+  tags_index_references_unknown_item_ids: 'hv.health.tagsIndexUnknownItems',
+  category_index_references_unknown_item_ids: 'hv.health.categoryIndexUnknownItems',
+  checked_out_index_references_unknown_item_ids: 'hv.health.checkedOutIndexUnknownItems',
+  low_stock_index_references_unknown_item_ids: 'hv.health.lowStockIndexUnknownItems',
+  items_by_location_index_references_unknown_item_ids: 'hv.health.locationIndexUnknownItems',
+  items_by_location_references_missing_location: 'hv.health.locationIndexMissingLocation',
+  items_by_location_bucket_mismatch: 'hv.health.locationBucketMismatch',
+  location_id_key_mismatch: 'hv.health.locationIdKeyMismatch',
+  items_total_count_mismatch: 'hv.health.itemsTotalMismatch',
+  locations_total_count_mismatch: 'hv.health.locationsTotalMismatch',
+  checked_out_count_mismatch: 'hv.health.checkedOutCountMismatch',
+  low_stock_count_mismatch: 'hv.health.lowStockCountMismatch',
+} as const satisfies Record<string, PluralKey>;
 
 /**
  * Collapse a raw `issues` array into one entry per distinct code, preserving
@@ -57,9 +60,8 @@ export function summarizeIssues(issues: readonly string[] | null | undefined): H
     const code = String(raw);
     counts.set(code, (counts.get(code) ?? 0) + 1);
   }
-  return [...counts.entries()].map(([code, count]) => ({
-    code,
-    count,
-    message: MESSAGES[code]?.replace('{n}', String(count)) ?? code,
-  }));
+  return [...counts.entries()].map(([code, count]) => {
+    const key = (MESSAGE_KEYS as Record<string, PluralKey | undefined>)[code];
+    return { code, count, message: key ? tn(key, count) : code };
+  });
 }

--- a/cards/haventory-card/src/ui/item-form.ts
+++ b/cards/haventory-card/src/ui/item-form.ts
@@ -1,3 +1,4 @@
+import { t } from '../i18n';
 import type {
   Item,
   ItemCreate,
@@ -138,11 +139,11 @@ export function formFromItem(item: Item | null): ItemFormModel {
 export function validateForm(model: ItemFormModel, original: Item | null = null): FieldError[] {
   const errors: FieldError[] = [];
   if (!model.name.trim()) {
-    errors.push({ field: 'name', message: 'Name is required.' });
+    errors.push({ field: 'name', message: t('hv.form.error.nameRequired') });
   } else if (model.name.trim().length > NAME_MAX_LENGTH) {
     errors.push({
       field: 'name',
-      message: `Name is limited to ${NAME_MAX_LENGTH} characters.`,
+      message: t('hv.form.error.nameTooLong', { max: NAME_MAX_LENGTH }),
     });
   }
   const storedDescription = original?.description ?? '';
@@ -152,7 +153,7 @@ export function validateForm(model: ItemFormModel, original: Item | null = null)
   ) {
     errors.push({
       field: 'description',
-      message: `Description is limited to ${DESCRIPTION_MAX_LENGTH} characters.`,
+      message: t('hv.form.error.descriptionTooLong', { max: DESCRIPTION_MAX_LENGTH }),
     });
   }
   const storedCategory = original?.category ?? '';
@@ -162,26 +163,26 @@ export function validateForm(model: ItemFormModel, original: Item | null = null)
   ) {
     errors.push({
       field: 'category',
-      message: `Category is limited to ${CATEGORY_MAX_LENGTH} characters.`,
+      message: t('hv.form.error.categoryTooLong', { max: CATEGORY_MAX_LENGTH }),
     });
   }
   if (!Number.isFinite(model.quantity) || !Number.isInteger(model.quantity) || model.quantity < 0) {
-    errors.push({ field: 'quantity', message: "Quantity can't be negative." });
+    errors.push({ field: 'quantity', message: t('hv.form.error.quantityNegative') });
   }
   if (model.lowStock !== null && (!Number.isFinite(model.lowStock) || model.lowStock < 0)) {
-    errors.push({ field: 'lowStock', message: 'Low-stock threshold must be 0 or more, or empty.' });
+    errors.push({ field: 'lowStock', message: t('hv.form.error.lowStockRange') });
   }
   // Counted after normalization, the way the backend counts it: two casings of
   // one tag are one tag on both sides.
   const tags = normalizeTags(model.tags);
   const storedTags = normalizeTags(original?.tags ?? []);
   if (tags.length > TAGS_MAX_COUNT && tags.length > storedTags.length) {
-    errors.push({ field: 'tags', message: `An item can carry at most ${TAGS_MAX_COUNT} tags.` });
+    errors.push({ field: 'tags', message: t('hv.form.error.tooManyTags', { max: TAGS_MAX_COUNT }) });
   }
   if (tags.some((tag) => tag.length > TAG_MAX_LENGTH && !storedTags.includes(tag))) {
     errors.push({
       field: 'tags',
-      message: `Each tag is limited to ${TAG_MAX_LENGTH} characters.`,
+      message: t('hv.form.error.tagTooLong', { max: TAG_MAX_LENGTH }),
     });
   }
   // Only while a date is set. The repeat is disabled without one and dropped
@@ -196,7 +197,7 @@ export function validateForm(model: ItemFormModel, original: Item | null = null)
     ) {
       errors.push({
         field: 'reminder',
-        message: `Repeat every 1 to ${REMINDER_COUNT_MAX}, or leave it empty for a one-off.`,
+        message: t('hv.form.error.reminderRange', { max: REMINDER_COUNT_MAX }),
       });
     }
   }
@@ -206,21 +207,21 @@ export function validateForm(model: ItemFormModel, original: Item | null = null)
     const key = row.key.trim();
     if (!key) continue;
     if (seen.has(key)) {
-      errors.push({ field: `custom:${row.id}`, message: `"${key}" is used twice.` });
+      errors.push({ field: `custom:${row.id}`, message: t('hv.form.error.customFieldDuplicate', { key }) });
       continue;
     }
     seen.add(key);
     if (key.length > CUSTOM_FIELD_KEY_MAX_LENGTH && !(key in storedFields)) {
       errors.push({
         field: `custom:${row.id}`,
-        message: `Field names are limited to ${CUSTOM_FIELD_KEY_MAX_LENGTH} characters.`,
+        message: t('hv.form.error.customFieldKeyTooLong', { max: CUSTOM_FIELD_KEY_MAX_LENGTH }),
       });
     }
     if (row.type === 'number' && (row.value.trim() === '' || !Number.isFinite(Number(row.value)))) {
-      errors.push({ field: `custom:${row.id}`, message: `"${key}" must be a number.` });
+      errors.push({ field: `custom:${row.id}`, message: t('hv.form.error.customFieldNotNumber', { key }) });
     }
     if (row.type === 'date' && row.value.trim() !== '' && !DATE_RE.test(row.value.trim())) {
-      errors.push({ field: `custom:${row.id}`, message: `"${key}" must be a date.` });
+      errors.push({ field: `custom:${row.id}`, message: t('hv.form.error.customFieldNotDate', { key }) });
     }
     const storedValue = storedFields[key];
     const storedValueLength = typeof storedValue === 'string' ? storedValue.length : 0;
@@ -231,14 +232,17 @@ export function validateForm(model: ItemFormModel, original: Item | null = null)
     ) {
       errors.push({
         field: `custom:${row.id}`,
-        message: `"${key}" is limited to ${CUSTOM_FIELD_VALUE_MAX_LENGTH} characters.`,
+        message: t('hv.form.error.customFieldValueTooLong', {
+          key,
+          max: CUSTOM_FIELD_VALUE_MAX_LENGTH,
+        }),
       });
     }
   }
   if (seen.size > CUSTOM_FIELDS_MAX_KEYS && seen.size > Object.keys(storedFields).length) {
     errors.push({
       field: 'customFields',
-      message: `An item can carry at most ${CUSTOM_FIELDS_MAX_KEYS} custom fields.`,
+      message: t('hv.form.error.tooManyCustomFields', { max: CUSTOM_FIELDS_MAX_KEYS }),
     });
   }
   return errors;

--- a/cards/haventory-card/src/ui/keyboard.ts
+++ b/cards/haventory-card/src/ui/keyboard.ts
@@ -14,6 +14,8 @@
  * on a PC names a key that is not on the keyboard.
  */
 
+import { t } from '../i18n';
+
 /** The slice of `navigator` this needs, so tests can pass a plain object. */
 export interface KeyboardPlatform {
   /** Chromium's replacement for the frozen `navigator.platform`. */
@@ -64,5 +66,5 @@ export function onEscape(close: () => void): (e: KeyboardEvent) => void {
 
 /** How to write "save" as a chord: `⌘↵` on a Mac, `Ctrl+Enter` everywhere else. */
 export function saveShortcutLabel(nav: KeyboardPlatform = navigator): string {
-  return hasCommandKey(nav) ? '⌘↵' : 'Ctrl+Enter';
+  return hasCommandKey(nav) ? '⌘↵' : t('hv.shortcut.ctrlEnter');
 }

--- a/cards/haventory-card/src/ui/location-path.ts
+++ b/cards/haventory-card/src/ui/location-path.ts
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import type { TemplateResult } from 'lit';
+import { t } from '../i18n';
 import { icon } from './icons';
 import { areaNameById, effectiveAreaIdForLocation } from './area';
 import type { AreaRef, Item, Location } from '../store/types';
@@ -75,7 +76,9 @@ export function locationPathParts(
  * glyph cannot go and the area has to say its own name.
  */
 export function pathTitle(parts: PathParts): string {
-  return [parts.areaName ? `Area: ${parts.areaName}` : '', parts.path].filter(Boolean).join(' · ');
+  return [parts.areaName ? t('hv.area.prefix', { name: parts.areaName }) : '', parts.path]
+    .filter(Boolean)
+    .join(' · ');
 }
 
 /**
@@ -149,7 +152,7 @@ export function areaMarkName(areaName: string | null, path: string): string | nu
 export function renderAreaChip(areaName: string | null): TemplateResult | null {
   if (!areaName) return null;
   return html`<span class="hv-area-chip" data-testid="area-chip"
-    >${icon('home', 12)}<span class="hv-sr-only">Area: </span
+    >${icon('home', 12)}<span class="hv-sr-only">${t('hv.area.srPrefix')}</span
     ><span class="hv-chip-text">${areaName}</span></span
   >`;
 }

--- a/cards/haventory-card/src/ui/media.test.ts
+++ b/cards/haventory-card/src/ui/media.test.ts
@@ -1,3 +1,4 @@
+import { setLanguage } from '../i18n';
 import { describe, it, expect, vi } from 'vitest';
 import {
   MEDIA_NAME_TOKEN_PARAM,
@@ -186,6 +187,8 @@ describe('pictureAlt', () => {
 
   it('distinguishes photos when there is more than one', () => {
     expect(pictureAlt('Drill', 1, 3)).toBe('Drill — photo 2 of 3');
+    setLanguage('de');
+    expect(pictureAlt('Drill', 1, 3)).toBe('Drill – Foto 2 von 3'); // codespell:ignore
   });
 });
 

--- a/cards/haventory-card/src/ui/media.ts
+++ b/cards/haventory-card/src/ui/media.ts
@@ -10,6 +10,7 @@
  * read a URL out of it synchronously, which is what a Lit template needs.
  */
 
+import { t } from '../i18n';
 import type { Attachment, AttachmentKind, Item } from '../store/types';
 
 /**
@@ -139,7 +140,9 @@ export function formatBytes(size: number): string {
 
 /** Alt text for one picture: the item names it, the index distinguishes it. */
 export function pictureAlt(itemName: string, index: number, total: number): string {
-  return total > 1 ? `${itemName} — photo ${index + 1} of ${total}` : `Photo of ${itemName}`;
+  return total > 1
+    ? t('hv.media.photoAlt', { name: itemName, index: index + 1, total })
+    : t('hv.media.photoAltOnly', { name: itemName });
 }
 
 /**

--- a/cards/haventory-card/src/ui/plural.test.ts
+++ b/cards/haventory-card/src/ui/plural.test.ts
@@ -1,17 +1,5 @@
-import { counted, plural } from './plural';
-
-describe('plural', () => {
-  it('agrees with the count', () => {
-    expect(plural(1, 'item')).toBe('item');
-    expect(plural(0, 'item')).toBe('items');
-    expect(plural(2, 'item')).toBe('items');
-  });
-
-  it('takes an explicit plural for irregular nouns', () => {
-    expect(plural(1, 'category', 'categories')).toBe('category');
-    expect(plural(11, 'category', 'categories')).toBe('categories');
-  });
-});
+import { setLanguage } from '../i18n';
+import { counted, showingCount } from './plural';
 
 describe('counted', () => {
   it('prints the number with its noun', () => {
@@ -19,6 +7,40 @@ describe('counted', () => {
     expect(counted(1, 'item')).toBe('1 item');
     expect(counted(0, 'item')).toBe('0 items');
     expect(counted(556, 'item')).toBe('556 items');
-    expect(counted(1, 'sub-location')).toBe('1 sub-location');
+    expect(counted(1, 'subLocation')).toBe('1 sub-location');
+  });
+
+  it('takes the noun from the dictionary, irregular plurals included', () => {
+    expect(counted(1, 'category')).toBe('1 category');
+    expect(counted(11, 'category')).toBe('11 categories');
+  });
+
+  it('counts in the language in force', () => {
+    setLanguage('de');
+    expect(counted(1, 'item')).toBe('1 Gegenstand');
+    expect(counted(3, 'item')).toBe('3 Gegenstände');
+    // German builds no plural for this one, which a derived `+ 's'` could not
+    // have expressed.
+    expect(counted(3, 'filter')).toBe('3 Filter');
+  });
+});
+
+describe('showingCount', () => {
+  it('names what is on screen against what matches', () => {
+    expect(showingCount(50, 60)).toBe('Showing 50 of 60 items');
+    expect(showingCount(50, 60, true)).toBe('Showing 50 of 60 matching items');
+    expect(showingCount(1, 1)).toBe('Showing 1 of 1 item');
+  });
+
+  it('drops the total the server has not priced yet', () => {
+    expect(showingCount(12, null)).toBe('Showing 12 items');
+    expect(showingCount(1, undefined)).toBe('Showing 1 item');
+  });
+
+  it('inflects the noun after "von" in German', () => {
+    setLanguage('de');
+    // Dative plural — the form a derived plural could never have produced.
+    expect(showingCount(50, 60)).toBe('50 von 60 Gegenständen werden angezeigt');
+    expect(showingCount(12, null)).toBe('12 Gegenstände werden angezeigt');
   });
 });

--- a/cards/haventory-card/src/ui/plural.ts
+++ b/cards/haventory-card/src/ui/plural.ts
@@ -1,5 +1,5 @@
 /**
- * English pluralization for the card's count strings.
+ * The card's count strings.
  *
  * Roughly half of them agreed with their number and half did not: the location
  * tree said "1 item" while the bulk bar, three components away, said "Move 1
@@ -7,15 +7,28 @@
  * of those was a hand-written `n === 1 ? '' : 's'`, so the drift was inevitable
  * rather than careless.
  *
- * Irregular nouns take an explicit plural: `counted(n, 'category', 'categories')`.
+ * The forms now come from the dictionaries, one pair per noun, which is also
+ * the only way a language that does not build its plural by appending a letter
+ * can have one. A count *inside* a sentence does not come through here at all —
+ * it gets a key for the whole sentence, because where the number sits and what
+ * the verb does with it are the sentence's business, not the noun's.
  */
-export function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
-  return count === 1 ? singular : pluralForm;
-}
+
+import { tn } from '../i18n';
+import type { PluralKey } from '../i18n';
+
+/**
+ * Every noun the card counts on its own, read off the key universe — so a
+ * `hv.count.*` pair added to the dictionaries is immediately callable, and one
+ * removed stops compiling at its call sites.
+ */
+export type CountNoun = {
+  [K in PluralKey]: K extends `hv.count.${infer Noun}` ? Noun : never;
+}[PluralKey];
 
 /** The count and its noun: `counted(1, 'item')` → "1 item". */
-export function counted(count: number, singular: string, pluralForm = `${singular}s`): string {
-  return `${count} ${plural(count, singular, pluralForm)}`;
+export function counted(count: number, noun: CountNoun): string {
+  return tn(`hv.count.${noun}`, count);
 }
 
 /**
@@ -28,7 +41,11 @@ export function counted(count: number, singular: string, pluralForm = `${singula
  * not priced the set yet. A surface may append its own suffix (the expanded
  * view offers "scroll to load more"), but not rephrase this.
  */
-export function showingCount(loaded: number, total: number | null | undefined, filtered = false): string {
-  if (total === null || total === undefined) return `Showing ${counted(loaded, 'item')}`;
-  return `Showing ${loaded} of ${counted(total, filtered ? 'matching item' : 'item')}`;
+export function showingCount(
+  loaded: number,
+  total: number | null | undefined,
+  filtered = false,
+): string {
+  if (total === null || total === undefined) return tn('hv.list.showingAll', loaded);
+  return tn(filtered ? 'hv.list.showingOfMatching' : 'hv.list.showingOf', total, { loaded });
 }

--- a/cards/haventory-card/src/ui/relative-time.test.ts
+++ b/cards/haventory-card/src/ui/relative-time.test.ts
@@ -1,4 +1,14 @@
-import { addDays, formatDate, isDue, isOverdue, parseTs, relativeTime, toIsoDate } from './relative-time';
+import { setLanguage } from '../i18n';
+import {
+  addDays,
+  formatDate,
+  isDue,
+  isOverdue,
+  parseTs,
+  quickDayOffsets,
+  relativeTime,
+  toIsoDate,
+} from './relative-time';
 
 const NOW = Date.parse('2026-07-24T12:00:00Z');
 
@@ -18,13 +28,22 @@ describe('parseTs', () => {
 });
 
 describe('relativeTime', () => {
-  it('formats each bucket the way the mocks do', () => {
+  it('picks one bucket per span and names it', () => {
     expect(relativeTime('2026-07-24T11:59:30Z', NOW)).toBe('just now');
-    expect(relativeTime('2026-07-24T11:45:00Z', NOW)).toBe('15 m ago');
-    expect(relativeTime('2026-07-24T10:00:00Z', NOW)).toBe('2 h ago');
-    expect(relativeTime('2026-07-21T12:00:00Z', NOW)).toBe('3 d ago');
-    expect(relativeTime('2026-07-17T12:00:00Z', NOW)).toBe('1 w ago');
-    expect(relativeTime('2024-07-24T12:00:00Z', NOW)).toBe('2 y ago');
+    expect(relativeTime('2026-07-24T11:45:00Z', NOW)).toBe('15 min. ago');
+    expect(relativeTime('2026-07-24T10:00:00Z', NOW)).toBe('2 hr. ago');
+    expect(relativeTime('2026-07-21T12:00:00Z', NOW)).toBe('3 days ago');
+    expect(relativeTime('2026-07-17T12:00:00Z', NOW)).toBe('1 wk. ago');
+    expect(relativeTime('2024-07-24T12:00:00Z', NOW)).toBe('2 yr. ago');
+  });
+
+  it('names the same spans in the language in force', () => {
+    setLanguage('de');
+    expect(relativeTime('2026-07-24T11:59:30Z', NOW)).toBe('gerade eben');
+    expect(relativeTime('2026-07-24T11:45:00Z', NOW)).toBe('vor 15 Min.');
+    expect(relativeTime('2026-07-24T10:00:00Z', NOW)).toBe('vor 2 Std.');
+    expect(relativeTime('2026-07-21T12:00:00Z', NOW)).toBe('vor 3 Tagen');
+    expect(relativeTime('2024-07-24T12:00:00Z', NOW)).toBe('vor 2 Jahren');
   });
 
   it('degrades to an em dash for unusable input and clamps future stamps', () => {
@@ -40,10 +59,28 @@ describe('formatDate', () => {
     expect(formatDate('2025-12-01', NOW)).toBe('Dec 1, 2025');
   });
 
+  it('writes the date the way the language does', () => {
+    setLanguage('de');
+    expect(formatDate('2026-07-31', NOW)).toBe('31. Juli');
+    expect(formatDate('2025-12-01', NOW)).toBe('1. Dez. 2025');
+  });
+
   it('passes through anything that is not YYYY-MM-DD, and dashes empties', () => {
     expect(formatDate(null, NOW)).toBe('—');
     expect(formatDate('whenever', NOW)).toBe('whenever');
+    // A month a calendar does not have. `Date` would roll it into next
+    // January; the stored string is the honest answer.
     expect(formatDate('2026-13-01', NOW)).toBe('2026-13-01');
+    expect(formatDate('2026-02-30', NOW)).toBe('2026-02-30');
+  });
+});
+
+describe('quickDayOffsets', () => {
+  it('offers a week, a month and a quarter, labelled in the language in force', () => {
+    expect(quickDayOffsets().map((o) => o.days)).toEqual([7, 30, 90]);
+    expect(quickDayOffsets()[0].label).toBe('+7 days');
+    setLanguage('de');
+    expect(quickDayOffsets()[0].label).toBe('+7 Tage');
   });
 });
 

--- a/cards/haventory-card/src/ui/relative-time.ts
+++ b/cards/haventory-card/src/ui/relative-time.ts
@@ -1,16 +1,59 @@
 /**
- * Compact relative-time formatting for list rows ("2 h ago", "3 d ago").
+ * Compact relative-time formatting for list rows ("2 hr. ago", "3 days ago").
  *
  * Backend `created_at` / `updated_at` are canonical ISO-8601 UTC with a trailing
  * `Z`, but event `ts` values carry microseconds and a `+00:00` offset instead.
  * `Date` parses both, so nothing here needs to special-case the shape.
+ *
+ * The spans and the dates come from `Intl`, keyed on the language in force —
+ * that is a whole vocabulary the dictionaries do not have to carry, and it is
+ * one every browser already ships. `style: 'short'` because these land in table
+ * cells and list rows where a full "2 Stunden" would not fit, and
+ * `numeric: 'always'` so every span reads the same way: "1 day ago", not
+ * "yesterday" beside "2 days ago".
  */
+
+import { language, t } from '../i18n';
 
 const MINUTE = 60_000;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 const YEAR = 365 * DAY;
+
+/**
+ * `Intl` formatters are expensive to construct and are asked for once per
+ * rendered row, so each is built once per language and kept. The language is
+ * fixed for the lifetime of a page; the cache is keyed on it anyway, because a
+ * test that switches languages inside one module registry would otherwise read
+ * the first one it asked for.
+ */
+const relativeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+const dateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function relativeFormatter(): Intl.RelativeTimeFormat {
+  const lang = language();
+  let formatter = relativeFormatters.get(lang);
+  if (!formatter) {
+    formatter = new Intl.RelativeTimeFormat(lang, { numeric: 'always', style: 'short' });
+    relativeFormatters.set(lang, formatter);
+  }
+  return formatter;
+}
+
+function dateFormatter(withYear: boolean): Intl.DateTimeFormat {
+  const key = `${language()}:${withYear ? 'y' : ''}`;
+  let formatter = dateFormatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(language(), {
+      month: 'short',
+      day: 'numeric',
+      ...(withYear ? { year: 'numeric' } : {}),
+    });
+    dateFormatters.set(key, formatter);
+  }
+  return formatter;
+}
 
 /** Parse an ISO timestamp, returning null for missing or unparsable input. */
 export function parseTs(iso: string | null | undefined): number | null {
@@ -29,30 +72,38 @@ export function relativeTime(iso: string | null | undefined, now: number = Date.
   if (ms === null) return '—';
 
   const delta = now - ms;
-  if (delta < 0) return 'just now';
-  if (delta < MINUTE) return 'just now';
-  if (delta < HOUR) return `${Math.floor(delta / MINUTE)} m ago`;
-  if (delta < DAY) return `${Math.floor(delta / HOUR)} h ago`;
-  if (delta < WEEK) return `${Math.floor(delta / DAY)} d ago`;
-  if (delta < YEAR) return `${Math.floor(delta / WEEK)} w ago`;
-  return `${Math.floor(delta / YEAR)} y ago`;
+  // Under a minute, and anything the clock says is still to come: a row saved
+  // on another device with a slightly fast clock is not "in 3 seconds".
+  if (delta < MINUTE) return t('hv.time.justNow');
+  const format = relativeFormatter();
+  if (delta < HOUR) return format.format(-Math.floor(delta / MINUTE), 'minute');
+  if (delta < DAY) return format.format(-Math.floor(delta / HOUR), 'hour');
+  if (delta < WEEK) return format.format(-Math.floor(delta / DAY), 'day');
+  if (delta < YEAR) return format.format(-Math.floor(delta / WEEK), 'week');
+  return format.format(-Math.floor(delta / YEAR), 'year');
 }
 
-const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
 /**
- * Format a `YYYY-MM-DD` date the way the mocks do: "Jul 31" within the current
- * year, "Jul 31, 2026" otherwise. Returns an em dash when unset.
+ * Format a `YYYY-MM-DD` date short: the day and the month within the current
+ * year, the year as well outside it. Returns an em dash when unset, and the
+ * raw string for anything that is not a date, so a stored value nobody can
+ * parse is still shown rather than blanked.
  */
 export function formatDate(date: string | null | undefined, now: number = Date.now()): string {
   if (!date) return '—';
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
   if (!m) return date;
   const [, y, mo, d] = m;
-  const month = MONTHS[Number(mo) - 1];
-  if (!month) return date;
-  const day = String(Number(d));
-  return Number(y) === new Date(now).getFullYear() ? `${month} ${day}` : `${month} ${day}, ${y}`;
+  // Built from the parts rather than from `Date.parse(date)`, which reads a
+  // bare `YYYY-MM-DD` as UTC midnight and lands on the previous day for anyone
+  // west of Greenwich.
+  const parsed = new Date(Number(y), Number(mo) - 1, Number(d));
+  // A `Date` rolls an impossible date forward — month 13 becomes next January,
+  // 31 February becomes March — so a stored value that says something no
+  // calendar does would come back out as a real date. Show it as it is stored
+  // instead, the same answer anything unparsable gets.
+  if (parsed.getMonth() !== Number(mo) - 1 || parsed.getDate() !== Number(d)) return date;
+  return dateFormatter(Number(y) !== new Date(now).getFullYear()).format(parsed);
 }
 
 /** True when a due date has passed. Undated items are never overdue. */
@@ -93,13 +144,12 @@ export function addDays(days: number, from: number = Date.now()): string {
  * than any inspection interval worth recording.
  *
  * Shared so the check-out popover and the editor's inspection field cannot
- * drift into offering different jumps for the same gesture.
+ * drift into offering different jumps for the same gesture. A function because
+ * the labels are copy, and copy is not known when this module is evaluated.
  */
-export const QUICK_DAY_OFFSETS: readonly { days: number; label: string }[] = [
-  { days: 7, label: '+7 days' },
-  { days: 30, label: '+30 days' },
-  { days: 90, label: '+90 days' },
-];
+export function quickDayOffsets(): readonly { days: number; label: string }[] {
+  return [7, 30, 90].map((days) => ({ days, label: t('hv.date.offsetDays', { days }) }));
+}
 
 /** What a "+X days" field starts at when it is first opened. */
 export const DEFAULT_CUSTOM_DAYS = 14;

--- a/cards/haventory-card/src/ui/reminder.ts
+++ b/cards/haventory-card/src/ui/reminder.ts
@@ -6,6 +6,8 @@
  * them here rather than each spelling out the date-and-interval rule.
  */
 
+import { tn } from '../i18n';
+import type { PluralKey } from '../i18n';
 import type { Item, ReminderInterval, ReminderUnit } from '../store/types';
 import { formatDate, toIsoDate } from './relative-time';
 
@@ -26,18 +28,18 @@ export function isReminderDue(item: Item, now: number = Date.now()): boolean {
   return !!date && date <= toIsoDate(now);
 }
 
-const UNIT_SINGULAR: Record<ReminderUnit, string> = {
-  days: 'day',
-  weeks: 'week',
-  months: 'month',
-};
+const UNIT_KEYS = {
+  days: 'hv.reminder.every.days',
+  weeks: 'hv.reminder.every.weeks',
+  months: 'hv.reminder.every.months',
+} as const satisfies Record<ReminderUnit, PluralKey>;
 
 /** "every 3 months", "every day" — the repeat in the words a household uses. */
 export function formatInterval(interval: ReminderInterval | null | undefined): string | null {
   if (!interval) return null;
-  const unit = UNIT_SINGULAR[interval.unit];
-  if (!unit) return null;
-  return interval.count === 1 ? `every ${unit}` : `every ${interval.count} ${interval.unit}`;
+  const key = UNIT_KEYS[interval.unit];
+  if (!key) return null;
+  return tn(key, interval.count);
 }
 
 /**

--- a/cards/haventory-card/src/ui/value-rewrite.ts
+++ b/cards/haventory-card/src/ui/value-rewrite.ts
@@ -1,5 +1,5 @@
+import { tn } from '../i18n';
 import { makeBulkOp } from '../store/store';
-import { plural } from './plural';
 import { normalizeTags } from './item-form';
 import type { BulkOperation, Item, ItemFilter } from '../store/types';
 
@@ -65,12 +65,11 @@ export function describeRewrite(
   from: string,
   to: string | null,
 ): string {
-  const noun = plural(count, 'item');
   if (to === null) {
     return kind === 'tag'
-      ? `Removes "${from}" from ${count} ${noun}.`
-      : `Clears the category on ${count} ${noun}.`;
+      ? tn('hv.rewrite.tag.remove', count, { from })
+      : tn('hv.rewrite.category.clear', count);
   }
-  if (kind === 'tag') return `Retags ${count} ${noun}, then removes "${from}".`;
-  return `Recategorises ${count} ${noun} as "${to}".`;
+  if (kind === 'tag') return tn('hv.rewrite.tag.retag', count, { from });
+  return tn('hv.rewrite.category.set', count, { to });
 }

--- a/custom_components/haventory/translations/de.json
+++ b/custom_components/haventory/translations/de.json
@@ -1,0 +1,193 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "HAventory",
+        "description": "Richte HAventory für die Inventarverwaltung in Home Assistant ein. Beide Antworten unten – und alles Weitere – kannst du später unter Konfigurieren ändern. Hinweis für danach: Eine Browserseite, die schon offen ist, übernimmt die Karte erst, wenn sie das nächste Mal lädt – ein Neuladen, oder ein Besuch des neuen HAventory-Eintrags in der Seitenleiste, holt sie herein.",
+        "data": {
+          "card_title": "Kartentitel",
+          "sidebar_panel_enabled": "HAventory in der Seitenleiste anzeigen"
+        },
+        "data_description": {
+          "card_title": "Überschrift auf der HAventory-Karte.",
+          "sidebar_panel_enabled": "Gibt HAventory eine eigene Seite, benannt nach dem Kartentitel oben. Jeder Benutzer kann den Eintrag weiterhin über den Bearbeitungsmodus der Seitenleiste ausblenden."
+        }
+      }
+    },
+    "create_entry": {
+      "default": "HAventory wurde erfolgreich eingerichtet. Lade diese Browserseite einmal neu: Karte und Symbol in der Seitenleiste werden geladen, wenn eine Seite geöffnet wird – eine Seite, die schon offen war, hat also beides noch nicht. Der neue HAventory-Eintrag in der Seitenleiste erledigt dasselbe: Seite und Karte stecken in einem Bündel, und ein offenes Dashboard zeigt die Karte in dem Moment, in dem dieses Bündel lädt."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "HAventory-Optionen",
+        "description": "Lege fest, welche Überschrift die Karte trägt, ob HAventory einen eigenen Eintrag in der Seitenleiste bekommt und welche Schnellfilter-Pillen sie anbietet.",
+        "data": {
+          "card_title": "Kartentitel",
+          "sidebar_panel_enabled": "HAventory in der Seitenleiste anzeigen",
+          "quick_filters": "Schnellfilter-Pillen"
+        },
+        "data_description": {
+          "card_title": "Überschrift auf der HAventory-Karte. Eine Dashboard-Karte mit eigener Option „title:“ behält ihre eigene. Lade das Dashboard neu, um eine Änderung zu sehen.",
+          "sidebar_panel_enabled": "Gibt HAventory eine eigene Seite, benannt nach dem Kartentitel oben. Das gilt für alle, die dieses Home Assistant nutzen; jeder Benutzer kann den Eintrag weiterhin über den Bearbeitungsmodus der Seitenleiste ausblenden. Der Eintrag erscheint und verschwindet, während du dieses Formular speicherst – ohne Neustart. Auf der Übersichtsseite kann HAventory über Bearbeiten und dann Verknüpfung hinzufügen auch als Kachel angeheftet werden.",
+          "quick_filters": "Die Ein-Tipp-Filter über der Gegenstandsliste, hier und auf der Seite in der Seitenleiste. Eine Pille erscheint weiterhin nur, wenn sie etwas zu zählen hat – ein Haushalt, der nie etwas ausleiht, sieht also so oder so keine Ausleih-Pille. „Gegenstände gesamt“ ist noch auf eine zweite Art die Ausnahme: Nur die Karte zeichnet sie als Pille, und nur in voller Breite – die Seite in der Seitenleiste und die volle Ansicht schreiben die Gesamtzahl stattdessen in ihre Kopfzeile, ob sie hier angehakt ist oder nicht. Eine Dashboard-Karte mit eigener Option „quick_filters:“ behält ihre eigene. Lade das Dashboard neu, um eine Änderung zu sehen."
+        },
+        "sections": {
+          "todo": {
+            "name": "Einkaufsliste",
+            "description": "Spiegelt Gegenstände mit niedrigem Bestand auf eine To-do-Liste von Home Assistant. Ein Gegenstand, der seine Bestandsschwelle erreicht oder unterschreitet, erscheint als Zeile mit seinem Namen und der nachzukaufenden Menge, und die Zeile verschwindet wieder, sobald der Gegenstand aufgefüllt ist. Lass die Liste leer, um das ausgeschaltet zu lassen – so ist es voreingestellt. Leerst du sie später, endet die Spiegelung und was auf der Liste steht, bleibt unangetastet; wählst du eine andere Liste, wandern die Zeilen stattdessen mit.",
+            "data": {
+              "todo_entity_id": "To-do-Liste"
+            },
+            "data_description": {
+              "todo_entity_id": "Jede To-do-Liste, die dieses Home Assistant kennt, auch eine, die der Haushalt schon gemeinsam nutzt. HAventory rührt immer nur die Zeilen an, die es selbst geschrieben hat – eine Liste, die du für anderes verwendest, kannst du also bedenkenlos wählen."
+            }
+          },
+          "rate_limit": {
+            "name": "WebSocket-Ratenbegrenzung",
+            "description": "Begrenzt, wie schnell ein Client HAventory nutzen darf: Befehle über dem Budget werden abgelehnt statt ausgeführt, und überzählige Live-Update-Ereignisse werden verworfen. Standardmäßig aus – normale Kartennutzung kommt nie in die Nähe. Schalte sie ein, wenn etwas mit HAventory spricht, das du nicht ganz unter Kontrolle hast, etwa ein Wandpanel, das dauernd neu verbindet, oder ein Skript in einer Schleife; lass sie bei großen Importen und Belastungstests aus. Was die einzelnen Einstellungen bedeuten und woran du erkennst, ob die Begrenzung greift: {docs_url}",
+            "data": {
+              "rate_limit_enabled": "WebSocket-Ratenbegrenzung aktivieren",
+              "rate_limit_commands_per_second": "Befehle pro Sekunde (ein Client)",
+              "rate_limit_commands_burst": "Befehls-Burst (ein Client)",
+              "rate_limit_global_commands_per_second": "Befehle pro Sekunde (alle Clients)",
+              "rate_limit_global_commands_burst": "Befehls-Burst (alle Clients)",
+              "rate_limit_events_per_second": "Live-Update-Ereignisse pro Sekunde (ein Client)",
+              "rate_limit_events_burst": "Live-Update-Ereignis-Burst (ein Client)",
+              "rate_limit_global_events_per_second": "Live-Update-Ereignisse pro Sekunde (alle Clients)",
+              "rate_limit_global_events_burst": "Live-Update-Ereignis-Burst (alle Clients)"
+            },
+            "data_description": {
+              "rate_limit_enabled": "Solange sie aus ist, wird nichts begrenzt und die Werte darunter werden ignoriert.",
+              "rate_limit_commands_per_second": "Dauerhafte Anfragen, die ein Client senden darf. Standard 20.",
+              "rate_limit_commands_burst": "Anfragen, die ein Client nach einer Ruhephase direkt hintereinander senden darf. Standard 60.",
+              "rate_limit_global_commands_per_second": "Dauerhafte Anfragen über alle Clients zusammen. Standard 100.",
+              "rate_limit_global_commands_burst": "Anfragen, die alle Clients zusammen direkt hintereinander senden dürfen. Standard 200.",
+              "rate_limit_events_per_second": "Dauerhafte Ereignisse, die einem Client gesendet werden dürfen. Standard 50.",
+              "rate_limit_events_burst": "Ereignisse, die einem Client nach einer ruhigen Phase direkt hintereinander gesendet werden dürfen. Standard 200.",
+              "rate_limit_global_events_per_second": "Dauerhafte Ereignisse über alle Clients zusammen. Standard 500.",
+              "rate_limit_global_events_burst": "Ereignisse, die allen Clients zusammen direkt hintereinander gesendet werden dürfen. Standard 1000."
+            }
+          }
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "items_total": {
+        "name": "Anzahl Gegenstände"
+      },
+      "low_stock": {
+        "name": "Anzahl niedriger Bestand"
+      },
+      "checked_out": {
+        "name": "Anzahl ausgeliehen"
+      },
+      "overdue": {
+        "name": "Anzahl überfällig ausgeliehen"
+      },
+      "checked_out_due": {
+        "name": "Anzahl Rückgabe fällig"
+      },
+      "inspection_overdue": {
+        "name": "Anzahl Prüfung überfällig"
+      },
+      "inspection_due": {
+        "name": "Anzahl Prüfung fällig"
+      },
+      "locations": {
+        "name": "Anzahl Orte"
+      }
+    }
+  },
+  "selector": {
+    "quick_filters": {
+      "options": {
+        "total": "Gegenstände gesamt",
+        "low_stock": "Niedriger Bestand",
+        "overdue": "Überfällig",
+        "inspection_due": "Prüfung fällig",
+        "reminder_due": "Erinnerung fällig",
+        "checked_out": "Ausgeliehen"
+      }
+    }
+  },
+  "services": {
+    "item_create": {
+      "name": "Gegenstand anlegen",
+      "description": "Legt einen neuen Gegenstand im Inventar an."
+    },
+    "item_update": {
+      "name": "Gegenstand aktualisieren",
+      "description": "Aktualisiert einen vorhandenen Gegenstand im Inventar."
+    },
+    "item_delete": {
+      "name": "Gegenstand löschen",
+      "description": "Löscht einen Gegenstand aus dem Inventar."
+    },
+    "item_move": {
+      "name": "Gegenstand verschieben",
+      "description": "Verschiebt einen Gegenstand an einen anderen Ort (oder in die oberste Ebene)."
+    },
+    "item_adjust_quantity": {
+      "name": "Menge anpassen",
+      "description": "Erhöht oder verringert die Menge eines Gegenstands."
+    },
+    "item_set_quantity": {
+      "name": "Menge setzen",
+      "description": "Setzt die Menge eines Gegenstands auf einen genauen Wert."
+    },
+    "item_check_out": {
+      "name": "Gegenstand ausleihen",
+      "description": "Markiert einen Gegenstand als ausgeliehen, mit Rückgabedatum."
+    },
+    "item_check_in": {
+      "name": "Gegenstand zurückgeben",
+      "description": "Markiert einen Gegenstand als nicht mehr ausgeliehen."
+    },
+    "reminder_bump": {
+      "name": "Erinnerung erledigen",
+      "description": "Markiert eine wiederkehrende Erinnerung als erledigt und setzt sie auf ihren nächsten Termin."
+    },
+    "location_create": {
+      "name": "Ort anlegen",
+      "description": "Legt einen neuen Aufbewahrungsort an."
+    },
+    "location_update": {
+      "name": "Ort aktualisieren",
+      "description": "Aktualisiert einen vorhandenen Aufbewahrungsort."
+    },
+    "location_delete": {
+      "name": "Ort löschen",
+      "description": "Löscht einen Aufbewahrungsort."
+    }
+  },
+  "issues": {
+    "schema_downgrade": {
+      "title": "HAventory kann die gespeicherten Daten nicht lesen",
+      "description": "HAventory hat angehalten, statt sich einzurichten: {error}\n\nDie Datei ist `.storage/{storage_key}` in deinem Home-Assistant-Konfigurationsverzeichnis, und sie wurde genau so gelassen, wie sie war. Dieser Hinweis verschwindet von selbst, sobald HAventory mit einem Speicher startet, den es lesen kann."
+    },
+    "corrupt_schema_version": {
+      "title": "HAventory kann nicht erkennen, welches Schema die gespeicherten Daten verwenden",
+      "description": "HAventory hat angehalten, statt sich einzurichten: {error}\n\nDie Datei ist `.storage/{storage_key}` in deinem Home-Assistant-Konfigurationsverzeichnis, und sie wurde genau so gelassen, wie sie war. Dieser Hinweis verschwindet von selbst, sobald HAventory mit einem Speicher startet, den es lesen kann."
+    },
+    "corrupt_store": {
+      "title": "HAventory kann einen Teil der gespeicherten Daten nicht lesen",
+      "fix_flow": {
+        "abort": {
+          "no_config_entry": "HAventory ist nicht mehr eingerichtet, es gibt also nichts neu zu laden.",
+          "backup_failed": "Die Kopie der gespeicherten Datei konnte nicht geschrieben werden, deshalb wurde nichts geändert. Ohne sie gäbe es keinen Weg zurück, also hat HAventory nicht geladen.",
+          "reload_failed": "HAventory ist immer noch nicht gestartet. Die Kopie wurde geschrieben und die gespeicherte Datei ist unverändert; sieh im Home-Assistant-Protokoll nach, was es aufgehalten hat."
+        },
+        "step": {
+          "confirm": {
+            "title": "HAventory ohne die unlesbaren Einträge laden",
+            "description": "HAventory konnte {items} Gegenstände und {locations} Orte nicht lesen und hat {cyclic_locations} Orte gefunden, deren Elternkette sich im Kreis dreht. Es hat angehalten, statt den Rest zu laden – es speichert bei jeder Änderung, und die erste Bearbeitung würde die Datei ohne sie neu schreiben.\n\nBestätigen kopiert `.storage/{storage_key}` nach `.storage/{backup_key}` und startet HAventory dann mit allem, was es lesen konnte. Die unlesbaren Einträge bleiben draußen, und die Kopie ist dein Weg, sie zurückzuholen.\n\nUm sie stattdessen zu behalten, schließe diesen Dialog und repariere die Einträge in der gespeicherten Datei, oder stelle sie aus einem Backup wieder her."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/test_translations.py
+++ b/tests/integration/test_translations.py
@@ -1,0 +1,66 @@
+"""Integration: the shipped ``translations/`` directory, read by real Home Assistant.
+
+Nothing offline reads these files the way a browser gets them. The offline
+``HomeAssistant`` stub has no translation machinery at all, and the offline
+tests in ``tests/test_config_flow_offline.py`` only compare the documents to
+each other — which would stay green if Home Assistant could not find, parse or
+serve them. hassfest validates the *shape* in CI and says nothing about whether
+a given language actually resolves.
+
+So the claim under test is the one a German household makes: with a profile set
+to Deutsch, the config flow, the options screen, the entity names, the
+quick-filter options and the service catalog come back in German, and a
+language nothing ships for falls back to English rather than to a key.
+"""
+
+from __future__ import annotations
+
+from custom_components.haventory.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import translation
+
+
+async def _catalog(hass: HomeAssistant, language: str, category: str) -> dict[str, str]:
+    return await translation.async_get_translations(hass, language, category, {DOMAIN})
+
+
+async def test_german_config_and_options_screens_resolve(hass: HomeAssistant) -> None:
+    """The two screens a household sees before anything else, in German."""
+
+    config = await _catalog(hass, "de", "config")
+    assert config[f"component.{DOMAIN}.config.step.user.data.card_title"] == "Kartentitel"
+
+    options = await _catalog(hass, "de", "options")
+    assert options[f"component.{DOMAIN}.options.step.init.title"] == "HAventory-Optionen"
+    # The rate-limit section's own text, which is nested two levels deeper than
+    # anything else in the document.
+    section = f"component.{DOMAIN}.options.step.init.sections.rate_limit"
+    assert options[f"{section}.name"] == "WebSocket-Ratenbegrenzung"
+    # The docs link arrives as a placeholder the flow fills; the German value
+    # has to still carry it or the sentence loses its link.
+    assert "{docs_url}" in options[f"{section}.description"]
+
+
+async def test_german_entities_selectors_and_services_resolve(hass: HomeAssistant) -> None:
+    """Everything else Home Assistant renders from a translation file."""
+
+    entity = await _catalog(hass, "de", "entity")
+    assert entity[f"component.{DOMAIN}.entity.sensor.items_total.name"] == "Anzahl Gegenstände"
+
+    selector = await _catalog(hass, "de", "selector")
+    key = f"component.{DOMAIN}.selector.quick_filters.options.checked_out"
+    assert selector[key] == "Ausgeliehen"
+
+    services = await _catalog(hass, "de", "services")
+    assert services[f"component.{DOMAIN}.services.item_check_out.name"] == "Gegenstand ausleihen"
+
+
+async def test_a_language_nothing_ships_falls_back_to_english(hass: HomeAssistant) -> None:
+    """No dictionary, no keys on the screen — the English string stands in.
+
+    Home Assistant does this itself; the test is here because it is the whole
+    reason a partial set of languages is safe to ship.
+    """
+
+    swedish = await _catalog(hass, "sv", "config")
+    assert swedish[f"component.{DOMAIN}.config.step.user.data.card_title"] == "Card title"

--- a/tests/test_config_flow_offline.py
+++ b/tests/test_config_flow_offline.py
@@ -11,6 +11,7 @@ Scenarios:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -424,6 +425,24 @@ async def test_options_form_fills_the_docs_link() -> None:
     assert form["description_placeholders"] == {"docs_url": RATE_LIMIT_DOCS_URL}
 
 
+def _translation_files() -> list[Path]:
+    """Every file Home Assistant reads a translated string out of."""
+
+    root = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
+    return [root / "strings.json", *sorted((root / "translations").glob("*.json"))]
+
+
+def _flatten(node: object, prefix: str = "") -> dict[str, str]:
+    """A nested translation document as `a.b.c` -> value."""
+
+    if not isinstance(node, dict):
+        return {prefix: str(node)}
+    out: dict[str, str] = {}
+    for key, value in node.items():
+        out.update(_flatten(value, f"{prefix}.{key}" if prefix else key))
+    return out
+
+
 def test_translation_strings_carry_no_urls() -> None:
     """hassfest fails the build on a URL in a translation string.
 
@@ -431,10 +450,45 @@ def test_translation_strings_carry_no_urls() -> None:
     `{placeholder}` the flow fills, never inline in the string.
     """
 
-    root = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
-    for path in (root / "strings.json", root / "translations" / "en.json"):
+    for path in _translation_files():
         text = path.read_text(encoding="utf-8")
         assert "http://" not in text and "https://" not in text, f"{path.name} contains a URL"
+
+
+def test_translations_mirror_the_strings_key_tree() -> None:
+    """Every shipped language answers to exactly the keys `strings.json` declares.
+
+    A key only one language carries is a screen that renders in English for
+    everyone else with nothing to say so, and a key a language carries that
+    `strings.json` has dropped is dead weight nothing reads.
+    """
+
+    root = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
+    expected = set(_flatten(json.loads((root / "strings.json").read_text(encoding="utf-8"))))
+    for path in sorted((root / "translations").glob("*.json")):
+        keys = set(_flatten(json.loads(path.read_text(encoding="utf-8"))))
+        assert keys == expected, f"{path.name} does not mirror strings.json"
+
+
+def test_translations_repeat_their_placeholders() -> None:
+    """A `{placeholder}` renames or vanishes silently, and renders literally.
+
+    Home Assistant fills these by name — `{docs_url}` on the options screen,
+    `{error}` and `{storage_key}` on a repairs issue — so a German value that
+    spells one differently prints the braces on the screen, and one that drops
+    it loses the only concrete detail the sentence carried. Nothing else
+    catches it: hassfest validates the shape of the file, not the insides of
+    its strings.
+    """
+
+    root = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
+    english = _flatten(json.loads((root / "strings.json").read_text(encoding="utf-8")))
+    placeholder = re.compile(r"\{(\w+)\}")
+    for path in sorted((root / "translations").glob("*.json")):
+        for key, value in _flatten(json.loads(path.read_text(encoding="utf-8"))).items():
+            assert set(placeholder.findall(value)) == set(placeholder.findall(english[key])), (
+                f"{path.name}: {key} does not carry the same placeholders as strings.json"
+            )
 
 
 def test_translation_flow_sections_match_strings() -> None:


### PR DESCRIPTION
## Summary

Two halves with almost nothing in common, as #190's notes put it: the backend already had
the mechanism and needed a file; the card had no mechanism at all.

**The card's mechanism** — `src/i18n/`:

- `t(key, params?)` and `tn(key, count, params?)` for a counted string, plus
  `setLanguage(tag)` and `resolveLanguage(tag)`.
- `en.ts` is the key universe. `TranslationKey` is `keyof typeof en`, so a key nothing
  defines does not compile at the call site, and `de.ts` is a complete
  `Record<TranslationKey, string>` — an English string added without a German one does not
  compile either.
- Resolution is exact tag → primary subtag → `en`, so `de-CH` reads German. A key a
  dictionary has not reached falls through to the **English string**, never to the key: a
  community dictionary on the day it arrives shows a mixed screen rather than
  `hv.action.retry` printed on a button.
- Plurals are two forms, `<key>.one` / `<key>.other`, with `{count}` passed to both. A form
  may leave the number out, which is how "every 1 days" becomes `täglich`.
- A module singleton, not a Lit context: half the card's copy lives in plain functions with
  no host element (`ui/empty-state`, `ui/health-codes`, `ui/plural`, `describeFailure`), and
  a context cannot reach any of them without changing every signature.

**The language source** — `hass.language` joins `HassLike` in `ha-contract.ts` (with a row
in that file's surface table). The card and the panel call `setLanguage` in their `set hass`
ahead of creating the store; the card editor does it on the update `hass` arrives on, since
Home Assistant sets it there as a plain property. `setLanguage` returns whether the resolved
language moved, so a host re-renders once and not on every `hass`.

**The backend** — `translations/de.json`, mirroring `strings.json`'s key tree: the config
flow, the options screen with both sections, the eight sensor names, the six quick-filter
options, the twelve services and the three repairs issues.

**The shared copy modules** — `ui/empty-state`, `ui/banners`, `ui/discard`,
`ui/editor-error`, `ui/health-codes`, `ui/plural`, `ui/relative-time`, `ui/reminder`,
`ui/item-form`, `ui/value-rewrite`, `ui/location-path`, `ui/keyboard`. The 21 `hv-*`
components follow in the next two PRs, so a German screen today is German where these
modules write it and English where a component still does — visible in the card screenshot
below, and gone by the third PR.

Refs #190

## Register and vocabulary

Read off the installed core's own German (`hass_frontend`'s `de` catalogue and
`homeassistant/components/*/translations/de.json` in the dev container), so the card reads
like the screen it sits on:

- informal address — `du`, `deinen`, `Lade das Dashboard neu`, which is what HA's own German
  uses throughout;
- HA's terms where HA has one: **Bereich** (area), **Kategorie**, **Label**, **Seitenleiste**,
  **Kachel**, **Verknüpfung**, **Übersicht**, **To-do-Liste**, **Aktualisieren**,
  **Abbrechen**, **Verwerfen**;
- HA's typography: an **en dash** (`–`) where the English writes an em dash — core's German
  catalogue has 37 of the former and none of the latter — a **space before an ellipsis**
  (`wird neu geladen …`), and German quotation marks `„…“`.

Three words HAventory had to choose for itself, because HA has no equivalent:

| concept | chosen | why not the alternatives |
| --- | --- | --- |
| item | **Gegenstand** | `Eintrag` is what HA calls a to-do line, and HAventory writes its low-stock items onto a to-do list beside them — the two must not read as the same thing. `Artikel` is stock in a shop. |
| location | **Ort** | Short enough to carry a nesting level in front of it in the tree. `Standort` is geographic in HA's usage (zones, device trackers); `Aufbewahrungsort` is right and unusable at 13 characters a row. |
| check out / in | **Ausleihen** / **Zurückgeben** | What a household actually does when someone takes the drill away. The stored status slug the backend seeds is untouched. |

One more that is a choice rather than a translation: a **tag** is a **Label**. HA's own
German calls its label registry "Labels", and `Tag` in German is the word for *day* — "1 Tag"
in a count line reads as "1 day". The service field stays `tags`, the way HA's own
`area_id` stays `area_id` behind `Bereich`.

## Decisions taken against the drifted notes

- **`counted()` changes shape in this PR, not the next two.** Its noun argument was an
  English string (`counted(n, 'sub-location')`); it is now a key-derived union
  (`counted(n, 'subLocation')`), because a language that does not build its plural by
  appending a letter cannot be served by the old signature. That means ~30 mechanical call
  sites in components move here, while the sentences around them stay English until PR 2/3.
  The alternative — a half-translated `plural.ts` spread over three PRs — is worse.
- **`plural()` is deleted.** Its last three callers outside `src/ui` were whole sentences
  (`hv-bulk-bar`'s result line, `hv-full-view`'s checked-out warning, `host-surfaces`'
  export-view subtitle), so those three sentences get keys here rather than leaving an
  English-only helper alive for two more PRs.
- **The health messages lose their `{n} item(s)` shape** and become two-form plurals. The
  `(s)` construction has no German equivalent that is not `Gegenstand/Gegenstände`, and the
  English improves. English wording changes as a result; the tests were updated with it.
- **`relativeTime` output changes in English too.** `Intl.RelativeTimeFormat` with
  `style: 'short'`, `numeric: 'always'` gives `2 hr. ago` / `3 days ago` where the card said
  `2 h ago` / `3 d ago`, and `vor 2 Std.` / `vor 3 Tagen` in German. `narrow` would have
  been closer to the old English but renders German minutes as `vor 2 m`. `just now` stays a
  dictionary string — `Intl` says `in 0 sec.` at a zero delta.
- **`formatDate` gained a guard the old code got for free.** The old month-name lookup
  returned the raw string for month 13; a `Date` built from the parts rolls it into next
  January, so the parts are checked back out of the `Date` and an impossible date is shown
  as stored.
- **`BUILT_IN_STATUSES`' labels stay English.** They are the card's stand-in until
  `haventory/config` answers, and what the backend answers with is *stored* data a household
  can rename. Translating the stand-in would make the chip change wording as the config
  arrives. Filed as a follow-up (below) — a German household does see three English status
  chips today.
- **`DEFAULT_CARD_TITLE` and the backend's own error `message` text stay English**, as the
  notes specify.
- **The docs-site / public-roadmap half of #190 is dropped, not filed** — the owner's
  decision comment scopes this issue to German, and there is no audience for a docs site
  yet. The closing comment on the third PR says so.

## Tests

Backend:

- `tests/test_config_flow_offline.py` — `test_translation_strings_carry_no_urls` now sweeps
  every file in `translations/`; new `test_translations_mirror_the_strings_key_tree` and
  `test_translations_repeat_their_placeholders` (a typo'd `{docs_url}` renders literally on
  the options screen and nothing else catches it).
- `tests/integration/test_translations.py` — **new**, and the only place the claim is
  actually tested: real Home Assistant resolving `de` for the config flow, the options
  screen including the nested `rate_limit` section, the entity names, the quick-filter
  selector and the service catalog, plus a language nothing ships for falling back to
  English. The offline stub has no translation machinery at all, so the offline tests only
  compare the documents to each other.

Card:

- `src/i18n/index.test.ts` — exact tag, `de-CH` through the primary subtag, an unknown tag
  to English; `setLanguage` reporting only real changes; interpolation, and a missing
  parameter left standing; a **partial** dictionary registered at runtime falling through to
  English per key.
- `src/i18n/catalog.test.ts` — every `.one` paired with an `.other`; no dictionary carrying a
  key English has dropped; every German value repeating the English placeholders; German
  complete; and no German string identical to its English (with an explicit allowlist, empty
  today).
- `src/ui/plural.test.ts`, `relative-time.test.ts`, `health-codes.test.ts` — each re-run
  under `setLanguage('de')` for the case a derived English plural could not have produced
  (`3 Filter`, the dative `60 Gegenständen`, `vor 3 Tagen`, `31. Juli`).
- `src/test.setup.ts` resets the language before every test, so a spec that switches to
  German cannot leak into the next one.

`.pre-commit-config.yaml`: codespell now skips the non-English dictionaries. `ist`, `sie`,
`oder` and `alle` are all real English typos and all ordinary German; `strings.json` and
`i18n/en.ts` stay in scope.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1263 passed, 22 skipped**;
      `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` → clean
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` → **1764 passed / 65 files**, `npm run build` → 636.89 kB
- [x] phacc (`scripts/test_integration.sh`, Docker recipe) → **138 passed**

## Live checks

Deployed to the dev Home Assistant, profile language set to Deutsch over
`frontend/set_user_data`, restored afterwards.

**The setup dialog** — the whole step description, both fields and both helper texts:

![the German config flow](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s8/190-de-setup.png)

**What it says on success** — the `create_entry` message, which is the one place the card's
"reload the page once" instruction is written:

![the German create_entry message](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s8/190-de-created.png)

**The options screen** — title, description, all three fields, the six quick-filter options
and the shopping-list section:

![the German options screen](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s8/190-de-options.png)

**The card, mid-migration** — this PR's half is German (`50 von 1087 Gegenständen werden
angezeigt`, the location paths, the area chips); the search placeholder still reads
`Search all 1087 Gegenstände…` because `hv-card-shell` writes that sentence and is translated
in PR 2. This is what proves `hass.language` reaches the singleton end to end:

![the card in German, partway](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s8/190-pr1-card-de.png)

Removing the config entry to open a fresh setup flow drops the entry's options; they were
read out of `core.config_entries` first and put back through the options flow, and the store
was untouched (`items_total=1087 locations_total=89` before and after).

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md`, the
      `CONTRIBUTING.md` recipe and the README line ship with PR 3, which closes the issue.
      `.claude/skills/run-haventory/SKILL.md` documents the two new screenshot harnesses here.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Follow-ups

- **The three built-in status labels are English for everyone.** `BUILT_IN_STATUSES` in
  `ui/status.ts` mirrors what the backend *seeds* into stored data at first setup, and the
  store's copy wins as soon as `haventory/config` answers — so translating the card's
  stand-in would make the chip change wording mid-load, and translating the seed would write
  a language into data a household then owns. A German install shows `OK`, `Missing` and
  `Needs repair` until someone renames them in the organize dialog. Filed as [#536](https://github.com/chrreiter/HAventory/issues/536)
  rather than fixed here: it is a backend-seeding question, not a card one, and the issue
  weighs the three ways it could go.

## The full key table

Everything both dictionaries carry, so the wording can be read in one place.

### The card — `src/i18n/en.ts` vs `src/i18n/de.ts`

| key | English | German |
| --- | --- | --- |
| `hv.action.refresh` | Refresh | Aktualisieren |
| `hv.action.retry` | Try again | Erneut versuchen |
| `hv.action.dismiss` | Dismiss | Schließen |
| `hv.action.discard` | Discard | Verwerfen |
| `hv.empty.loading.headline` | Loading items | Gegenstände werden geladen |
| `hv.empty.connectionLost.headline` | Can't reach Home Assistant | Home Assistant ist nicht erreichbar |
| `hv.empty.connectionLost.detail` | The list will fill in once the connection is back. | Die Liste füllt sich, sobald die Verbindung wieder steht. |
| `hv.empty.noMatches.headline` | No items match these filters | Keine Gegenstände passen zu diesen Filtern |
| `hv.empty.noMatches.clearAction` | Clear all | Alle zurücksetzen |
| `hv.empty.emptyLocation.headline` | Nothing in {location} | Nichts in {location} |
| `hv.empty.emptyLocation.headlineUnnamed` | Nothing in this location | Nichts an diesem Ort |
| `hv.empty.emptyLocation.addAction` | Add item here | Hier hinzufügen |
| `hv.empty.emptyLocation.clearAction` | Show everything | Alles anzeigen |
| `hv.empty.noItems.headline` | No items yet | Noch keine Gegenstände |
| `hv.empty.noItems.detail` | Add your first item, or restore a backup. | Füge deinen ersten Gegenstand hinzu oder stelle ein Backup wieder her. |
| `hv.empty.noItems.addAction` | Add your first item | Ersten Gegenstand hinzufügen |
| `hv.empty.noItems.importAction` | Import backup | Backup importieren |
| `hv.banner.connectionLost.heading` | Connection lost | Verbindung unterbrochen |
| `hv.banner.connectionLost.message` |  · showing the data already loaded. Changes may not save. |  · es werden die bereits geladenen Daten angezeigt. Änderungen werden möglicherweise nicht gespeichert. |
| `hv.banner.connectionLost.action` | Reconnect | Neu verbinden |
| `hv.banner.liveUpdates.heading` | Live updates paused | Live-Aktualisierungen pausiert |
| `hv.banner.liveUpdates.cause.unavailable` | HAventory is not available | HAventory ist nicht verfügbar |
| `hv.banner.liveUpdates.cause.rateLimited` | rate limited | Ratenbegrenzung aktiv |
| `hv.banner.liveUpdates.retrying` |  · {cause}. Retrying automatically; this list may be out of date until then. |  · {cause}. Es wird automatisch erneut versucht; bis dahin kann diese Liste veraltet sein. |
| `hv.banner.liveUpdates.stalled` |  · {cause}. This list may be out of date until you refresh. |  · {cause}. Diese Liste kann veraltet sein, bis du aktualisierst. |
| `hv.banner.retrying.heading` | Busy — retrying | Beschäftigt – wird wiederholt |
| `hv.banner.retrying.message.one` |  · {count} change queued |  · {count} Änderung in der Warteschlange |
| `hv.banner.retrying.message.other` |  · {count} changes queued |  · {count} Änderungen in der Warteschlange |
| `hv.banner.rateLimited.heading` | Rate limited | Ratenbegrenzung aktiv |
| `hv.banner.rateLimited.message` |  · some live updates may have been dropped, so this list can be out of date. |  · einige Live-Aktualisierungen wurden möglicherweise verworfen, daher kann diese Liste veraltet sein. |
| `hv.banner.reloading.heading` | Inventory was replaced by an import | Das Inventar wurde durch einen Import ersetzt |
| `hv.banner.reloading.message` |  · reloading… |  · wird neu geladen … |
| `hv.banner.conflict.heading` | Someone else changed this item. | Jemand anderes hat diesen Gegenstand geändert. |
| `hv.banner.conflict.viewLatest` | View latest | Aktuellen Stand ansehen |
| `hv.banner.conflict.reapply` | Re-apply my change | Meine Änderung erneut anwenden |
| `hv.discard.heading` | Discard your changes? | Änderungen verwerfen? |
| `hv.discard.message` | What you have typed since the last save is lost. | Alles, was du seit dem letzten Speichern eingegeben hast, geht verloren. |
| `hv.health.itemIdKeyMismatch.one` | {count} item is stored under a key that does not match its id. | {count} Gegenstand ist unter einem Schlüssel gespeichert, der nicht zu seiner ID passt. |
| `hv.health.itemIdKeyMismatch.other` | {count} items are stored under a key that does not match their id. | {count} Gegenstände sind unter Schlüsseln gespeichert, die nicht zu ihren IDs passen. |
| `hv.health.itemReferencesMissingLocation.one` | {count} item references a location that no longer exists — it appears under "No location". | {count} Gegenstand verweist auf einen Ort, den es nicht mehr gibt – er erscheint unter „Kein Ort“. |
| `hv.health.itemReferencesMissingLocation.other` | {count} items reference a location that no longer exists — they appear under "No location". | {count} Gegenstände verweisen auf einen Ort, den es nicht mehr gibt – sie erscheinen unter „Kein Ort“. |
| `hv.health.itemMissingFromLocationIndex.one` | {count} item is missing from the location index. | {count} Gegenstand fehlt im Ortsindex. |
| `hv.health.itemMissingFromLocationIndex.other` | {count} items are missing from the location index. | {count} Gegenstände fehlen im Ortsindex. |
| `hv.health.checkedOutItemMissingFromIndex.one` | {count} checked-out item is missing from the checked-out index. | {count} ausgeliehener Gegenstand fehlt im Ausleih-Index. |
| `hv.health.checkedOutItemMissingFromIndex.other` | {count} checked-out items are missing from the checked-out index. | {count} ausgeliehene Gegenstände fehlen im Ausleih-Index. |
| `hv.health.nonCheckedOutItemInIndex.one` | {count} item is in the checked-out index but is not checked out. | {count} Gegenstand steht im Ausleih-Index, ist aber nicht ausgeliehen. |
| `hv.health.nonCheckedOutItemInIndex.other` | {count} items are in the checked-out index but are not checked out. | {count} Gegenstände stehen im Ausleih-Index, sind aber nicht ausgeliehen. |
| `hv.health.lowStockItemMissingFromIndex.one` | {count} low-stock item is missing from the low-stock index. | {count} Gegenstand mit niedrigem Bestand fehlt im Bestandsindex. |
| `hv.health.lowStockItemMissingFromIndex.other` | {count} low-stock items are missing from the low-stock index. | {count} Gegenstände mit niedrigem Bestand fehlen im Bestandsindex. |
| `hv.health.nonLowStockItemInIndex.one` | {count} item is in the low-stock index but is not low on stock. | {count} Gegenstand steht im Bestandsindex, hat aber keinen niedrigen Bestand. |
| `hv.health.nonLowStockItemInIndex.other` | {count} items are in the low-stock index but are not low on stock. | {count} Gegenstände stehen im Bestandsindex, haben aber keinen niedrigen Bestand. |
| `hv.health.tagsIndexUnknownItems.one` | The tag index references {count} item that no longer exists. | Der Label-Index verweist auf {count} Gegenstand, den es nicht mehr gibt. |
| `hv.health.tagsIndexUnknownItems.other` | The tag index references {count} items that no longer exist. | Der Label-Index verweist auf {count} Gegenstände, die es nicht mehr gibt. |
| `hv.health.categoryIndexUnknownItems.one` | The category index references {count} item that no longer exists. | Der Kategorie-Index verweist auf {count} Gegenstand, den es nicht mehr gibt. |
| `hv.health.categoryIndexUnknownItems.other` | The category index references {count} items that no longer exist. | Der Kategorie-Index verweist auf {count} Gegenstände, die es nicht mehr gibt. |
| `hv.health.checkedOutIndexUnknownItems.one` | The checked-out index references {count} item that no longer exists. | Der Ausleih-Index verweist auf {count} Gegenstand, den es nicht mehr gibt. |
| `hv.health.checkedOutIndexUnknownItems.other` | The checked-out index references {count} items that no longer exist. | Der Ausleih-Index verweist auf {count} Gegenstände, die es nicht mehr gibt. |
| `hv.health.lowStockIndexUnknownItems.one` | The low-stock index references {count} item that no longer exists. | Der Bestandsindex verweist auf {count} Gegenstand, den es nicht mehr gibt. |
| `hv.health.lowStockIndexUnknownItems.other` | The low-stock index references {count} items that no longer exist. | Der Bestandsindex verweist auf {count} Gegenstände, die es nicht mehr gibt. |
| `hv.health.locationIndexUnknownItems.one` | The location index references {count} item that no longer exists. | Der Ortsindex verweist auf {count} Gegenstand, den es nicht mehr gibt. |
| `hv.health.locationIndexUnknownItems.other` | The location index references {count} items that no longer exist. | Der Ortsindex verweist auf {count} Gegenstände, die es nicht mehr gibt. |
| `hv.health.locationIndexMissingLocation.one` | The location index has {count} bucket for a missing location. | Der Ortsindex führt {count} Fach für einen Ort, den es nicht mehr gibt. |
| `hv.health.locationIndexMissingLocation.other` | The location index has {count} buckets for missing locations. | Der Ortsindex führt {count} Fächer für Orte, die es nicht mehr gibt. |
| `hv.health.locationBucketMismatch.one` | {count} location bucket disagrees with the items it holds. | {count} Fach im Ortsindex stimmt nicht mit den Gegenständen überein, die es führt. |
| `hv.health.locationBucketMismatch.other` | {count} location buckets disagree with the items they hold. | {count} Fächer im Ortsindex stimmen nicht mit den Gegenständen überein, die sie führen. |
| `hv.health.locationIdKeyMismatch.one` | {count} location is stored under a key that does not match its id. | {count} Ort ist unter einem Schlüssel gespeichert, der nicht zu seiner ID passt. |
| `hv.health.locationIdKeyMismatch.other` | {count} locations are stored under a key that does not match their id. | {count} Orte sind unter Schlüsseln gespeichert, die nicht zu ihren IDs passen. |
| `hv.health.itemsTotalMismatch.one` | The cached item total disagrees with the stored items. | Die zwischengespeicherte Gesamtzahl der Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein. |
| `hv.health.itemsTotalMismatch.other` | The cached item total disagrees with the stored items. | Die zwischengespeicherte Gesamtzahl der Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein. |
| `hv.health.locationsTotalMismatch.one` | The cached location total disagrees with the stored locations. | Die zwischengespeicherte Gesamtzahl der Orte stimmt nicht mit den gespeicherten Orten überein. |
| `hv.health.locationsTotalMismatch.other` | The cached location total disagrees with the stored locations. | Die zwischengespeicherte Gesamtzahl der Orte stimmt nicht mit den gespeicherten Orten überein. |
| `hv.health.checkedOutCountMismatch.one` | The cached checked-out count disagrees with the stored items. | Die zwischengespeicherte Zahl der ausgeliehenen Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein. |
| `hv.health.checkedOutCountMismatch.other` | The cached checked-out count disagrees with the stored items. | Die zwischengespeicherte Zahl der ausgeliehenen Gegenstände stimmt nicht mit den gespeicherten Gegenständen überein. |
| `hv.health.lowStockCountMismatch.one` | The cached low-stock count disagrees with the stored items. | Die zwischengespeicherte Zahl der Gegenstände mit niedrigem Bestand stimmt nicht mit den gespeicherten Gegenständen überein. |
| `hv.health.lowStockCountMismatch.other` | The cached low-stock count disagrees with the stored items. | Die zwischengespeicherte Zahl der Gegenstände mit niedrigem Bestand stimmt nicht mit den gespeicherten Gegenständen überein. |
| `hv.count.item.one` | {count} item | {count} Gegenstand |
| `hv.count.item.other` | {count} items | {count} Gegenstände |
| `hv.count.location.one` | {count} location | {count} Ort |
| `hv.count.location.other` | {count} locations | {count} Orte |
| `hv.count.subLocation.one` | {count} sub-location | {count} Unterort |
| `hv.count.subLocation.other` | {count} sub-locations | {count} Unterorte |
| `hv.count.tag.one` | {count} tag | {count} Label |
| `hv.count.tag.other` | {count} tags | {count} Labels |
| `hv.count.category.one` | {count} category | {count} Kategorie |
| `hv.count.category.other` | {count} categories | {count} Kategorien |
| `hv.count.status.one` | {count} status | {count} Status |
| `hv.count.status.other` | {count} statuses | {count} Status |
| `hv.count.field.one` | {count} field | {count} Feld |
| `hv.count.field.other` | {count} fields | {count} Felder |
| `hv.count.filter.one` | {count} filter | {count} Filter |
| `hv.count.filter.other` | {count} filters | {count} Filter |
| `hv.count.issue.one` | {count} issue | {count} Problem |
| `hv.count.issue.other` | {count} issues | {count} Probleme |
| `hv.count.problem.one` | {count} problem | {count} Problem |
| `hv.count.problem.other` | {count} problems | {count} Probleme |
| `hv.count.conflict.one` | {count} conflict | {count} Konflikt |
| `hv.count.conflict.other` | {count} conflicts | {count} Konflikte |
| `hv.count.nameClash.one` | {count} name clash | {count} Namenskonflikt |
| `hv.count.nameClash.other` | {count} name clashes | {count} Namenskonflikte |
| `hv.count.failedRow.one` | {count} failed row | {count} fehlgeschlagene Zeile |
| `hv.count.failedRow.other` | {count} failed rows | {count} fehlgeschlagene Zeilen |
| `hv.list.showingAll.one` | Showing {count} item | {count} Gegenstand wird angezeigt |
| `hv.list.showingAll.other` | Showing {count} items | {count} Gegenstände werden angezeigt |
| `hv.list.showingOf.one` | Showing {loaded} of {count} item | {loaded} von {count} Gegenstand wird angezeigt |
| `hv.list.showingOf.other` | Showing {loaded} of {count} items | {loaded} von {count} Gegenständen werden angezeigt |
| `hv.list.showingOfMatching.one` | Showing {loaded} of {count} matching item | {loaded} von {count} passendem Gegenstand wird angezeigt |
| `hv.list.showingOfMatching.other` | Showing {loaded} of {count} matching items | {loaded} von {count} passenden Gegenständen werden angezeigt |
| `hv.rewrite.tag.remove.one` | Removes "{from}" from {count} item. | Entfernt „{from}“ von {count} Gegenstand. |
| `hv.rewrite.tag.remove.other` | Removes "{from}" from {count} items. | Entfernt „{from}“ von {count} Gegenständen. |
| `hv.rewrite.tag.retag.one` | Retags {count} item, then removes "{from}". | Ändert das Label bei {count} Gegenstand und entfernt „{from}“. |
| `hv.rewrite.tag.retag.other` | Retags {count} items, then removes "{from}". | Ändert das Label bei {count} Gegenständen und entfernt „{from}“. |
| `hv.rewrite.category.clear.one` | Clears the category on {count} item. | Entfernt die Kategorie bei {count} Gegenstand. |
| `hv.rewrite.category.clear.other` | Clears the category on {count} items. | Entfernt die Kategorie bei {count} Gegenständen. |
| `hv.rewrite.category.set.one` | Recategorises {count} item as "{to}". | Ordnet {count} Gegenstand der Kategorie „{to}“ zu. |
| `hv.rewrite.category.set.other` | Recategorises {count} items as "{to}". | Ordnet {count} Gegenstände der Kategorie „{to}“ zu. |
| `hv.time.justNow` | just now | gerade eben |
| `hv.date.offsetDays` | +{days} days | +{days} Tage |
| `hv.reminder.every.days.one` | every day | täglich |
| `hv.reminder.every.days.other` | every {count} days | alle {count} Tage |
| `hv.reminder.every.weeks.one` | every week | wöchentlich |
| `hv.reminder.every.weeks.other` | every {count} weeks | alle {count} Wochen |
| `hv.reminder.every.months.one` | every month | monatlich |
| `hv.reminder.every.months.other` | every {count} months | alle {count} Monate |
| `hv.area.prefix` | Area: {name} | Bereich: {name} |
| `hv.area.srPrefix` | Area:  | Bereich:  |
| `hv.shortcut.ctrlEnter` | Ctrl+Enter | Strg+Enter |
| `hv.bulk.result.failed.one` | {count} failed and was left unchanged. | {count} ist fehlgeschlagen und blieb unverändert. |
| `hv.bulk.result.failed.other` | {count} failed and were left unchanged. | {count} sind fehlgeschlagen und blieben unverändert. |
| `hv.fullView.checkedOutWarning.one` | {count} of them is checked out | {count} davon ist ausgeliehen |
| `hv.fullView.checkedOutWarning.other` | {count} of them are checked out | {count} davon sind ausgeliehen |
| `hv.surfaces.exportView.filtered.one` | {count} filtered item · Keeps location paths | {count} gefilterter Gegenstand · behält Ortspfade |
| `hv.surfaces.exportView.filtered.other` | {count} filtered items · Keeps location paths | {count} gefilterte Gegenstände · behält Ortspfade |
| `hv.form.error.nameRequired` | Name is required. | Name ist erforderlich. |
| `hv.form.error.nameTooLong` | Name is limited to {max} characters. | Der Name darf höchstens {max} Zeichen lang sein. |
| `hv.form.error.descriptionTooLong` | Description is limited to {max} characters. | Die Beschreibung darf höchstens {max} Zeichen lang sein. |
| `hv.form.error.categoryTooLong` | Category is limited to {max} characters. | Die Kategorie darf höchstens {max} Zeichen lang sein. |
| `hv.form.error.quantityNegative` | Quantity can't be negative. | Die Menge darf nicht negativ sein. |
| `hv.form.error.lowStockRange` | Low-stock threshold must be 0 or more, or empty. | Die Bestandsschwelle muss 0 oder größer sein – oder leer bleiben. |
| `hv.form.error.tooManyTags` | An item can carry at most {max} tags. | Ein Gegenstand kann höchstens {max} Labels tragen. |
| `hv.form.error.tagTooLong` | Each tag is limited to {max} characters. | Jedes Label darf höchstens {max} Zeichen lang sein. |
| `hv.form.error.reminderRange` | Repeat every 1 to {max}, or leave it empty for a one-off. | Wiederholung von 1 bis {max}, oder leer lassen für einen einmaligen Termin. |
| `hv.form.error.customFieldDuplicate` | "{key}" is used twice. | „{key}“ kommt zweimal vor. |
| `hv.form.error.customFieldKeyTooLong` | Field names are limited to {max} characters. | Feldnamen dürfen höchstens {max} Zeichen lang sein. |
| `hv.form.error.customFieldNotNumber` | "{key}" must be a number. | „{key}“ muss eine Zahl sein. |
| `hv.form.error.customFieldNotDate` | "{key}" must be a date. | „{key}“ muss ein Datum sein. |
| `hv.form.error.customFieldValueTooLong` | "{key}" is limited to {max} characters. | „{key}“ darf höchstens {max} Zeichen lang sein. |
| `hv.form.error.tooManyCustomFields` | An item can carry at most {max} custom fields. | Ein Gegenstand kann höchstens {max} eigene Felder tragen. |

### The backend — `strings.json` vs `translations/de.json`

| key | English | German |
| --- | --- | --- |
| `config.step.user.title` | HAventory | HAventory |
| `config.step.user.description` | Set up HAventory for inventory management in Home Assistant. Both answers below, and everything else, can be changed later under Configure. Heads-up for afterwards: a browser page that is already open picks up the card only when it next loads — one reload, or a visit to the new HAventory sidebar entry, brings it in. | Richte HAventory für die Inventarverwaltung in Home Assistant ein. Beide Antworten unten – und alles Weitere – kannst du später unter Konfigurieren ändern. Hinweis für danach: Eine Browserseite, die schon offen ist, übernimmt die Karte erst, wenn sie das nächste Mal lädt – ein Neuladen, oder ein Besuch des neuen HAventory-Eintrags in der Seitenleiste, holt sie herein. |
| `config.step.user.data.card_title` | Card title | Kartentitel |
| `config.step.user.data.sidebar_panel_enabled` | Show HAventory in the sidebar | HAventory in der Seitenleiste anzeigen |
| `config.step.user.data_description.card_title` | Heading shown on the HAventory card. | Überschrift auf der HAventory-Karte. |
| `config.step.user.data_description.sidebar_panel_enabled` | Gives HAventory a page of its own, named after the card title above. Each user can still hide the entry through the sidebar's own Edit sidebar mode. | Gibt HAventory eine eigene Seite, benannt nach dem Kartentitel oben. Jeder Benutzer kann den Eintrag weiterhin über den Bearbeitungsmodus der Seitenleiste ausblenden. |
| `config.create_entry.default` | Successfully configured HAventory. Reload this browser page once: the card and its sidebar icon are loaded when a page opens, so a page that was already open has neither yet. Opening the new HAventory sidebar entry does the same job — panel and card ship in one bundle, and an open dashboard shows the card the moment that bundle loads. | HAventory wurde erfolgreich eingerichtet. Lade diese Browserseite einmal neu: Karte und Symbol in der Seitenleiste werden geladen, wenn eine Seite geöffnet wird – eine Seite, die schon offen war, hat also beides noch nicht. Der neue HAventory-Eintrag in der Seitenleiste erledigt dasselbe: Seite und Karte stecken in einem Bündel, und ein offenes Dashboard zeigt die Karte in dem Moment, in dem dieses Bündel lädt. |
| `options.step.init.title` | HAventory Options | HAventory-Optionen |
| `options.step.init.description` | Set the heading the card carries, whether HAventory has its own sidebar entry, and which quick-filter pills it offers. | Lege fest, welche Überschrift die Karte trägt, ob HAventory einen eigenen Eintrag in der Seitenleiste bekommt und welche Schnellfilter-Pillen sie anbietet. |
| `options.step.init.data.card_title` | Card title | Kartentitel |
| `options.step.init.data.sidebar_panel_enabled` | Show HAventory in the sidebar | HAventory in der Seitenleiste anzeigen |
| `options.step.init.data.quick_filters` | Quick-filter pills | Schnellfilter-Pillen |
| `options.step.init.data_description.card_title` | Heading shown on the HAventory card. A dashboard card with its own title: option keeps that one. Reload the dashboard to see a change. | Überschrift auf der HAventory-Karte. Eine Dashboard-Karte mit eigener Option „title:“ behält ihre eigene. Lade das Dashboard neu, um eine Änderung zu sehen. |
| `options.step.init.data_description.sidebar_panel_enabled` | Gives HAventory a page of its own, named after the card title above. This applies to everyone using this Home Assistant; each user can still hide the entry through the sidebar's own Edit sidebar mode. The entry appears and disappears as you save this form — no restart. On the Overview page, Edit then Add shortcut can also pin HAventory as a tile. | Gibt HAventory eine eigene Seite, benannt nach dem Kartentitel oben. Das gilt für alle, die dieses Home Assistant nutzen; jeder Benutzer kann den Eintrag weiterhin über den Bearbeitungsmodus der Seitenleiste ausblenden. Der Eintrag erscheint und verschwindet, während du dieses Formular speicherst – ohne Neustart. Auf der Übersichtsseite kann HAventory über Bearbeiten und dann Verknüpfung hinzufügen auch als Kachel angeheftet werden. |
| `options.step.init.data_description.quick_filters` | The one-tap filters shown above the item list, here and on the sidebar page. A pill still only appears when it has something to count, so a household that never checks anything out sees no checked-out pill either way. Item total is the exception in a second way: only the card draws it as a pill, and only at full width — the sidebar page and the full view print the total in their header instead, whether or not it is ticked here. A dashboard card with its own quick_filters: option keeps that one. Reload the dashboard to see a change. | Die Ein-Tipp-Filter über der Gegenstandsliste, hier und auf der Seite in der Seitenleiste. Eine Pille erscheint weiterhin nur, wenn sie etwas zu zählen hat – ein Haushalt, der nie etwas ausleiht, sieht also so oder so keine Ausleih-Pille. „Gegenstände gesamt“ ist noch auf eine zweite Art die Ausnahme: Nur die Karte zeichnet sie als Pille, und nur in voller Breite – die Seite in der Seitenleiste und die volle Ansicht schreiben die Gesamtzahl stattdessen in ihre Kopfzeile, ob sie hier angehakt ist oder nicht. Eine Dashboard-Karte mit eigener Option „quick_filters:“ behält ihre eigene. Lade das Dashboard neu, um eine Änderung zu sehen. |
| `options.step.init.sections.todo.name` | Shopping list | Einkaufsliste |
| `options.step.init.sections.todo.description` | Mirrors low-stock items onto a Home Assistant to-do list. An item at or below its low-stock threshold appears as a line naming it and how many to buy, and the line comes off again once the item is restocked. Leave the list empty to keep this off, which is the default. Clearing it later stops the mirroring and leaves whatever is on the list alone; picking a different list moves the lines across instead. | Spiegelt Gegenstände mit niedrigem Bestand auf eine To-do-Liste von Home Assistant. Ein Gegenstand, der seine Bestandsschwelle erreicht oder unterschreitet, erscheint als Zeile mit seinem Namen und der nachzukaufenden Menge, und die Zeile verschwindet wieder, sobald der Gegenstand aufgefüllt ist. Lass die Liste leer, um das ausgeschaltet zu lassen – so ist es voreingestellt. Leerst du sie später, endet die Spiegelung und was auf der Liste steht, bleibt unangetastet; wählst du eine andere Liste, wandern die Zeilen stattdessen mit. |
| `options.step.init.sections.todo.data.todo_entity_id` | To-do list | To-do-Liste |
| `options.step.init.sections.todo.data_description.todo_entity_id` | Any to-do list this Home Assistant knows, including one the household already shares. HAventory only ever touches the lines it wrote itself, so a list you use for other things is safe to pick. | Jede To-do-Liste, die dieses Home Assistant kennt, auch eine, die der Haushalt schon gemeinsam nutzt. HAventory rührt immer nur die Zeilen an, die es selbst geschrieben hat – eine Liste, die du für anderes verwendest, kannst du also bedenkenlos wählen. |
| `options.step.init.sections.rate_limit.name` | WebSocket rate limiting | WebSocket-Ratenbegrenzung |
| `options.step.init.sections.rate_limit.description` | Caps how fast one client may use HAventory: over-budget commands are refused instead of executed, and surplus live-update events are dropped. Off by default — ordinary card use never comes close. Turn it on when something you don't fully control talks to HAventory, such as a wall panel stuck reconnecting or a script in a loop; leave it off during large imports and stress tests. What each setting means, and how to tell whether limiting is firing: {docs_url} | Begrenzt, wie schnell ein Client HAventory nutzen darf: Befehle über dem Budget werden abgelehnt statt ausgeführt, und überzählige Live-Update-Ereignisse werden verworfen. Standardmäßig aus – normale Kartennutzung kommt nie in die Nähe. Schalte sie ein, wenn etwas mit HAventory spricht, das du nicht ganz unter Kontrolle hast, etwa ein Wandpanel, das dauernd neu verbindet, oder ein Skript in einer Schleife; lass sie bei großen Importen und Belastungstests aus. Was die einzelnen Einstellungen bedeuten und woran du erkennst, ob die Begrenzung greift: {docs_url} |
| `options.step.init.sections.rate_limit.data.rate_limit_enabled` | Enable WebSocket rate limiting | WebSocket-Ratenbegrenzung aktivieren |
| `options.step.init.sections.rate_limit.data.rate_limit_commands_per_second` | Commands per second (one client) | Befehle pro Sekunde (ein Client) |
| `options.step.init.sections.rate_limit.data.rate_limit_commands_burst` | Command burst (one client) | Befehls-Burst (ein Client) |
| `options.step.init.sections.rate_limit.data.rate_limit_global_commands_per_second` | Commands per second (all clients) | Befehle pro Sekunde (alle Clients) |
| `options.step.init.sections.rate_limit.data.rate_limit_global_commands_burst` | Command burst (all clients) | Befehls-Burst (alle Clients) |
| `options.step.init.sections.rate_limit.data.rate_limit_events_per_second` | Live-update events per second (one client) | Live-Update-Ereignisse pro Sekunde (ein Client) |
| `options.step.init.sections.rate_limit.data.rate_limit_events_burst` | Live-update event burst (one client) | Live-Update-Ereignis-Burst (ein Client) |
| `options.step.init.sections.rate_limit.data.rate_limit_global_events_per_second` | Live-update events per second (all clients) | Live-Update-Ereignisse pro Sekunde (alle Clients) |
| `options.step.init.sections.rate_limit.data.rate_limit_global_events_burst` | Live-update event burst (all clients) | Live-Update-Ereignis-Burst (alle Clients) |
| `options.step.init.sections.rate_limit.data_description.rate_limit_enabled` | While off, nothing is limited and the values below are ignored. | Solange sie aus ist, wird nichts begrenzt und die Werte darunter werden ignoriert. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_commands_per_second` | Sustained requests one client may send. Default 20. | Dauerhafte Anfragen, die ein Client senden darf. Standard 20. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_commands_burst` | Requests one client may send back-to-back after being idle. Default 60. | Anfragen, die ein Client nach einer Ruhephase direkt hintereinander senden darf. Standard 60. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_global_commands_per_second` | Sustained requests across all clients together. Default 100. | Dauerhafte Anfragen über alle Clients zusammen. Standard 100. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_global_commands_burst` | Requests all clients together may send back-to-back. Default 200. | Anfragen, die alle Clients zusammen direkt hintereinander senden dürfen. Standard 200. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_events_per_second` | Sustained events one client may be sent. Default 50. | Dauerhafte Ereignisse, die einem Client gesendet werden dürfen. Standard 50. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_events_burst` | Events one client may be sent back-to-back after a quiet spell. Default 200. | Ereignisse, die einem Client nach einer ruhigen Phase direkt hintereinander gesendet werden dürfen. Standard 200. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_global_events_per_second` | Sustained events across all clients together. Default 500. | Dauerhafte Ereignisse über alle Clients zusammen. Standard 500. |
| `options.step.init.sections.rate_limit.data_description.rate_limit_global_events_burst` | Events all clients together may be sent back-to-back. Default 1000. | Ereignisse, die allen Clients zusammen direkt hintereinander gesendet werden dürfen. Standard 1000. |
| `entity.sensor.items_total.name` | Item count | Anzahl Gegenstände |
| `entity.sensor.low_stock.name` | Low stock count | Anzahl niedriger Bestand |
| `entity.sensor.checked_out.name` | Checked out count | Anzahl ausgeliehen |
| `entity.sensor.overdue.name` | Checked out overdue count | Anzahl überfällig ausgeliehen |
| `entity.sensor.checked_out_due.name` | Checked out due count | Anzahl Rückgabe fällig |
| `entity.sensor.inspection_overdue.name` | Inspection overdue count | Anzahl Prüfung überfällig |
| `entity.sensor.inspection_due.name` | Inspection due count | Anzahl Prüfung fällig |
| `entity.sensor.locations.name` | Location count | Anzahl Orte |
| `selector.quick_filters.options.total` | Item total | Gegenstände gesamt |
| `selector.quick_filters.options.low_stock` | Low stock | Niedriger Bestand |
| `selector.quick_filters.options.overdue` | Overdue | Überfällig |
| `selector.quick_filters.options.inspection_due` | Due for inspection | Prüfung fällig |
| `selector.quick_filters.options.reminder_due` | Reminder due | Erinnerung fällig |
| `selector.quick_filters.options.checked_out` | Checked out | Ausgeliehen |
| `services.item_create.name` | Create item | Gegenstand anlegen |
| `services.item_create.description` | Create a new inventory item. | Legt einen neuen Gegenstand im Inventar an. |
| `services.item_update.name` | Update item | Gegenstand aktualisieren |
| `services.item_update.description` | Update an existing inventory item. | Aktualisiert einen vorhandenen Gegenstand im Inventar. |
| `services.item_delete.name` | Delete item | Gegenstand löschen |
| `services.item_delete.description` | Delete an inventory item. | Löscht einen Gegenstand aus dem Inventar. |
| `services.item_move.name` | Move item | Gegenstand verschieben |
| `services.item_move.description` | Move an item to a new location (or root). | Verschiebt einen Gegenstand an einen anderen Ort (oder in die oberste Ebene). |
| `services.item_adjust_quantity.name` | Adjust quantity | Menge anpassen |
| `services.item_adjust_quantity.description` | Add or subtract from item quantity. | Erhöht oder verringert die Menge eines Gegenstands. |
| `services.item_set_quantity.name` | Set quantity | Menge setzen |
| `services.item_set_quantity.description` | Set item quantity exactly. | Setzt die Menge eines Gegenstands auf einen genauen Wert. |
| `services.item_check_out.name` | Check out item | Gegenstand ausleihen |
| `services.item_check_out.description` | Mark an item as checked out with due date. | Markiert einen Gegenstand als ausgeliehen, mit Rückgabedatum. |
| `services.item_check_in.name` | Check in item | Gegenstand zurückgeben |
| `services.item_check_in.description` | Mark an item as not checked out. | Markiert einen Gegenstand als nicht mehr ausgeliehen. |
| `services.reminder_bump.name` | Bump reminder | Erinnerung erledigen |
| `services.reminder_bump.description` | Mark a recurring reminder done and move it on to its next occurrence. | Markiert eine wiederkehrende Erinnerung als erledigt und setzt sie auf ihren nächsten Termin. |
| `services.location_create.name` | Create location | Ort anlegen |
| `services.location_create.description` | Create a new storage location. | Legt einen neuen Aufbewahrungsort an. |
| `services.location_update.name` | Update location | Ort aktualisieren |
| `services.location_update.description` | Update an existing storage location. | Aktualisiert einen vorhandenen Aufbewahrungsort. |
| `services.location_delete.name` | Delete location | Ort löschen |
| `services.location_delete.description` | Delete a storage location. | Löscht einen Aufbewahrungsort. |
| `issues.schema_downgrade.title` | HAventory cannot read the stored data | HAventory kann die gespeicherten Daten nicht lesen |
| `issues.schema_downgrade.description` | HAventory stopped instead of setting up: {error}<br><br>The file is `.storage/{storage_key}` in your Home Assistant configuration directory, and it has been left exactly as it was. This card clears itself once HAventory starts against a store it can read. | HAventory hat angehalten, statt sich einzurichten: {error}<br><br>Die Datei ist `.storage/{storage_key}` in deinem Home-Assistant-Konfigurationsverzeichnis, und sie wurde genau so gelassen, wie sie war. Dieser Hinweis verschwindet von selbst, sobald HAventory mit einem Speicher startet, den es lesen kann. |
| `issues.corrupt_schema_version.title` | HAventory cannot tell which schema the stored data uses | HAventory kann nicht erkennen, welches Schema die gespeicherten Daten verwenden |
| `issues.corrupt_schema_version.description` | HAventory stopped instead of setting up: {error}<br><br>The file is `.storage/{storage_key}` in your Home Assistant configuration directory, and it has been left exactly as it was. This card clears itself once HAventory starts against a store it can read. | HAventory hat angehalten, statt sich einzurichten: {error}<br><br>Die Datei ist `.storage/{storage_key}` in deinem Home-Assistant-Konfigurationsverzeichnis, und sie wurde genau so gelassen, wie sie war. Dieser Hinweis verschwindet von selbst, sobald HAventory mit einem Speicher startet, den es lesen kann. |
| `issues.corrupt_store.title` | HAventory cannot read part of the stored data | HAventory kann einen Teil der gespeicherten Daten nicht lesen |
| `issues.corrupt_store.fix_flow.abort.no_config_entry` | HAventory is no longer set up, so there is nothing to reload. | HAventory ist nicht mehr eingerichtet, es gibt also nichts neu zu laden. |
| `issues.corrupt_store.fix_flow.abort.backup_failed` | The copy of the stored file could not be written, so nothing was changed. Without it there would be no way back, so HAventory did not load. | Die Kopie der gespeicherten Datei konnte nicht geschrieben werden, deshalb wurde nichts geändert. Ohne sie gäbe es keinen Weg zurück, also hat HAventory nicht geladen. |
| `issues.corrupt_store.fix_flow.abort.reload_failed` | HAventory still did not start. The copy was written and the stored file is unchanged; check the Home Assistant log for what stopped it. | HAventory ist immer noch nicht gestartet. Die Kopie wurde geschrieben und die gespeicherte Datei ist unverändert; sieh im Home-Assistant-Protokoll nach, was es aufgehalten hat. |
| `issues.corrupt_store.fix_flow.step.confirm.title` | Load HAventory without the unreadable entries | HAventory ohne die unlesbaren Einträge laden |
| `issues.corrupt_store.fix_flow.step.confirm.description` | HAventory could not read {items} item(s) and {locations} location(s), and found {cyclic_locations} location(s) whose parent chain loops back on itself. It stopped rather than load the rest — it saves on every change, and the first edit would rewrite the file without them.<br><br>Confirming copies `.storage/{storage_key}` to `.storage/{backup_key}` and then starts HAventory with everything it could read. The unreadable entries stay out, and the copy is how you get them back.<br><br>To keep them instead, close this dialog and repair those entries in the stored file, or restore it from a backup. | HAventory konnte {items} Gegenstände und {locations} Orte nicht lesen und hat {cyclic_locations} Orte gefunden, deren Elternkette sich im Kreis dreht. Es hat angehalten, statt den Rest zu laden – es speichert bei jeder Änderung, und die erste Bearbeitung würde die Datei ohne sie neu schreiben.<br><br>Bestätigen kopiert `.storage/{storage_key}` nach `.storage/{backup_key}` und startet HAventory dann mit allem, was es lesen konnte. Die unlesbaren Einträge bleiben draußen, und die Kopie ist dein Weg, sie zurückzuholen.<br><br>Um sie stattdessen zu behalten, schließe diesen Dialog und repariere die Einträge in der gespeicherten Datei, oder stelle sie aus einem Backup wieder her. |


## Handover

**Merged / left open**

All three self-merged; nothing is waiting on you.

- [#537](https://github.com/chrreiter/HAventory/pull/537) — `feat(i18n): translation mechanism, German backend translations and the shared copy modules`
- [#538](https://github.com/chrreiter/HAventory/pull/538) — `feat(i18n): translate the card components (1/2)`
- [#539](https://github.com/chrreiter/HAventory/pull/539) — `feat(i18n): translate the card components (2/2)`, closes [#190](https://github.com/chrreiter/HAventory/issues/190)

**Test this by hand**

The harness proved every surface *opens* in German and that the English is unchanged; what it
cannot judge is whether the German is any good. That is this list.

1. `[HA settings]` Profile → Sprache → **Deutsch**, then reload. Open Einstellungen → Geräte &
   Dienste → HAventory → **Konfigurieren**. Expected: the whole options screen in German,
   including the two collapsed sections (Einkaufsliste, WebSocket-Ratenbegrenzung) — open
   both; their descriptions are the longest prose the integration carries.
   **List every wording you would change.**
2. `[desktop]` Open `/haventory` and read it as a German speaker: the tree's `Kein Bereich` /
   `Kein Ort` bands, the column headers, the app-bar pills (`161 niedrig`, `54 überfällig`,
   `34 zu prüfen`, `122 ausgeliehen`), the footer line. Then open **Verwalten** and walk all
   four tabs; the Orte tab's merge step and the Status tab's delete guard carry the longest
   sentences in the card.
3. `[desktop]` Open the Filter panel and an item's editor. Expected: `Wo`, `Nur anzeigen`,
   `Sortierung`, and in the editor `Menge`, `Niedriger Bestand ab`, `Ort`, `Labels`,
   `Ausleihe`, `Erinnerung`, `Weitere Felder`.
4. `[phone]` Same instance at phone width or on a real phone: the filter sheet's apply button
   (`1087 Gegenstände anzeigen`), the detail sheet's fact rows, the add sheet. Watch for
   anything that wraps to two lines or clips — German runs 15–25% longer than English and the
   phone is where that shows first.
5. `[desktop]` Profile → Sprache → **English**, reload, and confirm the card reads exactly as
   it did before this session. (One caveat worth knowing: on a machine whose OS is German,
   clearing the profile language is *not* the same as choosing English — Home Assistant then
   falls back to the browser's language. Choose English explicitly.)

**Three word choices are the ones most worth a second opinion**, because everything else
follows from them: an item is a **Gegenstand**, a location is an **Ort**, and a tag is a
**Label**. Changing any of them is a find-and-replace in `cards/haventory-card/src/i18n/de.ts`
plus `custom_components/haventory/translations/de.json` — cheap now, expensive once a second
language copies them.

Corrections ship as one follow-up PR: S9 takes it if your list arrives before S9 starts,
otherwise S11.

**Decisions taken against drifted notes**

- `counted()`'s signature moved in PR #537 rather than being split across the three PRs — a
  language that does not build its plural by appending a letter cannot be served by
  `(count, singular, pluralForm?)`. `plural()` was deleted with it, which pulled three
  sentences from `hv-bulk-bar`, `hv-full-view` and `host-surfaces` forward into that PR.
- The health-code messages lost their `{n} item(s)` shape and became two-form plurals; the
  English improves and the German becomes possible at all.
- `relativeTime` moved to `Intl` with `style: 'short'`, `numeric: 'always'`, so the English
  reads `2 hr. ago` / `3 days ago` where it used to read `2 h ago` / `3 d ago`. `narrow` was
  closer to the old English but renders German minutes as `vor 2 m`.
- `BUILT_IN_STATUSES`' three labels stay English — they mirror stored data the backend seeds,
  and translating the card's stand-in would make the chip change wording mid-load. Filed as
  [#536](https://github.com/chrreiter/HAventory/issues/536).
- The card-picker entry, `setConfig`'s `Invalid config`, the diagnostics copy-report and the
  backend's own error `message` text stay English, each for a stated reason.
- The docs-site / public-roadmap half of #190 is dropped, not filed, per §6.8 and the owner's
  decision comment.

**Follow-ups**

- [#536](https://github.com/chrreiter/HAventory/issues/536) — the three seeded status labels
  are English in every language. Filed with the three ways it could go weighed, because the
  fix is a backend-seeding question rather than a card one.
- Named and deliberately **not** filed: the reminder unit select and the upload queue's state
  line were rendering raw enums as UI text (`months`, `uploading…`). Both are fixed in
  PR #539 rather than tracked.

**State left behind**

- **Dev HA**: back as it was. Profile language cleared (it was unset before this session);
  the config entry was removed and re-added once to photograph a fresh setup flow, and its
  options were read out of `core.config_entries` first and restored key for key — `card_title`,
  `sidebar_panel_enabled`, all nine rate-limit values, `todo_entity_id: todo.shopping_list`
  and the explicit six-pill `quick_filters`. The store was never touched: 1087 items / 89
  locations before and after. The deployed build is this branch's.
- **Branches**: `claude/v0-7-0-s8-i18n-mechanism`, `claude/v0-7-0-s8-card-1` and
  `claude/v0-7-0-s8-card-2` are merged and deleted. `claude-assets-v0-7-0-s8` holds the
  thirteen screenshots the three PR bodies link and stays.
- **For the next session**: `cards/haventory-card/src/i18n/en.ts` is now the only place a
  user-facing string may be written, and `de.ts` is typed to fail the build if one lands
  without its German. `catalog.test.ts` carries a `SAME_IN_BOTH` allowlist — fifteen keys
  whose German is identical to their English on purpose; adding a sixteenth is a decision, not
  a formality. codespell skips the non-English dictionaries by path, and a German string
  anywhere else needs a same-line `// codespell:ignore` (the directive does **not** work on
  its own line).
- **S9's `docs/frontend_architecture.md` edit** now shares a file with this session's new
  "The language the wording is in" section — different section, so a trivial conflict at most,
  as #190's notes predicted.
