### PR TITLE
fix(card): give each sidebar facet list one tab stop and an arrow layer

### DIFF
--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,6 +1,6 @@
 import './hv-full-view';
 import { componentCss, makeItem, mountComponent, mountStore, q, settle, stubViewport } from '../test.utils';
-import { deepActiveElement } from '../ui/dialog-focus';
+import { deepActiveElement, deepFocusables } from '../ui/dialog-focus';
 import { discardPrompt } from '../ui/discard';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVFullView } from './hv-full-view';
@@ -2358,6 +2358,199 @@ describe('hv-full-view: the detail sheet is the narrow read view', () => {
       expect(q(sr, '[data-testid="full-editor"]')).toBeTruthy();
     } finally {
       restore();
+    }
+  });
+});
+
+// Every status, category and tag row was a tab stop of its own, so the walk
+// from the search box to the first table row grew with the household's
+// vocabulary: 184 presses on a seeded install, 122 of them labels. Each list is
+// now one stop with the arrows moving inside it, the shape the locations tree
+// already carries.
+describe('hv-full-view: one tab stop per facet list', () => {
+  const faceted = [
+    makeItem({ id: '1', category: 'Cleaning', tags: ['heavy'] }),
+    makeItem({ id: '2', category: 'Garden', tags: ['metric'] }),
+    makeItem({ id: '3', category: 'Tools', tags: ['sharp'] }),
+    makeItem({ id: '4', category: 'Tools', tags: ['worn'] }),
+  ];
+  const SECTIONS = ['status', 'categories', 'tags'];
+
+  const rows = (sr: ShadowRoot, section: string) =>
+    [...sr.querySelectorAll(`[data-testid="sidebar-${section}-row"]`)] as HTMLElement[];
+  const stops = (sr: ShadowRoot, section: string) =>
+    rows(sr, section)
+      .filter((r) => r.getAttribute('tabindex') === '0')
+      .map((r) => r.dataset.value);
+  const focused = (sr: ShadowRoot) => (sr.activeElement as HTMLElement | null)?.dataset.value;
+  const press = async (el: HTMLElement, sr: ShadowRoot, key: string) => {
+    sr.activeElement?.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
+    );
+    await settle(el);
+  };
+
+  it('leaves one row of each list in the tab order and takes the rest out', async () => {
+    const { sr } = await mount({ items: faceted });
+
+    for (const section of SECTIONS) {
+      const list = rows(sr, section);
+      expect(list.length, section).toBeGreaterThan(2);
+      expect(stops(sr, section), section).toHaveLength(1);
+      expect(
+        list.filter((r) => r.getAttribute('tabindex') === '-1').length,
+        section,
+      ).toBe(list.length - 1);
+    }
+  });
+
+  it('names each list as a group, so the stop announces what it is inside', async () => {
+    const { sr } = await mount({ items: faceted });
+
+    const group = (section: string) => q(sr, `#sidebar-section-${section}`);
+    expect(group('status')?.getAttribute('role')).toBe('group');
+    expect(group('status')?.getAttribute('aria-label')).toBe('Status');
+    expect(group('categories')?.getAttribute('aria-label')).toBe('Categories');
+    expect(group('tags')?.getAttribute('aria-label')).toBe('Tags');
+  });
+
+  it('moves the stop and the focus with the arrows, and stops at both ends', async () => {
+    const { el, sr } = await mount({ items: faceted });
+    rows(sr, 'tags')[0].focus();
+
+    await press(el, sr, 'ArrowDown');
+    expect(focused(sr)).toBe('metric');
+    expect(stops(sr, 'tags')).toEqual(['metric']);
+
+    await press(el, sr, 'ArrowUp');
+    expect(focused(sr)).toBe('heavy');
+    // The top is the top: Up does not wrap round to the last label.
+    await press(el, sr, 'ArrowUp');
+    expect(focused(sr)).toBe('heavy');
+
+    await press(el, sr, 'End');
+    expect(focused(sr)).toBe('worn');
+    await press(el, sr, 'ArrowDown');
+    expect(focused(sr)).toBe('worn');
+    expect(stops(sr, 'tags')).toEqual(['worn']);
+
+    await press(el, sr, 'Home');
+    expect(focused(sr)).toBe('heavy');
+  });
+
+  it('moves only inside the list the key came from', async () => {
+    const { el, sr } = await mount({ items: faceted });
+    rows(sr, 'categories')[0].focus();
+
+    await press(el, sr, 'End');
+
+    expect(stops(sr, 'categories')).toEqual(['Tools']);
+    // The other two lists still hold their own first row.
+    expect(stops(sr, 'tags')).toEqual(['heavy']);
+    expect(stops(sr, 'status')).toEqual(['ok']);
+  });
+
+  // Pressed twice a category row ends up unselected, so what holds the stop
+  // afterwards can only be the press itself.
+  it('leaves the stop where a click put it', async () => {
+    const { el, sr } = await mount({ items: faceted });
+    const third = () => rows(sr, 'categories')[2];
+
+    third().click();
+    await settle(el);
+    third().click();
+    await settle(el);
+
+    expect(rows(sr, 'categories').map((r) => r.getAttribute('aria-pressed'))).toEqual([
+      'false',
+      'false',
+      'false',
+    ]);
+    expect(stops(sr, 'categories')).toEqual(['Tools']);
+  });
+
+  it('hands the stop to the selected row when the row holding it is drawn away', async () => {
+    const { el, store, sr } = await mount({ items: faceted });
+    rows(sr, 'tags')[0].click();
+    await settle(el);
+    rows(sr, 'tags')[0].focus();
+    await press(el, sr, 'ArrowDown');
+    expect(stops(sr, 'tags')).toEqual(['metric']);
+
+    const cache = store.state.value.distinctValuesCache!;
+    cache.tags = cache.tags.filter((v) => v.value !== 'metric');
+    el.requestUpdate();
+    await settle(el);
+
+    expect(stops(sr, 'tags')).toEqual(['heavy']);
+  });
+
+  it('falls back to the first row when nothing is selected either', async () => {
+    const { el, store, sr } = await mount({ items: faceted });
+    rows(sr, 'tags')[0].focus();
+    await press(el, sr, 'End');
+    expect(stops(sr, 'tags')).toEqual(['worn']);
+
+    const cache = store.state.value.distinctValuesCache!;
+    cache.tags = cache.tags.filter((v) => v.value !== 'worn');
+    el.requestUpdate();
+    await settle(el);
+
+    expect(stops(sr, 'tags')).toEqual(['heavy']);
+  });
+
+  it('gives a section that has just been reopened exactly one stop', async () => {
+    const { el, sr } = await mount({ items: faceted });
+    const toggle = () => q(sr, '[data-testid="sidebar-toggle-tags"]') as HTMLButtonElement;
+
+    toggle().click();
+    await settle(el);
+    expect(rows(sr, 'tags')).toHaveLength(0);
+
+    toggle().click();
+    await settle(el);
+    expect(stops(sr, 'tags')).toHaveLength(1);
+  });
+
+  // The measurement the issue is about: the walk grew with the household's
+  // vocabulary, so a sidebar holding 40 labels offered 40 more stops than one
+  // holding 3. Both now offer the same number.
+  it('holds the sidebar walk steady as the vocabulary grows', async () => {
+    const vocabulary = (size: number) =>
+      Array.from({ length: size }, (_, i) =>
+        makeItem({ id: `i${i}`, category: `Category ${i}`, tags: [`tag-${i}`] }),
+      );
+    const small = await mount({ items: vocabulary(3) });
+    const large = await mount({ items: vocabulary(40) });
+    const walk = (sr: ShadowRoot) =>
+      deepFocusables(q(sr, '[data-testid="full-sidebar"]')).length;
+
+    expect(rows(large.sr, 'tags')).toHaveLength(40);
+    expect(walk(large.sr)).toBe(walk(small.sr));
+    // Not a vacuous match: the sidebar does still offer its headings, its
+    // three "+" buttons, the locations tree and one stop per facet list.
+    // 13 stops either way as this is written; with every row back in the tab
+    // order the same two sidebars offered 19 and 93. The bounds are what the
+    // claim needs — a sidebar that had stopped drawing its facets would match
+    // itself at zero.
+    expect(walk(small.sr)).toBeGreaterThan(6);
+    expect(walk(small.sr)).toBeLessThan(20);
+  });
+
+  // The heading, its "+" and the any/all pair are one stop each and stay that
+  // way: a section is reached, opened and added to without the arrows.
+  it('leaves the section heading and its actions as tab stops', async () => {
+    const { sr } = await mount({ items: faceted });
+
+    for (const testid of [
+      'sidebar-toggle-status',
+      'sidebar-new-status',
+      'sidebar-toggle-categories',
+      'sidebar-new-categories',
+      'sidebar-toggle-tags',
+      'sidebar-new-tags',
+    ]) {
+      expect(q(sr, `[data-testid="${testid}"]`)?.getAttribute('tabindex'), testid).toBe(null);
     }
   });
 });

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -5,6 +5,7 @@ import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
 import { browseRow } from '../ui/browse-row';
 import { onEscape } from '../ui/keyboard';
