### PR TITLE
fix(backend): log a healthy empty store at DEBUG, not WARNING

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -72,7 +72,8 @@ bash scripts/reload_addon.sh --container home-assistant --sleep 30 --tail-logs
 ```
 
 Success looks like: `{"ok": true, "version": {...}}` plus a
-`Storage health: schema_version=N items=N locations=N` debug log line.
+`Storage health op=setup_storage_health schema_version=N items_count=N locations_count=N`
+debug log line.
 Backend-only change and HA already has the current card? The same script is still the
 path — it redeploys both; there is no partial-deploy variant.
 
@@ -105,8 +106,10 @@ docker exec home-assistant sh -lc \
 (`/config/www/haventory` is only there on instances deployed before the bundle moved into
 the integration package; new deploys write nothing to `www/`.)
 
-Then redeploy as above. A clean result logs `Storage health: schema_version=N items=0
-locations=0`. (`grep -il haventory /config/.storage/*` still matches
+Then redeploy as above. A clean result logs `Storage health op=setup_storage_health
+schema_version=N items_count=0 locations_count=0` — at DEBUG like every other healthy load,
+so an empty store says nothing at HA's default level. (`grep -il haventory /config/.storage/*`
+still matches
 `core.entity_registry` if the HA instance itself is named "HAventory Dev" — that is the
 weather entity's `original_name`, not a leftover.)
 

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -1346,18 +1346,24 @@ def _validate_storage_payload(payload: dict[str, Any], *, schema_version: int) -
 
 
 def _log_storage_health(payload: dict[str, Any], *, schema_version: int) -> None:
-    """Log storage health summary after validation."""
+    """Log storage health summary after validation.
+
+    Always DEBUG, whatever the counts. An empty store is what every fresh
+    install and every household that cleared its inventory boots with, and HA
+    surfaces WARNING with no logger configuration, so warning on 0/0 made a new
+    user's first line about HAventory a warning about a healthy state. A store
+    that did not load is a different case with its own refusals, its own
+    `corrupt_store` repair and its own ERROR lines.
+    """
 
     items = payload.get("items")
     locations = payload.get("locations")
     item_count = len(items) if isinstance(items, dict) else 0
     location_count = len(locations) if isinstance(locations, dict) else 0
 
-    level = logging.WARNING if item_count == 0 and location_count == 0 else logging.DEBUG
     # The three numbers are the context's, not the message's: it is rendered into
     # the line either way, and formatting them here as well printed each twice.
-    LOGGER.log(
-        level,
+    LOGGER.debug(
         "Storage health",
         extra={
             "domain": DOMAIN,

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -33,9 +33,21 @@ from homeassistant.helpers.storage import Store as HAStore
 from runtime_helpers import repo_of, runtime_of, setup_entry
 
 
+def _health_records(caplog) -> list[logging.LogRecord]:
+    """The storage-health lines one setup wrote."""
+
+    return [record for record in caplog.records if "Storage health" in record.getMessage()]
+
+
 @pytest.mark.asyncio
-async def test_setup_entry_logs_warning_for_empty_storage(monkeypatch, caplog) -> None:
-    """Empty storage payload logs a warning but completes setup."""
+async def test_setup_entry_logs_empty_storage_at_debug(monkeypatch, caplog) -> None:
+    """A store that loaded empty is a first run, not a fault: DEBUG, never WARNING.
+
+    Every fresh install starts at 0/0, and HA shows WARNING with no logger
+    configuration, so warning here made a new user's first line about HAventory
+    a warning about nothing. A store that is unreadable has its own refusals and
+    its own Repairs card.
+    """
 
     hass = HomeAssistant()
     entry = ConfigEntry()
@@ -46,16 +58,45 @@ async def test_setup_entry_logs_warning_for_empty_storage(monkeypatch, caplog) -
 
     monkeypatch.setattr(DomainStore, "async_load", _fake_load)
 
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.DEBUG)
 
     await setup_entry(hass, entry)
 
     assert isinstance(repo_of(hass), Repository)
-    assert any("Storage health" in record.message for record in caplog.records)
-    assert any(
-        record.levelname == "WARNING" and "Storage health" in record.message
-        for record in caplog.records
-    )
+    health = _health_records(caplog)
+    assert health, [record.getMessage() for record in caplog.records]
+    assert [record.levelno for record in health] == [logging.DEBUG]
+    assert "items_count=0" in health[-1].getMessage()
+    assert "locations_count=0" in health[-1].getMessage()
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_logs_populated_storage_at_debug(monkeypatch, caplog) -> None:
+    """A store with data logs the same line, at the same level, with its counts."""
+
+    hass = HomeAssistant()
+    entry = ConfigEntry()
+
+    source = Repository()
+    where = source.create_location(name="Garage")
+    source.create_item(ItemCreate(name="Drill", location_id=str(where.id)))
+    payload = {"schema_version": CURRENT_SCHEMA_VERSION, **source.export_state()}
+
+    async def _fake_load(self):  # type: ignore[no-untyped-def]
+        return deepcopy(payload)
+
+    monkeypatch.setattr(DomainStore, "async_load", _fake_load)
+
+    caplog.set_level(logging.DEBUG)
+
+    await setup_entry(hass, entry)
+
+    health = _health_records(caplog)
+    assert health, [record.getMessage() for record in caplog.records]
+    assert [record.levelno for record in health] == [logging.DEBUG]
+    assert "items_count=1" in health[-1].getMessage()
+    assert "locations_count=1" in health[-1].getMessage()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What was wrong

`_log_storage_health` picked its level from the counts:

```python
level = logging.WARNING if item_count == 0 and location_count == 0 else logging.DEBUG
```

0 items and 0 locations is what every fresh install boots with, and HA shows WARNING with no
`logger:` configuration, so the first line a new user ever read about HAventory was

```
WARNING (MainThread) [custom_components.haventory] Storage health op=setup_storage_health schema_version=9 items_count=0 locations_count=0
```

and it came back on every restart until they created their first item or location — while
`haventory/health` answered `healthy: true` with an empty `issues` list the whole time. It also
tripped the release plan's exit criterion 4, which reads the log for anything at WARNING+ that is
not a contract-defined client-recoverable rejection.

## What changed

The line keeps its message and its three context fields and loses the level branch: a load that
validated is logged at DEBUG whatever the counts.

The suspicion the WARNING carried — "the store loaded empty and perhaps should not have" — has
nothing left to stand on. The counts cannot tell a first run from a store that vanished, a
household that emptied its inventory restarts into exactly the same 0/0, and a store that did not
load has its own refusals, its own `corrupt_store` repair and its own ERROR lines.

Also swept the run-haventory skill for text about this line: it already described a debug log
line, so only the stale rendering of the message (`Storage health: schema_version=N items=N
locations=N`, which predates the `op=`/`items_count=` shape the context logger writes) needed
correcting, plus a note that a clean instance now says nothing at HA's default level. No file in
`docs/`, `dev/release_testing_plan.md` or the test-haventory skill listed the WARNING as expected.

## How it was tested

`tests/test_init_offline.py` pinned the WARNING; it now pins the opposite, on both sides:

- `test_setup_entry_logs_empty_storage_at_debug` — the line is present for an empty store, at
  DEBUG, carrying `items_count=0 locations_count=0`, and setup writes nothing at WARNING or above.
  Confirmed red before the fix (`assert [30] == [10]`).
- `test_setup_entry_logs_populated_storage_at_debug` — the same line, same level, with the counts
  of a store that has data.

Backend gates green: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1335 passed, 22
skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`. The in-process
`tests/integration/test_logging.py` case for this line already reads at DEBUG and is unaffected.

The live check is the session's: restart the clean 0.7.0 instance with an empty store and see no
WARNING from `custom_components.haventory`.

## Follow-ups

- Nothing distinguishes a first run from a store that existed and yielded nothing. If that
  distinction is ever wanted, it needs a signal the counts do not carry — whether a store file was
  there at all — and it belongs on a surface a user can act on, not in a log line a healthy install
  writes on every boot.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)
