### PR TITLE
fix(card): keep the filtered total honest when an event inserts a row

### DIFF
--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -1598,3 +1598,183 @@ describe('Store: import reload signalling', () => {
     expect(store.state.value.items.map((i) => i.id)).toEqual(['1', '2']);
   });
 });
+
+/**
+ * The number under the list has to survive a row nobody in this browser asked
+ * for. `total` comes off the last `item/list` reply and the event path patches
+ * `items`, so with a filter on, the two used to drift apart and the footer read
+ * "Showing 1 of 0 matching items".
+ */
+describe('Store: the filtered total after an event-inserted row', () => {
+  const spanner = makeItem({ id: 'sp', name: 'Spanner' });
+  const hammer = makeItem({ id: 'ha', name: 'Hammer' });
+
+  /** A store with `q` applied and its first filtered page loaded. */
+  async function searched(q: string, items = [spanner]) {
+    const hass = makeMockHass({ items });
+    const store = new Store(hass, fast);
+    await store.init();
+    store.setFilters({ q });
+    await vi.advanceTimersByTimeAsync(300);
+    return { hass, store };
+  }
+
+  it('counts a row an event inserts, with no round trip to wait for', async () => {
+    vi.useFakeTimers();
+    try {
+      const { hass, store } = await searched('spanner', []);
+      expect(store.state.value.total).toBe(0);
+
+      // The mock's own list is what a recount reads, so the item exists there
+      // too — this is the other browser having created it.
+      hass.__setItems([spanner]);
+      const listsBefore = hass.__calls.filter((c) => c === 'haventory/item/list').length;
+      hass.__emit('items', 'created', { item: spanner });
+
+      // Straight away, before the recount is even scheduled to fire.
+      expect(store.state.value.items).toHaveLength(1);
+      expect(store.state.value.total).toBe(1);
+      expect(hass.__calls.filter((c) => c === 'haventory/item/list').length).toBe(listsBefore);
+
+      await vi.advanceTimersByTimeAsync(300);
+      expect(store.state.value.total).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The subscription is filtered by location, not by the search text, so a row
+  // that does not match the typed query arrives all the same. The card cannot
+  // tell — the server can.
+  it('takes the total back off the server when the row does not match', async () => {
+    vi.useFakeTimers();
+    try {
+      const { hass, store } = await searched('spanner');
+      expect(store.state.value.total).toBe(1);
+
+      hass.__setItems([spanner, hammer]);
+      hass.__emit('items', 'created', { item: hammer });
+      expect(store.state.value.total).toBe(2);
+
+      await vi.advanceTimersByTimeAsync(300);
+      // One spanner matches "spanner"; the loaded list holds two rows, and
+      // `showingCount` is what stops that pair printing an impossible line.
+      expect(store.state.value.total).toBe(1);
+      expect(store.state.value.items).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('follows a delete down, and never below zero', async () => {
+    vi.useFakeTimers();
+    try {
+      const { hass, store } = await searched('spanner');
+      hass.__setItems([]);
+      hass.__emit('items', 'deleted', { item: spanner });
+
+      expect(store.state.value.total).toBe(0);
+      await vi.advanceTimersByTimeAsync(300);
+      expect(store.state.value.total).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // An item on a page nobody has scrolled to leaves the match set without
+  // touching the loaded rows, so there is no delta to apply — only the server
+  // knows the set got smaller.
+  it('re-prices a change the loaded list cannot see', async () => {
+    vi.useFakeTimers();
+    try {
+      const other = makeItem({ id: 'sp2', name: 'Spanner, small' });
+      const { hass, store } = await searched('spanner', [spanner, other]);
+      expect(store.state.value.total).toBe(2);
+
+      hass.__setItems([spanner]);
+      hass.__emit('items', 'deleted', { item: makeItem({ id: 'gone', name: 'Never loaded' }) });
+      expect(store.state.value.total).toBe(2);
+
+      await vi.advanceTimersByTimeAsync(300);
+      expect(store.state.value.total).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // `updated` rather than `created`, so the number below counts one thing: a
+  // create also books a tree refetch, which prices its own filtered count
+  // through the same command and cannot be told apart from this one.
+  it('asks once for a burst, and not at all with no filter on', async () => {
+    vi.useFakeTimers();
+    try {
+      const { hass, store } = await searched('spanner');
+      const before = hass.__calls.filter((c) => c === 'haventory/item/list').length;
+      for (const quantity of [1, 2, 3]) {
+        hass.__emit('items', 'updated', { item: { ...spanner, quantity } });
+      }
+      await vi.advanceTimersByTimeAsync(300);
+      expect(hass.__calls.filter((c) => c === 'haventory/item/list').length - before).toBe(1);
+
+      store.clearFilters();
+      await vi.advanceTimersByTimeAsync(300);
+      const unfiltered = hass.__calls.filter((c) => c === 'haventory/item/list').length;
+      hass.__emit('items', 'created', { item: makeItem({ id: 'd', name: 'Chisel' }) });
+      await vi.advanceTimersByTimeAsync(300);
+      expect(hass.__calls.filter((c) => c === 'haventory/item/list').length).toBe(unfiltered);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels a recount the dispose leaves pending', async () => {
+    vi.useFakeTimers();
+    try {
+      const { hass, store } = await searched('spanner', [spanner, hammer]);
+      hass.__emit('items', 'created', { item: hammer });
+      const listed = hass.__calls.filter((c) => c === 'haventory/item/list').length;
+      store.dispose();
+      await vi.advanceTimersByTimeAsync(300);
+      expect(hass.__calls.filter((c) => c === 'haventory/item/list').length).toBe(listed);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The filter can change while the count for the previous one is on the wire.
+  // `listItems` has already answered for the new filter by then, so the late
+  // answer would replace a right number with a stale one — held open here so
+  // the two really do overlap.
+  it('drops a recount whose filter moved while it was in flight', async () => {
+    const small = makeItem({ id: 'ha2', name: 'Hammer, small' });
+    const hass = makeMockHass({ items: [spanner, hammer, small] });
+    const store = new Store(hass, fast);
+    await store.init();
+    store.setFilters({ q: 'spanner' });
+    await vi.waitUntil(() => store.state.value.total === 1);
+
+    // Every count-shaped list is held, because the tree refetch an event also
+    // books prices its own through the same command: holding "the first one"
+    // would be holding whichever won the race.
+    const original = hass.callWS.bind(hass);
+    const held: (() => void)[] = [];
+    hass.callWS = (async (msg: Record<string, unknown>) => {
+      if (String(msg.type) === 'haventory/item/list' && msg.limit === 1) {
+        await new Promise<void>((resolve) => held.push(resolve));
+      }
+      return original(msg);
+    }) as typeof hass.callWS;
+
+    hass.__emit('items', 'created', { item: hammer });
+    await vi.waitUntil(() => held.length > 0);
+
+    store.setFilters({ q: 'hammer' });
+    await vi.waitUntil(() => store.state.value.total === 2);
+    held.forEach((release) => release());
+    // The full page load setFilters started is unheld and has already landed;
+    // this is the held answers finishing their chains behind it.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(store.state.value.total).toBe(2);
+  });
+});

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -353,10 +353,13 @@ export class Store {
   private treeRefreshHandle: ReturnType<typeof setTimeout> | null = null;
   private facetRefreshHandle: ReturnType<typeof setTimeout> | null = null;
   private areasRefreshHandle: ReturnType<typeof setTimeout> | null = null;
+  private totalRefreshHandle: ReturnType<typeof setTimeout> | null = null;
   /** Identifies the newest facet-tally request, so a superseded one cannot land. */
   private distinctRefreshSeq = 0;
   /** Identifies the newest tree refetch, for the same reason. */
   private treeRefreshSeq = 0;
+  /** Identifies the newest filtered-total recount, for the same reason. */
+  private totalRefreshSeq = 0;
   /** Identifies the newest subscribe round, so a superseded one stops reporting. */
   private subscribeRound = 0;
   /** Subscribes in the current round that have not resolved or been refused yet. */
@@ -761,6 +764,10 @@ export class Store {
       clearTimeout(this.treeRefreshHandle);
       this.treeRefreshHandle = null;
     }
+    if (this.totalRefreshHandle !== null) {
+      clearTimeout(this.totalRefreshHandle);
+      this.totalRefreshHandle = null;
+    }
     if (this.facetRefreshHandle !== null) {
       clearTimeout(this.facetRefreshHandle);
       this.facetRefreshHandle = null;
@@ -790,6 +797,7 @@ export class Store {
       return;
     }
     const items = this.state.value.items.slice();
+    const loadedBefore = items.length;
     const idx = items.findIndex((x) => x.id === item.id);
     switch (evt.action) {
       case 'created':
@@ -808,7 +816,24 @@ export class Store {
         break;
       }
     }
-    this.stateObs.set({ items });
+    // `total` counts every match across all pages and came off the last
+    // `item/list` reply, computed before this event existed. Moving it by what
+    // the event did to the loaded list keeps the footer's two numbers telling
+    // one story straight away, with no round trip and nothing to wait for.
+    const total = this.state.value.total;
+    const delta = items.length - loadedBefore;
+    this.stateObs.set(
+      total !== null && delta !== 0 ? { items, total: Math.max(0, total + delta) } : { items },
+    );
+    // That step is optimistic, and it has to be: a subscription is filtered by
+    // location only, so a row handed to a card with a search typed into it may
+    // not belong to the set the footer is counting — and an item on a page
+    // nobody has scrolled to can leave the set without the loaded list moving
+    // at all. Both are what the server is asked about here. Coalesced, and a
+    // count rather than a re-list: `countMatching` asks for one row and reads
+    // the total off the reply, which leaves the loaded pages and the scroll
+    // position alone.
+    if (activeFilterCount(this.state.value.filters) > 0) this.scheduleTotalRefresh();
     // Category/tag distributions can change on create/update/delete — keep the
     // autocomplete source fresh. Other actions (quantity, check-out) can't.
     if (evt.action === 'created' || evt.action === 'updated' || evt.action === 'deleted') {
@@ -819,6 +844,34 @@ export class Store {
     if (evt.action === 'created' || evt.action === 'deleted' || evt.action === 'moved') {
       this.scheduleTreeRefresh();
     }
+  }
+
+  /**
+   * Re-price the active filter's match set, coalesced.
+   *
+   * A burst of events — a bulk move, an import, a script adding a shelf's worth
+   * of items — must ask once, the way `scheduleTreeRefresh` does and for the
+   * same reason.
+   */
+  private scheduleTotalRefresh(delayMs = 250) {
+    if (this.totalRefreshHandle !== null) clearTimeout(this.totalRefreshHandle);
+    this.totalRefreshHandle = setTimeout(() => {
+      this.totalRefreshHandle = null;
+      void this.refreshTotal().catch(() => undefined);
+    }, delayMs);
+  }
+
+  private async refreshTotal(): Promise<void> {
+    const seq = ++this.totalRefreshSeq;
+    const filters = this.state.value.filters;
+    const asked = JSON.stringify(toWireFilter(filters));
+    const total = await this.countMatching(filters);
+    // A newer recount has taken over, the filter moved under this one — in
+    // which case `listItems` has already answered for the new one — or the
+    // count failed and left nothing to apply.
+    if (seq !== this.totalRefreshSeq || total === null) return;
+    if (JSON.stringify(toWireFilter(this.state.value.filters)) !== asked) return;
+    this.stateObs.set({ total });
   }
 
   /**

--- a/cards/haventory-card/src/ui/plural.test.ts
+++ b/cards/haventory-card/src/ui/plural.test.ts
@@ -37,6 +37,21 @@ describe('showingCount', () => {
     expect(showingCount(1, undefined)).toBe('Showing 1 item');
   });
 
+  // The rows are the store's newest reading, the total is the last list
+  // reply's: an event that adds a row a filtered list has not been re-priced
+  // for leaves the second behind the first, and "Showing 1 of 0 matching items"
+  // is a sentence that cannot be true.
+  it('says only what is on screen when the total is behind the rows', () => {
+    expect(showingCount(1, 0, true)).toBe('Showing 1 item');
+    expect(showingCount(51, 50, true)).toBe('Showing 51 items');
+    expect(showingCount(2, 1)).toBe('Showing 2 items');
+  });
+
+  it('keeps the pair while the two still agree', () => {
+    expect(showingCount(1, 1, true)).toBe('Showing 1 of 1 matching item');
+    expect(showingCount(0, 0, true)).toBe('Showing 0 of 0 matching items');
+  });
+
   it('inflects the noun after "von" in German', () => {
     setLanguage('de');
     // Dative plural — the form a derived plural could never have produced.

--- a/cards/haventory-card/src/ui/plural.ts
+++ b/cards/haventory-card/src/ui/plural.ts
@@ -40,12 +40,21 @@ export function counted(count: number, noun: CountNoun): string {
  * filters, so with any of them on the noun says so; null means the server has
  * not priced the set yet. A surface may append its own suffix (the expanded
  * view offers "scroll to load more"), but not rephrase this.
+ *
+ * The two numbers are read at different moments — the total off a list reply,
+ * the rows including whatever a subscription event has added since — so they
+ * can disagree, and a total behind the rows would print a line that cannot be
+ * true ("Showing 1 of 0 matching items"). Then the count of what is on screen
+ * is the part still worth saying, and the claim about the match set is dropped
+ * rather than repaired with a number nothing stands behind.
  */
 export function showingCount(
   loaded: number,
   total: number | null | undefined,
   filtered = false,
 ): string {
-  if (total === null || total === undefined) return tn('hv.list.showingAll', loaded);
+  if (total === null || total === undefined || total < loaded) {
+    return tn('hv.list.showingAll', loaded);
+  }
   return tn(filtered ? 'hv.list.showingOfMatching' : 'hv.list.showingOf', total, { loaded });
 }


### PR DESCRIPTION
## Summary

With a search or filter active, a row arriving through a subscription event was added to
the list without touching `total` — which came off the last `item/list` reply, computed
before the item existed — so the footer rendered a line that cannot be true:

```
Showing 1 of 0 matching items
```

Nothing re-listed until the filter changed, so it stayed wrong for as long as the screen
was left alone.

Closes #505

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## What the store does now, and why it is three parts rather than one

The issue lists three answers and warns that each is wrong on its own. Reading the store
beside the events is what settles it: **`total` and `items` are read at different moments,
and the card cannot tell whether a row it was handed belongs to the filtered set** — the
subscription is scoped by location and area only (`ws.py`'s `haventory/subscribe` takes
`location_id`/`location_ids`/`area_id`/`include_subtree`/`inspection_overdue_only`, and no
search text). So all three parts are about the same gap, at three different distances:

1. **`onItemsEvent` moves `total` by what it did to the loaded list.** Insert → `+1`,
   removal → `-1`, floored at zero. The ordinary case — the other phone adds a spanner
   while this one has "spanner" typed — counts up immediately, with no round trip and
   nothing to wait for. This alone is not enough: it is a guess about a set the card
   cannot see.

2. **While a filter is active, the store re-prices the set against the server.** Coalesced
   at 250 ms with a superseded-round guard, the way `scheduleTreeRefresh` already is, and
   through the existing `countMatching` — which asks `item/list` for **one** row and reads
   the total off the reply. That is why it is not the re-list the issue costs out: a
   re-list would drop loaded pages and the scroll position, and this leaves both alone.

   It earns its round trip by catching what part 1 cannot: a row that does not match the
   search text, and a change on a page nobody has scrolled to (an item deleted three pages
   down leaves the match set without the loaded rows moving at all). The cost sits beside
   what the same events already book — `refreshDistinctValues` and a `location/tree` walk,
   the second of which is a full tree with no parameters and considerably more expensive
   than a one-row list.

   A recount is dropped when a newer one has started, when the count failed, and when the
   filter moved while it was in flight — in that last case `listItems` has already answered
   for the new filter, so the late reply would replace a right number with a stale one.

3. **`showingCount` says only what is on screen when the total is behind the rows.** The
   two numbers come from different moments, so they can always disagree for a beat — and
   in the one case the card genuinely cannot resolve (a non-matching row is on screen, the
   server says it does not match), it is right for them to. Then "Showing 2 items" is the
   part still true, and the claim about the match set is dropped rather than repaired with
   a number nothing stands behind. No new string: it is the `showingAll` form the footer
   already uses before the server has priced the set.

**Not taken:** incrementing `total` optimistically and stopping there (part 1 alone —
wrong whenever the row does not match, and the footer would then assert it does); and
re-listing per event while a filter is active (correct, but pays a full page load and the
scroll position for what a one-row count answers).

**Not in scope, and named rather than fixed:** with *no* filter active, an item deleted on
a page that is not loaded still leaves `total` one too high, because there is no delta to
apply and no recount is scheduled. It is the whole-inventory count, so the error is one in
a thousand-odd and invisible; buying it back costs a round trip per event on every card in
the house. See Follow-ups.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1277 passed, 22
      skipped; `ruff check`, `ruff format --check`, `mypy` all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → **1793 passed (66 files)**, `npm audit --audit-level=high` → 0
      vulnerabilities, `npm run build` OK.

Offline cover against the store with a search active and an event arriving, in both
directions — `Store: the filtered total after an event-inserted row` in
`store.revamp.test.ts`:

- a row that **matches**: counted immediately, and no `item/list` issued before the debounce
  fires;
- a row that **does not match**: counted optimistically, then taken back off the server;
- a delete followed down, and never below zero;
- a change the loaded list cannot see (an item deleted that was never loaded) re-priced
  from the server although no row moved;
- one ask per burst, and none at all with no filter on;
- a recount cancelled by `dispose`, and one whose filter moved **while it was on the wire**
  — that last one holds every count-shaped list open so the two really overlap, and it
  fails without the guard (checked by removing it).

Plus `showingCount` in `plural.test.ts`: the count-only fallback when the total is behind
the rows, and the pair kept while they still agree.

### Live checks — dev HA, two tabs, the mutation from a third connection

`two_tab.mjs` is exactly the issue's scenario: two tabs are two independent HA WebSocket
connections, both have the probe name typed into the search box, and the item is created
over a third — so neither tab made the change. Run both ways, as the issue reports it:
the default is the `call_service` frame Developer Tools → Actions sends
(`haventory.item_create`), and `--ws` is `haventory/item/create`.

**A matching row — before / after** (service call; the `--ws` run is the same picture and
is on the assets branch as `*-505-ws-*.png`):

![before: Showing 1 of 0 matching items](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/before-505-service-a.png)
![after: Showing 1 of 1 matching item](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr3-505-service-a.png)

Both tabs, both mutators, all six of the harness's own checks `[PASS]`, probe deleted each
time.

**A row that does not match** — one tab searching `spanner-<stamp>`, a `hammer-<stamp>`
created over the third connection:

| | rows on screen | footer |
|---|---|---|
| before, on `main` | 2 | `Showing 2 of 1 matching item` |
| after | 2 | `Showing 2 items` |

![after: Showing 2 items with a non-matching row on screen](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s10b/s10b/pr3-505-nonmatch.png)

`main` prints the mirror image of the reported line — two rows claimed as one match. After,
the footer stops claiming anything about the match set and counts what is there. (The
before run is `before-505-nonmatch.png` on the assets branch; it was taken by building
`main`'s bundle into the same container, so nothing but the card differed.)

**No regressions across the surfaces:** `visual_pass.mjs` → **42/42 surfaces captured**,
exit 0 — 14 card surfaces at desktop width, 8 at phone width, 10 panel and 8 panel-mobile,
with the session's three changes deployed.

Screenshots live on the orphan branch `claude-assets-v0-7-0-s10b`, merged into nothing.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added (both directions, plus the coalescing, cancellation and in-flight-race
      cases).
- [x] Docs: no contract change — the backend is asked an existing question more often.
- [x] No WebSocket API change; `docs/backend_api_contract.md` already says event delivery
      is best-effort and that a client which must not miss state re-lists on demand, which
      is what this does.
- [x] Invariants untouched.

## Follow-ups

- **Unfiltered `total` drifts on a delete the loaded list cannot see.** Named above; not
  filed. The number is the whole inventory's, so the error is one row in a thousand and
  never produces an impossible line, and the fix would be a round trip per event on every
  open card. That fails CLAUDE.md's bar for an issue.
- **The list itself still shows a row that does not match.** This PR makes the footer stop
  claiming it matches, and does not remove it — the card has no way to test the backend's
  search normalization, and dropping the row would mean re-listing per event, which is the
  cost the issue rules out. It is also the behaviour that makes the ordinary case work: the
  spanner appearing on the other phone is the point. Not filed, for the same reason it is
  not fixed: a re-list per event is the only way to do better and it is not worth it.


## Handover

**Merged / left open**

Three PRs, all merged by the session, all branches deleted. Nothing is left open.

- #552 — `fix(card): say Overdue on the table row, not Checked out` (closes #499)
- #553 — `fix(card): one tone for a date that has passed` (closes #498)
- #554 — `fix(card): keep the filtered total honest when an event inserts a row` (closes #505)

V0.7.0 has no open issues left after these three. The only pull request open on the
repository is release-please's `chore(main): release 0.7.0` (#491), untouched, which waits
for S11.

**Test this by hand**

1. `[desktop]` `[phone]` **In a light theme**, give one item a Due date and a Next
   inspection date both in the past, then read it on all four surfaces: the compact card
   row, the expanded card's table, `/haventory`, and its detail sheet. Expect one story
   told the same way four times — the row chip beside the name says **Overdue** in red
   (not "Checked out"), and every bare date that has gone by is the **same red** in every
   cell and every fact, the sheet's Due fact included. The chips keep two tones on
   purpose: red "Overdue", amber "Inspection due", each carrying the word that says which
   it is. The harness only proves the pixels agree with the tokens; whether the one-tone
   rule reads right to a person is the part that needs eyes. `Duct Tape #0103` on the dev
   instance is already such an item.
2. `[phone]` **A flagged status is not a date.** Find an item with status "Needs repair"
   and no dates (`Bike Pump #0359`) on a phone-width card. Its line should stay **amber**,
   and the amber should now match the low-quantity amber on the same row rather than being
   a shade darker.
3. `[phone]` **Two screens on the same inventory.** Type a word into one phone's search
   box; on the other, add an item whose name contains that word. The row should appear on
   the first phone on its own, and the line under the list should be the number of rows
   above it. Then add an item that does **not** contain the word: the row still appears
   (that is deliberate — the card cannot test the backend's search), and the footer should
   drop the word "matching" and count only what is on screen rather than claiming the row
   matches.
4. `[desktop]` **A column switched off.** Hide the Due column in the column picker and
   check an overdue row still says "Overdue" — the chip does not defer to that column, and
   that is the case a real install hits by scrolling sideways rather than by hiding
   anything.

What the harness proved instead, so it does not need re-doing by hand: both gates on every
commit; `two_tab.mjs` green both ways (service call and WebSocket command) with the footer
counting the new row; the non-matching direction driven live against `main`'s bundle and
this one in the same container; and `visual_pass.mjs` **42/42 surfaces** with all three
changes deployed. Before/after screenshots in both themes are in each PR body.

**Decisions taken against drifted notes**

- **#499's line numbers are pre-i18n throughout** (`hv-data-table.ts:668`, `:609-611`,
  `hv-list-row.ts:619-631`, `hv-detail-sheet.ts:675-690`); every one was found by grepping
  the key. The chip is now at `hv-data-table.ts` ~723 reading `t('hv.term.checkedOut')`.
- **No config option for the overdue chip**, as #499 argues and the plan directs.
- **The overdue chip does not defer to the Due column**, unlike the status chip beside it:
  the Due column prints a date, not the word, so there is nothing to say twice.
- **No inspection chip in the table**, decided against #499's own suggestion of a
  column-aware one. `NAME_COLUMN_SIZE` is `minmax(250px, 2fr)` and its note records 34px of
  slack in the default column set at the panel's docked width, #314 measured two chips at
  138px of that 250px track, and `inspection_date` is **on** by default — so a
  `!inspectionColumn` chip would draw for nobody on a default install and still not draw at
  375px, which is the width the gap was reported at.
- **#498 resolved as "one tone", not "one token"**, which the plan left open: red for every
  bare date that has passed, chips keeping their two tones because each carries a word. The
  Reminder cell is included — #498's own third point is that amber carried three meanings in
  one row — so amber in a table row now means low quantity and nothing else.
- **`hv-list-row`'s `.secondary.inspect` was one class doing two jobs** (the inspection-due
  line and the flagged-status line), which is why they could not take different tones. Split
  into `.overdue` / `.out` / `.flagged`.
- **#505's three candidate answers were all declined as written**; the shipped fix is the
  optimistic delta *and* a coalesced server recount *and* an honest footer, because the two
  numbers are read at different moments and the card cannot test the backend's search. The
  recount is a one-row `countMatching`, not the re-list the issue costs out.

**Follow-ups**

Two named and deliberately not filed, both in #554's body with the reasoning:

- With **no** filter active, `total` still drifts by one when an item on an unloaded page is
  deleted. It is the whole-inventory count, never produces an impossible line, and buying it
  back costs a round trip per event on every open card.
- The **list** still shows a row that does not match the active search. Removing it needs a
  re-list per event — the cost #505 rules out — and the same insert is what makes the
  ordinary case work.

One from #553, also not filed: the detail sheet is the only screen carrying both
vocabularies at once (an amber "Inspection due" chip near the top, a red date in the facts
far below). They are never adjacent, and it reads as intended on the instance.

Nothing here clears CLAUDE.md's bar of mattering in a real install.

**State left behind**

- **Dev HA restored.** The two-tab and non-matching harnesses each created and deleted
  their own probe item; counts are back at **1087 items / 89 locations**, as found. The
  profile language was set to `en` so the footer screenshots would be legible (the harness
  browser reports `navigator.language=de`) and is set back to `null`, which is what it was.
  The container currently carries **#554's** card bundle, built from the merged branch.
- **Branches:** all three feature branches deleted locally and on the remote. Screenshots
  live on the orphan branch **`claude-assets-v0-7-0-s10b`**, which is merged into nothing
  and which the PR bodies link to — do not delete it while the PRs are worth reading.
- **`main` carries all three fixes**; `dev/V0_7_0_implementation.md` is untouched and S11
  deletes it.
