### PR TITLE
feat(services): give every service field a name and a description

### DIFF
--- a/custom_components/haventory/services.yaml
+++ b/custom_components/haventory/services.yaml
@@ -1,6 +1,4 @@
 item_create:
-  name: Create item
-  description: Create a new inventory item
   fields:
     name:
       required: true
@@ -84,8 +82,6 @@ item_create:
         object:
 
 item_update:
-  name: Update item
-  description: Update fields on an existing item
   fields:
     item_id:
       required: true
@@ -168,8 +164,6 @@ item_update:
         object:
 
 item_delete:
-  name: Delete item
-  description: Delete an item by id
   fields:
     item_id:
       required: true
@@ -181,8 +175,6 @@ item_delete:
         number:
 
 item_move:
-  name: Move item
-  description: Move an item to a new location (or root)
   fields:
     item_id:
       required: true
@@ -198,8 +190,6 @@ item_move:
         number:
 
 item_adjust_quantity:
-  name: Adjust quantity
-  description: Add or subtract from item quantity
   fields:
     item_id:
       required: true
@@ -215,8 +205,6 @@ item_adjust_quantity:
         number:
 
 item_set_quantity:
-  name: Set quantity
-  description: Set item quantity exactly
   fields:
     item_id:
       required: true
@@ -232,8 +220,6 @@ item_set_quantity:
         number:
 
 item_check_out:
-  name: Check out item
-  description: Mark an item as checked out with due date
   fields:
     item_id:
       required: true
@@ -250,8 +236,6 @@ item_check_out:
         number:
 
 item_check_in:
-  name: Check in item
-  description: Mark an item as not checked out
   fields:
     item_id:
       required: true
@@ -263,8 +247,6 @@ item_check_in:
         number:
 
 reminder_bump:
-  name: Bump reminder
-  description: Mark a recurring reminder done and move it on to its next occurrence
   fields:
     item_id:
       required: true
@@ -278,8 +260,6 @@ reminder_bump:
         number:
 
 location_create:
-  name: Create location
-  description: Create a new location under an optional parent
   fields:
     name:
       required: true
@@ -296,8 +276,6 @@ location_create:
         text:
 
 location_update:
-  name: Update location
-  description: Rename and/or move a location
   fields:
     location_id:
       required: true
@@ -318,8 +296,6 @@ location_update:
         text:
 
 location_delete:
-  name: Delete location
-  description: Delete a location by id
   fields:
     location_id:
       required: true

