### PR TITLE
fix(card): show the import preview's missing-attachment caveat

### DIFF
--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -254,6 +254,51 @@ describe('hv-import-sheet: preview', () => {
     expect(text).toContain('and 3 more');
   });
 
+  it('says how many attachments name files this install does not hold', async () => {
+    // An export carries attachment metadata and not the bytes, so restoring one
+    // onto a fresh machine leaves every reference pointing at nothing. The
+    // count is already on the wire; not showing it is the difference between a
+    // decision and a surprise.
+    const el = await mount({ preview: preview({ attachments: { referenced: 14, missing: 7 } }) });
+    const text =
+      q(el, '[data-testid="import-attachments-missing"]')?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+    expect(text).toContain('7 of 14 attachments name files this install does not have');
+    expect(text).toContain('those photos and manuals will show as missing after the import');
+    // The full-fidelity path, since this one cannot be.
+    expect(text).toContain('Home Assistant backup carries the files as well');
+  });
+
+  it('counts a single missing attachment in the singular', async () => {
+    const el = await mount({ preview: preview({ attachments: { referenced: 3, missing: 1 } }) });
+    const text =
+      q(el, '[data-testid="import-attachments-missing"]')?.textContent?.replace(/\s+/g, ' ') ?? '';
+    expect(text).toContain('1 of 3 attachments names a file this install does not have');
+    expect(text).toContain('that photo or manual');
+  });
+
+  it('says nothing about attachments when every referenced file is here', async () => {
+    const present = await mount({ preview: preview({ attachments: { referenced: 14, missing: 0 } }) });
+    expect(q(present, '[data-testid="import-attachments-missing"]')).toBe(null);
+
+    // A backend that predates the count omits the key entirely.
+    const absent = await mount({ preview: preview() });
+    expect(absent.preview?.attachments).toBeUndefined();
+    expect(q(absent, '[data-testid="import-attachments-missing"]')).toBe(null);
+  });
+
+  it('puts the attachment caveat below the name clashes and above the button', async () => {
+    const el = await mount({
+      preview: preview({
+        warnings: [{ code: 'name_collision', path: 'items[0]', message: 'a clash' }],
+        attachments: { referenced: 2, missing: 2 },
+      }),
+    });
+    expect(all(el, '.alert').map((a) => a.dataset.testid)).toEqual([
+      'import-warnings',
+      'import-attachments-missing',
+    ]);
+  });
+
   it('states the all-or-nothing behaviour and what it costs other clients', async () => {
     const el = await mount({ preview: preview() });
     const text = el.shadowRoot?.textContent?.replace(/\s+/g, ' ') ?? '';

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -612,6 +612,12 @@ export class HVImportSheet extends LitElement {
     const willWrite = itemWrites + locationWrites;
     // Absent on a preview from a backend that predates warnings.
     const warnings = preview.warnings ?? [];
+    // The export carries attachment metadata and not the bytes, so a document
+    // written on another machine points at files this one never had. There is
+    // nothing to fix before importing — but the photos are gone afterwards, and
+    // a user who was not told reads that as data loss. Zeroes when the backend
+    // predates the count, which renders as nothing.
+    const files = preview.attachments ?? { referenced: 0, missing: 0 };
 
     return html`
       <div class="head">
@@ -657,6 +663,18 @@ export class HVImportSheet extends LitElement {
                       })}</span
                     >`
                   : null}
+              </span>
+            </div>`
+          : null}
+        ${files.missing
+          ? html`<div class="alert warn" data-testid="import-attachments-missing">
+              <span class="glyph">${icon('alert', 18)}</span>
+              <span>
+                ${tn('hv.import.attachmentsMissing', files.missing, {
+                  missing: files.missing,
+                  referenced: files.referenced,
+                })}
+                <span class="hint">${t('hv.import.attachmentsMissingHint')}</span>
               </span>
             </div>`
           : null}

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -739,6 +739,11 @@ export const de: Record<TranslationKey, string> = {
   'hv.import.warnings.other':
     '{clashes} – die Datei würde Einträge unter einem Namen hinzufügen, den hier schon etwas trägt, aber mit einer anderen ID. Der Import ordnet allein über die ID zu, also entstehen Duplikate statt Aktualisierungen.',
   'hv.import.warningsMore': '… und {count} weitere.',
+  'hv.import.attachmentsMissing.one':
+    '{missing} von {referenced} Anhängen nennt eine Datei, die es auf dieser Installation nicht gibt – dieses Foto oder diese Anleitung fehlt nach dem Import.',
+  'hv.import.attachmentsMissing.other':
+    '{missing} von {referenced} Anhängen nennen Dateien, die es auf dieser Installation nicht gibt – diese Fotos und Anleitungen fehlen nach dem Import.',
+  'hv.import.attachmentsMissingHint': 'Ein Home-Assistant-Backup sichert die Dateien mit.',
   'hv.import.allOrNothing':
     'Der Import gilt ganz oder gar nicht: Jeder Fehler rollt das ganze Dokument zurück. Bei Erfolg lädt jede verbundene Karte ihre Daten neu.',
   'hv.import.importing': 'Wird importiert …',

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -775,6 +775,11 @@ export const en = {
   'hv.import.warnings.other':
     '{clashes} — the file would add entries under a name something here already uses, under a different id. Import matches on the id alone, so these become duplicates rather than an update.',
   'hv.import.warningsMore': '…and {count} more.',
+  'hv.import.attachmentsMissing.one':
+    '{missing} of {referenced} attachments names a file this install does not have — that photo or manual will show as missing after the import.',
+  'hv.import.attachmentsMissing.other':
+    '{missing} of {referenced} attachments name files this install does not have — those photos and manuals will show as missing after the import.',
+  'hv.import.attachmentsMissingHint': 'A Home Assistant backup carries the files as well.',
   'hv.import.allOrNothing':
     'Import is all-or-nothing: any failure rolls the whole document back. On success every connected card reloads its data.',
   'hv.import.importing': 'Importing…',

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -550,6 +550,14 @@ export interface ImportPreview {
   items: ImportBuckets;
   locations: ImportBuckets;
   counts: { items?: ImportBucketCounts; locations?: ImportBucketCounts };
+  /**
+   * How many attachment references the imported dataset would hold, and how
+   * many of them name a file this install does not have. An export carries
+   * attachment metadata and not bytes, so importing one onto another machine
+   * leaves dangling references — a caveat, not an error. Optional, like
+   * `warnings`, so a preview from a backend that predates it still type-checks.
+   */
+  attachments?: { referenced: number; missing: number };
 }
 
 /** Result of haventory/import/execute after a successful apply. */


### PR DESCRIPTION
## What was wrong

`haventory/import/preview` already answers with `attachments: {referenced, missing}` — how many
attachment references the imported dataset would hold, and how many of them name a file this
install does not have. The card never showed it, and not because a render dropped it: the field
was not modelled at all. `ImportPreview` in `src/store/types.ts` carried `valid`, `errors`,
`warnings`, `policy`, `document`, `items`, `locations` and `counts`, and `hv-import-sheet.ts`
contained no occurrence of the word `attachment`.

That silence falls on the path the card invites people down. The empty state offers *Import
backup* beside *Add your first item*, so "export here, import on the new box" is the advertised
route, and it is exactly the case where every referenced file is absent. The preview said three
items would update and nothing else; the photos and manuals turned up broken afterwards. The
README already promised "the preview reports how many before you write anything" — that sentence
is now true.

## What changed

- `ImportPreview` gains `attachments?: { referenced: number; missing: number }`. Optional like
  `warnings`, so a preview from a backend that predates the count still type-checks.
- `_renderPreview` renders an `alert warn` block (`data-testid="import-attachments-missing"`)
  between the name-clash warnings and the error slot whenever `missing` is above zero: how many
  of how many, what it means for those files after the import, and a pointer at Home Assistant's
  own backups as the path that carries the bytes. `missing === 0`, or the field absent, renders
  nothing.
- Three new strings in `en.ts` and `de.ts` — `hv.import.attachmentsMissing.one` / `.other` and
  `hv.import.attachmentsMissingHint`.

No backend change: the contract in `docs/backend_api_contract.md` already describes the field, and
the server already sends it.

## How it was tested

Four new cases in `hv-import-sheet.test.ts`, written red first: the counts render for
`{referenced: 14, missing: 7}`, a single missing file reads in the singular, nothing renders for
`missing: 0` or for a preview with no `attachments` key, and the block sits below the warnings and
above the button. `src/i18n/catalog.test.ts` covers the en/de key and placeholder parity for the
three new strings without changes.

Card gate green: `npx eslint .`, `npm run typecheck`, `npx vitest run` (70 files, 1905 tests),
`npm run build`. The backend half is untouched.

Still to check live (the session does this): `drive_import.mjs` against an export whose attachment
ids name nothing here shows the line above the Import button, and `import_policies.mjs` still
passes.

## Follow-ups

- The card's own missing-file handling for individual attachment rows is #598's subject; this PR
  only adds the count-level caveat in the preview.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)
