### PR TITLE
fix: refuse a tags value that is not a list of strings

### DIFF
--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -585,8 +585,13 @@ def validate_custom_fields(
                 )
 
 
-def validate_tags(tags: list[str] | None, *, previous: Collection[str] = ()) -> list[str]:
+def validate_tags(tags: object, *, previous: Collection[str] = ()) -> list[str]:
     """Normalize an *item's* tag list and enforce the item-side tag caps.
+
+    Every item write crosses here, which is why the shape is checked here too:
+    :func:`normalize_tags` iterates whatever it is handed, and ``item/update``
+    types ``tags`` as ``object``, so a string would reach the store as its
+    characters. ``None`` is what clears the list.
 
     Separate from :func:`normalize_tags`, which also normalizes *filter* values:
     a filter naming sixty tags is a query, not an item, and is not over any
@@ -598,7 +603,7 @@ def validate_tags(tags: list[str] | None, *, previous: Collection[str] = ()) -> 
     absolute check would refuse along with everything else.
     """
 
-    normalized = normalize_tags(tags)
+    normalized = normalize_string_list(tags, field_name="tags", casefold=True)
     previous_tags = set(previous)
     for tag in normalized:
         if tag not in previous_tags and len(tag) > TAG_MAX_LENGTH:
@@ -614,12 +619,14 @@ def validate_tags(tags: list[str] | None, *, previous: Collection[str] = ()) -> 
 ITEM_FILTER_KEYS: Final[frozenset[str]] = frozenset(ItemFilter.__annotations__)
 
 
-def normalize_filter_values(value: object, *, field_name: str, casefold: bool = False) -> list[str]:
-    """Normalize a multi-select filter list: trim, drop blanks, de-duplicate.
+def normalize_string_list(value: object, *, field_name: str, casefold: bool = False) -> list[str]:
+    """Normalize a list of strings a caller writes whole: trim, drop blanks, dedupe.
 
     A bare string is the mistake worth naming rather than absorbing: iterating
     one yields characters, so ``categories: "Tools"`` would quietly filter by
