### PR TITLE
test(skills): classify core's own ERROR lines for a refused service call as known

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -567,8 +567,12 @@ uv run python .claude/skills/run-haventory/log_sweep.py --all --show 20
 Groups the container log into records (so a traceback stays with its header) and sorts them
 three ways: **BLOCKING** — an HAventory traceback, an `unknown_error`, or a
 client-recoverable code logged at ERROR; **EXPECTED** — the contract's WARNING rejections,
-which fuzz layers produce by the hundred; **KNOWN** — type-loose frames HA core rejects
-before `ws_guard` runs (open item 53), surfaced without failing the sweep. Exits 1 on any
+which fuzz layers produce by the hundred; **KNOWN** — ERROR lines HA core writes on its own
+account for a rejection the integration already logged at WARNING: type-loose frames it
+rejects before `ws_guard` runs (open item 53), a refused `haventory.*` service call (core's
+`call_service` logs every `HomeAssistantError` at ERROR, its own `ServiceValidationError`
+included) and the REST `/api/services` view's 500 for the same refusal — surfaced without
+failing the sweep, because no change in the integration can quiet them. Exits 1 on any
 blocking finding. Run it after every online layer: offline stubs stay green while real HA
 throws, which is how the `__slots__` bug was found.
 

--- a/.claude/skills/run-haventory/log_sweep.py
+++ b/.claude/skills/run-haventory/log_sweep.py
@@ -17,10 +17,14 @@ Three findings are reported separately, because they mean different things:
               boundary, which is what the taxonomy exists to prevent.
   EXPECTED    contract-defined WARNING rejections. Fuzz layers produce these by
               the hundred; they are the policy working.
-  KNOWN       type-loose frames rejected by HA core's own schema check before
-              ``ws_guard`` runs, logged by ``websocket_api`` at ERROR with the
-              client payload. Tracked as open item 53 — a deliberate trade-off,
-              not a regression, so it is surfaced without failing the sweep.
+  KNOWN       ERROR lines HA core writes on its own account for a rejection
+              this integration already logged at WARNING: type-loose frames
+              rejected by core's schema check before ``ws_guard`` runs (open
+              item 53), a ``haventory.*`` service call the handler refused (the
+              WebSocket ``call_service`` command logs every ``HomeAssistantError``
+              at ERROR, core's own ``ServiceValidationError`` included), and the
+              REST ``/api/services`` view's 500 for the same refusal. Surfaced
+              without failing the sweep, because no change here can quiet them.
 
 Usage (from the repo root):
   uv run python .claude/skills/run-haventory/log_sweep.py                 # last 30m
@@ -70,6 +74,20 @@ HAVENTORY = re.compile(r"haventory", re.IGNORECASE)
 CORE_SCHEMA_REJECT = re.compile(
     r"websocket_api\.http\.connection.*(expected |invalid |required key|extra keys)", re.IGNORECASE
 )
+# HA core's own ERROR for a `haventory.*` service call the handler refused: the
+# WebSocket `call_service` command logs every `HomeAssistantError` at ERROR —
+# its own `ServiceValidationError` included — and the script engine logs every
+# failed action the same way, so the line is core's severity policy, not this
+# integration's. The integration's own WARNING for the same rejection sits
+# beside it; that one is what the taxonomy judges.
+CORE_SERVICE_CALL_REJECT = re.compile(
+    r"websocket_api\.http\.connection.*Error during service call to haventory\."
+)
+# The REST `/api/services` view maps only `vol.Invalid` and `ServiceNotFound`
+# to 400 and lets every other `HomeAssistantError` reach aiohttp as a 500 with a
+# traceback — for core's services as much as for these. A traceback under
+# `aiohttp.server` that ends on a recoverable HAventory exception is that view.
+CORE_REST_SERVICE_REJECT = re.compile(r"\[aiohttp\.server\] Error handling request")
 # HA prints this for every custom integration at every startup.
 LOADER_NOTICE = re.compile(r"homeassistant\.loader\].*custom integration")
 # The storage layer only ever raises StorageError and its subclasses, so ERROR is
@@ -132,6 +150,10 @@ def classify(record: list[str]) -> tuple[str, str]:
         return "BLOCKING", "unknown_error reached the boundary"
     if loud and CORE_SCHEMA_REJECT.search(body):
         return "KNOWN", "HA core schema rejection before ws_guard (item 53)"
+    if loud and CORE_SERVICE_CALL_REJECT.search(head) and not has_traceback:
+        return "KNOWN", "HA core logs a refused service call at ERROR (core's own severity)"
+    if loud and CORE_REST_SERVICE_REJECT.search(head) and recoverable:
+        return "KNOWN", "HA core's REST services view answers a refused call with a 500"
     if loud and (
         any(name in body for name in ACTIONABLE_EXCEPTIONS) or STORAGE_LOGGER.search(head)
     ):


### PR DESCRIPTION
## What

`log_sweep.py` gains two KNOWN rules beside the one it had for item 53, and its docstring and the skill's paragraph say what KNOWN now covers:

- the WebSocket `call_service` command's `Error during service call to haventory.<service>: …` line — core logs every `HomeAssistantError` a service raises at ERROR, its own `ServiceValidationError` included (`websocket_api/commands.py`, the two `except` branches), and the script engine logs every failed action at ERROR regardless of type (`helpers/script.py`, `_log_exception`);
- the REST `/api/services` view's `[aiohttp.server] Error handling request` traceback, when it ends on a recoverable HAventory exception — `APIDomainServicesView.post` maps only `vol.Invalid` and `ServiceNotFound` to 400 and lets every other `HomeAssistantError` reach aiohttp as a 500, for core's services as much as for these.

## Why

Round four's sweep on merged `main` passed every stress layer, the WS smokes and the live-update smoke, and then the log sweep reported `BLOCKING: 4 … verdict: FAIL` — three of the four were those `call_service` lines from the session's own `haventory.item_update` probes with a bad date, the fourth the REST 500 from the same probe. Beside each sat the integration's own WARNING for the same rejection, which is the half the taxonomy judges. A sweep that fails on lines no change in the integration can quiet hides the next real failure, the same way the `pm-08-columns` recipe did in #589.

Whether the integration should raise `ServiceValidationError` instead of its `HomeAssistantError` subclasses is a separate question (the WS error code and the message prefix would change; the log severity would not, on 2026.7), and not one this harness change answers.

## How it was verified

`uv run python .claude/skills/run-haventory/log_sweep.py --since 200m` over the window that failed: `BLOCKING: 0`, `KNOWN: 6` (3 refused service calls, 2 item-53 schema rejections, 1 REST 500), `EXPECTED: 104`, `verdict: PASS`. `ruff check` and `ruff format --check` clean on the file. No product code changes.

## Follow-ups

None.
