### PR TITLE
fix(card): one tone for a date that has passed

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -306,21 +306,18 @@ export class HVDataTable extends LitElement {
         color: var(--hv-warn);
         font-weight: 500;
       }
-      .cell.due.overdue {
-        color: var(--hv-error);
-        font-weight: 500;
-      }
-      /* Amber rather than the due column's red: a passed inspection date is a
-         chore on an item still on the shelf, not an item that is late back. */
-      .cell.inspection.due {
-        color: var(--hv-warn);
-        font-weight: 500;
-      }
-      /* Same amber as the inspection column, and for the same reason: a reminder
-         that has come round is a chore, not a lateness. Due includes today, so
-         this lights up on the day the household asked to be reminded. */
+      /* One tone for a date that has passed, whichever of the three columns
+         prints it. A bare date cell has no word beside it, so a second hue here
+         is the whole signal and reads as a severity ranking the card never
+         explains. Naming which kind of lateness it is belongs to the chips —
+         "Overdue" in the name cell, "Inspection due" on the row and the sheet —
+         and they keep their own two tones because the word carries what the
+         colour cannot. Inspection and reminder dates include today: the day a
+         date names is the day it is asking. */
+      .cell.due.overdue,
+      .cell.inspection.due,
       .cell.reminder.due {
-        color: var(--hv-warn);
+        color: var(--hv-error);
         font-weight: 500;
       }
       .cell.updated {

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -275,6 +275,24 @@ describe('hv-detail-sheet: read view', () => {
     }
   });
 
