### PR TITLE
fix(skills): submit the 0.7.0 options form whole, and only put the rate-limit knobs in their own section

### DIFF
--- a/.claude/skills/run-haventory/reload_probe.mjs
+++ b/.claude/skills/run-haventory/reload_probe.mjs
@@ -161,14 +161,26 @@ const panelAfterReload = await panel.page.locator("haventory-panel").count();
 async function openOptionsForm() {
   return rest("POST", "/api/config/config_entries/options/flow", { handler: entry.entry_id });
 }
+// Every section travels with the values the form shows for it. An empty section is
+// not "leave it as it is": the flow reads an absent optional key as unset, so an
+// empty `todo` section would switch the to-do bridge off on the way through. A
+// field with no value is left out rather than sent as null, for the same reason.
 function valuesFrom(form) {
+  const valueOf = (field) => field.description?.suggested_value ?? field.default;
   const values = {};
   for (const field of form.data_schema ?? []) {
-    if (field.type === "expandable") continue;
-    values[field.name] = field.description?.suggested_value ?? field.default;
+    if (field.type === "expandable") {
+      const section = {};
+      for (const inner of field.schema ?? []) {
+        const value = valueOf(inner);
+        if (value !== undefined && value !== null) section[inner.name] = value;
+      }
+      values[field.name] = section;
+      continue;
+    }
+    values[field.name] = valueOf(field);
   }
-  // The two collapsed sections: empty means "leave them as they are".
-  return { ...values, todo: {}, rate_limit: {} };
+  return values;
 }
 async function submit(values) {
   const form = await openOptionsForm();

--- a/.claude/skills/run-haventory/rl_banner.mjs
+++ b/.claude/skills/run-haventory/rl_banner.mjs
@@ -103,11 +103,29 @@ async function setRateLimit(enabled, overrides = {}) {
     show_advanced_options: false,
   });
   if (!flow.flow_id) throw new Error(`could not start options flow: ${JSON.stringify(flow).slice(0, 200)}`);
-  const res = await rest("POST", `/api/config/config_entries/options/flow/${flow.flow_id}`, {
-    rate_limit_enabled: enabled,
-    ...RL_DEFAULTS,
-    ...overrides,
-  });
+  // The knobs sit in one section of a form whose every top-level key is required, so
+  // the submit echoes the whole form as it stands — each field's `default`, or the
+  // `suggested_value` an optional field such as the to-do list entity carries — and
+  // overlays the knobs onto the section that holds them. A field with no value is
+  // left out rather than sent as null: the flow reads an absent optional key as unset.
+  const valueOf = (field) => field.description?.suggested_value ?? field.default;
+  const payload = {};
+  for (const field of flow.data_schema ?? []) {
+    if (field.type !== "expandable") {
+      payload[field.name] = valueOf(field);
+      continue;
+    }
+    const section = {};
+    for (const inner of field.schema ?? []) {
+      const value = valueOf(inner);
+      if (value !== undefined && value !== null) section[inner.name] = value;
+    }
+    if ((field.schema ?? []).some((inner) => inner.name === "rate_limit_enabled")) {
+      Object.assign(section, { rate_limit_enabled: enabled, ...RL_DEFAULTS, ...overrides });
+    }
+    payload[field.name] = section;
+  }
+  const res = await rest("POST", `/api/config/config_entries/options/flow/${flow.flow_id}`, payload);
   // A value the schema rejects comes back as the form again, with `errors` —
   // rate limiting then silently stays as it was and every later assertion in the
   // scenario measures nothing. The rates below sit above the flow's minimums

