### PR TITLE
feat(card): make an item's and a location's id readable and copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,10 @@ script:
           location_id: "8a11…"
 ```
 
-To read an id: open an item from the card and the last fact on its detail sheet is the
-**ID**, with **Copy** beside it. A location's is in its editor, under ⋮ → **Organize** →
-Locations → ✎. A JSON export (⋮ → **Export backup**) carries both as well.
+To read an id: open an item from the card and its **ID** is on it, with **Copy** beside it —
+the last fact on the detail sheet a narrow surface opens, the last row of the edit form
+everywhere else. A location's is in its editor, under ⋮ → **Organize** → Locations → ✎. A JSON
+export (⋮ → **Export backup**) carries both as well.
 
 Every action returns the entity it touched, so a script can chain calls through
 `response_variable`. The sensors and what each one counts, the event payloads, the calendar,

--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ script:
           location_id: "8a11…"
 ```
 
-The ids those take are the ones in a JSON export (⋮ → **Export backup**); nothing in the
-card shows an id today.
+To read an id: open an item from the card and the last fact on its detail sheet is the
+**ID**, with **Copy** beside it. A location's is in its editor, under ⋮ → **Organize** →
+Locations → ✎. A JSON export (⋮ → **Export backup**) carries both as well.
 
 Every action returns the entity it touched, so a script can chain calls through
 `response_variable`. The sensors and what each one counts, the event payloads, the calendar,

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -1,6 +1,7 @@
 import './hv-detail-sheet';
 import {
   all,
+  componentCss,
   makeAttachment,
   makeItem,
   makeManual,
@@ -9,6 +10,13 @@ import {
   q,
   settle as settleEl,
 } from '../test.utils';
+// The clipboard itself is `ui/clipboard`'s own test; what the sheet owes is
+// asking the helper and believing its answer, which needs both answers.
+vi.mock('../ui/clipboard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/clipboard')>()),
+  copyText: vi.fn(async () => true),
+}));
+import { copyText } from '../ui/clipboard';
 import { discardPrompt } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { toIsoDate } from '../ui/relative-time';
@@ -1135,5 +1143,82 @@ describe('hv-detail-sheet: documents', () => {
       const later = await mount({ reminder_date: '2099-01-01', reminder_interval: MONTHLY });
       expect(q(later, '[data-testid="sheet-reminder"]')?.classList.contains('late')).toBe(false);
     });
