### PR TITLE
fix(card): give the locations tree one tab stop and an arrow layer

### DIFF
--- a/cards/haventory-card/src/components/hv-location-tree.test.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.test.ts
@@ -779,3 +779,178 @@ describe('hv-location-tree: the whole row is the target', () => {
     expect(q(el, '[data-testid="tree-row"][data-id="kitchen"]')?.getAttribute('tabindex')).toBe('0');
   });
 });
+
+// A tree is one tab stop with a roving tabindex, not one per row: this tree
+// stands between the full view's search box and its table, and with the seeded
+// household expanded it put more than forty stops in that gap. Tab lands on the
+// tree once, the arrows move inside it, Tab leaves.
+describe('hv-location-tree: one tab stop', () => {
+  const stops = (el: HVLocationTree) =>
+    [
+      ...(el.shadowRoot?.querySelectorAll(
+        '[data-testid="tree-row"][tabindex="0"], [data-testid="tree-area-head"][tabindex="0"]',
+      ) ?? []),
+    ] as HTMLElement[];
+
+  const press = async (el: HVLocationTree, target: Element, key: string) => {
+    target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+    await el.updateComplete;
+  };
+
+  it('leaves exactly one node focusable, whatever is open', async () => {
+    const el = await mount();
+    expect(stops(el)).toHaveLength(1);
+    expect(stops(el)[0].dataset.id).toBe('garage');
+
+    (q(el, '[data-testid="tree-twisty"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(ids(el)).toContain('shelf-a');
+    expect(stops(el)).toHaveLength(1);
+  });
+
+  it('moves the stop and the focus with ArrowDown, and back with ArrowUp', async () => {
+    const el = await mount();
+    const garage = q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLElement;
+    garage.focus();
+
+    await press(el, garage, 'ArrowDown');
+    const kitchen = q(el, '[data-testid="tree-row"][data-id="kitchen"]') as HTMLElement;
+    expect(el.shadowRoot?.activeElement).toBe(kitchen);
+    expect(stops(el)).toEqual([kitchen]);
+
+    await press(el, kitchen, 'ArrowUp');
+    expect(el.shadowRoot?.activeElement).toBe(garage);
+    expect(stops(el)).toEqual([garage]);
+  });
+
+  it('opens a closed row with ArrowRight and steps into it with the next one', async () => {
+    const el = await mount();
+    const garage = q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLElement;
+    garage.focus();
+
+    await press(el, garage, 'ArrowRight');
+    expect(ids(el)).toEqual(['garage', 'shelf-a', 'shelf-b', 'kitchen']);
+    // Opening moves nothing: the row that disclosed the children keeps focus.
+    expect(el.shadowRoot?.activeElement).toBe(garage);
+
+    await press(el, garage, 'ArrowRight');
+    expect((el.shadowRoot?.activeElement as HTMLElement)?.dataset.id).toBe('shelf-a');
+  });
+
+  it('collapses an open row with ArrowLeft and keeps focus on it', async () => {
+    const el = await mount();
+    const garage = q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLElement;
+    garage.focus();
+    await press(el, garage, 'ArrowRight');
+    expect(ids(el)).toContain('shelf-a');
+
+    await press(el, garage, 'ArrowLeft');
+    expect(ids(el)).toEqual(['garage', 'kitchen']);
+    expect(el.shadowRoot?.activeElement).toBe(garage);
+    expect(stops(el)).toEqual([garage]);
+  });
+
+  it('steps out to the parent with ArrowLeft on a closed child', async () => {
+    const el = await mount();
+    const garage = q(el, '[data-testid="tree-row"][data-id="garage"]') as HTMLElement;
+    garage.focus();
+    await press(el, garage, 'ArrowRight');
+    const shelfA = q(el, '[data-testid="tree-row"][data-id="shelf-a"]') as HTMLElement;
+    shelfA.focus();
+
+    await press(el, shelfA, 'ArrowLeft');
+    expect(el.shadowRoot?.activeElement).toBe(garage);
+    // The branch is still open — Left stepped out rather than closing it.
+    expect(ids(el)).toContain('shelf-a');
+  });
+
+  it('reaches both ends with Home and End', async () => {
+    const el = await mount();
+    const kitchen = q(el, '[data-testid="tree-row"][data-id="kitchen"]') as HTMLElement;
+    kitchen.focus();
+
+    await press(el, kitchen, 'Home');
+    expect((el.shadowRoot?.activeElement as HTMLElement)?.dataset.id).toBe('garage');
+    await press(el, el.shadowRoot!.activeElement!, 'End');
+    expect((el.shadowRoot?.activeElement as HTMLElement)?.dataset.id).toBe('kitchen');
+  });
+
+  it('takes the twisty out of the tab order, since Right and Left do its job', async () => {
+    const el = await mount();
+    expect(q(el, '[data-testid="tree-twisty"]')?.getAttribute('tabindex')).toBe('-1');
+    // Still a button, still clickable — only unreachable by Tab.
+    expect(q(el, '[data-testid="tree-twisty"]')?.tagName).toBe('BUTTON');
+  });
+
+  it('starts the stop on the selected row rather than the first', async () => {
+    const el = await mount({ selectedId: 'kitchen' });
+    expect(stops(el)[0].dataset.id).toBe('kitchen');
+  });
+
+  it('gives an empty tree its create button, so the tree is never a hole', async () => {
+    const el = await mount({ nodes: [], allowCreate: true });
+    expect(stops(el)).toHaveLength(0);
+    const create = q(el, '[data-testid="tree-create"]') as HTMLButtonElement;
+    expect(create).toBeTruthy();
+    expect(create.getAttribute('tabindex')).toBe(null);
+  });
+});
+
+describe('hv-location-tree: one tab stop across area bands', () => {
+  const AREAS = [
+    { id: 'area-kitchen', name: 'Kitchen' },
+    { id: 'area-garage', name: 'Garage' },
+  ];
+  const areaTree: LocationTreeNode[] = [
+    node('fridge', 'Fridge', null, [3, 9], [node('top', 'Top Shelf', 'fridge', [6, 6])], 'area-kitchen'),
+    node('bench', 'Bench', null, [2, 2], [], 'area-garage'),
+    node('attic', 'Attic', null, [5, 5]),
+  ];
+  const mountAreas = (props: Partial<HVLocationTree> = {}) =>
+    mount({ nodes: areaTree, areas: AREAS, ...props });
+
+  const walk = (el: HVLocationTree) =>
+    [
+      ...(el.shadowRoot?.querySelectorAll(
+        '[data-testid="tree-area-head"], [data-testid="tree-row"]',
+      ) ?? []),
+    ] as HTMLElement[];
+
+  it('walks heads and rows together, so Up from a first root reaches its area', async () => {
+    const el = await mountAreas();
+    const bench = q(el, '[data-testid="tree-row"][data-id="bench"]') as HTMLElement;
+    bench.focus();
+
+    bench.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true }));
+    await el.updateComplete;
+
+    const active = el.shadowRoot?.activeElement as HTMLElement;
+    expect(active.dataset.testid ?? active.getAttribute('data-testid')).toBe('tree-area-head');
+    expect(active.dataset.area).toBe('area-garage');
+  });
+
+  it('leaves one stop across the whole thing, heads included', async () => {
+    const el = await mountAreas();
+    expect(walk(el).filter((n) => n.getAttribute('tabindex') === '0')).toHaveLength(1);
+    expect(walk(el).filter((n) => n.getAttribute('tabindex') === '-1').length).toBeGreaterThan(3);
+  });
+
+  it('takes the area twisty and the area name out of the tab order', async () => {
+    const el = await mountAreas({ areaSelectable: true });
+    expect(q(el, '[data-testid="tree-area-twisty"]')?.getAttribute('tabindex')).toBe('-1');
+    expect(q(el, '[data-testid="tree-area-select"]')?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('picks an area from its head, now that the name button is not a stop', async () => {
+    const el = await mountAreas({ areaSelectable: true });
+    const picked: string[] = [];
+    el.addEventListener('select-area', (e) => picked.push((e as CustomEvent).detail.areaId));
+
+    const head = q(el, '[data-testid="tree-area-head"][data-area="area-garage"]') as HTMLElement;
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    head.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(picked).toEqual(['area-garage']);
+  });
+});

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -342,12 +342,145 @@ export class HVLocationTree extends LitElement {
   /** The first-location field is showing, and what has been typed into it. */
   @state() private _creating = false;
   @state() private _newName = '';
+  /**
+   * Which node holds the tree's one tab stop, as `_nodeKey` writes it.
+   *
+   * A tree is a single stop with a roving tabindex, not one per row: this tree
+   * stands between a full view's search box and its table, and a household with
+   * five areas and a dozen expanded roots put more than forty stops in that gap.
+   * Null until the first walk resolves it, which `updated` does.
+   */
+  @state() private _activeKey: string | null = null;
 
-  /** Revealing the name field has to put the caret in it, or it asks for a
-   *  second tap before it can be typed into. */
   protected updated(changed: Map<string, unknown>) {
+    // Revealing the name field has to put the caret in it, or it asks for a
+    // second tap before it can be typed into.
     if (changed.has('_creating') && this._creating) {
       this.renderRoot.querySelector<HTMLInputElement>('[data-testid="tree-create-name"]')?.focus();
+    }
+    this._syncRovingTabindex();
+  }
+
+  /**
+   * Every node the arrows walk, in the order they are drawn.
+   *
+   * Read from the DOM rather than derived from `nodes`: a collapsed row renders
+   * no descendants and a collapsed band renders no roots, so what is here is
+   * already exactly what is visible — and a second walk over the data would be
+   * a second copy of the filter, expand and area rules to keep in step.
+   * Excluded rows are left out; they are drawn to show where a subtree cannot
+   * go, and cannot be chosen.
+   */
+  private _walk(): HTMLElement[] {
+    const rows = this.renderRoot.querySelectorAll<HTMLElement>(
+      '[data-testid="tree-area-head"], [data-testid="tree-row"]',
+    );
+    return [...rows].filter((el) => el.getAttribute('aria-disabled') !== 'true');
+  }
+
+  /** One namespace for both kinds of node, so `_activeKey` can name either. */
+  private _nodeKey(el: HTMLElement): string {
+    return el.dataset.id ? `loc:${el.dataset.id}` : `area:${el.dataset.area}`;
+  }
+
+  /**
+   * Leave exactly one node in the tab order, and give that node's own actions
+   * their only way in.
+   *
+   * Written here rather than in `render` because the walk is the rendered DOM:
+   * a template cannot ask which row comes first without rebuilding the walk
+   * from the data it was drawn from.
+   */
+  private _syncRovingTabindex() {
+    const walk = this._walk();
+    if (!walk.length) {
+      this._activeKey = null;
+      return;
+    }
+    const held = walk.find((el) => this._nodeKey(el) === this._activeKey);
+    // The selection is where the tab stop belongs before anyone has moved it:
+    // arriving on the tree and pressing Enter should re-pick what is already
+    // chosen, not jump the household back to its first room.
+    const selected = walk.find((el) => el.getAttribute('aria-selected') === 'true');
+    const active = held ?? selected ?? walk[0];
+    this._activeKey = this._nodeKey(active);
+    for (const el of walk) {
+      const isActive = el === active;
+      el.tabIndex = isActive ? 0 : -1;
+      // A row's merge, edit, delete and overflow buttons have no key of their
+      // own to reach them by, so they ride with their row: Tab from the active
+      // node steps through that node's actions and then leaves the tree.
+      for (const action of el.querySelectorAll<HTMLElement>('.actions button')) {
+        action.tabIndex = isActive ? 0 : -1;
+      }
+    }
+  }
+
+  /** Move the tab stop to `el` and take focus with it. */
+  private _activate(el: HTMLElement | undefined) {
+    if (!el) return;
+    this._activeKey = this._nodeKey(el);
+    el.tabIndex = 0;
+    el.focus();
+    this.requestUpdate();
+  }
+
+  /** The node one level out from `el` — the nearest earlier, shallower node. */
+  private _parentOf(walk: HTMLElement[], index: number): HTMLElement | undefined {
+    const level = Number(walk[index].getAttribute('aria-level') ?? '1');
+    for (let i = index - 1; i >= 0; i--) {
+      if (Number(walk[i].getAttribute('aria-level') ?? '1') < level) return walk[i];
+    }
+    return undefined;
+  }
+
+  /** Open or close the node `el` stands for, whichever kind it is. */
+  private _toggleNode(el: HTMLElement) {
+    if (el.dataset.id) this._toggle(el.dataset.id);
+    else if (el.dataset.area) {
+      this._toggleArea(el.dataset.area === NO_AREA_KEY ? NO_AREA_KEY : `area:${el.dataset.area}`);
+    }
+  }
+
+  /**
+   * The arrow layer the ARIA tree pattern asks for, and the other half of the
+   * single tab stop: with one node reachable by Tab, the arrows are the only
+   * way to the rest, and the twisties are out of the tab order because Right
+   * and Left do what they do.
+   */
+  private _onTreeKeydown(e: KeyboardEvent) {
+    const keys = ['ArrowDown', 'ArrowUp', 'ArrowRight', 'ArrowLeft', 'Home', 'End'];
+    if (!keys.includes(e.key)) return;
+    const walk = this._walk();
+    const index = walk.findIndex((el) => el.contains(e.target as Node));
+    if (index < 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    const current = walk[index];
+    const expanded = current.getAttribute('aria-expanded');
+    // While a filter is running every node is drawn open whatever the expand
+    // state says, so collapsing one would move nothing on the screen.
+    const filtering = this.filterText.trim().length > 0;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        return this._activate(walk[index + 1]);
+      case 'ArrowUp':
+        return this._activate(walk[index - 1]);
+      case 'Home':
+        return this._activate(walk[0]);
+      case 'End':
+        return this._activate(walk[walk.length - 1]);
+      case 'ArrowRight':
+        // Open what is closed; on what is already open, step into it — the
+        // first child is the next node drawn.
+        if (expanded === 'false') return this._toggleNode(current);
+        if (expanded === 'true') return this._activate(walk[index + 1]);
+        return;
+      case 'ArrowLeft':
+        if (expanded === 'true' && !filtering) return this._toggleNode(current);
+        return this._activate(this._parentOf(walk, index));
     }
   }
 
@@ -391,6 +524,9 @@ export class HVLocationTree extends LitElement {
   /** Pick a node — from anywhere on its row, which is one target. */
   private _select(node: LocationTreeNode, excluded: boolean) {
     if (excluded) return;
+    // The tab stop goes where the user just acted, so returning to the tree by
+    // Tab comes back to the row they chose rather than the one they left.
+    this._activeKey = `loc:${node.id}`;
     this._emit('select', { locationId: node.id, node });
   }
 
@@ -470,7 +606,7 @@ export class HVLocationTree extends LitElement {
           aria-level=${depth + 1}
           aria-disabled=${ifDefined(isExcluded ? 'true' : undefined)}
           title=${node.path?.display_path ?? node.name}
-          tabindex=${isExcluded ? -1 : 0}
+          tabindex="-1"
           data-testid="tree-row"
           data-id=${node.id}
           data-depth=${depth}
@@ -489,6 +625,7 @@ export class HVLocationTree extends LitElement {
             ? html`<button
                 class="twisty hv-browse-row-lead"
                 data-testid="tree-twisty"
+                tabindex="-1"
                 aria-label=${open
                   ? t('hv.tree.collapse', { name: node.name })
                   : t('hv.tree.expand', { name: node.name })}
@@ -632,14 +769,24 @@ export class HVLocationTree extends LitElement {
       aria-expanded=${ifDefined(empty ? undefined : String(open))}
       aria-controls=${ifDefined(empty ? undefined : areaRootsId(key))}
       aria-level="1"
+      tabindex="-1"
       data-testid="tree-area-head"
       data-area=${group?.id ?? NO_AREA_KEY}
+      @keydown=${(e: KeyboardEvent) => {
+        // The head is a treeitem and, where areas are pickable, the target its
+        // own name button used to be — so it answers the keys a button would.
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        e.preventDefault();
+        if (pickable) this._emit('select-area', { areaId: group.id });
+        else if (!empty) this._toggleArea(key);
+      }}
     >
       ${empty
         ? html`<span class="twisty hv-browse-row-lead placeholder">${icon('chevronRight', 17)}</span>`
         : html`<button
             class="twisty hv-browse-row-lead"
             data-testid="tree-area-twisty"
+            tabindex="-1"
             data-area=${group?.id ?? NO_AREA_KEY}
             aria-label=${open ? `Collapse ${name}` : `Expand ${name}`}
             @click=${(e: Event) => {
@@ -653,6 +800,7 @@ export class HVLocationTree extends LitElement {
         ? html`<button
             class="area-name"
             data-testid="tree-area-select"
+            tabindex="-1"
             data-area=${group.id}
             title=${name}
             @click=${() => this._emit('select-area', { areaId: group.id })}
@@ -775,7 +923,7 @@ export class HVLocationTree extends LitElement {
         ].filter(Boolean)
       : this.nodes.map((n) => this._renderNode(n, 0, false)).filter(Boolean);
     return html`
-      <div role="tree" aria-label=${t('hv.tree.label')}>
+      <div role="tree" aria-label=${t('hv.tree.label')} @keydown=${this._onTreeKeydown}>
         ${this.showAll
           ? html`<button
               class="row hv-browse-row ${!this.orphansSelected && !this._anySelected() ? 'selected' : ''}"


### PR DESCRIPTION
## Summary

`hv-location-tree` sits between the full view's search box and its table, and every row
carried `tabindex="0"` while every twisty, area twisty and area name was a `<button>`. On the
seeded household with twelve roots expanded that is **92 tab stops** in the gap — a
keyboard-only household member could not reach an item from the top of the page.

It now follows the ARIA tree pattern: **exactly one node is in the tab order at a time**, and
the arrows move inside it.

| Key | What it does |
|---|---|
| ↓ / ↑ | next / previous **visible** node — area heads among them, so ↑ from a first root reaches its band |
| → | opens a closed node; steps into an open one |
| ← | collapses an open node; steps out to the parent of a closed one |
| Home / End | first / last node |
| Enter / Space | select, as before — and an area head answers them too, now that its name button is not its own stop |

`tree-twisty`, `tree-area-twisty` and `tree-area-select` become `tabindex="-1"`: they stay
clickable, and → / ← / Enter reach everything they do, so nothing is lost.

Closes #559

### Two things the plan did not have right

**§1 was right that the arrow layer did not exist** — the row's `@keydown` answered Enter and
Space and returned on everything else — so both halves are written here, not just the roving
one. §1 was also right that area heads were not stops; they are now part of the walk, which is
what makes ↑ out of a first root land somewhere sensible.

**The roving index is reconciled against the rendered DOM**, in `updated()`, rather than
computed in `render()`. A collapsed row renders no descendants and a collapsed band renders no
roots, so **what is drawn is already exactly the visible walk** — deriving a second walk from
`nodes` would be a second copy of the filter, expand, area and exclusion rules to keep in step
with the template.

**A row's actions ride with their row.** §2.F3 lists `tree-more` and `tree-merge` as becoming
`-1` and does not mention `tree-edit` or `tree-delete`. Left as plain stops, the Organize
dialog would still be four stops per row — the same bug on another surface. Made permanently
`-1`, keyboard users would lose merge, edit and delete entirely, since no key reaches them.
They are therefore tabbable **only while their row is the active node**: Tab into the tree
lands on that row, Tab again steps through its actions, Tab again leaves.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `1281 passed, 22 skipped` · `ruff check` clean · `ruff format --check` clean ·
      `mypy` clean
- [x] Frontend: `eslint` clean · `typecheck` clean · `vitest 1809 passed / 66 files` ·
      `build` OK
- phacc not required — nothing under `custom_components/` changed.

Thirteen new tests in `hv-location-tree.test.ts`: exactly one stop whatever is open; ↓ and ↑
move the stop *and* the focus; → opens without moving and then steps in; ← collapses and keeps
focus; ← on a closed child steps out **without** collapsing the branch; Home/End; the twisty,
area twisty and area name are not stops; the stop starts on the selected row rather than the
first; an empty tree still offers its create button; the walk crosses area bands; and an area
is pickable from its head.

### Live check — measured, on the dev instance

Seeded household, `/haventory` at 1280×900, twelve roots expanded to their first level (58
rows, 5 area heads), counting the same elements in the same rendered tree:

| | tab stops the tree offers |
|---|---|
| before | **92** — 58 rows + twisties + 5 area twisties + area names |
| after | **1** |

In the walk itself, the tree is one press between the two buttons around it:

```
 9. button[sidebar-toggle-locations]  Orte
10. button[sidebar-new-location]      Neuer Ort
11. button[tree-all]                  Alle Gegenstände 558
12. div[tree-area-head]               Bereich: Bedroom 28      ← the whole tree
13. button[tree-orphans]              Kein Ort 6
```

**All six hosts checked in the browser**, not only in jsdom, because a roving tabindex changes
what a dialog's initial focus can land on:

```
PASS  full view sidebar (panel)          trees=1  [rows 13 heads 5 stops 1 stray 0]
PASS  filter panel (panel)               trees=2  [stops 1 stray 0] x2
PASS  organize dialog · Locations        trees=2  [stops 1 stray 0] x2
PASS  item editor location field         trees=2  [stops 1 stray 0] x2
PASS  bulk bar move                      trees=2  [stops 1 stray 0] x2
PASS  card full view (dashboard)         trees=1  [stops 1 stray 0]
        ArrowDown on each: "Bereich: Bedroom" -> "Schlafzimmer 2", stops after = 1
```

(`trees=2` is the panel's browsing sidebar plus the surface's own — both reconcile
independently, which is the thing worth checking.) `ui/dialog-focus.ts` needed no change:
`DialogFocus.sync` focuses the dialog **panel**, not a tree node, and `deepFocusables` already
skips `tabindex="-1"`.

`visual_pass.mjs --only desktop` — 15/15, no console errors.

### The acceptance number, honestly

§2.F3 asks for "at most 12 presses from the search box to the first table row". **The tree
fix alone cannot deliver that, and the measurement is why:** after this change the first table
row is still 184 presses away, and the tree is 1 of them.

| Section | Stops |
|---|---|
| header — five badges, Add, Organize, overflow | 8 |
| locations — toggle, New location, All items, **the tree (1)**, No location | 5 |
| status — toggle, New status, 7 rows | 9 |
| categories — toggle, New category, **27 rows** | 29 |
| tags — toggle, New label, **122 rows** | 126 |
| six sortable column headers | 6 |
| **first table row** | **184** |

The plan assumed the tree was the whole gap; the sidebar's facet lists are six times its size,
and they grow with the household's vocabulary. Same harm, different component, so it is filed
rather than folded in here: **#574**, staged V0.8.0.

## Screenshots (card / UI changes)

None — nothing visible moved. The change is which element carries `tabindex="0"`.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge cases).
- [x] No docs change — no documented behaviour moved.
- [x] No WebSocket API change.
- [x] Essential invariants preserved.

## Handover

1. **Merged / left open** — #572 (calendar language) and #573 (phone action row) are merged;
   this is the third. F4 (#563, thumbnails) has not started.
2. **Test this by hand** — `[desktop]` a real screen reader on the tree: the roving index and
   the arrow layer are the pattern NVDA and VoiceOver expect, but browse-mode behaviour is not
   something Playwright can observe. `[desktop]` a keyboard walk through the Organize dialog's
   merge/edit/delete now that they ride with the active row.
3. **Decisions taken against drifted notes** — the DOM-reconciled walk, the active-row actions,
   and the acceptance number above.
4. **Follow-ups** — **#574** filed (the sidebar's tag and category lists, 155 of the 184
   stops). Nothing else.
5. **State left behind** — the dev Home Assistant's server language is still `de` (was `en`,
   country AT); the closing pass restores it. Assets branch
   `claude-assets-v0-7-0-fixups` carries F1's and F2's pictures; this PR added none.
