### PR TITLE
docs: state the invalid_format / validation_error split as a rule; count the sortable fields right

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ Closes #
 
 <!-- Both gates must be green. Paste the commands you ran / their results. -->
 
-- [ ] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q`, `uv run ruff check .`, `uv run mypy`
+- [ ] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
 - [ ] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`, `npm run build`
 
 ## Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ full toolchain and helper scripts.
 # Backend
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q
 uv run ruff check .
+uv run ruff format --check .   # CI fails on formatting alone; `ruff check` does not cover it
 uv run mypy
 
 # Frontend (in cards/haventory-card)

--- a/README.md
+++ b/README.md
@@ -493,8 +493,13 @@ Run any Python tool through uv (`uv run <tool>`), so it uses the locked dev envi
 - **uv** — Python env, dependency resolution, and lockfile (`uv.lock`). Dev deps live in
   `pyproject.toml` under `[dependency-groups]`; `requirements-dev.txt` is a generated,
   pip-installable export kept for environments without uv.
-- **Ruff** `0.15.x` — lint + format, configured in `pyproject.toml`.
-- **mypy** `2.x` — type checking (non-strict baseline; scoped to `custom_components/haventory`).
+- **Ruff** — lint + format, configured and pinned in `pyproject.toml`; the hook in
+  `.pre-commit-config.yaml` pins the same version and `tests/test_toolchain_pins.py`
+  holds the two together.
+- **mypy** `2.x` — type checking, scoped to `custom_components/haventory`. The core
+  modules are held to per-module strict mode against the local HA stubs in `stubs/`
+  and the rest of the integration sits at the non-strict baseline; which modules those
+  are is the `[[tool.mypy.overrides]]` list in `pyproject.toml`.
 - **ESLint** `10` (flat config `cards/haventory-card/eslint.config.js`) + `@typescript-eslint 8`.
 - **TypeScript** `6`, **Vite** `8`, **Vitest** `4` (+ `@vitest/coverage-v8`) for the card.
 - **pre-commit** — ruff, codespell, basic hooks.
@@ -505,6 +510,7 @@ Run any Python tool through uv (`uv run <tool>`), so it uses the locked dev envi
 # Backend
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q
 uv run ruff check .
+uv run ruff format --check .   # CI fails on formatting alone; `ruff check` does not cover it
 uv run mypy
 
 # Frontend (in cards/haventory-card)
@@ -567,8 +573,11 @@ uv pip install --python .venv-integration/bin/python -r requirements-integration
 Do **not** set `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` for this mode. `tests/conftest.py`
 detects the real `homeassistant` package these tests pull in and installs none of the
 offline stubs, so the two modes never collide; the offline run never collects
-`tests/integration/`. Covered: config-entry setup/unload, WebSocket item CRUD end-to-end,
-Store persistence round-trip, and `haventory/areas/list` against the real area registry.
+`tests/integration/`. What they cover has grown to most of the HA-facing surface —
+config-entry setup/unload, WebSocket CRUD and error envelopes, persistence and schema
+migration, services and their broadcasts, the sensors, calendar, repairs, diagnostics,
+to-do bridge, attachments, translations, the retired-files sweep and the frontend
+registration — one file per subject under `tests/integration/`.
 
 > Restricted-egress environments (e.g. sandboxes that can't fetch Python 3.14 or the HA
 > core) can't run this mode — CI provisions Python 3.14 and runs it in its own job.
