### PR TITLE
fix(card): cap the filter panel's label chips behind More…

### DIFF
--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -340,6 +340,105 @@ describe('hv-filter-panel: tags', () => {
   });
 });
 
+/**
+ * A vocabulary larger than the label cap, named so the alphabetical order the
+ * backend sends is also the order these read in.
+ */
+const manyTags = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    value: `tag-${String(i).padStart(2, '0')}`,
+    count: count - i,
+  }));
+
+const withTags = (count: number) => ({ distinct: { ...distinct, tags: manyTags(count) } });
+
+describe('hv-filter-panel: the label cap', () => {
+  it('shows the first eight labels and collapses the tail behind More…', async () => {
+    const el = await mount({}, withTags(30));
+    const shown = all(el, '[data-testid="filter-tag"]').map((c) => c.dataset.value);
+
+    expect(shown).toEqual([
+      'tag-00',
+      'tag-01',
+      'tag-02',
+      'tag-03',
+      'tag-04',
+      'tag-05',
+      'tag-06',
+      'tag-07',
+    ]);
+    const more = q(el, '[data-testid="filter-tag-more"]')!;
+    expect(more.textContent).toContain('22');
+
+    (more as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(all(el, '[data-testid="filter-tag"]')).toHaveLength(30);
+    expect(q(el, '[data-testid="filter-tag-more"]')).toBe(null);
+  });
+
+  // Hiding the one chip that says the filter is on would leave the group
+  // looking untouched.
+  it('keeps a selected label past the cut on screen', async () => {
+    const el = await mount({ tags: ['tag-29'] }, withTags(30));
+    const shown = all(el, '[data-testid="filter-tag"]').map((c) => c.dataset.value);
+
+    expect(shown).toHaveLength(9);
+    expect(shown.at(-1)).toBe('tag-29');
+    expect(q(el, '[data-testid="filter-tag-more"]')!.textContent).toContain('21');
+  });
+
+  it('draws no More… when the household names fewer labels than the cap', async () => {
+    const el = await mount();
+
+    expect(all(el, '[data-testid="filter-tag"]')).toHaveLength(3);
+    expect(q(el, '[data-testid="filter-tag-more"]')).toBe(null);
+  });
+
+  it('still shows a typed label no item carries, with the cap in force', async () => {
+    const el = await mount({ tags: ['nobody-uses-this'] }, withTags(30));
+    const shown = all(el, '[data-testid="filter-tag"]').map((c) => c.dataset.value);
+
+    expect(shown).toHaveLength(9);
+    expect(shown.at(-1)).toBe('nobody-uses-this');
+    // A typed label is not one of the known ones the cut counted.
+    expect(q(el, '[data-testid="filter-tag-more"]')!.textContent).toContain('22');
+    expect(q(el, '[data-testid="filter-tag-add"]')).toBeTruthy();
+  });
+
+  // Expanding is a view preference, not a filter, so clearing the filters
+  // leaves it alone — the same as the category group's.
+  it('stays expanded across a clear and a staged cancel', async () => {
+    const el = await mount({ tags: ['tag-03'] }, { ...withTags(30), mobile: true });
+    (q(el, '[data-testid="filter-tag-more"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    el.clearAll();
+    await el.updateComplete;
+    expect(all(el, '[data-testid="filter-tag"]')).toHaveLength(30);
+
+    el.resetDraft();
+    await el.updateComplete;
+    expect(all(el, '[data-testid="filter-tag"]')).toHaveLength(30);
+  });
+
+  // The point of the cap: a stop per label put the household's whole
+  // vocabulary between the sort controls and whatever follows the panel — the
+  // item list on a desktop, the sheet's Cancel and Show N items on a phone.
+  it('spends the same tab stops on a large vocabulary as on a small one', async () => {
+    const stopsIn = async (count: number) => {
+      const el = await mount({}, withTags(count));
+      const group = q(el, '[data-testid="filter-tag-add"]')!.closest('.group')!;
+      const stops = group.querySelectorAll('button, input, select').length;
+      el.remove();
+      return stops;
+    };
+
+    expect(await stopsIn(122)).toBe(await stopsIn(30));
+    // Eight chips, More…, the any/all pair and the add field.
+    expect(await stopsIn(122)).toBe(12);
+  });
+});
+
 describe('hv-filter-panel: show only vs sort', () => {
   // Sort is a daily toggle and the tag cloud renders every tag the household
   // has, so on a phone anything under it is several screens into the sheet.
@@ -837,9 +936,9 @@ describe('hv-filter-panel: inspection due', () => {
 
 /**
  * The seven chips that hold a filter's on/off state, and the filter that turns
- * each one on. The location chip and "More…" are not among them: the first is a
- * disclosure that names the location it holds, the second only reveals the rest
- * of the category tail.
+ * each one on. The location chip and the two "More…" chips are not among them:
+ * the first is a disclosure that names the location it holds, the others only
+ * reveal the rest of a capped group's tail.
  */
 const STATEFUL_CHIPS: { name: string; sel: string; on: Partial<StoreFilters> }[] = [
   {
@@ -892,8 +991,9 @@ describe('hv-filter-panel: pressed state', () => {
       // Every toggle in the panel paints itself, rows included: a row is a chip
       // in another shape, not a checkbox that paints a box inside it.
       const painted = (b: HTMLElement) => b.classList.contains('on');
+      const skip = ['filter-location', 'filter-category-more', 'filter-tag-more'];
       const toggles = all(el, 'button.chip, button.check').filter(
-        (b) => b.dataset.testid !== 'filter-location' && b.dataset.testid !== 'filter-category-more',
+        (b) => !skip.includes(b.dataset.testid ?? ''),
       );
 
       expect(toggles.length, `mobile=${mobile}`).toBeGreaterThanOrEqual(STATEFUL_CHIPS.length);

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -28,6 +28,14 @@ const SORT_FIELDS: readonly SortField[] = [
 const CATEGORY_CHIP_LIMIT = 4;
 
 /**
+ * The same for tags, higher because a household names far more of them than it
+ * names categories — eight is two rows of chips at phone width. Without a cap
+ * the group is as long as the whole vocabulary, and every label is a tab stop
+ * between the sort controls and whatever follows the panel.
+ */
+const TAG_CHIP_LIMIT = 8;
+
+/**
  * The element the location chip discloses, named so `aria-controls` can point at
  * it. The holder stays in the tree whether or not it is open — an `aria-controls`
  * that resolves to nothing announces the chip as controlling nothing — and only
@@ -351,6 +359,7 @@ export class HVFilterPanel extends LitElement {
   @state() private _draft: StoreFilters | null = null;
   @state() private _locationOpen = false;
   @state() private _showAllCategories = false;
+  @state() private _showAllTags = false;
   @state() private _tagDraft = '';
   /** Direction a date row falls back to while it holds no date. */
   @state() private _dateDirection: Record<DateField, 'after' | 'before'> = {
@@ -617,6 +626,15 @@ export class HVFilterPanel extends LitElement {
     // Always show selected tags, even ones typed in that no item carries yet.
     const known = all.map((t) => t.value);
     const extras = f.tags.filter((t) => !known.includes(t));
+    // The category group's cut, with the same rule for a selection past it: the
+    // chip that says the filter is on must not be the one "More…" hides.
+    const shown = this._showAllTags
+      ? all
+      : [
+          ...all.slice(0, TAG_CHIP_LIMIT),
+          ...all.slice(TAG_CHIP_LIMIT).filter((t) => selected.has(t.value)),
+        ];
+    const hidden = all.length - shown.length;
     return html`
       <div class="group">
         <div class="group-head">
@@ -642,7 +660,7 @@ export class HVFilterPanel extends LitElement {
           </span>
         </div>
         <div class="chips">
-          ${all.map(
+          ${shown.map(
             (t) => html`<button
               class="hv-chip toggle tag chip ${selected.has(t.value) ? 'on' : ''}"
               data-testid="filter-tag"
@@ -665,6 +683,17 @@ export class HVFilterPanel extends LitElement {
               ${icon('check', 12)}${tagLabel(t)}
             </button>`,
           )}
+          ${hidden > 0
+            ? html`<button
+                class="hv-chip toggle chip more"
+                data-testid="filter-tag-more"
+                @click=${() => {
+                  this._showAllTags = true;
+                }}
+              >
+                ${t('hv.filter.more')} <span class="hv-tally">${hidden}</span>
+              </button>`
+            : null}
           <label class="field" data-testid="filter-tag-add">
             <span class="hv-sr-only">${t('hv.filter.addTag')}</span>
             <input

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -172,6 +172,16 @@ pair are ordinary tab stops, so a section is still reached, opened and added to 
 arrows. `ui/roving-list.ts` holds the walk and the key handling; `hv-location-tree` runs the
 same shape for the Locations section behind its own shadow boundary.
 
+`hv-filter-panel` answers the same problem by showing less rather than by moving the stop:
+its category and tag groups draw the first `CATEGORY_CHIP_LIMIT` (4) and `TAG_CHIP_LIMIT`
+(8) chips and collapse the rest behind a "More…" chip carrying the hidden tally, so the
+group costs a fixed handful of tab stops whatever the household has named. A selected value
+past the cut is drawn anyway — the chip that says the filter is on must not be the one
+"More…" hides — and the expansion is per mount, left alone by "Clear all" and by the sheet's
+Cancel. Both lists arrive from `distinct_values` sorted alphabetically, so the cut is the
+head of the alphabet, not the most-used values; the tag group's add field takes any label as
+typed, so nothing has to be expanded to reach one.
+
 Each of the four headings offers a create action, and the three that can be counted state
 how many of their thing there is — Status is the household's own vocabulary, whose size says
 nothing about the inventory the facet navigates. Categories and tags come with their


### PR DESCRIPTION
## Summary

The filter panel drew **every** label the household names as its own chip button — 122 on the
seeded dev household — so the labels group grew with the vocabulary rather than with anything
the user picked. Keyboard-only that put 122 tab stops between the sort controls and whatever
follows the panel: the item list on the desktop card, the sheet's *Cancel* / *Show N items* on
a phone, which is the only way to apply the filter there.

The category group in the same panel already had the answer, so labels get the same shape:

- `TAG_CHIP_LIMIT = 8` beside `CATEGORY_CHIP_LIMIT = 4` — higher because a household names far
  more labels than categories, and eight is two rows of chips at phone width.
- `_showAllTags` state and a `filter-tag-more` chip carrying the hidden tally, rendered after
  the chips and before the add field, identical in behaviour to `filter-category-more`.
- A selected label past the cut is drawn anyway: the chip that says the filter is on must not
  be the one *More…* hides. The tally counts only what is actually hidden.
- The typed `extras` and the `filter-tag-add` input are untouched — the field takes any label as
  typed, so nothing has to be expanded to reach one.
- `clearAll()` and `resetDraft()` leave `_showAllTags` alone, the way they already leave
  `_showAllCategories`: expanding is a view preference, not a filter.
- No roving tabindex here, per the plan; see Follow-ups.

**Which labels the cut shows.** `distinct_values` sorts tags case-insensitively by value
(`repository.get_distinct_field_values`), so the panel shows the first eight of the alphabet,
not the eight most used. The order is unchanged by this PR.
`docs/frontend_architecture.md` records that beside the sidebar's one-tab-stop lists, since
both are answers to the same problem.

A second, unrelated commit fixes a red offline suite on `main`:
`tests/test_local_day_offline.py` compared `datetime.now(UTC)` — the host's own clock — against
the constant naming the calendar day the file was written around, so the whole backend gate
went red from 2026-08-23 onward. The fixture already freezes `dt_util.now`; the assertion now
reads that instant and converts it to UTC. Without it CI here (and on every other branch cut
today) is red for a reason that has nothing to do with this fix.

Closes #583

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

TDD: the five new cases were written against the uncapped panel and four of them failed before
the change (the fifth, "fewer labels than the cap", passes either way and is the control).

New in `hv-filter-panel.test.ts`, under `hv-filter-panel: the label cap`:

- 30 labels → exactly the first eight chips, by value, plus a `filter-tag-more` whose tally
  reads 22; clicking it draws all 30 and the More chip is gone.
- A selected label past the cut is drawn and the tally drops to 21.
- Fewer labels than the cap → three chips and no More chip.
- A typed label no item carries is still drawn as a selected chip while the cap holds, and the
  tally still counts the 22 known ones.
- Expanding survives `clearAll()` and `resetDraft()` in the staged (phone) mode.
- The point of the cap, stated as a measurement: the labels group spends the same number of tab
  stops on a 122-label vocabulary as on a 30-label one — 12, being eight chips, *More…*, the
  any/all pair and the add field.

The chip-enumerating test that excluded `filter-category-more` from the `aria-pressed` sweep
now excludes `filter-tag-more` the same way, and the `STATEFUL_CHIPS` comment names both.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1301 passed, 22 skipped),
  `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (26 source files)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
  `npx vitest run` (68 files, 1870 tests), `npm run build`

phacc is not required: nothing under `custom_components/` changed apart from the built bundle,
which is git-ignored.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`docs/frontend_architecture.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync. — no API change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None here — the worktree carries no `.env` and the dev instance belongs to the session, which
measures the acceptance live: on the desktop card, Tab from the sort select to the first item
row (was ~125 presses), and on the phone sheet from the sort select to *Cancel*.

## Follow-ups

- The cut is alphabetical because `distinct_values` sorts by value. Showing the eight most-used
  labels first would make the cap far more useful on a large household, but it is a backend
  ordering question (`get_distinct_field_values` feeds autocomplete and the organize dialog
  too), so it is not in this diff. Worth an issue if the live check finds the first eight
  unhelpful.
- The expanded list is still one tab stop per chip. If that ever matters — a household with a
  few hundred labels expanding the group deliberately — `ui/roving-list.ts` is the shape: one
  stop, arrows inside it, the container as a `role="group"`. Not filed: expanding is a
  deliberate act, and the cap is what the issue asked for.
- `hv-full-view`'s sidebar draws its own label list; that one got its single tab stop in #574
  and is unaffected here.
