### PR TITLE
fix(card): say Overdue on the table row, not Checked out

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../test.utils';
 import { ACTIONS_COLUMN_WIDTH } from '../store/columns';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
-import { toIsoDate } from '../ui/relative-time';
+import { addDays, toIsoDate } from '../ui/relative-time';
 import { rowMenuEntries } from './hv-list-row';
 import type { HVDataTable } from './hv-data-table';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
@@ -278,7 +278,52 @@ describe('hv-data-table: columns', () => {
     ]);
     expect(q(el, '[data-testid="cell-quantity"]')?.classList.contains('low')).toBe(true);
     expect(q(el, '[data-testid="cell-due_date"]')?.classList.contains('overdue')).toBe(true);
-    expect(el.shadowRoot?.textContent).toContain('Checked out');
+    expect(el.shadowRoot?.textContent).toContain('Overdue');
+  });
+});
+
+// The row's own word for lateness, which is what a table scrolled sideways or
+// pinned to its name column has left to say it with.
+describe('hv-data-table: the checked-out chip names an overdue loan', () => {
+  it('reads Overdue in the error tone once the due date has passed', async () => {
+    const el = await mount([{ id: '1', checked_out: true, due_date: '2020-01-01' }]);
+    const chip = q(el, '[data-testid="table-checked-out"]');
+    expect(chip?.textContent?.trim()).toBe('Overdue');
+    expect(chip?.classList.contains('error')).toBe(true);
+    expect(chip?.classList.contains('state')).toBe(false);
+  });
+
+  it('stays a calm Checked out while the loan still has time to run', async () => {
+    const el = await mount([{ id: '1', checked_out: true, due_date: addDays(3) }]);
+    const chip = q(el, '[data-testid="table-checked-out"]');
+    expect(chip?.textContent?.trim()).toBe('Checked out');
+    expect(chip?.classList.contains('state')).toBe(true);
+  });
+
+  // A loan with no return date agreed cannot be late, and neither can an item
+  // nobody has taken — the chip only exists for the first of those.
+  it('leaves a dateless loan calm, and draws nothing for an item on the shelf', async () => {
+    const dateless = await mount([{ id: '1', checked_out: true, due_date: null }]);
+    expect(q(dateless, '[data-testid="table-checked-out"]')?.textContent?.trim()).toBe(
+      'Checked out',
+    );
+
+    const shelved = await mount([{ id: '1', checked_out: false, due_date: '2020-01-01' }]);
+    expect(q(shelved, '[data-testid="table-checked-out"]')).toBe(null);
+  });
+
+  // The Due column carries a date, not the word — so unlike the status chip
+  // above, this one has nothing to stand down for and says it either way.
+  it('says it whether or not the Due column is on screen', async () => {
+    for (const columns of [['due_date'], ['quantity']] as const) {
+      const el = await mount([{ id: '1', checked_out: true, due_date: '2020-01-01' }], {
+        columns: [...columns],
+      });
+      expect(
+        q(el, '[data-testid="table-checked-out"]')?.textContent?.trim(),
+        `columns=${columns.join()}`,
+      ).toBe('Overdue');
+    }
   });
 });
 

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -626,7 +626,11 @@ export class HVDataTable extends LitElement {
     const columns = this._columns;
     // The name cell's chip is the flagged-status signal for a table that has no
     // Status column. With the column shown it would put the same word twice on
-    // one row, so the column takes over and the chip stands down.
+    // one row, so the column takes over and the chip stands down. The
+    // checked-out chip below has nothing to stand down for — the Due column
+    // carries a date, not the word — so it names an overdue loan either way,
+    // which is the only thing left saying so once the table is scrolled
+    // sideways or pinned to its name column.
     const statusColumn = columns.includes('status');
     // Low stands down for Checked out in the same cell, the way a phone row's
     // one line already picks the most interrupting thing it has to say: both
@@ -720,7 +724,13 @@ export class HVDataTable extends LitElement {
                         })
                       : null}
                     ${item.checked_out
-                      ? html`<span class="hv-chip state">${t('hv.term.checkedOut')}</span>`
+                      ? html`<span
+                          class="hv-chip ${isOverdue(item.due_date) ? 'error' : 'state'}"
+                          data-testid="table-checked-out"
+                          >${isOverdue(item.due_date)
+                            ? t('hv.term.overdue')
+                            : t('hv.term.checkedOut')}</span
+                        >`
                       : null}
                   </span>
                   ${columns.map((key) => this._cell(item, key))}


### PR DESCRIPTION
## Summary

The full view's table — what the expanded card and the `/haventory` sidebar panel both
render — drew one chip for every checked-out item: a calm blue "Checked out", whether the
loan had three weeks left to run or was three weeks past its due date. The compact row and
the detail sheet have said "Overdue" in the error tone all along, so the surface with the
least room was the only one naming the exception, and the two with the most stayed quiet.

The name cell's chip now reads `hv.term.overdue` in the error tone once
`isOverdue(item.due_date)` is true, which is what `hv-list-row` and `hv-detail-sheet`
already do with the same chip. No new chip and no new key — both strings and `isOverdue`
were already in the table's imports.

