### PR TITLE
ci: hold the Home Assistant pins on the `uv` side too, and keep Dependabot off the generated export

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,23 +22,9 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
 
-  # Python dev toolchain via uv (reads pyproject.toml + uv.lock; GA since
-  # 2025-03). Group minor/patch; majors arrive individually.
+  # Python dev toolchain via uv (pyproject.toml + uv.lock). Group minor/patch;
+  # majors arrive individually.
   - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 3
-    groups:
-      python-dev:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
-
-  # Integration test harness (pip): `requirements-integration.txt` at the root.
-  # The dependency graph already scans that file, so an advisory in it alerts;
-  # what was missing is the pull request that fixes it.
-  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -54,8 +40,55 @@ updates:
       # a bump arrives as a red pull request that reopens every week. Both move
       # together, by hand, when the declared floor moves.
       #
+      # The ignore belongs on this block as well as on `pip` below: the `uv`
+      # updater reads the root's requirements files too, not only the two
+      # manifests it is named for, and proposes both pins straight into
+      # `requirements-integration.txt` when it is left out here.
+      #
       # Scoped to version updates rather than ignored outright: a security update
       # for either must still be able to open a pull request.
+      - dependency-name: "homeassistant"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "home-assistant-frontend"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    groups:
+      python-dev:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # Integration test harness (pip): `requirements-integration.txt` at the root.
+  # The dependency graph already scans that file, so an advisory in it alerts;
+  # what was missing is the pull request that fixes it.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+    exclude-paths:
+      # That one file is the whole point of this block, but the pip updater parses
+      # every manifest it finds in the directory — including the two the `uv`
+      # block owns. `requirements-dev.txt` is a `uv export` and says "do not edit
+      # by hand" on line 1; a pip edit to `pyproject.toml` leaves `uv.lock` behind,
+      # which the next `uv` command rewrites under whoever runs it. In scope, each
+      # dev package therefore arrives twice — once from `uv` with the lock, once
+      # from here without it.
+      #
+      # `exclude-paths` covers version updates only. A security advisory in either
+      # file can still open a pull request here; the `uv` block is what fixes one
+      # properly, and a duplicate is cheap next to a missed advisory.
+      - "pyproject.toml"
+      - "requirements-dev.txt"
+    ignore:
+      # The same two pins as the `uv` block above, for the same reason and with
+      # the same version-update scope — this is the block aimed at the file that
+      # carries them, so the ignore has to be here too.
       - dependency-name: "homeassistant"
         update-types:
           - "version-update:semver-major"

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -464,7 +464,13 @@ throughout.
 - PR hygiene: Conventional-Commit PR-title check, path-based auto-labeling
   (`.github/labeler.yml`), labels-as-code (`.github/labels.yml`), CODEOWNERS review
   requests, and issue/PR templates.
-- Dependabot: grouped updates for `github-actions`, `npm` (card), and `uv` (Python).
+- Dependabot: grouped updates for `github-actions`, `npm` (card) and `uv` (Python), plus a
+  `pip` block for `requirements-integration.txt` so an advisory in that file arrives as a
+  pull request and not only as an alert. Both root Python blocks ignore *version* updates
+  to `homeassistant` and `home-assistant-frontend` — they are the declared floor and the
+  wheel that release asks for, not dependencies to keep current — and the `pip` block is
+  scoped off `pyproject.toml` and the generated `requirements-dev.txt`, which belong to the
+  `uv` block.
 - `main` is protected by a checked-in ruleset (`.github/rulesets/main.json`): pull request
   required, the CI/CodeQL/dependency-review/PR-title checks required, no force-push or
   deletion. Edit it under *Settings → Rules → Rulesets*, or `PUT` the file to

--- a/tests/test_repo_hardening_offline.py
+++ b/tests/test_repo_hardening_offline.py
@@ -9,7 +9,9 @@ unfiltered trigger.
 Then two things a workflow run cannot tell you about itself: that every
 third-party action it calls is pinned to an immutable revision, and that
 Dependabot is configured to keep ``requirements-integration.txt`` patched
-without fighting the pins that file carries deliberately.
+without fighting the pins that file carries deliberately, without bumping them
+from the other block that reads the same file, and without proposing the dev
+toolchain a second time out of a generated export.
 
 Last, the two scheduled runs — ``ha-latest`` and ``card-smoke`` — each of which
 can be worthless in ways a green run of its own would not reveal: reporting a
