### PR TITLE
fix(card): hold the panel heading whole and clear the app bar's dead spacers

### DIFF
--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -268,6 +268,59 @@ describe('hv-full-view: the app bar between a phone and a wide desktop', () => {
       restore();
     }
   });
+
+  // Negative space is shared by shrink × basis, so a shrinkable heading takes a
+  // slice of every pixel the bar is over — and a slice of a fraction of a pixel
+  // is enough for the ellipsis to fire. At a 900px window in German the bar read
+  // "HAvento…" while the strip still had 188 of its 335px showing.
+  it('elides the heading at its own cap rather than at the first pixel of overflow', () => {
+    const wide = mediaBlock('@media (min-width: 701px)');
+    expect(wide).toMatch(/\.appbar h2 \{[^}]*flex: none/);
+    expect(wide).toMatch(/\.appbar h2 \{[^}]*max-width:/);
+    expect(wide).toMatch(/\.appbar h2 \{[^}]*text-overflow: ellipsis/);
+    // The strip is still what gives first, and the phone branch keeps the
+    // stretching heading its own row was written for.
+    expect(wide).toMatch(/\.appbar \.pills \{[^}]*flex-shrink: 100/);
+    expect(mediaBlock('@media (max-width: 700px)')).toMatch(/\.appbar h2 \{[^}]*flex: 1/);
+  });
+
+  // Both bars carried a spacer that the blanket rule hid at every width, so it
+  // drew nothing anywhere.
+  it('carries no spacer in the app bar, in either mode', async () => {
+    const { el, sr } = await mount({ items: flagged });
+    expect((q(sr, '.appbar') as HTMLElement).querySelector('.spacer')).toBe(null);
+
+    el.startSelecting = true;
+    el.open = false;
+    await el.updateComplete;
+    el.open = true;
+    await settle(el);
+    expect((q(sr, '[data-testid="selection-bar"]') as HTMLElement).querySelector('.spacer')).toBe(null);
+
+    const css = componentCss('hv-full-view');
+    expect(css).not.toMatch(/\.appbar \.spacer/);
+    // The phone panel's commit row is where the class still earns its keep.
+    expect(css).toMatch(/\.spacer \{[^}]*margin-left: auto/);
+  });
+
+  it('puts Clear selection at the right edge above the phone breakpoint', async () => {
+    const { el, sr } = await mount({ items: flagged });
+    el.startSelecting = true;
+    el.open = false;
+    await el.updateComplete;
+    el.open = true;
+    await settle(el);
+
+    // Styling it by data-testid would tie the stylesheet to the test hooks.
+    const clear = q(sr, '[data-testid="selection-clear"]') as HTMLButtonElement;
+    expect(clear.classList.contains('clear')).toBe(true);
+    expect(mediaBlock('@media (min-width: 701px)')).toMatch(
+      /\.appbar\.selecting \.clear \{[^}]*margin-left: auto/,
+    );
+    // Below it the count's flex:1 already holds the buttons at the edge, and an
+    // auto margin on a row that wraps is a phantom item.
+    expect(mediaBlock('@media (max-width: 700px)')).not.toMatch(/\.clear \{[^}]*margin-left: auto/);
+  });
 });
 
 describe('hv-full-view: shell', () => {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -391,10 +391,20 @@ export class HVFullView extends LitElement {
         }
         /* The heading is whatever the dashboard called this card, so it has no
            length the bar can count on. It elides rather than pushing the row
-           off the side — but only once the strip has given everything it has,
-           which is what the shrink weight buys: a cut title reads as broken,
-           where a strip scrolled off its last pill does not. */
+           off the side, but not before the strip has given what it has — and a
+           shrink weight cannot buy that: negative space is shared by shrink ×
+           basis, so a shrinkable heading takes a slice of every pixel the bar
+           is over, and a slice of a fraction of a pixel is enough to swap the
+           last letters for an ellipsis. So it does not shrink at all: it draws
+           at its own width up to a cap and elides only past the cap, leaving
+           the strip as what gives. The cap is a share of the bar rather than a
+           pixel count, so it scales with it — a fixed one wide enough to be
+           worth having would not fit the 614px bar the narrowest non-phone
+           window leaves. min-width holds the flex item's automatic minimum off
+           the cap. */
         .appbar h2 {
+          flex: none;
+          max-width: 30%;
           min-width: 0;
           overflow: hidden;
           text-overflow: ellipsis;
@@ -403,13 +413,15 @@ export class HVFullView extends LitElement {
           flex-shrink: 100;
         }
         /* Two auto margins on one line share the free space between them, so a
-           spacer here would strand the pill strip halfway across the bar. The
-           actions carry the one margin that holds the group at the right
-           edge. */
-        .appbar .spacer {
-          display: none;
-        }
+           second one would strand the pill strip halfway across the bar. This
+           is the one that holds the actions at the right edge. */
         .appbar .add {
+          margin-left: auto;
+        }
+        /* Selection mode's own right-hand group is a single button, and it
+           belongs at the far side of the bar, where it is on a phone too.
+           Below this breakpoint the count's flex:1 already puts it there. */
+        .appbar.selecting .clear {
           margin-left: auto;
         }
         /* First step. The add button's label is the widest thing on the bar
@@ -537,11 +549,6 @@ export class HVFullView extends LitElement {
         }
         .appbar .add {
           padding: 0 14px;
-        }
-        /* An auto margin cannot push anything anywhere once the row wraps, and
-           it would only add a phantom flex item to the line. */
-        .appbar .spacer {
-          display: none;
         }
 
         /* Selection mode reuses this bar and broke in its own way. .subcount
@@ -2192,11 +2199,10 @@ export class HVFullView extends LitElement {
                 : t('hv.fullView.loadAll', { total })}
             </button>`
           : null}
-        <span class="spacer"></span>
         <!-- Selection mode opens at zero, so the bar's one action starts with
              nothing to act on; live rather than greyed it offers a no-op. -->
         <button
-          class="ghost plain"
+          class="ghost plain clear"
           data-testid="selection-clear"
           ?disabled=${selected === 0}
           @click=${() => this.store?.clearSelection()}
@@ -2340,7 +2346,6 @@ export class HVFullView extends LitElement {
               }}
             />
           </label>
-          <span class="spacer"></span>
           ${pills.some((pill) => pill !== null)
             ? html`<div class="pills" data-testid="full-pills">${pills}</div>`
             : null}


### PR DESCRIPTION
Three leftovers of #605 in the panel's app bar, all in `hv-full-view`.

## What was wrong

**The heading elided before the pill strip had bottomed out.** Above 701px the heading had
`min-width: 0` plus an ellipsis and the default `flex-shrink: 1`, against the strip's
`flex-shrink: 100`. A flex container shares negative space by shrink weight times basis, so the
heading gets a slice of *every* pixel the bar is over — and a slice of a fraction of a pixel is
enough for `text-overflow: ellipsis` to swap the last letters out. At a 900px window in German
(bar 644px) the bar read "HAvento…" while the strip still showed 188 of its 335px. The comment
above the rule promised the opposite, which a shrink weight cannot deliver.

**A dead `<span class="spacer">` in both bars.** `.appbar .spacer { display: none }` was declared
in both media blocks, so neither bar's spacer drew anything at any width.

**Clear selection was not at the right edge above 701px.** Because of the rule above, the
selection bar's one action sat against the count with the rest of the bar empty to its right —
where on a phone it is at the far side.

## What changed

- The heading no longer shrinks at all above 701px: `flex: none` plus `max-width: 30%`. It draws
  at its own width and elides only past the cap, so the strip is what gives. The cap is a share
  of the bar rather than a pixel count so it scales down with it — a fixed cap wide enough to be
  worth having would not fit the 614px bar that the narrowest non-phone window leaves. The
  comment above the rule now says this instead of promising the shrink-weight order. The
  `@media (max-width: 700px)` branch keeps its `flex: 1` heading.
- Both `<span class="spacer">` elements are gone from the app bar and the selection bar, along
  with the two `.appbar .spacer { display: none }` rules. The phone panel's commit row keeps its
  spacer and the base `.spacer { margin-left: auto }`.
- The Clear selection button carries a `clear` class and `margin-left: auto` in the ≥701px block,
  which puts it at the bar's far side. Below the breakpoint the count's `flex: 1` already holds
  the buttons at the edge, and an auto margin on a row that wraps is only a phantom flex item, so
  the rule stays out of the narrow branch.

## How it was tested

Three new cases in `hv-full-view.test.ts`, red before the change and green after — jsdom lays
nothing out, so they assert the structure and the CSS rules the way the file's other layout tests
do (`componentCss` plus the existing `mediaBlock` helper):

- the ≥701px heading rule declares `flex: none`, a `max-width` and the ellipsis, the strip keeps
  `flex-shrink: 100`, and the phone branch keeps `flex: 1`;
- neither the app bar nor the selection bar renders a `.spacer`, no `.appbar .spacer` rule
  survives, and the base `.spacer` rule does;
- the Clear button carries the `clear` class, the ≥701px block gives it `margin-left: auto`, and
  the phone block does not.

Full card gate green: `npx eslint .`, `npm run typecheck`, `npx vitest run` (70 files, 1937
tests), `npm run build`. No backend file is touched. The pixel behaviour is verified live on the
clean 2026.7.4 container by the session that opened this.

## Follow-ups

- The 30% cap is a judgement, not a measurement: it keeps "HAventory" (~95px at 18px) whole on
  every bar down to 614px and stops a long dashboard title from taking the row, but no dashboard
  title long enough to hit it exists in the repo's fixtures. If a household reports a title
  clipped earlier than it likes, the cap is the one number to move.
- The selection bar still wraps above 701px (`.appbar.selecting { flex-wrap: wrap }`, unchanged).
  If the sentence ever wraps, Clear lands at the right edge of the second line rather than the
  first; nothing in the issue asks for a different arrangement and it is not reachable at the
  widths measured.

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