Closes #499

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Decisions taken, and what they were measured against

**No config option.** The issue argues against one and this takes its argument: the chip
replaces a word rather than adding chrome, and an option would let a dashboard hide that
an item is late while still showing that it is out.

**The chip does not defer to the Due column.** The status chip beside it does defer
(`!statusColumn`), because with a Status column shown it would print the same word twice
on one row. The Due column prints a *date*, not the word, so there is nothing to stand
down for — and the two measurements in #499 are both cases where the column is switched on
and still not on screen. The render comment above `statusColumn` now says this.

**Bare "Overdue", not "Overdue · Aug 7".** The desktop compact row uses
`hv.term.overdueOn` because it has the width; the name track does not, and the Due column
carries the date already. "Overdue" is four characters shorter than "Checked out", so this
gives width back rather than taking it.

**The inspection half is left to its column** — decided against the issue's suggestion of
a column-aware chip, with the measurement in front of me:

- `NAME_COLUMN_SIZE` is `minmax(250px, 2fr)`, and the note on it records that at the
  1360px content box the docked HA sidebar leaves the panel, the default column set has
  **34px of slack** — every flexible track is already frozen on its floor, so a new chip
  is paid for out of the name, not out of the table.
- #314 (PR #372) measured "Checked out" + "Low" at **138px of that 250px track** and
  dropped one of the two. "Inspection due" is wider than "Checked out", and German
  "Prüfung fällig" wider still, so a third chip reopens exactly what #314 closed.
- A column-aware chip would not reach the case that motivated the issue. `inspection_date`
  is **on by default** (`OFF_BY_DEFAULT` holds only `reminder_date`), so
  `!inspectionColumn` renders nothing on a default install — and at 375px, where the name
  cell is pinned and every date column has scrolled away, the column counts as *shown* and
  the chip still would not draw. It would cost a translation surface and appear only for
  someone who had deliberately hidden the column.

