### PR TITLE
fix(card): keep the phone editor's action row on one line in German

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -672,6 +672,16 @@ destructive clean-start mode), then `Online smoke test completed successfully.`
   crash but leaves no console output and no HA log entry. `screenshot.mjs` blocks
   service workers for this reason; the resulting single `navigator.serviceWorker is
   undefined` console error comes from HA's own bundle, not the card.
+- **`--full` mis-paints a fixed sheet on a page that scrolls.** A `fullPage` capture
+  stitches the document at its own height, and the card's sheets are
+  `position: fixed; bottom: 0; max-height: 92dvh` — so on a page even 28px taller than the
+  viewport the panel's edge and the content slotted into it are painted against two
+  different heights, and whatever sits at the top of the sheet comes out clipped by about
+  9px. Nothing is clipped in the DOM: `getBoundingClientRect()` in the same state puts the
+  panel at 65 and the pill at 74. This is what produced
+  [#560](https://github.com/chrreiter/HAventory/issues/560)'s screenshot. Photograph a
+  sheet with a plain viewport capture (what `visual_pass.mjs` does), and read a rect before
+  believing a `--full` picture of one.
 - **HA dark mode is independent of the OS `prefers-color-scheme`** — a card has to be
   checked in all four combinations. Drive HA's side with a `selectedTheme`
   localStorage entry (`{"dark":true}`) before load, the OS side with

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1,4 +1,4 @@
-import { setLanguage } from '../i18n';
+import { setLanguage, t } from '../i18n';
 import './hv-item-editor';
 import {
   all,
@@ -528,6 +528,28 @@ describe('hv-item-editor: saving', () => {
       'editor-save',
     ]);
     expect(editorCss()).toMatch(/\.actions \.spacer \{[^}]*margin-left: auto/);
+  });
+
+  // Measured at 375px in the panel's detail sheet: the row has 343px and the
+  // three German labels plus their gaps want 352.2, so Save dropped onto a line
+  // of its own at the left edge. The verb alone costs the row 78px.
+  it('shows Delete as the bare verb on a phone and the whole phrase elsewhere', async () => {
+    const narrow = await mount(makeItem({ id: '1', name: 'A' }), { mobile: true });
+    const wide = await mount(makeItem({ id: '1', name: 'A' }));
+
+    const label = (el: Element) =>
+      q(el, '[data-testid="editor-delete"]')?.textContent?.trim();
+    expect(label(narrow)).toBe(t('hv.action.delete'));
+    expect(label(wide)).toBe(t('hv.action.deleteItem'));
+    expect(label(narrow)).not.toBe(label(wide));
+
+    // Shorter on the screen, unchanged to a screen reader — on both branches,
+    // so the name never depends on the width.
+    for (const el of [narrow, wide]) {
+      expect(q(el, '[data-testid="editor-delete"]')?.getAttribute('aria-label')).toBe(
+        t('hv.action.deleteItem'),
+      );
+    }
   });
 
   // Three buttons in one row, three shapes: measured at a 390px viewport in the

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -746,7 +746,12 @@ export class HVItemEditor extends LitElement {
       }
       /* Delete is hv-text-button danger from the shared sheet — the same
          borderless red every other destructive action in the card uses (the
-         detail sheet's own Delete item, the organize dialog's Delete). */
+         detail sheet's own Delete item, the organize dialog's Delete).
+         The row is Delete, Cancel and Save, and only three labels wide: at
+         375px it has 343px to spend, which German's full "Gegenstand löschen"
+         overruns by 9px and drops Save onto a line of its own. That is why the
+         narrow branch shows the bare verb; wrap stays as the last resort for a
+         language longer still. */
       .actions {
         display: flex;
         align-items: center;
@@ -2817,6 +2822,7 @@ export class HVItemEditor extends LitElement {
                 ? html`<button
                     class="hv-text-button danger"
                     data-testid="editor-delete"
+                    aria-label=${t('hv.action.deleteItem')}
                     @click=${() =>
                       this.dispatchEvent(
                         new CustomEvent('delete-item', {
@@ -2826,7 +2832,7 @@ export class HVItemEditor extends LitElement {
                         }),
                       )}
                   >
-                    ${t('hv.action.deleteItem')}
+                    ${t(this.mobile ? 'hv.action.delete' : 'hv.action.deleteItem')}
                   </button>`
                 : null}
               <span class="spacer"></span>


### PR DESCRIPTION
## Summary

#560 reports two things about the phone-width detail sheet. The plan
(`dev/V0_7_0_fixups.md` §2.F2) said to measure before touching anything, and the measurement
splits them: **one is a real layout bug and is fixed here; the other is an artifact of how
the screenshot was taken.**

Closes #560

## 1. The German footer wrap — real, fixed

Measured live at 375px in the panel's detail sheet, `hv-item-editor`'s sticky action row:

| | before |
|---|---|
| row has | **343.0px** |
| row wants | **352.2px** — `Gegenstand löschen` 142.9 + `Abbrechen` 87.0 + `Speichern` 98.3 + 3 × 8px gap |
| short by | **9.2px** |
| result | `flex-wrap` drops Save onto a second line at the left edge; the row grows 48px → **100px** |

The narrow branch now shows Delete as the bare verb — `hv.action.delete`, a key the card
already ships in both languages — with the whole phrase kept as the button's `aria-label`.
That is the same shape #561 used on the app bar's add button one commit earlier.

| | after |
|---|---|
| row wants | **282.7px** of 343 — `Löschen` 73.4 + `Abbrechen` 87.0 + `Speichern` 98.3 + gaps |
| headroom | **60.3px** |
| result | one row, height back to **48px** |

`flex-wrap: wrap` stays as the last resort for a language longer still. English is
unaffected in width and reads `Delete` instead of `Delete item` on a phone only.

| before (de) | after (de) | after (en) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-fixups/f2/phone-editor-de-before.png) | ![after de](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-fixups/f2/phone-editor-de-after.png) | ![after en](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-fixups/f2/phone-editor-en-after.png) |

