### PR TITLE
fix: name the date field that was refused

### DIFF
--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -82,8 +82,7 @@ from .models import (
     serialize_status_definition,
     validate_attachment_meta,
     validate_due_date_rules,
-    validate_inspection_date,
-    validate_reminder_date,
+    validate_optional_date,
     validate_reminder_interval,
     validate_reminder_rules,
     validate_required_name,
@@ -500,7 +499,7 @@ def _validate_inspection_date_doc(
     if inspection_date is None:
         return
     try:
-        validate_inspection_date(inspection_date)
+        validate_optional_date(inspection_date, field_name="inspection_date")
     except ValidationError as exc:
         errors.append(_err(f"{base}.inspection_date", str(exc)))
 
@@ -524,13 +523,13 @@ def _validate_reminder_doc(base: str, doc: dict[str, Any], errors: list[dict[str
 
     if reminder_date is not None:
         try:
-            validate_reminder_date(reminder_date)
+            validate_optional_date(reminder_date, field_name="reminder_date")
         except ValidationError as exc:
             errors.append(_err(f"{base}.reminder_date", str(exc)))
             refused = True
     if anchor is not None:
         try:
-            validate_reminder_date(anchor)
+            validate_optional_date(anchor, field_name="reminder_anchor")
         except ValidationError as exc:
             errors.append(_err(f"{base}.reminder_anchor", str(exc)))
             refused = True

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -446,19 +446,23 @@ def new_uuid4_str() -> str:
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
-def normalize_date_yyyy_mm_dd(value: str) -> str:
+def normalize_date_yyyy_mm_dd(value: str, *, field_name: str) -> str:
     """Validate and normalize a YYYY-MM-DD date string.
+
+    ``field_name`` is required because the refusal names it: several fields run
+    through here, and the message is the whole of what a script, an action call
+    or an import document gets back.
 
     Returns the normalized value or raises ValidationError.
     """
 
     if not isinstance(value, str) or not DATE_RE.match(value):
-        raise ValidationError("due_date must be in 'YYYY-MM-DD' format")
+        raise ValidationError(f"{field_name} must be in 'YYYY-MM-DD' format")
     try:
         # This ensures the date components are valid (e.g., no Feb 30)
         datetime.strptime(value, "%Y-%m-%d")
     except ValueError as exc:
-        raise ValidationError("due_date must be a valid calendar date (YYYY-MM-DD)") from exc
+        raise ValidationError(f"{field_name} must be a valid calendar date (YYYY-MM-DD)") from exc
     return value
 
 
@@ -744,7 +748,7 @@ def validate_due_date_rules(*, checked_out: bool, due_date: str | None) -> str |
         return None
     if not checked_out:
         raise ValidationError("due_date is only valid when checked_out is true")
-    return normalize_date_yyyy_mm_dd(due_date)
+    return normalize_date_yyyy_mm_dd(due_date, field_name="due_date")
 
 
 def validate_item_status(
@@ -955,29 +959,18 @@ def load_attachments(value: object) -> list[AttachmentMeta]:
     return [validate_attachment_meta(entry) for entry in value]
 
 
-def validate_inspection_date(inspection_date: str | None) -> str | None:
-    """Validate inspection_date format (YYYY-MM-DD) if provided.
+def validate_optional_date(value: str | None, *, field_name: str) -> str | None:
+    """Validate one optional YYYY-MM-DD field, naming it in any refusal.
 
-    The date is when the item is next due for inspection; a past date is
-    accepted and means the inspection is overdue.
+    Only the shape is checked, because a date in the past means something on
+    every field that runs through here: an inspection date behind today is
+    overdue, and a reminder anchor behind today is still where its series
+    counts from.
     """
 
-    if inspection_date is None:
+    if value is None:
         return None
-    return normalize_date_yyyy_mm_dd(inspection_date)
-
-
-def validate_reminder_date(reminder_date: str | None) -> str | None:
-    """Validate the reminder anchor's format if provided.
-
-    A past anchor is accepted: it is the date the series counts from, and a
-    recurring reminder set up years ago is still due on whichever occurrence
-    comes next.
-    """
-
-    if reminder_date is None:
-        return None
-    return normalize_date_yyyy_mm_dd(reminder_date)
+    return normalize_date_yyyy_mm_dd(value, field_name=field_name)
 
 
 def validate_reminder_interval(value: object) -> ReminderInterval | None:
@@ -1017,7 +1010,7 @@ def validate_reminder_rules(
     an occurrence reads as a reminder that quietly does nothing.
     """
 
-    normalized_date = validate_reminder_date(reminder_date)
+    normalized_date = validate_optional_date(reminder_date, field_name="reminder_date")
     interval = validate_reminder_interval(reminder_interval)
     if interval is not None and normalized_date is None:
         raise ValidationError("reminder_interval requires a reminder_date to count from")
@@ -1042,7 +1035,7 @@ def load_reminder_anchor(value: object, *, reminder_date: str | None) -> str | N
     if not isinstance(value, str) or not value or value > reminder_date:
         return reminder_date
     try:
-        return normalize_date_yyyy_mm_dd(value)
+        return normalize_date_yyyy_mm_dd(value, field_name="reminder_anchor")
     except ValidationError:
         return reminder_date
 
@@ -1210,7 +1203,9 @@ def create_item_from_create(
     _validate_item_core_fields(name, quantity, low_stock_threshold)
     validate_custom_fields(custom_fields)
     normalized_due_date = validate_due_date_rules(checked_out=checked_out, due_date=due_date)
-    normalized_inspection_date = validate_inspection_date(inspection_date)
+    normalized_inspection_date = validate_optional_date(
+        inspection_date, field_name="inspection_date"
+    )
     normalized_reminder_date, reminder_interval = validate_reminder_rules(
         reminder_date=payload.get("reminder_date"),
         reminder_interval=payload.get("reminder_interval"),
@@ -1299,7 +1294,9 @@ def _update_checkout_and_due_date(new_item: Item, update: ItemUpdate) -> None:
 
 def _update_inspection_date(new_item: Item, update: ItemUpdate) -> None:
     if "inspection_date" in update:
-        new_item.inspection_date = validate_inspection_date(update["inspection_date"])
+        new_item.inspection_date = validate_optional_date(
+            update["inspection_date"], field_name="inspection_date"
+        )
 
 
 def _update_reminder(new_item: Item, update: ItemUpdate) -> None:

--- a/tests/test_import_export_offline.py
+++ b/tests/test_import_export_offline.py
@@ -729,6 +729,32 @@ def test_preview_holds_an_imported_item_to_the_always_enforced_rules(
 
 
 @pytest.mark.parametrize(
+    ("overrides", "field"),
+    [
+        ({"inspection_date": "2026-13-01"}, "inspection_date"),
+        ({"reminder_date": "2026-02-30"}, "reminder_date"),
+        (
+            {"reminder_date": "2026-09-01", "reminder_anchor": "2026-02-30"},
+            "reminder_anchor",
+        ),
+    ],
+)
+def test_a_refused_document_date_names_the_field_its_path_points_at(
+    overrides: dict, field: str
+) -> None:
+    """Path and message have to agree, or the author is sent to another line."""
+
+    repo = Repository()
+    report, target = ie.plan_import(
+        repo, _envelope(_item_doc(**overrides)), current_schema_version=CURRENT_SCHEMA_VERSION
+    )
+
+    assert target is None
+    reported = {e["path"]: e["message"] for e in report["errors"]}
+    assert reported[f"items[0].{field}"] == f"{field} must be a valid calendar date (YYYY-MM-DD)"
+
+
+@pytest.mark.parametrize(
     "overrides",
     [
         {"description": "d" * (DESCRIPTION_MAX_LENGTH + 1)},

--- a/tests/test_models_offline.py
+++ b/tests/test_models_offline.py
@@ -40,6 +40,7 @@ from custom_components.haventory.models import (
     serialize_reminder_interval,
     serialize_status_definition,
     validate_attachment_meta,
+    validate_optional_date,
     validate_status_definition,
 )
 
@@ -207,6 +208,68 @@ async def test_invalid_inspection_date_format_raises_validation_error() -> None:
     item = create_item_from_create({"name": "Equipment"})
     with pytest.raises(ValidationError):
         apply_item_update(item, ItemUpdate(inspection_date="invalid-date"))
+
+
+# -----------------------------
+# Date fields
+# -----------------------------
+
+FORMAT_REFUSAL = "{field} must be in 'YYYY-MM-DD' format"
+CALENDAR_REFUSAL = "{field} must be a valid calendar date (YYYY-MM-DD)"
+
+DATE_FIELDS = ["due_date", "inspection_date", "reminder_date"]
+
+
+def _item_payload_with_date(field: str, value: str) -> dict:
+    """An otherwise valid create payload carrying one date field."""
+
+    payload: dict = {"name": "Boiler", field: value}
+    if field == "due_date":
+        # A due date only exists on a checked-out item; without this the create
+        # is refused by that rule instead of by the date's format.
+        payload["checked_out"] = True
+    return payload
+
+
+@pytest.mark.parametrize("field", DATE_FIELDS)
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [("2026-1-1", FORMAT_REFUSAL), ("2026-02-30", CALENDAR_REFUSAL)],
+)
+def test_a_refused_date_names_the_field_that_carried_it(
+    field: str, value: str, message: str
+) -> None:
+    """The message is all a script or import author gets to work from.
+
+    It also pins the two texts themselves: all three fields share them, so a
+    reworded refusal changes what every automation surface reports.
+    """
+
+    with pytest.raises(ValidationError) as refusal:
+        create_item_from_create(_item_payload_with_date(field, value))
+
+    assert str(refusal.value) == message.format(field=field)
+
+
+@pytest.mark.parametrize("field", DATE_FIELDS)
+def test_a_real_calendar_date_is_kept_on_every_date_field(field: str) -> None:
+    item = create_item_from_create(_item_payload_with_date(field, "2026-02-28"))
+
+    assert getattr(item, field) == "2026-02-28"
+
+
+def test_an_update_names_the_date_field_it_refused() -> None:
+    item = create_item_from_create({"name": "Boiler"})
+
+    with pytest.raises(ValidationError) as refusal:
+        apply_item_update(item, ItemUpdate(inspection_date="2026-13-01"))
+
+    assert str(refusal.value) == CALENDAR_REFUSAL.format(field="inspection_date")
+
+
+def test_an_absent_optional_date_is_not_a_refusal() -> None:
+    assert validate_optional_date(None, field_name="inspection_date") is None
+    assert validate_optional_date("2026-02-28", field_name="inspection_date") == "2026-02-28"
 
 
 # -----------------------------

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -67,6 +67,25 @@ async def test_item_create_and_update_flow_logs_and_mutates() -> None:
 
 
 @pytest.mark.asyncio
+async def test_item_update_refuses_a_bad_inspection_date_by_its_own_name() -> None:
+    """An action is typed by hand, and the refusal is all the author is shown."""
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    await services_mod.service_item_create(hass, {"name": "Boiler"})
+    repo: Repository = repo_of(hass)
+    item_id = next(iter(repo._debug_get_internal_indexes()["items_by_id"]))
+
+    with pytest.raises(ValidationError) as refusal:
+        await services_mod.service_item_update(
+            hass, {"item_id": item_id, "inspection_date": "2026-02-30"}
+        )
+
+    assert str(refusal.value) == "inspection_date must be a valid calendar date (YYYY-MM-DD)"
+    assert repo.get_item(item_id).inspection_date is None
+
+
+@pytest.mark.asyncio
 async def test_item_move_and_quantity_helpers() -> None:
     """Move item between locations and adjust quantities via helpers."""
 

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -98,6 +98,31 @@ async def test_item_update_normalizes_a_tag_list_carrying_a_null() -> None:
 
 
 @pytest.mark.asyncio
+async def test_item_update_refuses_a_bad_inspection_date_by_its_own_name() -> None:
+    """A client sending a malformed date is told which of its fields is wrong."""
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    ws_setup(hass)
+
+    created = await ws_send(hass, 1, "haventory/item/create", name="Boiler")
+    item_id = created["result"]["id"]
+    version = created["result"]["version"]
+
+    res = await ws_send(
+        hass, 2, "haventory/item/update", item_id=item_id, inspection_date="2026-13-01"
+    )
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    assert res["error"]["message"] == "inspection_date must be a valid calendar date (YYYY-MM-DD)"
+
+    stored = await ws_send(hass, 3, "haventory/item/get", item_id=item_id)
+    assert stored["result"]["version"] == version
+    assert stored["result"]["inspection_date"] is None
+
+
+@pytest.mark.asyncio
 async def test_item_quantity_and_checkout_helpers() -> None:
     """Adjust/set quantity and check in/out via WS."""
 


### PR DESCRIPTION
## Summary

A date refused anywhere in the integration reported `due_date`, because
`models.normalize_date_yyyy_mm_dd` built both of its messages around that one name.
`inspection_date`, `reminder_date` and an import document's `reminder_anchor` all run
through it, so an automation author sending `inspection_date: 2026-02-30` was told a field
they never set was wrong — and the message is the whole of what a script, an action call or
an import report gives them.

The field name is now a required keyword argument of `normalize_date_yyyy_mm_dd`, and the
two wrappers around it — `validate_inspection_date` and `validate_reminder_date`, identical
apart from their docstrings — collapse into `validate_optional_date(value, field_name=...)`.
Every caller in `models.py` and `import_export.py` moves with them; there are no
compatibility shims. `due_date`'s two texts come out byte-identical, which the new tests
pin: no test asserted this wording before, so they are also the first record of it.

The messages are now:

- `<field> must be in 'YYYY-MM-DD' format`
- `<field> must be a valid calendar date (YYYY-MM-DD)`

Closes #566

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [ ] Frontend (`cards/haventory-card`): not applicable — the card is untouched.

Final counts on this branch:

```
1321 passed, 22 skipped in 9.32s     # main is 1305 passed, 22 skipped
All checks passed!                   # ruff check .
186 files already formatted          # ruff format --check .
Success: no issues found in 26 source files   # mypy
```

Tests added, all of them failing before the fix and green after:

- `tests/test_models_offline.py` — `due_date`, `inspection_date` and `reminder_date`, each
  against both refusals (`2026-1-1` for the format, `2026-02-30` for the calendar), assert
  the full message including the field name; a valid date is kept on all three; an update
  naming a bad `inspection_date` says so; `validate_optional_date(None, ...)` is still not a
  refusal.
- `tests/test_ws_items_offline.py` — `haventory/item/update` with `inspection_date:
  "2026-13-01"` answers `validation_error` naming `inspection_date`, and the item comes back
  with its `version` and its empty `inspection_date` untouched.
- `tests/test_services_offline.py` — `service_item_update` with `inspection_date:
  "2026-02-30"` (the issue's own repro, one layer below the Actions form) raises with the
  field named, and the stored item is unchanged.
- `tests/test_import_export_offline.py` — a preview report's message agrees with the path it
  is filed under, for `inspection_date`, `reminder_date` and `reminder_anchor`.

Not run here: the in-process phacc suite (CI's `integration` job covers it) and the live
check on the dev Home Assistant, which the session owning that instance runs against this
branch.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + several error cases).
- [x] Docs updated where behavior changed — none needed. `docs/backend_api_contract.md`
      describes the error envelope and `docs/data_shapes.md` → "Validation notes" the rule,
      neither quotes a message; nothing else in the tree quotes one either.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and
      `docs/data_shapes.md` in sync — `ws.py` is not touched; the contract is unchanged
      apart from the wording of a `validation_error` message.
- [x] Essential invariants preserved (case-insensitive search, denormalized
      `location_path`, optimistic `version`).

## Decisions

- **`field_name` is a required keyword argument**, not positional, matching `parse_uuid4` —
  the neighbouring validator that does the same job of naming a field in its refusal. Every
  call site reads `field_name="inspection_date"` on its own.
- **The document anchor's message says `reminder_anchor`, not `reminder_date`.** The plan
  suggested `reminder_date` for that path, but `import_export._validate_reminder_doc` files
  a bad anchor under `items[0].reminder_anchor`; a message naming a different field there
  points the author at the wrong line. `models.load_reminder_anchor` names it the same way
  for consistency, though that one's refusal is caught and never reaches a caller — a stored
  anchor it cannot read falls back to the reminder date, as before.
- **The two docstrings' real content is kept in one place.** `validate_optional_date` says
  why only the shape is checked: a past inspection date is overdue and a past reminder anchor
  is still where its series counts from, so neither is refused.
- **No compatibility shims.** `validate_inspection_date` and `validate_reminder_date` are
  gone rather than left as aliases; `import_export.py` is the only other module that imported
  them.

## Follow-ups

- `models.validate_due_date_rules` still hard-codes `due_date` in its "only valid when
  checked_out is true" message, which is correct today because only that field carries the
  rule — worth a look if a second field ever does.

## Screenshots (card / UI changes)

None — backend only.