So the inspection signal stays the Next inspection column, and its colour is settled in
the second PR of this set (#498).

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1277 passed, 22
      skipped; `ruff check` → All checks passed; `ruff format --check` → 184 files already
      formatted; `mypy` → no issues in 26 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → **1773 passed (65 files)**, `npm audit --audit-level=high` → 0
      vulnerabilities, `npm run build` OK.

New tests in `hv-data-table.test.ts` (`the checked-out chip names an overdue loan`): the
overdue chip's text and error tone, the calm chip for a loan still in date, a dateless loan
and a shelved item (no chip at all), and the chip saying it with the Due column both on and
off.

### Live checks — dev HA (1087 items, 54 overdue), light **and** dark

`Duct Tape #0103` is checked out, due `2026-08-07`, inspection `2026-06-29` — both in the
past. Search "Duct Tape" in the `/haventory` panel; `#0103` and `#0589` are the overdue
rows.

**Panel, 1920×1080, sidebar docked (~1400px table), light — before / after**

![panel at 1920 before, both overdue rows reading Checked out](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-panel-1920-light.png)
![panel at 1920 after, both overdue rows reading Overdue](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr1-panel-1920-light.png)

**Panel, 375×812, name cell pinned — before / after.** This is #499's second measurement:
the one cell that stays on screen while the table scrolls sideways.

![panel at 375 before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-panel-375-light.png)
![panel at 375 after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr1-panel-375-light.png)

**Dark theme, 1920 — before / after**

![panel at 1920 dark before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-panel-1920-dark.png)
![panel at 1920 dark after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr1-panel-1920-dark.png)

`s10b/pr1-panel-375-dark.png` on the same branch is the fourth combination.

The reference the table now matches — the compact card row, unchanged by this PR:

![the compact card row already reading Overdue · due Aug 7](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-card-list-light.png)

Screenshots are hosted on the orphan branch `claude-assets-v0-7-0-s10b`, which is merged
into nothing.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added (happy path + dateless, shelved, and column-on/column-off cases).
- [x] Docs: no behavior documented in `docs/` changes — this is card copy, and the card's
      strings live in the dictionaries.
- [x] No WebSocket API change.
- [x] Invariants untouched.

## Follow-ups

- The dark-theme shots above show the other half of this row's problem plainly: `Aug 7`
  (Due, red) and `Jun 29` (Next inspection, amber) are nearly the same colour in dark and
  two different ones in light. That is #498, and the next PR in this set.


## Handover

**Merged / left open**

Three PRs, all merged by the session, all branches deleted. Nothing is left open.

- #552 — `fix(card): say Overdue on the table row, not Checked out` (closes #499)
- #553 — `fix(card): one tone for a date that has passed` (closes #498)
- #554 — `fix(card): keep the filtered total honest when an event inserts a row` (closes #505)

V0.7.0 has no open issues left after these three. The only pull request open on the
repository is release-please's `chore(main): release 0.7.0` (#491), untouched, which waits
for S11.

**Test this by hand**

1. `[desktop]` `[phone]` **In a light theme**, give one item a Due date and a Next
   inspection date both in the past, then read it on all four surfaces: the compact card
   row, the expanded card's table, `/haventory`, and its detail sheet. Expect one story
   told the same way four times — the row chip beside the name says **Overdue** in red
   (not "Checked out"), and every bare date that has gone by is the **same red** in every
   cell and every fact, the sheet's Due fact included. The chips keep two tones on
   purpose: red "Overdue", amber "Inspection due", each carrying the word that says which
   it is. The harness only proves the pixels agree with the tokens; whether the one-tone
   rule reads right to a person is the part that needs eyes. `Duct Tape #0103` on the dev
   instance is already such an item.
2. `[phone]` **A flagged status is not a date.** Find an item with status "Needs repair"
   and no dates (`Bike Pump #0359`) on a phone-width card. Its line should stay **amber**,
   and the amber should now match the low-quantity amber on the same row rather than being
   a shade darker.
3. `[phone]` **Two screens on the same inventory.** Type a word into one phone's search
   box; on the other, add an item whose name contains that word. The row should appear on
   the first phone on its own, and the line under the list should be the number of rows
   above it. Then add an item that does **not** contain the word: the row still appears
   (that is deliberate — the card cannot test the backend's search), and the footer should
   drop the word "matching" and count only what is on screen rather than claiming the row
   matches.
4. `[desktop]` **A column switched off.** Hide the Due column in the column picker and
   check an overdue row still says "Overdue" — the chip does not defer to that column, and
   that is the case a real install hits by scrolling sideways rather than by hiding
   anything.

What the harness proved instead, so it does not need re-doing by hand: both gates on every
commit; `two_tab.mjs` green both ways (service call and WebSocket command) with the footer
counting the new row; the non-matching direction driven live against `main`'s bundle and
this one in the same container; and `visual_pass.mjs` **42/42 surfaces** with all three
changes deployed. Before/after screenshots in both themes are in each PR body.

**Decisions taken against drifted notes**

- **#499's line numbers are pre-i18n throughout** (`hv-data-table.ts:668`, `:609-611`,
  `hv-list-row.ts:619-631`, `hv-detail-sheet.ts:675-690`); every one was found by grepping
  the key. The chip is now at `hv-data-table.ts` ~723 reading `t('hv.term.checkedOut')`.
- **No config option for the overdue chip**, as #499 argues and the plan directs.
- **The overdue chip does not defer to the Due column**, unlike the status chip beside it:
  the Due column prints a date, not the word, so there is nothing to say twice.
- **No inspection chip in the table**, decided against #499's own suggestion of a
  column-aware one. `NAME_COLUMN_SIZE` is `minmax(250px, 2fr)` and its note records 34px of
  slack in the default column set at the panel's docked width, #314 measured two chips at
  138px of that 250px track, and `inspection_date` is **on** by default — so a
  `!inspectionColumn` chip would draw for nobody on a default install and still not draw at
  375px, which is the width the gap was reported at.
- **#498 resolved as "one tone", not "one token"**, which the plan left open: red for every
  bare date that has passed, chips keeping their two tones because each carries a word. The
  Reminder cell is included — #498's own third point is that amber carried three meanings in
  one row — so amber in a table row now means low quantity and nothing else.
- **`hv-list-row`'s `.secondary.inspect` was one class doing two jobs** (the inspection-due
  line and the flagged-status line), which is why they could not take different tones. Split
  into `.overdue` / `.out` / `.flagged`.
- **#505's three candidate answers were all declined as written**; the shipped fix is the
  optimistic delta *and* a coalesced server recount *and* an honest footer, because the two
  numbers are read at different moments and the card cannot test the backend's search. The
  recount is a one-row `countMatching`, not the re-list the issue costs out.

**Follow-ups**

Two named and deliberately not filed, both in #554's body with the reasoning:

- With **no** filter active, `total` still drifts by one when an item on an unloaded page is
  deleted. It is the whole-inventory count, never produces an impossible line, and buying it
  back costs a round trip per event on every open card.
- The **list** still shows a row that does not match the active search. Removing it needs a
  re-list per event — the cost #505 rules out — and the same insert is what makes the
  ordinary case work.

One from #553, also not filed: the detail sheet is the only screen carrying both
vocabularies at once (an amber "Inspection due" chip near the top, a red date in the facts
far below). They are never adjacent, and it reads as intended on the instance.

Nothing here clears CLAUDE.md's bar of mattering in a real install.

**State left behind**

- **Dev HA restored.** The two-tab and non-matching harnesses each created and deleted
  their own probe item; counts are back at **1087 items / 89 locations**, as found. The
  profile language was set to `en` so the footer screenshots would be legible (the harness
  browser reports `navigator.language=de`) and is set back to `null`, which is what it was.
  The container currently carries **#554's** card bundle, built from the merged branch.
- **Branches:** all three feature branches deleted locally and on the remote. Screenshots
  live on the orphan branch **`claude-assets-v0-7-0-s10b`**, which is merged into nothing
  and which the PR bodies link to — do not delete it while the PRs are worth reading.
- **`main` carries all three fixes**; `dev/V0_7_0_implementation.md` is untouched and S11
  deletes it.