+  });
+});
+
+describe('hv-detail-sheet: the id an automation names', () => {
+  const UUID = '0f2c4a11-6b3d-4a5e-9c8f-2d1e0b7a4c63';
+  const copy = vi.mocked(copyText);
+  const button = (el: HVDetailSheet) => q<HTMLButtonElement>(el, '[data-testid="sheet-copy-id"]')!;
+
+  beforeEach(() => {
+    copy.mockReset();
+    copy.mockResolvedValue(true);
+  });
+
+  it('prints the whole id, last in the facts', async () => {
+    const el = await mount({ id: UUID });
+    const keys = all(el, '[data-testid="sheet-fact"]').map((f) => f.dataset.key);
+    expect(keys.slice(-2)).toEqual(['updated', 'id']);
+    // Elided it would be unpastable, which is the only reason to print it.
+    expect(q(el, '[data-testid="sheet-id"]')?.textContent?.trim()).toBe(UUID);
+  });
+
+  // jsdom lays out no shadow DOM, so the rule is read off the stylesheet.
+  it('offers the whole id to one tap rather than to a 36-character drag', async () => {
+    await mount({ id: UUID });
+    expect(componentCss('hv-detail-sheet')).toMatch(/\.fact \.value\.id \{[^}]*user-select: all/);
+  });
+
+  it('copies the id and says so once the copy has happened', async () => {
+    const el = await mount({ id: UUID });
+    expect(button(el).textContent?.trim()).toBe('Copy');
+
+    button(el).click();
+    await settle(el);
+
+    expect(copy).toHaveBeenCalledWith(UUID);
+    expect(button(el).textContent?.trim()).toBe('Copied');
+  });
+
+  // Home Assistant on the LAN over plain http:// is not a secure context, and
+  // an old browser there has no fallback either. "Copied" would name whatever
+  // was on the clipboard before, so the value stays on screen and unclaimed.
+  it('claims nothing when the browser refused the copy', async () => {
+    copy.mockResolvedValue(false);
+    const el = await mount({ id: UUID });
+
+    button(el).click();
+    await settle(el);
+
+    expect(button(el).textContent?.trim()).toBe('Copy');
+  });
+
+  it('goes back to offering the copy a couple of seconds later', async () => {
+    const el = await mount({ id: UUID });
+    vi.useFakeTimers();
+    try {
+      button(el).click();
+      await settle(el);
+      expect(button(el).textContent?.trim()).toBe('Copied');
+
+      await vi.advanceTimersByTimeAsync(2500);
+      await el.updateComplete;
+      expect(button(el).textContent?.trim()).toBe('Copy');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('forgets it copied when the sheet moves to another item', async () => {
+    const el = await mount({ id: UUID });
+    button(el).click();
+    await settle(el);
+
+    el.item = makeItem({ id: 'i-8' });
+    await settle(el);
+
+    expect(q(el, '[data-testid="sheet-id"]')?.textContent?.trim()).toBe('i-8');
+    expect(button(el).textContent?.trim()).toBe('Copy');
   });
 });

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -22,6 +22,7 @@ import {
 } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import { discardPrompt } from '../ui/discard';
+import { COPIED_MS, copyText } from '../ui/clipboard';
 import { ViewportNarrow } from '../ui/responsive';
 import type { AreaRef, Item, Location, LocationTreeNode, MediaConfig, ScalarValue, StatusDefinition } from '../store/types';
 import './hv-bottom-sheet';
@@ -254,6 +255,19 @@ export class HVDetailSheet extends LitElement {
       .fact .text-action[disabled] {
         color: var(--hv-text-tertiary);
       }
+      /* The id is not read, it is pasted — so it is printed in full and offered
+         to one tap: user-select: all takes the whole uuid from a single click or
+         long-press, which is the copy route left when the browser has no
+         clipboard API (Home Assistant over plain http:// is not a secure
+         context). A uuid carries no space to break at, so it is allowed to break
+         anywhere rather than push the button off a phone's row. */
+      .fact .value.id {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 11.5px;
+        overflow-wrap: anywhere;
+        -webkit-user-select: all;
+        user-select: all;
+      }
       .actions {
         display: grid;
         gap: 9px;
@@ -438,6 +452,13 @@ export class HVDetailSheet extends LitElement {
    * view, dismissing the sheet takes the whole surface down.
    */
   @state() private _pendingDiscard: 'read' | 'close' | null = null;
+  /**
+   * Whether the id was copied a moment ago. Set only on a copy the browser
+   * confirmed — the button is the only feedback there is, so it must not
+   * announce a clipboard that still holds something else.
+   */
+  @state() private _copiedId = false;
+  private _copiedTimer?: ReturnType<typeof setTimeout>;
 
   private readonly _urls = new MediaUrls(this);
   /** Window width, for the confirm this sheet raises over itself. */
@@ -466,7 +487,34 @@ export class HVDetailSheet extends LitElement {
       this._checkoutOpen = false;
       this._lightbox = null;
       this._pendingDiscard = null;
+      this._clearCopied();
     }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._clearCopied();
+  }
+
+  private _clearCopied() {
+    clearTimeout(this._copiedTimer);
+    this._copiedTimer = undefined;
+    this._copiedId = false;
+  }
+
+  /**
+   * Put the item's id on the clipboard, and say so only if it got there.
+   *
+   * The label reverts on its own: a button that stays "Copied" reads as the
+   * name of what it does, and the next copy would then look like a no-op.
+   */
+  private async _copyId(id: string) {
+    if (!(await copyText(id))) return;
+    clearTimeout(this._copiedTimer);
+    this._copiedId = true;
+    this._copiedTimer = setTimeout(() => {
+      this._copiedId = false;
+    }, COPIED_MS);
   }
 
   /** True when the edit form is open with unsaved changes. */
@@ -785,6 +833,21 @@ export class HVDetailSheet extends LitElement {
               version: item.version,
             })}</span
           >
+        </div>
+        <!-- Every haventory action that touches one item takes this string as
+             item_id, and until it was printed here the only way to read one was
+             to export the whole inventory as JSON and search it. Last in the
+             list: it is the one fact that is not about the item itself. -->
+        <div class="fact" data-testid="sheet-fact" data-key="id">
+          <span>${t('hv.term.id')}</span>
+          <code class="value id" data-testid="sheet-id">${item.id}</code>
+          <button
+            class="text-action"
+            data-testid="sheet-copy-id"
+            @click=${() => void this._copyId(item.id)}
+          >
+            ${this._copiedId ? t('hv.action.copied') : t('hv.action.copy')}
+          </button>
         </div>
       </div>
 

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
@@ -1,7 +1,14 @@
 import './hv-diagnostics-panel';
 import type { HVDiagnosticsPanel } from './hv-diagnostics-panel';
 import type { DegradedState, HealthResult, StatsCounts } from '../store/types';
-import { all, mountComponent, q } from '../test.utils';
+import { all, mountComponent, q, settle } from '../test.utils';
+// The clipboard itself is `ui/clipboard`'s own test; what this panel owes is
+// asking the helper and believing its answer, which needs both answers.
+vi.mock('../ui/clipboard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/clipboard')>()),
+  copyText: vi.fn(async () => true),
+}));
+import { copyText } from '../ui/clipboard';
 
 const counts: StatsCounts = {
   items_total: 250,
@@ -142,6 +149,31 @@ describe('hv-diagnostics-panel: actions', () => {
     expect(el.report).toContain('healthy: false');
     expect(el.report).toContain('low_stock_count_mismatch');
     expect(el.report).toContain('subscriptions: items=true');
+  });
+
+  it('copies the report and says so once the copy has happened', async () => {
+    const el = await mount();
+    const button = q(el, '[data-testid="diagnostics-copy"]') as HTMLButtonElement;
+
+    button.click();
+    await settle(el);
+
+    expect(copyText).toHaveBeenCalledWith(el.report);
+    expect(button.textContent?.trim()).toBe('Copied');
+  });
+
+  // A report the household is told it has, and has not, is worse than a button
+  // that stayed put: Home Assistant over plain http:// is not a secure context,
+  // and an old browser there has no fallback either.
+  it('says nothing about a copy the browser refused', async () => {
+    vi.mocked(copyText).mockResolvedValueOnce(false);
+    const el = await mount();
+    const button = q(el, '[data-testid="diagnostics-copy"]') as HTMLButtonElement;
+
+    button.click();
+    await settle(el);
+
+    expect(button.textContent?.trim()).toBe('Copy report');
   });
 
   // This panel writes nothing, so its way out must not wear the shape that

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.ts
@@ -10,6 +10,7 @@ import { summarizeIssues } from '../ui/health-codes';
 import { relativeTime } from '../ui/relative-time';
 import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
+import { copyText } from '../ui/clipboard';
 import type { DegradedState, HealthResult, StatsCounts, VersionInfo } from '../store/types';
 
 /**
@@ -394,12 +395,11 @@ export class HVDiagnosticsPanel extends LitElement {
             <button
               class="hv-text-button"
               data-testid="diagnostics-copy"
-              @click=${() => {
-                void navigator.clipboard?.writeText?.(this.report).catch(() => undefined);
-                this._copied = true;
+              @click=${async () => {
+                this._copied = await copyText(this.report);
               }}
             >
-              ${this._copied ? t('hv.diagnostics.copied') : t('hv.diagnostics.copyReport')}
+              ${this._copied ? t('hv.action.copied') : t('hv.diagnostics.copyReport')}
             </button>
             <!-- This panel reports; it commits nothing. Its way out is drawn as
                  an outline so the filled shape keeps meaning "this writes". -->

--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -1,7 +1,14 @@
 import './hv-import-sheet';
 import type { HVImportSheet } from './hv-import-sheet';
 import type { ImportPreview, ImportSummary } from '../store/types';
-import { all, mountComponent, q } from '../test.utils';
+import { all, mountComponent, q, settle } from '../test.utils';
+// The clipboard itself is `ui/clipboard`'s own test; what this sheet owes is
+// asking the helper and believing its answer, which needs both answers.
+vi.mock('../ui/clipboard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/clipboard')>()),
+  copyText: vi.fn(async () => true),
+}));
+import { copyText } from '../ui/clipboard';
 
 const VALID_DOC = '{"haventory_export_version":1,"items":[],"locations":[]}';
 
@@ -354,8 +361,23 @@ describe('hv-import-sheet: invalid document', () => {
     const copy = q(el, '[data-testid="import-copy-errors"]') as HTMLButtonElement;
     expect(copy.textContent).toContain('Copy errors');
     copy.click();
-    await el.updateComplete;
+    await settle(el);
+    expect(copyText).toHaveBeenCalledWith(expect.stringContaining('items[14].quantity'));
     expect(copy.textContent).toContain('Copied');
+  });
+
+  // Home Assistant on the LAN over plain http:// is not a secure context, and
+  // an old browser there has no fallback either. Saying "Copied" would send the
+  // household off to paste whatever was on the clipboard before.
+  it('says nothing about a copy the browser refused', async () => {
+    vi.mocked(copyText).mockResolvedValueOnce(false);
+    const el = await mount({ preview: invalid });
+    const copy = q(el, '[data-testid="import-copy-errors"]') as HTMLButtonElement;
+
+    copy.click();
+    await settle(el);
+
+    expect(copy.textContent).toContain('Copy errors');
   });
 });
 

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -8,6 +8,7 @@ import { icon } from '../ui/icons';
 import { counted } from '../ui/plural';
 import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
+import { copyText } from '../ui/clipboard';
 import type { ImportBucketCounts, ImportPolicy, ImportPreview, ImportSummary } from '../store/types';
 
 // Every policy decides one thing: what happens to an item the file and the
@@ -433,10 +434,9 @@ export class HVImportSheet extends LitElement {
     this._parseError = null;
   }
 
-  private _copyErrors() {
+  private async _copyErrors() {
     const text = (this.preview?.errors ?? []).map((e) => `${e.path}: ${e.message}`).join('\n');
-    void navigator.clipboard?.writeText?.(text).catch(() => undefined);
-    this._copied = true;
+    this._copied = await copyText(text);
   }
 
   // ---------- States ----------
@@ -585,8 +585,8 @@ export class HVImportSheet extends LitElement {
       </div>
       <div class="foot">
         <span class="hint">${t('hv.import.fixAndRetry')}</span>
-        <button class="hv-text-button" data-testid="import-copy-errors" @click=${() => this._copyErrors()}>
-          ${this._copied ? t('hv.diagnostics.copied') : t('hv.import.copyErrors')}
+        <button class="hv-text-button" data-testid="import-copy-errors" @click=${() => void this._copyErrors()}>
+          ${this._copied ? t('hv.action.copied') : t('hv.import.copyErrors')}
         </button>
         <button
           class="hv-pill"

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -12,6 +12,13 @@ import {
   settle,
   stubViewport,
 } from '../test.utils';
+// The clipboard itself is `ui/clipboard`'s own test; what the editor owes is
+// asking the helper and believing its answer, which needs both answers.
+vi.mock('../ui/clipboard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/clipboard')>()),
+  copyText: vi.fn(async () => true),
+}));
+import { copyText } from '../ui/clipboard';
 import { discardPrompt } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, MEDIA_SIZE_PARAM, attachmentNameToken } from '../ui/media';
 import { addDays } from '../ui/relative-time';
@@ -2763,6 +2770,96 @@ describe('hv-item-editor: reminders', () => {
     expect(saves[0].changes?.reminder_interval).toBe(null);
   });
 
+});
+
+describe('hv-item-editor: the id an automation names', () => {
+  const UUID = '0f2c4a11-6b3d-4a5e-9c8f-2d1e0b7a4c63';
+  const copy = vi.mocked(copyText);
+  const button = (el: HVItemEditor) => q<HTMLButtonElement>(el, '[data-testid="editor-copy-id"]')!;
+
+  beforeEach(() => {
+    copy.mockReset();
+    copy.mockResolvedValue(true);
+  });
+
+  // The editor is the only surface a desktop gets: the detail sheet that also
+  // prints the id opens on a card ≤600px and in the full view below 700px.
+  it('prints the whole id of the item being edited', async () => {
+    const el = await mount(makeItem({ id: UUID }));
+    // Elided it would be unpastable, which is the only reason to print it.
+    expect(q(el, '[data-testid="editor-id"]')?.textContent?.trim()).toBe(UUID);
+  });
+
+  // jsdom lays out no shadow DOM, so the rule is read off the stylesheet.
+  it('offers the whole id to one tap rather than to a 36-character drag', async () => {
+    await mount(makeItem({ id: UUID }));
+    expect(editorCss()).toMatch(/\.id-row code \{[^}]*user-select: all/);
+  });
+
+  it('says nothing on the create form, which has no id yet', async () => {
+    const el = await mount(null);
+    expect(q(el, '[data-testid="editor-id"]')).toBeNull();
+    expect(q(el, '[data-testid="editor-copy-id"]')).toBeNull();
+  });
+
+  // The action row is Delete, Cancel and Save, and at 375px those three have
+  // 343px to spend — a fourth label there would take the row onto two lines.
+  it('keeps the copy out of the phone action row', async () => {
+    const el = await mount(makeItem({ id: UUID }), { mobile: true });
+    expect(button(el).closest('.actions')).toBeNull();
+  });
+
+  it('copies the id and says so once the copy has happened', async () => {
+    const el = await mount(makeItem({ id: UUID }));
+    expect(button(el).textContent?.trim()).toBe('Copy');
+
+    button(el).click();
+    await settle(el);
+
+    expect(copy).toHaveBeenCalledWith(UUID);
+    expect(button(el).textContent?.trim()).toBe('Copied');
+  });
+
+  // Home Assistant on the LAN over plain http:// is not a secure context, and
+  // an old browser there has no fallback either. "Copied" would name whatever
+  // was on the clipboard before, so the value stays on screen and unclaimed.
+  it('claims nothing when the browser refused the copy', async () => {
+    copy.mockResolvedValue(false);
+    const el = await mount(makeItem({ id: UUID }));
+
+    button(el).click();
+    await settle(el);
+
+    expect(button(el).textContent?.trim()).toBe('Copy');
+  });
+
+  it('goes back to offering the copy a couple of seconds later', async () => {
+    const el = await mount(makeItem({ id: UUID }));
+    vi.useFakeTimers();
+    try {
+      button(el).click();
+      await settle(el);
+      expect(button(el).textContent?.trim()).toBe('Copied');
+
+      await vi.advanceTimersByTimeAsync(2500);
+      await el.updateComplete;
+      expect(button(el).textContent?.trim()).toBe('Copy');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('forgets it copied when the form moves to another item', async () => {
+    const el = await mount(makeItem({ id: UUID }));
+    button(el).click();
+    await settle(el);
+
+    el.item = makeItem({ id: 'i-8' });
+    await settle(el);
+
+    expect(q(el, '[data-testid="editor-id"]')?.textContent?.trim()).toBe('i-8');
+    expect(button(el).textContent?.trim()).toBe('Copy');
+  });
 });
 
 describe('hv-item-editor: the language in force', () => {

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -16,6 +16,7 @@ import {
 import { saveShortcutLabel } from '../ui/keyboard';
 import { counted } from '../ui/plural';
 import { discardPrompt } from '../ui/discard';
+import { COPIED_MS, copyText } from '../ui/clipboard';
 import { ViewportNarrow } from '../ui/responsive';
 import { nextZBase } from '../utils/zindex';
 import {
@@ -745,6 +746,30 @@ export class HVItemEditor extends LitElement {
         font: 400 12px var(--hv-font);
         color: var(--hv-text-secondary);
       }
+      /* The id is not read, it is pasted — printed in full and offered to one
+         tap: user-select: all takes the whole uuid from a single click or
+         long-press, which is the copy route left when the browser has no
+         clipboard API (Home Assistant over plain http:// is not a secure
+         context). A uuid carries no space to break at, so it is allowed to
+         break anywhere rather than push the button off a phone's row.
+         A row of its own above the actions, never a fourth control inside
+         them: that row is Delete, Cancel and Save, and at 375px the three of
+         them have 343px to spend. */
+      .id-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+      }
+      .id-row code {
+        min-width: 0;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 11.5px;
+        color: var(--hv-text-secondary);
+        overflow-wrap: anywhere;
+        -webkit-user-select: all;
+        user-select: all;
+      }
       /* Delete is hv-text-button danger from the shared sheet — the same
          borderless red every other destructive action in the card uses (the
          detail sheet's own Delete item, the organize dialog's Delete).
@@ -1185,6 +1210,13 @@ export class HVItemEditor extends LitElement {
   @state() private _lightbox: number | null = null;
   /** Escape on a dirty form asks before it throws the typing away. */
   @state() private _confirmDiscard = false;
