### PR TITLE
fix(backend): measure every date against the instance's own day

### DIFF
--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -2,6 +2,7 @@ import type { CSSResult } from 'lit';
 import { vi } from 'vitest';
 
 import { Store } from './store/store';
+import { toIsoDate } from './ui/relative-time';
 import type {
   AnyEventPayload,
   AreaRef,
@@ -746,12 +747,19 @@ export function makeMockHass(initial?: MockConfig): MockHass {
   return hass;
 }
 
-/** Today in UTC, the day every one of these rules compares against. */
+/**
+ * Today in this machine's zone, the day every one of these rules compares against.
+ *
+ * `toIsoDate` is what the components themselves read, and the backend now names
+ * the instance's own day rather than a UTC one. Slicing an ISO string would give
+ * the UTC day instead, which agrees with neither for part of every day — a mock
+ * that disagreed with the code it stands in for on any machine outside UTC.
+ */
 function mockToday(): string {
-  return new Date().toISOString().slice(0, 10);
+  return toIsoDate();
 }
 
-/** Mirror of the backend's overdue rule: a due date strictly before today (UTC). */
+/** Mirror of the backend's overdue rule: a due date strictly before today. */
 function isMockOverdue(item: Item): boolean {
   return !!item.due_date && item.due_date < mockToday();
 }

--- a/custom_components/haventory/const.py
+++ b/custom_components/haventory/const.py
@@ -289,7 +289,7 @@ class HaventorySensorDescription:
     entity's ``unique_id``; ``translation_key`` names the entry under
     ``entity.sensor`` in `strings.json`. ``date_derived`` marks the counts that
     move with the calendar rather than with a mutation, which is what makes them
-    subscribe to the UTC-midnight rollover as well as to mutations.
+    subscribe to the local-midnight rollover as well as to mutations.
     """
 
     key: str

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -6,7 +6,10 @@ provides validation and normalization helpers to enforce invariants and produce
 denormalized location paths.
 
 The intent is to keep these models framework-agnostic and free of I/O. Higher
-layers (WebSocket/API, storage) are expected to compose these helpers.
+layers (WebSocket/API, storage) are expected to compose these helpers. The one
+Home Assistant import is `dt_util`, for the household's own calendar day: it
+reads a module global rather than a `hass`, and every date a user reads or
+writes is measured in that day.
 """
 
 from __future__ import annotations
@@ -18,6 +21,8 @@ from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, Final, Literal, NotRequired, TypedDict
+
+from homeassistant.util import dt as dt_util
 
 from .const import (
     DEFAULT_STATUS_COLOR,
@@ -1541,9 +1546,17 @@ def item_is_low_stock(item: Item) -> bool:
     return item.quantity <= thr
 
 
-def today_utc_date() -> str:
-    """Today's date as YYYY-MM-DD in UTC — the reference point for "overdue"."""
-    return datetime.now(UTC).date().isoformat()
+def today_local_date() -> str:
+    """Today's date as YYYY-MM-DD in the instance's time zone.
+
+    One day for the whole household: the calendar entity, the reminder bump,
+    the card's chips and these predicates all measure against the day Home
+    Assistant is configured for, so a row and a count cannot disagree for the
+    hours a UTC day and a local one differ by. `dt_util.now()` reads
+    `DEFAULT_TIME_ZONE`, which Home Assistant sets from its own configuration,
+    so this needs no `hass` handle.
+    """
+    return dt_util.now().date().isoformat()
 
 
 def item_is_overdue(item: Item, *, today: str = "") -> bool:
@@ -1552,13 +1565,13 @@ def item_is_overdue(item: Item, *, today: str = "") -> bool:
     A due date only exists while an item is checked out (see
     ``validate_due_date_rules``), so this needs no separate checked-out test.
     Both sides are YYYY-MM-DD, which compares correctly as text. ``today``
-    defaults to the current UTC date; callers filtering many items pass it in
-    once rather than re-reading the clock per item.
+    defaults to the instance's current local date; callers filtering many items
+    pass it in once rather than re-reading the clock per item.
     """
 
     if not item.due_date:
         return False
-    return item.due_date < (today or today_utc_date())
+    return item.due_date < (today or today_local_date())
 
 
 def item_is_due(item: Item, *, today: str = "") -> bool:
@@ -1573,7 +1586,7 @@ def item_is_due(item: Item, *, today: str = "") -> bool:
 
     if not item.due_date:
         return False
-    return item.due_date <= (today or today_utc_date())
+    return item.due_date <= (today or today_local_date())
 
 
 def item_inspection_is_overdue(item: Item, *, today: str = "") -> bool:
@@ -1586,7 +1599,7 @@ def item_inspection_is_overdue(item: Item, *, today: str = "") -> bool:
 
     if not item.inspection_date:
         return False
-    return item.inspection_date < (today or today_utc_date())
+    return item.inspection_date < (today or today_local_date())
 
 
 def item_inspection_is_due(item: Item, *, today: str = "") -> bool:
@@ -1601,7 +1614,7 @@ def item_inspection_is_due(item: Item, *, today: str = "") -> bool:
 
     if not item.inspection_date:
         return False
-    return item.inspection_date <= (today or today_utc_date())
+    return item.inspection_date <= (today or today_local_date())
 
 
 def item_reminder_is_due(item: Item, *, today: str = "") -> bool:
@@ -1615,7 +1628,7 @@ def item_reminder_is_due(item: Item, *, today: str = "") -> bool:
 
     if not item.reminder_date:
         return False
-    return item.reminder_date <= (today or today_utc_date())
+    return item.reminder_date <= (today or today_local_date())
 
 
 def _parse_location_selection(location_ids: Sequence[str]) -> list[uuid.UUID]:
@@ -1670,11 +1683,12 @@ def filter_items(
     - checked_out: exact match
     - low_stock_only: quantity <= threshold (0 valid, None disables)
     - orphaned_only: only items without a location (location_id is None)
-    - overdue_only: due_date set and strictly before today (UTC)
-    - checked_out_due_only: due_date set and on or before today (UTC)
-    - inspection_overdue_only: inspection_date set and strictly before today (UTC)
-    - inspection_due_only: inspection_date set and on or before today (UTC)
-    - reminder_due_only: reminder_date set and on or before today (UTC)
+    - overdue_only: due_date set and strictly before today
+    - checked_out_due_only: due_date set and on or before today
+    - inspection_overdue_only: inspection_date set and strictly before today
+    - inspection_due_only: inspection_date set and on or before today
+    - reminder_due_only: reminder_date set and on or before today
+    - "today" in those five is the instance's local day, read once per query
     - the three ``*_due_only`` keys count today and the two ``*overdue*`` ones do
       not: a due date names the day something is being asked for, not the last
       day it is not
@@ -1740,7 +1754,7 @@ def filter_items(
         inspection_due_only,
         reminder_due_only,
     )
-    today = today_utc_date() if any(date_predicates) else ""
+    today = today_local_date() if any(date_predicates) else ""
 
     predicates_active = (
         bool(q)

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -67,7 +67,7 @@ from .models import (
     selected_location_ids,
     serialize_status_definition,
     sort_items,
-    today_utc_date,
+    today_local_date,
     validate_location_name,
     validate_required_name,
     validate_status_definition,
@@ -1784,7 +1784,7 @@ class Repository:
         than the whole inventory.
         """
 
-        today = today_utc_date()
+        today = today_local_date()
         return sum(
             1
             for iid in self._checked_out_item_ids
@@ -1800,7 +1800,7 @@ class Repository:
         has to ``_count_inspection_overdue``.
         """
 
-        today = today_utc_date()
+        today = today_local_date()
         return sum(
             1
             for iid in self._checked_out_item_ids
@@ -1816,7 +1816,7 @@ class Repository:
         independent of any check-out, so any item can carry one.
         """
 
-        today = today_utc_date()
+        today = today_local_date()
         return sum(
             1 for it in self._items_by_id.values() if item_inspection_is_overdue(it, today=today)
         )
@@ -1829,7 +1829,7 @@ class Repository:
         differ by exactly the items whose inspection date is today.
         """
 
-        today = today_utc_date()
+        today = today_local_date()
         return sum(
             1 for it in self._items_by_id.values() if item_inspection_is_due(it, today=today)
         )
@@ -1842,7 +1842,7 @@ class Repository:
         one the household still has to act on.
         """
 
-        today = today_utc_date()
+        today = today_local_date()
         return sum(1 for it in self._items_by_id.values() if item_reminder_is_due(it, today=today))
 
     def count_matching_by_location(self, flt: ItemFilter | None = None) -> dict[str | None, int]:

--- a/custom_components/haventory/sensor.py
+++ b/custom_components/haventory/sensor.py
@@ -1,9 +1,10 @@
 """The promoted inventory counts as sensor entities on one HAventory device.
 
 Push only — no coordinator and no polling. Two things move a state: a mutation,
-through the dispatcher signal `events.notify_mutation` sends, and UTC midnight,
-for the counts that are derived from the calendar and so change with no mutation
-at all. `const.SENSOR_DESCRIPTIONS` is the catalog; nothing here is per-count.
+through the dispatcher signal `events.notify_mutation` sends, and the
+instance's local midnight, for the counts that are derived from the calendar
+and so change with no mutation at all. `const.SENSOR_DESCRIPTIONS` is the
+catalog; nothing here is per-count.
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.event import async_track_utc_time_change
+from homeassistant.helpers.event import async_track_time_change
 
 from .const import (
     DOMAIN,
@@ -76,10 +77,11 @@ class HaventoryCountSensor(SensorEntity):
         )
         if self._description.date_derived:
             # A date-derived count compares today's date against stored dates,
-            # so it moves at midnight with nothing having been mutated. UTC,
-            # because the counts themselves compare against a UTC date.
+            # so it moves at midnight with nothing having been mutated. The
+            # instance's midnight, not UTC's: the counts compare against the
+            # instance's local day, the same one `calendar.py` rolls over on.
             self.async_on_remove(
-                async_track_utc_time_change(
+                async_track_time_change(
                     self.hass, self._handle_time_change, hour=0, minute=0, second=0
                 )
             )

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -62,7 +62,7 @@ from .models import (
     new_uuid4,
     normalize_tags,
     serialize_status_definition,
-    today_utc_date,
+    today_local_date,
     validate_attachment_meta,
     validate_item_filter,
     validate_sort,
@@ -644,14 +644,14 @@ def _payload_inspection_is_overdue(item: dict[str, Any]) -> bool:
 
     The matcher is handed the event payload rather than the stored ``Item``, so
     it cannot call ``item_inspection_is_overdue`` — but it must agree with it,
-    and with ``inspection_overdue_only`` on ``item/list``. Same comparison:
-    YYYY-MM-DD text, strictly before today in UTC.
+    and with ``inspection_overdue_only`` on ``item/list``. Same comparison and
+    the same clock: YYYY-MM-DD text, strictly before the instance's local day.
     """
 
     date = item.get("inspection_date")
     if not isinstance(date, str) or not date:
         return False
-    return date < today_utc_date()
+    return date < today_local_date()
 
 
 def _item_matches_filter(item: dict[str, Any], sub: Subscription) -> bool:
@@ -1375,12 +1375,12 @@ async def ws_reminder_bump(
     the same reminder land on the same answer, and neither of them can re-anchor
     a series by accident.
 
-    Today is the **local** one, the day the calendar runs on. A reminder is a
+    Today is the instance's local day, the one every other surface runs on —
+    the calendar, the counts, the sensors and the card's chips. A reminder is a
     household-facing date rather than a timestamp, and bumping is what somebody
-    does in the evening — which west of Greenwich is already tomorrow in UTC, so
-    counting from the UTC day would skip the occurrence their own calendar is
-    showing them for tomorrow. The two date-derived counts still measure against
-    the UTC day; see the README's note on the two boundaries.
+    does in the evening: west of Greenwich that is already tomorrow in UTC, so
+    counting from a UTC day would skip the occurrence their own calendar is
+    showing them for tomorrow.
     """
 
     repo = _repo(hass)

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -28,16 +28,15 @@ One HAventory device under Settings → Devices & services, carrying:
 each *due* count is its *overdue* twin plus whatever falls today, and never smaller than it.
 
 They update the moment something changes — a card edit, a `haventory.*` service call, an
-import — with no polling interval to tune. The four date-derived ones also roll over at UTC
+import — with no polling interval to tune. The four date-derived ones also roll over at
 midnight, so "Checked out overdue count" grows overnight without anybody touching the
 inventory.
 
-**UTC midnight, deliberately, and it is not the calendar's midnight.** These counts
-compare stored dates against the UTC day, which is also the day `item/list`'s overdue
-filters use; the calendar and the reminder bump run on your Home Assistant timezone's day,
-because those are dates you read and act on rather than numbers. The two boundaries coincide
-in London and diverge everywhere else: at UTC-8 "Checked out overdue count" ticks up at 4 pm
-local, eight hours before the calendar stops showing that item as due today.
+**One day, and it is your Home Assistant's.** Everything that decides whether a date has
+passed — these counts, `item/list`'s overdue filters, the calendar entity, the reminder bump
+and the card's own chips and pills — measures against the day your instance is configured
+for, and rolls over at its midnight. Change the time zone in Home Assistant and they all
+move together.
 
 Put "Low stock count: 3" on a dashboard next to the weather and nobody has to open the card to
 know whether a shopping trip is due.

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -127,11 +127,12 @@ Defaults when enabled (tokens/second, burst): commands 20/60 per connection, 100
 - `haventory/stats`
   - Result: `{items_total: number, low_stock_count: number, checked_out_count: number, overdue_count: number, checked_out_due_count: number, inspection_overdue_count: number, inspection_due_count: number, reminder_due_count: number, missing_count: number, needs_repair_count: number, status_counts: {[slug]: number}, locations_total: number, no_location_count: number}`
   - `no_location_count` is the number of items without a location (`location_id == null`, i.e. the `orphaned_only` filter's population).
-  - `overdue_count` is the number of items whose `due_date` is strictly before today in UTC (the `overdue_only` filter's population). It is derived from the calendar, not from stored state, so it can change without any mutation — no event is emitted when the date rolls over.
-  - `checked_out_due_count` is the number of items whose `due_date` is **on or before** today in UTC (the `checked_out_due_only` filter's population) — the same population as `overdue_count` plus the items due back today, so it is never smaller than it. Calendar-derived with the same no-event caveat.
-  - `inspection_overdue_count` is the number of items whose `inspection_date` — the date the item is next due for inspection — is strictly before today in UTC (the `inspection_overdue_only` filter's population). It counts the whole inventory, not just checked-out items, because an inspection is independent of any check-out. Calendar-derived in the same way as `overdue_count`, with the same no-event caveat.
-  - `inspection_due_count` is the number of items whose `inspection_date` is **on or before** today in UTC — the same population as `inspection_overdue_count` plus the items due today, so it is never smaller than it. *Due* includes today and *overdue* does not, the same distinction `checked_out_due_count` and `reminder_due_count` draw (the `inspection_due_only` filter's population). Calendar-derived with the same no-event caveat as the counts above.
-  - `reminder_due_count` is the number of items whose `reminder_date` is on or before today in UTC (the `reminder_due_only` filter's population). It **includes today**, as every *due* count does: a reminder names the day it is asking about, so an item reminding today is still one to act on, where a due date has to pass before it is late. Calendar-derived with the same no-event caveat as the counts above.
+  - `overdue_count` is the number of items whose `due_date` is strictly before today (the `overdue_only` filter's population). It is derived from the calendar, not from stored state, so it can change without any mutation — no event is emitted when the date rolls over.
+  - `checked_out_due_count` is the number of items whose `due_date` is **on or before** today (the `checked_out_due_only` filter's population) — the same population as `overdue_count` plus the items due back today, so it is never smaller than it. Calendar-derived with the same no-event caveat.
+  - `inspection_overdue_count` is the number of items whose `inspection_date` — the date the item is next due for inspection — is strictly before today (the `inspection_overdue_only` filter's population). It counts the whole inventory, not just checked-out items, because an inspection is independent of any check-out. Calendar-derived in the same way as `overdue_count`, with the same no-event caveat.
+  - `inspection_due_count` is the number of items whose `inspection_date` is **on or before** today — the same population as `inspection_overdue_count` plus the items due today, so it is never smaller than it. *Due* includes today and *overdue* does not, the same distinction `checked_out_due_count` and `reminder_due_count` draw (the `inspection_due_only` filter's population). Calendar-derived with the same no-event caveat as the counts above.
+  - `reminder_due_count` is the number of items whose `reminder_date` is on or before today (the `reminder_due_only` filter's population). It **includes today**, as every *due* count does: a reminder names the day it is asking about, so an item reminding today is still one to act on, where a due date has to pass before it is late. Calendar-derived with the same no-event caveat as the counts above.
+  - "Today" in those five is the day Home Assistant is configured for — the same day `calendar.haventory` rolls over on, `haventory/reminder/bump` counts from and the card's chips read. One boundary, at the instance's midnight, on every surface.
   - `missing_count` / `needs_repair_count` count items whose stored `status` is `missing` / `needs_repair` — each the population of the `status` filter set to that slug. Stored state, not calendar-derived: they only change on a mutation, and every mutation emits `stats/counts`.
   - `status_counts` is the same figure for **every** defined slug, including `ok`. Additive to the two keys above rather than a replacement for them, so a client written against the earlier shape keeps working.
 
@@ -295,9 +296,9 @@ with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
     lands on its next *future* occurrence rather than another date already past, and no
     occurrence in between is skipped — a 31st series bumped in February lands on the 28th,
     and the next one is 31 March.
-  - Today is the **local** day, the one `calendar.haventory` rolls over on, not the UTC day
-    the two date-derived counts use. A reminder is a household-facing date, and bumping is
-    what somebody does in the evening.
+  - Today is the instance's local day, the one `calendar.haventory` rolls over on and the
+    one the date-derived counts and filters use. A reminder is a household-facing date, and
+    bumping is what somebody does in the evening.
   - `validation_error` when the item has no reminder, and when it has one with no interval:
     a one-off has no next occurrence, and `haventory/reminder/clear` is what ends it. Also
     when the stored dates cannot be read, which only a hand-edited store produces.

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -54,7 +54,8 @@ not an item mutation, so tokens held for optimistic concurrency survive the rena
 "recently updated" sort is not shuffled by rows nobody touched.
 
 `inspection_date` is a **forward-looking** date: when the item is next due for inspection.
-A value strictly before today (UTC) means that inspection is overdue — the population behind
+A value strictly before today — the day Home Assistant is configured for, as everywhere
+else in HAventory — means that inspection is overdue: the population behind
 the `inspection_overdue_only` filter and the `inspection_overdue_count` stat; a value on or
 before today means it is due, which is what `inspection_due_only` and `inspection_due_count`
 report. It is
@@ -277,11 +278,12 @@ counts items at the node or any descendant (so it is always >= the direct count)
   - `checked_out?: boolean`
   - `low_stock_only?: boolean`
   - `orphaned_only?: boolean` (only items without a location, i.e. `location_id == null`)
-  - `overdue_only?: boolean` (only items whose `due_date` is strictly before today, UTC)
-  - `checked_out_due_only?: boolean` (only items whose `due_date` is **on or before** today, UTC — `overdue_only`'s population plus the items due back today)
-  - `inspection_overdue_only?: boolean` (only items whose `inspection_date` is strictly before today, UTC; independent of check-out state)
-  - `inspection_due_only?: boolean` (only items whose `inspection_date` is **on or before** today, UTC — `inspection_overdue_only`'s population plus the items due today; independent of check-out state)
-  - `reminder_due_only?: boolean` (only items whose `reminder_date` is **on or before** today, UTC — today counts, because a reminder names the day it is asking about)
+  - `overdue_only?: boolean` (only items whose `due_date` is strictly before today)
+  - `checked_out_due_only?: boolean` (only items whose `due_date` is **on or before** today — `overdue_only`'s population plus the items due back today)
+  - `inspection_overdue_only?: boolean` (only items whose `inspection_date` is strictly before today; independent of check-out state)
+  - `inspection_due_only?: boolean` (only items whose `inspection_date` is **on or before** today — `inspection_overdue_only`'s population plus the items due today; independent of check-out state)
+  - `reminder_due_only?: boolean` (only items whose `reminder_date` is **on or before** today — today counts, because a reminder names the day it is asking about)
+  - "today" in those five is the day Home Assistant is configured for, read once per query — the same day the counts, the calendar entity and the card's chips use
   - `location_id?: uuid-v4|null`
   - `location_ids?: uuid-v4[]` (multi-select beside `location_id`; see the union rule below)
   - `area_id?: string`
@@ -372,7 +374,7 @@ Counts object used in `stats` results and events:
 ```
 
 `no_location_count` is the number of items without a location (`location_id == null`).
-`overdue_count` is the number of items whose `due_date` is strictly before today (UTC);
+`overdue_count` is the number of items whose `due_date` is strictly before today;
 it moves with the calendar, so the same data can report a different count tomorrow.
 `checked_out_due_count` asks it inclusive of today, so it is `overdue_count` plus the items
 due back today and is never smaller than it.

--- a/stubs/homeassistant/util/__init__.pyi
+++ b/stubs/homeassistant/util/__init__.pyi
@@ -1,0 +1,1 @@
+"""Minimal Home Assistant stubs for offline type checking."""

--- a/stubs/homeassistant/util/dt.pyi
+++ b/stubs/homeassistant/util/dt.pyi
@@ -1,0 +1,14 @@
+"""Minimal Home Assistant stubs for offline type checking.
+
+Only the three names the integration reads. `DEFAULT_TIME_ZONE` is a module
+attribute in Home Assistant too, and a test that moves the instance's zone
+rebinds it, so it is typed here rather than hidden behind a getter.
+"""
+
+from datetime import datetime, tzinfo
+
+DEFAULT_TIME_ZONE: tzinfo
+
+def now(time_zone: tzinfo | None = None) -> datetime: ...
+def utcnow() -> datetime: ...
+def as_local(value: datetime) -> datetime: ...

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -21,11 +21,24 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry, async_
 
 LOW_THRESHOLD = 3
 
+# 13:30 UTC on 22 August is 01:30 on the **23rd** in New Zealand — the window a
+# UTC-reading count and the household's own calendar disagree over.
+NZ_ZONE = "Pacific/Auckland"
+NZ_LATE_EVENING = datetime(2026, 8, 22, 11, 0, tzinfo=UTC)
+NZ_JUST_PAST_MIDNIGHT = datetime(2026, 8, 22, 12, 0, 30, tzinfo=UTC)
+NZ_EARLY_MORNING = datetime(2026, 8, 22, 13, 30, tzinfo=UTC)
+NZ_TODAY = "2026-08-23"
 
-def _utc_day_offset(days: int) -> str:
-    """A UTC calendar date `days` from today, as YYYY-MM-DD."""
 
-    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
+def _local_day_offset(days: int) -> str:
+    """A calendar date `days` from today in the instance's zone, as YYYY-MM-DD.
+
+    Every date-derived count compares against Home Assistant's own day, and this
+    harness does not run in UTC, so a UTC offset would name a different date for
+    part of every day.
+    """
+
+    return (dt_util.now().date() + timedelta(days=days)).isoformat()
 
 
 async def _setup(hass: HomeAssistant) -> MockConfigEntry:
@@ -196,7 +209,7 @@ async def test_an_item_due_back_today_is_due_and_not_overdue(hass: HomeAssistant
     await hass.services.async_call(
         DOMAIN,
         "item_check_out",
-        {"item_id": borrowed["item"]["id"], "due_date": _utc_day_offset(0)},
+        {"item_id": borrowed["item"]["id"], "due_date": _local_day_offset(0)},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -210,7 +223,7 @@ async def test_an_item_due_back_today_is_due_and_not_overdue(hass: HomeAssistant
     await hass.services.async_call(
         DOMAIN,
         "item_check_out",
-        {"item_id": late["item"]["id"], "due_date": _utc_day_offset(-1)},
+        {"item_id": late["item"]["id"], "due_date": _local_day_offset(-1)},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -242,7 +255,7 @@ async def test_an_inspection_due_today_is_due_and_not_overdue(hass: HomeAssistan
     await hass.services.async_call(
         DOMAIN,
         "item_create",
-        {"name": "Harness", "inspection_date": _utc_day_offset(0)},
+        {"name": "Harness", "inspection_date": _local_day_offset(0)},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -253,7 +266,7 @@ async def test_an_inspection_due_today_is_due_and_not_overdue(hass: HomeAssistan
     await hass.services.async_call(
         DOMAIN,
         "item_create",
-        {"name": "Ladder", "inspection_date": _utc_day_offset(-1)},
+        {"name": "Ladder", "inspection_date": _local_day_offset(-1)},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -262,27 +275,57 @@ async def test_an_inspection_due_today_is_due_and_not_overdue(hass: HomeAssistan
     assert hass.states.get(overdue).state == "1"
 
 
-async def test_the_inspection_due_sensor_moves_at_utc_midnight(
+async def test_the_inspection_due_sensor_reads_the_instances_day(
+    hass: HomeAssistant, freezer
+) -> None:
+    """The issue's reproduction, east of Greenwich (#568).
+
+    At 01:30 on the 23rd in Auckland it is still the 22nd in UTC. A count that
+    read the UTC day answered 0 here while the row's chip, the calendar and the
+    card's pill all called the same item due — for the first twelve hours of
+    every day.
+    """
+
+    await hass.config.async_set_time_zone(NZ_ZONE)
+    freezer.move_to(NZ_EARLY_MORNING)
+
+    entry = await _setup(hass)
+    due = _entity_id_for(hass, entry, "inspection_due_count")
+
+    await hass.services.async_call(
+        DOMAIN, "item_create", {"name": "Harness", "inspection_date": NZ_TODAY}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert dt_util.now().date().isoformat() == NZ_TODAY
+    assert hass.states.get(due).state == "1"
+
+
+async def test_the_inspection_due_sensor_rolls_over_at_the_instances_midnight(
     hass: HomeAssistant, freezer
 ) -> None:
     """A date-derived count rewrites on the rollover, with nothing mutated.
 
     Tomorrow's inspection becomes today's without anybody touching the item, so
     a sensor that only listened for mutations would sit at yesterday's figure
-    all day.
+    all day. Pinned to a zone ahead of UTC, where the household's midnight comes
+    first: a rewrite scheduled for UTC's would not have fired yet at this
+    instant, which is what makes this the rollover and not just the clock.
     """
+
+    await hass.config.async_set_time_zone(NZ_ZONE)
+    freezer.move_to(NZ_LATE_EVENING)
 
     entry = await _setup(hass)
     due = _entity_id_for(hass, entry, "inspection_due_count")
-    tomorrow = _utc_day_offset(1)
 
     await hass.services.async_call(
-        DOMAIN, "item_create", {"name": "Harness", "inspection_date": tomorrow}, blocking=True
+        DOMAIN, "item_create", {"name": "Harness", "inspection_date": NZ_TODAY}, blocking=True
     )
     await hass.async_block_till_done()
     assert hass.states.get(due).state == "0"
 
-    freezer.move_to(f"{tomorrow}T00:00:30+00:00")
+    freezer.move_to(NZ_JUST_PAST_MIDNIGHT)
     async_fire_time_changed(hass, dt_util.utcnow())
     await hass.async_block_till_done()
 

--- a/tests/test_local_day_offline.py
+++ b/tests/test_local_day_offline.py
@@ -1,0 +1,172 @@
+"""One household day, pinned east of Greenwich.
+
+Every date-derived answer HAventory gives — the five item predicates, the five
+`filter_items` flags, the five repository counts behind the sensors and
+`haventory/stats`, and the subscription matcher — has to name the same day as
+the calendar entity, the reminder bump and the card's chips: the one Home
+Assistant is configured for. Until #568 those first four read a UTC day, so
+between local midnight and UTC midnight a row said Overdue while the sensor,
+the pill and `overdue_only` said not yet.
+
+The offline suite and the dev container both run in UTC, which is the one zone
+where the bug is invisible, so the zone is pinned here. A fixed +12 offset
+stands in for `Pacific/Auckland` in August: `zoneinfo` needs a tzdata package
+the offline environment does not carry on every host, and the offset is what
+the assertions turn on.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from custom_components.haventory.models import (
+    Item,
+    ItemCreate,
+    filter_items,
+    item_inspection_is_due,
+    item_inspection_is_overdue,
+    item_is_due,
+    item_is_overdue,
+    item_reminder_is_due,
+    today_local_date,
+)
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.serialization import serialize_item
+from custom_components.haventory.ws import _item_matches_filter
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from runtime_helpers import install_runtime
+
+# 13:30 UTC on 22 August is 01:30 on the **23rd** in New Zealand: the window in
+# which the two days disagree, and the instant every case below is frozen at.
+INSTANT_UTC = datetime(2026, 8, 22, 13, 30, tzinfo=UTC)
+NZ = timezone(timedelta(hours=12))
+LOCAL_TODAY = "2026-08-23"
+UTC_TODAY = "2026-08-22"
+
+
+@pytest.fixture
+def household_in_new_zealand(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Move the instance east of Greenwich and stop the clock inside the window.
+
+    `monkeypatch` puts both back afterwards; the rest of the suite assumes UTC.
+    """
+
+    monkeypatch.setattr(dt_util, "DEFAULT_TIME_ZONE", NZ)
+    monkeypatch.setattr(dt_util, "now", lambda *_a, **_k: INSTANT_UTC.astimezone(NZ))
+
+
+def _item(**fields: object) -> Item:
+    repo = Repository()
+    payload: ItemCreate = {"name": "Harness", **fields}  # type: ignore[typeddict-item]
+    return repo.create_item(payload)
+
+
+def _repo_with(**fields: object) -> Repository:
+    repo = Repository()
+    payload: ItemCreate = {"name": "Harness", **fields}  # type: ignore[typeddict-item]
+    repo.create_item(payload)
+    return repo
+
+
+@pytest.mark.usefixtures("household_in_new_zealand")
+def test_today_is_the_instances_day_and_not_the_utc_one() -> None:
+    """The whole fix in one line: 01:30 in Auckland is still yesterday in UTC."""
+
+    assert today_local_date() == LOCAL_TODAY
+    assert datetime.now(UTC).date().isoformat() == UTC_TODAY
+
+
+@pytest.mark.usefixtures("household_in_new_zealand")
+def test_an_inspection_dated_today_is_due_on_every_surface() -> None:
+    """The issue's reproduction: the predicate, the count and the filter agree."""
+
+    item = _item(inspection_date=LOCAL_TODAY)
+
+    assert item_inspection_is_due(item) is True
+    assert item_inspection_is_overdue(item) is False
+
+    repo = _repo_with(inspection_date=LOCAL_TODAY)
+    counts = repo.get_counts()
+    assert counts["inspection_due_count"] == 1
+    assert counts["inspection_overdue_count"] == 0
+
+    assert [i.id for i in filter_items([item], {"inspection_due_only": True})] == [item.id]
+
+
+@pytest.mark.usefixtures("household_in_new_zealand")
+def test_a_date_that_passed_locally_is_overdue_before_utc_agrees() -> None:
+    """Yesterday for the household is still today in UTC, and it counts as past."""
+
+    item = _item(checked_out=True, due_date=UTC_TODAY)
+
+    assert item_is_overdue(item) is True
+    assert item_is_due(item) is True
+
+    repo = _repo_with(checked_out=True, due_date=UTC_TODAY)
+    counts = repo.get_counts()
+    assert counts["overdue_count"] == 1
+    assert counts["checked_out_due_count"] == 1
+
+    assert [i.id for i in filter_items([item], {"overdue_only": True})] == [item.id]
+
+
+@pytest.mark.usefixtures("household_in_new_zealand")
+def test_a_reminder_dated_today_has_come_round() -> None:
+    """A reminder counts today, and the bump already read this same day."""
+
+    item = _item(reminder_date=LOCAL_TODAY)
+
+    assert item_reminder_is_due(item) is True
+    assert _repo_with(reminder_date=LOCAL_TODAY).get_counts()["reminder_due_count"] == 1
+    assert [i.id for i in filter_items([item], {"reminder_due_only": True})] == [item.id]
+
+
+@pytest.mark.usefixtures("household_in_new_zealand")
+def test_tomorrow_is_not_yet_due_anywhere() -> None:
+    """The other edge of the window: moving the day forward must not over-count.
+
+    A UTC reading would call 2026-08-24 two days away and this one day away, but
+    neither is today, so nothing here may report it as due.
+    """
+
+    item = _item(inspection_date="2026-08-24", reminder_date="2026-08-24")
+
+    assert item_inspection_is_due(item) is False
+    assert item_reminder_is_due(item) is False
+
+    repo = _repo_with(inspection_date="2026-08-24", reminder_date="2026-08-24")
+    counts = repo.get_counts()
+    assert counts["inspection_due_count"] == 0
+    assert counts["reminder_due_count"] == 0
+
+    assert filter_items([item], {"inspection_due_only": True}) == []
+
+
+@pytest.mark.usefixtures("household_in_new_zealand")
+@pytest.mark.parametrize(
+    ("inspection_date", "expected"),
+    [("2026-08-21", True), (UTC_TODAY, True), (LOCAL_TODAY, False), ("2026-08-24", False)],
+)
+def test_the_subscription_matcher_and_the_item_predicate_read_one_day(
+    inspection_date: str, expected: bool
+) -> None:
+    """`inspection_overdue_only` runs twice on the same item, over two shapes.
+
+    `item/list` asks the `Item` predicate and a subscription asks the serialized
+    payload, so the two are separate pieces of code that have to answer the same
+    thing for the same date — including on the day the household turned over and
+    UTC has not.
+    """
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    item = _item(inspection_date=inspection_date)
+
+    payload = serialize_item(hass, item)
+    matched = _item_matches_filter(payload, {"topic": "items", "inspection_overdue_only": True})
+
+    assert item_inspection_is_overdue(item) is expected
+    assert matched is expected

--- a/tests/test_sensor_offline.py
+++ b/tests/test_sensor_offline.py
@@ -62,6 +62,22 @@ def test_only_the_calendar_derived_counts_track_midnight() -> None:
     }
 
 
+def test_the_rollover_is_the_instances_midnight_and_not_utcs() -> None:
+    """The counts read the instance's local day, so the rewrite has to follow it.
+
+    Read off the source because nothing offline stubs
+    `homeassistant.components.sensor`, so the module cannot be imported here.
+    That the subscription actually fires at local midnight is asserted in
+    `tests/integration/test_sensor.py`; what this catches is the one-word slip
+    back to the UTC helper, which no offline test could otherwise see.
+    """
+
+    source = (PACKAGE / "sensor.py").read_text(encoding="utf-8")
+
+    assert "async_track_utc_time_change" not in source
+    assert "async_track_time_change" in source
+
+
 def test_the_forwarded_platforms_are_the_two_this_integration_owns() -> None:
     """A platform in the tuple with no module beside it fails setup outright."""
 


### PR DESCRIPTION
## Summary

Three clocks decided whether a date had passed. The calendar entity, the reminder bump and the card's chips read Home Assistant's own day; `models.today_utc_date()` read a UTC one, and with it the five `item_*_is_*` predicates, the five `filter_items` date flags, the five repository `_count_*` walks behind the sensors, `haventory/stats` and the card's quick-filter pills, plus `ws._payload_inspection_is_overdue` and the sensors' midnight rollover. Between the two midnights a row said Overdue while the sensor, the pill and `overdue_only` said not yet — every night in Berlin, every morning in Auckland, for every household outside UTC.

The backend now names one day: the instance's.

- `models.today_utc_date()` → `today_local_date()`, returning `dt_util.now().date().isoformat()`. The predicates keep their keyword-only `today` parameter and `filter_items` stays pure — `today` is a value read once per query, never a `hass` handle in `models.py` or `repository.py`. Every call site renamed; no alias left behind.
- `ws._payload_inspection_is_overdue` reads the same day. It stays a payload function — the matcher runs once per subscription per event and is handed the serialized item, so reusing the `Item` predicate would mean building an `Item` per event. The agreement between the two is pinned by a parametrised test that feeds one date through both shapes.
- `sensor.py`: `async_track_utc_time_change` → `async_track_time_change`, so the date-derived counts rewrite at the instance's midnight the way `calendar.py` already does. Module docstring, the comment in `async_added_to_hass` and `const.HaventorySensorDescription`'s docstring follow.
- `ws.reminder_bump`'s docstring no longer points at "the README's note on the two boundaries" — there is one boundary now.
- Docs: `docs/automations.md`'s "UTC midnight, deliberately" paragraph becomes one sentence saying every surface uses the instance's day and rolls over at its midnight; `docs/backend_api_contract.md` (the five count bullets, the `reminder_bump` note) and `docs/data_shapes.md` (the `inspection_date` paragraph, the five filter bullets, the stats paragraph) drop "in UTC" and each gain one line naming the day. The only `UTC` statements left in those files are about timestamp format — `created_at` / `updated_at` are still ISO-8601 UTC with `Z`, unchanged.
- Card: no component change. `src/test.utils.ts`' `mockToday()` sliced a UTC ISO string while the components it mirrors compare against the browser's local day (`toIsoDate`), so on any machine outside UTC the mock disagreed with the code it stands in for for part of every day — a suite green here that would flake at midnight elsewhere. It now reads `toIsoDate()`.

**Departures from the plan.** Two, both because the source or the host disagreed with it.

- The plan asked for `zoneinfo.ZoneInfo("Pacific/Auckland")` in the offline test. The offline environment carries no `tzdata`, so `zoneinfo` cannot resolve an IANA key on a Windows host and the test would only run on CI. It uses a fixed `+12` offset instead — New Zealand's August offset, and the number the assertions turn on — which is also what the existing zone-pinned test (`test_a_bump_counts_from_the_household_day_not_the_utc_one`) already does. The phacc test does use `Pacific/Auckland` through `hass.config.async_set_time_zone`, where HA's own tzdata is present.
- The plan asked the offline sensor test to assert the rollover is registered through `async_track_time_change` "by checking what the stub records". Nothing offline stubs `homeassistant.components.sensor`, so `sensor.py` cannot be imported offline at all — `tests/test_sensor_offline.py` says so in its own module docstring. The offline test reads the module source instead, the way `test_logs_offline.py` sweeps for `logging.getLogger`; the behavioural assertion lives in phacc.

One more thing the plan did not name: `models.py` now carries a Home Assistant import (`dt_util`), its first. It reads a module global rather than a `hass`, so the module stays free of I/O and of any request context, and its docstring records that. `stubs/homeassistant/util/dt.pyi` was added so the strict-mode modules type-check against a real signature rather than `Any`.

Closes #568

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

Behaviour does change for anyone outside UTC — that is the point — but no shape, name or default moves.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1301 passed, 22 skipped**; `ruff check`, `ruff format --check` (186 files) and `mypy` (26 source files) clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` → **1814 passed / 66 files**, `npm run build` → 714.60 kB.
- [x] phacc, in the `ghcr.io/astral-sh/uv:bookworm` container: `scripts/test_integration.sh` → **149 passed** in 121 s.

Every new test was checked against the old behaviour rather than assumed to be catching it:

- `tests/test_local_day_offline.py` — with the body of `today_local_date()` put back to `datetime.now(UTC)`, **5 of the 9 cases fail**.
- `tests/integration/test_sensor.py::test_the_inspection_due_sensor_reads_the_instances_day` — same revert, fails.
- `tests/integration/test_sensor.py::test_the_inspection_due_sensor_rolls_over_at_the_instances_midnight` — with `sensor.py` alone put back to `async_track_utc_time_change` and the local day kept, fails. The instant it fires at (12:00:30 UTC, 00:00:30 in Auckland) is before UTC midnight, which is what makes it a test of the tracker and not just of the clock.

Not run: the live check against the dev Home Assistant, which is the session's — set the instance to `Pacific/Auckland`, give an item that day's date as `inspection_date`, and read the sensor, the pill and the row chip together.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None — no card component changed; the only frontend edit is a test helper.

## Follow-ups

- The browser's zone can still differ from the instance's — a phone abroad reads its own day for the chips while the sensors and filters read the household's. `hass.config.time_zone` is on the connection the card already holds and would close it.
- The counts are recomputed on every read and the rollover only rewrites the sensor states; a card left open overnight still shows yesterday's pills until the next mutation or a refresh. Unchanged by this PR, and unchanged from before it.
- `tests/integration/test_sensor.py`'s other date cases still run in whatever zone the harness defaults to. They are correct there now that the helper reads `dt_util.now()`, but nothing pins that zone, so they exercise one clock rather than two.
