### PR TITLE
fix(panel): keep an open /haventory page across a reload

### DIFF
--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -117,9 +117,14 @@ _EXTRA_JS_URL_KEY = "extra_js_url"
 # route: aiohttp cannot unregister a route, so a reload must not add a second.
 _MEDIA_VIEW_KEY = "media_view_registered"
 
-# Whether the sidebar panel is currently registered. Entry-scoped: unload takes
-# the panel back, so a reload starts from nothing registered.
-_PANEL_REGISTERED_KEY = "panel_registered"
+# What the sidebar panel is registered with right now — the title and the module
+# URL, the only two inputs that can change while Home Assistant runs — or absent
+# when no panel is registered. Written and cleared together with the frontend's
+# own registry by the two functions at the bottom of this module, so the two
+# never disagree. It outlives a plain unload on purpose: a reload passes through
+# one, and a browser standing on `/haventory` is sent to the default dashboard
+# the moment the panel leaves `hass.panels`.
+_PANEL_STATE_KEY = "panel_state"
 
 # How many ids of each kind the corrupt-store refusal quotes. Enough to grep the
 # file with, few enough that a wholesale corruption does not paste thousands of
@@ -545,7 +550,7 @@ def _cleanup_ws_test_stub_registry(hass: HomeAssistant) -> None:
         )
 
 
-async def _async_teardown_entry(hass: HomeAssistant, *, op: str) -> None:
+async def _async_teardown_entry(hass: HomeAssistant, *, op: str, release_panel: bool) -> None:
     """Give up everything the config entry owns, in the order that keeps it safe.
 
     Every step here runs while the entry is **not** loaded — Home Assistant marks
@@ -558,6 +563,10 @@ async def _async_teardown_entry(hass: HomeAssistant, *, op: str) -> None:
     subscribers, while the subscription registry still lists them; then hand back
     the frontend registrations, which read the URL the bucket recorded. Home
     Assistant clears `runtime_data` itself once this returns.
+
+    `release_panel` says whether the sidebar entry goes with them; the callers
+    decide, because only they can tell an entry that is coming straight back from
+    one that is not.
     """
 
     await _async_flush_pending_writes(hass, op=op)
@@ -570,8 +579,11 @@ async def _async_teardown_entry(hass: HomeAssistant, *, op: str) -> None:
     _remove_extra_js_url(hass)
 
     # A sidebar entry outliving the backend it opens is a link to a page that
-    # cannot load; setup registers it again.
-    _remove_sidebar_panel(hass)
+    # cannot load — but a reload comes through here too, and the page a browser
+    # has open is what disappears with the panel. So it is handed back only when
+    # the entry is not coming back on its own, and setup converges it otherwise.
+    if release_panel:
+        _remove_sidebar_panel(hass)
 
     _forget_registration_flags(hass)
 
@@ -584,6 +596,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     cannot unregister — refuse from here until setup runs again. That covers a
     disabled entry, which stays in this state, and a reload, which passes through
     it for as long as setup takes.
+
+    The sidebar entry is the one thing those two want handled differently, so
+    they are told apart here: Home Assistant sets `disabled_by` before it
+    unloads, and a reload leaves it alone.
     """
 
     # Ahead of the teardown, which empties the bucket the handler list lives in.
@@ -594,7 +610,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # unavailable rather than being gone.
     unloaded = await _async_unload_platforms(hass, entry)
 
-    await _async_teardown_entry(hass, op="unload")
+    disabled = getattr(entry, "disabled_by", None) is not None
+    await _async_teardown_entry(hass, op="unload", release_panel=disabled)
 
     return unloaded
 
@@ -642,7 +659,7 @@ async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:
     """
 
     await _unregister_frontend_module(hass)
-    await _async_teardown_entry(hass, op="remove")
+    await _async_teardown_entry(hass, op="remove", release_panel=True)
 
 
 def _read_manifest_version() -> str:
@@ -879,10 +896,11 @@ def _sidebar_panel_enabled(entry: ConfigEntry) -> bool:
 def _remove_sidebar_panel(hass: HomeAssistant) -> None:
     """Take the sidebar entry back, whether or not one is registered.
 
-    `warn_if_unknown=False`: this also runs as the first half of a register, and
-    on the first setup of an install there is nothing there to remove.
+    `warn_if_unknown=False`: this also runs as the first half of replacing a
+    registration, and on the first setup of an install there is nothing there to
+    remove.
     """