## 2. The clipped Save pill — not a product bug

§1 of the plan already flagged that nothing in the CSS explains it. The measurement says why:
**there is nothing to explain.** In the exact state the issue describes — `/haventory`, 375px,
row → edit — the live rects are:

```
panel (.sheet)     top 65   height 747   max-height 92dvh = 747.04px
bar   (.bar.edit)  top 66   height  57
pill  (sheet-save) top 74   height  40
```

Nine pixels of clearance, in English and German alike, and no ancestor between the pill and
the panel sets `overflow`, `clip-path` or a mask.

What produced the screenshot is the capture. S11's image is **750×1680 = 375×840 CSS** — 28px
taller than the 812 viewport, so it is a `--full` (`fullPage`) capture of a page that
scrolled. The sheet is `position: fixed; bottom: 0; max-height: 92dvh`; a stitched capture
lays the document out at its own height, so the panel's edge and the content slotted into it
end up painted against two different viewport heights and whatever sits at the top of the
sheet comes out clipped.

Reproduced on purpose, on today's `main`, by growing the document 28px and capturing both
ways in the same run:

| `--full` on a scrolling page — **750×1680**, byte-identical dimensions to the issue's image | plain viewport capture, same state — **750×1624** |
|---|---|
| ![artifact](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-fixups/f2/fullpage-capture-artifact.png) | ![clean](https://raw.githubusercontent.com/chrreiter/HAventory/claude-assets-v0-7-0-fixups/f2/viewport-capture-same-state.png) |

The left one clips the pill and the right one does not, from the same DOM, in the same
browser, milliseconds apart.

And the page only scrolled because of the app bar: S11's screenshot shows the heading
collapsed to `HAv…` and the overflow button gone, which is **#558** — the wrapped second row
is where the extra 28px came from. **#561 (34297f9) fixed #558 one commit after #560 was
filed**, so the panel page is now exactly 812 tall and the pill is whole either way. Nothing
in `hv-detail-sheet.ts`, `hv-bottom-sheet.ts` or `hv-item-editor.ts` changed between the
issue's base (874758c) and now — `git log 874758c..HEAD` on those three files is empty — so
this is not "fixed by accident and unverified": the sheet is byte-identical and the condition
that made the capture lie is gone.

The trap is now a gotcha in the `run-haventory` skill, because it cost one false bug report
and would cost the next one too: `visual_pass.mjs` captures the viewport, but
`screenshot.mjs --full` does not, and a fixed sheet is exactly what it mis-paints.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `1281 passed, 22 skipped` · `ruff check` clean · `ruff format --check` clean ·
      `mypy` clean
- [x] Frontend: `eslint` clean · `typecheck` clean · `vitest 1797 passed / 66 files` ·
      `build` OK
- phacc not required — nothing under `custom_components/` changed.

New test — `hv-item-editor.test.ts`, "shows Delete as the bare verb on a phone and the whole
phrase elsewhere": the two branches render different labels (happy path plus the negative
half, `narrow !== wide`), and **both** carry the full phrase as `aria-label`, so the
accessible name never depends on the width.

### Live check

Deployed to the dev Home Assistant, server language Deutsch, and re-measured at 375px — the
numbers in the table above are that run. Both narrow surface passes green afterwards, because
six hosts mount this editor and only two of them are the sheet:

```
visual_pass.mjs --only panel-mobile   8/8   pm-01…pm-08
visual_pass.mjs --only mobile         9/9   m-layout, m-01…m-08
```

Theme was not varied: the change is which of two existing strings a button prints, which no
theme reads.

## Screenshots (card / UI changes)

Above, in both sections.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge case).
- [x] No docs change — no user-facing behaviour moved; the skill gotcha is contributor-facing.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Handover

1. **Merged / left open** — #572 (F1, calendar language) is open alongside this. Assets on
   `claude-assets-v0-7-0-fixups`.
2. **Test this by hand** — `[phone]` a real device: this is Chromium emulation at 375px, and
   the row's fit depends on the platform font, so iOS Safari and the Companion webview are
   worth one look each. `[HA settings]` a German reader on `Löschen` standing alone next to
   `Abbrechen` and `Speichern` — it matches the card's own `hv.action.delete`, but the
   sentence around it is new.
3. **Decisions taken against drifted notes** — §2.F2 assumed the clipped pill needed a CSS
   change and asked for "the smallest change those numbers justify". The numbers justify
   none, so none was made; section 2 above is the evidence rather than a claim.
4. **Follow-ups** — when a language *does* overrun the row, Save still lands bottom-left
   rather than staying with Cancel. Not filed: with 60px of headroom in the longest language
   that ships, no real household reaches it, which is below CLAUDE.md's bar.
5. **State left behind** — the dev Home Assistant's server language is still `de` (it was
   `en`, country AT); the closing pass restores it. The dev HA currently runs this branch's
   card on top of F1's backend.
