### PR TITLE
fix(card): keep the detail sheet's action pair on one line in German

### DIFF
--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -1,4 +1,5 @@
 import './hv-detail-sheet';
+import { setLanguage } from '../i18n';
 import {
   all,
   componentCss,
@@ -1220,5 +1221,39 @@ describe('hv-detail-sheet: the id an automation names', () => {
 
     expect(q(el, '[data-testid="sheet-id"]')?.textContent?.trim()).toBe('i-8');
     expect(button(el).textContent?.trim()).toBe('Copy');
+  });
+});
+
+describe('hv-detail-sheet: the action pair', () => {
+  // The pair splits a phone's row in half — about 176px a side at 390px — and
+  // the sheet is what a phone user opens for every item.
+  it('names the editor alike in the header and the pill, in German', async () => {
+    setLanguage('de');
+    const el = await mount({ id: '1' });
+
+    const header = q(el, '[data-testid="sheet-edit"]')?.textContent?.trim();
+    expect(header).toBe('Bearbeiten');
+    // Two routes into one editor: the shorter of the two names fits the half,
+    // and the header already carries it.
+    expect(q(el, '[data-testid="sheet-edit-details"]')?.textContent?.trim()).toBe(header);
+  });
+
+  it('keeps the fuller English label on the pill', async () => {
+    const el = await mount({ id: '1' });
+
+    // The two are not held equal — only kept inside the half they are given.
+    expect(q(el, '[data-testid="sheet-edit-details"]')?.textContent?.trim()).toBe('Edit details');
+    expect(q(el, '[data-testid="sheet-edit"]')?.textContent?.trim()).toBe('Edit');
+  });
+
+  // jsdom lays out no shadow DOM, so the rule is read off the stylesheet.
+  it('lets the wider of the two labels take the room it needs', async () => {
+    await mount({ id: '1' });
+    const css = componentCss('hv-detail-sheet');
+
+    expect(css).toMatch(
+      /\.actions \.pair \{[^}]*grid-template-columns: minmax\(max-content, 1fr\) minmax\(max-content, 1fr\)/,
+    );
+    expect(css).toMatch(/\.actions \.pair > button \{[^}]*white-space: nowrap/);
   });
 });

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -273,10 +273,17 @@ export class HVDetailSheet extends LitElement {
         gap: 9px;
         padding: 12px 14px 16px;
       }
+      /* Two labels, half a phone row each — about 176px at 390px. Equal halves
+         while both labels fit in one, which is the look; a label a few pixels
+         longer than its half takes what it needs and the other yields, rather
+         than stacking onto a second line inside a 48px pill. */
       .actions .pair {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(max-content, 1fr) minmax(max-content, 1fr);
         gap: 10px;
+      }
+      .actions .pair > button {
+        white-space: nowrap;
       }
       /* The pair's other half. It shares the row with an .hv-pill.large, and a
          stretch grid gives both the taller one's height — so a private height

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -321,7 +321,7 @@ export const de: Record<TranslationKey, string> = {
   'hv.sheet.markDone': 'Erledigt',
   'hv.sheet.markDoneTitle':
     'Diese Erinnerung als erledigt markieren und auf ihren nächsten Termin setzen',
-  'hv.sheet.editDetails': 'Details bearbeiten',
+  'hv.sheet.editDetails': 'Bearbeiten',
   'hv.sheet.editItem': 'Gegenstand bearbeiten',
 
   'hv.editor.heading.new': 'Neuer Gegenstand',

--- a/tests/test_local_day_offline.py
+++ b/tests/test_local_day_offline.py
@@ -76,7 +76,10 @@ def test_today_is_the_instances_day_and_not_the_utc_one() -> None:
     """The whole fix in one line: 01:30 in Auckland is still yesterday in UTC."""
 
     assert today_local_date() == LOCAL_TODAY
-    assert datetime.now(UTC).date().isoformat() == UTC_TODAY
+    # The frozen instant, not the machine's clock: the pair is a claim about
+    # the zone the household is in, and reading the real day here made the
+    # whole file pass only on the date the constants were written.
+    assert INSTANT_UTC.date().isoformat() == UTC_TODAY
 
 
 @pytest.mark.usefixtures("household_in_new_zealand")


### PR DESCRIPTION
## Summary

On a German phone the detail sheet's primary action read *Details bearbeiten*. The action
pair splits the sheet's row in half — 176px a side at 390px — and the label needs about
196px, so it stacked onto two lines inside its pill beside a one-line *Ausleihen*, on the
surface a phone user opens for every item.

The sheet already offers the same editor twice: the header's text button carries
`hv.action.edit` = *Bearbeiten*. The pill now takes that name in German, so the two routes
into one editor agree and the label fits its half. English keeps *Edit details*, and the
editor's own heading (*Gegenstand bearbeiten*) is untouched.

The pair's grid is the guard behind it: `1fr 1fr` → `minmax(max-content, 1fr)` twice, with
`white-space: nowrap` on both buttons. While both labels fit in half the row the tracks stay
equal, which is today's look and leaves English exactly as it was; a label a few pixels
longer than its half takes what it needs and the other yields instead of wrapping. Nothing
else in the card has this shape — the import sheet's, the editor's and the organize dialog's
`1fr 1fr` grids are preview tables and form fields, not an action pair, and the card's filter
sheet footer fits in German per #582's report.

One unrelated red test came with the day: `test_local_day_offline.py` compared the machine's
own clock against a UTC date written on 22 August, so the offline suite fails on every branch
from 23 August on. It reads the fixture's frozen instant now — a one-line change, in its own
commit, because it blocks CI for this PR and every other open one.

Closes #581

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

Three cases in `hv-detail-sheet.test.ts`:

- German: the header button and the pill name the editor with the same word — the relation
  the fix rests on, asserted on the rendered buttons rather than on the dictionary.
- English: the pill keeps the fuller *Edit details* while the header keeps *Edit*, so
  "make the two agree" cannot be read as "shorten both".
- The pair's tracks and the no-wrap rule, read off the component's stylesheet. jsdom lays
  out no shadow DOM, so a `getComputedStyle` read would resolve nothing here; this is the
  same route `.fact .value.id` and the table's hover actions already take.

Existing tests that reach the editor through `sheet-edit-details` pass unchanged.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1301 passed, 22 skipped),
  `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
  `npx vitest run` (1867 passed), `npm run build` — all green.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`) — no behavior a doc describes changed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no API change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

The measurement is the session's: at 375px and 390px in `de-DE`, on the card and on the
`/haventory` panel, the pill's label lays out on one line (`Range.getClientRects()`, the
method that found the wrap), and English is unchanged.

## Follow-ups

- The pair's tracks overflow rather than wrap if both labels' intrinsic widths ever exceed
  the row together — roughly 22 characters each at 390px, against the ten either verb takes
  today. A wrapping flex row would degrade more gently if a future language gets near it.
- Every German label the card sizes against its English original is one measurement away
  from this finding; a phone-width German pass over the remaining sheets would find the rest
  in one go rather than one issue at a time (#560, #561, this one).
