### PR TITLE
fix(todo): stop logging an ERROR for a start listener that has already fired

### DIFF
--- a/custom_components/haventory/todo_bridge.py
+++ b/custom_components/haventory/todo_bridge.py
@@ -19,6 +19,7 @@ rollback.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -116,8 +117,7 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> None:
         for event_type in (EVENT_ITEM_CHANGED, EVENT_LOW_STOCK):
             on_unload(listen(event_type, _on_inventory_event))
 
-    listen_once = getattr(bus, "async_listen_once", None)
-    if getattr(hass, "is_running", True) or not (callable(listen_once) and callable(on_unload)):
+    if getattr(hass, "is_running", True) or not (callable(listen) and callable(on_unload)):
         await async_reconcile(hass)
         return
 
@@ -125,10 +125,27 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> None:
     # while Home Assistant is still starting, and the pass refuses to write to a
     # list it cannot see. Waiting for the start event is what lets a restart
     # converge on its own, without anything in the inventory having to change.
+    #
+    # `async_listen`, not `async_listen_once`: a one-time listener takes itself
+    # off the bus the moment it fires, so the unsubscribe it hands back names a
+    # listener Home Assistant no longer has — and the unload that calls it gets
+    # an ERROR line carrying this module's name for something that worked.
+    # Removing it here gives the removal one owner, and whichever of the two
+    # paths gets there first leaves nothing for the other to do.
+    remove_started: Callable[[], None] | None = None
+
+    def _stop_waiting_for_start() -> None:
+        nonlocal remove_started
+        if remove_started is not None:
+            remove_started()
+            remove_started = None
+
     async def _on_started(_event: Any) -> None:
+        _stop_waiting_for_start()
         await async_reconcile(hass)
 
-    on_unload(listen_once(EVENT_HOMEASSISTANT_STARTED, _on_started))
+    remove_started = listen(EVENT_HOMEASSISTANT_STARTED, _on_started)
+    on_unload(_stop_waiting_for_start)
 
 
 async def async_reconcile(hass: HomeAssistant) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,11 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
         def __init__(self) -> None:
             self.fired: list[tuple[str, dict]] = []
             self.listeners: list[tuple[str, object]] = []
+            # Removals of a listener the bus no longer has. Real Home Assistant
+            # answers one with `Unable to remove unknown job listener` at ERROR,
+            # naming the caller's module — so a test asserting that a caller
+            # never asks twice needs the attempt, which `listeners` cannot show.
+            self.unknown_removals: list[str] = []
 
         def async_fire(self, event_type, event_data=None, *_args, **_kwargs) -> None:
             self.fired.append((event_type, dict(event_data or {})))
@@ -144,6 +149,8 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             def _remove() -> None:
                 if entry in self.listeners:
                     self.listeners.remove(entry)
+                else:
+                    self.unknown_removals.append(event_type)
 
             return _remove
 

--- a/tests/integration/test_todo_bridge.py
+++ b/tests/integration/test_todo_bridge.py
@@ -15,6 +15,8 @@ entity itself assigns.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from custom_components.haventory import todo_bridge
 from custom_components.haventory.const import CONF_TODO_ENTITY_ID, DOMAIN
