### PR TITLE
fix(card): give a picture whose file is gone the missing state

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ What HAventory does *not* do today, stated up front so none of it is a surprise:
   WebSocket result the card writes to a file, so it cannot carry binaries; photos and
   manuals live on disk under `<config>/haventory/attachments/`. Importing a document onto
   an install that does not hold those files keeps the references and shows a "file
-  missing" state — the preview reports how many before you write anything, and the item's
-  Documents list marks each affected row rather than offering a link to a 404.
+  missing" state — the preview reports how many before you write anything, and the card
+  marks each affected entry rather than offering a link to a 404 or a broken image: the
+  Documents list on the row, the photo where its tile would be, wherever the card draws one.
   **Home Assistant's own backups are the full-fidelity path**: the media directory sits
   inside the config directory, so a backup and restore carries the files and the store
   together and consistently.

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -420,6 +420,76 @@ describe('hv-data-table: row thumbnail', () => {
 
     expect(q(el, '[data-testid="row-thumb"]')).toBeNull();
   });
+
+  describe('and its file is gone', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    /** Two rows with a picture each, both failing to load it. */
+    async function broken(probe: () => unknown) {
+      vi.stubGlobal('fetch', probe);
+      const el = await mount(
+        [
+          { id: 'i-1', name: 'Cordless drill', attachments: [makeAttachment({ id: 'att-1' })] },
+          { id: 'i-2', name: 'Hammer', attachments: [makeAttachment({ id: 'att-2' })] },
+        ],
+        { media: makeMediaBindings() },
+      );
+      await el.updateComplete;
+      await el.updateComplete;
+      for (const img of all(el, '[data-testid="row-thumb"]')) {
+        img.dispatchEvent(new Event('error'));
+      }
+      for (let i = 0; i < 4; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await el.updateComplete;
+      }
+      return el;
+    }
+
+    it('draws a missing mark in place of the browser’s broken-image glyph', async () => {
+      const el = await broken(vi.fn(async () => new Response(null, { status: 404 })));
+
+      const marks = all(el, '[data-testid="row-thumb-missing"]');
+      expect(marks).toHaveLength(2);
+      // Glyph-only in a 34px box, so the state has to reach a screen reader and
+      // a pointer some other way.
+      expect(marks[0].getAttribute('aria-label')).toBe('File missing');
+      expect(marks[0].getAttribute('title')).toBe('File missing');
+      // No <img> at all: an element with a src is what draws the glyph and
+      // spills the alt text out of the tile.
+      expect(el.shadowRoot?.querySelector('img')).toBeNull();
+      // It still leads the cell, so a restored inventory keeps its rhythm
+      // rather than shifting every name left by a tile.
+      expect(q(el, '.name-cell')?.firstElementChild).toBe(marks[0]);
+    });
+
+    it('asks the backend nothing for a table whose pictures load', async () => {
+      const probe = vi.fn(async () => new Response(null, { status: 404 }));
+      vi.stubGlobal('fetch', probe);
+      const el = await mount([{ id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] }], {
+        media: makeMediaBindings(),
+      });
+      await el.updateComplete;
+      await el.updateComplete;
+
+      expect(q(el, '[data-testid="row-thumb"]')).toBeTruthy();
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('keeps the tile when the probe cannot say the file is gone', async () => {
+      const el = await broken(
+        vi.fn(async () => {
+          throw new Error('offline');
+        }),
+      );
+
+      expect(q(el, '[data-testid="row-thumb-missing"]')).toBeNull();
+      expect(q(el, '[data-testid="row-thumb"]')?.classList.contains('broken')).toBe(true);
+      expect(componentCss('hv-data-table')).toMatch(/\.thumb\.broken \{ visibility: hidden/);
+    });
+  });
 });
 
 describe('hv-data-table: sorting', () => {

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -18,6 +18,7 @@ import {
 import {
   MEDIA_VARIANT_THUMB,
   MediaUrls,
+  PictureFallback,
   ROW_THUMB_SIZE,
   attachmentNameToken,
   pictureAlt,
@@ -195,6 +196,24 @@ export class HVDataTable extends LitElement {
         border-radius: 6px;
         object-fit: cover;
         background: var(--hv-surface-raised);
+      }
+      /* The tile of a picture whose file the backend no longer has. It keeps the
+         box, because a restore without the media directory leaves every row in
+         this state and a table that dropped them all would hand the width back
+         to the name column row by row. */
+      .thumb.missing {
+        display: inline-grid;
+        place-items: center;
+        box-sizing: border-box;
+        border: 1px dashed var(--hv-divider);
+        color: var(--hv-text-tertiary);
+      }
+      /* Between the failure and the probe's answer. Hidden rather than removed:
+         what an errored <img> draws is the browser's broken-image glyph with the
+         alt text spilling out of a 34px square, which is the whole thing this
+         state exists to keep out of the cell. */
+      .thumb.broken {
+        visibility: hidden;
       }
       /*
        * A phone shows about a quarter of this table — the template's floor is
@@ -431,6 +450,7 @@ export class HVDataTable extends LitElement {
   @property({ attribute: false }) media: MediaBindings | null = null;
 
   private readonly _urls = new MediaUrls(this);
+  private readonly _thumbs = new PictureFallback(this, this._urls);
 
   protected willUpdate() {
     this._urls.configure(this.media?.sign ?? null);
@@ -444,10 +464,24 @@ export class HVDataTable extends LitElement {
    * one, so this never decides whether the picture appears. `loading="lazy"`
    * and `decoding="async"` still matter — a long table would otherwise fetch
    * and decode every row's tile at once.
+   *
+   * A file the backend no longer has is answered from the failure rather than
+   * probed for up front — see `PictureFallback`.
    */
   private _renderThumb(item: Item) {
     const first = pictures(item.attachments)[0];
     if (!first) return null;
+    const state = this._thumbs.state(item.id, first.id);
+    if (state === 'missing') {
+      return html`<span
+        class="thumb missing"
+        data-testid="row-thumb-missing"
+        role="img"
+        aria-label=${t('hv.term.fileMissing')}
+        title=${t('hv.term.fileMissing')}
+        >${icon('camera', 18)}</span
+      >`;
+    }
     const src = this._urls.get(
       item.id,
       first.id,
@@ -456,12 +490,14 @@ export class HVDataTable extends LitElement {
     );
     if (!src) return null;
     return html`<img
-      class="thumb"
+      class=${state === 'errored' ? 'thumb broken' : 'thumb'}
       data-testid="row-thumb"
       src=${src}
       alt=${pictureAlt(item.name, 0, 1)}
       loading="lazy"
       decoding="async"
+      @error=${() => this._thumbs.noteError(item.id, first.id)}
+      @load=${() => this._thumbs.noteLoad(item.id, first.id)}
     />`;
   }
 

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -967,6 +967,60 @@ describe('hv-detail-sheet: lightbox navigation', () => {
   });
 });
 
+/**
+ * A restore that brought the store back without the config directory's media
+ * tree leaves every picture like this, so the strip is a run of these rather
+ * than one odd tile.
+ */
+describe('hv-detail-sheet: a picture whose file is gone', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function serve(status: number) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status })),
+    );
+  }
+
+  it('draws the strip’s tile as missing instead of a broken image', async () => {
+    serve(404);
+    const el = await mount(
+      { id: 'i-1', name: 'Coffee maker', attachments: [makeAttachment({ id: 'att-1' })] },
+      { media: makeMediaBindings() },
+    );
+    for (let i = 0; i < 4; i += 1) await settle(el);
+
+    const tile = q(el, '[data-testid="sheet-photo-missing"]');
+    expect(tile).toBeTruthy();
+    expect(tile?.textContent).toContain('File missing');
+    expect(tile?.querySelector('.hv-chip.warning')).toBeTruthy();
+    // Nothing to open and nothing to draw a broken glyph with.
+    expect(q(el, '[data-testid="sheet-photo-open"]')).toBeNull();
+    expect(el.shadowRoot?.querySelector('img')).toBeNull();
+    // The strip stays, so the item still says it has a photo on record.
+    expect(q(el, '[data-testid="sheet-gallery"]')).toBeTruthy();
+  });
+
+  it('keeps a picture the probe could not rule out', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    );
+    const el = await mount(
+      { id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] },
+      { media: makeMediaBindings() },
+    );
+    for (let i = 0; i < 4; i += 1) await settle(el);
+
+    expect(q(el, '[data-testid="sheet-photo-missing"]')).toBeNull();
+    expect(q(el, '[data-testid="sheet-photo-open"]')).toBeTruthy();
+  });
+});
+
 describe('hv-detail-sheet: documents', () => {
   /** Answers every liveness probe the section makes; 206 is a live file. */
   function serve(status: number) {

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -340,6 +340,21 @@ export class HVDetailSheet extends LitElement {
         object-fit: cover;
         background: var(--hv-surface-raised);
       }
+      /* A picture whose file the backend no longer has: the same box, so the
+         strip keeps its rhythm, carrying the amber mark the document rows below
+         already use for the same fact. */
+      .gallery .missing {
+        display: grid;
+        place-items: center;
+        gap: 6px;
+        box-sizing: border-box;
+        width: 116px;
+        height: 116px;
+        border: 1px dashed var(--hv-divider);
+        border-radius: 10px;
+        background: var(--hv-surface-raised);
+        color: var(--hv-text-tertiary);
+      }
       .documents {
         padding: 0 18px 14px;
       }
@@ -614,12 +629,25 @@ export class HVDetailSheet extends LitElement {
    *
    * Each figure is a button: tapping one opens the lightbox, which is the only
    * way to see a photo at a useful size on a phone.
+   *
+   * A picture whose file the backend cannot find is drawn as missing rather
+   * than handed to an `<img>` that can only draw the browser's broken-image
+   * glyph — the same reason the document rows below probe, and the same state a
+   * restore without the media directory puts every photo in.
    */
   private _renderGallery(item: Item) {
     const shots = pictures(item.attachments);
     if (!shots.length) return null;
     return html`<div class="gallery" data-testid="sheet-gallery">
       ${shots.map((picture, index) => {
+        if (this._urls.presence(item.id, picture.id) === 'missing') {
+          return html`<figure data-testid="sheet-photo">
+            <span class="missing" data-testid="sheet-photo-missing">
+              ${icon('camera', 24)}
+              <span class="hv-chip warning">${t('hv.term.fileMissing')}</span>
+            </span>
+          </figure>`;
+        }
         const src = this._urls.get(item.id, picture.id, attachmentNameToken(picture));
         if (!src) return null;
         return html`<figure data-testid="sheet-photo">

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1878,6 +1878,62 @@ describe('hv-item-editor: opening a document', () => {
   });
 });
 
+/**
+ * The state an import onto a fresh machine leaves every picture in — the export
+ * carries the metadata and not the bytes. A photo used to get the browser's
+ * broken-image glyph here while its manual sibling got the chip.
+ */
+describe('hv-item-editor: a picture whose file is gone', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function serve(status: number) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status })),
+    );
+  }
+
+  it('gives it the same missing state a manual already gets', async () => {
+    serve(404);
+    const el = await mount(
+      makeItem({ id: 'i-1', name: 'Coffee maker', attachments: [makeAttachment({ id: 'p-1' })] }),
+      { media: makeMediaBindings() },
+    );
+    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+
+    const tile = q(el, '[data-testid="editor-photo-missing"]');
+    expect(tile).toBeTruthy();
+    expect(tile?.textContent).toContain('File missing');
+    expect(tile?.querySelector('.hv-chip.warning')).toBeTruthy();
+    // No <img>: an element with a src is what draws the glyph and spills the
+    // alt text out of a 72px tile. And nothing to open, because the lightbox
+    // has nothing to show.
+    expect(el.shadowRoot?.querySelector('img')).toBeNull();
+    expect(q(el, '[data-testid="editor-photo-open"]')).toBeNull();
+    // The reference is still the item's to clear.
+    expect(q(el, '[data-testid="editor-photo-remove"]')).toBeTruthy();
+  });
+
+  it('keeps a picture the probe could not rule out', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    );
+    const el = await mount(
+      makeItem({ id: 'i-1', attachments: [makeAttachment({ id: 'p-1' })] }),
+      { media: makeMediaBindings() },
+    );
+    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+
+    expect(q(el, '[data-testid="editor-photo-missing"]')).toBeNull();
+    expect(q(el, '[data-testid="editor-photo-open"]')).toBeTruthy();
+  });
+});
+
 describe('hv-item-editor: photo order and the cover', () => {
   function pick(el: HVItemEditor, files: File[]) {
     const input = q(el, '[data-testid="editor-photo-input"]') as HTMLInputElement;

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -891,6 +891,26 @@ export class HVItemEditor extends LitElement {
         height: 72px;
         color: var(--hv-text-tertiary);
       }
+      /* A picture whose file the backend no longer has. The tile keeps its box
+         so the strip does not reflow around it, and says what is wrong with the
+         same amber mark the document rows carry. */
+      .photos .placeholder.missing {
+        gap: 4px;
+        box-sizing: border-box;
+        border: 1px dashed var(--hv-input-border);
+        border-radius: 8px;
+      }
+      /* The one place the card-wide chip metric does not fit: this chip sits
+         inside a 72px tile, where 11.5px on a single line would be clipped by
+         the tile's own edge. */
+      .photos .placeholder.missing .hv-chip {
+        max-width: 100%;
+        padding: 1px 5px;
+        font-size: 10px;
+        line-height: 1.2;
+        white-space: normal;
+        text-align: center;
+      }
       /* Under the thumbnail rather than over it: these sit on whatever photo
          was uploaded, and no overlay treatment is legible against every one.
          The same 24px square the organize dialog's reorder buttons take, so
@@ -2408,16 +2428,30 @@ export class HVItemEditor extends LitElement {
         @drop=${drop.drop}
       >
         ${shots.map((picture, index) => {
+          // Asked the same way the document rows ask, and for the same reason:
+          // an export carries the references and not the bytes, so a fresh
+          // install genuinely holds pictures whose files were never uploaded to
+          // it. One item's photos are few enough to ask about up front, which
+          // is what keeps the browser from ever being handed a URL it can only
+          // draw its broken-image glyph for.
+          const missing = this._urls.presence(item.id, picture.id) === 'missing';
           // The tile, not the picture: tapping one opens the lightbox, which
           // asks for the stored file itself.
-          const src = this._urls.get(
-            item.id,
-            picture.id,
-            attachmentNameToken(picture),
-            MEDIA_VARIANT_THUMB,
-          );
+          const src = missing
+            ? null
+            : this._urls.get(
+                item.id,
+                picture.id,
+                attachmentNameToken(picture),
+                MEDIA_VARIANT_THUMB,
+              );
           return html`<figure data-testid="editor-photo">
-            ${src
+            ${missing
+              ? html`<span class="placeholder missing" data-testid="editor-photo-missing">
+                  ${icon('camera', 20)}
+                  <span class="hv-chip warning">${t('hv.term.fileMissing')}</span>
+                </span>`
+              : src
               ? html`<button
                   class="open"
                   data-testid="editor-photo-open"

--- a/cards/haventory-card/src/components/hv-lightbox.test.ts
+++ b/cards/haventory-card/src/components/hv-lightbox.test.ts
@@ -252,3 +252,47 @@ describe('hv-lightbox: chrome over any photo', () => {
     expect(Number(panel(el)?.style.zIndex)).toBeGreaterThan(0);
   });
 });
+
+/**
+ * The tiles that open this refuse to open a picture whose file is gone, so this
+ * covers the file that goes missing while the photo is on screen — and any host
+ * that opens the lightbox by index without looking.
+ */
+describe('hv-lightbox: a picture whose file is gone', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function failed(probe: () => unknown) {
+    vi.stubGlobal('fetch', probe);
+    const el = await mount({ id: 'i-1', name: 'Drill', attachments: shots(1) }, 0);
+    q(el, 'img')?.dispatchEvent(new Event('error'));
+    for (let i = 0; i < 4; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await settle(el);
+    }
+    return el;
+  }
+
+  it('says the file is missing rather than filling the frame with a broken glyph', async () => {
+    const el = await failed(vi.fn(async () => new Response(null, { status: 404 })));
+
+    expect(q(el, '[data-testid="lightbox-missing"]')?.textContent).toContain('File missing');
+    expect(q(el, 'img')).toBeNull();
+    // Still a dialog: closing it is how the user gets back, and the controls
+    // that do that are outside the frame.
+    expect(panel(el)).toBeTruthy();
+    expect(q(el, '[data-testid="lightbox-close"]')).toBeTruthy();
+  });
+
+  it('keeps the photo when the probe cannot say the file is gone', async () => {
+    const el = await failed(
+      vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    );
+
+    expect(q(el, '[data-testid="lightbox-missing"]')).toBeNull();
+    expect(shown(el)).toBe('Photo of Drill');
+  });
+});

--- a/cards/haventory-card/src/components/hv-lightbox.ts
+++ b/cards/haventory-card/src/components/hv-lightbox.ts
@@ -4,7 +4,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { icon } from '../ui/icons';
 import { DialogFocus } from '../ui/dialog-focus';
-import { MediaUrls, attachmentNameToken, pictureAlt, pictures } from '../ui/media';
+import { MediaUrls, PictureFallback, attachmentNameToken, pictureAlt, pictures } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import type { Item } from '../store/types';
 import { nextZBase } from '../utils/zindex';
@@ -51,6 +51,17 @@ export class HVLightbox extends LitElement {
         max-width: 100vw;
         max-height: 100vh;
         object-fit: contain;
+      }
+      /* A photo whose file the backend no longer has. White ink like every
+         other control here: the frame behind it is the opaque black above, not
+         a themed surface. */
+      .lightbox .missing {
+        display: grid;
+        place-items: center;
+        gap: 12px;
+        padding: 24px;
+        color: #fff;
+        font: 500 15px var(--hv-font);
       }
       .lightbox .close {
         position: absolute;
@@ -120,6 +131,7 @@ export class HVLightbox extends LitElement {
   @state() private _zBase: number | null = null;
 
   private readonly _urls = new MediaUrls(this);
+  private readonly _pictures = new PictureFallback(this, this._urls);
   private readonly _focus = new DialogFocus();
 
   protected willUpdate(changed: Map<string, unknown>) {
@@ -173,6 +185,12 @@ export class HVLightbox extends LitElement {
     // signature was in flight would flash the page underneath, drop focus on
     // `<body>` — taking Escape with it — and come back a stranger.
     const src = this._urls.get(item.id, shot.id, attachmentNameToken(shot));
+    // The tiles that open this refuse to open a picture whose file is gone, so
+    // what is left for here is the file that goes away while the photo is on
+    // screen. Answered from the failure rather than probed for, because every
+    // arrow press would otherwise ask the backend about a photo it is about to
+    // draw perfectly well.
+    const missing = this._pictures.state(item.id, shot.id) === 'missing';
 
     const many = shots.length > 1;
     const nav = (delta: number) => (e: Event) => {
@@ -207,7 +225,18 @@ export class HVLightbox extends LitElement {
       }}
       @click=${this._close}
     >
-      ${src ? html`<img src=${src} alt=${pictureAlt(item.name, index, shots.length)} />` : null}
+      ${missing
+        ? html`<div class="missing" data-testid="lightbox-missing">
+            ${icon('camera', 48)}
+            <span>${t('hv.term.fileMissing')}</span>
+          </div>`
+        : src
+        ? html`<img
+            src=${src}
+            alt=${pictureAlt(item.name, index, shots.length)}
+            @error=${() => this._pictures.noteError(item.id, shot.id)}
+          />`
+        : null}
       <button class="close" data-testid="lightbox-close" aria-label=${t('hv.lightbox.close')} @click=${this._close}>
         ${icon('close', 22)}
       </button>

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -1,6 +1,14 @@
 import { setLanguage } from '../i18n';
 import './hv-list-row';
-import { makeAttachment, makeItem, makeManual, makeMediaBindings, mountComponent, q } from '../test.utils';
+import {
+  componentCss,
+  makeAttachment,
+  makeItem,
+  makeManual,
+  makeMediaBindings,
+  mountComponent,
+  q,
+} from '../test.utils';
 import { MEDIA_NAME_TOKEN_PARAM, MEDIA_SIZE_PARAM, attachmentNameToken } from '../ui/media';
 import { elideMobilePath, elidePath, isLowStock, rowMenuEntries } from './hv-list-row';
 import { addDays, toIsoDate } from '../ui/relative-time';
@@ -631,6 +639,91 @@ describe('hv-list-row thumbnail', () => {
     await el.updateComplete;
 
     expect(q(el, '[data-testid="row-thumb"]')).toBeNull();
+  });
+});
+
+/**
+ * A restore that brought the store back without the media directory leaves
+ * every picture on every item in this state, so it is a screenful of tiles and
+ * not one odd row.
+ */
+describe('hv-list-row: a picture whose file is gone', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Answers every liveness probe with `status`. */
+  function serve(status: number) {
+    const probe = vi.fn(async () => new Response(null, { status }));
+    vi.stubGlobal('fetch', probe);
+    return probe;
+  }
+
+  /** A row with one picture, drawn and then failing to load it. */
+  async function broken(probe = () => serve(404)) {
+    const fetched = probe();
+    const el = await mount(
+      { id: 'i-1', name: 'Cordless drill', attachments: [makeAttachment({ id: 'att-1' })] },
+      { media: makeMediaBindings() },
+    );
+    await el.updateComplete;
+    await el.updateComplete;
+    q(el, '[data-testid="row-thumb"]')?.dispatchEvent(new Event('error'));
+    for (let i = 0; i < 4; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+    }
+    return { el, fetched };
+  }
+
+  it('draws a missing mark in place of the browser’s broken-image glyph', async () => {
+    const { el } = await broken();
+
+    const mark = q(el, '[data-testid="row-thumb-missing"]');
+    expect(mark).toBeTruthy();
+    // Glyph-only in a 34px box, so the state has to reach a screen reader and
+    // a pointer some other way.
+    expect(mark?.getAttribute('aria-label')).toBe('File missing');
+    expect(mark?.getAttribute('title')).toBe('File missing');
+    // No <img> at all: an element with a src is what draws the glyph and spills
+    // the alt text out of the tile.
+    expect(el.shadowRoot?.querySelector('img')).toBeNull();
+  });
+
+  it('costs nothing on a row whose picture loads', async () => {
+    const probe = serve(404);
+    const el = await mount(
+      { id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] },
+      { media: makeMediaBindings() },
+    );
+    await el.updateComplete;
+    await el.updateComplete;
+
+    expect(q(el, '[data-testid="row-thumb"]')).toBeTruthy();
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('keeps the tile when the probe cannot say the file is gone', async () => {
+    const { el } = await broken(() => {
+      const probe = vi.fn(async () => {
+        throw new Error('offline');
+      });
+      vi.stubGlobal('fetch', probe);
+      return probe;
+    });
+
+    expect(q(el, '[data-testid="row-thumb-missing"]')).toBeNull();
+    // The image element stays, and the glyph it would draw is hidden until the
+    // question is settled.
+    const img = q(el, '[data-testid="row-thumb"]');
+    expect(img?.classList.contains('broken')).toBe(true);
+    expect(componentCss('hv-list-row')).toMatch(/\.thumb\.broken \{ visibility: hidden/);
+
+    // A re-signed URL for the same bytes is what finally answers it, and the
+    // row must not keep hiding a picture the browser is now showing.
+    img?.dispatchEvent(new Event('load'));
+    await el.updateComplete;
+    expect(q(el, '[data-testid="row-thumb"]')?.classList.contains('broken')).toBe(false);
   });
 });
 

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -11,6 +11,7 @@ import { itemStatus, renderStatusChip, statusLabel } from '../ui/status';
 import {
   MEDIA_VARIANT_THUMB,
   MediaUrls,
+  PictureFallback,
   ROW_THUMB_SIZE,
   ROW_THUMB_SIZE_TOUCH,
   attachmentNameToken,
@@ -173,6 +174,25 @@ export class HVListRow extends LitElement {
       :host([mobile]) .thumb {
         width: ${unsafeCSS(ROW_THUMB_SIZE_TOUCH)}px;
         height: ${unsafeCSS(ROW_THUMB_SIZE_TOUCH)}px;
+      }
+      /* The tile of a picture whose file the backend no longer has. It keeps
+         the box, because a restore without the media directory leaves every row
+         in this state and a list that dropped them all would reflow entirely.
+         The glyph says a picture belongs here; the title and the label say why
+         it is not being shown. */
+      .thumb.missing {
+        display: inline-grid;
+        place-items: center;
+        box-sizing: border-box;
+        border: 1px dashed var(--hv-divider);
+        color: var(--hv-text-tertiary);
+      }
+      /* Between the failure and the probe's answer. Hidden rather than removed:
+         what an errored <img> draws is the browser's broken-image glyph with the
+         alt text spilling out of a 34px square, which is the whole thing this
+         state exists to keep off the row. */
+      .thumb.broken {
+        visibility: hidden;
       }
       /* A mark, not a chip: that an item has a manual is a fact about it, not
          a state anyone has to act on, so it stays out of the hue vocabulary the
@@ -406,6 +426,7 @@ export class HVListRow extends LitElement {
   @property({ attribute: false }) media: MediaBindings | null = null;
 
   private readonly _urls = new MediaUrls(this);
+  private readonly _thumbs = new PictureFallback(this, this._urls);
 
   private _dayUnsub?: () => void;
 
@@ -437,10 +458,24 @@ export class HVListRow extends LitElement {
    * one, so this never decides whether the picture appears. `loading="lazy"`
    * and `decoding="async"` still matter — a long list would otherwise fetch and
    * decode everything at once.
+   *
+   * A file the backend no longer has is answered from the failure rather than
+   * probed for up front — see `PictureFallback`.
    */
   private _renderThumb() {
     const first = pictures(this.item.attachments)[0];
     if (!first) return null;
+    const state = this._thumbs.state(this.item.id, first.id);
+    if (state === 'missing') {
+      return html`<span
+        class="thumb missing"
+        data-testid="row-thumb-missing"
+        role="img"
+        aria-label=${t('hv.term.fileMissing')}
+        title=${t('hv.term.fileMissing')}
+        >${icon('camera', 18)}</span
+      >`;
+    }
     const src = this._urls.get(
       this.item.id,
       first.id,
@@ -449,12 +484,14 @@ export class HVListRow extends LitElement {
     );
     if (!src) return null;
     return html`<img
-      class="thumb"
+      class=${state === 'errored' ? 'thumb broken' : 'thumb'}
       data-testid="row-thumb"
       src=${src}
       alt=${pictureAlt(this.item.name, 0, 1)}
       loading="lazy"
       decoding="async"
+      @error=${() => this._thumbs.noteError(this.item.id, first.id)}
+      @load=${() => this._thumbs.noteLoad(this.item.id, first.id)}
     />`;
   }
 

--- a/cards/haventory-card/src/ui/media.test.ts
+++ b/cards/haventory-card/src/ui/media.test.ts
@@ -6,6 +6,7 @@ import {
   MEDIA_URL_TEMPLATE,
   MEDIA_VARIANT_THUMB,
   MediaUrls,
+  PictureFallback,
   SIGNED_URL_TTL_SECONDS,
   attachmentNameToken,
   attachmentTitle,
@@ -490,5 +491,97 @@ describe('MediaUrls', () => {
 
     expect(urls.get('item-1', 'att-1')).toBeNull();
     expect(second.sign).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PictureFallback', () => {
+  it('leaves a tile alone until the browser says the URL did not load', () => {
+    const h = host();
+    const urls = new MediaUrls(h, { fetch: vi.fn(async () => new Response(null, { status: 404 })) });
+
+    expect(new PictureFallback(h, urls).state('item-1', 'att-1')).toBe('ok');
+  });
+
+  it('asks whether the file is there only after a tile failed, and once', async () => {
+    const h = host();
+    const signer = deferredSigner();
+    const probe = vi.fn(async () => new Response(null, { status: 404 }));
+    const urls = new MediaUrls(h, { fetch: probe });
+    urls.configure(signer.sign);
+    const fallback = new PictureFallback(h, urls);
+
+    // A list draws its tiles without asking the backend anything about them.
+    expect(fallback.state('item-1', 'att-1')).toBe('ok');
+    expect(probe).not.toHaveBeenCalled();
+
+    fallback.noteError('item-1', 'att-1');
+    signer.resolve('/signed');
+    await Promise.resolve();
+    // Nothing can be probed before there is a URL to probe.
+    expect(fallback.state('item-1', 'att-1')).toBe('errored');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fallback.state('item-1', 'att-1')).toBe('missing');
+    expect(fallback.state('item-1', 'att-1')).toBe('missing');
+    expect(probe).toHaveBeenCalledTimes(1);
+    // The answer lands outside a render, so the host has to be told.
+    expect(h.renders).toBeGreaterThan(0);
+  });
+
+  it('keeps a picture the probe could not rule out rather than calling it missing', async () => {
+    const h = host();
+    const signer = deferredSigner();
+    const urls = new MediaUrls(h, {
+      fetch: vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    });
+    urls.configure(signer.sign);
+    const fallback = new PictureFallback(h, urls);
+
+    fallback.noteError('item-1', 'att-1');
+    signer.resolve('/signed');
+    await Promise.resolve();
+    fallback.state('item-1', 'att-1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fallback.state('item-1', 'att-1')).toBe('errored');
+  });
+
+  it('takes a tile back once its picture loads', async () => {
+    const h = host();
+    const signer = deferredSigner();
+    const urls = new MediaUrls(h, {
+      fetch: vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    });
+    urls.configure(signer.sign);
+    const fallback = new PictureFallback(h, urls);
+
+    fallback.noteError('item-1', 'att-1');
+    signer.resolve('/signed');
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fallback.state('item-1', 'att-1')).toBe('errored');
+
+    // The next URL for the same bytes is the first chance to learn that it was
+    // the request that failed and not the file.
+    fallback.noteLoad('item-1', 'att-1');
+
+    expect(fallback.state('item-1', 'att-1')).toBe('ok');
+  });
+
+  it('answers per attachment, so one broken tile says nothing about the next', async () => {
+    const h = host();
+    const signer = deferredSigner();
+    const urls = new MediaUrls(h, { fetch: vi.fn(async () => new Response(null, { status: 404 })) });
+    urls.configure(signer.sign);
+    const fallback = new PictureFallback(h, urls);
+
+    fallback.noteError('item-1', 'att-1');
+
+    expect(fallback.state('item-1', 'att-2')).toBe('ok');
+    expect(fallback.state('item-2', 'att-1')).toBe('ok');
   });
 });

--- a/cards/haventory-card/src/ui/media.ts
+++ b/cards/haventory-card/src/ui/media.ts
@@ -432,3 +432,65 @@ export class MediaUrls {
     );
   }
 }
+
+/**
+ * What a tile should draw once the browser has had its try at the URL.
+ *
+ * `errored` is the gap between the failure and the answer: the picture may be
+ * gone, or the signature may have lapsed under a connection that dropped, and
+ * the two look identical from inside an `<img>`.
+ */
+export type PictureState = 'ok' | 'errored' | 'missing';
+
+/**
+ * The missing-file state for surfaces that let the browser try the URL first.
+ *
+ * A row cannot probe up front the way a document list does: a table of two
+ * hundred items would ask the backend two hundred extra questions to draw tiles
+ * that are almost always fine. It waits for the `<img>` to fail instead and
+ * only then asks whether the file is missing or the request merely failed — one
+ * probe per broken tile, none at all for a healthy list.
+ *
+ * Only a 404 turns into `missing`: an inconclusive probe leaves the tile in
+ * `errored`, where the caller hides the browser's glyph without claiming the
+ * picture is gone.
+ */
+export class PictureFallback {
+  private readonly host: MediaHost;
+  private readonly urls: MediaUrls;
+  private readonly errored = new Set<string>();
+
+  constructor(host: MediaHost, urls: MediaUrls) {
+    this.host = host;
+    this.urls = urls;
+  }
+
+  /** What to draw for one picture, without asking anything of a tile that loads. */
+  state(itemId: string, attachmentId: string): PictureState {
+    if (!this.errored.has(`${itemId}/${attachmentId}`)) return 'ok';
+    return this.urls.presence(itemId, attachmentId) === 'missing' ? 'missing' : 'errored';
+  }
+
+  /** One tile's image failed to load; find out whether its file is there. */
+  noteError(itemId: string, attachmentId: string): void {
+    this.errored.add(`${itemId}/${attachmentId}`);
+    // Starts the probe. Its answer arrives outside a render, which is what the
+    // re-render below and `MediaUrls`' own host call are for.
+    this.urls.presence(itemId, attachmentId);
+    this.host.requestUpdate();
+  }
+
+  /**
+   * One tile's image loaded after all.
+   *
+   * The failure a probe could not explain sticks to the attachment, and the
+   * next URL for those same bytes — a re-signed one, half an hour later — is
+   * the first chance to find out it was the request and not the file. Without
+   * this the tile would stay in the state a single dropped connection left it
+   * in, holding a picture the browser is now showing.
+   */
+  noteLoad(itemId: string, attachmentId: string): void {
+    if (!this.errored.delete(`${itemId}/${attachmentId}`)) return;
+    this.host.requestUpdate();
+  }
+}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -452,7 +452,7 @@ re-render it — so each container subscribes to `store.state.onChange` itself i
 | `area.ts` | Resolving the HA area behind a location: id → name, and the ancestor walk that mirrors the backend's own resolver. |
 | `location-path.ts` | The `/` → `›` convention for a location path, a location's label with a caller-supplied fallback, and the area-beside-the-path composition (`itemPathParts` / `locationPathParts` / `pathTitle` / `renderAreaChip`). |
 | `dialog-focus.ts` | Initial focus and focus return for modal surfaces. Opening must move focus into the panel or its Escape handler never fires. |
-| `media.ts` | Item attachments: the media path builder, the `MediaUrls` signed-URL cache (request, reuse, refresh before expiry, a distinguishable failed state, and the liveness probe that tells a reference whose file is gone from one that opens), the per-kind `pictures()` / `manuals()` selectors and the title-or-filename fallback, and the `MediaBindings` shape a host hands its components. |
+| `media.ts` | Item attachments: the media path builder, the `MediaUrls` signed-URL cache (request, reuse, refresh before expiry, a distinguishable failed state, and the liveness probe that tells a reference whose file is gone from one that opens), `PictureFallback` for the surfaces that let the browser try the URL first, the per-kind `pictures()` / `manuals()` selectors and the title-or-filename fallback, and the `MediaBindings` shape a host hands its components. |
 | `downscale.ts` | Re-encoding an oversized photo in the browser before it is uploaded: the size and type rules, the capped-edge arithmetic, and the decode/encode seam. Fails open — anything that does not work hands the original file back. |
 | `status.ts` | The item-status vocabulary: the definitions a surface renders from (backend's, or the built-in three until `haventory/config` answers), the label / tone-class / glyph lookups with their fallbacks, the colour and glyph vocabularies the management picker offers, and `renderStatusChip` — one renderer so the mark cannot drift between a table cell and a detail sheet. |
 | `keyboard.ts` | `onEscape()` for the surfaces where Escape means exactly "close", and the platform-correct save-shortcut label. |
@@ -629,6 +629,17 @@ Any other key in that record is ignored, so an older or newer payload never brea
   `ui/discard`, so the same decision never reads as two different questions. The phone sheets
   are part of this: `hv-bottom-sheet` reports a scrim tap or a swipe-down and leaves the
   closing to its host, which is what lets `hv-detail-sheet` answer for the form inside it.
+- **An attachment whose file is gone is a state, not an error.** Metadata outlives bytes —
+  a JSON export carries the references and not the files, and a backup that took `.storage`
+  without the config directory's `haventory/` tree leaves every attachment on every item
+  like this — so every surface draws a *File missing* placeholder rather than a dead link or
+  a broken `<img>`. Which way it is found differs by surface. The document rows, the
+  editor's photo grid and the detail sheet's strip ask `MediaUrls.presence()` up front: one
+  item's attachments are few, and asking first is what keeps a URL that can only fail from
+  ever reaching an `<img>`. The row tiles and the lightbox wait for the image to fail and
+  ask then (`PictureFallback`), because a table of two hundred rows would otherwise put two
+  hundred extra questions to the backend to draw tiles that are almost always fine. Only a
+  404 counts as missing; an inconclusive probe leaves the picture alone.
 - **Optimistic writes** stay as they were; a rejected save keeps the expander open with the
   user's text in it, and conflicts render as a banner with *View latest* / *Re-apply*.
 - **Bulk work is chunked**, so progress is determinate and cancel stops cleanly after the


### PR DESCRIPTION
## What was wrong

The card has had a *File missing* state since attachments shipped, and it applied to
manuals only. A picture whose file the backend no longer has went straight into an `<img>`,
so the editor's photo grid, the detail sheet's strip and both row surfaces drew the
browser's broken-image glyph with the alt text spilling out of the tile — while the manual
sitting next to it got the amber chip.

Two ordinary ways a household reaches that state: restoring a JSON export onto a new
machine (the export carries the metadata and not the bytes, #597), and a Home Assistant
backup that took `.storage` but not the config directory's `haventory/` tree. Both leave
every picture on every item like this, so it is a screenful of broken glyphs.

## What changed

A picture whose file is gone now reaches the state its manual sibling already had. How the
question is asked differs by surface, because the cost does:

- **`hv-item-editor`'s photo grid and `hv-detail-sheet`'s strip** ask
  `MediaUrls.presence()` up front, exactly as the document rows beside them do. One item's
  photos are few, and asking first is what keeps a URL that can only fail from ever reaching
  an `<img>`. The tile becomes a placeholder (`editor-photo-missing` / `sheet-photo-missing`)
  carrying the same amber `hv-chip warning` *File missing* mark: the box keeps its size so
  the strip does not reflow, remove and reorder stay available so the reference can be
  cleared, and there is nothing to open.
- **The row tiles** (`hv-data-table`, `hv-list-row`) cannot afford that — a table of two
  hundred rows would put two hundred extra questions to the backend to draw tiles that are
  almost always fine. A new `PictureFallback` in `ui/media.ts` waits for the `<img>` to fail
  and asks once then: a 404 becomes a muted placeholder box (`row-thumb-missing`, glyph plus
  `title`/`aria-label`), anything else leaves the picture alone and only hides the glyph
  (`.thumb.broken { visibility: hidden }`) so the alt text never spills. A later URL for the
  same bytes that does load takes the tile back.
- **`hv-lightbox`** uses the same seam, so a file that goes away under an open photo says so
  instead of filling the frame with a broken image.

Only a 404 counts as missing. A probe that could not reach the backend leaves the picture
exactly as it was — the same rule the document rows already follow.

## How it was tested

New offline tests, red before the change and green after (11 of them fail on `main`'s
sources with the new tests in place):

- `ui/media.test.ts` — `PictureFallback`: nothing asked until a tile fails, one probe per
  broken tile, a 404 is `missing`, an unreachable probe stays `errored`, a load takes the
  tile back, and the answer is per attachment.
- `hv-item-editor.test.ts`, `hv-detail-sheet.test.ts` — the missing tile with its chip, no
  `<img>` and no way to open it; the picture kept when the probe cannot say.
- `hv-data-table.test.ts`, `hv-list-row.test.ts` — the placeholder and its name, the tile
  still leading the cell, nothing asked of the backend for a table whose pictures load, and
  the hidden-glyph gap while the probe is out.
- `hv-lightbox.test.ts` — the missing panel, and the photo kept on an inconclusive probe.

Card gate green: `npx eslint .`, `npm run typecheck`, `npx vitest run` (1918 passed),
`npm run build`. Backend suite run as well and untouched: 1334 passed, 22 skipped.

No new i18n keys — `hv.term.fileMissing` already exists in `en.ts` and `de.ts`. `README.md`'s
export caveat and `docs/frontend_architecture.md` now say the state covers photos too.

## Follow-ups

- **No new icon.** The design sketch mentioned an `imageOff`-style glyph; the card's icon set
  has none, and the set is verbatim Material Design Icons path data, so rather than invent
  path data and attribute it to MDI the placeholders reuse the `camera` glyph the editor's
  photo placeholder already draws. The amber chip, the `title` and the dashed box are what
  carry the meaning. Swapping in real `mdiImageOff` data later is a one-line change.
- A tile whose probe was inconclusive (offline, a 500) stays a blank box rather than a
  picture until the URL is re-signed, at most half an hour later, and then loads. That is
  strictly better than the broken glyph it replaces, and it is the honest answer while
  "missing" is unproven — but it is the one state that does not self-heal immediately.
- `0.7.0` thumbnails already written to disk are unaffected either way; this is a card-only
  change and touches no stored bytes.

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