--- a/custom_components/haventory/strings.json
+++ b/custom_components/haventory/strings.json
@@ -122,51 +122,303 @@
   "services": {
     "item_create": {
       "name": "Create item",
-      "description": "Create a new inventory item."
+      "description": "Create a new inventory item.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "What the item is called."
+        },
+        "description": {
+          "name": "Description",
+          "description": "Free text about the item."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "How many there are, as a whole number from 0 up. Defaults to 1."
+        },
+        "status": {
+          "name": "Status",
+          "description": "The item's condition, as a status slug: ok, missing, needs_repair, or one this household added. Defaults to ok."
+        },
+        "checked_out": {
+          "name": "Checked out",
+          "description": "Whether someone has the item out on loan. Defaults to no."
+        },
+        "due_date": {
+          "name": "Due date",
+          "description": "When the item is due back, as YYYY-MM-DD. Only accepted while it is checked out."
+        },
+        "inspection_date": {
+          "name": "Next inspection",
+          "description": "When the item is next due for inspection, as YYYY-MM-DD. A date before today is overdue."
+        },
+        "reminder_date": {
+          "name": "Reminder date",
+          "description": "When the reminder is next due, as YYYY-MM-DD. A repeating reminder counts from this date."
+        },
+        "reminder_interval": {
+          "name": "Reminder repeat",
+          "description": "How often the reminder comes round, as unit and count — for example unit months, count 3. The unit is days, weeks or months, and a repeat needs a reminder date to count from."
+        },
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location to put the item in. Leave it out to create the item without a location."
+        },
+        "tags": {
+          "name": "Tags",
+          "description": "A list of tags. Saving trims them, lower-cases them and drops repeats."
+        },
+        "category": {
+          "name": "Category",
+          "description": "One free-text category for the item."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "The quantity at or below which the item counts as low on stock, as a whole number from 0 up. Leave it out for no threshold."
+        },
+        "custom_fields": {
+          "name": "Custom fields",
+          "description": "Extra fields of your own, as name and value. A value is text, a number or true/false."
+        }
+      }
     },
     "item_update": {
       "name": "Update item",
-      "description": "Update an existing inventory item."
+      "description": "Update an existing inventory item.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to update."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        },
+        "name": {
+          "name": "Name",
+          "description": "A new name for the item."
+        },
+        "description": {
+          "name": "Description",
+          "description": "Free text about the item. Null clears it."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "How many there are, as a whole number from 0 up."
+        },
+        "status": {
+          "name": "Status",
+          "description": "The item's condition, as a status slug: ok, missing, needs_repair, or one this household added. Setting ok is how a flagged item clears."
+        },
+        "checked_out": {
+          "name": "Checked out",
+          "description": "Whether someone has the item out on loan."
+        },
+        "due_date": {
+          "name": "Due date",
+          "description": "When the item is due back, as YYYY-MM-DD. Only accepted while it is checked out; null clears it."
+        },
+        "inspection_date": {
+          "name": "Next inspection",
+          "description": "When the item is next due for inspection, as YYYY-MM-DD. Null clears it."
+        },
+        "reminder_date": {
+          "name": "Reminder date",
+          "description": "When the reminder is next due, as YYYY-MM-DD. Writing it restarts a repeating reminder from that date; null clears the reminder."
+        },
+        "reminder_interval": {
+          "name": "Reminder repeat",
+          "description": "How often the reminder comes round, as unit and count — for example unit months, count 3. Null makes it a one-off."
+        },
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location that holds the item. Null leaves it without a location."
+        },
+        "tags": {
+          "name": "Tags",
+          "description": "The whole list of tags, replacing the ones stored. Null clears them."
+        },
+        "category": {
+          "name": "Category",
+          "description": "One free-text category for the item. Null clears it."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "The quantity at or below which the item counts as low on stock, as a whole number from 0 up. Null removes the threshold."
+        },
+        "custom_fields_set": {
+          "name": "Custom fields to set",
+          "description": "Custom fields to add or overwrite, as name and value. Fields the item carries that this does not name are left alone."
+        },
+        "custom_fields_unset": {
+          "name": "Custom fields to remove",
+          "description": "The names of the custom fields to take off the item."
+        }
+      }
     },
     "item_delete": {
       "name": "Delete item",
-      "description": "Delete an inventory item."
+      "description": "Delete an inventory item.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to delete."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_move": {
       "name": "Move item",
-      "description": "Move an item to a new location (or root)."
+      "description": "Move an item to a new location (or root).",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to move."
+        },
+        "new_location_id": {
+          "name": "New location ID",
+          "description": "The id of the location to move the item into; the WebSocket API calls this field location_id. Leaving it out, or sending null, leaves the item without a location."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_adjust_quantity": {
       "name": "Adjust quantity",
-      "description": "Add or subtract from item quantity."
+      "description": "Add or subtract from item quantity.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item whose quantity to change."
+        },
+        "delta": {
+          "name": "Change",
+          "description": "How much to add to the quantity. A negative number subtracts."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_set_quantity": {
       "name": "Set quantity",
-      "description": "Set item quantity exactly."
+      "description": "Set item quantity exactly.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item whose quantity to set."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "The quantity to store, as a whole number from 0 up."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_check_out": {
       "name": "Check out item",
-      "description": "Mark an item as checked out with due date."
+      "description": "Mark an item as checked out with due date.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to check out."
+        },
+        "due_date": {
+          "name": "Due date",
+          "description": "When the item is due back, as YYYY-MM-DD."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_check_in": {
       "name": "Check in item",
-      "description": "Mark an item as not checked out."
+      "description": "Mark an item as not checked out.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to check back in."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "reminder_bump": {
       "name": "Bump reminder",
-      "description": "Mark a recurring reminder done and move it on to its next occurrence."
+      "description": "Mark a recurring reminder done and move it on to its next occurrence.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item whose reminder has just been done."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "location_create": {
       "name": "Create location",
-      "description": "Create a new storage location."
+      "description": "Create a new storage location.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "What the location is called."
+        },
+        "parent_id": {
+          "name": "Parent location ID",
+          "description": "The id of the location this one sits inside. Leave it out to create it at the top level."
+        },
+        "area_id": {
+          "name": "Area ID",
+          "description": "The id of a Home Assistant area. It is stored at the top of the location's tree, so it applies to every location under that one."
+        }
+      }
     },
     "location_update": {
       "name": "Update location",
-      "description": "Update an existing storage location."
+      "description": "Update an existing storage location.",
+      "fields": {
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location to update."
+        },
+        "name": {
+          "name": "Name",
+          "description": "A new name for the location."
+        },
+        "new_parent_id": {
+          "name": "New parent location ID",
+          "description": "The id of the location to move this one inside; the WebSocket API calls this field parent_id. Null moves it to the top level."
+        },
+        "area_id": {
+          "name": "Area ID",
+          "description": "The id of a Home Assistant area. It is stored at the top of the location's tree, so it applies to every location under that one."
+        }
+      }
     },
     "location_delete": {
       "name": "Delete location",
-      "description": "Delete a storage location."
+      "description": "Delete a storage location.",
+      "fields": {
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location to delete. It has to be empty first: no locations inside it and no items in it."
+        }
+      }
     }
   },
   "issues": {

--- a/custom_components/haventory/translations/de.json
+++ b/custom_components/haventory/translations/de.json
@@ -122,51 +122,303 @@
   "services": {
     "item_create": {
       "name": "Gegenstand anlegen",
-      "description": "Legt einen neuen Gegenstand im Inventar an."
+      "description": "Legt einen neuen Gegenstand im Inventar an.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Wie der Gegenstand heißt."
+        },
+        "description": {
+          "name": "Beschreibung",
+          "description": "Freier Text zum Gegenstand."
+        },
+        "quantity": {
+          "name": "Menge",
+          "description": "Wie viele es davon gibt, als ganze Zahl ab 0. Standard ist 1."
+        },
+        "status": {
+          "name": "Status",
+          "description": "Der Zustand des Gegenstands als Status-Kürzel: ok, missing, needs_repair oder eines, das dieser Haushalt angelegt hat. Standard ist ok."
+        },
+        "checked_out": {
+          "name": "Ausgeliehen",
+          "description": "Ob jemand den Gegenstand ausgeliehen hat. Standard ist nein."
+        },
+        "due_date": {
+          "name": "Rückgabedatum",
+          "description": "Wann der Gegenstand zurück soll, als JJJJ-MM-TT. Nur zulässig, solange er ausgeliehen ist."
+        },
+        "inspection_date": {
+          "name": "Nächste Prüfung",
+          "description": "Wann der Gegenstand das nächste Mal geprüft werden soll, als JJJJ-MM-TT. Ein Datum vor heute ist überfällig."
+        },
+        "reminder_date": {
+          "name": "Erinnerungsdatum",
+          "description": "Wann die Erinnerung das nächste Mal fällig ist, als JJJJ-MM-TT. Eine wiederkehrende Erinnerung zählt ab diesem Datum."
+        },
+        "reminder_interval": {
+          "name": "Wiederholung der Erinnerung",
+          "description": "Wie oft die Erinnerung wiederkehrt, als unit und count – zum Beispiel unit months, count 3. Als unit sind days, weeks und months erlaubt, und eine Wiederholung braucht ein Erinnerungsdatum, ab dem sie zählt."
+        },
+        "location_id": {
+          "name": "Orts-ID",
+          "description": "Die ID des Orts, an den der Gegenstand kommt. Ohne Angabe wird er ohne Ort angelegt."
+        },
+        "tags": {
+          "name": "Labels",
+          "description": "Eine Liste von Labels. Beim Speichern werden Leerzeichen am Rand entfernt, alles kleingeschrieben und doppelte Einträge zusammengefasst."
+        },
+        "category": {
+          "name": "Kategorie",
+          "description": "Eine frei gewählte Kategorie für den Gegenstand."
+        },
+        "low_stock_threshold": {
+          "name": "Schwelle für niedrigen Bestand",
+          "description": "Bei welcher Menge und darunter der Gegenstand als niedriger Bestand gilt, als ganze Zahl ab 0. Ohne Angabe gibt es keine Schwelle."
+        },
+        "custom_fields": {
+          "name": "Eigene Felder",
+          "description": "Zusätzliche eigene Felder als Name und Wert. Ein Wert ist Text, eine Zahl oder wahr/falsch."
+        }
+      }
     },
     "item_update": {
       "name": "Gegenstand aktualisieren",
-      "description": "Aktualisiert einen vorhandenen Gegenstand im Inventar."
+      "description": "Aktualisiert einen vorhandenen Gegenstand im Inventar.",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, der geändert werden soll."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        },
+        "name": {
+          "name": "Name",
+          "description": "Ein neuer Name für den Gegenstand."
+        },
+        "description": {
+          "name": "Beschreibung",
+          "description": "Freier Text zum Gegenstand. Null löscht ihn."
+        },
+        "quantity": {
+          "name": "Menge",
+          "description": "Wie viele es davon gibt, als ganze Zahl ab 0."
+        },
+        "status": {
+          "name": "Status",
+          "description": "Der Zustand des Gegenstands als Status-Kürzel: ok, missing, needs_repair oder eines, das dieser Haushalt angelegt hat. Mit ok wird ein gesetzter Status wieder aufgehoben."
+        },
+        "checked_out": {
+          "name": "Ausgeliehen",
+          "description": "Ob jemand den Gegenstand ausgeliehen hat."
+        },
+        "due_date": {
+          "name": "Rückgabedatum",
+          "description": "Wann der Gegenstand zurück soll, als JJJJ-MM-TT. Nur zulässig, solange er ausgeliehen ist; null löscht das Datum."
+        },
+        "inspection_date": {
+          "name": "Nächste Prüfung",
+          "description": "Wann der Gegenstand das nächste Mal geprüft werden soll, als JJJJ-MM-TT. Null löscht das Datum."
+        },
+        "reminder_date": {
+          "name": "Erinnerungsdatum",
+          "description": "Wann die Erinnerung das nächste Mal fällig ist, als JJJJ-MM-TT. Ein neues Datum setzt eine wiederkehrende Erinnerung auf dieses Datum zurück; null löscht die Erinnerung."
+        },
+        "reminder_interval": {
+          "name": "Wiederholung der Erinnerung",
+          "description": "Wie oft die Erinnerung wiederkehrt, als unit und count – zum Beispiel unit months, count 3. Null macht daraus einen einmaligen Termin."
+        },
+        "location_id": {
+          "name": "Orts-ID",
+          "description": "Die ID des Orts, an dem der Gegenstand liegt. Mit null hat er keinen Ort mehr."
+        },
+        "tags": {
+          "name": "Labels",
+          "description": "Die vollständige Liste der Labels; sie ersetzt die gespeicherten. Null löscht alle."
+        },
+        "category": {
+          "name": "Kategorie",
+          "description": "Eine frei gewählte Kategorie für den Gegenstand. Null löscht sie."
+        },
+        "low_stock_threshold": {
+          "name": "Schwelle für niedrigen Bestand",
+          "description": "Bei welcher Menge und darunter der Gegenstand als niedriger Bestand gilt, als ganze Zahl ab 0. Null entfernt die Schwelle."
+        },
+        "custom_fields_set": {
+          "name": "Eigene Felder setzen",
+          "description": "Eigene Felder, die hinzukommen oder überschrieben werden, als Name und Wert. Felder, die hier nicht vorkommen, bleiben unverändert."
+        },
+        "custom_fields_unset": {
+          "name": "Eigene Felder entfernen",
+          "description": "Die Namen der eigenen Felder, die vom Gegenstand entfernt werden."
+        }
+      }
     },
     "item_delete": {
       "name": "Gegenstand löschen",
-      "description": "Löscht einen Gegenstand aus dem Inventar."
+      "description": "Löscht einen Gegenstand aus dem Inventar.",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, der gelöscht werden soll."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        }
+      }
     },
     "item_move": {
       "name": "Gegenstand verschieben",
-      "description": "Verschiebt einen Gegenstand an einen anderen Ort (oder in die oberste Ebene)."
+      "description": "Verschiebt einen Gegenstand an einen anderen Ort (oder in die oberste Ebene).",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, der verschoben werden soll."
+        },
+        "new_location_id": {
+          "name": "Neue Orts-ID",
+          "description": "Die ID des Orts, an den der Gegenstand kommt; in der WebSocket-API heißt dieses Feld location_id. Ohne Angabe oder mit null hat er danach keinen Ort mehr."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        }
+      }
     },
     "item_adjust_quantity": {
       "name": "Menge anpassen",
-      "description": "Erhöht oder verringert die Menge eines Gegenstands."
+      "description": "Erhöht oder verringert die Menge eines Gegenstands.",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, dessen Menge geändert werden soll."
+        },
+        "delta": {
+          "name": "Änderung",
+          "description": "Wie viel zur Menge hinzukommt. Eine negative Zahl zieht ab."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        }
+      }
     },
     "item_set_quantity": {
       "name": "Menge setzen",
-      "description": "Setzt die Menge eines Gegenstands auf einen genauen Wert."
+      "description": "Setzt die Menge eines Gegenstands auf einen genauen Wert.",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, dessen Menge gesetzt werden soll."
+        },
+        "quantity": {
+          "name": "Menge",
+          "description": "Die Menge, die gespeichert wird, als ganze Zahl ab 0."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        }
+      }
     },
     "item_check_out": {
       "name": "Gegenstand ausleihen",
-      "description": "Markiert einen Gegenstand als ausgeliehen, mit Rückgabedatum."
+      "description": "Markiert einen Gegenstand als ausgeliehen, mit Rückgabedatum.",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, der ausgeliehen werden soll."
+        },
+        "due_date": {
+          "name": "Rückgabedatum",
+          "description": "Wann der Gegenstand zurück soll, als JJJJ-MM-TT."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        }
+      }
     },
     "item_check_in": {
       "name": "Gegenstand zurückgeben",
-      "description": "Markiert einen Gegenstand als nicht mehr ausgeliehen."
+      "description": "Markiert einen Gegenstand als nicht mehr ausgeliehen.",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, der zurückgegeben werden soll."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        }
+      }
     },
     "reminder_bump": {
       "name": "Erinnerung erledigen",
-      "description": "Markiert eine wiederkehrende Erinnerung als erledigt und setzt sie auf ihren nächsten Termin."
+      "description": "Markiert eine wiederkehrende Erinnerung als erledigt und setzt sie auf ihren nächsten Termin.",
+      "fields": {
+        "item_id": {
+          "name": "Gegenstands-ID",
+          "description": "Die ID des Gegenstands, dessen Erinnerung gerade erledigt wurde."
+        },
+        "expected_version": {
+          "name": "Erwartete Version",
+          "description": "Die Version, auf der der Gegenstand stehen soll. Hat er sich seitdem geändert, wird der Aufruf als Konflikt abgelehnt, statt die fremde Änderung zu überschreiben."
+        }
+      }
     },
     "location_create": {
       "name": "Ort anlegen",
-      "description": "Legt einen neuen Aufbewahrungsort an."
+      "description": "Legt einen neuen Aufbewahrungsort an.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Wie der Ort heißt."
+        },
+        "parent_id": {
+          "name": "ID des übergeordneten Orts",
+          "description": "Die ID des Orts, in dem dieser liegt. Ohne Angabe entsteht er auf oberster Ebene."
+        },
+        "area_id": {
+          "name": "Bereichs-ID",
+          "description": "Die ID eines Home-Assistant-Bereichs. Sie wird ganz oben im Ortsbaum gespeichert und gilt damit für alle Orte darunter."
+        }
+      }
     },
     "location_update": {
       "name": "Ort aktualisieren",
-      "description": "Aktualisiert einen vorhandenen Aufbewahrungsort."
+      "description": "Aktualisiert einen vorhandenen Aufbewahrungsort.",
+      "fields": {
+        "location_id": {
+          "name": "Orts-ID",
+          "description": "Die ID des Orts, der geändert werden soll."
+        },
+        "name": {
+          "name": "Name",
+          "description": "Ein neuer Name für den Ort."
+        },
+        "new_parent_id": {
+          "name": "Neue ID des übergeordneten Orts",
+          "description": "Die ID des Orts, in den dieser verschoben wird; in der WebSocket-API heißt dieses Feld parent_id. Null verschiebt ihn auf die oberste Ebene."
+        },
+        "area_id": {
+          "name": "Bereichs-ID",
+          "description": "Die ID eines Home-Assistant-Bereichs. Sie wird ganz oben im Ortsbaum gespeichert und gilt damit für alle Orte darunter."
+        }
+      }
     },
     "location_delete": {
       "name": "Ort löschen",
-      "description": "Löscht einen Aufbewahrungsort."
+      "description": "Löscht einen Aufbewahrungsort.",
+      "fields": {
+        "location_id": {
+          "name": "Orts-ID",
+          "description": "Die ID des Orts, der gelöscht werden soll. Er muss vorher leer sein: keine Orte darin und keine Gegenstände."
+        }
+      }
     }
   },
   "issues": {

--- a/custom_components/haventory/translations/en.json
+++ b/custom_components/haventory/translations/en.json
@@ -122,51 +122,303 @@
   "services": {
     "item_create": {
       "name": "Create item",
-      "description": "Create a new inventory item."
+      "description": "Create a new inventory item.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "What the item is called."
+        },
+        "description": {
+          "name": "Description",
+          "description": "Free text about the item."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "How many there are, as a whole number from 0 up. Defaults to 1."
+        },
+        "status": {
+          "name": "Status",
+          "description": "The item's condition, as a status slug: ok, missing, needs_repair, or one this household added. Defaults to ok."
+        },
+        "checked_out": {
+          "name": "Checked out",
+          "description": "Whether someone has the item out on loan. Defaults to no."
+        },
+        "due_date": {
+          "name": "Due date",
+          "description": "When the item is due back, as YYYY-MM-DD. Only accepted while it is checked out."
+        },
+        "inspection_date": {
+          "name": "Next inspection",
+          "description": "When the item is next due for inspection, as YYYY-MM-DD. A date before today is overdue."
+        },
+        "reminder_date": {
+          "name": "Reminder date",
+          "description": "When the reminder is next due, as YYYY-MM-DD. A repeating reminder counts from this date."
+        },
+        "reminder_interval": {
+          "name": "Reminder repeat",
+          "description": "How often the reminder comes round, as unit and count — for example unit months, count 3. The unit is days, weeks or months, and a repeat needs a reminder date to count from."
+        },
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location to put the item in. Leave it out to create the item without a location."
+        },
+        "tags": {
+          "name": "Tags",
+          "description": "A list of tags. Saving trims them, lower-cases them and drops repeats."
+        },
+        "category": {
+          "name": "Category",
+          "description": "One free-text category for the item."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "The quantity at or below which the item counts as low on stock, as a whole number from 0 up. Leave it out for no threshold."
+        },
+        "custom_fields": {
+          "name": "Custom fields",
+          "description": "Extra fields of your own, as name and value. A value is text, a number or true/false."
+        }
+      }
     },
     "item_update": {
       "name": "Update item",
-      "description": "Update an existing inventory item."
+      "description": "Update an existing inventory item.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to update."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        },
+        "name": {
+          "name": "Name",
+          "description": "A new name for the item."
+        },
+        "description": {
+          "name": "Description",
+          "description": "Free text about the item. Null clears it."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "How many there are, as a whole number from 0 up."
+        },
+        "status": {
+          "name": "Status",
+          "description": "The item's condition, as a status slug: ok, missing, needs_repair, or one this household added. Setting ok is how a flagged item clears."
+        },
+        "checked_out": {
+          "name": "Checked out",
+          "description": "Whether someone has the item out on loan."
+        },
+        "due_date": {
+          "name": "Due date",
+          "description": "When the item is due back, as YYYY-MM-DD. Only accepted while it is checked out; null clears it."
+        },
+        "inspection_date": {
+          "name": "Next inspection",
+          "description": "When the item is next due for inspection, as YYYY-MM-DD. Null clears it."
+        },
+        "reminder_date": {
+          "name": "Reminder date",
+          "description": "When the reminder is next due, as YYYY-MM-DD. Writing it restarts a repeating reminder from that date; null clears the reminder."
+        },
+        "reminder_interval": {
+          "name": "Reminder repeat",
+          "description": "How often the reminder comes round, as unit and count — for example unit months, count 3. Null makes it a one-off."
+        },
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location that holds the item. Null leaves it without a location."
+        },
+        "tags": {
+          "name": "Tags",
+          "description": "The whole list of tags, replacing the ones stored. Null clears them."
+        },
+        "category": {
+          "name": "Category",
+          "description": "One free-text category for the item. Null clears it."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "The quantity at or below which the item counts as low on stock, as a whole number from 0 up. Null removes the threshold."
+        },
+        "custom_fields_set": {
+          "name": "Custom fields to set",
+          "description": "Custom fields to add or overwrite, as name and value. Fields the item carries that this does not name are left alone."
+        },
+        "custom_fields_unset": {
+          "name": "Custom fields to remove",
+          "description": "The names of the custom fields to take off the item."
+        }
+      }
     },
     "item_delete": {
       "name": "Delete item",
-      "description": "Delete an inventory item."
+      "description": "Delete an inventory item.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to delete."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_move": {
       "name": "Move item",
-      "description": "Move an item to a new location (or root)."
+      "description": "Move an item to a new location (or root).",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to move."
+        },
+        "new_location_id": {
+          "name": "New location ID",
+          "description": "The id of the location to move the item into; the WebSocket API calls this field location_id. Leaving it out, or sending null, leaves the item without a location."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_adjust_quantity": {
       "name": "Adjust quantity",
-      "description": "Add or subtract from item quantity."
+      "description": "Add or subtract from item quantity.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item whose quantity to change."
+        },
+        "delta": {
+          "name": "Change",
+          "description": "How much to add to the quantity. A negative number subtracts."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_set_quantity": {
       "name": "Set quantity",
-      "description": "Set item quantity exactly."
+      "description": "Set item quantity exactly.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item whose quantity to set."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "The quantity to store, as a whole number from 0 up."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_check_out": {
       "name": "Check out item",
-      "description": "Mark an item as checked out with due date."
+      "description": "Mark an item as checked out with due date.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to check out."
+        },
+        "due_date": {
+          "name": "Due date",
+          "description": "When the item is due back, as YYYY-MM-DD."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "item_check_in": {
       "name": "Check in item",
-      "description": "Mark an item as not checked out."
+      "description": "Mark an item as not checked out.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item to check back in."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "reminder_bump": {
       "name": "Bump reminder",
-      "description": "Mark a recurring reminder done and move it on to its next occurrence."
+      "description": "Mark a recurring reminder done and move it on to its next occurrence.",
+      "fields": {
+        "item_id": {
+          "name": "Item ID",
+          "description": "The id of the item whose reminder has just been done."
+        },
+        "expected_version": {
+          "name": "Expected version",
+          "description": "The version the item is expected to be at. If it has changed since, the call is refused as a conflict instead of overwriting the other edit."
+        }
+      }
     },
     "location_create": {
       "name": "Create location",
-      "description": "Create a new storage location."
+      "description": "Create a new storage location.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "What the location is called."
+        },
+        "parent_id": {
+          "name": "Parent location ID",
+          "description": "The id of the location this one sits inside. Leave it out to create it at the top level."
+        },
+        "area_id": {
+          "name": "Area ID",
+          "description": "The id of a Home Assistant area. It is stored at the top of the location's tree, so it applies to every location under that one."
+        }
+      }
     },
     "location_update": {
       "name": "Update location",
-      "description": "Update an existing storage location."
+      "description": "Update an existing storage location.",
+      "fields": {
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location to update."
+        },
+        "name": {
+          "name": "Name",
+          "description": "A new name for the location."
+        },
+        "new_parent_id": {
+          "name": "New parent location ID",
+          "description": "The id of the location to move this one inside; the WebSocket API calls this field parent_id. Null moves it to the top level."
+        },
+        "area_id": {
+          "name": "Area ID",
+          "description": "The id of a Home Assistant area. It is stored at the top of the location's tree, so it applies to every location under that one."
+        }
+      }
     },
     "location_delete": {
       "name": "Delete location",
-      "description": "Delete a storage location."
+      "description": "Delete a storage location.",
+      "fields": {
+        "location_id": {
+          "name": "Location ID",
+          "description": "The id of the location to delete. It has to be empty first: no locations inside it and no items in it."
+        }
+      }
     }
   },
   "issues": {

--- a/tests/test_services_offline.py
+++ b/tests/test_services_offline.py
@@ -260,25 +260,52 @@ async def test_repository_exceptions_are_logged(monkeypatch, caplog) -> None:
 
 
 def test_service_catalog_agrees_across_registration_yaml_and_strings() -> None:
-    """Every registered service is described in `services.yaml` and translated.
+    """Every registered service, and every field it takes, is declared and translated.
 
     Home Assistant renders a service in the UI from three files that nothing
-    joins up: `services.py` registers it, `services.yaml` declares its fields,
-    and `strings.json` supplies the name and description the frontend shows —
-    falling back to the `services.yaml` text only where the translation is
-    missing. A service added to one file and not the others still works over the
-    API, so the gap shows up as a shabby entry in the service picker rather than
-    as a failure.
+    joins up: `services.py` registers it and types what it accepts,
+    `services.yaml` declares the fields and their selectors, and `strings.json`
+    supplies every piece of text the frontend shows. A service or a field added
+    to one file and not the others still works over the API, so the gap surfaces
+    as a bare key in Developer Tools → Actions rather than as a failure.
+
+    `services.yaml` carries no text of its own. Home Assistant falls back to it
+    where a translation is missing, so a name left there would render for every
+    language instead of the one it was written in, and it is the one place
+    user-facing text would sit outside `strings.json`.
     """
 
     package = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
-    registered = {name for name, _handler, _schema in services_mod.SERVICES}
-    documented = set(yaml.safe_load((package / "services.yaml").read_text(encoding="utf-8")))
+    registered = {name: schema for name, _handler, schema in services_mod.SERVICES}
+    documented = yaml.safe_load((package / "services.yaml").read_text(encoding="utf-8"))
     translated = json.loads((package / "strings.json").read_text(encoding="utf-8"))["services"]
 
-    assert documented == registered, "services.yaml and the SERVICES table disagree"
-    assert set(translated) == registered, "strings.json and the SERVICES table disagree"
-    assert all(entry.keys() == {"name", "description"} for entry in translated.values())
+    assert set(documented) == set(registered), "services.yaml and the SERVICES table disagree"
+    assert set(translated) == set(registered), "strings.json and the SERVICES table disagree"
+
+    for service, schema in registered.items():
+        accepted = {str(marker) for marker in schema.schema}
+        declared = documented[service]["fields"]
+        entry = translated[service]
+
+        assert set(documented[service]) == {"fields"}, (
+            f"services.yaml's {service} carries text that belongs in strings.json"
+        )
+        assert set(declared) == accepted, (
+            f"services.yaml and the schema disagree about {service}'s fields"
+        )
+        for field, spec in declared.items():
+            assert {"name", "description"}.isdisjoint(spec), (
+                f"services.yaml's {service}.{field} carries text that belongs in strings.json"
+            )
+
+        assert entry.keys() == {"name", "description", "fields"}, service
+        assert set(entry["fields"]) == accepted, (
+            f"strings.json and the schema disagree about {service}'s fields"
+        )
+        for field, text in entry["fields"].items():
+            assert text.keys() == {"name", "description"}, f"{service}.{field}"
+            assert all(value.strip() for value in text.values()), f"{service}.{field}"
 
 
 # -----------------------------


### PR DESCRIPTION
## Summary

Developer Tools → Actions showed every field of the twelve `haventory.*` services as its raw
key — `item_id`, `expected_version`, `new_location_id`, `due_date`, `reminder_interval` — with
nothing saying what the value is, what format it takes, or that `new_location_id` is what the
WebSocket API calls `location_id`. The README sells the automation story, and that form is the
first thing an automation author meets.

All **57** fields across the twelve services now carry a `name` and a `description` under
`services.<service>.fields.<field>` in `strings.json`, `translations/en.json` and
`translations/de.json` — 114 new keys per language, 342 strings in all. The service-level
`name` / `description` pairs were already there and are unchanged.

`services.yaml` drops its 24 service-level `name:` / `description:` lines and keeps only
`required`, `example`, `selector` and its two existing comments. Home Assistant reads field
text from the translations and falls back to the YAML only where a translation is missing, so
text left in the YAML would render for every language rather than for the one it was written
in — and it is the one place user-facing text would sit outside `strings.json`.

What a description says: what the value is, the format it takes, and the name it goes by
elsewhere where those differ. The facts come from `services.py`'s voluptuous schemas,
`docs/backend_api_contract.md` and `docs/data_shapes.md` — a rule neither the schema nor the
docs state is not in the text. Style follows Home Assistant core: sentence-case field names,
one or two short sentences, full stops. The German follows the register and vocabulary of the
existing `de.json` (`Gegenstand`, `Ort`, `Menge`, `Rückgabedatum`, `Erinnerung`) and of the
card's `src/i18n/de.ts` for the words the integration had not named yet (`Labels`,
`Kategorie`, `Nächste Prüfung`, `Eigene Felder`, `Bereich`).

Closes #569

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`
- [ ] Frontend (`cards/haventory-card`): not touched by this change — the diff is the
      integration package and one backend test.

```
1305 passed, 22 skipped in 10.86s
All checks passed!            # ruff check
186 files already formatted   # ruff format --check
Success: no issues found in 26 source files   # mypy
```

`main` passes the same 1305 tests: this PR extends an existing test rather than adding one, so
the total is expected to be unchanged.

hassfest, run locally the way CI's `validation` job runs it:

```
docker run --rm -v "<worktree>://github/workspace" ghcr.io/home-assistant/hassfest
...
Validating services... done in 0.02s
Validating translations... done in 0.04s
...
Integrations: 1
Invalid integrations: 0
```

`tests/test_services_offline.py::test_service_catalog_agrees_across_registration_yaml_and_strings`
now joins the three sources field for field rather than service for service:

- every registered service's voluptuous schema, `services.yaml`'s field keys and
  `strings.json`'s `fields` keys are the same set;
- every translated service has exactly `{"name", "description", "fields"}`, and every field
  exactly `{"name", "description"}`, both non-empty after stripping;
- `services.yaml` carries no `name` or `description` at service or field level.

The error case is covered by the same test: it went red on the tree as it stood (`services.yaml's
item_create carries text that belongs in strings.json`) before the three files were written, and
it fails again for a field added to a schema without text, for text left in the YAML, and for an
empty string in either language.

`tests/test_config_flow_offline.py` holds `en.json` and `de.json` to `strings.json`'s key tree,
its placeholders and the no-inline-URL rule; those three tests cover the new keys without any
change. No new `{placeholder}` was introduced.

Not tested here: how the form actually renders. The session that holds the dev Home Assistant
checks `GET /api/services` and photographs Developer Tools → Actions for `haventory.item_move`
and `haventory.item_create` in English and in German.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — none needed. `README.md`'s automation section names
      the actions without describing the form, and `CONTRIBUTING.md` → "Adding a language" is
      still accurate: a new language is still a copy of `en.json` with an identical key tree.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
      `docs/data_shapes.md` in sync — no API change here; the WebSocket surface is unchanged.
- [x] Essential invariants preserved — no code path was touched.

## Decisions

- **`feat`, not `fix`.** Nothing behaved wrongly; text that was never written is now there.
  #569 is filed as an enhancement.
- **The schema, not `services.yaml`, is the field list the test starts from.** The plan asked
  for `strings.json`'s `fields` keys to equal `services.yaml`'s. Reading the voluptuous schemas
  as well costs one line and closes the other half of the gap: a field added to `services.py`
  and to neither of the other two files now fails here rather than shipping as a service that
  silently ignores what an automation sends it. The three sets agree today, so the assertion
  is green on `main`'s code.
- **`inspection_date` is "Next inspection" / "Nächste Prüfung"**, not "Inspection date", so the
  Actions form and the card's own column read the same on both surfaces. `tags` is "Tags" in
  English and `Labels` in German for the same reason — that is the pair the card already uses,
  and `Label` is Home Assistant's own German word.
- **`null` is named where it clears something**, on the `item_update` fields the docs say it
  clears, and nowhere else. The two `item_move` / `location_update` fields say which name the
  WebSocket API gives them, as #569 asked.
- The three JSON files were rewritten through `json.dumps(..., ensure_ascii=False, indent=2)`
  with CRLF endings, which reproduces each file byte for byte before the edit — checked — so
  the diff is the services block and nothing else.

## Follow-ups

- `services.yaml` gives an `example` to only some fields (`item_create` has them,
  `item_update` has none), so the Actions form still shows an example placeholder for one
  service and not for the next. Filling the gaps is a small, separate pass.
- `item_create.tags` declares the `text:` selector although the schema takes a list of
  strings; `item_update.tags` declares `object:` for the same value. The Actions form therefore
  offers a single-line text box for one and a YAML box for the other.

## Screenshots (card / UI changes)

None — no card change. The Developer Tools → Actions captures in both languages are part of
the session's live check.
