### PR TITLE
fix(calendar): write event summaries in the server language

### DIFF
--- a/custom_components/haventory/calendar.py
+++ b/custom_components/haventory/calendar.py
@@ -11,6 +11,7 @@ over on a day nobody touched the inventory.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
@@ -20,15 +21,28 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_change
+from homeassistant.helpers.translation import async_get_translations
 from homeassistant.util import dt as dt_util
 
-from .calendar_projection import ProjectedEvent, build_events, next_event, window_dates
+from .calendar_projection import (
+    SUMMARY_PATTERNS,
+    ProjectedEvent,
+    build_events,
+    next_event,
+    window_dates,
+)
 from .const import CALENDAR_UNIQUE_ID, DOMAIN, INTEGRATION_VERSION, SIGNAL_INVENTORY_CHANGED
 from .logs import context_logger
 from .models import Item
 from .runtime import find_runtime
 
 LOGGER = context_logger(__name__)
+
+# Which section of `strings.json` the summary patterns live in. Home Assistant
+# reads any top-level section as a translation category, but hassfest validates
+# `strings.json` against a fixed set of them and rejects an invented one, so the
+# three patterns sit in `common` under `calendar_`-prefixed keys.
+TRANSLATION_CATEGORY = "common"
 
 
 async def async_setup_entry(
@@ -55,6 +69,7 @@ class HaventoryCalendar(CalendarEntity):
         # declares `single_config_entry`, so there is never a second one to tell
         # this apart from, and the reserved entity_id is pinned to this string.
         self._attr_unique_id = CALENDAR_UNIQUE_ID
+        self._summaries: Mapping[str, str] = SUMMARY_PATTERNS
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="HAventory",
@@ -67,6 +82,7 @@ class HaventoryCalendar(CalendarEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to the two things that move the reported event."""
 
+        self._summaries = await _async_summaries(self.hass)
         self.async_on_remove(
             async_dispatcher_connect(self.hass, SIGNAL_INVENTORY_CHANGED, self._handle_update)
         )
@@ -98,7 +114,7 @@ class HaventoryCalendar(CalendarEntity):
         items = self._items()
         if items is None:
             return None
-        upcoming = next_event(items, dt_util.now().date())
+        upcoming = next_event(items, dt_util.now().date(), summaries=self._summaries)
         return _as_calendar_event(upcoming) if upcoming is not None else None
 
     async def async_get_events(
@@ -110,7 +126,10 @@ class HaventoryCalendar(CalendarEntity):
         if items is None:
             return []
         start, end = window_dates(dt_util.as_local(start_date), dt_util.as_local(end_date))
-        return [_as_calendar_event(event) for event in build_events(items, start, end)]
+        return [
+            _as_calendar_event(event)
+            for event in build_events(items, start, end, summaries=self._summaries)
+        ]
 
     def _items(self) -> list[Item] | None:
         """Every item, or none while the entry is unloaded.
@@ -133,6 +152,30 @@ class HaventoryCalendar(CalendarEntity):
             )
             return None
         return list(result["items"])
+
+
+async def _async_summaries(hass: HomeAssistant) -> Mapping[str, str]:
+    """The three summary patterns, in the language the server runs in.
+
+    `hass.config.language` rather than the reading user's: an event summary is
+    also `calendar.haventory`'s `message` attribute, which an automation
+    templates, and an entity's state has one language — the server's, which is
+    what Home Assistant names its own entities in.
+
+    Resolved once, on the entity, because `CalendarEntity.event` is a
+    synchronous property that cannot await one. Home Assistant loads English
+    first and lays the requested language over it, so a key a translation has
+    not reached keeps its English pattern with nothing to arrange here.
+    """
+
+    resources = await async_get_translations(
+        hass, hass.config.language, TRANSLATION_CATEGORY, integrations=[DOMAIN]
+    )
+    prefix = f"component.{DOMAIN}.{TRANSLATION_CATEGORY}."
+    return {
+        kind: resources.get(f"{prefix}calendar_{kind}", default)
+        for kind, default in SUMMARY_PATTERNS.items()
+    }
 
 
 def _as_calendar_event(event: ProjectedEvent) -> CalendarEvent:

--- a/custom_components/haventory/calendar_projection.py
+++ b/custom_components/haventory/calendar_projection.py
@@ -15,9 +15,10 @@ occurrences the window covers, and none of them is written anywhere.
 from __future__ import annotations
 
 from calendar import monthrange
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
+from types import MappingProxyType
 
 from .logs import context_logger
 from .models import Item, ReminderInterval
@@ -38,6 +39,19 @@ _REPORTED_UNREADABLE: set[tuple[str, str, str]] = set()
 KIND_DUE = "due"
 KIND_INSPECTION = "inspection"
 KIND_REMINDER = "reminder"
+
+# How each kind's summary is written, keyed by kind. English, because this
+# module has no Home Assistant to ask; `calendar.py` resolves the household's
+# language once and passes the result in. The item's name is a `{name}`
+# placeholder rather than a suffix so a translation can put the noun where its
+# language puts it.
+SUMMARY_PATTERNS: Mapping[str, str] = MappingProxyType(
+    {
+        KIND_DUE: "{name} due back",
+        KIND_INSPECTION: "{name} inspection",
+        KIND_REMINDER: "{name} reminder",
+    }
+)
 
 # What one item's reminder may contribute to one window. A bound on the answer,
 # not on the data: a daily reminder against a decade-wide window is a request
@@ -82,7 +96,13 @@ def window_dates(start: datetime, end: datetime) -> tuple[date, date]:
     return start.date(), (last + _ONE_DAY if end.time() != time.min else last)
 
 
-def build_events(items: Iterable[Item], start: date, end: date) -> list[ProjectedEvent]:
+def build_events(
+    items: Iterable[Item],
+    start: date,
+    end: date,
+    *,
+    summaries: Mapping[str, str] = SUMMARY_PATTERNS,
+) -> list[ProjectedEvent]:
     """Every occurrence inside `[start, end)`, ordered for display.
 
     A date exactly on `start` is included and one exactly on `end` is not, which
@@ -90,10 +110,15 @@ def build_events(items: Iterable[Item], start: date, end: date) -> list[Projecte
     produces.
     """
 
-    return sorted(_iter_events(items, start, end), key=_order)
+    return sorted(_iter_events(items, start, end, summaries=summaries), key=_order)
 
 
-def next_event(items: Iterable[Item], on_or_after: date) -> ProjectedEvent | None:
+def next_event(
+    items: Iterable[Item],
+    on_or_after: date,
+    *,
+    summaries: Mapping[str, str] = SUMMARY_PATTERNS,
+) -> ProjectedEvent | None:
     """The earliest occurrence from `on_or_after` onwards, or none.
 
     What the entity reports as its state. An all-day occurrence covers the whole
@@ -106,7 +131,11 @@ def next_event(items: Iterable[Item], on_or_after: date) -> ProjectedEvent | Non
     window costs no more than a bounded one.
     """
 
-    return min(_iter_events(items, on_or_after, date.max, limit=1), key=_order, default=None)
+    return min(
+        _iter_events(items, on_or_after, date.max, limit=1, summaries=summaries),
+        key=_order,
+        default=None,
+    )
 
 
 def next_occurrence_after(
@@ -124,28 +153,49 @@ def next_occurrence_after(
 
 
 def _iter_events(
-    items: Iterable[Item], start: date, end: date, *, limit: int = MAX_REMINDER_OCCURRENCES
+    items: Iterable[Item],
+    start: date,
+    end: date,
+    *,
+    limit: int = MAX_REMINDER_OCCURRENCES,
+    summaries: Mapping[str, str] = SUMMARY_PATTERNS,
 ) -> Iterator[ProjectedEvent]:
     for item in items:
-        yield from _item_events(item, start, end, limit=limit)
+        yield from _item_events(item, start, end, limit=limit, summaries=summaries)
 
 
-def _item_events(item: Item, start: date, end: date, *, limit: int) -> Iterator[ProjectedEvent]:
-    for kind, stored, summary in (
-        (KIND_DUE, item.due_date, f"{item.name} due back"),
-        (KIND_INSPECTION, item.inspection_date, f"{item.name} inspection"),
+def _summary(summaries: Mapping[str, str], kind: str, item: Item) -> str:
+    """One event's title, from the pattern its kind is written with.
+
+    Substituted rather than `str.format`ted: an item name may hold braces, and a
+    translation Home Assistant could not parse would otherwise raise here and
+    cost the whole calendar its events rather than that one row its title.
+    """
+
+    pattern = summaries.get(kind) or SUMMARY_PATTERNS[kind]
+    return pattern.replace("{name}", item.name)
+
+
+def _item_events(
+    item: Item, start: date, end: date, *, limit: int, summaries: Mapping[str, str]
+) -> Iterator[ProjectedEvent]:
+    for kind, stored in (
+        (KIND_DUE, item.due_date),
+        (KIND_INSPECTION, item.inspection_date),
     ):
         if stored is None:
             continue
         day = _stored_date(item, f"{kind}_date", stored)
         if day is None or not (start <= day < end):
             continue
-        yield _event(item, kind, summary, day, uid=f"{item.id}:{kind}")
+        yield _event(item, kind, _summary(summaries, kind, item), day, uid=f"{item.id}:{kind}")
 
-    yield from _reminder_events(item, start, end, limit=limit)
+    yield from _reminder_events(item, start, end, limit=limit, summaries=summaries)
 
 
-def _reminder_events(item: Item, start: date, end: date, *, limit: int) -> Iterator[ProjectedEvent]:
+def _reminder_events(
+    item: Item, start: date, end: date, *, limit: int, summaries: Mapping[str, str]
+) -> Iterator[ProjectedEvent]:
     """Every occurrence of the item's reminder inside `[start, end)`.
 
     With no interval `reminder_date` is the whole series — a one-off. With one,
@@ -162,7 +212,7 @@ def _reminder_events(item: Item, start: date, end: date, *, limit: int) -> Itera
     if occurrence is None:
         return
     interval = item.reminder_interval
-    summary = f"{item.name} reminder"
+    summary = _summary(summaries, KIND_REMINDER, item)
 
     if interval is None:
         if start <= occurrence < end:

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -1,4 +1,9 @@
 {
+  "common": {
+    "calendar_due": "{name} due back",
+    "calendar_inspection": "{name} inspection",
+    "calendar_reminder": "{name} reminder"
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/haventory/translations/de.json
+++ b/custom_components/haventory/translations/de.json
@@ -1,4 +1,9 @@
 {
+  "common": {
+    "calendar_due": "Rückgabe: {name}",
+    "calendar_inspection": "Prüfung: {name}",
+    "calendar_reminder": "Erinnerung: {name}"
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -1,4 +1,9 @@
 {
+  "common": {
+    "calendar_due": "{name} due back",
+    "calendar_inspection": "{name} inspection",
+    "calendar_reminder": "{name} reminder"
+  },
   "config": {
     "step": {
       "user": {

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -111,6 +111,11 @@ school holidays and bin collections:
 | `Extinguisher inspection` | the `inspection_date` on any item |
 | `HVAC filter reminder` | the **reminder** on any item, and every repeat of it |
 
+The titles above are the English ones. A summary is written in the language Home Assistant
+itself runs in — Settings → System → General — not the reading user's, because the same text
+is `calendar.haventory`'s `message` attribute and an automation templating it gets one
+answer whoever is looking.
+
 Each is an all-day event on its date, described by the item's location path. The entity's
 attributes always carry the nearest event still to come, however far out it is; its state
 follows Home Assistant's own convention and reads `on` only while an event is actually

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -101,6 +101,39 @@ async def test_async_get_events_projects_both_dated_fields(hass: HomeAssistant) 
     assert projected[0]["end"] == (due + timedelta(days=1)).isoformat()
 
 
+async def test_the_summaries_are_written_in_the_servers_language(hass: HomeAssistant) -> None:
+    """Both surfaces the text reaches, in German: the event a calendar card
+    lists and the `message` attribute a notification automation templates.
+
+    Only real here — the patterns come from `translations/de.json` through Home
+    Assistant's own loader, which the offline suite has no counterpart for.
+    """
+
+    hass.config.language = "de"
+    await _setup(hass)
+
+    today = dt_util.now().date()
+    await _create(hass, name="Leiter", checked_out=True, due_date=today.isoformat())
+    await _create(
+        hass, name="Feuerlöscher", inspection_date=(today + timedelta(days=5)).isoformat()
+    )
+
+    assert hass.states.get(ENTITY_ID).attributes["message"] == "Rückgabe: Leiter"
+
+    window_end = dt_util.start_of_local_day() + timedelta(days=30)
+    events = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {"entity_id": ENTITY_ID, "end_date_time": window_end},
+        blocking=True,
+        return_response=True,
+    )
+    assert [e["summary"] for e in events[ENTITY_ID]["events"]] == [
+        "Rückgabe: Leiter",
+        "Prüfung: Feuerlöscher",
+    ]
+
+
 async def test_checking_an_item_out_due_today_turns_the_calendar_on(hass: HomeAssistant) -> None:
     """A mutation repaints the entity with no polling and no time travel.
 

--- a/tests/test_calendar_offline.py
+++ b/tests/test_calendar_offline.py
@@ -441,3 +441,71 @@ def test_a_reminder_with_no_anchor_projects_from_its_own_date() -> None:
     events = build_events([item], WINDOW_START, date(2026, 11, 1))
 
     assert [e.start for e in events] == [date(2026, 8, 10), date(2026, 9, 10), date(2026, 10, 10)]
+
+
+# ---------------------------------------------------------------------------
+# Summary patterns — the household's language reaches every kind
+# ---------------------------------------------------------------------------
+
+GERMAN = {
+    KIND_DUE: "Rückgabe: {name}",
+    KIND_INSPECTION: "Prüfung: {name}",
+    KIND_REMINDER: "Erinnerung: {name}",
+}
+
+
+def test_passed_patterns_are_applied_to_all_three_kinds() -> None:
+    """The whole point: no summary is written in this module's own language."""
+
+    ladder = _item("Ladder", due="2026-08-10")
+    extinguisher = _item("Extinguisher", inspection="2026-08-20")
+    filter_change = _reminder("HVAC filter", anchor="2026-08-25")
+
+    events = build_events(
+        [ladder, extinguisher, filter_change], WINDOW_START, WINDOW_END, summaries=GERMAN
+    )
+
+    assert [e.summary for e in events] == [
+        "Rückgabe: Ladder",
+        "Prüfung: Extinguisher",
+        "Erinnerung: HVAC filter",
+    ]
+
+
+def test_next_event_writes_its_summary_the_same_way() -> None:
+    """The entity's state attribute comes through here, not `build_events`."""
+
+    ladder = _item("Ladder", due="2026-08-10")
+
+    german = next_event([ladder], WINDOW_START, summaries=GERMAN)
+    assert german is not None and german.summary == "Rückgabe: Ladder"
+
+    english = next_event([ladder], WINDOW_START)
+    assert english is not None and english.summary == "Ladder due back"
+
+
+def test_a_kind_the_patterns_are_missing_keeps_its_english() -> None:
+    """A translation that has not reached every key still projects a summary.
+
+    Home Assistant lays the requested language over English before this is
+    built, so a gap here means a mapping assembled some other way — and the
+    English pattern is a better answer than a title-less event.
+    """
+
+    events = build_events(
+        [_item("Ladder", due="2026-08-10"), _item("Extinguisher", inspection="2026-08-20")],
+        WINDOW_START,
+        WINDOW_END,
+        summaries={KIND_INSPECTION: "Prüfung: {name}"},
+    )
+
+    assert [e.summary for e in events] == ["Ladder due back", "Prüfung: Extinguisher"]
+
+
+def test_braces_in_an_item_name_survive_the_substitution() -> None:
+    """A name is a value, never part of the pattern: households label things
+    `{spare}` and a formatter would raise on one."""
+
+    events = build_events([_item("Fuse {spare}", due="2026-08-10")], WINDOW_START, WINDOW_END)
+
+    assert [e.summary for e in events] == ["Fuse {spare} due back"]


### PR DESCRIPTION
## Summary

`calendar.haventory` wrote its three event summaries as f-string literals in the projection,
so a German household read `Beamer Epson EH-TW7000 due back` under a German `Ganztägig`, and
the same English text reached the entity's `message` attribute — which is what a notification
automation templates.

The patterns move into the string catalog as `{name}` placeholders, so a translation can put
its noun where its language puts it rather than after the name. `calendar_projection` takes
them as a keyword argument defaulting to English and stays free of Home Assistant;
`HaventoryCalendar` resolves them **once**, in `async_added_to_hass`, because
`CalendarEntity.event` is a synchronous property that cannot await one, and the server's
language does not change without a restart.

`hass.config.language`, not the reading user's: one entity state has one language, and Home
Assistant names its own entities in the server's.

Closes #562

### The design changed in one place, against the plan

`dev/V0_7_0_fixups.md` §2.F1 puts the patterns in a **`calendar` section** of `strings.json`.
That would fail CI: hassfest validates `strings.json` against a strict `vol.Schema` whose
top-level keys are a fixed list (`title`, `config`, `options`, `selector`, `entity`,
`services`, `exceptions`, `common`, …), and an invented `calendar` key is rejected. Home
Assistant's *runtime* loader is the permissive half — `helpers/translation.py`'s
`build_resources` reads any top-level section as a category — which is what the plan checked.

So the three keys sit in `common`, which the schema defines as `{cv.slug: str}` with no extra
rules, under a `calendar_` prefix. Verified against the running core before writing anything —
`automation` ships `common.validation_failed_title` with a `{name}` placeholder, and asking
the live instance for it returns the German:

```
$ driver.py send '{"type":"frontend/get_translations","language":"de",
                   "category":"common","integration":["automation"]}'
"component.automation.common.validation_failed_title":
  "Automation {name} konnte nicht eingerichtet werden"
```

Two smaller notes:

- **No `homeassistant.helpers.translation` stub in `tests/conftest.py`**, which §2.F1 also
  asks for. `homeassistant.components.calendar` is not stubbed either, so `calendar.py` cannot
  be imported offline at all and the stub would pin nothing on its own. The plan's own reason
  stands unchanged: the phacc test is what proves the real path.
- The pattern is applied with `str.replace`, not `str.format`. A name may hold braces —
  households label things `{spare}` — and HA's placeholder validator *keeps* a translation its
  parser chokes on (`except ValueError: continue`), so a formatter here could raise and cost
  the whole calendar its events rather than one row its title.

### German

`Rückgabe: {name}`, `Prüfung: {name}`, `Erinnerung: {name}` — the nouns the card's own German
dictionary already uses for these three fields (`hv.editor.dueDate` → *Rückgabedatum*,
`hv.column.inspection_date` → *Nächste Prüfung*, `hv.column.reminder_date` → *Erinnerung*).
Noun first, because that is what the placeholder is for. English is unchanged, so every
existing assertion keeps its meaning.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `1281 passed, 22 skipped` · `ruff check` clean · `ruff format --check` clean ·
      `mypy` clean (26 source files)
- [x] Frontend (`cards/haventory-card`): `eslint` clean · `typecheck` clean ·
      `vitest 1796 passed / 66 files` · `build` OK
- [x] **phacc** (container recipe, required for anything under `custom_components/`):
      `144 passed in 115.97s`

New tests:

| Where | What |
|---|---|
| `test_calendar_offline.py` | passed patterns reach all three kinds; `next_event` writes its summary the same way; a kind the mapping is missing keeps its English; **braces in an item name survive** |
| `tests/integration/test_calendar.py` | with `hass.config.language = "de"`, both the `message` attribute and the `get_events` summaries are German — through HA's own loader and `translations/de.json` |

`tests/test_config_flow_offline.py` already fails a language that does not mirror
`strings.json` and one whose placeholders differ, so `en.json`/`de.json` are held to the new
keys with no new test.

### Live check

Dev Home Assistant set to Deutsch (Settings → System → General), integration redeployed,
container restarted. The two items #562 named by hand:

```
2026-08-22  Erinnerung: Katzenfutter Nassfutter (Karton 24)
2026-08-22  Prüfung: Erste-Hilfe-Kasten
2026-08-22  Prüfung: Rauchmelder Wohnzimmer
2026-08-22  Rückgabe: Beamer Epson EH-TW7000
2026-08-22  Rückgabe: Leinwand 100" mobil
2026-08-24  Erinnerung: Pool-Chlortabletten
```

and `calendar.haventory`'s `message` attribute read
`Erinnerung: Katzenfutter Nassfutter (Karton 24)`.

## Screenshots (card / UI changes)

The same surface #562 photographed, after — a core `calendar` card on the dev dashboard's
`Kalender` view, German instance:

![calendar card in German, after](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-fixups/f1/calendar-card-de-after.png)

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs updated where behavior changed — `docs/automations.md` now says the summary is
      written in the server's language and why it is not the reader's.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Handover

1. **Merged / left open** — this is the first of four; nothing else is open from this session
   yet. Assets branch `claude-assets-v0-7-0-fixups`.
2. **Test this by hand** — `[HA settings]` a German native reader on the three summaries:
   *Rückgabe / Prüfung / Erinnerung* are the card's own established nouns, but noun-colon-name
   is a new sentence shape nothing else in the product uses. `[log]` nothing — the change adds
   no log line.
3. **Decisions taken against drifted notes** — the `common`-vs-`calendar` section above, the
   dropped conftest stub, and `replace` over `format`.
4. **Follow-ups** — none found in this file.
5. **State left behind** — the dev Home Assistant's **server language is currently `de`**; it
   was `en` (country AT, tz UTC) and the session restores it in its closing pass.