-    five single letters instead of by a category.
+    five single letters instead of by a category, and ``tags: "kitchen"`` would
+    store seven one-letter tags. ``None`` is the empty list — on an item's tags,
+    the value that clears them.
     """
 
     if value is None:
@@ -652,7 +659,7 @@ def selected_categories(flt: ItemFilter) -> list[str]:
     scalar = (flt.get("category") or "").strip().casefold() if "category" in flt else ""
     if scalar:
         selection.append(scalar)
-    for value in normalize_filter_values(
+    for value in normalize_string_list(
         flt.get("categories"), field_name="categories", casefold=True
     ):
         if value not in selection:
@@ -672,7 +679,7 @@ def selected_location_ids(flt: ItemFilter) -> list[str]:
     scalar = flt.get("location_id") if "location_id" in flt else None
     if scalar is not None:
         selection.append(str(scalar).strip())
-    for value in normalize_filter_values(flt.get("location_ids"), field_name="location_ids"):
+    for value in normalize_string_list(flt.get("location_ids"), field_name="location_ids"):
         if value not in selection:
             selection.append(value)
     return selection
@@ -1360,7 +1367,7 @@ def _update_location_and_path(
 
 def _update_tags_category_threshold(new_item: Item, update: ItemUpdate) -> None:
     if "tags" in update:
-        new_item.tags = validate_tags(update.get("tags") or [], previous=new_item.tags)
+        new_item.tags = validate_tags(update.get("tags"), previous=new_item.tags)
     if "category" in update:
         _validate_optional_text(
             update["category"],

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -60,7 +60,7 @@ from .models import (
     ItemUpdate,
     iso_utc_now,
     new_uuid4,
-    normalize_tags,
+    normalize_string_list,
     serialize_status_definition,
     today_local_date,
     validate_attachment_meta,
@@ -306,6 +306,16 @@ def _payload_item_id(payload: dict[str, Any]) -> str:
     return value
 
 
+def _payload_tags(payload: dict[str, Any]) -> list[str]:
+    """Extract a normalized tag list from an (unschema'd) op payload.
+
+    The item-side caps are left to the write these ops build, which weighs them
+    against the tags the item already carries: a payload that removes an
+    over-cap legacy list must not be refused for naming that many tags.
+    """
+    return normalize_string_list(payload.get("tags"), field_name="tags", casefold=True)
+
+
 def _payload_int(payload: dict[str, Any], key: str) -> int:
     """Extract a required integer field from an (unschema'd) op payload."""
     value = payload.get(key)
@@ -387,7 +397,7 @@ def _op_item_add_tags(hass: HomeAssistant, payload: dict[str, Any]) -> tuple[dic
     repo = _repo(hass)
     item_id = _payload_item_id(payload)
     expected = payload.get("expected_version")
-    tags = normalize_tags(payload.get("tags"))
+    tags = _payload_tags(payload)
     current = repo.get_item(item_id)
     new_tags = list(dict.fromkeys(list(current.tags) + list(tags)))
     updated = repo.update_item(item_id, ItemUpdate(tags=new_tags), expected_version=expected)
@@ -400,7 +410,7 @@ def _op_item_remove_tags(
     repo = _repo(hass)
     item_id = _payload_item_id(payload)
     expected = payload.get("expected_version")
-    to_remove = set(normalize_tags(payload.get("tags")))
+    to_remove = set(_payload_tags(payload))
     current = repo.get_item(item_id)
     new_tags = [t for t in list(current.tags) if t not in to_remove]
     updated = repo.update_item(item_id, ItemUpdate(tags=new_tags), expected_version=expected)

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -64,7 +64,11 @@ that keep a concrete schema type, and therefore still answer `invalid_format`.
 `tags` is the one name on both sides: concrete on `item/create`, `item/add_tags` and
 `item/remove_tags`, `object` on `item/update`. The same wrong value therefore answers a
 different code depending on which command carried it, which is the reason to handle both
-rather than to key on the field name.
+rather than to key on the field name. Under either code nothing is written: a `tags` that is
+not a list of strings — a bare string above all, which iterates as its characters — is
+refused before the list is read. The `items/bulk` payloads carry no schema at all, so
+`item_update`, `item_add_tags` and `item_remove_tags` answer that row with
+`validation_error` and leave the item as it was.
 
 `tests/test_docs_contract_offline.py` reads the schemas back off the registered handlers and
 fails when this list and the code disagree, so a new concretely-typed field arrives here in

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -633,6 +633,9 @@ shapes as the WebSocket surface — no bespoke service shape exists:
   logged once; the rest of the inventory still renders.
 - `name` trimmed; max length 120 for items and locations.
 - `custom_fields` keys must be non-empty strings; values must be scalars.
+- `tags` is a list of strings on every item write, and `null` clears the list. A value that
+  is not one — a bare string, which iterates as its characters — is refused rather than
+  read, on the whole-list write and on the two tag operations alike.
 
 #### Input caps
 

--- a/tests/test_models_offline.py
+++ b/tests/test_models_offline.py
@@ -42,6 +42,7 @@ from custom_components.haventory.models import (
     validate_attachment_meta,
     validate_optional_date,
     validate_status_definition,
+    validate_tags,
 )
 
 UUID4_RE = re.compile(
@@ -95,6 +96,37 @@ async def test_tag_normalization_and_update_clears_fields() -> None:
 
     updated2 = apply_item_update(updated, ItemUpdate(description=None, category=None))
     assert updated2.description is None and updated2.category is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "chisel",
+        {"kitchen": True},
+        7,
+        ["tools", 7],
+        ["tools", None],
+    ],
+)
+def test_a_tags_value_that_is_not_a_list_of_strings_is_refused(value: object) -> None:
+    """The type is checked before the list is iterated.
+
+    A string iterates as its characters, so `tags: "chisel"` would store six
+    one-letter tags — a write the caller never asked for, from a type slip that
+    nothing else on the path can catch. An entry that is not a string is the
+    same slip one level down.
+    """
+
+    with pytest.raises(ValidationError, match="tags must be a list of strings"):
+        validate_tags(value)
+
+
+def test_a_tag_list_is_normalized_and_a_null_clears() -> None:
+    """`None` is how a caller empties the list, and a list is normalized as before."""
+
+    assert validate_tags(None) == []
+    assert validate_tags([]) == []
+    assert validate_tags(["Tools", "  tools  ", "DIY"]) == ["tools", "diy"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_bulk_offline.py
+++ b/tests/test_ws_bulk_offline.py
@@ -6,6 +6,7 @@ Scenarios:
 - a deleted row frees its attachment files, after the batch's one write
 - a failed write frees nothing
 - only the rows that were deleted free files
+- a row whose payload has the wrong shape fails only itself
 """
 
 from __future__ import annotations
@@ -282,3 +283,58 @@ async def test_bulk_frees_the_files_of_the_deleted_row_only(monkeypatch) -> None
     assert order == ["save", "unlink"]
     assert unlinked == [(str(gone.id), str(gone_meta.id))]
     assert [str(a.id) for a in repo.get_item(kept.id).attachments] == [str(kept_meta.id)]
+
+
+@pytest.mark.asyncio
+async def test_a_row_whose_tags_are_a_string_fails_only_itself() -> None:
+    """Bulk payloads carry no schema, so the model's tag rule is the only guard.
+
+    `tags: "kitchen"` iterates as its characters on both the whole-list write
+    and the two tag ops, so each row is refused and the item keeps the tags it
+    had while the rest of the batch runs.
+    """
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    ws_setup(hass)
+
+    created = await ws_send(hass, 1, "haventory/item/create", name="Chisel", tags=["tools"])
+    item_id = created["result"]["id"]
+
+    NEW_QTY = 4
+    ops = [
+        {
+            "op_id": "update",
+            "kind": "item_update",
+            "payload": {"item_id": item_id, "tags": "kitchen"},
+        },
+        {
+            "op_id": "add",
+            "kind": "item_add_tags",
+            "payload": {"item_id": item_id, "tags": "kitchen"},
+        },
+        {
+            "op_id": "remove",
+            "kind": "item_remove_tags",
+            "payload": {"item_id": item_id, "tags": "tools"},
+        },
+        {
+            "op_id": "ok",
+            "kind": "item_set_quantity",
+            "payload": {"item_id": item_id, "quantity": NEW_QTY},
+        },
+    ]
+
+    res = await ws_send(hass, 2, "haventory/items/bulk", operations=ops)
+
+    assert res["success"] is True
+    results = res["result"]["results"]
+    for op_id in ("update", "add", "remove"):
+        assert results[op_id]["success"] is False
+        assert results[op_id]["error"]["code"] == "validation_error"
+        assert results[op_id]["error"]["message"] == "tags must be a list of strings"
+    assert results["ok"]["success"] is True
+
+    got = await ws_send(hass, 3, "haventory/item/get", item_id=item_id)
+    assert got["result"]["tags"] == ["tools"]
+    assert got["result"]["quantity"] == NEW_QTY

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -67,32 +67,37 @@ async def test_item_create_get_update_delete_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_item_update_normalizes_a_tag_list_carrying_a_null() -> None:
+async def test_item_update_refuses_a_tag_list_carrying_a_null() -> None:
     """`item/update` is the one command that can carry a null tag to the model.
 
     Every other command taking tags declares `[str]`, which Home Assistant
     refuses a null against before dispatch. `item/update` types each field as
-    `object` and leaves the shape to `apply_item_update`, so `normalize_tags`
-    has to drop the null rather than store it — a stored `None` would break
-    every tag index and filter that assumes strings.
+    `object` and leaves the shape to `apply_item_update`, which answers with
+    the same rule one layer down — a stored `None` would break every tag index
+    and filter that assumes strings, and dropping it silently would store a
+    list the caller did not send.
     """
 
     hass = HomeAssistant()
     install_runtime(hass)
     ws_setup(hass)
 
-    created = await ws_send(hass, 1, "haventory/item/create", name="Battery")
+    created = await ws_send(hass, 1, "haventory/item/create", name="Battery", tags=["li-ion"])
     item_id = created["result"]["id"]
 
     res = await ws_send(
         hass, 2, "haventory/item/update", item_id=item_id, tags=["Li-Ion", None, " spare "]
     )
 
-    assert res["success"] is True
-    assert res["result"]["tags"] == ["li-ion", "spare"]
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    assert res["error"]["message"] == "tags must be a list of strings"
+
+    unchanged = await ws_send(hass, 3, "haventory/item/get", item_id=item_id)
+    assert unchanged["result"]["tags"] == ["li-ion"]
 
     # The narrow schemas hold the line for the commands that declare `[str]`.
-    refused = await ws_send(hass, 3, "haventory/item/add_tags", item_id=item_id, tags=["x", None])
+    refused = await ws_send(hass, 4, "haventory/item/add_tags", item_id=item_id, tags=["x", None])
     assert refused["success"] is False
     assert refused["error"]["code"] == "invalid_format"
 
@@ -120,6 +125,39 @@ async def test_item_update_refuses_a_bad_inspection_date_by_its_own_name() -> No
     stored = await ws_send(hass, 3, "haventory/item/get", item_id=item_id)
     assert stored["result"]["version"] == version
     assert stored["result"]["inspection_date"] is None
+
+
+@pytest.mark.asyncio
+async def test_item_update_refuses_a_string_tags_and_keeps_the_item() -> None:
+    """A string `tags` writes nothing, and a null still clears the list.
+
+    `tags: "kitchen"` iterates as seven characters, so the item would come back
+    carrying seven one-letter tags a caller never wrote. The refusal leaves the
+    item's tags and its version alone, which is what tells a client its edit
+    did not land.
+    """
+
+    hass = HomeAssistant()
+    install_runtime(hass)
+    ws_setup(hass)
+
+    created = await ws_send(hass, 1, "haventory/item/create", name="Chisel", tags=["tools"])
+    item_id = created["result"]["id"]
+    version_before = created["result"]["version"]
+
+    res = await ws_send(hass, 2, "haventory/item/update", item_id=item_id, tags="kitchen")
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "validation_error"
+    assert res["error"]["message"] == "tags must be a list of strings"
+
+    unchanged = await ws_send(hass, 3, "haventory/item/get", item_id=item_id)
+    assert unchanged["result"]["tags"] == ["tools"]
+    assert unchanged["result"]["version"] == version_before
+
+    cleared = await ws_send(hass, 4, "haventory/item/update", item_id=item_id, tags=None)
+    assert cleared["success"] is True
+    assert cleared["result"]["tags"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`haventory/item/update` types `tags` as `object` so that a wrong type is answered by the
model as `validation_error` rather than by Home Assistant's schema layer — but the model
handed the value straight to `normalize_tags`, which iterates whatever it is given. A string
iterates as its characters, so `{"tags": "kitchen"}` saved the item with the seven tags `k`,
`i`, `t`, `c`, `h`, `e`, `n` and reported success. The two bulk ops `item_add_tags` and
`item_remove_tags` carry no schema at all and read the same field the same way.

The fix puts the shape check where every item write crosses. `validate_tags` now takes its
list through `normalize_string_list` — the guard `categories` and `location_ids` already use,
renamed from `normalize_filter_values` because it is no longer filter-only — so a value that
is not a list of strings answers `validation_error` with `tags must be a list of strings` and
writes nothing. `tags: null` still clears the list. The two bulk tag ops read their field
through a `_payload_tags` extractor beside `_payload_item_id`, applying the same rule per row.

`item/create`, `item/add_tags`, `item/remove_tags` and both services declare `[str]`, so they
already refused a string before the model saw it; their behaviour is unchanged.

Closes #567

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1313 passed, 22
      skipped** (`main` at `e63a97e`: 1305 passed, 22 skipped — eight new cases, one existing
      test rewritten); `uv run ruff check .` → *All checks passed!*; `uv run ruff format
      --check .` → *186 files already formatted*; `uv run mypy` → *Success: no issues found
      in 26 source files*.
- [ ] Frontend (`cards/haventory-card`): not run — the card is not touched by this change.

Every new test was written first and watched fail against the unfixed code (eight failures,
including `assert True is False` on the `item/update` refusal).

New and changed tests:

- `tests/test_models_offline.py::test_a_tags_value_that_is_not_a_list_of_strings_is_refused`
  — `"chisel"`, a dict, an int, `["tools", 7]` and `["tools", None]` each raise with the
  message.
- `tests/test_models_offline.py::test_a_tag_list_is_normalized_and_a_null_clears` — `None` and
  `[]` give `[]`, and a list is still trimmed, casefolded and de-duplicated.
- `tests/test_ws_items_offline.py::test_item_update_refuses_a_string_tags_and_keeps_the_item`
  — the issue's repro over the socket: `validation_error`, the item read back with the same
  tags **and the same `version`**, and `tags: null` still clearing.
- `tests/test_ws_items_offline.py::test_item_update_refuses_a_tag_list_carrying_a_null` — the
  existing test for the one command that can carry a null tag to the model, rewritten to the
  new contract (see the decision below).
- `tests/test_ws_bulk_offline.py::test_a_row_whose_tags_are_a_string_fails_only_itself` — an
  `item_update`, an `item_add_tags` and an `item_remove_tags` row each carrying `"kitchen"`
  fail their own row, a fourth row succeeds, and the item keeps its tags.

Not verified on a running instance from here: this branch is offline work, and the dev Home
Assistant belongs to the session that opened this PR. The live check it runs is `item/update`
with `tags: "kitchen"` (refused, item unchanged), an `items/bulk` `item_add_tags` row with the
same value (that row refused), `tags: null` (cleared) and `tags: ["kitchen"]` (saved).

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + several error cases).
- [x] Docs updated where behavior changed (`docs/backend_api_contract.md`,
      `docs/data_shapes.md`; `README.md` says nothing about tag types).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
      `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved — the refusal happens before the item is copied, so a
      refused update leaves `version`, `updated_at` and `location_path` untouched.

## Decisions

- **Entries are checked too, not only the container.** The plan left this open and asked which
  way it went. A non-string *entry* is refused, which means the existing
  `test_item_update_normalizes_a_tag_list_carrying_a_null` changed from "the null is dropped
  and the write succeeds" to "the write is refused and the item is unchanged". Three reasons:
  the message the issue asks for says *a list of strings*; every schema'd command already
  refuses `["x", null]` outright and leaves the item alone, so `item/update` was the odd one
  out; and #230's plan to widen those schemas to `object` would otherwise turn today's
  refusals into silent drops the day it lands. The constraint the old test recorded — no
  `None` ever reaches the tag index — still holds, by the stronger route.
- **Reused the filter guard instead of writing a second one.** `normalize_filter_values`
  already did exactly this job for `categories` and `location_ids`, down to the message, so
  `validate_tags` calls it and it is renamed `normalize_string_list` (three call sites, all in
  `models.py`). One rule, one message, one implementation.
- **The bulk tag ops keep their cap behaviour.** `_payload_tags` normalizes and type-checks
  but does not apply the item caps; those stay on the write the op builds, which weighs them
  against the tags the item already carries. Applying them to the payload would refuse an
  `item_remove_tags` row that names every tag of an over-cap legacy item — the edit that fixes
  it.
- **`apply_item_update` passes `update.get("tags")` rather than `update.get("tags") or []`.**
  `validate_tags(None)` is `[]`, so a null still clears; the difference is that `tags: ""` and
  `tags: 0` are now refused instead of silently clearing the list.
- **Left the `items/bulk` entry in the contract alone.** The rule is written once, in the
  paragraph that already enumerates which command answers what for `tags`, and covers the bulk
  ops there — a second copy in the `items/bulk` bullet list would be one more thing to keep
  true.

## Follow-ups

- `normalize_tags` still iterates whatever it is handed on the *filter* path: `tags_any` /
  `tags_all` with a bare string filter by single letters rather than answering
  `validation_error`. A query writes nothing, so it is a wrong answer rather than a wrong
  write, but the two multi-select filters beside it (`categories`, `location_ids`) already
  refuse the same mistake.
- `haventory/subscribe` builds `location_ids` with `[str(value) for value in raw_ids or []]`,
  which coerces a non-string entry rather than refusing it — the same guard would fit.

## Screenshots (card / UI changes)

None — backend only.
