### PR TITLE
test(skills): hold the HA-settings screenshot harnesses to the half of the URL rule that applies

### DIFF
--- a/.claude/skills/run-haventory/card_views.test.mjs
+++ b/.claude/skills/run-haventory/card_views.test.mjs
@@ -230,11 +230,19 @@ const codeOf = (file) =>
     .filter((line) => !/^\s*\/\//.test(line))
     .join("\n");
 
+// A harness that opens Home Assistant's own pages — the integration's settings
+// entry, the config flow behind a `my` redirect — has no card to find and nothing
+// to ask this module for. It is held to the second half of the rule only: it
+// must not name a dashboard either.
+const opensTheCard = (code) => /haventory-card|cardPath/.test(code);
+
 for (const file of HARNESSES.filter((f) => codeOf(f).includes("page.goto("))) {
   const name = path.basename(file);
   test(`${name} takes its URL from card_views, never its own`, () => {
     const code = codeOf(file);
-    assert.match(code, /import \{[^}]*\bcardPath\b[^}]*\} from ["'][^"']*card_views\.mjs["']/);
+    if (opensTheCard(code)) {
+      assert.match(code, /import \{[^}]*\bcardPath\b[^}]*\} from ["'][^"']*card_views\.mjs["']/);
+    }
     assert.doesNotMatch(code, /["'`][^"'`]*\/(lovelace|dashboard-)[^"'`]*["'`]/);
   });
 }


### PR DESCRIPTION
## Summary

S11's first automated regimen — `node --test` in `.claude/skills/run-haventory/` — was red on `main`: the sweep that holds every harness to "ask `card_views.mjs` for the card's URL, never write your own" also swept in `shot_options.mjs` and `shot_config_flow.mjs`, which S8 added (#537) after the sweep (#525). Those two open Home Assistant's own pages (the integration's settings entry, the config flow behind a `my` redirect); they have no card to find and nothing to ask the module for, so the `cardPath` import the test demanded could never be right for them.

The sweep now requires the import only of a harness that opens the card (`haventory-card` or `cardPath` in its code) and keeps refusing a hard-coded `/lovelace` or `/dashboard-` literal in every harness, the two settings scripts included. No harness changes.

CI does not run this suite, which is why the red never surfaced; it is documented in the skill's "Test" section as the harness's own cover.

Refs #236 (V0.7.0 closing pass).

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

- `node --test` in the skill dir: 34 pass / 2 fail before, **36 pass / 0 fail** after.
- Both gates green on `main` at b878bfe (the change touches only the harness test): backend 1277 passed / 22 skipped, ruff, format, mypy clean; frontend eslint, tsc, vitest 1793 passed / 66 files, build.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — this is the test.
- [x] Docs unchanged (nothing user-visible changed).

## Handover

1. **Merged / left open** — this PR, self-merged under §4 once CI is green.
2. **Test this by hand** — nothing by hand; `node --test` is the proof.
3. **Decisions taken against drifted notes** — none.
4. **Follow-ups** — none.
5. **State left behind** — none; harness-only.