+  // The sheet used to mark the smaller thing and leave the bigger one plain: an
+  // amber Next inspection fact directly under a Due fact in ordinary black, on
+  // an item whose chip above already said "Overdue".
+  it('marks a Due date that has passed, the way the inspection fact beneath it is marked', async () => {
+    const el = await mount({ checked_out: true, due_date: '2020-01-01' });
+    const due = all(el, '[data-testid="sheet-fact"]').find((f) => f.dataset.key === 'due');
+    expect(due?.querySelector('.value')?.classList.contains('late')).toBe(true);
+  });
+
+  it('leaves a Due date still ahead of today, and an unset one, unmarked', async () => {
+    for (const due_date of ['2099-01-01', null]) {
+      const el = await mount({ checked_out: due_date !== null, due_date });
+      const due = all(el, '[data-testid="sheet-fact"]').find((f) => f.dataset.key === 'due');
+      expect(due?.querySelector('.value')?.classList.contains('late'), String(due_date)).toBe(false);
+      el.remove();
+    }
+  });
+
   it('shows the version alongside when it was updated', async () => {
     const el = await mount({ version: 14 });
     expect(q(el, '[data-testid="sheet-updated"]')?.textContent).toContain('v14');

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -228,10 +228,13 @@ export class HVDetailSheet extends LitElement {
       .fact .value.yes {
         color: var(--hv-success);
       }
-      /* An inspection date that has passed asks for something to be done, so
-         it does not read as a neutral fact. Same amber as the chip above it. */
+      /* A date that has passed is not a neutral fact, and every fact that
+         prints one is marked the same way — the same red the table's date cells
+         and the compact row's line use. The chips at the top of the sheet are
+         where the kind of lateness is named, so down here the colour says only
+         that the day has gone by. */
       .fact .value.late {
-        color: var(--hv-warn-deep);
+        color: var(--hv-error);
         font-weight: 500;
       }
       /* The one fact row that acts. The value keeps its margin-left:auto, so the
@@ -742,7 +745,7 @@ export class HVDetailSheet extends LitElement {
       <div class="facts">
         <div class="fact" data-testid="sheet-fact" data-key="due">
           <span>${t('hv.sheet.fact.due')}</span>
-          <span class="value ${item.due_date ? '' : 'unset'}"
+          <span class="value ${item.due_date ? '' : 'unset'} ${overdue ? 'late' : ''}"
             >${item.due_date ? formatDate(item.due_date) : t('hv.term.notSet')}</span
           >
         </div>

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -194,7 +194,9 @@ describe('hv-list-row: content', () => {
     const secondary = q(el, '[data-testid="row-secondary"]');
     expect(q(el, '[data-testid="row-inspection-due"]')).toBeTruthy();
     expect(secondary?.textContent).toContain('Inspection due');
-    expect(secondary?.classList.contains('inspect')).toBe(true);
+    // The line prints a date that has passed, so it takes the same tone the
+    // table's cells and the sheet's facts give one.
+    expect(secondary?.classList.contains('overdue')).toBe(true);
   });
 
   // Someone holding the item outranks a chore on the shelf, so the line keeps
@@ -244,7 +246,33 @@ describe('hv-list-row: content', () => {
     const el = await mount({ status: 'needs_repair' }, { mobile: true });
     const secondary = q(el, '[data-testid="row-secondary"]');
     expect(q(el, '[data-testid="row-status"]')?.textContent?.trim()).toBe('Needs repair');
-    expect(secondary?.classList.contains('inspect')).toBe(true);
+    // Amber, and not the tone a passed date takes: this line names a state, not
+    // a day that has gone by.
+    expect(secondary?.classList.contains('flagged')).toBe(true);
+    expect(secondary?.classList.contains('overdue')).toBe(false);
+  });
+
+  // The two the tone has to tell apart on one line: a flagged item whose
+  // inspection is also due says the status and stays amber, because that is
+  // what the line ends up printing.
+  it('keeps the flagged tone when an inspection is due behind it', async () => {
+    const el = await mount(
+      { status: 'needs_repair', inspection_date: '2020-05-06' },
+      { mobile: true },
+    );
+    const secondary = q(el, '[data-testid="row-secondary"]');
+    expect(secondary?.classList.contains('flagged')).toBe(true);
+    expect(secondary?.classList.contains('overdue')).toBe(false);
+  });
+
+  it('marks an overdue loan on the phone line, and leaves one still in date alone', async () => {
+    const late = await mount({ checked_out: true, due_date: '2020-01-01' }, { mobile: true });
+    expect(q(late, '[data-testid="row-secondary"]')?.classList.contains('overdue')).toBe(true);
+
+    const inDate = await mount({ checked_out: true, due_date: '2099-01-01' }, { mobile: true });
+    const secondary = q(inDate, '[data-testid="row-secondary"]');
+    expect(secondary?.classList.contains('overdue')).toBe(false);
+    expect(secondary?.classList.contains('out')).toBe(true);
   });
 
   it('lets the flagged status outrank the inspection chore, but not the checkout', async () => {

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -246,16 +246,21 @@ export class HVListRow extends LitElement {
       .secondary.out {
         color: var(--hv-primary-dark);
       }
-      /* A passed due date is the one thing on this line worth interrupting for,
-         and "due Jul 2" in the same blue as "due Aug 24" said nothing. */
+      /* A date that has passed is the one thing on this line worth interrupting
+         for — "due Jul 2" in the same blue as "due Aug 24" said nothing — and it
+         is the same red the table's date cells and the sheet's facts use. The
+         line names the date it is talking about, so the colour is left saying
+         only that it has gone by. */
       .secondary.overdue {
         color: var(--hv-error);
         font-weight: 500;
       }
-      /* Amber, not that red: red here means an item is out and late back, while
-         an inspection that has come due is a chore on something on the shelf. */
-      .secondary.inspect {
-        color: var(--hv-warn-deep);
+      /* A flagged status is not a date and stays out of that vocabulary. Plain
+         --hv-warn rather than --hv-warn-deep, which is the ink for text laid on
+         --hv-warn-bg and is a shade meant for a tint, not for the row's own
+         surface. */
+      .secondary.flagged {
+        color: var(--hv-warn);
         font-weight: 500;
       }
       .dot {
@@ -541,7 +546,17 @@ export class HVListRow extends LitElement {
     // past the edge elides, so the width decides how much of it survives.
     const status = itemStatus(item);
     const flagged = status !== 'ok';
-    const mobileState = item.checked_out ? 'out' : flagged || inspectionDue ? 'inspect' : '';
+    // The line takes its tone from what it ends up saying, which follows the
+    // same order the branches below do. A date that has passed outranks the
+    // rest: an inspection line only ever prints one, and a check-out line
+    // prints one whenever the loan carries a due date it has gone past.
+    const mobileState = overdue || (!item.checked_out && !flagged && inspectionDue)
+      ? 'overdue'
+      : item.checked_out
+        ? 'out'
+        : flagged
+          ? 'flagged'
+          : '';
 
     return html`
       <div
@@ -587,10 +602,7 @@ export class HVListRow extends LitElement {
               : null}
           </span>
           <span
-            class="secondary ${this.mobile ? mobileState : 'hv-chip-line'} ${overdue &&
-            this.mobile
-              ? 'overdue'
-              : ''}"
+            class="secondary ${this.mobile ? mobileState : 'hv-chip-line'}"
             data-testid="row-secondary"
             title=${secondaryFull}
           >

--- a/cards/haventory-card/src/ui/passed-date-tone.test.ts
+++ b/cards/haventory-card/src/ui/passed-date-tone.test.ts
@@ -1,0 +1,69 @@
+import '../components/hv-data-table';
+import '../components/hv-detail-sheet';
+import '../components/hv-list-row';
+import { componentCss } from '../test.utils';
+
+/**
+ * One tone for a date that has passed, wherever the card prints a bare one.
+ *
+ * The three surfaces each draw the same item — a table cell, a phone row's one
+ * line, a fact in the detail sheet — and each used to pick its own colour, so
+ * the same passed date read as red in one column and amber in the next. Beside
+ * a word ("Overdue", "Inspection due") a second hue reinforces something the
+ * text has already said; on a bare date it *is* the message, and a two-hue
+ * vocabulary there claims a ranking of urgency the card never explains.
+ *
+ * Held here rather than in each component's own tests because the rule is that
+ * the three agree: a check inside one file passes while the other two drift.
+ */
+
+/** A component's rules with comments dropped — they quote selectors and commas. */
+function rulesOf(tag: string): string {
+  return componentCss(tag).replace(/\/\*[\s\S]*?\*\//g, ' ');
+}
+
+/** The `color` of the rule whose selector list holds `selector`. */
+function colorFor(tag: string, selector: string): string | null {
+  for (const rule of rulesOf(tag).matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (!rule[1].split(',').some((s) => s.trim() === selector)) continue;
+    const color = rule[2].match(/(?:^|;)\s*color:\s*([^;]+)/);
+    if (color) return color[1].trim();
+  }
+  return null;
+}
+
+describe('a date that has passed reads the same on every surface', () => {
+  const SURFACES: [tag: string, selector: string, what: string][] = [
+    ['hv-data-table', '.cell.due.overdue', 'the table’s Due cell'],
+    ['hv-data-table', '.cell.inspection.due', 'the table’s Next inspection cell'],
+    ['hv-data-table', '.cell.reminder.due', 'the table’s Reminder cell'],
+    ['hv-list-row', '.secondary.overdue', 'the compact row’s line'],
+    ['hv-detail-sheet', '.fact .value.late', 'the detail sheet’s fact'],
+  ];
+
+  for (const [tag, selector, what] of SURFACES) {
+    it(`paints ${what} in --hv-error`, () => {
+      expect(colorFor(tag, selector), `${tag} ${selector}`).toBe('var(--hv-error)');
+    });
+  }
+
+  // --hv-warn-deep is the ink for text laid on --hv-warn-bg — a banner, a chip,
+  // the diagnostics panel. Two of these surfaces used it on their own plain
+  // background, which is the drift only a light theme showed: #7a4d00 there
+  // against #b26b00 in the table, for one and the same fact.
+  it('leaves the on-tint amber to the fills that carry it', () => {
+    for (const tag of ['hv-list-row', 'hv-detail-sheet']) {
+      const dateRules = rulesOf(tag)
+        .split('}')
+        .filter((r) => /\.overdue|\.late/.test(r.split('{')[0] ?? ''));
+      expect(dateRules.length, tag).toBeGreaterThan(0);
+      expect(dateRules.join('}'), tag).not.toMatch(/--hv-warn-deep/);
+    }
+  });
+
+  // A flagged status is the one thing on the phone row that is not a date, so
+  // it keeps amber — the plain-surface one, not the on-tint ink.
+  it('keeps a flagged status out of the vocabulary', () => {
+    expect(colorFor('hv-list-row', '.secondary.flagged')).toBe('var(--hv-warn)');
+  });
+});


### PR DESCRIPTION
## Summary

An item whose **Due** date and whose **Next inspection** date had both gone by drew the two
in two colours in the table — Due in `--hv-error`, inspection in `--hv-warn` — with nothing
on screen saying why one was louder than the other. In a bare date cell the colour is the
whole signal, so a second hue there reads as a severity ranking the card never explains.

One tone now, everywhere the card prints a bare date that has passed:

| surface | before | after |
|---|---|---|
| table, Due cell | `--hv-error` | `--hv-error` |
| table, Next inspection cell | `--hv-warn` | `--hv-error` |
| table, Reminder cell | `--hv-warn` | `--hv-error` |
| compact row, phone line (overdue) | `--hv-error` | `--hv-error` |
| compact row, phone line (inspection due) | `--hv-warn-deep` | `--hv-error` |
| detail sheet, late fact | `--hv-warn-deep` | `--hv-error` |
| detail sheet, **Due** fact | *unmarked* | `--hv-error` |
| compact row, phone line (flagged status) | `--hv-warn-deep` | `--hv-warn` |

Closes #498

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## The decision, taken in the light of #499

#499 shipped first (#552) and the table row now names lateness in a word. That is what
makes the first of the issue's three directions the right one: **one tone for a passed
date, with the word beside it saying which kind of lateness it is.** So

- **the chips keep their two tones.** "Overdue" is red, "Inspection due" is amber, and
  each carries the word that says which it is — which is exactly the case #498 grants
  ("that reasoning holds wherever the tone sits beside a word").
- **the bare dates take one.** A cell or a fact printing `Jun 29` has no word, so its
  colour is left saying only that the day has gone by.

Red rather than amber, because the Due cell is already red and the "Overdue" chip on the
same row is too — downgrading the loudest of the three to match the quietest would have put
a red chip next to an amber date on one row.

**The Reminder cell is in.** #498's third point is that amber carried three meanings in one
table row against red's one, and its CSS comment gave "same amber as the inspection column"
as its reason — a comment about a rule that would no longer exist. A reminder date that has
come round is a date that has passed. After this, amber in a table row means one thing:
low quantity, which is not a date.

**`--hv-warn-deep` goes back to being one thing.** It is the ink for text laid on
`--hv-warn-bg` (banner, diagnostics panel, import sheet, organize dialog, every warning
chip); the two places using it on a plain surface were the drift only a light theme showed
— `#7a4d00` on the row and the sheet against `#b26b00` in the table, for one and the same
fact. The phone row's flagged-status line, the only one of the two that is not about a
date, takes plain `--hv-warn` and so now matches the low-quantity amber on its own row.

**One class was doing two jobs.** `hv-list-row`'s `.secondary.inspect` coloured both the
inspection-due line *and* the flagged-status line, so the two could not take different
tones. The line's tone is now picked once, in the same order the render branches are
written: a passed date, then who has the item, then what it is flagged with —
`.secondary.overdue`, `.secondary.out`, `.secondary.flagged`.

**The three CSS comments that gave the old split as their reason are rewritten** —
`hv-data-table.ts`, `hv-list-row.ts`, `hv-detail-sheet.ts` — since a comment describing a
rule the code no longer follows is worse than none.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1277 passed, 22
      skipped; `ruff check`, `ruff format --check`, `mypy` all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → **1784 passed (66 files)**, `npm audit --audit-level=high` → 0
      vulnerabilities, `npm run build` OK.

New `src/ui/passed-date-tone.test.ts` is where the rule is pinned, and it is deliberately
one file across three components: a check living inside `hv-data-table.test.ts` passes
while the row and the sheet drift, which is how the two ambers got apart in the first
place. It reads each component's own stylesheet and asserts the five selectors resolve to
`var(--hv-error)`, that no date rule in the row or the sheet mentions `--hv-warn-deep`, and
that the flagged-status line is `var(--hv-warn)`.

Per-component tests added or adjusted: the sheet marks a passed Due date and leaves a
future or unset one alone; the row's inspection-due line takes the passed-date class, an
overdue loan does and a loan still in date does not, and a flagged status stays amber —
including the case that made the old shared class ambiguous, a flagged item whose
inspection is also due.

### Live checks — dev HA, light **and** dark

Same item as #552: `Duct Tape #0103`, due `2026-08-07`, inspection `2026-06-29`, both past.

**Panel, 1920×1080, sidebar docked, light — before / after.** `Aug 7` and `Jun 29` were
red and amber; they are now one colour.

![panel at 1920 light before, Aug 7 red and Jun 29 amber](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-panel-1920-light.png)
![panel at 1920 light after, both dates red](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr2-panel-1920-light.png)

**Detail sheet, light — before / after.** The Due fact was plain black under a chip that
already said "Overdue"; the inspection fact under it was amber. Both are marked now, and
the chips above still name which is which.

![detail sheet before, Due plain and Next inspection amber](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-card-sheet-light.png)
![detail sheet after, both facts red](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr2-card-sheet-light.png)

**Dark — before / after,** both surfaces, where the two ambers were indistinguishable and
the unmarked Due fact was the only visible half of the problem:

![panel at 1920 dark before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-panel-1920-dark.png)
![panel at 1920 dark after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr2-panel-1920-dark.png)
![detail sheet dark before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-card-sheet-dark.png)
![detail sheet dark after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr2-card-sheet-dark.png)

**The compact row, both branches of the tone change.** `Christmas Lights #0347` (inspection
`2026-07-15`, nobody has it) now reads its line in the same red an overdue loan gets;
`Bike Pump #0359` (`needs_repair`) stays amber, and it is the same amber as the low dot and
the low quantity on its own row.

![phone row, Inspection due Jul 15 in red](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr2-card-list-inspection-light.png)
![phone row, Needs repair Garage in amber](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr2-card-list-flagged-light.png)

Screenshots live on the orphan branch `claude-assets-v0-7-0-s10b`, merged into nothing.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added (the shared rule, plus per-surface happy path and the unmarked cases).
- [x] Docs: nothing in `docs/` describes these tones.
- [x] No WebSocket API change.
- [x] Invariants untouched.

## Follow-ups

- The one place the two vocabularies now sit on a single screen is the detail sheet: an
  amber "Inspection due · Jun 29" chip near the top and a red `Jun 29` fact far below it,
  with the hero, gallery, documents and description between them. That is the vocabulary
  working as described — the chip names the kind, the fact says the day has gone by — and
  they are never adjacent. Not filed: it reads as intended on the instance, and an issue
  for it would be arguing with the decision this PR records rather than reporting a defect.


## Handover

**Merged / left open**

Three PRs, all merged by the session, all branches deleted. Nothing is left open.

- #552 — `fix(card): say Overdue on the table row, not Checked out` (closes #499)
- #553 — `fix(card): one tone for a date that has passed` (closes #498)
- #554 — `fix(card): keep the filtered total honest when an event inserts a row` (closes #505)

V0.7.0 has no open issues left after these three. The only pull request open on the
repository is release-please's `chore(main): release 0.7.0` (#491), untouched, which waits
for S11.

**Test this by hand**

1. `[desktop]` `[phone]` **In a light theme**, give one item a Due date and a Next
   inspection date both in the past, then read it on all four surfaces: the compact card
   row, the expanded card's table, `/haventory`, and its detail sheet. Expect one story
   told the same way four times — the row chip beside the name says **Overdue** in red
   (not "Checked out"), and every bare date that has gone by is the **same red** in every
   cell and every fact, the sheet's Due fact included. The chips keep two tones on
   purpose: red "Overdue", amber "Inspection due", each carrying the word that says which
   it is. The harness only proves the pixels agree with the tokens; whether the one-tone
   rule reads right to a person is the part that needs eyes. `Duct Tape #0103` on the dev
   instance is already such an item.
2. `[phone]` **A flagged status is not a date.** Find an item with status "Needs repair"
   and no dates (`Bike Pump #0359`) on a phone-width card. Its line should stay **amber**,
   and the amber should now match the low-quantity amber on the same row rather than being
   a shade darker.
3. `[phone]` **Two screens on the same inventory.** Type a word into one phone's search
   box; on the other, add an item whose name contains that word. The row should appear on
   the first phone on its own, and the line under the list should be the number of rows
   above it. Then add an item that does **not** contain the word: the row still appears
   (that is deliberate — the card cannot test the backend's search), and the footer should
   drop the word "matching" and count only what is on screen rather than claiming the row
   matches.
4. `[desktop]` **A column switched off.** Hide the Due column in the column picker and
   check an overdue row still says "Overdue" — the chip does not defer to that column, and
   that is the case a real install hits by scrolling sideways rather than by hiding
   anything.

What the harness proved instead, so it does not need re-doing by hand: both gates on every
commit; `two_tab.mjs` green both ways (service call and WebSocket command) with the footer
counting the new row; the non-matching direction driven live against `main`'s bundle and
this one in the same container; and `visual_pass.mjs` **42/42 surfaces** with all three
changes deployed. Before/after screenshots in both themes are in each PR body.

**Decisions taken against drifted notes**

- **#499's line numbers are pre-i18n throughout** (`hv-data-table.ts:668`, `:609-611`,
  `hv-list-row.ts:619-631`, `hv-detail-sheet.ts:675-690`); every one was found by grepping
  the key. The chip is now at `hv-data-table.ts` ~723 reading `t('hv.term.checkedOut')`.
- **No config option for the overdue chip**, as #499 argues and the plan directs.
- **The overdue chip does not defer to the Due column**, unlike the status chip beside it:
  the Due column prints a date, not the word, so there is nothing to say twice.
- **No inspection chip in the table**, decided against #499's own suggestion of a
  column-aware one. `NAME_COLUMN_SIZE` is `minmax(250px, 2fr)` and its note records 34px of
  slack in the default column set at the panel's docked width, #314 measured two chips at
  138px of that 250px track, and `inspection_date` is **on** by default — so a
  `!inspectionColumn` chip would draw for nobody on a default install and still not draw at
  375px, which is the width the gap was reported at.
- **#498 resolved as "one tone", not "one token"**, which the plan left open: red for every
  bare date that has passed, chips keeping their two tones because each carries a word. The
  Reminder cell is included — #498's own third point is that amber carried three meanings in
  one row — so amber in a table row now means low quantity and nothing else.
- **`hv-list-row`'s `.secondary.inspect` was one class doing two jobs** (the inspection-due
  line and the flagged-status line), which is why they could not take different tones. Split
  into `.overdue` / `.out` / `.flagged`.
- **#505's three candidate answers were all declined as written**; the shipped fix is the
  optimistic delta *and* a coalesced server recount *and* an honest footer, because the two
  numbers are read at different moments and the card cannot test the backend's search. The
  recount is a one-row `countMatching`, not the re-list the issue costs out.

**Follow-ups**

Two named and deliberately not filed, both in #554's body with the reasoning:

- With **no** filter active, `total` still drifts by one when an item on an unloaded page is
  deleted. It is the whole-inventory count, never produces an impossible line, and buying it
  back costs a round trip per event on every open card.
- The **list** still shows a row that does not match the active search. Removing it needs a
  re-list per event — the cost #505 rules out — and the same insert is what makes the
  ordinary case work.

One from #553, also not filed: the detail sheet is the only screen carrying both
vocabularies at once (an amber "Inspection due" chip near the top, a red date in the facts
far below). They are never adjacent, and it reads as intended on the instance.

Nothing here clears CLAUDE.md's bar of mattering in a real install.

**State left behind**

- **Dev HA restored.** The two-tab and non-matching harnesses each created and deleted
  their own probe item; counts are back at **1087 items / 89 locations**, as found. The
  profile language was set to `en` so the footer screenshots would be legible (the harness
  browser reports `navigator.language=de`) and is set back to `null`, which is what it was.
  The container currently carries **#554's** card bundle, built from the merged branch.
- **Branches:** all three feature branches deleted locally and on the remote. Screenshots
  live on the orphan branch **`claude-assets-v0-7-0-s10b`**, which is merged into nothing
  and which the PR bodies link to — do not delete it while the PRs are worth reading.
- **`main` carries all three fixes**; `dev/V0_7_0_implementation.md` is untouched and S11
  deletes it.
