### PR TITLE
fix(skills): give the restart layer a budget that outlasts a post-kill boot

### DIFF
--- a/.claude/skills/test-haventory/stress.py
+++ b/.claude/skills/test-haventory/stress.py
@@ -1324,7 +1324,11 @@ async def cmd_restart() -> None:
         print("\n  waiting for HA to come back ...")
         control = None
         ready = False
-        for _ in range(30):
+        # A `docker restart` is a kill as far as Home Assistant is concerned, so the boot
+        # that follows repairs the recorder's unfinished session before it loads a single
+        # integration -- about 100 s on the dev host with a few hundred items. The budget
+        # has to outlast that, or the on-disk cross-check below never runs.
+        for _ in range(80):
             await asyncio.sleep(3)
             try:
                 c = await connect()


### PR DESCRIPTION
## Summary

`stress.py restart` waited 30 × 3 s for Home Assistant to come back after its mid-storm `docker restart`, and on the dev host the boot that follows a kill takes about 100 s: Home Assistant spends the first ~45 s before it scans `custom_components` at all and the recorder repairs its unfinished session ("could not validate that the sqlite3 database … was shutdown cleanly") before any integration loads. The layer gave up at 90 s and printed `FAIL: HA did not become ready within timeout`, so the on-disk cross-check it exists for never ran — S11's first regimen pass hit exactly that. The budget is now 80 × 3 s.

Refs #236 (V0.7.0 closing pass).

## Type of change

- [x] Documentation / tooling / CI

## How was this tested?

Live against the dev HA (main at 874758c, 558 seeded items), this branch's `stress.py restart`:

```
  docker restart issued (rc=0, 10.7s)
  storm created ~81 before restart; interrupted workers=6 (storage_error/conn-drop mid-restart is EXPECTED)
  waiting for HA to come back ...
  reconnected.
  healthy=True issues=[]
  API items_total=844 (was 758 + up to 81 storm survivors) gen=937
  health.counts == stats: PASS
  ON-DISK store: {'schema_version': 9, 'disk_items': 844, 'disk_locations': 92}
  on-disk == API (post-restart): PASS (disk 844 vs api 844)
  index-drift oracle: PASS (no drift)
  known seed items survived restart: 5/5 PASS
```

`py_compile` and pre-commit (ruff, ruff-format, codespell) clean; nothing outside `.claude/skills/` changed, both gates green on `main`.

## Checklist

- [x] PR title follows Conventional Commits.
- [ ] Tests — the harness has no unit cover for its readiness wait; the live run above is the test.
- [x] Docs unchanged.

## Handover

1. **Merged / left open** — this PR, self-merged under §4 once CI is green.
2. **Test this by hand** — nothing by hand.
3. **Decisions taken against drifted notes** — none.
4. **Follow-ups** — none.
5. **State left behind** — harness-only.