@@ -26,8 +28,8 @@ from homeassistant.components.todo import (
     TodoListEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -267,6 +269,67 @@ async def test_unloading_the_entry_stops_the_bridge_listening(
     # The list keeps what it had: an unloaded entry gives up its own runtime,
     # not the household's shopping list.
     assert todo_list.summaries == [f"Peanut butter {TIMES}2"]
+
+
+def _started_listeners(hass: HomeAssistant) -> int:
+    return hass.bus.async_listeners().get(EVENT_HOMEASSISTANT_STARTED, 0)
+
+
+async def test_the_boot_time_start_listener_is_gone_once_it_has_fired(
+    hass: HomeAssistant, todo_list: _TestTodoList, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A restart and then a reload must leave nothing at ERROR carrying our name.
+
+    Set up while Home Assistant is still starting, the bridge defers its first
+    pass to the start event. Home Assistant's own bookkeeping is what makes the
+    second removal visible: the bus refuses a listener it cannot match with
+    `Unable to remove unknown job listener`, at ERROR, quoting the frame that
+    asked. The offline bus keeps no such record, so this is the only place the
+    line can appear.
+    """
+
+    hass.set_state(CoreState.not_running)
+    before = _started_listeners(hass)
+
+    entry = await _setup_haventory(hass, entity_id=LIST_ENTITY_ID)
+    assert _started_listeners(hass) == before + 1
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+    # Fewer, not `before`: Home Assistant's own one-time listeners for this event
+    # go with the same firing, so the count after it is not the count before it.
+    assert _started_listeners(hass) < before + 1
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors == []
+
+
+async def test_an_unload_before_the_start_event_releases_the_listener(
+    hass: HomeAssistant, todo_list: _TestTodoList, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The other order — stopped or reloaded mid-boot — and the bus is left clean.
+
+    Left on it, the listener would run a pass against a runtime Home Assistant
+    has already taken back, the moment startup finished.
+    """
+
+    hass.set_state(CoreState.not_running)
+    before = _started_listeners(hass)
+    entry = await _setup_haventory(hass, entity_id=LIST_ENTITY_ID)
+    assert _started_listeners(hass) == before + 1
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert _started_listeners(hass) == before
+    assert [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR] == []
 
 
 async def test_the_options_flow_offers_the_shopping_list_field(hass: HomeAssistant) -> None:

--- a/tests/test_todo_bridge_offline.py
+++ b/tests/test_todo_bridge_offline.py
@@ -376,6 +376,44 @@ async def test_the_first_pass_waits_for_startup_when_home_assistant_is_still_boo
 
 
 @pytest.mark.asyncio
+async def test_the_start_listener_is_taken_off_the_bus_once_it_has_fired() -> None:
+    """The unload must not ask again for a listener that is already gone.
+
+    Real Home Assistant answers a removal it cannot match with
+    `Unable to remove unknown job listener` at ERROR, naming the frame that
+    asked — an HAventory line describing something that worked.
+    """
+
+    hass, _repo, _services, entry = await _bridge(is_running=False)
+    started = hass.bus.listeners_for(EVENT_HOMEASSISTANT_STARTED)
+    await started[0](None)
+    assert hass.bus.listeners_for(EVENT_HOMEASSISTANT_STARTED) == []
+
+    for release in entry._on_unload:
+        release()
+
+    assert hass.bus.unknown_removals == []
+
+
+@pytest.mark.asyncio
+async def test_an_unload_before_the_start_event_still_takes_it_off() -> None:
+    """The other order: Home Assistant stopped, or the entry reloaded, mid-boot.
+
+    Left on the bus, the listener would run a pass against a torn-down runtime
+    the moment startup finished.
+    """
+
+    hass, _repo, _services, entry = await _bridge(is_running=False)
+    assert len(hass.bus.listeners_for(EVENT_HOMEASSISTANT_STARTED)) == 1
+
+    for release in entry._on_unload:
+        release()
+
+    assert hass.bus.listeners == []
+    assert hass.bus.unknown_removals == []
+
+
+@pytest.mark.asyncio
 async def test_a_stored_row_missing_half_of_itself_is_dropped_on_load() -> None:
     """A row that cannot be retracted would hold its item off the list for good."""
 


### PR DESCRIPTION
## Summary

The first reload after a Home Assistant restart logged an ERROR naming HAventory for
something that had already worked:

```
ERROR (MainThread) [homeassistant.core] Unable to remove unknown job listener
(<Job onetime listen homeassistant_started
 <function async_setup.<locals>._on_started at 0x…>
 HassJobType.Callback
 <_OneTimeListener custom_components.haventory.todo_bridge:…_on_started>>, None)
```

Set up while Home Assistant is still starting, the shopping-list bridge defers its first
pass to the start event, because a list owned by another integration may not be in the
state machine yet. It registered that with `async_listen_once` and handed the unsubscribe
to `async_on_unload` — but a one-time listener takes itself off the bus the moment it
fires, so by unload time the unsubscribe named a listener Home Assistant no longer had.

The listener is registered with `async_listen` now and removed by whichever of the two
paths reaches it first — the start event, or the unload — so the other finds nothing left
to do.

Closes #508

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Why not the flag the issue sketched

The issue's shape — keep `async_listen_once`, wrap the unsub so it is a no-op after
`_on_started` runs — leaves a window. `_OneTimeListener.__call__` in the installed core
takes the listener off the bus and *then* schedules the callback:

```python
        if not self.remove:
            return
        self.remove()
        self.remove = None
        self.hass.async_run_hass_job(self.listener_job, event)
```

`_on_started` is a coroutine, so it runs as a task on a later loop iteration; a flag it
sets is not set yet in between. Owning the removal instead has no such window and costs
the same three lines, so the flag became `_stop_waiting_for_start`, which both paths call
and which is idempotent by construction.

## How was this tested?

- [x] Backend: `1277 passed, 22 skipped`; `ruff check`, `ruff format --check` (184 files)
      and `mypy` (26 source files) clean.
- [x] Frontend (`cards/haventory-card`): `npm audit --audit-level=high` → 0
      vulnerabilities, eslint clean, `tsc --noEmit` clean, `1769 passed (65 files)`, build
      708.63 kB.
- [x] phacc (`scripts/test_integration.sh`, Docker recipe): **`143 passed in 90.52s`** —
      the floor run §6.10a also asks for after the toolchain bump, on a tree that carries
      it (ruff 0.16.3, mypy 2.3.1).

**phacc is where this bug is visible at all.** The offline bus stub records who listens and
never dispatches, and it has no job-listener bookkeeping — the removal that logs the ERROR
is a no-op there. `tests/integration/test_todo_bridge.py` gained two:

| test | what it does |
|---|---|
| `test_the_boot_time_start_listener_is_gone_once_it_has_fired` | `CoreState.not_running` → setup adds one `homeassistant_started` listener → fire the event → unload, and assert **nothing at ERROR** |
| `test_an_unload_before_the_start_event_releases_the_listener` | the other order — stopped or reloaded mid-boot — the listener count comes back to what it was and nothing is logged |

**It bites.** With `main`'s `todo_bridge.py` in place and everything else identical, the
first of those fails with the issue's own line:

```
E  AssertionError: assert ['Unable to r...10>>>, None)'] == []
E    Left contains one more item: 'Unable to remove unknown job listener (<Job onetime
E    listen homeassistant_started <function async_setup.<locals>._on_s...istener
E    custom_components.haventory.todo_bridge:<function async_setup.<locals>._on_started …>>>, None)'
FAILED tests/integration/test_todo_bridge.py::test_the_boot_time_start_listener_is_gone_once_it_has_fired
1 failed, 9 passed
```

**Offline** (`tests/test_todo_bridge_offline.py`) — the contract, in the mode that runs on
every commit:

| test | what it pins |
|---|---|
| `test_the_start_listener_is_taken_off_the_bus_once_it_has_fired` | the listener is off the bus after it fires, and the unload asks for nothing the bus does not have |
| `test_an_unload_before_the_start_event_still_takes_it_off` | unloading mid-boot leaves the bus empty |

The first is red against `main`'s module (`Left contains one more item:
<function async_setup.<locals>._on_started>`).

`tests/conftest.py`'s bus stub grew `unknown_removals`: real Home Assistant answers a
removal it cannot match with that ERROR line, so a test asserting a caller never asks twice
needs the *attempt*, which the listener list alone cannot show.

## Live checks

The dev Home Assistant (2026.7.4), restarted so the bridge takes the boot-time path — a
reload on a running instance registers nothing and would prove nothing. Then the core is
waited for until `RUNNING` (the start event has fired), then the config entry is reloaded
from REST, which is what Settings → Devices & services sends.

**Before — `main`'s `todo_bridge.py`**, same container, same everything else:

```
entry: 01M0JHF4BHVN5B2ZKZR2770GH9 loaded  core: RUNNING
reload: {'require_restart': False}
count: 1
2026-08-22 09:17:47.279 ERROR (MainThread) [homeassistant.core] Unable to remove unknown
job listener (<Job onetime listen homeassistant_started <function
async_setup.<locals>._on_started at 0x7665a6473ed0> HassJobType.Callback <_OneTimeListener
custom_components.haventory.todo_bridge:<function async_setup.<locals>._on_started at
0x7665a6473ed0>>>, None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/core.py", line 1772, in _async_remove_listener
```

**After — this branch**, restarted, waited for `RUNNING`, then reloaded **twice**:

```
unknown-job-listener count: 0
ERROR lines naming haventory: 0
total ERROR lines: 0
```

`home-assistant.log` is rotated on every start, so those counts are this boot's.

The panel checks §6.10a groups into the same pass are in
[#550](https://github.com/chrreiter/HAventory/pull/550), which merged before this branch was
cut; the build deployed for the run above carries both fixes.

## Decisions taken against drifted notes

1. **`async_listen` instead of a flag on `async_listen_once`.** The issue asked for a
   two-line wrap; the window that leaves is written out above. Same size, no window.
2. **`tests/conftest.py`'s bus stub had to grow one field.** Without `unknown_removals` the
   offline half of this fix cannot be asserted at all — the stub's remove is tolerant, so a
   second removal is invisible. It stands in for what real HA does with one: log it at
   ERROR.
3. **No documentation change.** Nothing in `docs/` or `README.md` describes the bridge's
   start-event deferral; the module comment is where the constraint lives, and it now says
   why the one-shot helper is not used.

## Follow-ups

None. Nothing out of scope turned up in this diff.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — happy path (fires, then unload) plus the edge case (unload
      before it fires), offline and in-process.
- [x] Docs updated where behavior changed — none needed (see decision 3).
- [x] No WebSocket API change.
- [x] Essential invariants untouched — no repository, storage or model code in this diff.

## Handover

**1. Merged / left open**

All four merged by this session; nothing left open. In order:

- [#548](https://github.com/chrreiter/HAventory/pull/548) — *ci: hold the Home Assistant
  pins on the `uv` side too, and keep Dependabot off the generated export*. Closes #544.
- [#549](https://github.com/chrreiter/HAventory/pull/549) — the `python-dev` group,
  recreated by Dependabot against the fixed config: **7 updates, no
  `requirements-integration.txt`**. Its red `backend (3.14)` was fixed on its own branch
  (`.pre-commit-config.yaml`'s ruff rev and the test skill's documented `ruff==` command,
  which `tests/test_toolchain_pins.py` holds together with `pyproject.toml`'s).
- [#550](https://github.com/chrreiter/HAventory/pull/550) — *fix(panel): keep an open
  /haventory page across a reload*. Closes #507.
- **this PR** — *fix(todo): stop logging an ERROR for a start listener that has already
  fired*. Closes #508.

Triage of the other six bump pull requests, each closed with its reason on the thread:
#523 merged (actions group, green); #516–#520 closed (duplicates of the group's table, each
editing the generated `requirements-dev.txt`); #522 closed (the frontend wheel is pinned to
what the declared floor's own manifest asks for). **No Dependabot pull request is open
against V0.7.0.** The release-please PR (#491) was not touched.

**2. Test this by hand**

1. `[desktop]` Sit on `/haventory`, apply a filter and scroll, then Settings → Devices &
   services → HAventory → **Reload**. Expected: the tab is still on `/haventory`, still
   filtered, still where you scrolled. Then Configure → Submit without changing anything:
   the same. Then Configure → turn the sidebar panel off: the tab *does* go to the
   dashboard, which is the case that is meant to.
2. `[log]` Restart Home Assistant, wait for it to finish starting, reload the HAventory
   entry, then Settings → System → Logs. Expected: nothing at ERROR carrying `haventory`.
   (Harness-proved above with two reloads and `grep`; this is the same check through the UI
   a user would use.)
3. `[HA settings]` Insights → Dependency graph → Dependabot: the next weekly run should
   propose neither a Home Assistant pin nor a package the `uv` group already carries.
   Nothing to do until it runs — the first scheduled run after this is the confirmation.

Everything else the harness proved: the before/after A/B for both fixes on the dev instance
(single-module swaps, same container and store), 143 phacc tests, both gate halves, and CI
green on all four pull requests.

**3. Decisions taken against drifted notes**

- **#544 — `exclude-paths`, not an `allow` list.** `allow` covers security updates as well
  as version ones, so an allow-list would have narrowed the `pip` block's security reach —
  the one thing that block exists for. Checked against the current options reference on the
  day: `exclude-paths` is a list of globs, applied before manifest parsing, version updates
  only.
- **#544 — `pyproject.toml` excluded as well as the generated export.** #516 proves the pip
  updater reads it (`ruff==` is the only pinned entry there), so excluding only
  `requirements-dev.txt` would have left half the duplicate behind, this time without
  `uv.lock`.
- **#507 — the narrower fix, and the reason stated.** `frontend.async_register_built_in_panel`
  has `update` and it does what the issue hoped, at the floor and on the dev instance
  alike; `panel_custom.async_register_panel` does not forward it, and reaching past that
  helper means hand-building the `_panel_custom` config block.
- **#507 — the teardown changed too.** The issue names `_async_apply_sidebar_panel`; a
  reload passes through `_async_teardown_entry` first, so skipping the remove in the apply
  alone would have fixed nothing.
- **#507 — a disabled entry still gives the panel back**, told apart from a reload by
  `disabled_by`, which HA sets before it unloads.
- **#508 — `async_listen` rather than a flag on `async_listen_once`.** The one-time listener
  removes itself *before* scheduling the coroutine, so a flag set inside it is not set in
  between.

None of the three issues was edited.

**4. Follow-ups**

- **Not filed:** `exclude-paths` is version-updates-only, so a *security* advisory in
  `requirements-dev.txt` or `pyproject.toml` can still open a pip pull request against a
  generated file. Upstream behaviour, written into the file comment, and the fix on the day
  is to merge the `uv` one instead.
- **Not filed:** a *rename* still redirects an open `/haventory` tab, because a changed
  registration has to be removed first. §6.10a names the rename as a case the
  remove-then-register exists for, and closing it costs a hand-built `_panel_custom` block.
- Nothing filed as an issue: neither clears CLAUDE.md's real-world bar.

**5. State left behind**

- **The dev Home Assistant is as it was found.** 1087 items / 89 locations, 161 low, 122
  checked out, 36 needs repair — the numbers S10 handed over; `haventory/health` clean. The
  options were driven during the #507 live check (card title, the sidebar toggle) and
  restored in the same run; the config entry, the dashboards and the profile language were
  not touched. The container is running **this branch's** build, which includes #550.
- **Both probe scripts were deleted** rather than committed — `s10a_panel_probe.mjs` in
  `.claude/skills/run-haventory/`, and a throwaway that found which element on `/haventory`
  takes the table's overflow (`hv-data-table`, `data-testid="full-table"`). The working tree
  is clean apart from this branch.
- The phacc container is `hav-int-s10a` (`ghcr.io/astral-sh/uv:python3.14-bookworm`, the
  repo bind-mounted at `/work`, venv on the `hav-int-venv` volume). It can be removed:
  `docker rm -f hav-int-s10a`.
- Branches: all four merged branches were deleted on merge. Nothing outstanding.