@@ -750,12 +759,13 @@ throughout.
   [Finding HAventory after install](#finding-haventory-after-install).
 - **Standard card** — one Add button and a single ⋮ menu (Select items, Organize, Refresh,
   Diagnostics, Export backup / Export current view, Import); Columns is offered in the full
-  view, which is the only surface it changes. Live stat badges — items, low stock, overdue,
-  due for inspection, checked out — are click-to-filter, and which of them a household
-  offers is set under Settings → Devices & services → HAventory → **Configure**, or per
-  dashboard with the card's `quick_filters:`. Rows carry a quantity stepper, a
-  LOW badge, an overdue check-out chip, an "Inspection due" chip, an amber status chip
-  when an item is flagged Missing / Needs repair, and hover actions.
+  view, which is the only surface it changes. Live stat badges — items, low stock,
+  overdue, due for inspection, reminders to do, checked out — are click-to-filter, and
+  which of them a household offers is set under Settings → Devices & services →
+  HAventory → **Configure**, or per dashboard with the card's `quick_filters:`. Rows
+  carry a quantity stepper, a LOW badge, an overdue check-out chip, an "Inspection due"
+  chip, an amber status chip when an item is flagged Missing / Needs repair, and hover
+  actions.
 - **Filters** — a collapsible panel exposing the whole backend filter object: location
   (from a real tree), area, include-subtree, category chips with counts, tag chips with an
   any/all toggle, low-stock-only, checked-out, overdue, inspection-due, reminder-due and no-location —
@@ -932,7 +942,7 @@ changed name on its next refresh or reload; the change is not pushed live.
 
 `quick_filters` says which pills are *allowed*; a pill still only shows when it has
 something to count, so `low_stock` draws nothing while nothing is low. An explicit empty
-list is a choice and offers none. `total` is narrower than the other four: only the card
+list is a choice and offers none. `total` is narrower than the other five: only the card
 draws it as a pill, and only at full width — the full view and the sidebar page print the
 total in their header instead, whichever way it is set.
 
@@ -940,7 +950,7 @@ Omitting the key hands the decision to **Quick-filter pills** under Settings →
 services → HAventory → **Configure**, which is the one place that reaches every surface:
 the sidebar panel has no dashboard config of its own, so that setting is all it reads.
 Leave both unset — a fresh install, or any dashboard written before either option existed
-— and all five pills are offered.
+— and all six pills are offered.
 
 ### CI/CD & Ops
 

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -38,7 +38,37 @@ Guarantees (every `haventory/*` command is wrapped by the same guard):
 
 Transport-level errors produced by Home Assistant itself (before a handler runs) are outside this taxonomy and can also be observed by clients: `invalid_format` (request failed the command's voluptuous schema) and `unknown_command` (integration not loaded or unknown `type`).
 
-Several fields are deliberately typed `object` in their command schema rather than concretely, so that a wrong type is answered by the handler as `validation_error` instead of by Home Assistant as `invalid_format`. The difference matters to an operator: core refuses the frame before the guard runs and logs the client's payload at ERROR, while the guard names the field at WARNING with no traceback. The fields treated this way are the ones a client most plausibly gets wrong: `name` (`item/create`, `location/create`, `location/update`), `quantity` (`item/create`, `item/update`, `item/set_quantity`), `delta` (`item/adjust_quantity`), `operations` (`items/bulk`), and `filter` / `sort` / `limit` / `cursor` (`item/list`, `location/tree`, `export`). Every other field keeps its concrete schema type, and a wrong type there is still `invalid_format`.
+#### Which of the two answers a wrong type
+
+Most fields in a command schema are deliberately typed `object` rather than concretely, so
+that a wrong type is answered by the handler as `validation_error` instead of by Home
+Assistant as `invalid_format`. The difference matters to an operator: core refuses the frame
+before the guard runs and logs the client's payload at ERROR, while the guard names the field
+at WARNING with no traceback.
+
+That is the default, and it widens whenever a command gains a typed-input pass, so the
+object-typed fields are not listed here. What is listed is the **exception** set: the fields
+that keep a concrete schema type, and therefore still answer `invalid_format`.
+
+- `expected_version`, on every command that takes it.
+- The dates, and the two fields that travel with them: `due_date`, `inspection_date`,
+  `reminder_date`, `reminder_interval`, `checked_out`.
+- The collections a caller writes whole: `tags`, `custom_fields`, `custom_fields_set`,
+  `custom_fields_unset`, `set`, `unset`, `attachment_ids`.
+- The attachment handles: `file_id`, `kind`, `filename`, `title`.
+- `haventory/subscribe`'s own three: `topic`, `include_subtree`, `inspection_overdue_only`.
+- Every field the `haventory/status/*` commands take: `slug`, `slugs`, `label`, `color`,
+  `icon`, `order`, `reassign_to`.
+- Import's `document` and `policy`.
+
+`tags` is the one name on both sides: concrete on `item/create`, `item/add_tags` and
+`item/remove_tags`, `object` on `item/update`. The same wrong value therefore answers a
+different code depending on which command carried it, which is the reason to handle both
+rather than to key on the field name.
+
+`tests/test_docs_contract_offline.py` reads the schemas back off the registered handlers and
+fails when this list and the code disagree, so a new concretely-typed field arrives here in
+the same change.
 
 ### Logging
 
@@ -89,7 +119,7 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
   - Request: `{id, type: "haventory/config"}` (no payload)
   - Result: `{card_title: string, quick_filters: string[] | null, statuses: StatusDefinition[], media: MediaConfig}`
   - `card_title` is the heading set in the integration's options flow (Settings → Devices & services → HAventory → **Configure**), defaulting to `"HAventory"`. Only display settings appear here — rate-limit tunables stay server-side.
-  - `quick_filters` is which quick-filter pills the integration offers, out of `total`, `low_stock`, `overdue`, `inspection_due`, `checked_out`, set in the same options flow. `null` means no choice was made and leaves it to the client — a dashboard's own `quick_filters:` first, every pill otherwise — while `[]` is an explicit choice of no pills; the two are never interchangeable. Names the backend does not know are dropped before sending.
+  - `quick_filters` is which quick-filter pills the integration offers, out of `total`, `low_stock`, `overdue`, `inspection_due`, `reminder_due`, `checked_out`, set in the same options flow. `null` means no choice was made and leaves it to the client — a dashboard's own `quick_filters:` first, every pill otherwise — while `[]` is an explicit choice of no pills; the two are never interchangeable. Names the backend does not know are dropped before sending.
   - `statuses` is the status vocabulary in display order (see data shapes). Items store only a slug, so this is where a surface gets the label to render one with.
   - `media` is `{picture_mime_types: string[], max_pictures_per_item: number, manual_mime_types: string[], max_manuals_per_item: number, max_attachment_bytes: number}` — the attachment limits, reported so a picker can refuse a doomed file before uploading it. **Advisory only**: every one of them is re-derived server-side from the file's own bytes. The media *route* is deliberately not here; it is a constant on both sides of the language boundary (`/api/haventory/media/{item_id}/{attachment_id}`), pinned by a test.
   - Read at card init and on refresh, not pushed: changing the option emits no event, so an open dashboard shows the new heading after a refresh or reload.
@@ -530,7 +560,8 @@ Note: a successful import emits `items/reloaded` and `locations/reloaded` (no `i
   `version` or `updated_at`, so an `expected_version` taken before a rename is still
   accepted after it. Clients learn about the new paths from the `locations` event, not from
   per-item events — none are emitted for the rewrite.
-- Locations are not versioned in Phase 1.
+- Locations carry no `version` and take no `expected_version`. A location edit is
+  last-write-wins; only items are under optimistic concurrency.
 
 ### Timestamps
 

--- a/tests/test_docs_contract_offline.py
+++ b/tests/test_docs_contract_offline.py
@@ -1,0 +1,139 @@
+"""Hold `docs/backend_api_contract.md` to the code it describes.
+
+Two claims in that document are lists of names the code owns, and both went stale
+without anything noticing: the fields whose wrong type answers `invalid_format`
+rather than `validation_error`, and the quick-filter vocabulary `haventory/config`
+reports. A list nobody checks is a promise a client author reads once and builds
+against, so each is compared here against its source of truth.
+
+The field list is read back off the registered handlers rather than out of `ws.py`'s
+text: `_ws_schema` is what the connection applies to a frame, so a field it types
+`object` is exactly a field whose wrong type reaches the guard.
+
+Scenarios:
+- the contract's exception list names every concretely-typed command field, and no other
+- the extractor reports a missing name rather than silently matching an empty list
+- the contract's `quick_filters` vocabulary is `QUICK_FILTER_KEYS`
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from custom_components.haventory import ws
+from custom_components.haventory.const import QUICK_FILTER_KEYS
+
+CONTRACT = Path(__file__).resolve().parents[1] / "docs" / "backend_api_contract.md"
+
+#: The heading whose bullets enumerate the fields that keep a concrete schema type.
+EXCEPTIONS_HEADING = "#### Which of the two answers a wrong type"
+
+#: Fields the envelope carries rather than the command declaring them.
+ENVELOPE_KEYS = frozenset({"id", "type"})
+
+
+def _bulleted_names(markdown: str, heading: str) -> set[str]:
+    """Collect the backticked field names from one section's bullet list.
+
+    Only the bullets are read — whole bullets, so a name that wrapped onto the
+    next line still counts — which leaves the prose around them free to name
+    types and commands. A command path carries a ``/`` and so cannot be mistaken
+    for a field name.
+    """
+
+    lines = markdown.splitlines()
+    try:
+        start = lines.index(heading) + 1
+    except ValueError:
+        raise AssertionError(f"{heading!r} is not in {CONTRACT.name}") from None
+
+    names: set[str] = set()
+    in_bullet = False
+    for line in lines[start:]:
+        if line.startswith("#"):
+            break
+        if line.startswith("- "):
+            in_bullet = True
+        elif not line.strip() or not line.startswith(" "):
+            in_bullet = False
+        if in_bullet:
+            names.update(re.findall(r"`([a-z][a-z0-9_]*)`", line))
+    return names
+
+
+def _concretely_typed_fields() -> set[str]:
+    """Every command field that is not typed ``object`` in its schema."""
+
+    fields: set[str] = set()
+    for name in dir(ws):
+        schema = getattr(getattr(ws, name), "_ws_schema", None)
+        if not schema:  # unregistered, or a command declaring nothing but its type
+            continue
+        mapping = schema.schema if hasattr(schema, "schema") else schema.validators[0].schema
+        for marker, validator in mapping.items():
+            key = str(marker)
+            if key not in ENVELOPE_KEYS and validator is not object:
+                fields.add(key)
+    return fields
+
+
+def test_contract_names_every_concretely_typed_field() -> None:
+    """The `invalid_format` exception list is the code's, name for name."""
+
+    documented = _bulleted_names(CONTRACT.read_text(encoding="utf-8"), EXCEPTIONS_HEADING)
+    actual = _concretely_typed_fields()
+
+    assert actual, "no concretely-typed fields found — the schemas were not read"
+    assert documented == actual, (
+        "docs/backend_api_contract.md and ws.py disagree about which fields answer "
+        f"invalid_format. Only in the document: {sorted(documented - actual)}. "
+        f"Only in the code: {sorted(actual - documented)}."
+    )
+
+
+def test_the_extractor_reports_a_missing_name() -> None:
+    """A green run cannot mean "read no names".
+
+    The comparison is only worth trusting if a document that has fallen behind
+    fails it, so the extractor is run against one bullet with a name removed.
+    """
+
+    markdown = "\n".join(
+        [
+            EXCEPTIONS_HEADING,
+            "",
+            "Prose naming `object` and `haventory/status/*`, neither of them a field.",
+            "",
+            "- The handles: `file_id`, `filename`, and one that wrapped onto the",
+            "  next line: `attachment_ids`.",
+            "",
+            "Trailing prose naming `document`, which is not in a bullet.",
+            "",
+            "### Next section",
+            "",
+            "- `never_read`",
+        ]
+    )
+
+    assert _bulleted_names(markdown, EXCEPTIONS_HEADING) == {
+        "file_id",
+        "filename",
+        "attachment_ids",
+    }
+
+    with pytest.raises(AssertionError, match="is not in"):
+        _bulleted_names(markdown, "#### No such heading")
+
+
+def test_contract_names_the_whole_quick_filter_vocabulary() -> None:
+    """`haventory/config`'s documented pill names are `QUICK_FILTER_KEYS`."""
+
+    text = CONTRACT.read_text(encoding="utf-8")
+    line = next(
+        ln for ln in text.splitlines() if ln.lstrip().startswith("- `quick_filters` is which")
+    )
+    offered = line.split("out of ", 1)[1].split(", set in", 1)[0]
+
+    assert re.findall(r"`([a-z][a-z0-9_]*)`", offered) == list(QUICK_FILTER_KEYS)


### PR DESCRIPTION
## Summary

Two documented promises that no longer matched the code, plus what reading both files end to
end turned up.

**The `invalid_format` / `validation_error` split.** The contract named eight fields as the
ones deliberately typed `object` — `name`, `quantity`, `delta`, `operations`, and
`filter` / `sort` / `limit` / `cursor`. That was the set one widening pass ago. The code now
types **22 distinct names** that way, across 64 schema slots, so the paragraph had the rule
backwards for most of the API: a client written against it handles `invalid_format` where the
guard actually answers `validation_error`.

Re-enumerating the object-typed fields would drift again the next time a command gains a
typed-input pass, which is exactly how this one drifted. So the paragraph now states the
**default** — most fields are `object` — and enumerates the **exception** set instead: the
29 names that keep a concrete schema type and therefore still answer `invalid_format`,
grouped by what they are (`expected_version`; the dates; the collections written whole; the
attachment handles; `haventory/subscribe`'s three; every field of `haventory/status/*`;
import's two).

`tags` is the one name on both sides — concrete on `item/create`, `item/add_tags` and
`item/remove_tags`, `object` on `item/update` — and the document says so, because it is the
case that makes "handle both codes" the right advice rather than "look the field up".

**The sortable-field count was already fixed**, in #487: the README no longer says a number,
it says "sort across every sortable field". Verified rather than assumed — `SORT_FIELDS` now
holds **eight** (`reminder_date` joined after this issue was filed, so the issue's "there are
seven" is stale too), and `hv-filter-panel.ts`'s own `SORT_FIELDS` offers all eight, so the
replacement wording is true. Nothing to change; recorded here because the issue asks for it.

Closes #441

## What the sweep of both files found

Read end to end, as the issue asks, since both of its findings came from spot-checks.

| Where | Was | Is |
|---|---|---|
| `README.md` gate block | `pytest`, `ruff check`, `mypy` | + `ruff format --check`, which **CI fails on by itself** |
| `CONTRIBUTING.md` gate block | same omission | same fix |
| `.github/pull_request_template.md` | same omission | same fix |
| `README.md` tooling list | "Ruff `0.15.x`" | the pin is **0.16.2**; the copy is replaced by a pointer at `pyproject.toml`, so there is nothing left to drift |
| `README.md` tooling list | mypy "non-strict baseline" | names the strict core too, by pointing at the `[[tool.mypy.overrides]]` list rather than copying it |
| `README.md` phacc section | "Covered: config-entry setup/unload, WS item CRUD, Store round-trip, `areas/list`" | four subjects out of **22 test files** — rewritten to what is actually there |
| `README.md` ×3 + contract ×1 | five quick-filter pills, "the other four" | **six**: `reminder_due` was missing from all four claims |
| contract, Versioning | "Locations are not versioned in Phase 1" | says what is true without pointing at a phase nobody can open |

The ruff one is worth a note: `tests/test_toolchain_pins.py` holds the pre-commit hook, the CI
job and the `test-haventory` skill to the `pyproject.toml` pin, but not the README — which is
why that copy could sit two minors behind on `main`. Removing the copy is the fix that keeps
working.

## Tests

New `tests/test_docs_contract_offline.py`, three cases:

- **`test_contract_names_every_concretely_typed_field`** — the happy path. It reads
  `_ws_schema` back off the registered handlers rather than parsing `ws.py`'s text, because
  `_ws_schema` is what the connection applies to a frame: a field it types `object` is exactly
  a field whose wrong type reaches the guard. Compared set-to-set against the document's
  bullets, with a message naming which side each disagreement is on.
- **`test_the_extractor_reports_a_missing_name`** — the edge case, so a green run cannot mean
  "read no names". The extractor runs against a stand-in section holding a bullet that wraps
  onto a second line, prose naming `object` and a command path (neither of which is a field),
  a trailing paragraph, and a bullet under the *next* heading — and must return exactly the
  three field names. A missing heading raises rather than returning an empty set.
- **`test_contract_names_the_whole_quick_filter_vocabulary`** — the `haventory/config` pill
  list against `QUICK_FILTER_KEYS`, which is the check that catches `reminder_due` going
  missing again.

Checked that the first one actually bites, both directions, before trusting it:

```
# with `file_id` deleted from the document
AssertionError: … Only in the document: []. Only in the code: ['file_id'].
# with `nonesuch` added to the document
AssertionError: … Only in the document: ['nonesuch']. Only in the code: [].
```

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1266 passed, 22 skipped**;
      `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` → clean
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
      `npx vitest run` → **1769 passed / 65 files**, `npm run build` → 708.63 kB

No source change outside `tests/`, so no phacc run (§6.9: not required). CI's `integration`
job covers it.

## Live checks

None — §6.9 lists none, and nothing here is observable only against a running Home Assistant.
Every claim this PR changes was checked against the code that implements it: `ws.py`'s
registered schemas, `const.py`'s `QUICK_FILTER_KEYS`, `models.py`'s `SORT_FIELDS`,
`pyproject.toml`'s pins and overrides, `ls tests/integration/`.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge case).
- [x] Docs updated — that is the change.
- [x] No WebSocket API change; `ws.py` untouched.
- [x] Essential invariants preserved.

## Follow-ups

- **`tags` is typed inconsistently across the commands that take it** — `[str]` on
  `item/create`, `item/add_tags` and `item/remove_tags`, `object` on `item/update`. So
  `{"tags": "kitchen"}` answers `invalid_format` on three commands and `validation_error` on
  the fourth. **Named and deliberately not filed**: the wire behaviour is correct either way,
  both codes are documented, and the card sends a list from every path — it clears no
  real-world bar. Documented rather than fixed, so nobody has to rediscover it.
- **`scripts/ws_subscribe.py` offers `items` / `locations` / `stats` but not `statuses`**,
  which the API has had since the status vocabulary landed. A dev helper, not shipped
  behaviour; **not filed**. The README describes the script accurately, so nothing there is
  wrong today.
- Left to #217 (S10), which owns the README rewrite: the `WP4.1` reference at the top of the
  frontend section, the `Phase 1` / `Phase 2` / `Phase 2.5` / `Phase 3` "Implementation
  Status" block, and the `--examples-config` claim §6.10 already names.


## Handover

The session's full handover is in
[PR #543](https://github.com/chrreiter/HAventory/pull/543)'s body, which is the PR left open
for the owner. The part that belongs to this one:

**Merged / left open** — this PR is merged (twelve green checks, `integration` and
`validation` included); #543 is open and waiting on the owner's merge, per §6.9. There was no
third PR: S8's German wording list has not arrived, so those corrections stay with S11.

**Test this by hand** — nothing for this PR. Every claim it changes was checked against the
code that implements it (`ws.py`'s registered schemas, `QUICK_FILTER_KEYS`, `SORT_FIELDS`,
`pyproject.toml`'s pins and overrides, `ls tests/integration/`), and
`tests/test_docs_contract_offline.py` now holds two of them there — verified to fail in both
directions before being trusted.

**Decisions taken against drifted notes** — the README half of #441 was already fixed in
#487, in the drift-proof form the issue asked for; the issue's own "there are seven sortable
fields" is stale as well, since `SORT_FIELDS` now holds eight.

**Follow-ups** — two, both in the note above, both named and deliberately not filed.

**State left behind** — branch `claude/v0-7-0-s9-docs-truth` deleted on merge. The dev Home
Assistant was not touched by this session at all.