+import { rovingTarget, syncRovingTabindex } from '../ui/roving-list';
 import { icon } from '../ui/icons';
 import { t, tn } from '../i18n';
 import { counted, showingCount } from '../ui/plural';
@@ -65,6 +66,24 @@ const SEARCH_DEBOUNCE_MS = 200;
 
 /** The sidebar's collapsible sections, in the order they appear. */
 type SidebarSection = 'locations' | 'status' | 'categories' | 'tags';
+
+/**
+ * The sections whose rows the sidebar draws itself.
+ *
+ * Locations is the odd one out: its rows belong to `hv-location-tree`, which
+ * runs the same one-stop pattern behind its own shadow boundary.
+ */
+type FacetSection = Exclude<SidebarSection, 'locations'>;
+
+const FACET_SECTIONS: FacetSection[] = ['status', 'categories', 'tags'];
+
+/**
+ * Names a facet row by the value it stands for, so a stop survives a redraw
+ * that keeps the row. One namespace across the three lists, since one field
+ * holds all three keys.
+ */
+const facetRowKey = (section: FacetSection, value: string | undefined) =>
+  `${section}:${value ?? ''}`;
 
 /**
  * The element a section heading discloses, named so `aria-controls` can point at
@@ -824,6 +843,19 @@ export class HVFullView extends LitElement {
     tags: true,
   };
   /**
+   * Which row holds each facet list's one tab stop, as `facetRowKey` writes it.
+   *
+   * A facet list is as long as the household's vocabulary, and a row per tab
+   * stop put that vocabulary between this surface's search box and its table.
+   * Null until the first walk over the rendered rows resolves it, which
+   * `updated` does.
+   */
+  @state() private _facetStop: Record<FacetSection, string | null> = {
+    status: null,
+    categories: null,
+    tags: null,
+  };
+  /**
    * True on a phone-width viewport (`NARROW_QUERY`).
    *
    * This surface switches its own layout on the matching `@media` block below,
@@ -940,6 +972,51 @@ export class HVFullView extends LitElement {
         this._prevFocus.focus();
       }
     }
+    for (const section of FACET_SECTIONS) this._syncFacetStop(section);
+  }
+
+  /** The rows of one facet list, in the order they are drawn. */
+  private _facetRows(section: FacetSection): HTMLElement[] {
+    return [
+      ...this.renderRoot.querySelectorAll<HTMLElement>(`[data-testid="sidebar-${section}-row"]`),
+    ];
+  }
+
+  /**
+   * Leave one row of `section` in the tab order.
+   *
+   * Written here rather than in `render` because the walk is the rendered DOM:
+   * a template cannot ask which row comes first without rebuilding the walk
+   * from the values it was drawn from.
+   */
+  private _syncFacetStop(section: FacetSection) {
+    const held = syncRovingTabindex(this._facetRows(section), this._facetStop[section], (el) =>
+      facetRowKey(section, el.dataset.value),
+    );
+    this._holdFacetStop(section, held);
+  }
+
+  /**
+   * Remember which row holds a list's stop, without redrawing for a key that
+   * has not moved — `updated` writes this, so an unconditional assignment would
+   * queue a render for every render.
+   */
+  private _holdFacetStop(section: FacetSection, key: string | null) {
+    if (this._facetStop[section] === key) return;
+    this._facetStop = { ...this._facetStop, [section]: key };
+  }
+
+  /**
+   * The arrow layer, and the other half of the single tab stop: with one row
+   * reachable by Tab, the arrows are the only way to the rest. Enter and Space
+   * are left alone — the rows are buttons and already answer to both.
+   */
+  private _onFacetKeydown(section: FacetSection, e: KeyboardEvent) {
+    const next = rovingTarget(e, this._facetRows(section));
+    if (!next) return;
+    this._holdFacetStop(section, facetRowKey(section, next.dataset.value));
+    this._syncFacetStop(section);
+    next.focus();
   }
 
   private get _tree(): HVLocationTree | null {
@@ -1405,7 +1482,13 @@ export class HVFullView extends LitElement {
           </button>
         </span>
       </div>
-      <div id=${sectionPanelId('status')} ?hidden=${!this._sections.status}>
+      <div
+        id=${sectionPanelId('status')}
+        role="group"
+        aria-label=${t('hv.filter.status')}
+        ?hidden=${!this._sections.status}
+        @keydown=${(e: KeyboardEvent) => this._onFacetKeydown('status', e)}
+      >
         ${this._sections.status
           ? statusList(this.st?.statuses).map(({ slug: s }) => {
               const on = filters.status === s;
@@ -1415,7 +1498,11 @@ export class HVFullView extends LitElement {
                 data-testid="sidebar-status-row"
                 data-value=${s}
                 aria-pressed=${String(on)}
-                @click=${() => this._setFilters({ status: on ? null : s })}
+                tabindex="-1"
+                @click=${() => {
+                  this._holdFacetStop('status', facetRowKey('status', s));
+                  this._setFilters({ status: on ? null : s });
+                }}
               >
                 <span class="hv-browse-row-lead ${on ? '' : 'placeholder'}">${icon('check', 15)}</span>
                 <span class="label hv-browse-row-label">${statusLabel(s, this.st?.statuses)}</span>
@@ -1475,7 +1562,13 @@ export class HVFullView extends LitElement {
           </button>
         </span>
       </div>
-      <div id=${sectionPanelId(section)} ?hidden=${!open}>
+      <div
+        id=${sectionPanelId(section)}
+        role="group"
+        aria-label=${label}
+        ?hidden=${!open}
+        @keydown=${(e: KeyboardEvent) => this._onFacetKeydown(section, e)}
+      >
         ${open
           ? values.length
             ? values.map(
@@ -1484,7 +1577,11 @@ export class HVFullView extends LitElement {
                   data-testid=${`sidebar-${section}-row`}
                   data-value=${v.value}
                   aria-pressed=${String(isOn(v.value))}
-                  @click=${() => onPick(v.value)}
+                  tabindex="-1"
+                  @click=${() => {
+                    this._holdFacetStop(section, facetRowKey(section, v.value));
+                    onPick(v.value);
+                  }}
                 >
                   <span class="hv-browse-row-lead ${isOn(v.value) ? '' : 'placeholder'}"
                     >${icon('check', 15)}</span

--- a/cards/haventory-card/src/ui/roving-list.test.ts
+++ b/cards/haventory-card/src/ui/roving-list.test.ts
@@ -1,0 +1,125 @@
+import { rovingTarget, syncRovingTabindex } from './roving-list';
+
+/** A facet list in miniature: pressable rows, each wrapping its own label. */
+function list(values: string[], selected?: string) {
+  const box = document.createElement('div');
+  for (const value of values) {
+    const row = document.createElement('button');
+    row.dataset.value = value;
+    row.setAttribute('aria-pressed', String(value === selected));
+    const label = document.createElement('span');
+    label.textContent = value;
+    row.append(label);
+    box.append(row);
+  }
+  document.body.append(box);
+  return [...box.querySelectorAll('button')] as HTMLElement[];
+}
+
+const keyOf = (el: HTMLElement) => `tags:${el.dataset.value}`;
+const stops = (rows: HTMLElement[]) =>
+  rows.filter((r) => r.getAttribute('tabindex') === '0').map((r) => r.dataset.value);
+
+/** A real `keydown` on `target`, handed back so the test can read what came of it. */
+function press(target: Element, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('syncRovingTabindex', () => {
+  it('leaves one row in the tab order and takes the rest out', () => {
+    const rows = list(['blue', 'green', 'red']);
+    expect(syncRovingTabindex(rows, null, keyOf)).toBe('tags:blue');
+    expect(stops(rows)).toEqual(['blue']);
+    expect(rows.map((r) => r.getAttribute('tabindex'))).toEqual(['0', '-1', '-1']);
+  });
+
+  it('starts on the selected row rather than the first', () => {
+    const rows = list(['blue', 'green', 'red'], 'red');
+    expect(syncRovingTabindex(rows, null, keyOf)).toBe('tags:red');
+    expect(stops(rows)).toEqual(['red']);
+  });
+
+  it('keeps a held row holding the stop across a redraw', () => {
+    const rows = list(['blue', 'green', 'red'], 'red');
+    expect(syncRovingTabindex(rows, 'tags:green', keyOf)).toBe('tags:green');
+    expect(stops(rows)).toEqual(['green']);
+  });
+
+  // A narrowed vocabulary or a cleared filter can draw the held row away, and
+  // the stop has to land somewhere or the list leaves the tab order entirely.
+  it('hands the stop to the selected row when the held one is gone', () => {
+    const rows = list(['blue', 'red'], 'red');
+    expect(syncRovingTabindex(rows, 'tags:green', keyOf)).toBe('tags:red');
+    expect(stops(rows)).toEqual(['red']);
+  });
+
+  it('falls back to the first row when nothing is selected either', () => {
+    const rows = list(['blue', 'red']);
+    expect(syncRovingTabindex(rows, 'tags:green', keyOf)).toBe('tags:blue');
+    expect(stops(rows)).toEqual(['blue']);
+  });
+
+  it('holds nothing for an empty list', () => {
+    expect(syncRovingTabindex([], 'tags:green', keyOf)).toBe(null);
+  });
+});
+
+describe('rovingTarget', () => {
+  it('moves one row down and one row up', () => {
+    const rows = list(['blue', 'green', 'red']);
+    expect(rovingTarget(press(rows[0], 'ArrowDown'), rows)).toBe(rows[1]);
+    expect(rovingTarget(press(rows[1], 'ArrowUp'), rows)).toBe(rows[0]);
+  });
+
+  // No wrap: the ends of a filter list are ends, and wrapping past them reads
+  // as the focus having jumped somewhere else entirely.
+  it('stays put at both ends', () => {
+    const rows = list(['blue', 'green', 'red']);
+    expect(rovingTarget(press(rows[2], 'ArrowDown'), rows)).toBe(rows[2]);
+    expect(rovingTarget(press(rows[0], 'ArrowUp'), rows)).toBe(rows[0]);
+  });
+
+  it('reaches both ends with Home and End', () => {
+    const rows = list(['blue', 'green', 'red']);
+    expect(rovingTarget(press(rows[1], 'Home'), rows)).toBe(rows[0]);
+    expect(rovingTarget(press(rows[1], 'End'), rows)).toBe(rows[2]);
+  });
+
+  // The row holds the focus, so it is usually the target; a key can still
+  // arrive from the label inside it.
+  it('finds the row from a target inside it', () => {
+    const rows = list(['blue', 'green', 'red']);
+    const label = rows[1].querySelector('span') as HTMLElement;
+    expect(rovingTarget(press(label, 'ArrowDown'), rows)).toBe(rows[2]);
+  });
+
+  // Handled keys are claimed so the sidebar does not scroll out from under the
+  // row they just moved to; everything else is left to the browser and to the
+  // button's own Enter and Space.
+  it('claims the keys it answers to and no others', () => {
+    const rows = list(['blue', 'green', 'red']);
+    const handled = press(rows[0], 'ArrowDown');
+    expect(rovingTarget(handled, rows)).toBe(rows[1]);
+    expect(handled.defaultPrevented).toBe(true);
+
+    const ignored = press(rows[0], 'ArrowRight');
+    expect(rovingTarget(ignored, rows)).toBe(null);
+    expect(ignored.defaultPrevented).toBe(false);
+    expect(rovingTarget(press(rows[0], 'Enter'), rows)).toBe(null);
+  });
+
+  it('ignores a key pressed outside the rows', () => {
+    const rows = list(['blue', 'green', 'red']);
+    const outside = document.createElement('button');
+    document.body.append(outside);
+    const event = press(outside, 'ArrowDown');
+    expect(rovingTarget(event, rows)).toBe(null);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/cards/haventory-card/src/ui/roving-list.ts
+++ b/cards/haventory-card/src/ui/roving-list.ts
@@ -1,0 +1,67 @@
+/**
+ * A list of rows as one tab stop, with the arrows moving inside it.
+ *
+ * A facet list is as long as the household's vocabulary, and every row being a
+ * tab stop of its own put that vocabulary between the search box and the table:
+ * a household with 122 labels made 184 presses of the walk. One row holds
+ * `tabindex="0"`, the rest hold `-1`, and Arrow, Home and End move that stop
+ * about — the same pattern the locations tree carries, kept here so the three
+ * sidebar lists cannot drift apart from each other.
+ *
+ * The rows are read from the rendered DOM by the caller rather than derived
+ * from the data: what is drawn is already exactly what is walkable, and a
+ * second walk over the values would be a second copy of the collapse and
+ * filter rules to keep in step.
+ */
+
+/** The keys this layer answers to; everything else is the browser's. */
+const MOVE_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End'];
+
+/** Where the stop belongs before anyone has moved it: on what is already picked. */
+const isSelected = (el: HTMLElement) => el.getAttribute('aria-pressed') === 'true';
+
+/**
+ * Leave exactly one row in the tab order, and say which row that is.
+ *
+ * `held` is the key the caller stored last. A row drawn away since — a narrowed
+ * vocabulary, a cleared filter — hands the stop to the selected row if there is
+ * one and to the first row otherwise, so the list is never left without a way
+ * in. Null back means the list is empty and there is nothing to hold.
+ */
+export function syncRovingTabindex(
+  rows: HTMLElement[],
+  held: string | null,
+  keyOf: (el: HTMLElement) => string,
+): string | null {
+  if (!rows.length) return null;
+  const active = rows.find((el) => keyOf(el) === held) ?? rows.find(isSelected) ?? rows[0];
+  for (const el of rows) el.tabIndex = el === active ? 0 : -1;
+  return keyOf(active);
+}
+
+/**
+ * The row a key press moves to, or null when the press is not this list's.
+ *
+ * The ends do not wrap: the end of a filter list is an end, and coming back
+ * round to the other one reads as the focus having jumped somewhere else. Only
+ * a handled key is claimed — Enter and Space stay the row's own, and an
+ * unclaimed ArrowDown still scrolls the sidebar.
+ */
+export function rovingTarget(e: KeyboardEvent, rows: HTMLElement[]): HTMLElement | null {
+  if (!MOVE_KEYS.includes(e.key)) return null;
+  const index = rows.findIndex((el) => el.contains(e.target as Node));
+  if (index < 0) return null;
+  e.preventDefault();
+  e.stopPropagation();
+  switch (e.key) {
+    case 'ArrowDown':
+      return rows[Math.min(index + 1, rows.length - 1)];
+    case 'ArrowUp':
+      return rows[Math.max(index - 1, 0)];
+    case 'Home':
+      return rows[0];
+    case 'End':
+      return rows[rows.length - 1];
+  }
+  return null;
+}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -159,6 +159,19 @@ than by a component of their own: they are flat lists of `distinct_values` entri
 rows only have to look like `hv-location-tree`'s — which, being in another shadow root,
 could not have shared the rule either way.
 
+Each of those lists — status, categories and tags — is **one tab stop**, not one per row:
+the list is as long as the household's vocabulary, and a stop per row put that vocabulary
+between the search box and the table. The container carries `role="group"` with the
+section's name, one row holds `tabindex="0"` and the rest `-1`, and ArrowDown/ArrowUp move
+inside the list while Home and End reach its ends; neither end wraps. The rows stay
+`<button aria-pressed>`, so Enter and Space still press them. Which row holds the stop is
+kept per section in `_facetStop` and reconciled against the rendered rows after every
+render: a held row drawn away — a narrowed vocabulary, a cleared filter — hands the stop to
+the selected row, or to the first one. The section heading, its "+" and the tags any/all
+pair are ordinary tab stops, so a section is still reached, opened and added to without the
+arrows. `ui/roving-list.ts` holds the walk and the key handling; `hv-location-tree` runs the
+same shape for the Locations section behind its own shadow boundary.
+
 Each of the four headings offers a create action, and the three that can be counted state
 how many of their thing there is — Status is the household's own vocabulary, whose size says
 nothing about the inventory the facet navigates. Categories and tags come with their
@@ -426,6 +439,7 @@ re-render it — so each container subscribes to `store.state.onChange` itself i
 | `downscale.ts` | Re-encoding an oversized photo in the browser before it is uploaded: the size and type rules, the capped-edge arithmetic, and the decode/encode seam. Fails open — anything that does not work hands the original file back. |
 | `status.ts` | The item-status vocabulary: the definitions a surface renders from (backend's, or the built-in three until `haventory/config` answers), the label / tone-class / glyph lookups with their fallbacks, the colour and glyph vocabularies the management picker offers, and `renderStatusChip` — one renderer so the mark cannot drift between a table cell and a detail sheet. |
 | `keyboard.ts` | `onEscape()` for the surfaces where Escape means exactly "close", and the platform-correct save-shortcut label. |
+| `roving-list.ts` | A long list of rows as one tab stop: which row holds `tabindex="0"` after a redraw (`syncRovingTabindex`), and which row an Arrow, Home or End press moves to (`rovingTarget`). Used by the sidebar's three facet lists; `hv-location-tree` carries its own copy of the pattern, since a tree also has to open and close nodes. |
 | `plural.ts` | Count agreement for every count string in the card. |
 | `theme.ts` | Whether the card is painted on a light or dark surface, read from HA's own theme variables rather than `prefers-color-scheme`. |
 


### PR DESCRIPTION
## Summary

The full view's sidebar drew every status, category and tag as a `<button>` in the tab order,
so the walk from the search box to the first table row grew with the household's vocabulary
rather than with anything the user had chosen to open: 7 + 27 + 122 rows on the seeded
install, 184 presses to the table. #575 had already taken the locations tree from 92 stops to
one, which turned out to be the smaller half of the problem.

Each of the three lists is now **one tab stop with an arrow layer**, the shape the tree
carries:

- The rows' container (the `aria-controls` panel each heading already discloses) gets
  `role="group"` and the section's name as its label, plus a `keydown` handler. One row holds
  `tabindex="0"`, the rest `-1`.
- ArrowDown and ArrowUp move without wrapping — the end of a filter list is an end — Home and
  End reach the ends, and only those four keys are claimed. Left and Right are left alone.
- The rows stay `<button aria-pressed>`: their click behaviour, testids, classes and paint are
  unchanged, and Enter and Space press them natively.
- Which row holds the stop is kept per section in `_facetStop` (`status:<slug>`,
  `categories:<value>`, `tags:<value>`) and reconciled against the rendered rows after every
  render. A held row drawn away — a narrowed distinct-values list, a cleared filter — hands the
  stop to the **selected** row if there is one and to the first row otherwise, so a list is
  never left without a way in. Clicking a row leaves the stop on it.
- The section headings, the three "+" buttons and the tags any/all pair stay ordinary tab
  stops: a section is still reached, opened and added to without the arrows. A collapsed
  section renders no rows, so it needs nothing.
- The walk, the reconcile and the key handling live in `src/ui/roving-list.ts` so the three
  lists cannot drift apart from each other. `hv-location-tree` keeps its own copy — a tree also
  has to open and close nodes, and rewriting it onto the helper is a refactor for its own PR
  (Follow-ups).

**Measured**, in the component suite, over the sidebar's focusable controls (`deepFocusables`,
which is a tab-order walk across shadow boundaries): **13 stops for a household with 3 labels
and 13 for one with 40**, against **19 and 93** for the same two sidebars with every row put
back in the tab order. On the seeded household that is 156 facet rows collapsing to 3 stops,
which puts the issue's 184-press walk at about 30.

Nothing under `custom_components/` changed, so phacc was not run. The dev HA was not touched;
the live check is the session's.

Closes #574

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1291 passed, 22 skipped),
      `uv run ruff check .`, `uv run ruff format --check .` (183 files), `uv run mypy`
      (26 source files) — all green, untouched by this change but run as the gate asks.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`
      (67 files, 1836 tests), `npm run build` — all green.

New tests, written before the fix and failing on it:

- `src/ui/roving-list.test.ts` (new): the stop lands on the first row, on the selected row
  before anything has moved, and stays on a held row across a redraw; a vanished held row
  falls back to the selected row and then to the first; an empty list holds nothing. For the
  keys: down and up move one, both ends stay put, Home and End reach them, a press from inside
  a row's label still finds the row, handled keys are `preventDefault`ed and Enter/ArrowRight
  are not, and a press from outside the rows is ignored.
- `src/components/hv-full-view.test.ts`, "one tab stop per facet list": one row of each of the
  three lists in the tab order and the rest out; each list named as a group; the arrows and
  Home/End moving `shadowRoot.activeElement` with no wrap at either end; a key moving only
  inside the list it came from; the stop staying where a click put it (pressed twice, so the
  row ends up unselected and only the click can explain the stop); the held row being drawn
  away falling back to the selected row and, separately, to the first; a reopened section
  getting exactly one stop; the headings and "+" buttons keeping no `tabindex`; and the
  measurement above.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md`: the new
      `ui/roving-list.ts` row in the module table, and a paragraph on the sidebar section
      describing the one-stop shape.
- [x] WebSocket API unchanged.
- [x] Essential invariants untouched — this is card markup and key handling only.

## Screenshots (card / UI changes)

None: nothing visible changed. The rows keep their classes, their layout and their pressed
paint; only `tabindex`, a container `role`/`aria-label` and a `keydown` handler are new.

## Follow-ups

- `hv-filter-panel` draws every known tag as its own chip button (`_renderTagGroup`, no cap —
  categories are capped at `CATEGORY_CHIP_LIMIT` behind a "More…" button), so the filter panel
  carries the same 122-stop walk inside itself on the seeded household. Out of scope here; the
  panel is a different component and its own surface.
- `hv-location-tree` still carries its own `_walk` / `_syncRovingTabindex` / arrow handling.
  Folding it onto `ui/roving-list.ts` would need the helper to grow open/close and parent
  stepping, so it is a refactor for a later PR rather than a rider on a fix.