+  /**
+   * Whether the item's id was copied a moment ago. Set only on a copy the
+   * browser confirmed — the button is the only feedback there is, so it must
+   * not announce a clipboard that still holds something else.
+   */
+  @state() private _copiedId = false;
+  private _copiedTimer?: ReturnType<typeof setTimeout>;
   /** Why creating a first location from the picker failed. */
   @state() private _locationError: string | null = null;
   /**
@@ -1253,6 +1285,7 @@ export class HVItemEditor extends LitElement {
       this._lightbox = null;
       this._locationError = null;
       this._createdLocations = [];
+      this._clearCopied();
       this._closeCategory();
       return;
     }
@@ -1576,6 +1609,28 @@ export class HVItemEditor extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this._closeCategory();
+    this._clearCopied();
+  }
+
+  private _clearCopied() {
+    clearTimeout(this._copiedTimer);
+    this._copiedTimer = undefined;
+    this._copiedId = false;
+  }
+
+  /**
+   * Put the item's id on the clipboard, and say so only if it got there.
+   *
+   * The label reverts on its own: a button that stays "Copied" reads as the
+   * name of what it does, and the next copy would then look like a no-op.
+   */
+  private async _copyId(id: string) {
+    if (!(await copyText(id))) return;
+    clearTimeout(this._copiedTimer);
+    this._copiedId = true;
+    this._copiedTimer = setTimeout(() => {
+      this._copiedId = false;
+    }, COPIED_MS);
   }
 
   private _chooseCategory(value: string) {
@@ -2423,6 +2478,35 @@ export class HVItemEditor extends LitElement {
     </div>`;
   }
 
+  /**
+   * The string every `haventory.*` action names this item by, as `item_id`.
+   *
+   * This form is the only surface a desktop gets: the detail sheet that also
+   * prints the id opens on a card element of 600px or less, and in the full
+   * view only below the 700px viewport query — while automation YAML is
+   * written on a wide screen. Last in the grid, below the fields and above the
+   * actions: it is a fact about the item, not something to fill in.
+   *
+   * The create form has no id yet and says nothing rather than showing a blank.
+   */
+  private _renderIdRow() {
+    const id = this.item?.id;
+    if (!id) return null;
+    return html`<div class="cell span3">
+      <span class="hv-label">${t('hv.term.id')}</span>
+      <div class="id-row">
+        <code data-testid="editor-id">${id}</code>
+        <button
+          class="hv-text-button"
+          data-testid="editor-copy-id"
+          @click=${() => void this._copyId(id)}
+        >
+          ${this._copiedId ? t('hv.action.copied') : t('hv.action.copy')}
+        </button>
+      </div>
+    </div>`;
+  }
+
   /** Hand the picked files to the queue and let the same file be picked again. */
   private _onPicked(e: Event, kind: AttachmentKind) {
     const input = e.target as HTMLInputElement;
@@ -2823,6 +2907,8 @@ export class HVItemEditor extends LitElement {
           ${this.mobile
             ? html`<div class="cell span3">${this._renderMoreFields()}</div>`
             : html`${this._renderStateFields()} ${this._renderCustomFields()}`}
+
+          ${this._renderIdRow()}
 
           <div class="cell span3 actions-cell">
             <div class="actions">

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1,6 +1,13 @@
 import { setLanguage } from '../i18n';
 import './hv-organize-dialog';
 import { all, componentCss, makeItem, mountComponent, mountStore, q, settle } from '../test.utils';
+// The clipboard itself is `ui/clipboard`'s own test; what the dialog owes is
+// asking the helper and believing its answer, which needs both answers.
+vi.mock('../ui/clipboard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/clipboard')>()),
+  copyText: vi.fn(async () => true),
+}));
+import { copyText } from '../ui/clipboard';
 import { HVOrganizeDialog } from './hv-organize-dialog';
 import type { OrganizeTab } from './hv-organize-dialog';
 import type { AreaRef, Item, Location, StatusDefinition } from '../store/types';
@@ -1629,6 +1636,80 @@ describe('hv-organize-dialog: disclosures come into view', () => {
     expect(scrolls).toHaveLength(2);
     expect(scrolls[1].el).toBe(q(sr, '[data-testid="location-editor"]'));
     expect(sr.activeElement).toBe(q(sr, '[data-testid="location-name"]'));
+  });
+});
+
+describe('hv-organize-dialog: the id an automation names', () => {
+  const locations = [loc('garage', 'Garage', null, 'area-garage'), loc('shelf-a', 'Shelf A', 'garage')];
+  const copy = vi.mocked(copyText);
+
+  /** Open the editor over an existing location, the way the tree's ✎ does. */
+  async function editing(id: string) {
+    const { el, sr } = await mount({ locations });
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (
+      tree.shadowRoot?.querySelector(`[data-testid="tree-edit"][data-id="${id}"]`) as HTMLButtonElement
+    ).click();
+    await settle(el);
+    return { el, sr };
+  }
+
+  beforeEach(() => {
+    copy.mockReset();
+    copy.mockResolvedValue(true);
+  });
+
+  it('shows a location its id, and copies it', async () => {
+    const { el, sr } = await editing('garage');
+    expect(q(sr, '[data-testid="location-id"]')?.textContent?.trim()).toBe('garage');
+
+    const button = q<HTMLButtonElement>(sr, '[data-testid="location-copy-id"]')!;
+    expect(button.textContent?.trim()).toBe('Copy');
+    button.click();
+    await settle(el);
+
+    expect(copy).toHaveBeenCalledWith('garage');
+    expect(q(sr, '[data-testid="location-copy-id"]')?.textContent?.trim()).toBe('Copied');
+  });
+
+  // The same refusal the detail sheet answers for: over plain http:// there may
+  // be no clipboard at all, and a button that says Copied anyway names whatever
+  // was on it before.
+  it('claims nothing when the browser refused the copy', async () => {
+    copy.mockResolvedValue(false);
+    const { el, sr } = await editing('garage');
+
+    q<HTMLButtonElement>(sr, '[data-testid="location-copy-id"]')!.click();
+    await settle(el);
+
+    expect(q(sr, '[data-testid="location-copy-id"]')?.textContent?.trim()).toBe('Copy');
+  });
+
+  it('offers no id on the editor for a location that does not exist yet', async () => {
+    const { el, sr } = await mount({ locations });
+    (q(sr, '[data-testid="organize-new-location"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(q(sr, '[data-testid="location-editor"]')).toBeTruthy();
+    expect(q(sr, '[data-testid="location-id"]')).toBe(null);
+    expect(q(sr, '[data-testid="location-copy-id"]')).toBe(null);
+  });
+
+  it('forgets it copied when the editor is opened again', async () => {
+    const { el, sr } = await editing('garage');
+    q<HTMLButtonElement>(sr, '[data-testid="location-copy-id"]')!.click();
+    await settle(el);
+    expect(q(sr, '[data-testid="location-copy-id"]')?.textContent?.trim()).toBe('Copied');
+
+    (q(sr, '[data-testid="location-cancel"]') as HTMLButtonElement).click();
+    await settle(el);
+    const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;
+    (
+      tree.shadowRoot?.querySelector('[data-testid="tree-edit"][data-id="garage"]') as HTMLButtonElement
+    ).click();
+    await settle(el);
+
+    expect(q(sr, '[data-testid="location-copy-id"]')?.textContent?.trim()).toBe('Copy');
   });
 });
 

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -30,6 +30,7 @@ import { renderAreaChip } from '../ui/location-path';
 import { countLocations } from '../store/location-tree';
 import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
+import { COPIED_MS, copyText } from '../ui/clipboard';
 import { describeFailure } from './hv-bulk-bar';
 import { makeBulkOp } from '../store/store';
 import type { Store } from '../store/store';
@@ -526,6 +527,27 @@ export class HVOrganizeDialog extends LitElement {
       :host([mobile]) .cell.wide {
         grid-column: span 1;
       }
+      /* The id is not read, it is pasted — printed in full and offered to one
+         tap: user-select: all takes the whole uuid from a single click or
+         long-press, which is the copy route left when the browser has no
+         clipboard API (Home Assistant over plain http:// is not a secure
+         context). A uuid carries no space to break at, so it is allowed to break
+         anywhere rather than push the button out of the dialog. */
+      .id-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+      }
+      .id-row code {
+        min-width: 0;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 11.5px;
+        color: var(--hv-text-secondary);
+        overflow-wrap: anywhere;
+        -webkit-user-select: all;
+        user-select: all;
+      }
       .control {
         box-sizing: border-box;
         width: 100%;
@@ -708,6 +730,13 @@ export class HVOrganizeDialog extends LitElement {
   @state() private _locParent: string | null = null;
   @state() private _locParentOpen = false;
   @state() private _locError: string | null = null;
+  /**
+   * Whether the open editor's id was copied a moment ago. Set only on a copy the
+   * browser confirmed — the button is the only feedback there is, so it must not
+   * announce a clipboard that still holds something else.
+   */
+  @state() private _copiedId = false;
+  private _copiedTimer?: ReturnType<typeof setTimeout>;
   @state() private _guard: { locationId: string; message: string } | null = null;
   /** Location being merged away, with the location it is merging into. */
   @state() private _mergingLocation: string | null = null;
@@ -752,6 +781,27 @@ export class HVOrganizeDialog extends LitElement {
     super.disconnectedCallback();
     this._storeUnsub?.();
     this._storeUnsub = undefined;
+    this._clearCopied();
+  }
+
+  private _clearCopied() {
+    clearTimeout(this._copiedTimer);
+    this._copiedTimer = undefined;
+    this._copiedId = false;
+  }
+
+  /**
+   * Put the open location's id on the clipboard, and say so only if it got
+   * there. The label reverts on its own: left standing it reads as the name of
+   * what the button does, and the next copy looks like a press that did nothing.
+   */
+  private async _copyId(id: string) {
+    if (!(await copyText(id))) return;
+    clearTimeout(this._copiedTimer);
+    this._copiedId = true;
+    this._copiedTimer = setTimeout(() => {
+      this._copiedId = false;
+    }, COPIED_MS);
   }
 
 
@@ -905,6 +955,7 @@ export class HVOrganizeDialog extends LitElement {
     this._locParentOpen = false;
     this._locError = null;
     this._guard = null;
+    this._clearCopied();
   }
 
   private async _saveLocation() {
@@ -1333,6 +1384,26 @@ export class HVOrganizeDialog extends LitElement {
               : null}
           </div>
         </div>
+        ${
+          // haventory.item_create and location_create take this string as
+          // location_id / parent_id. A location that has not been saved yet has
+          // none, so the create form says nothing rather than showing a blank.
+          nodeId === 'new'
+            ? null
+            : html`<div class="cell wide">
+                <span class="hv-label">${t('hv.term.id')}</span>
+                <div class="id-row">
+                  <code data-testid="location-id">${nodeId}</code>
+                  <button
+                    class="hv-text-button"
+                    data-testid="location-copy-id"
+                    @click=${() => void this._copyId(nodeId)}
+                  >
+                    ${this._copiedId ? t('hv.action.copied') : t('hv.action.copy')}
+                  </button>
+                </div>
+              </div>`
+        }
       </div>
       ${this._locError
         ? html`<div class="failure" role="alert" data-testid="location-error">${this._locError}</div>`

--- a/cards/haventory-card/src/i18n/catalog.test.ts
+++ b/cards/haventory-card/src/i18n/catalog.test.ts
@@ -68,6 +68,7 @@ describe('the German dictionary', () => {
       'hv.filter.sortField.name',
       'hv.table.name',
       'hv.organize.locationName',
+      'hv.term.id',
       // Nothing but placeholders and punctuation — there is no word to move.
       'hv.editor.upload.progress',
       'hv.sheet.updatedValue',

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -250,6 +250,8 @@ export const de: Record<TranslationKey, string> = {
   'hv.action.checkIn': 'Zurückgeben',
   'hv.action.checkOut': 'Ausleihen',
   'hv.action.checkOutEllipsis': 'Ausleihen …',
+  'hv.action.copy': 'Kopieren',
+  'hv.action.copied': 'Kopiert',
 
   'hv.term.noLocation': 'Kein Ort',
   'hv.term.checkedOut': 'Ausgeliehen',
@@ -261,6 +263,7 @@ export const de: Record<TranslationKey, string> = {
   'hv.term.yes': 'Ja',
   'hv.term.no': 'Nein',
   'hv.term.fileMissing': 'Datei fehlt',
+  'hv.term.id': 'ID',
   'hv.term.due': 'fällig {date}',
   'hv.term.overdueOn': 'Überfällig · {date}',
   'hv.term.checkedOutUntil': 'Ausgeliehen · fällig {date}',
@@ -688,7 +691,6 @@ export const de: Record<TranslationKey, string> = {
   'hv.diagnostics.integrationVersion': 'Version der Integration',
   'hv.diagnostics.healthyNote':
     'Eine gesunde Integration meldet hier nichts. Die Zähler bleiben bei null, solange die Ratenbegrenzung nicht aktiviert ist und greift.',
-  'hv.diagnostics.copied': 'Kopiert',
   'hv.diagnostics.copyReport': 'Bericht kopieren',
 
   'hv.import.title': 'Backup importieren',

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -270,6 +270,8 @@ export const en = {
   'hv.action.checkIn': 'Check in',
   'hv.action.checkOut': 'Check out',
   'hv.action.checkOutEllipsis': 'Check out…',
+  'hv.action.copy': 'Copy',
+  'hv.action.copied': 'Copied',
 
   // Words the card names a fact with, wherever it names one.
   'hv.term.noLocation': 'No location',
@@ -282,6 +284,11 @@ export const en = {
   'hv.term.yes': 'Yes',
   'hv.term.no': 'No',
   'hv.term.fileMissing': 'File missing',
+  // The label over an item's or a location's uuid, on both surfaces that print
+  // one. Deliberately the initialism rather than "Identifier": it is what the
+  // service fields are called (`item_id`, `location_id`), which is what the
+  // household is about to paste it into.
+  'hv.term.id': 'ID',
   'hv.term.due': 'due {date}',
   'hv.term.overdueOn': 'Overdue · {date}',
   'hv.term.checkedOutUntil': 'Checked out · due {date}',
@@ -722,7 +729,6 @@ export const en = {
   'hv.diagnostics.integrationVersion': 'Integration version',
   'hv.diagnostics.healthyNote':
     'A healthy integration reports nothing here. The counters stay at zero unless rate limiting is enabled and tripped.',
-  'hv.diagnostics.copied': 'Copied',
   'hv.diagnostics.copyReport': 'Copy report',
 
   // hv-import-sheet.

--- a/cards/haventory-card/src/ui/clipboard.test.ts
+++ b/cards/haventory-card/src/ui/clipboard.test.ts
@@ -1,0 +1,96 @@
+import { copyText } from './clipboard';
+
+/**
+ * jsdom ships neither half of the browser's clipboard: `navigator.clipboard` is
+ * absent and `document.execCommand` is unimplemented. So each case installs the
+ * shape it is about and the teardown takes it away again — which also makes the
+ * bare environment the honest "no clipboard at all" case.
+ */
+function withClipboard(writeText: (text: string) => Promise<void>) {
+  const spy = vi.fn(writeText);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: spy },
+    configurable: true,
+  });
+  return spy;
+}
+
+function withExecCommand(result: boolean) {
+  const selected: string[] = [];
+  const spy = vi.fn((command: string) => {
+    // What the browser copies is the current selection, so the value under test
+    // is the one on the element this helper put in the document — not the
+    // argument, which is only ever the word "copy".
+    if (command === 'copy') selected.push(document.querySelector('textarea')?.value ?? '');
+    return result;
+  });
+  Object.defineProperty(document, 'execCommand', { value: spy, configurable: true });
+  return { spy, selected };
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, 'clipboard');
+  Reflect.deleteProperty(document, 'execCommand');
+});
+
+describe('copyText', () => {
+  it('writes through the async clipboard where there is one', async () => {
+    const writeText = withClipboard(async () => undefined);
+    const { spy } = withExecCommand(true);
+
+    expect(await copyText('0f2c-4a11')).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('0f2c-4a11');
+    // The deprecated path steals the selection and moves focus; it is the
+    // fallback, not a belt-and-braces second write.
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to execCommand when the async API refuses', async () => {
+    // The refusal every install over plain http:// hits, plus a denied
+    // permission and an unfocused document: all of them land here.
+    withClipboard(async () => {
+      throw new Error('NotAllowedError');
+    });
+    const { selected } = withExecCommand(true);
+
+    expect(await copyText('0f2c-4a11')).toBe(true);
+    expect(selected).toEqual(['0f2c-4a11']);
+  });
+
+  it('falls back when the browser exposes no async clipboard at all', async () => {
+    const { selected } = withExecCommand(true);
+
+    expect(await copyText('shelf-b')).toBe(true);
+    expect(selected).toEqual(['shelf-b']);
+  });
+
+  it('reports failure when neither route exists', async () => {
+    // A caller that says "Copied" here would be naming whatever was on the
+    // clipboard before, which is worse than saying nothing.
+    expect(await copyText('shelf-b')).toBe(false);
+  });
+
+  it('reports failure when execCommand declines the copy', async () => {
+    withExecCommand(false);
+
+    expect(await copyText('shelf-b')).toBe(false);
+  });
+
+  it('leaves nothing of its own in the document', async () => {
+    withExecCommand(true);
+
+    await copyText('shelf-b');
+    expect(document.querySelector('textarea')).toBe(null);
+  });
+
+  it('gives focus back to whatever had it', async () => {
+    withExecCommand(true);
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    await copyText('shelf-b');
+    expect(document.activeElement).toBe(input);
+    input.remove();
+  });
+});

--- a/cards/haventory-card/src/ui/clipboard.ts
+++ b/cards/haventory-card/src/ui/clipboard.ts
@@ -1,0 +1,70 @@
+/**
+ * Copying one short string, on the installs Home Assistant actually runs on.
+ *
+ * `navigator.clipboard` is exposed only in a secure context, and a Home
+ * Assistant reached over plain `http://` on the LAN is not one — which is most
+ * installs. So the async API is tried first and a detached `<textarea>` plus
+ * the deprecated `document.execCommand('copy')` stands behind it: on those
+ * browsers it is the only route there is.
+ *
+ * The boolean is the whole contract. A caller may say "Copied" only when this
+ * returns `true`; announcing a copy that never happened names whatever was on
+ * the clipboard before, which is worse than announcing nothing and leaving the
+ * value on screen to be selected by hand.
+ */
+/**
+ * How long a copy button says "Copied" before it offers the copy again.
+ *
+ * The label has to come back: left standing it reads as the name of what the
+ * button does, and the next copy then looks like a press that did nothing.
+ */
+export const COPIED_MS = 2000;
+
+export async function copyText(text: string): Promise<boolean> {
+  const clipboard = navigator.clipboard as Clipboard | undefined;
+  if (typeof clipboard?.writeText === 'function') {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      // A denied permission, a document the browser does not consider focused,
+      // or an API present but refused outside a secure context. Every one of
+      // them still leaves the selection route below open.
+    }
+  }
+  return selectionCopy(text);
+}
+
+/**
+ * The pre-`navigator.clipboard` route: put the text somewhere selectable,
+ * select it, and ask the document to copy the selection.
+ *
+ * Off-screen rather than hidden — `display: none` and `visibility: hidden` are
+ * both unselectable, and a selection is the only thing `execCommand` can copy.
+ * `readonly` keeps a mobile keyboard from opening over the surface that asked.
+ */
+function selectionCopy(text: string): boolean {
+  const exec = (document as Document & { execCommand?: (command: string) => boolean }).execCommand;
+  if (typeof exec !== 'function') return false;
+  const area = document.createElement('textarea');
+  area.value = text;
+  area.setAttribute('readonly', '');
+  area.style.position = 'fixed';
+  area.style.top = '-1000px';
+  area.style.opacity = '0';
+  const previous = document.activeElement as HTMLElement | null;
+  document.body.appendChild(area);
+  try {
+    area.select();
+    area.setSelectionRange(0, text.length);
+    return exec.call(document, 'copy');
+  } catch {
+    return false;
+  } finally {
+    area.remove();
+    // Selecting moved the caret out of the surface that asked for the copy;
+    // inside a dialog that would drop focus on the document body, where Escape
+    // no longer reaches the thing the user is looking at.
+    previous?.focus?.();
+  }
+}


### PR DESCRIPTION
## Summary

Every `haventory.*` action that touches one item takes its id as `item_id`, and
`item_create` / `location_create` take a location's as `location_id` / `parent_id`. The card
printed none of them, so the only way to read one was to export the whole inventory as JSON
and search it — which the README said out loud.

- **Item, on a phone.** The detail sheet's facts list gains a last row, `data-key="id"`,
  labelled **ID**: the full uuid in a monospace `<code>` (`data-testid="sheet-id"`) with
  `user-select: all`, so one click or long-press selects the whole thing, and a **Copy**
  text-action beside it (`sheet-copy-id`) shaped like the `sheet-reminder-bump` button next
  to it.
- **Item, everywhere else.** The sheet is a narrow-surface answer — `hv-card-shell` opens it
  only when the card element is ≤600px and `hv-full-view` only below the 700px viewport query;
  on a wide card and in the full view on a desktop a row expands into `hv-item-editor`
  instead, and a desktop is where automation YAML gets written. So the edit form carries the
  same row (`editor-id` / `editor-copy-id`), for an existing item only. It sits below the last
  field and above the actions, as a fact about the item rather than a field to fill in — and
  outside the actions row, which is Delete, Cancel and Save with 343px to spend at 375px
  (#573). The row also shows inside the sheet's editor, where the facts list behind it is not
  on screen.
- **Location.** The same row in the organize dialog's location editor (`location-id` /
  `location-copy-id`), for an existing location only — the create form has no id yet and says
  nothing rather than showing a blank.
- **Copying.** New `src/ui/clipboard.ts`: `copyText(text): Promise<boolean>` tries
  `navigator.clipboard.writeText`, falls back to a detached `<textarea>` plus
  `document.execCommand('copy')`, and returns whether either route worked. This is the whole
  point of the helper — `navigator.clipboard` is exposed only in a secure context, and a Home
  Assistant reached over plain `http://` on the LAN is not one, which is most installs. A
  button says "Copied" only on `true`; on `false` the value stays on screen, selectable, and
  nothing claims success. The label reverts after `COPIED_MS` (2 s).
- The **diagnostics panel** and the **import sheet** set their `_copied` state unconditionally
  today, so both claim a copy that may never have happened. Both now go through the helper
  (the plan invited this if it was small; it was), and their shared string moves from
  `hv.diagnostics.copied` to `hv.action.copied` beside the other shared verbs.
- Strings in `en.ts` and `de.ts`: `hv.action.copy` (Kopieren), `hv.action.copied` (Kopiert),
  `hv.term.id` (ID, listed in the catalog test's `SAME_IN_BOTH`).

Closes #546

### Decisions, and where the source disagreed with the plan

- **The identity question is not answered here.** The issue weighs an alternative — letting the
  services name an item by name plus location instead of by id. That is an identity decision,
  and identity-by-id is a deliberate invariant on the import path, so it needs a decision
  rather than an implementation. This PR implements the issue's proposed solution only.
- **One string key, not two.** The plan named `t('hv.sheet.fact.id')`; the same row now exists
  on three surfaces, so it is `hv.term.id` — `hv.sheet.*` read wrongly inside the organize
  dialog, and two keys holding "ID" is the drift the `hv.action.*` block exists to prevent.
- **`docs/automations.md` needed no change.** The plan expected the README's "nothing in the
  card shows an id today" sentence to appear there too; it does not — `automations.md` only
  uses `item_id: "0f2c…"` in examples, which stay correct. README line 180 is the one place,
  and now names the item itself as the route (sheet or edit form, whichever the width opens)
  and keeps the JSON export as a second.
- **The README sentence names the card, not "⋮ on a row".** The plan's wording assumed the ⋮
  menu opens the detail sheet on every width. It does not, which is why the edit form carries
  the row too — the sentence names the item, so it stays true whichever surface a width opens.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Both gates green in the worktree, on the final commit.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1291 passed, 22 skipped;
      `ruff check .` → all checks passed; `ruff format --check .` → 183 files already
      formatted; `mypy` → no issues in 26 source files. (Nothing under `custom_components/`
      changed, so phacc was not needed.)
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → **1842 passed** across 67 files, `npm run build` → one 720.96 kB
      bundle.

New tests — 28 cases:

- `src/ui/clipboard.test.ts` (7): the async clipboard is used where there is one and the
  deprecated path is *not* also fired; the fallback runs when `writeText` rejects and when
  there is no `navigator.clipboard` at all, copying the value that was actually selected;
  `false` when neither route exists and when `execCommand` declines; the textarea leaves
  nothing in the document; focus goes back where it was.
- `hv-detail-sheet.test.ts` (6): the row prints the whole id and sits last, after Updated;
  the stylesheet carries `user-select: all` on it; clicking calls the helper with the id and
  flips to Copied; a refused copy claims nothing; the label reverts after 2.5 s of fake time;
  moving to another item forgets it copied.
- `hv-item-editor.test.ts` (8): the form prints the whole id of the item being edited and
  offers it to one tap; the create form renders neither element; the copy button is **not**
  inside `.actions`, which is the row #573 measured at 343px; clicking calls the helper with
  the id and flips to Copied; a refused copy claims nothing; the label reverts; re-binding
  `.item` to another item forgets it copied.
- `hv-organize-dialog.test.ts` (4): the editor over an existing location shows and copies its
  id; a refused copy claims nothing; the "new" editor renders neither element; re-opening the
  editor forgets it copied.
- `hv-diagnostics-panel.test.ts` (2) and `hv-import-sheet.test.ts` (1, plus the existing
  "offers to copy the problems out" tightened to assert what was handed to the clipboard):
  each says "Copied" only on a copy the browser confirmed.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case — a refused copy, a
      browser with no clipboard at all, and the create form that has no id).
- [x] Docs updated where behavior changed (`README.md`; no backend contract change).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and
      `docs/data_shapes.md` in sync — n/a, card-only.
- [x] Essential invariants preserved — n/a, nothing here writes.

## Screenshots (card / UI changes)

Not taken: the dev Home Assistant belongs to the session that staged this fix, and the plan
reserves the live check (the copy landing in the clipboard on `http://localhost:8123`, a
secure context) to it. The `http://` LAN case, where the `execCommand` fallback is the only
route, is a hand test on a phone.

## Follow-ups

- `hv-location-tree`'s ✎ is the only route to a location's id; the tree's own rows carry none.
  Fine for now — a household reads one location id far less often than an item's.
- `hv.diagnostics.copyReport` and `hv.import.copyErrors` could both become `hv.action.copy`
  now that the "Copied" half is shared, but each names *what* it copies, which is worth the
  extra key on a crowded footer.
