### PR TITLE
test(skills): open the panel-mobile columns picker through the overflow menu

### DIFF
--- a/.claude/skills/run-haventory/surfaces.mjs
+++ b/.claude/skills/run-haventory/surfaces.mjs
@@ -369,7 +369,9 @@ export const PANEL_MOBILE_SURFACES = [
   },
   {
     id: "08-columns",
-    open: [["click", `${PANEL} [data-testid="columns-expanded"]`], ["wait", 600]],
+    // Through the overflow menu: under 700px the context bar renders no
+    // columns button, and the menu's Columns entry is the one route there.
+    open: [["click", PANEL_OVERFLOW], ["click", panelMenu("columns")], ["wait", 600]],
     expect: `${PANEL} [data-testid="column-options"]`,
   },
 ];


### PR DESCRIPTION
## What

`visual_pass.mjs`'s `pm-08-columns` surface (the sidebar panel at phone width) clicked `columns-expanded`, which #587 stopped rendering under 700px. The recipe now opens the column picker through the ⋮ menu's Columns entry, the way `07-organize` already reaches its dialog.

## Why

Round three's sweep on merged `main` scored 41/42 in both light and dark with this one surface timing out on a selector the surface no longer has. A harness that is red for a reason the product chose hides the next real failure.

## How it was verified

`node visual_pass.mjs --only panel-mobile --surfaces columns` → 1/1 captured, the picker open in the capture. No product code changes.

## Follow-ups

None.
