### PR TITLE
fix: free an item's attachment files on every delete surface

### DIFF
--- a/custom_components/haventory/media.py
+++ b/custom_components/haventory/media.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import shutil
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
@@ -63,7 +63,7 @@ from .const import (
 )
 from .exceptions import ValidationError
 from .logs import context_logger
-from .models import AttachmentKind, AttachmentMeta
+from .models import AttachmentKind, AttachmentMeta, load_attachments
 from .runtime import find_runtime
 
 LOGGER = context_logger(__name__)
@@ -445,6 +445,29 @@ async def async_delete_attachments(
             continue
     if targets:
         await hass.async_add_executor_job(_delete_blocking, targets)
+
+
+async def async_delete_item_files(hass: HomeAssistant, items: Iterable[Mapping[str, Any]]) -> None:
+    """Delete the attachment files of every deleted item passed in.
+
+    Takes serialized item bodies — the shape ``serialization.serialize_item``
+    produces — because the surfaces that delete an item hold the body they
+    removed and not the ``Item`` itself.
+
+    Every caller runs this **after** its save has succeeded, for the same reason
+    ``attachment/remove`` deletes last: an orphaned file is swept at the next
+    setup, while a file deleted ahead of a failed save would leave stored
+    metadata naming nothing.
+    """
+
+    pairs: list[tuple[str, AttachmentMeta]] = []
+    for body in items:
+        item_id = str(body.get("id") or "")
+        if not item_id:
+            continue
+        pairs.extend((item_id, meta) for meta in load_attachments(body.get("attachments")))
+    if pairs:
+        await async_delete_attachments(hass, pairs)
 
 
 async def async_sweep_orphans(

--- a/custom_components/haventory/services.py
+++ b/custom_components/haventory/services.py
@@ -18,6 +18,7 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.util import dt as dt_util
 
+from . import media as media_mod
 from .const import DOMAIN
 from .events import notify_counts, notify_location_mutation, notify_mutation
 from .exceptions import (
@@ -249,6 +250,7 @@ async def service_item_delete(hass: HomeAssistant, data: dict) -> dict[str, Any]
         removed = serialize_item(hass, repo.get_item(payload["item_id"]))
         repo.delete_item(payload["item_id"], expected_version=expected)
         await async_persist_repo(hass)
+        await media_mod.async_delete_item_files(hass, [removed])
         notify_mutation(hass, action="deleted", item=removed)
         return {"item": removed}
     except (vol.Invalid, ValidationError, NotFoundError, ConflictError, StorageError) as exc:

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -1185,12 +1185,7 @@ async def ws_item_delete(
     serialized_before = serialize_item(hass, before)
     repo.delete_item(item_id, expected_version=msg.get("expected_version"))
     await _persist_repo(hass)
-    # After the save, for the same reason attachment/remove deletes last: an
-    # orphaned file is swept at setup, while a file deleted ahead of a failed
-    # save would leave stored metadata pointing at nothing.
-    await media_mod.async_delete_attachments(
-        hass, [(str(before.id), a) for a in before.attachments]
-    )
+    await media_mod.async_delete_item_files(hass, [serialized_before])
     notify_mutation(hass, action="deleted", item=serialized_before)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), None))
 
@@ -1820,6 +1815,13 @@ async def ws_items_bulk(
         # before anything else so neither the summary nor an event describes a
         # batch that never reached disk. The whole batch shares this one write.
         await _persist_repo(hass)
+
+        # `deleted` is the action `_op_item_delete` alone returns, so it names
+        # exactly the rows whose files nothing references any more. A row that
+        # failed is not in `successful_ops` and keeps every file it had.
+        await media_mod.async_delete_item_files(
+            hass, [body for _op_id, body, action in successful_ops if action == "deleted"]
+        )
 
         LOGGER.info(
             "Bulk operation completed",

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -246,6 +246,7 @@ with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
 - `haventory/item/delete`
   - Payload: `{item_id: string, expected_version?: number}`
   - Result: `null`; emits `items/deleted` with the pre-delete snapshot under `item`, and `stats/counts`.
+  - The item's attachment files are deleted with it, after the save. A write that fails leaves every file where it was — the item is still in the store, and its metadata still names them.
 
 - `haventory/item/adjust_quantity`
   - Payload: `{item_id: string, delta: number, expected_version?: number}`
@@ -372,6 +373,7 @@ with no WebSocket client at all. Payload shapes: `docs/data_shapes.md`.
   - Supported `kind` values: `item_update`, `item_delete`, `item_move`, `item_adjust_quantity`, `item_set_quantity`, `item_check_out`, `item_check_in`, `item_add_tags`, `item_remove_tags`, `item_update_custom_fields`, `item_set_low_stock_threshold`.
   - Result: `{results: { [op_id: string]: {success: true, result: <Item>} | {success: false, error: {code, message, context}} }}`; if any success, a single `stats/counts` event is emitted.
   - A failed op fails only itself; the batch continues and reports it under its `op_id`. A failed *write*, by contrast, fails the whole command with `storage_error` and returns no `results` map at all — the batch is one write.
+  - An `item_delete` row frees the item's attachment files, after the batch's one write and on the same terms as `item/delete`: a row that failed keeps every file it had, and a failed write frees nothing at all.
   - **`op_id`s must be unique within one batch**, and are compared as strings — `1` and `"1"` are the same id. A repeat rejects the whole command with `validation_error` and runs nothing, because the results map is keyed by `op_id` and could only report one verdict for the two operations.
 
 - `haventory/item/list`

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -617,7 +617,8 @@ shapes as the WebSocket surface — no bespoke service shape exists:
   can template `reminder_date` out of the response. The rule behind it lives in one place,
   `calendar_projection.bumped_reminder_date`, which the WebSocket command also calls.
 - `item_delete` and `location_delete` return the entity as it last stood, read before the
-  removal. Deleting an unknown id is `not_found`, not an empty envelope.
+  removal. Deleting an unknown id is `not_found`, not an empty envelope. `item_delete` also
+  frees the item's attachment files after the write, exactly as `haventory/item/delete` does.
 - The response is produced **after** the durable write, so an answer means the mutation is
   persisted — the same ordering the WebSocket contract states for events.
 - `OPTIONAL`, not `ONLY`: a caller that omits `response_variable` is unaffected.

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -530,6 +530,58 @@ async def test_deleting_the_item_deletes_its_files(
     assert not path.exists()
 
 
+async def test_a_bulk_delete_deletes_the_item_files(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+) -> None:
+    """The card's bulk bar and the organize dialog delete through `items/bulk`."""
+
+    await _setup(hass)
+    client = await hass_client()
+    ws = await hass_ws_client(hass)
+    item = await _create_item(ws)
+    attachment = await _attach(ws, client, item)
+    path = media.attachment_path(
+        media.media_root(hass), item["id"], attachment["id"], attachment["mime"]
+    )
+    assert path.is_file()
+
+    await ws.send_json(
+        {
+            "id": 91,
+            "type": "haventory/items/bulk",
+            "operations": [
+                {"op_id": "d", "kind": "item_delete", "payload": {"item_id": item["id"]}}
+            ],
+        }
+    )
+    deleted = await ws.receive_json()
+    assert deleted["success"] is True, deleted
+    assert deleted["result"]["results"]["d"]["success"] is True, deleted
+
+    assert not path.exists()
+
+
+async def test_the_item_delete_service_deletes_the_item_files(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+) -> None:
+    """Only this mode dispatches a service: the offline stub has no registry."""
+
+    await _setup(hass)
+    client = await hass_client()
+    ws = await hass_ws_client(hass)
+    item = await _create_item(ws)
+    attachment = await _attach(ws, client, item)
+    path = media.attachment_path(
+        media.media_root(hass), item["id"], attachment["id"], attachment["mime"]
+    )
+    assert path.is_file()
+
+    await hass.services.async_call(DOMAIN, "item_delete", {"item_id": item["id"]}, blocking=True)
+    await hass.async_block_till_done()
+
+    assert not path.exists()
+
+
 async def test_setup_sweeps_a_file_no_metadata_references(
     hass: HomeAssistant, hass_storage: dict
 ) -> None:

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -18,6 +18,7 @@ import pytest
 import voluptuous as vol
 import yaml
 from custom_components.haventory import events as events_mod
+from custom_components.haventory import media as media_mod
 from custom_components.haventory import services as services_mod
 from custom_components.haventory.const import EVENT_ITEM_CHANGED
 from custom_components.haventory.exceptions import (
@@ -26,6 +27,7 @@ from custom_components.haventory.exceptions import (
     StorageError,
     ValidationError,
 )
+from custom_components.haventory.models import AttachmentMeta, iso_utc_now, new_uuid4
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from homeassistant.core import HomeAssistant, SupportsResponse
@@ -603,3 +605,78 @@ async def test_the_bump_service_keeps_the_series_on_its_own_day() -> None:
     assert bumped["item"]["reminder_date"] == "2026-09-30"
     assert bumped["item"]["reminder_anchor"] == "2026-08-31"
     assert repo.get_item(item_id).reminder_anchor == "2026-08-31"
+
+
+# -----------------------------
+# The files of a deleted item
+#
+# `haventory.item_delete` removes an item the same way `haventory/item/delete`
+# does, so it owes the same files: unlinked once the write has landed, and left
+# where they are when it has not.
+# -----------------------------
+
+
+def _attachment_meta() -> AttachmentMeta:
+    return AttachmentMeta(
+        id=new_uuid4(),
+        kind="picture",
+        filename="photo.png",
+        mime="image/png",
+        size=16,
+        uploaded_at=iso_utc_now(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_item_delete_service_frees_the_files_after_the_save(monkeypatch) -> None:
+    hass = HomeAssistant()
+    repo = Repository()
+    install_runtime(hass, repository=repo)
+    store = DomainStore(hass)
+    runtime_of(hass).store = store
+    item = repo.create_item({"name": "Drill"})
+    meta = _attachment_meta()
+    repo.add_attachment(item.id, meta)
+
+    order: list[str] = []
+    unlinked: list[tuple[str, str]] = []
+
+    async def _spy_save(_payload):  # type: ignore[no-untyped-def]
+        order.append("save")
+
+    async def _spy_delete(_hass, pairs):  # type: ignore[no-untyped-def]
+        order.append("unlink")
+        unlinked.extend((item_id, str(entry.id)) for item_id, entry in pairs)
+
+    monkeypatch.setattr(store, "async_save", _spy_save)
+    monkeypatch.setattr(media_mod, "async_delete_attachments", _spy_delete)
+
+    await services_mod.service_item_delete(hass, {"item_id": str(item.id)})
+
+    assert order == ["save", "unlink"]
+    assert unlinked == [(str(item.id), str(meta.id))]
+
+
+@pytest.mark.asyncio
+async def test_item_delete_service_frees_nothing_when_the_save_fails(monkeypatch) -> None:
+    hass = HomeAssistant()
+    repo = Repository()
+    install_runtime(hass, repository=repo)
+    item = repo.create_item({"name": "Drill"})
+    repo.add_attachment(item.id, _attachment_meta())
+
+    unlinked: list[tuple[str, str]] = []
+
+    async def _spy_delete(_hass, pairs):  # type: ignore[no-untyped-def]
+        unlinked.extend((item_id, str(entry.id)) for item_id, entry in pairs)
+
+    async def _persist(_hass):  # type: ignore[no-untyped-def]
+        raise StorageError("disk full")
+
+    monkeypatch.setattr(media_mod, "async_delete_attachments", _spy_delete)
+    monkeypatch.setattr(services_mod, "async_persist_repo", _persist)
+
+    with pytest.raises(StorageError):
+        await services_mod.service_item_delete(hass, {"item_id": str(item.id)})
+
+    assert unlinked == []

--- a/tests/test_ws_bulk_offline.py
+++ b/tests/test_ws_bulk_offline.py
@@ -3,11 +3,18 @@
 Scenarios:
 - mixed success and failure results are mapped by op_id
 - single persist when at least one operation succeeds (spy DomainStore.async_save)
+- a deleted row frees its attachment files, after the batch's one write
+- a failed write frees nothing
+- only the rows that were deleted free files
 """
 
 from __future__ import annotations
 
 import pytest
+from custom_components.haventory import media as media_mod
+from custom_components.haventory.exceptions import StorageError
+from custom_components.haventory.models import AttachmentMeta, iso_utc_now, new_uuid4
+from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
@@ -138,3 +145,140 @@ async def test_bulk_empty_and_invalid_operations_and_duplicate_ids(monkeypatch) 
     res = await ws_send(hass, 8, "haventory/items/bulk", operations=ops_ok)
     assert res["success"] is True
     assert set(res["result"]["results"]) == {"a", "b"}
+
+
+# -----------------------------
+# The files of the rows that were deleted
+#
+# One rule for every surface that deletes an item: once the write has landed,
+# the files of each removed item are unlinked. The ordering is the point — a
+# file deleted ahead of a save that then fails leaves stored metadata naming
+# nothing, while a file left behind by a failed unlink is swept at setup.
+# -----------------------------
+
+
+def _meta() -> AttachmentMeta:
+    return AttachmentMeta(
+        id=new_uuid4(),
+        kind="picture",
+        filename="photo.png",
+        mime="image/png",
+        size=16,
+        uploaded_at=iso_utc_now(),
+    )
+
+
+def _hass_with_store() -> tuple[HomeAssistant, Repository, DomainStore]:
+    hass = HomeAssistant()
+    repo = Repository()
+    install_runtime(hass, repository=repo)
+    store = DomainStore(hass)
+    runtime_of(hass).store = store
+    ws_setup(hass)
+    return hass, repo, store
+
+
+def _record_save_and_unlink(
+    monkeypatch, store: DomainStore
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """Spy the write and the unlink into one ordered list, plus the pairs."""
+
+    order: list[str] = []
+    unlinked: list[tuple[str, str]] = []
+
+    async def _spy_save(_payload):  # type: ignore[no-untyped-def]
+        order.append("save")
+
+    async def _spy_delete(_hass, pairs):  # type: ignore[no-untyped-def]
+        order.append("unlink")
+        unlinked.extend((item_id, str(meta.id)) for item_id, meta in pairs)
+
+    monkeypatch.setattr(store, "async_save", _spy_save)
+    monkeypatch.setattr(media_mod, "async_delete_attachments", _spy_delete)
+    return order, unlinked
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_frees_the_files_after_the_batch_write(monkeypatch) -> None:
+    """A bulk delete unlinks the item's files, and not before the save."""
+
+    hass, repo, store = _hass_with_store()
+    item = repo.create_item({"name": "Drill"})
+    meta = _meta()
+    repo.add_attachment(item.id, meta)
+    order, unlinked = _record_save_and_unlink(monkeypatch, store)
+
+    res = await ws_send(
+        hass,
+        1,
+        "haventory/items/bulk",
+        operations=[{"op_id": "d", "kind": "item_delete", "payload": {"item_id": str(item.id)}}],
+    )
+
+    assert res["success"] is True
+    assert res["result"]["results"]["d"]["success"] is True
+    assert order == ["save", "unlink"]
+    assert unlinked == [(str(item.id), str(meta.id))]
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_frees_nothing_when_the_write_fails(monkeypatch) -> None:
+    """A batch answered `storage_error` still has its files on disk."""
+
+    hass, repo, store = _hass_with_store()
+    item = repo.create_item({"name": "Drill"})
+    repo.add_attachment(item.id, _meta())
+    _order, unlinked = _record_save_and_unlink(monkeypatch, store)
+
+    async def _raise(_payload):  # type: ignore[no-untyped-def]
+        raise StorageError("disk full")
+
+    monkeypatch.setattr(store, "async_save", _raise)
+
+    res = await ws_send(
+        hass,
+        1,
+        "haventory/items/bulk",
+        operations=[{"op_id": "d", "kind": "item_delete", "payload": {"item_id": str(item.id)}}],
+    )
+
+    assert res["success"] is False
+    assert res["error"]["code"] == "storage_error"
+    assert unlinked == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_frees_the_files_of_the_deleted_row_only(monkeypatch) -> None:
+    """A row refused on a stale version keeps every file it had."""
+
+    hass, repo, store = _hass_with_store()
+    gone = repo.create_item({"name": "Drill"})
+    gone_meta = _meta()
+    repo.add_attachment(gone.id, gone_meta)
+    kept = repo.create_item({"name": "Saw"})
+    kept_meta = _meta()
+    repo.add_attachment(kept.id, kept_meta)
+    order, unlinked = _record_save_and_unlink(monkeypatch, store)
+
+    STALE_VERSION = 99
+    res = await ws_send(
+        hass,
+        1,
+        "haventory/items/bulk",
+        operations=[
+            {"op_id": "gone", "kind": "item_delete", "payload": {"item_id": str(gone.id)}},
+            {
+                "op_id": "stale",
+                "kind": "item_delete",
+                "payload": {"item_id": str(kept.id), "expected_version": STALE_VERSION},
+            },
+        ],
+    )
+
+    results = res["result"]["results"]
+    assert results["gone"]["success"] is True
+    assert results["stale"]["success"] is False
+    assert results["stale"]["error"]["code"] == "conflict"
+    assert order == ["save", "unlink"]
+    assert unlinked == [(str(gone.id), str(gone_meta.id))]
+    assert [str(a.id) for a in repo.get_item(kept.id).attachments] == [str(kept_meta.id)]


### PR DESCRIPTION
## Summary

Three surfaces delete an item and only one of them freed the item's attachment
files. `haventory/item/delete` unlinked them right after its save;
`_op_item_delete` — the op `haventory/items/bulk` dispatches through, which is
what the card's bulk bar and the organize dialog use — ended at
`repo.delete_item(...)`, and `services.py`'s `service_item_delete` had the same
gap. Until the next restart's orphan sweep those bytes stayed on disk, silently.

The issue names the bulk path; the service has the same bug and is fixed here
too, in the same commit, because it is the same rule and the same tail.

**The rule, now in one place:** after the persist succeeds, unlink the files of
every item the call removed. `media.async_delete_item_files(hass, items)` takes
the serialized item bodies each caller already holds — `serialized_before` on
the single path, the successful `"deleted"` rows on the bulk path, `removed` in
the service — reads their `attachments` back with `models.load_attachments`, and
delegates to the existing `async_delete_attachments`. A persist that raises
reaches none of them, so it frees nothing; a bulk row that failed is not in
`successful_ops`, so it keeps every file it had; and a media failure after the
persist still propagates exactly as it does on the single path today.

Closes #565

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## Decisions

- **Keyed on the action, not a deferred step.** The plan offered two shapes. The
  deferred step (an op hands its post-persist work back to whichever caller
  persists) changes the return contract of all eleven ops and of
  `_execute_item_op`, which three sibling fixes are rebasing over right now — and
  the V0.8.0 op-table collapse (#230) will rewrite that contract on its own
  terms anyway. Keying on the `"deleted"` action needs no signature change: it is
  the action `_op_item_delete` alone returns, so it names exactly the rows whose
  files nothing references any more.
- **All three callers go through the helper**, including `haventory/item/delete`,
  which already worked. Two copies of a rule is how the bulk path came to be
  missing it; the single path's behaviour, ordering and the reason for the
  ordering are unchanged, the reason now living in the helper's docstring.
- **The helper takes serialized bodies rather than `Item` objects.** The bulk
  loop never holds the `Item` — `_op_item_delete` reads the body before removing
  it and hands that back — and `load_attachments` reads exactly the shape
  `serialize_attachment_meta` writes.
- **Media deletion runs before the mutation events**, as the single path orders
  it, and before the batch's summary log.
- `docs/backend_api_contract.md` gains the sentence on both `item/delete` (which
  did not state it either) and `items/bulk`; `docs/data_shapes.md`'s service
  bullet gains the clause for `item_delete`, since the service is one of the
  three surfaces fixed.
- Three surfaces is all of them. `location_delete` cannot leak: the repository
  refuses to delete a location that still contains items, so no delete cascades
  to an item.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1310
  passed, 22 skipped** (5 new; `main` collects 1305). `uv run ruff check .` →
  All checks passed. `uv run ruff format --check .` → 186 files already
  formatted. `uv run mypy` → Success: no issues found in 26 source files.
- [x] In-process (phacc), run locally in a container on the shared venv volume:
  `bash scripts/test_integration.sh` → **140 passed, 13 skipped** (the skips are
  `tests/integration/test_frontend.py`'s, which need a built card).
- [ ] Frontend (`cards/haventory-card`): not run — this PR touches no card file.

Each new test was seen failing first. With the three source files stashed, the
two new in-process tests fail and `test_deleting_the_item_deletes_its_files`
still passes, which is the shape of the bug; with them restored, all three pass.

New tests:

- `tests/test_ws_bulk_offline.py` — a bulk `item_delete` of an item carrying an
  attachment records `["save", "unlink"]` in that order and unlinks that item's
  pair; a save that raises answers `storage_error` and unlinks nothing; a batch
  of one deleted row and one row refused on a stale version unlinks only the
  deleted one and leaves the other's metadata intact.
- `tests/test_services_offline.py` — `service_item_delete` unlinks after the
  save; a raising persist raises `StorageError` and unlinks nothing.
- `tests/integration/test_attachments.py` — twins of
  `test_deleting_the_item_deletes_its_files` through `haventory/items/bulk` and
  through `hass.services.async_call("haventory", "item_delete", …)`, both
  checking the real file is gone. The offline stub has no service registry, so
  the service dispatch is only assertable in this mode.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
  `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved.

## Follow-ups

- `haventory/import/execute` frees files by a different mechanism — a full
  `async_sweep_orphans` against the new metadata rather than a named list, which
  is the right shape for a wholesale replace. It is correct as it stands; it is
  simply a second place that knows when a file stops being referenced.
- Nothing structural stops a future delete surface from missing this again. The
  check that would catch it belongs with the op-table collapse (#230), where
  every single-item command goes through one tail, rather than as a test per
  caller.