@@ -23,7 +25,7 @@ from __future__ import annotations
 import itertools
 import json
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import pytest
@@ -48,8 +50,16 @@ FIRST_PARTY_ACTION = re.compile(r"^actions/")
 IMMUTABLE_REVISION = re.compile(r"@(?:[0-9a-f]{40}|sha256:[0-9a-f]{64})$")
 
 # The two pins `requirements-integration.txt` carries as derived numbers rather
-# than as dependencies to keep current.
+# than as dependencies to keep current. Both updaters pointed at the repository
+# root read that file, so both have to be told.
 HA_PINS = ("homeassistant", "home-assistant-frontend")
+ROOT_PYTHON_ECOSYSTEMS = ("uv", "pip")
+
+# The root manifests the `uv` block owns, and which the `pip` block therefore has
+# to be scoped off: `requirements-dev.txt` is a `uv export` that says so on line
+# 1, and `pyproject.toml` has a lockfile beside it that a pip edit would not
+# touch.
+UV_OWNED_MANIFESTS = ("pyproject.toml", "requirements-dev.txt")
 VERSION_UPDATE_TYPES = frozenset(
     {
         "version-update:semver-major",
@@ -232,6 +242,21 @@ def ignored_update_types(block: dict[str, Any]) -> dict[str, set[str]]:
     }
 
 
+def still_scanned(block: dict[str, Any], paths: tuple[str, ...]) -> list[str]:
+    """Which of ``paths`` this block's ``exclude-paths`` leaves in its scan.
+
+    ``exclude-paths`` entries are glob patterns resolved against the block's
+    ``directory``, so a literal path and ``**/name`` are both legitimate ways to
+    write the same exclusion.
+    """
+    patterns = block.get("exclude-paths", [])
+    return [
+        path
+        for path in paths
+        if not any(PurePosixPath(path).full_match(pattern) for pattern in patterns)
+    ]
+
+
 def test_third_party_actions_are_pinned_by_digest() -> None:
     """A tag can be moved under the workflow that calls it; a digest cannot."""
     for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
@@ -271,25 +296,60 @@ def test_dependabot_updates_the_integration_requirements() -> None:
     assert dependabot_block("pip", "/") is not None
 
 
-def test_dependabot_leaves_the_ha_pins_alone() -> None:
+@pytest.mark.parametrize("ecosystem", ROOT_PYTHON_ECOSYSTEMS)
+def test_dependabot_leaves_the_ha_pins_alone(ecosystem: str) -> None:
     """Both pins are derived numbers: a version bump of either is a red build.
 
     ``homeassistant`` is the floor ``hacs.json`` declares, and
     ``home-assistant-frontend`` must equal what that release's own manifest asks
     for — so an automated bump is not an upgrade. Ignoring them outright would
-    also swallow the security update this block exists to receive, so the ignore
-    names version updates and nothing else.
+    also swallow the security update the ``pip`` block exists to receive, so the
+    ignore names version updates and nothing else.
+
+    Both root blocks need it. The ``uv`` updater is named for ``pyproject.toml``
+    and ``uv.lock`` but reads the root's requirements files as well, and writes
+    either pin straight into ``requirements-integration.txt`` when it is not
+    told otherwise.
+    """
+    block = dependabot_block(ecosystem, "/")
+    assert block is not None, f"no {ecosystem} block for the repository root"
+    ignored = ignored_update_types(block)
+
+    assert set(HA_PINS) <= set(ignored), f"{ecosystem} block ignores {sorted(ignored)}"
+    for name in HA_PINS:
+        assert ignored[name] == VERSION_UPDATE_TYPES, (
+            f"{name} is ignored for {sorted(ignored[name]) or 'every update'} in the "
+            f"{ecosystem} block — a blanket ignore also mutes the security channel"
+        )
+
+
+def test_dependabot_keeps_pip_off_the_manifests_uv_owns() -> None:
+    """The generated export is not a manifest to edit, and never on its own.
+
+    ``requirements-dev.txt`` is written by ``uv export`` and carries "do not edit
+    by hand" on its first line; ``pyproject.toml`` is half of a pair whose other
+    half is ``uv.lock``. The pip updater parses both anyway, so every dev package
+    the ``uv`` group already carries arrives a second time, in a shape that
+    dirties the tree for whoever runs ``uv`` next.
     """
     block = dependabot_block("pip", "/")
     assert block is not None
-    ignored = ignored_update_types(block)
+    left_in = still_scanned(block, UV_OWNED_MANIFESTS)
 
-    assert set(HA_PINS) <= set(ignored), f"pip block ignores {sorted(ignored)}"
-    for name in HA_PINS:
-        assert ignored[name] == VERSION_UPDATE_TYPES, (
-            f"{name} is ignored for {sorted(ignored[name]) or 'every update'} — a blanket "
-            f"ignore also mutes the security channel"
-        )
+    assert left_in == [], f"pip block still scans {left_in} — add them to exclude-paths"
+
+
+def test_an_unscoped_pip_block_is_reported() -> None:
+    """The shape the block had while it was opening the duplicates."""
+    unscoped: dict[str, Any] = {}
+    literal = {"exclude-paths": ["pyproject.toml", "requirements-dev.txt"]}
+    globbed = {"exclude-paths": ["**/*.toml", "**/requirements-dev.txt"]}
+    partial = {"exclude-paths": ["requirements-dev.txt"]}
+
+    assert still_scanned(unscoped, UV_OWNED_MANIFESTS) == list(UV_OWNED_MANIFESTS)
+    assert still_scanned(literal, UV_OWNED_MANIFESTS) == []
+    assert still_scanned(globbed, UV_OWNED_MANIFESTS) == []
+    assert still_scanned(partial, UV_OWNED_MANIFESTS) == ["pyproject.toml"]
 
 
 def test_a_blanket_ignore_is_told_from_a_scoped_one() -> None:


### PR DESCRIPTION
## Summary

Eight Dependabot pull requests stood open against V0.7.0, three of them red, from two
faults in `.github/dependabot.yml`.

**The `uv` block can see `requirements-integration.txt`.** The ignore that holds the two
Home Assistant pins was moved to the `pip` block on the reasoning that the `uv` updater
"reads `pyproject.toml` and `uv.lock` and can never see them". It reads the root's
requirements files as well — #521 (`dependabot/uv/python-dev-…`) writes
`homeassistant 2026.6.0 → 2026.8.2` into that file, and #522
(`dependabot/uv/home-assistant-frontend-…`) does the same for the wheel. Both pins are
ignored on **both** root Python blocks now, version-update-scoped in each so a security
update can still open a pull request.

**The `pip` block parsed two manifests that are not its business.** It exists for
`requirements-integration.txt`, but Dependabot's pip updater takes every manifest in the
directory — including `requirements-dev.txt`, whose first line reads *"GENERATED by
`uv export --only-group dev` — do not edit by hand"*, and `pyproject.toml`, whose other
half is `uv.lock`. `exclude-paths` now takes both out of that block's scan.

Closes #544

## Type of change

- [x] Documentation / tooling / CI

## The Dependabot schema, checked on the day

`exclude-paths` is in the current options reference: a **list of glob patterns**, resolved
against the block's `directory`, applied *before* manifest parsing — "Dependabot will not
list, parse, or open pull requests for excluded paths". It is marked **version updates
only**, which is stated in the file comment: a security advisory in either excluded file
can still open a pull request here, and that is the right trade — the `uv` block is what
fixes one properly, and a duplicate pull request is cheap next to a missed advisory.

`allow` was the other candidate the issue named. It is rejected: `allow` is marked for
version **and** security updates, so an allow-list of the three names
`requirements-integration.txt` pins would silently narrow this block's security coverage —
the one thing the block was added for — and a fourth pin added to that file would be
skipped without saying so. `exclude-paths` scopes by file, which is what actually went
wrong.

## Why `pyproject.toml` is excluded and not only the export

#516 is the evidence: `build(deps-dev): bump ruff from 0.16.2 to 0.16.3` edits
`pyproject.toml` **and** `requirements-dev.txt`. `ruff==0.16.2` is the only `==`-pinned
entry in `[dependency-groups] dev`, so excluding the export alone would still leave the
pip block opening a ruff pull request against `pyproject.toml` — this time without
`uv.lock` beside it, which the next `uv` command rewrites under whoever runs it.

## How was this tested?

- [x] Backend: `1273 passed, 22 skipped`; `ruff check`, `ruff format --check` (184 files)
      and `mypy` (26 source files) clean.
- [x] Frontend (`cards/haventory-card`): `npm audit --audit-level=high` → 0
      vulnerabilities, eslint clean, `tsc --noEmit` clean, `1769 passed (65 files)`, build
      708.63 kB.
- phacc: not required — nothing under `custom_components/` or `tests/integration/`
  changed. The floor run happens after #521 lands, since that is what moves the pinned dev
  stack under it.

**The new guards bite.** `tests/test_repo_hardening_offline.py` grew:

- `test_dependabot_leaves_the_ha_pins_alone` is now parametrised over `uv` and `pip`, so
  the ignore cannot be moved from one block to the other again.
- `test_dependabot_keeps_pip_off_the_manifests_uv_owns` resolves each `exclude-paths`
  entry as a glob (`PurePosixPath.full_match`), so a literal path and `**/name` both
  count.
- `test_an_unscoped_pip_block_is_reported` is the error case: no `exclude-paths` reports
  both files, an exclusion of the export alone reports `pyproject.toml`.

Verified by mutation — dropping the `uv` block's `ignore` and the `pip` block's
`exclude-paths` and re-running turns exactly those two red
(`FAILED …::test_dependabot_leaves_the_ha_pins_alone[uv]`,
`FAILED …::test_dependabot_keeps_pip_off_the_manifests_uv_owns`), and restoring them turns
them green.

## Triage of the eight open bump pull requests

| PR | Verdict | Reason left on the thread |
| --- | --- | --- |
| [#523](https://github.com/chrreiter/HAventory/pull/523) | **merged** | The actions group, green — `setup-uv` v10.0.0 → v10.0.1 and three `codeql-action` steps v4.37.6 → v4.37.7, all still digest-pinned. |
| [#516](https://github.com/chrreiter/HAventory/pull/516) | closed | ruff 0.16.3 into the generated export *and* `pyproject.toml`, neither with `uv.lock`. Red on `backend (3.14)` because 0.16.3 reflows what 0.16.2 formatted — fixed inside #521, where the bump belongs. |
| [#517](https://github.com/chrreiter/HAventory/pull/517) | closed | filelock — duplicate of #521's table, edits the generated export. |
| [#518](https://github.com/chrreiter/HAventory/pull/518) | closed | python-discovery — same. |
| [#519](https://github.com/chrreiter/HAventory/pull/519) | closed | platformdirs — same. |
| [#520](https://github.com/chrreiter/HAventory/pull/520) | closed | pygments — same. |
| [#522](https://github.com/chrreiter/HAventory/pull/522) | closed | `home-assistant-frontend` is pinned to what the declared floor's own `frontend` manifest asks for; `tests/integration/test_frontend.py` is why `integration` was red. It moves by hand when the floor moves. |
| [#521](https://github.com/chrreiter/HAventory/pull/521) | closed by Dependabot | The `python-dev` group, eight bumps, one of them the `homeassistant` pin. Six seconds after this merged Dependabot closed it itself — *"these dependencies are no longer being updated by Dependabot"* — because the group's contents had changed. The `@dependabot recreate` that followed answered *"looks like this PR is closed"*, and needed to do nothing: |
| [#549](https://github.com/chrreiter/HAventory/pull/549) | **merged** | the same group, recreated against the fixed config, **7 updates and no `requirements-integration.txt` in the diff**. `backend (3.14)` was red on `tests/test_toolchain_pins.py`, which holds three copies of the ruff version together: Dependabot moved `pyproject.toml` and left `.pre-commit-config.yaml`'s hook rev and the test skill's documented `ruff==` command behind. Both moved in a commit pushed to that pull request's own branch, not in a follow-up. ruff 0.16.3 reflowed nothing — `ruff format --check` was clean before and after. |

Each closed thread carries its reason and names this pull request as what stops the
proposal returning. None was closed with `@dependabot ignore` — the config is the fix, and
an ignore rule would have muted the package rather than the file.

**No Dependabot pull request is open against V0.7.0 any more**, and the recreated group is
the proof the config change did what it was for: seven packages, none of them a Home
Assistant pin, none of them an edit to the generated export on its own.

## Decisions taken against drifted notes

1. **`exclude-paths`, not an `allow` list** — reasons above. The issue offered either.
2. **Two paths excluded, not one.** The issue and the plan both name
   `requirements-dev.txt`; `pyproject.toml` has to go with it, or #516's shape comes back
   halved (see above).
3. **The long comment lives on the `uv` block now**, with a short pointer on `pip`. The
   `uv` block comes first in the file and is the one whose ignore went missing; the
   comment says in one place why the same two names appear twice.
4. **`docs/developing.md`'s Dependabot line was stale** — it listed three blocks and no
   `pip`. It now names all four, both ignores and the exclusion.

## Follow-ups

- **Not filed:** `exclude-paths` covers version updates only, so a *security* advisory in
  `requirements-dev.txt` or `pyproject.toml` can still open a pip pull request editing a
  generated file. It is upstream behaviour, it is written into the file comment, and the
  fix — merge the `uv` one instead — is one line of judgment on a rare day. No issue.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — happy path (both blocks ignore, both files excluded) plus the
      error case (unscoped block, partially scoped block).
- [x] Docs updated where behavior changed (`docs/developing.md`).
- [x] No WebSocket API change.
- [x] No runtime code touched; the invariants are unaffected.
