### PR TITLE
fix(card): keep a phone-width panel row one line high whatever the path's depth

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -168,6 +168,84 @@ describe('hv-data-table: a path too long for its column', () => {
 });
 
 describe('hv-data-table: narrow screens', () => {
+  const AREAS = [
+    { id: 'area-kitchen', name: 'Küche' },
+    { id: 'area-garage', name: 'Garage' },
+  ];
+  const DEEP = 'Küche / Hochschrank / Oberstes Fach / Vorratsbox / Backzutaten';
+
+  const mountNarrow = (display_path: string, props: Partial<HVDataTable> = {}, areaId = 'area-kitchen') =>
+    mount(
+      [
+        {
+          id: '1',
+          effective_area_id: areaId,
+          location_path: { id_path: [], name_path: [], display_path, sort_key: '' },
+        },
+      ],
+      { columns: ['location'], areas: AREAS, narrow: true, ...props },
+    );
+
+  const cellOf = (el: HVDataTable) => q(el, '[data-testid="cell-location"]')!;
+
+  // At phone width the table scrolls sideways and the LOCATION column is off
+  // the right edge, but its wrapped path still set the row's height: a
+  // five-segment path made a 129px row against 65px for a one-segment one, for
+  // a column the reader cannot see. One line, whatever the depth.
+  it('writes the path on one line where the column is scrolled off screen', async () => {
+    const el = await mountNarrow(DEEP);
+    const cell = cellOf(el);
+
+    expect(cell.querySelectorAll('.hv-path-seg').length).toBe(0);
+    expect(cell.textContent?.replace(/\s+/g, ' ').trim()).toBe('Küche › … › Backzutaten');
+    // The whole path is still readable where nothing elides it.
+    expect(cell.getAttribute('title')).toBe(
+      'Area: Küche · Küche › Hochschrank › Oberstes Fach › Vorratsbox › Backzutaten',
+    );
+  });
+
+  // The same line the card's phone rows write, down to the area coming back
+  // out of the elision as a chip rather than a path segment.
+  it('marks the area beside the elided line, not inside it', async () => {
+    const el = await mountNarrow('Werkstatt / Schrank / Schublade A', {}, 'area-garage');
+    const cell = cellOf(el);
+
+    expect(cell.querySelector('[data-testid="area-chip"]')?.textContent).toContain('Garage');
+    expect(cell.querySelector('.hv-chip-line-text')?.textContent?.replace(/\s+/g, ' ').trim()).toBe(
+      '… › Schublade A',
+    );
+  });
+
+  it('still says nothing is filed there with an em dash', async () => {
+    const el = await mount([{ id: '1' }], { columns: ['location'], areas: AREAS, narrow: true });
+    expect(cellOf(el).textContent?.trim()).toBe('—');
+  });
+
+  // Desktop keeps every segment: there the column is on screen and the height
+  // it costs is height the reader gets something for.
+  it('gives the path its segments back at desktop width', async () => {
+    const el = await mountNarrow(DEEP);
+    el.narrow = false;
+    await el.updateComplete;
+
+    expect([...cellOf(el).querySelectorAll('.hv-path-seg')].map((s) => s.textContent?.replace(' › ', ''))).toEqual(
+      ['Küche', 'Hochschrank', 'Oberstes Fach', 'Vorratsbox', 'Backzutaten'],
+    );
+  });
+
+  // jsdom lays nothing out, so the rule that clamps the cell is only assertable
+  // as text — and the attribute is the only thing that rule can select on.
+  it('reflects the phone flag and clamps the cell from CSS', async () => {
+    const el = await mountNarrow(DEEP);
+    expect(el.hasAttribute('narrow')).toBe(true);
+    el.narrow = false;
+    await el.updateComplete;
+    expect(el.hasAttribute('narrow')).toBe(false);
+
+    const css = componentCss('hv-data-table');
+    expect(css).toMatch(/:host\(\[narrow\]\) \.cell\.path[^{]*\{[^}]*flex-wrap: nowrap/);
+    expect(css).toMatch(/:host\(\[narrow\]\) \.cell\.path[^{]*\{[^}]*white-space: nowrap/);
+  });
 
   it('reflects the selecting flag, which is all the pinning rules can read', async () => {
     const el = await mount([{ id: '1' }], { selectable: true });

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -32,6 +32,7 @@ import './hv-overflow-menu';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
 import {
   areaMarkName,
+  elideMobilePath,
   itemPathParts,
   pathTitle,
   renderAreaChip,
@@ -292,6 +293,29 @@ export class HVDataTable extends LitElement {
         align-items: center;
         row-gap: 2px;
       }
+      /*
+       * At phone width the table scrolls sideways and this column is off the
+       * right edge, where a wrapped path was still setting the row's height —
+       * five segments made a 129px row against 65px for one, for a column the
+       * reader cannot see into. So the cell takes one line here, on the elided
+       * form the card's phone rows already write, and the row's height stops
+       * depending on how deep the tree is. The title attribute still carries
+       * the whole path, and scrolling the column into view reaches this line.
+       *
+       * The text is a block rather than a flex row on this branch: the elision
+       * has already decided what to drop, and text-overflow has nothing to act
+       * on inside a flex container.
+       */
+      :host([narrow]) .cell.path,
+      :host([narrow]) .cell.path > .hv-chip-line-text {
+        flex-wrap: nowrap;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      :host([narrow]) .cell.path > .hv-chip-line-text {
+        display: block;
+      }
       /* A segment holds its line, and elides only when one segment on its own
          is wider than the whole column — the point past which there is no break
          left to take. */
@@ -424,6 +448,15 @@ export class HVDataTable extends LitElement {
   /** Reflected: the sticky name column offsets itself past the checkbox track
    * from CSS, which can only see an attribute. */
   @property({ type: Boolean, reflect: true }) selectable = false;
+  /**
+   * True on a phone-width viewport, set by the host that reads the query.
+   *
+   * The table keeps every column at every width and scrolls sideways, so at
+   * this width the location column sits off the right edge — and a path that
+   * wraps there buys height nothing on screen spends. Reflected: the rule that
+   * clamps the cell is CSS, and CSS can only see an attribute.
+   */
+  @property({ type: Boolean, reflect: true }) narrow = false;
   /** HA areas, to name the one each item's location resolves to. */
   @property({ attribute: false }) areas: AreaRef[] = [];
   @property({ attribute: false }) selection: Set<string> = new Set();
@@ -601,12 +634,30 @@ export class HVDataTable extends LitElement {
         return html`<span class="cell" role="cell" data-testid="cell-category" title=${item.category ?? ''}>${item.category || '—'}</span>`;
       case 'location': {
         const parts = itemPathParts(item, this.areas);
+        const mark = areaMarkName(parts.areaName, parts.path);
+        // On a phone the column is scrolled off screen, so the path gets one
+        // line and drops its middle rather than growing the row for segments
+        // nobody can see. The area comes back out of the elision as the same
+        // chip the wide cell hangs beside the path — the card's phone rows
+        // write this exact line.
+        if (this.narrow) {
+          const lead = elideMobilePath(mark, parts.path);
+          return html`<span
+            class="cell path hv-chip-line"
+            role="cell"
+            data-testid="cell-location"
+            title=${pathTitle(parts)}
+            >${renderAreaChip(lead.area)}<span class="hv-chip-line-text"
+              >${lead.rest || '—'}</span
+            ></span
+          >`;
+        }
         return html`<span
           class="cell path hv-chip-line"
           role="cell"
           data-testid="cell-location"
           title=${pathTitle(parts)}
-          >${renderAreaChip(areaMarkName(parts.areaName, parts.path))}<span class="hv-chip-line-text"
+          >${renderAreaChip(mark)}<span class="hv-chip-line-text"
             >${parts.path ? renderPathSegments(parts.path) : '—'}</span
           ></span
         >`;

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1493,6 +1493,21 @@ describe('hv-full-view: phone-width children', () => {
     }
   });
 
+  // The table is scrolled sideways at this width, so its LOCATION column is off
+  // the screen — and a wrapped path there was still setting the row's height.
+  // The table cannot read the media query itself; this is where it learns.
+  it('tells the table when it is on a phone', async () => {
+    for (const narrow of [true, false]) {
+      const restore = stubViewport(narrow);
+      try {
+        const { sr } = await mount({ items: [makeItem({ id: '1' })] });
+        expect(q(sr, '[data-testid="full-table"]')?.hasAttribute('narrow'), String(narrow)).toBe(narrow);
+      } finally {
+        restore();
+      }
+    }
+  });
+
   // The panel stages its edits on a phone and drops its own footer, expecting
   // its host to provide one. Telling it "phone" without that would stage every
   // edit with no way to apply it.

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -2317,6 +2317,7 @@ export class HVFullView extends LitElement {
               .columns=${this.columns}
               .sort=${filters.sort as Sort}
               ?selectable=${this._selecting}
+              ?narrow=${this._narrow}
               .selection=${selection}
               @sort-change=${(e: CustomEvent) => this._setFilters({ sort: (e.detail as { sort: Sort }).sort })}
               @near-end=${(e: CustomEvent) =>

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -2,7 +2,7 @@ import { setLanguage } from '../i18n';
 import './hv-list-row';
 import { makeAttachment, makeItem, makeManual, makeMediaBindings, mountComponent, q } from '../test.utils';
 import { MEDIA_NAME_TOKEN_PARAM, MEDIA_SIZE_PARAM, attachmentNameToken } from '../ui/media';
-import { elideMobilePath, elidePath, isLowStock, rowMenuEntries } from './hv-list-row';
+import { isLowStock, rowMenuEntries } from './hv-list-row';
 import { addDays, toIsoDate } from '../ui/relative-time';
 import type { HVListRow } from './hv-list-row';
 import type { Item } from '../store/types';
@@ -26,67 +26,6 @@ describe('isLowStock', () => {
   it('is low at or below the threshold', () => {
     expect(isLowStock(makeItem({ quantity: 3, low_stock_threshold: 3 }))).toBe(true);
     expect(isLowStock(makeItem({ quantity: 4, low_stock_threshold: 3 }))).toBe(false);
-  });
-});
-
-describe('elidePath', () => {
-  it('leaves a path that already fits alone', () => {
-    expect(elidePath('Garage')).toBe('Garage');
-    expect(elidePath('Garage › Shelf A')).toBe('Garage › Shelf A');
-  });
-
-  // The leaf is the whole point: it is the segment that says where the item
-  // actually is, and right-clipping was dropping exactly that.
-  it('drops the middle rather than the leaf', () => {
-    expect(elidePath('Workshop › Parts Cabinet › Drawer A › Small Bin')).toBe('Workshop › … › Small Bin');
-  });
-
-  // A phone row has ~200px for this line, and three real segments plus a
-  // category needs well over that, so three has to elide as well.
-  it('elides at three segments, not just at four', () => {
-    expect(elidePath('Workshop › Parts Cabinet › Drawer A')).toBe('Workshop › … › Drawer A');
-  });
-
-  it('keeps both ends however deep the tree gets', () => {
-    expect(elidePath('A › B › C › D › E › F')).toBe('A › … › F');
-  });
-
-  it('handles an item with no location at all', () => {
-    expect(elidePath('')).toBe('');
-  });
-});
-
-describe('elideMobilePath', () => {
-  // The area still has to travel through the elision as the leading segment, or
-  // a deep path would drop it; what comes back is the same line with the area
-  // separated out for the row to mark instead of punctuate.
-  it('keeps the room and the bin, and hands the room back on its own', () => {
-    expect(elideMobilePath('Garage', 'Workshop › Parts Cabinet › Drawer A › Small Bin')).toEqual({
-      area: 'Garage',
-      rest: '… › Small Bin',
-    });
-  });
-
-  it('leaves a path that fits alone, area and all', () => {
-    expect(elideMobilePath('Garage', 'Shelf A')).toEqual({ area: 'Garage', rest: 'Shelf A' });
-  });
-
-  it('gives back exactly what elidePath does when there is no area', () => {
-    const path = 'Workshop › Parts Cabinet › Drawer A › Small Bin';
-    expect(elideMobilePath(null, path)).toEqual({ area: null, rest: elidePath(path) });
-  });
-
-  // An area name carrying the separator lands as two segments, so the elided
-  // string no longer starts with it and there is nothing safe to mark. The line
-  // then reads as it always did — the wrong words marked would be worse.
-  it('marks nothing when the area name is itself split by the separator', () => {
-    const result = elideMobilePath('Kitchen › Pantry', 'Shelf A › Box 2');
-    expect(result.area).toBe(null);
-    expect(result.rest).toBe(elidePath('Kitchen › Pantry › Shelf A › Box 2'));
-  });
-
-  it('marks an area that has no path under it', () => {
-    expect(elideMobilePath('Garage', '')).toEqual({ area: 'Garage', rest: '' });
   });
 });
 

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -3,7 +3,13 @@ import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
-import { areaMarkName, itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
+import {
+  areaMarkName,
+  elideMobilePath,
+  itemPathParts,
+  pathTitle,
+  renderAreaChip,
+} from '../ui/location-path';
 import { icon } from '../ui/icons';
 import { onDayChange } from '../ui/day-clock';
 import { formatDate, isDue, isOverdue } from '../ui/relative-time';
@@ -55,54 +61,6 @@ export function rowMenuEntries(item: Item): OverflowMenuEntry[] {
     { divider: true },
     { id: 'delete', label: t('hv.action.deleteItem'), glyph: 'del' },
   ];
-}
-
-/**
- * Drop the middle of a long path so both ends survive a narrow row.
- *
- * A path reads root-first and clips from the right, so on a phone the half that
- * goes is the half worth keeping: "Workshop › Parts Cabinet › Drawer A › Small
- * Bin" rendered as "Workshop › Parts Cabinet › D…", naming the room but not the
- * drawer or the bin the item is actually in. The root still says which room and
- * the leaf says where in it; the ancestors between them are what a phone can
- * afford to lose, and the detail sheet still shows the path in full.
- *
- * Two, not three: a phone row has about 200px for this line, and a real
- * three-segment path ("Workshop › Parts Cabinet › Drawer A", plus a category
- * after it) needs well over that — so at three it still clipped the leaf off
- * the end, which is the whole thing this is here to prevent.
- */
-export function elidePath(path: string, maxSegments = 2): string {
-  const segments = path.split(' › ');
-  if (segments.length <= maxSegments) return path;
-  return `${segments[0]} › … › ${segments[segments.length - 1]}`;
-}
-
-/**
- * The phone row's location line, with the area separated back out of the front
- * of it.
- *
- * The area has to travel through `elidePath` as the leading segment — that is
- * the half the elision keeps — but it is Home Assistant's, not one of our
- * locations, and the `›` after it reads as though it were one. So the line is
- * composed and elided exactly as it is shown, then the leading segment is taken
- * back off for the caller to mark instead of punctuate.
- *
- * An area name that itself contains ` › ` lands as two segments and the elided
- * string no longer starts with it. Then there is nothing safe to mark and the
- * whole string comes back as `rest`, which renders as the line always did
- * rather than putting the mark on the wrong words.
- */
-export function elideMobilePath(
-  areaName: string | null,
-  path: string,
-): { area: string | null; rest: string } {
-  const composed = elidePath([areaName, path].filter(Boolean).join(' › '));
-  if (!areaName) return { area: null, rest: composed };
-  if (composed === areaName) return { area: areaName, rest: '' };
-  const prefix = `${areaName} › `;
-  if (!composed.startsWith(prefix)) return { area: null, rest: composed };
-  return { area: areaName, rest: composed.slice(prefix.length) };
 }
 
 /**

--- a/cards/haventory-card/src/ui/location-path.test.ts
+++ b/cards/haventory-card/src/ui/location-path.test.ts
@@ -1,6 +1,8 @@
 import { render } from 'lit';
 import {
   areaMarkName,
+  elideMobilePath,
+  elidePath,
   itemPathParts,
   locationLabel,
   locationPathParts,
@@ -133,6 +135,67 @@ describe('pathLabel', () => {
 
   it('is just the path when there is no area', () => {
     expect(pathLabel({ areaName: null, path: 'Fridge' })).toBe('Fridge');
+  });
+});
+
+describe('elidePath', () => {
+  it('leaves a path that already fits alone', () => {
+    expect(elidePath('Garage')).toBe('Garage');
+    expect(elidePath('Garage › Shelf A')).toBe('Garage › Shelf A');
+  });
+
+  // The leaf is the whole point: it is the segment that says where the item
+  // actually is, and right-clipping was dropping exactly that.
+  it('drops the middle rather than the leaf', () => {
+    expect(elidePath('Workshop › Parts Cabinet › Drawer A › Small Bin')).toBe('Workshop › … › Small Bin');
+  });
+
+  // A phone row has ~200px for this line, and three real segments plus a
+  // category needs well over that, so three has to elide as well.
+  it('elides at three segments, not just at four', () => {
+    expect(elidePath('Workshop › Parts Cabinet › Drawer A')).toBe('Workshop › … › Drawer A');
+  });
+
+  it('keeps both ends however deep the tree gets', () => {
+    expect(elidePath('A › B › C › D › E › F')).toBe('A › … › F');
+  });
+
+  it('handles an item with no location at all', () => {
+    expect(elidePath('')).toBe('');
+  });
+});
+
+describe('elideMobilePath', () => {
+  // The area still has to travel through the elision as the leading segment, or
+  // a deep path would drop it; what comes back is the same line with the area
+  // separated out for the row to mark instead of punctuate.
+  it('keeps the room and the bin, and hands the room back on its own', () => {
+    expect(elideMobilePath('Garage', 'Workshop › Parts Cabinet › Drawer A › Small Bin')).toEqual({
+      area: 'Garage',
+      rest: '… › Small Bin',
+    });
+  });
+
+  it('leaves a path that fits alone, area and all', () => {
+    expect(elideMobilePath('Garage', 'Shelf A')).toEqual({ area: 'Garage', rest: 'Shelf A' });
+  });
+
+  it('gives back exactly what elidePath does when there is no area', () => {
+    const path = 'Workshop › Parts Cabinet › Drawer A › Small Bin';
+    expect(elideMobilePath(null, path)).toEqual({ area: null, rest: elidePath(path) });
+  });
+
+  // An area name carrying the separator lands as two segments, so the elided
+  // string no longer starts with it and there is nothing safe to mark. The line
+  // then reads as it always did — the wrong words marked would be worse.
+  it('marks nothing when the area name is itself split by the separator', () => {
+    const result = elideMobilePath('Kitchen › Pantry', 'Shelf A › Box 2');
+    expect(result.area).toBe(null);
+    expect(result.rest).toBe(elidePath('Kitchen › Pantry › Shelf A › Box 2'));
+  });
+
+  it('marks an area that has no path under it', () => {
+    expect(elideMobilePath('Garage', '')).toEqual({ area: 'Garage', rest: '' });
   });
 });
 

--- a/cards/haventory-card/src/ui/location-path.ts
+++ b/cards/haventory-card/src/ui/location-path.ts
@@ -120,6 +120,56 @@ export function renderPathSegments(path: string): TemplateResult[] {
 }
 
 /**
+ * Drop the middle of a long path so both ends survive one line.
+ *
+ * A path reads root-first and clips from the right, so on a phone the half that
+ * goes is the half worth keeping: "Workshop › Parts Cabinet › Drawer A › Small
+ * Bin" rendered as "Workshop › Parts Cabinet › D…", naming the room but not the
+ * drawer or the bin the item is actually in. The root still says which room and
+ * the leaf says where in it; the ancestors between them are what a phone can
+ * afford to lose, and the detail sheet still shows the path in full.
+ *
+ * Two, not three: a phone row has about 200px for this line, and a real
+ * three-segment path ("Workshop › Parts Cabinet › Drawer A", plus a category
+ * after it) needs well over that — so at three it still clipped the leaf off
+ * the end, which is the whole thing this is here to prevent.
+ *
+ * The counterpart to {@link renderPathSegments}: a surface that can give a path
+ * more than one line keeps every segment, one that has exactly one elides here.
+ */
+export function elidePath(path: string, maxSegments = 2): string {
+  const segments = path.split(PATH_SEPARATOR);
+  if (segments.length <= maxSegments) return path;
+  return `${segments[0]}${PATH_SEPARATOR}…${PATH_SEPARATOR}${segments[segments.length - 1]}`;
+}
+
+/**
+ * A one-line location, with the area separated back out of the front of it.
+ *
+ * The area has to travel through `elidePath` as the leading segment — that is
+ * the half the elision keeps — but it is Home Assistant's, not one of our
+ * locations, and the `›` after it reads as though it were one. So the line is
+ * composed and elided exactly as it is shown, then the leading segment is taken
+ * back off for the caller to mark instead of punctuate.
+ *
+ * An area name that itself contains ` › ` lands as two segments and the elided
+ * string no longer starts with it. Then there is nothing safe to mark and the
+ * whole string comes back as `rest`, which renders as the line always did
+ * rather than putting the mark on the wrong words.
+ */
+export function elideMobilePath(
+  areaName: string | null,
+  path: string,
+): { area: string | null; rest: string } {
+  const composed = elidePath([areaName, path].filter(Boolean).join(PATH_SEPARATOR));
+  if (!areaName) return { area: null, rest: composed };
+  if (composed === areaName) return { area: areaName, rest: '' };
+  const prefix = `${areaName}${PATH_SEPARATOR}`;
+  if (!composed.startsWith(prefix)) return { area: null, rest: composed };
+  return { area: areaName, rest: composed.slice(prefix.length) };
+}
+
+/**
  * The area worth marking beside a path, or nothing.
  *
  * Naming a root location after the area it stands in is the most natural thing

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -364,6 +364,15 @@ mark is the separator, and it costs the line about what that separator cost. An 
 that itself contains ` › ` splits into two segments and comes back unmarked, which reads as
 the line always did rather than marking the wrong words.
 
+Both live in `ui/location-path.ts`, because `hv-data-table` writes the same line: its
+`narrow` property — the phone breakpoint, handed down by `hv-full-view`, which is the only
+thing that can read a media query on the table's behalf — swaps the wrapping location cell
+for the elided one. The table keeps every column and scrolls sideways, so at that width the
+location column is off the right edge, and a path that wrapped there still set the row's
+height: five segments cost a 129px row against 65px for one, for a column nobody can see
+into. One line, whatever the depth; the cell's `title` still carries the path whole. Above
+the breakpoint the column is on screen and `renderPathSegments` keeps every segment.
+
 Threading is by property, outward from the two containers that hold `areasCache`.
 `hv-card-shell` and `hv-full-view` pass `.areas` to `hv-list` (which forwards to
 `hv-list-row`), `hv-data-table`, `hv-detail-sheet`, `hv-item-editor`, `hv-filter-panel`,


### PR DESCRIPTION
## What was wrong

At phone width the panel keeps every column and scrolls the table sideways, so LOCATION sits
off the right edge — the reported cell's left edge was at x=576 on a 390px viewport. The cell
still wrapped its path over as many lines as the path had parts and the row still counted them,
so a five-level path cost a 129px row against 65px for a one-level one. Half the screen, spent
on a column nobody can see into, and the households most likely to hit it are the ones using
the deep trees HAventory exists for. The dashboard card's narrow rows were already the control:
one elided line, every row the same height.

## What changed

- `hv-data-table` gains `narrow` (reflected, so the CSS rule can select on it). `hv-full-view`
  passes `?narrow=${this._narrow}` — its own phone breakpoint, since a table cannot read a media
  query on its own behalf.
- On that branch the location cell renders `elideMobilePath(areaMark, path)`: root › … › leaf on
  one line, with the area beside it as the same chip the wide cell hangs there, and `title` still
  carrying the whole path unelided. Scrolling the column into view reaches that same line.
- `elidePath` / `elideMobilePath` move from `hv-list-row.ts` to `ui/location-path.ts`, which is
  the module that owns path rendering, and both surfaces import them from there. Their tests move
  with them into `location-path.test.ts`; behaviour is unchanged (the moved copies use the
  module's `PATH_SEPARATOR` instead of a repeated `' › '` literal).
- CSS: `:host([narrow]) .cell.path` and its text wrapper go `flex-wrap: nowrap; white-space:
  nowrap; overflow: hidden; text-overflow: ellipsis`. One addition to the planned rule — the text
  wrapper also becomes `display: block` on this branch, because `text-overflow` has nothing to act
  on inside the flex container the wide branch needs.
- Desktop is untouched: the column is on screen there, `renderPathSegments` still gives every
  segment its own break, and the row height it costs buys something.
- `docs/frontend_architecture.md`'s area-beside-a-path section says the table writes this line too,
  and why the helpers now live in `ui/location-path.ts`.

## How it was tested

Failing tests first, confirmed red against the unfixed source (4 failures), then green:

- `hv-data-table.test.ts` — a narrow table writes `Küche › … › Backzutaten` with no
  `.hv-path-seg` elements and the full path still in `title`; the area comes back out of the
  elision as a chip (`… › Schublade A` beside a *Garage* chip); an item filed nowhere still reads
  `—`; flipping `narrow` off gives all five segments back; the attribute reflects and the clamp
  rule is in the component's CSS (jsdom lays nothing out, so the rule is only assertable as text).
- `hv-full-view.test.ts` — the attribute is forwarded at phone width and absent above it.
- Card gate green: `npx eslint .`, `npm run typecheck`, `npx vitest run` (70 files, 1907 tests),
  `npm run build`. No backend file touched.

The pixel claim — every row 65px at 390px whatever the depth, desktop unchanged — is the live
check on the clean 0.7.0 instance, which this branch cannot run.

## Follow-ups

- The same inflation happens on desktop (129px against 55px), and stays: there the path is on
  screen and earning its height. Only the phone case is fixed.
- The breakpoint is the card's existing `NARROW_QUERY` (700px). Between 700px and roughly the
  table's 1366px minimum the table also scrolls sideways, so a deep path can be off-screen there
  too; nothing in the report asks for that width and it is not addressed here.

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)
