### PR TITLE
fix(card): keep the panel phone filter footer and toolbar one row each

### DIFF
--- a/cards/haventory-card/src/components/hv-filter-chips.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.test.ts
@@ -3,7 +3,7 @@ import './hv-filter-chips';
 import { chipsFor, clearedValueFor } from './hv-filter-chips';
 import { defaultFilters } from '../store/store';
 import type { Location, StatusDefinition, StoreFilters } from '../store/types';
-import { mountComponent } from '../test.utils';
+import { componentCss, mountComponent } from '../test.utils';
 
 type Chips = HTMLElement & {
   filters: StoreFilters;
@@ -360,5 +360,31 @@ describe('hv-filter-chips', () => {
     const el = await mount({ filters: { ...defaultFilters(), overdueOnly: true } });
     const chip = el.shadowRoot?.querySelector('[data-testid="filter-chip"]') as HTMLElement;
     expect(chip.getAttribute('aria-label')).toBe('Clear filter Overdue');
+  });
+
+  // A search term, a list of tags or a nested location path has no length this
+  // row can rely on, and the row shares a phone-width line with the filter
+  // toggle. The chip summarizes; the whole value stays readable on hover and
+  // in the accessible name.
+  it('holds a long label to the cap and keeps the whole of it on the title', async () => {
+    const term = 'x'.repeat(60);
+    const el = await mount({ filters: { ...defaultFilters(), q: term } });
+    const chip = el.shadowRoot?.querySelector('[data-testid="filter-chip"]') as HTMLElement;
+    const label = chip.querySelector('.hv-chip-text') as HTMLElement;
+
+    expect(label.textContent).toBe(`"${term}"`);
+    expect(chip.getAttribute('title')).toBe(`"${term}"`);
+    expect(chip.getAttribute('aria-label')).toBe(`Clear filter "${term}"`);
+    expect(componentCss('hv-filter-chips')).toMatch(
+      /\.chip > \.hv-chip-text \{[^}]*text-overflow: ellipsis/,
+    );
+    expect(componentCss('hv-filter-chips')).toMatch(/\.chip > \.hv-chip-text \{[^}]*max-width:/);
+  });
+
+  it('wraps a short label in the same element, so one chip is not shaped unlike the next', async () => {
+    const el = await mount({ filters: { ...defaultFilters(), overdueOnly: true } });
+    const chip = el.shadowRoot?.querySelector('[data-testid="filter-chip"]') as HTMLElement;
+    expect((chip.querySelector('.hv-chip-text') as HTMLElement).textContent).toBe('Overdue');
+    expect(chip.getAttribute('title')).toBe('Overdue');
   });
 });

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -216,6 +216,24 @@ export class HVFilterChips extends LitElement {
       .chip:hover {
         opacity: 0.85;
       }
+      /*
+       * A chip names a narrowing; it is not where the value is read. Nothing
+       * caps what a household can put into one — a search term, a run of tags,
+       * a path several levels deep — and this row shares a phone-width line
+       * with the filter toggle, so one uncapped chip takes the row away from
+       * the controls beside it. The whole text stays on the title and on the
+       * accessible name.
+       *
+       * The elision belongs on the label rather than on the chip: the chip is
+       * an inline-flex container, so text-overflow on it would do nothing and
+       * the trailing × has to stay outside the clipped box to remain visible.
+       */
+      .chip > .hv-chip-text {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 20ch;
+      }
       .chip svg {
         opacity: 0.8;
       }
@@ -247,6 +265,7 @@ export class HVFilterChips extends LitElement {
             style=${ifDefined(entry.toneStyle)}
             data-testid="filter-chip"
             data-key=${entry.key}
+            title=${entry.label}
             aria-label=${`Clear filter ${entry.label}`}
             @click=${() =>
               this.dispatchEvent(
@@ -257,7 +276,7 @@ export class HVFilterChips extends LitElement {
                 }),
               )}
           >
-            ${entry.label}${icon('close', 15)}
+            <span class="hv-chip-text">${entry.label}</span>${icon('close', 15)}
           </button>`,
         )}
         <button

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1575,6 +1575,99 @@ describe('hv-full-view: phone-width children', () => {
       restore();
     }
   });
+
+  // Three controls on one 375px row is one too many for a language that spells
+  // `hv.action.clearAll` in two long words: the clear button broke over two
+  // lines and stacked the primary button's count sentence over three. The
+  // card's filter sheet already carries the clear in a head row; this is that
+  // shape.
+  it('carries the clear-all in a head row and leaves the phone footer two buttons', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
+      (q(sr, '[data-testid="full-filters-toggle"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      const head = q(sr, '[data-testid="full-panel-head"]') as HTMLElement;
+      expect(head).toBeTruthy();
+      expect(head.querySelector('[data-testid="full-panel-clear"]')).toBeTruthy();
+
+      const foot = q(sr, '[data-testid="full-panel-foot"]') as HTMLElement;
+      expect([...foot.querySelectorAll('button')].map((b) => b.dataset.testid)).toEqual([
+        'full-panel-cancel',
+        'full-panel-apply',
+      ]);
+      // The head is read before the filters it clears, so it sits above the
+      // scroll box rather than after it.
+      expect(head.nextElementSibling?.classList.contains('panel-scroll')).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('clears the staged set from the moved clear button, and counts what is staged', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1', quantity: 0, low_stock_threshold: 5 })] });
+      (q(sr, '[data-testid="full-filters-toggle"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      const count = () => (q(sr, '[data-testid="full-panel-count"]') as HTMLElement).textContent?.trim();
+      expect(count()).toBe('0 active');
+
+      const panel = q(sr, '[data-testid="full-filter-panel"]') as HTMLElement;
+      (panel.shadowRoot?.querySelector('[data-testid="filter-low-stock-only"]') as HTMLButtonElement).click();
+      await settle(el);
+      expect(count()).toBe('1 active');
+
+      (q(sr, '[data-testid="full-panel-clear"]') as HTMLButtonElement).click();
+      await settle(el);
+      expect(count()).toBe('0 active');
+      expect(
+        (panel.shadowRoot?.querySelector('[data-testid="filter-low-stock-only"]') as HTMLElement).getAttribute(
+          'aria-pressed',
+        ),
+      ).toBe('false');
+    } finally {
+      restore();
+    }
+  });
+
+  it('leaves the desktop panel without a head row', async () => {
+    const restore = stubViewport(false);
+    try {
+      const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
+      (q(sr, '[data-testid="full-filters-toggle"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      expect(q(sr, '[data-testid="full-panel-head"]')).toBe(null);
+      expect(q(sr, '[data-testid="full-panel-clear"]')).toBe(null);
+    } finally {
+      restore();
+    }
+  });
+
+  // The ⋮ menu carries "Columns…" on every host, so the phone toolbar can drop
+  // the icon button and keep its remaining controls on one row.
+  it('drops the column picker button on a phone', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+      expect(q(sr, '[data-testid="columns-expanded"]')).toBe(null);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the column picker button where the row has room for it', async () => {
+    const restore = stubViewport(false);
+    try {
+      const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+      expect(q(sr, '[data-testid="columns-expanded"]')).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
 });
 
 describe('hv-full-view: app bar filters', () => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -660,7 +660,28 @@ export class HVFullView extends LitElement {
            underneath it. */
         overscroll-behavior-y: contain;
       }
-      /* Only rendered on a phone, where the panel stages its edits. */
+      /* Both only rendered on a phone, where the panel stages its edits. */
+      .panel-head {
+        display: flex;
+        flex: none;
+        align-items: center;
+        gap: 10px;
+        padding: 2px 0 8px;
+        border-bottom: 1px solid var(--hv-row-divider);
+      }
+      .panel-head .heading {
+        font-size: 16px;
+        font-weight: 500;
+        color: var(--hv-text);
+      }
+      .panel-head .staged {
+        font-size: 12.5px;
+        color: var(--hv-text-secondary);
+      }
+      .panel-head .hv-text-button {
+        margin-left: auto;
+        flex: none;
+      }
       .panel-foot {
         display: flex;
         flex: none;
@@ -668,8 +689,13 @@ export class HVFullView extends LitElement {
         gap: 8px;
         padding: 10px 0 2px;
       }
+      /* The count is a sentence with the number inside it, so a label a few
+         pixels wider than the button's share of the row would stack its words
+         rather than run past the edge. The row has one other control and an
+         auto margin between them, which is the give this takes. */
       .panel-foot .hv-pill {
         min-width: 130px;
+        white-space: nowrap;
       }
       .footer {
         padding: 10px 20px;
@@ -871,6 +897,12 @@ export class HVFullView extends LitElement {
    * what pressing it will show — the same contract the card's filter sheet has.
    */
   @state() private _stagedCount: number | null = null;
+  /**
+   * The phone panel's in-flight filter set, so its head row counts what is
+   * staged rather than what is applied — the two differ for as long as the
+   * panel is open, which is exactly when the number is read.
+   */
+  @state() private _stagedFilters: StoreFilters | null = null;
   @state() private _selecting = false;
   @state() private _bulkProgress: BulkProgress | null = null;
   @state() private _bulkResult: BulkResultView | null = null;
@@ -922,6 +954,10 @@ export class HVFullView extends LitElement {
   private _narrowQuery?: MediaQueryList | null;
   private _onNarrowChange = (e: MediaQueryListEvent) => {
     this._narrow = e.matches;
+    // The panel drops its draft when it stops being on a phone, so a staged set
+    // held from before the rotation would have the head row counting filters
+    // the controls under it no longer carry.
+    this._stagedFilters = null;
   };
 
   /** Price a staged (not yet applied) filter set, so the footer can be honest. */
@@ -945,6 +981,7 @@ export class HVFullView extends LitElement {
         this._selecting = this.startSelecting;
       } else {
         this._filtersOpen = false;
+        this._stagedFilters = null;
         this._editing = null;
         this._detailItemId = null;
         this._editorError = null;
@@ -1750,6 +1787,37 @@ export class HVFullView extends LitElement {
   }
 
   /**
+   * The phone panel's head row: what the panel is, how much of it is staged,
+   * and the way out of all of it.
+   *
+   * Clear all sits here rather than beside the commit buttons because three
+   * controls do not fit a 375px row in every language: German's
+   * `hv.action.clearAll` broke over two lines and left the button beside it
+   * stacking its count sentence over three. The card's filter sheet has
+   * carried this same head row all along, which is why its footer never had
+   * the problem.
+   */
+  private _renderPanelHead(filters: StoreFilters) {
+    const staged = activeFilterCount(this._stagedFilters ?? filters);
+    return html`<div class="panel-head" data-testid="full-panel-head">
+      <span class="heading">${t('hv.card.filters')}</span>
+      <span class="staged" data-testid="full-panel-count">
+        ${t('hv.card.filtersActive', { count: staged })}
+      </span>
+      <button class="hv-text-button" data-testid="full-panel-clear" @click=${() => this._panel()?.clearAll()}>
+        ${t('hv.action.clearAll')}
+      </button>
+    </div>`;
+  }
+
+  // Resolved per click, never captured at render time: on the render that first
+  // draws the panel this element does not exist yet, so a captured reference
+  // would leave every button that names it doing nothing.
+  private _panel() {
+    return this.renderRoot?.querySelector<HVFilterPanel>('[data-testid="full-filter-panel"]');
+  }
+
+  /**
    * The phone panel's commit row.
    *
    * `hv-filter-panel` stages its edits when it is on a phone and drops its own
@@ -1758,14 +1826,8 @@ export class HVFullView extends LitElement {
    * without this would stage every edit with no way to apply it.
    */
   private _renderPanelFoot() {
-    // Resolved per click, never captured at render time: on the render that
-    // first draws the panel this element does not exist yet, so a captured
-    // reference would leave all three buttons doing nothing.
-    const panel = () => this.renderRoot?.querySelector<HVFilterPanel>('[data-testid="full-filter-panel"]');
+    const panel = this._panel.bind(this);
     return html`<div class="panel-foot" data-testid="full-panel-foot">
-      <button class="hv-text-button" data-testid="full-panel-clear" @click=${() => panel()?.clearAll()}>
-        ${t('hv.action.clearAll')}
-      </button>
       <span class="spacer"></span>
       <button
         class="hv-text-button"
@@ -1773,6 +1835,7 @@ export class HVFullView extends LitElement {
         @click=${() => {
           panel()?.resetDraft();
           this._filtersOpen = false;
+          this._stagedFilters = null;
         }}
       >
         ${t('hv.action.cancel')}
@@ -1858,25 +1921,33 @@ export class HVFullView extends LitElement {
             aria-controls=${FILTER_PANEL_ID}
             @click=${() => {
               this._filtersOpen = !this._filtersOpen;
-              // The phone panel stages its edits, so its button has a number to
-              // print from the moment it opens.
+              // The phone panel stages its edits, so its head row and its
+              // button both have a number to print from the moment it opens.
+              this._stagedFilters = this._filtersOpen && this._narrow ? filters : null;
               if (this._filtersOpen && this._narrow) this._priceStaged(filters);
             }}
           >
             ${icon('tune', 16)}${t('hv.card.filters')}
           </button>
-          <button
-            class="hv-icon-button"
-            data-testid="columns-expanded"
-            aria-label=${t('hv.fullView.chooseColumns')}
-            title=${t('hv.fullView.chooseColumns')}
-            @click=${() =>
-              this.dispatchEvent(
-                new CustomEvent('menu-action', { detail: { id: 'columns' }, bubbles: true, composed: true }),
-              )}
-          >
-            ${icon('viewColumn', 20)}
-          </button>
+          <!-- Not on a phone. This row also carries the chips and their clear
+               button, and in German the four together were one control too
+               many for 375px: the picker dropped onto a line of its own under
+               the chip. The ⋮ menu offers Columns on both hosts, so nothing is
+               lost by leaving it as the only route there at this width. -->
+          ${this._narrow
+            ? null
+            : html`<button
+                class="hv-icon-button"
+                data-testid="columns-expanded"
+                aria-label=${t('hv.fullView.chooseColumns')}
+                title=${t('hv.fullView.chooseColumns')}
+                @click=${() =>
+                  this.dispatchEvent(
+                    new CustomEvent('menu-action', { detail: { id: 'columns' }, bubbles: true, composed: true }),
+                  )}
+              >
+                ${icon('viewColumn', 20)}
+              </button>`}
         </span>
       </div>
     `;
@@ -2163,6 +2234,7 @@ export class HVFullView extends LitElement {
             <div class="panel-holder" id=${FILTER_PANEL_ID} ?hidden=${!this._filtersOpen}>
               ${this._filtersOpen
                 ? html`
+                  ${this._narrow ? this._renderPanelHead(filters) : null}
                   <div class="panel-scroll">
                   <hv-filter-panel
                     .statuses=${this.st?.statuses ?? null}
@@ -2177,11 +2249,15 @@ export class HVFullView extends LitElement {
                     .counts=${counts ?? null}
                     ?mobile=${this._narrow}
                     @change=${(e: CustomEvent) => this._setFilters(e.detail as Partial<StoreFilters>)}
-                    @stage=${(e: CustomEvent) =>
-                      this._priceStaged((e.detail as { filters: StoreFilters }).filters)}
+                    @stage=${(e: CustomEvent) => {
+                      const staged = (e.detail as { filters: StoreFilters }).filters;
+                      this._stagedFilters = staged;
+                      this._priceStaged(staged);
+                    }}
                     @apply=${(e: CustomEvent) => {
                       this._setFilters(e.detail as StoreFilters);
                       this._filtersOpen = false;
+                      this._stagedFilters = null;
                     }}
                     @clear-filters=${() => this.store?.clearFilters()}
                   ></hv-filter-panel>

--- a/cards/haventory-card/src/haventory-panel.test.ts
+++ b/cards/haventory-card/src/haventory-panel.test.ts
@@ -425,6 +425,21 @@ describe('haventory-panel: the ⋮ menu', () => {
     ]);
   });
 
+  // The phone toolbar drops its column-picker button because this entry is the
+  // route to the same dialog there. If it ever left the menu, the panel would
+  // have no way to choose columns on a phone at all.
+  it('keeps the columns entry on a phone, where the toolbar button is gone', async () => {
+    const restore = stubViewport(true);
+    try {
+      const { sr, view } = await mountPanel();
+      expect(ids(view())).toContain('columns');
+      expect(view().shadowRoot?.querySelector('[data-testid="columns-expanded"]')).toBe(null);
+      expect(sr.querySelector('[data-testid="host-columns"]')).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+
   // The filtered export would be the whole inventory again, so it is not offered
   // until a filter is on — same rule the card's menu follows.
   it('offers the filtered export only once something is filtered', async () => {

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -205,8 +205,14 @@ children of `hv-full-view`, which never set the property — so at 375px the exp
 the editor's three-column desktop grid in 156px + 78px + 78px; `hv-full-view` now reads the
 viewport query and hands the property down. Note what came with it: `hv-filter-panel` in
 `mobile` mode *stages* its edits and drops its own footer, expecting the host to provide one,
-so the expanded view also grew the Clear all / Cancel / "Show N items" row the card's filter
-sheet has. In the other direction, `HostSurfaces` was fed the card's measurement, so the
+so the expanded view also grew the commit row the card's filter sheet has: a head row above
+the panel — the heading, how many filters are staged, and Clear all — and a footer of Cancel
+and "Show N items". Three controls on one row is one too many for a 375px screen in German,
+which is why the head row exists on both surfaces rather than only on the card's. For the
+same reason the phone toolbar drops its column-picker button and leaves the ⋮ menu's
+Columns entry as the route there.
+
+In the other direction, `HostSurfaces` was fed the card's measurement, so the
 organize dialog took its full-bleed phone page on a desktop monitor whenever the card sat in
 a normal column — and expanding the card changed nothing, because the measured element was
 still the card underneath.


### PR DESCRIPTION
## Summary

At 375px in German the sidebar panel overflowed in two rows the dashboard card never did.

**The filter footer** held Clear all, Cancel and the count button on one row. The clear
button broke over two lines and the count button stacked its three words. The card's filter
sheet has always had the shape that fits — a head row above the panel and two buttons in the
footer — so the panel takes it: `full-panel-head` above the scroll box carries the *Filters*
heading, how many filters are staged (`hv.card.filtersActive`, the same string the card's
sheet head prints), and the existing `full-panel-clear` right-aligned. `full-panel-foot` is
left with `full-panel-cancel` and `full-panel-apply`, and the pill gets `white-space: nowrap`
so a count sentence a few pixels wider than its share of the row takes the room instead of
stacking. Every testid is unchanged.

The staged count comes from the source the card uses: the full view now keeps the set the
panel stages (it was already pricing that set through `_priceStaged`) and counts it with
`activeFilterCount`, falling back to the applied set before the first stage event. It is
cleared on apply, on cancel, when the view closes and when the viewport stops being narrow —
the panel drops its own draft at that last one, so a held staged set would have the head row
counting filters the controls under it no longer carry.

**The toolbar** under a search held the `"box" ×` chip, its Clear all, the Filters button and
the column picker. In German that is one control too many for the row and the picker dropped
onto a line of its own. `columns-expanded` is no longer rendered below 700px. The ⋮ menu
offers Columns on both hosts that serve this view (`hv-card-shell` passes
`surfaces.menuEntries()` to the full view unfiltered — only its *own* card menu drops the
entry — and `haventory-panel` passes the same list), so the dialog is still one tap away; a
panel test pins that entry at the width the button is gone at, so it cannot quietly leave the
menu and strand the phone.

A filter chip's label is now capped with an ellipsis at every width, with the whole of it on
the button's `title` and in its accessible name. A search term, a run of tags or a nested
path has no length this row can rely on, and one chip should not take a phone row away from
the controls beside it. The label moved into a `.hv-chip-text` span, which is the element the
shared chip block already elides for area and status chips.

The second commit is unrelated to the issue but blocks the gate:
`tests/test_local_day_offline.py` asserted the UTC day against a fixed string through
`datetime.now(UTC)`, which the test's fixture does not stop — it held on the day the case was
written (2026-08-22) and has failed on every day since. It now reads the frozen instant back
in UTC, which asserts the same thing at any wall-clock time. Without it every PR opened
against `main` today is red.

Closes #582

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1301 passed, 22 skipped),
  `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
  `npx vitest run` (1872 passed, 68 files), `npm run build` — all clean.

New cases:

- `hv-full-view.test.ts` — narrow: the head row renders above the scroll box with
  `full-panel-clear` inside it and the footer holds exactly cancel and apply; the moved clear
  button still reaches the panel's `clearAll()` and the head's count follows the staged set
  (0 → 1 → 0) rather than the applied one; wide: no head row and no clear button. Narrow: the
  column picker button is gone; wide: it is there.
- `haventory-panel.test.ts` — at phone width the ⋮ still offers `columns` and the host's
  column dialog is mounted, while the toolbar button is not rendered.
- `hv-filter-chips.test.ts` — a 60-character search term keeps its whole text on the `title`
  and in the accessible name while the label sits in the capped, elided element; a short label
  is wrapped in the same element, so one chip is not shaped unlike the next.

Not run: phacc. Nothing under `custom_components/` changed — the only backend file touched is
a test.

The measured acceptance (375px, `de-DE`, `/haventory`: the footer one row with the pill on one
line, the toolbar after a search one row, English unchanged) is the session's live check.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md` now describes the
  head row and the dropped picker button beside the phone-panel paragraph it already had.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
  `docs/data_shapes.md` in sync — no API change here.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

None from here — this worktree carries no `.env` and does not touch the dev instance. The
session takes the German 375px captures of the footer and the toolbar as part of the live
check.

## Follow-ups

- `hv-filter-chips.ts` builds each chip's accessible name from an English literal
  (`` `Clear filter ${label}` ``) rather than through `t()`, so a German reader hears an
  English verb on every filter chip. Out of scope here; worth its own key beside
  `hv.action.clearAll`.
- The chip cap is a fixed `20ch`. It bounds the damage rather than measuring the row, so a
  phone showing four filter chips at once still wraps them — correctly, but a chip row that
  counted its overflow ("+2") the way the filter panel caps its categories would read better.
- `.panel-head` restates the card sheet head's three declarations in a second shadow root.
  Both rows now exist to solve the same problem, so the shape is a candidate for `ui/`.
