### PR TITLE
fix(card): keep the full view's phone-width bars whole in German

### DIFF
--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -53,6 +53,49 @@ async function mount(
 }
 
 describe('hv-full-view: phone-width app bar', () => {
+  // The first row of the narrow bar holds four controls and only the heading
+  // can shrink, so the add button's label decides whether the row stays whole.
+  // "Gegenstand hinzufügen" on its own is wider than the room the row has,
+  // which squeezed the heading to "H…" and sent the overflow menu to a second
+  // row; the short label keeps the row, and the full wording is still the
+  // button's accessible name.
+  it('shortens the add button on the narrow branch without losing its name', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+      const add = q(sr, '[data-testid="full-add-item"]') as HTMLButtonElement;
+      expect(add.textContent?.trim()).toBe('Add');
+      expect(add.getAttribute('aria-label')).toBe('Add item');
+      expect(add.getAttribute('title')).toBe('Add item');
+    } finally {
+      restore();
+    }
+  });
+
+  it('spells the add button out where the bar has room for it', async () => {
+    const restore = stubViewport(false);
+    try {
+      const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+      const add = q(sr, '[data-testid="full-add-item"]') as HTMLButtonElement;
+      expect(add.textContent?.trim()).toBe('Add item');
+      expect(add.getAttribute('aria-label')).toBe('Add item');
+    } finally {
+      restore();
+    }
+  });
+
+  // The crumb and its count can fill a phone-width row on their own. The
+  // filter toggle and the column picker then have to move down together:
+  // as separate flex items the picker wrapped alone under the toggle.
+  it('moves the filter toggle and the column picker as one unit', async () => {
+    const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+    const toggle = q(sr, '[data-testid="full-filters-toggle"]') as HTMLElement;
+    const columns = q(sr, '[data-testid="columns-expanded"]') as HTMLElement;
+    expect(toggle.parentElement).toBe(columns.parentElement);
+    expect(toggle.parentElement?.classList.contains('context-actions')).toBe(true);
+    expect(toggle.parentElement?.parentElement?.classList.contains('context')).toBe(true);
+    expect(componentCss('hv-full-view')).toMatch(/\.context-actions \{[^}]*margin-left: auto/);
+  });
 
   it('keeps the apply button out of the scroll, where the count is visible', async () => {
     const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -534,6 +534,13 @@ export class HVFullView extends LitElement {
         padding: 12px 20px;
         flex-wrap: wrap;
       }
+      .context-actions {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-left: auto;
+      }
       .crumb {
         font-size: 13px;
         color: var(--hv-text-secondary);
@@ -1731,44 +1738,49 @@ export class HVFullView extends LitElement {
               : null}
           </span>
         </span>
-        <span class="spacer"></span>
-        ${filterCount > 0
-          ? html`<hv-filter-chips
-              .statuses=${this.st?.statuses ?? null}
-              .filters=${filters}
-              .locations=${st?.locationsFlatCache ?? null}
-              .areas=${st?.areasCache?.areas ?? []}
-              @remove-filter=${(e: CustomEvent) =>
-                this._setFilters((e.detail as { patch: Partial<StoreFilters> }).patch)}
-              @clear-filters=${() => this.store?.clearFilters()}
-            ></hv-filter-chips>`
-          : null}
-        <button
-          class="filters-button ${this._filtersOpen ? 'on' : ''}"
-          data-testid="full-filters-toggle"
-          aria-expanded=${String(this._filtersOpen)}
-          aria-controls=${FILTER_PANEL_ID}
-          @click=${() => {
-            this._filtersOpen = !this._filtersOpen;
-            // The phone panel stages its edits, so its button has a number to
-            // print from the moment it opens.
-            if (this._filtersOpen && this._narrow) this._priceStaged(filters);
-          }}
-        >
-          ${icon('tune', 16)}${t('hv.card.filters')}
-        </button>
-        <button
-          class="hv-icon-button"
-          data-testid="columns-expanded"
-          aria-label=${t('hv.fullView.chooseColumns')}
-          title=${t('hv.fullView.chooseColumns')}
-          @click=${() =>
-            this.dispatchEvent(
-              new CustomEvent('menu-action', { detail: { id: 'columns' }, bubbles: true, composed: true }),
-            )}
-        >
-          ${icon('viewColumn', 20)}
-        </button>
+        <!-- One flex item for everything right of the crumb, so that when the
+             crumb and its count fill a phone-width row the chips and both
+             buttons move to the next line together, rather than the column
+             picker wrapping on its own under the filter button. -->
+        <span class="context-actions">
+          ${filterCount > 0
+            ? html`<hv-filter-chips
+                .statuses=${this.st?.statuses ?? null}
+                .filters=${filters}
+                .locations=${st?.locationsFlatCache ?? null}
+                .areas=${st?.areasCache?.areas ?? []}
+                @remove-filter=${(e: CustomEvent) =>
+                  this._setFilters((e.detail as { patch: Partial<StoreFilters> }).patch)}
+                @clear-filters=${() => this.store?.clearFilters()}
+              ></hv-filter-chips>`
+            : null}
+          <button
+            class="filters-button ${this._filtersOpen ? 'on' : ''}"
+            data-testid="full-filters-toggle"
+            aria-expanded=${String(this._filtersOpen)}
+            aria-controls=${FILTER_PANEL_ID}
+            @click=${() => {
+              this._filtersOpen = !this._filtersOpen;
+              // The phone panel stages its edits, so its button has a number to
+              // print from the moment it opens.
+              if (this._filtersOpen && this._narrow) this._priceStaged(filters);
+            }}
+          >
+            ${icon('tune', 16)}${t('hv.card.filters')}
+          </button>
+          <button
+            class="hv-icon-button"
+            data-testid="columns-expanded"
+            aria-label=${t('hv.fullView.chooseColumns')}
+            title=${t('hv.fullView.chooseColumns')}
+            @click=${() =>
+              this.dispatchEvent(
+                new CustomEvent('menu-action', { detail: { id: 'columns' }, bubbles: true, composed: true }),
+              )}
+          >
+            ${icon('viewColumn', 20)}
+          </button>
+        </span>
       </div>
     `;
   }
@@ -1988,12 +2000,20 @@ export class HVFullView extends LitElement {
                 ${t('hv.card.badge.checkedOut', { count: counts.checked_out_count })}
               </button>`
             : null}
+          <!-- On a phone the bar's first row holds the menu, this button, the
+               organize pin and the overflow, and only the heading can shrink.
+               The full German label is wider than the row has left, which
+               squeezed the heading to "H…" and pushed the overflow onto a
+               second row; the short label the card header uses keeps the row
+               whole. The full wording stays on the accessible name. -->
           <button
             class="add"
             data-testid="full-add-item"
+            aria-label=${t('hv.card.addItem')}
+            title=${t('hv.card.addItem')}
             @click=${() => this._leaveEditor('new')}
           >
-            ${icon('plus', 16)}${t('hv.card.addItem')}
+            ${icon('plus', 16)}${t(this._narrow ? 'hv.card.addShort' : 'hv.card.addItem')}
           </button>
           <button
             class="tap"


### PR DESCRIPTION
## Summary

On a phone the full view's app bar did not fit its first row in German: "Gegenstand hinzufügen" on the add button is wider than the room the row has once the menu, the organize pin and the overflow are placed, and the heading was the only thing allowed to shrink — so it collapsed to "H…" and the overflow wrapped onto a second row on its own. The list toolbar had the same shape: the crumb and its count fill the row and the column picker, a separate flex item, wrapped alone under the Filter button.

Two changes in `hv-full-view`:

- On the narrow branch the add button shows the short label the card header already uses (`hv.card.addShort`, "Add"/"Neu"); the full wording stays on `aria-label` and `title`, so its accessible name does not change.
- The toolbar's filter chips, filter toggle and column picker are one flex item (`.context-actions`, `margin-left: auto`), so when the crumb needs the row they move down together.

English is unchanged on a desktop and one label shorter on a phone. German is new in 0.7.0, so this is a new bug rather than a regression; S8's own `m-08-full-view` capture already showed the clipped heading.

Closes #558.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- Three new tests in `hv-full-view.test.ts`: the narrow branch shows the short label and keeps the full one as the name; the wide branch spells it out; the toggle and the picker share one `.context-actions` parent that carries `margin-left: auto`.
- Frontend gate in the branch worktree: `npx eslint .`, `npm run typecheck`, `npx vitest run` → 66 files / **1796 passed** (1793 on `main`), `npm run build`.
- Backend untouched; the backend gate is green on `main` at 874758c (1277 passed / 22 skipped, ruff, format, mypy).
- Live on the dev HA with the profile in German, 375×812, bundle deployed by hash:

| | before | after |
|---|---|---|
| `/haventory` | ![before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s11/s11/panel-375-de-before.png) | ![after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s11/s11/panel-375-de-after.png) |
| card full view | ![before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s11/s11/card-full-view-375-de-before.png) | ![after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-s11/s11/card-full-view-375-de-after.png) |

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + the wide-branch counterpart).
- [x] Docs unchanged — no behaviour a user configures changed.
- [x] No WebSocket API change.
- [x] Invariants untouched.

## Handover

1. **Merged / left open** — this PR, self-merged under §4 once CI is green.
2. **Test this by hand** — `[phone]` open `/haventory` in German on a real phone: the blue bar reads "HAventory · + Neu · 📍 · ⋮" on one row, and under it "Alle Gegenstände · 558 Gegenstände" with the Filter and columns buttons together on the next line. Tap "+ Neu": the editor opens as before.
3. **Decisions taken against drifted notes** — none.
4. **Follow-ups** — the German filter sheet's footer wraps its three actions onto two lines each at 375 px (legible; noted on #558 for the wording pass #540, not filed on its own).
5. **State left behind** — the dev HA serves this branch's bundle (deployed for the live check); `main` is redeployed after the merge.