--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -585,16 +585,27 @@ async def set_rate_limit(
     # The form groups the rate-limit knobs into a section, so they must be submitted nested
     # under that section's name rather than flat, and every top-level key is required — a
     # partial submit is rejected with "required key not provided". HA seeds each field's
-    # `default` from the entry's current options, so echoing the returned schema back
-    # preserves the settings this layer is not trying to change.
+    # `default` (or, for an optional field such as the to-do list entity, its
+    # `suggested_value`) from the entry's current options, so echoing the returned schema
+    # back preserves the settings this layer is not trying to change. The knobs go into
+    # the one section that holds them: the form has other sections, and a key they do not
+    # declare is rejected as "extra keys not allowed". A field with no value is left out
+    # rather than sent as null — the flow reads an absent optional key as "unset".
+    def _value(field: dict[str, Any]) -> Any:
+        suggested = (field.get("description") or {}).get("suggested_value")
+        return field.get("default") if suggested is None else suggested
+
     user_input: dict[str, Any] = {}
     for field in flow.get("data_schema", []):
         if field.get("type") == "expandable":
-            section = {f["name"]: f.get("default") for f in field.get("schema", [])}
-            section.update({"rate_limit_enabled": enabled, **RL_DEFAULTS, **overrides})
+            section = {
+                f["name"]: _value(f) for f in field.get("schema", []) if _value(f) is not None
+            }
+            if any(f["name"] == "rate_limit_enabled" for f in field.get("schema", [])):
+                section.update({"rate_limit_enabled": enabled, **RL_DEFAULTS, **overrides})
             user_input[field["name"]] = section
         else:
-            user_input[field["name"]] = field.get("default")
+            user_input[field["name"]] = _value(field)
 
     res = await _http(
         session, "POST", f"/api/config/config_entries/options/flow/{flow_id}", user_input


### PR DESCRIPTION
## Summary

Three harnesses drive HAventory's options flow headlessly, and all three fell behind the 0.7.0 form, which gained a `todo` section (the to-do bridge, #450) whose entity field travels as a `suggested_value` rather than a `default`:

- `stress.py ratelimit` wrote the rate-limit knobs into **every** expandable section and echoed `null` for `todo_entity_id`, so the submit came back `extra keys not allowed @ data['todo'][…]` and `Entity None is neither a valid entity ID…` — the layer was red in S11's regimen run.
- `rl_banner.mjs` still sent the knobs flat, which the sectioned form refuses.
- `reload_probe.mjs` sent `todo: {}` and `rate_limit: {}` on the theory that an empty section means "leave it". It does not: `_flatten_options` carries only what the sections contain and the flow reads an absent optional key as unset, so every run **switched the to-do bridge off and reset the rate-limit knobs** on the instance it probed — while reporting that it had restored the settings. That is most likely how the dev instance came to hold `todo_entity_id: ""` beside 161 stale to-do links.

All three now echo the form as it stands — each field's `default`, or the `suggested_value` an optional field carries — leave valueless fields out rather than sending `null`, and overlay the knobs onto the one section that declares `rate_limit_enabled`.

Refs #236 (V0.7.0 closing pass).

## Type of change

- [x] Bug fix (harness)
- [x] Documentation / tooling / CI

## How was this tested?

- Live against the dev HA (main at b878bfe, to-do bridge on `todo.shopping_list`): `stress.py ratelimit` goes from the refusal above to a clean run; `rl_banner.mjs` and `reload_probe.mjs` run green and the entry's `todo_entity_id` and rate-limit options read back unchanged afterwards. Evidence in the PR thread.
- `node --check` on both `.mjs` files, `py_compile` on `stress.py`; pre-commit (ruff, ruff-format, codespell) clean.
- Both gates green on `main` (nothing outside `.claude/skills/` changed).

## Checklist

- [x] PR title follows Conventional Commits.
- [ ] Tests added/updated — the harnesses have no unit cover for their REST submits; the live runs above are the test.
- [x] Docs unchanged.

## Handover

1. **Merged / left open** — this PR, self-merged under §4 once CI is green.
2. **Test this by hand** — nothing by hand; the live runs are linked in the thread.
3. **Decisions taken against drifted notes** — none.
4. **Follow-ups** — none.
5. **State left behind** — harness-only. The dev HA's bridge is on `todo.shopping_list` and stays on.