-    hass.data.setdefault(DOMAIN, {}).pop(_PANEL_REGISTERED_KEY, None)
+    hass.data.setdefault(DOMAIN, {}).pop(_PANEL_STATE_KEY, None)
     if async_remove_panel is None:
         return
 
@@ -899,15 +917,28 @@ def _remove_sidebar_panel(hass: HomeAssistant) -> None:
 async def _async_apply_sidebar_panel(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Converge the sidebar entry on what the options and the build ask for.
 
-    Removing first makes every path — first setup, reload, options toggle,
-    rename — the same one call, and is what keeps a second registration from
-    raising `ValueError: Overwriting panel haventory`. Both calls fire the
-    frontend's panel-update event, so the sidebar follows without a restart.
+    A registration already in place is left exactly as it is. Changing one means
+    removing it first — `panel_custom.async_register_panel` does not forward
+    `frontend.async_register_built_in_panel`'s `update` argument, so registering
+    over a path already taken raises `ValueError: Overwriting panel haventory` —
+    and for the moment the panel is missing from `hass.panels`, the frontend
+    sends whoever is standing on its page back to the default dashboard. That
+    cost belongs to the two changes that need it, the sidebar toggle and the
+    rename, and to nothing else: not to a reload, and not to an options save that
+    leaves the panel's own settings alone.
+
+    Both calls fire the frontend's panel-update event, so the sidebar follows
+    without a restart.
     """
     bucket = hass.data.setdefault(DOMAIN, {})
-    _remove_sidebar_panel(hass)
+
+    def give_back() -> None:
+        """Drop the panel if there is one; say nothing when there never was."""
+        if bucket.get(_PANEL_STATE_KEY) is not None:
+            _remove_sidebar_panel(hass)
 
     if not _sidebar_panel_enabled(entry):
+        give_back()
         LOGGER.debug(
             "Sidebar panel disabled in the options; not registering",
             extra={"domain": DOMAIN, "op": "panel_register"},
@@ -917,6 +948,7 @@ async def _async_apply_sidebar_panel(hass: HomeAssistant, entry: ConfigEntry) ->
     # The panel is the card bundle's second element, so without a build there is
     # nothing for it to load — same graceful skip the card loaders take.
     if not os.path.isfile(_CARD_BUNDLE_PATH):  # noqa: ASYNC240
+        give_back()
         LOGGER.debug(
             "Card bundle not built; skipping sidebar panel registration",
             extra={
@@ -928,6 +960,7 @@ async def _async_apply_sidebar_panel(hass: HomeAssistant, entry: ConfigEntry) ->
         return
 
     if async_register_panel is None:
+        give_back()
         LOGGER.debug(
             "panel_custom component not available; HAventory gets no sidebar entry",
             extra={"domain": DOMAIN, "op": "panel_register", "url": PANEL_URL_PATH},
@@ -938,6 +971,21 @@ async def _async_apply_sidebar_panel(hass: HomeAssistant, entry: ConfigEntry) ->
     # The exact string both card loaders receive: a second URL for the same
     # module defeats the browser's module map and defines the element twice.
     url = await _async_card_url(hass)
+    wanted = (title, url)
+
+    if bucket.get(_PANEL_STATE_KEY) == wanted:
+        LOGGER.debug(
+            "Sidebar panel already registered as asked; leaving it in place",
+            extra={
+                "domain": DOMAIN,
+                "op": "panel_register",
+                "url": PANEL_URL_PATH,
+                "module_url": url,
+            },
+        )
+        return
+
+    give_back()
 
     try:
         await async_register_panel(
@@ -962,7 +1010,7 @@ async def _async_apply_sidebar_panel(hass: HomeAssistant, entry: ConfigEntry) ->
         )
         return
 
-    bucket[_PANEL_REGISTERED_KEY] = True
+    bucket[_PANEL_STATE_KEY] = wanted
     LOGGER.debug(
         "Registered the HAventory sidebar panel",
         extra={

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -66,10 +66,16 @@ the *same* module URL both card loaders get (`__init__.py`, `_async_apply_sideba
 so the browser's module map evaluates the bundle once whichever surface is opened first.
 The registration's `config` carries `{"title": <card title option>}`, which is where the
 panel's `panel.config.title` heading comes from; the sidebar entry itself is named by the
-same option. Registration is remove-then-register, because HA raises on a second
-registration of a URL path that is already taken. The `sidebar_panel_enabled` option turns
-it off, and both calls fire the frontend's panel-update event, so the sidebar follows
-without a restart.
+same option. Changing a registration is remove-then-register, because
+`panel_custom.async_register_panel` does not forward
+`frontend.async_register_built_in_panel`'s `update` argument and HA raises on a second
+registration of a URL path that is already taken. Only a change pays for that: while the
+panel is out of `hass.panels` the frontend sends whoever is standing on `/haventory` to
+the default dashboard, so a reload — and an options save that leaves the title alone —
+recognises the registration it already has and touches nothing. Unload keeps the panel for
+the same reason; it is handed back when the entry is disabled or removed. The
+`sidebar_panel_enabled` option turns it off, and both calls fire the frontend's
+panel-update event, so the sidebar follows without a restart.
 
 Both hosts hold a `HostSurfaces` instance (`src/host-surfaces.ts`): every surface
 `hv-full-view` can raise but not answer itself — the column picker, the export download,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,11 +324,15 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             entry_id: str = "haventory-test-entry",
             domain: str = "haventory",
             state=None,
+            disabled_by=None,
         ) -> None:
             self.options: dict = dict(options or {})
             self.entry_id = entry_id
             self.domain = domain
             self.state = state if state is not None else ConfigEntryState.LOADED
+            # Home Assistant sets this before it unloads, which is how an unload
+            # that is a disable is told from one that is half of a reload.
+            self.disabled_by = disabled_by
             self._update_listeners: list = []
             self._on_unload: list = []
 

--- a/tests/integration/test_frontend.py
+++ b/tests/integration/test_frontend.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 from custom_components.haventory.const import (
+    CONF_CARD_TITLE,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
     DOMAIN,
@@ -22,6 +23,7 @@ from custom_components.haventory.const import (
     PANEL_URL_PATH,
 )
 from homeassistant.components import frontend
+from homeassistant.config_entries import ConfigEntryDisabler
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
@@ -204,27 +206,80 @@ async def test_the_sidebar_panel_lands_in_the_real_panel_registry(hass: HomeAssi
 
 
 @needs_bundle
-async def test_reload_does_not_hit_the_overwriting_panel_error(hass: HomeAssistant) -> None:
-    """`async_register_built_in_panel` raises on a path already taken.
+async def test_a_reload_leaves_the_same_panel_object_in_place(hass: HomeAssistant) -> None:
+    """A browser standing on `/haventory` is sent away the moment the panel goes.
 
-    Unguarded, that raise comes out of `async_setup_entry` and leaves the entry
-    in a retry loop with no sidebar entry at all.
+    Identity rather than presence: a remove-then-register inside the reload
+    would put a different `Panel` in the registry, and would already have fired
+    the panel-update event that moves the browser. Only the real `frontend`
+    component has that registry, so the offline suite cannot see this.
+    """
+    entry = await _setup(hass)
+    panel = hass.data[frontend.DATA_PANELS][PANEL_URL_PATH]
+
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.data[frontend.DATA_PANELS][PANEL_URL_PATH] is panel
+
+
+@needs_bundle
+async def test_an_unload_on_its_own_keeps_the_sidebar_panel(hass: HomeAssistant) -> None:
+    """The half of a reload the panel has to survive, asserted on its own.
+
+    A reload is an unload followed by a setup; if the unload took the panel, the
+    setup could only put a new one back and the page would be gone either way.
     """
     entry = await _setup(hass)
 
-    assert await hass.config_entries.async_reload(entry.entry_id)
+    assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     assert PANEL_URL_PATH in hass.data[frontend.DATA_PANELS]
 
 
 @needs_bundle
-async def test_unload_removes_the_sidebar_panel(hass: HomeAssistant) -> None:
-    """No backend, no sidebar entry: the page it opens could not load anyway."""
-    entry = await _setup(hass)
-    assert PANEL_URL_PATH in hass.data[frontend.DATA_PANELS]
+async def test_a_rename_replaces_the_panel_without_the_overwriting_error(
+    hass: HomeAssistant,
+) -> None:
+    """`async_register_built_in_panel` raises on a path already taken.
 
-    assert await hass.config_entries.async_unload(entry.entry_id)
+    Renaming is the path that registers a second time now, so it is the path
+    that has to remove first. Unguarded, the raise comes out of the options
+    listener, the sidebar keeps the old name, and nothing about it reaches the
+    user.
+    """
+    entry = await _setup(hass)
+
+    hass.config_entries.async_update_entry(entry, options={CONF_CARD_TITLE: "Pantry"})
+    await hass.async_block_till_done()
+
+    panel = hass.data[frontend.DATA_PANELS][PANEL_URL_PATH]
+    assert panel.sidebar_title == "Pantry"
+    assert panel.config["title"] == "Pantry"
+
+
+@needs_bundle
+async def test_a_disabled_entry_gives_the_sidebar_panel_back(hass: HomeAssistant) -> None:
+    """A disabled entry stays unloaded, so its sidebar entry opens nothing.
+
+    Home Assistant sets `disabled_by` before it unloads; that ordering is what
+    the unload path reads, and it is real-core behaviour a stub cannot vouch for.
+    """
+    entry = await _setup(hass)
+
+    assert await hass.config_entries.async_set_disabled_by(entry.entry_id, ConfigEntryDisabler.USER)
+    await hass.async_block_till_done()
+
+    assert PANEL_URL_PATH not in hass.data[frontend.DATA_PANELS]
+
+
+@needs_bundle
+async def test_removing_the_entry_gives_the_sidebar_panel_back(hass: HomeAssistant) -> None:
+    """The other end: nothing is coming back to serve the page it opens."""
+    entry = await _setup(hass)
+
+    await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
 
     assert PANEL_URL_PATH not in hass.data[frontend.DATA_PANELS]

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -920,8 +920,13 @@ async def test_registers_the_sidebar_panel_against_the_card_bundle(hav_init):
 
 
 @pytest.mark.asyncio
-async def test_applying_twice_over_leaves_one_panel(hav_init):
-    """Registering onto a path already taken raises in HA — so remove first, always."""
+async def test_applying_twice_over_registers_once(hav_init):
+    """An options save that changes nothing about the panel must not touch it.
+
+    Registering onto a path already taken raises in HA, so a changed
+    registration has to be removed first — and for the moment it is gone, the
+    frontend sends whoever is on `/haventory` back to the default dashboard.
+    """
     hass = make_hass()
     entry = ConfigEntry()
 
@@ -929,28 +934,37 @@ async def test_applying_twice_over_leaves_one_panel(hav_init):
     await hav_init._async_apply_sidebar_panel(hass, entry)
 
     assert list(hass.data[DATA_PANELS]) == [PANEL_URL_PATH]
-    assert panel_registration_attempts(hass) == [PANEL_URL_PATH] * 2
+    assert panel_registration_attempts(hass) == [PANEL_URL_PATH]
 
 
 @pytest.mark.asyncio
-async def test_reload_re_registers_the_panel_exactly_once(hav_init):
-    """Setup → unload → setup: two registrations attempted, one panel live, nothing raised."""
+async def test_a_reload_leaves_the_panel_in_place(hav_init):
+    """Setup → unload → setup, and the panel never leaves the registry.
+
+    The page a browser has open is what disappears with it, so the reload path
+    neither removes nor re-registers: it recognises the registration it already
+    has.
+    """
     hass = make_hass()
     entry = ConfigEntry()
 
     await setup_frontend(hav_init, hass, entry)
+    panel = registered_panel(hass)
+
     await hav_init.async_unload_entry(hass, entry)
+    assert registered_panel(hass) is panel
+
     await setup_frontend(hav_init, hass, entry)
 
-    assert list(hass.data[DATA_PANELS]) == [PANEL_URL_PATH]
-    assert panel_registration_attempts(hass) == [PANEL_URL_PATH] * 2
+    assert registered_panel(hass) is panel
+    assert panel_registration_attempts(hass) == [PANEL_URL_PATH]
 
 
 @pytest.mark.asyncio
-async def test_unload_takes_the_sidebar_entry_back(hav_init):
-    """A sidebar entry outliving its backend opens a page that cannot load."""
+async def test_a_disabled_entry_takes_the_sidebar_entry_back(hav_init):
+    """A disabled entry stays unloaded, so its sidebar entry opens nothing."""
     hass = make_hass()
-    entry = ConfigEntry()
+    entry = ConfigEntry(disabled_by="user")
 
     await setup_frontend(hav_init, hass, entry)
     assert registered_panel(hass) is not None
@@ -958,7 +972,43 @@ async def test_unload_takes_the_sidebar_entry_back(hav_init):
     await hav_init.async_unload_entry(hass, entry)
 
     assert registered_panel(hass) is None
-    assert hass.data[hav_init.DOMAIN].get("panel_registered") is None
+    assert hass.data[hav_init.DOMAIN].get("panel_state") is None
+
+
+@pytest.mark.asyncio
+async def test_removing_the_entry_takes_the_sidebar_entry_back(hav_init):
+    """Removal is the other end: nothing is coming back to serve the page."""
+    hass = make_hass()
+    entry = ConfigEntry()
+
+    await setup_frontend(hav_init, hass, entry)
+    await hav_init.async_unload_entry(hass, entry)
+    assert registered_panel(hass) is not None
+
+    await hav_init.async_remove_entry(hass, entry)
+
+    assert registered_panel(hass) is None
+    assert hass.data[hav_init.DOMAIN].get("panel_state") is None
+
+
+@pytest.mark.asyncio
+async def test_a_rename_across_a_reload_replaces_the_panel(hav_init):
+    """The recognised registration is the one that was made, not merely "a panel".
+
+    A title changed while the entry was unloaded still has to reach the sidebar,
+    which is the case a bare "is something registered?" check would miss.
+    """
+    hass = make_hass()
+    entry = ConfigEntry(options={CONF_CARD_TITLE: "Pantry"})
+
+    await setup_frontend(hav_init, hass, entry)
+    await hav_init.async_unload_entry(hass, entry)
+
+    entry.options[CONF_CARD_TITLE] = "Garage"
+    await setup_frontend(hav_init, hass, entry)
+
+    assert registered_panel(hass).sidebar_title == "Garage"
+    assert panel_registration_attempts(hass) == [PANEL_URL_PATH] * 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A browser sitting on `/haventory` was thrown to the default dashboard whenever the config
entry reloaded — and by an options save too, which reloads nothing but re-registers the
panel the same way. The sidebar entry came back, so the user could click in again; what
they lost was the page they were on, its filter, its scroll position and any open editor.

Both halves of the reload took the panel out of `hass.panels`, and the frontend redirects
whoever is standing on a panel that disappears: teardown removed it, and setup's converge
step removed it again before registering.

Now the panel stays through a plain unload — the half of a reload it has to survive — and
`_async_apply_sidebar_panel` recognises a registration that already matches and touches
nothing. It is handed back when the entry is **disabled** or **removed**, the two ways an
entry stops serving without coming back.

Closes #507

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## What the floor's core can and cannot do

The issue asked whether `frontend.async_register_built_in_panel`'s `update` argument makes
the remove-then-register unnecessary. Read out of the installed core rather than the docs,
at the floor (`homeassistant==2026.6.0`, in the phacc venv) and on the dev instance
(2026.7.4) — the two are identical here:

```python
    if not update and panel.frontend_url_path in panels:
        raise ValueError(f"Overwriting panel {panel.frontend_url_path}")

    panels[panel.frontend_url_path] = panel
    hass.bus.async_fire(EVENT_PANELS_UPDATED)
```

So `update=True` does exactly what the issue hoped: overwrite in place, fire the
panel-update event, never remove. **But it cannot be reached from here.** The integration
registers through `panel_custom.async_register_panel`, the public helper that builds the
`_panel_custom` config block HA's frontend needs in order to load a custom element, and
that helper takes no `update` — it calls `async_register_built_in_panel` with the default:

```python
    frontend.async_register_built_in_panel(
        hass,
        component_name="custom",
        sidebar_title=sidebar_title,
        sidebar_icon=sidebar_icon,
        frontend_url_path=frontend_url_path,
        config=config,
        require_admin=require_admin,
        config_panel_domain=config_panel_domain,
    )
```

Reaching `update` therefore means building the `_panel_custom` block here and calling
`frontend` directly — taking on an internal shape HA is free to move, for the sake of the
one case (a rename) the narrower fix does not cover. So this PR takes the narrower fix the
issue named as the fallback, and `panel_custom` stays the only way this integration
registers a panel.

## The shape

1. **`_async_teardown_entry` gained `release_panel`.** `async_unload_entry` passes
   `entry.disabled_by is not None`; `async_remove_entry` passes `True`. Home Assistant sets
   `disabled_by` *before* it unloads (`config_entries.async_set_disabled_by` assigns it and
   only then calls `async_reload`), which is what lets an unload that is a disable be told
   from one that is half of a reload.
2. **`_async_apply_sidebar_panel` remembers what it registered** — the title and the module
   URL, the only two registration inputs that can change while HA runs — and returns
   untouched when the desired registration matches. Remove-then-register is what every
   *change* still takes, because registering over a path already taken raises.
3. `_PANEL_REGISTERED_KEY` (a bool) became `_PANEL_STATE_KEY` (that pair). It is written and
   cleared together with the frontend's own registry by the same two functions, so the two
   cannot disagree.

**What changed for a user beyond the fix:** a *disabled* entry still takes its sidebar entry
away, and a *removed* one still does. A reload whose setup then fails now leaves the panel
registered instead of taking it away — the entry shows its error in Settings either way, and
a sidebar entry that opens a page saying the backend is unavailable is easier to act on than
one that silently vanished.

## How was this tested?

- [x] Backend: `1275 passed, 22 skipped`; `ruff check`, `ruff format --check` and `mypy`
      clean.
- [x] Frontend (`cards/haventory-card`): eslint clean, `tsc --noEmit` clean,
      `1769 passed (65 files)`, `npm audit --audit-level=high` → 0 vulnerabilities, build
      708.63 kB.
- [x] phacc (`scripts/test_integration.sh`, Docker recipe): **`141 passed in 120.00s`**.

**Offline** (`tests/test_frontend_registration.py`) — what carries the new contract:

| test | what it pins |
|---|---|
| `test_applying_twice_over_registers_once` | an options save that changes nothing registers once, not twice |
| `test_a_reload_leaves_the_panel_in_place` | setup → unload → setup leaves the *same* panel object, one registration attempt in total |
| `test_a_disabled_entry_takes_the_sidebar_entry_back` | `disabled_by` set → the panel goes |
| `test_removing_the_entry_takes_the_sidebar_entry_back` | removal → the panel goes, after an unload that kept it |
| `test_a_rename_across_a_reload_replaces_the_panel` | the error case for the recognition: a title changed *while unloaded* still has to reach the sidebar, which a bare "is something registered?" check would miss |

`tests/conftest.py`'s `ConfigEntry` stub grew `disabled_by`, which real HA sets before it
unloads.

**phacc** (`tests/integration/test_frontend.py`) — because the offline stub's panel registry
is hand-written and knows nothing about how a real `frontend` component or a real
`config_entries` behaves:

| test | what only the real core can show |
|---|---|
| `test_a_reload_leaves_the_same_panel_object_in_place` | identity through `hass.config_entries.async_reload` — a remove-then-register would leave a different `Panel` |
| `test_an_unload_on_its_own_keeps_the_sidebar_panel` | the half of the reload the fix is in |
| `test_a_rename_replaces_the_panel_without_the_overwriting_error` | the `ValueError: Overwriting panel haventory` guard, now on the path that actually re-registers |
| `test_a_disabled_entry_gives_the_sidebar_panel_back` | `async_set_disabled_by` really does set `disabled_by` before unloading |
| `test_removing_the_entry_gives_the_sidebar_panel_back` | removal through `async_remove` |

## Live checks

Driven against the dev Home Assistant (2026.7.4, 1087 items / 89 locations) with a real
browser sitting on `/haventory`: a filter typed in, the table scrolled, a row's editor open.
The entry is reloaded and the options re-saved over REST — what Settings → Devices &
services sends. The same run then does the two changes that *are* allowed to move the panel.

**Same container, same card bytes, same store**: only
`custom_components/haventory/__init__.py` was swapped between the two runs (`main`'s copy in,
then this branch's back).

**Before — `main`'s module:**

```
before             url=/haventory     panel=1 search="e" rows=50 editors=1 scroll=[div.editor-holder=481 hv-data-table=900]
after reload       url=/home/overview panel=0 search="(gone)" rows=0 editors=0 scroll=[]
after options save url=/home/overview panel=0 search="(gone)" rows=0 editors=0 scroll=[]
```

**After — this branch:**

```
before             url=/haventory panel=1 search="e" rows=50 editors=1 scroll=[div.editor-holder=481 hv-data-table=900]
after reload       url=/haventory panel=1 search="e" rows=50 editors=1 scroll=[div.editor-holder=481 hv-data-table=900]
after options save url=/haventory panel=1 search="e" rows=50 editors=1 scroll=[div.editor-holder=481 hv-data-table=900]
```

```
[PASS] the page really was scrolled
[PASS] the page really had an editor open
[PASS] the reload left the tab on /haventory
[PASS] the panel element is still rendered
[PASS] the filter survived the reload
[PASS] the scroll position survived the reload
[PASS] the open editor survived the reload
[PASS] the options save left the tab on /haventory
[PASS] the filter survived the options save
[PASS] the scroll position survived the options save
[PASS] the open editor survived the options save
[PASS] the toggle really removes the sidebar entry
[PASS] the toggle brings it back
[PASS] the rename reaches the sidebar
[PASS] the rename is undone
```

On `main`'s module the same fifteen read: the first two pass, the nine reload/options ones
all fail, the four toggle/rename ones pass.

**The control that stops those PASSes being vacuous.** The same run disables the sidebar
panel from the options and watches the same tab:

```
after toggle off   url=/home/overview panel=0 sidebar=false
after toggle on    url=/home/overview panel=0 sidebar=true    (the tab does not come back on its own)
after rename       url=/home/overview           title="S10a rename probe"
after restore      url=/home/overview           title="HAventory"
```

The redirect is real and still fires the moment the panel leaves `hass.panels` — which is
what the reload no longer does. The toggle and the rename both still reach the sidebar, so
the remove-then-register path they take is intact. The first two checks exist for the same
reason: an unscrolled page with no editor open would have compared nothing to nothing.

## Decisions taken against drifted notes

1. **The narrower fix, and why.** `update` exists at the floor and does what the issue
   hoped, but `panel_custom.async_register_panel` does not forward it (quoted above). The
   issue asked for that to be said out loud if the floor could not do it: the floor's
   *core* can, the public helper cannot, and reaching past it is a worse trade than the one
   case it buys.
2. **The teardown had to change too, not only the apply.** The issue points at
   `_async_apply_sidebar_panel`, and skipping the remove there is half the fix: a reload
   passes through `_async_teardown_entry` first, which removed the panel before setup ever
   ran. Both halves are in this PR.
3. **A disabled entry keeps the old behaviour.** "Skip the remove when nothing changed"
   taken literally would leave a dead sidebar entry behind a disabled integration, which
   stays unloaded indefinitely. `disabled_by` is set before HA unloads, so the two are told
   apart at the call site rather than guessed at.
4. **Kept `panel_custom`, so the `ValueError` guard keeps its test** — §6.10a asked for
   that. The test moved to the path that now re-registers: a rename.

## Follow-ups

- **Not filed:** a rename still redirects an open `/haventory` tab, because a changed
  registration has to be removed first. Reaching `update=True` would fix it and costs a
  hand-built `_panel_custom` block; renaming the panel is a deliberate act on the panel's
  own settings, and §6.10a names the rename as a case the remove-then-register exists for.
  Not worth the internal dependency.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — happy path plus the error case (a rename across an unload; the
      `Overwriting panel` guard).
- [x] Docs updated where behavior changed (`docs/frontend_architecture.md`).
- [x] No WebSocket API change.
- [x] Essential invariants untouched — no repository, storage or model code in this diff.
