### PR TITLE
chore(skills): add the DOM probe harness to run-haventory

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -357,6 +357,43 @@ running *inside* WSL2 publishes onto the VM rather than the LAN, so that case ad
 needs mirrored networking mode or a `netsh interface portproxy` forward. This is the only way
 to test real fingers, momentum scrolling, iOS Safari, and the HA Companion app's webview.
 
+### Measure the DOM / read a component's state
+
+```bash
+cd .claude/skills/run-haventory
+node probe.mjs --eval 'deepQuery("hv-list").getBoundingClientRect().toJSON()'
+node probe.mjs --element haventory-card --mobile \
+  --search projector --tap '[data-testid="row-secondary"]' --out row.png
+node probe.mjs --viewport 900x800 --locale de-DE \
+  --eval '({ bar: deepQuery(".appbar").clientWidth, heading: deepQuery(".appbar h2").scrollWidth })'
+```
+
+`probe.mjs` is `screenshot.mjs`'s sibling for numbers instead of pixels: same login, the same
+`--path`/`--element`/`--mobile`/`--viewport`/`--locale`/`--dark`, the same actions in the order
+typed (`--search`, `--click`/`--tap`, `--fill '<sel>=><value>'`, `--press`, `--wait`) — plus
+`--eval '<expression>'`, which runs last. It answers what a screenshot only shows: whether that
+chip really fits inside its line, what state a component holds, and — by injecting a `<style>`
+into a shadow root — whether a CSS hypothesis works on the running card before it is written
+into the source. `node probe.mjs --help` lists every flag, and `--out` still takes a screenshot
+of the state the actions left behind.
+
+- The JSON result is the **only** thing on stdout; the target line, each action and any console
+  error go to stderr, so `node probe.mjs --eval … | jq .` works.
+- `deepQuery(sel)` / `deepQueryAll(sel)` are in scope and walk every open shadow root — a plain
+  `querySelector` stops at the first boundary and every HAventory component sits behind one. The
+  expression may `await`, and its value has to survive `JSON.stringify`: return
+  `…getBoundingClientRect().toJSON()` or a plain object of numbers, never a node.
+- Defaults are the sidebar panel (`/haventory`, `haventory-panel`) at 1280x900 with no touch.
+  `--element haventory-card` with no `--path` asks `card_views.mjs` where the card is.
+- **`--viewport` alone only resizes the window**, unlike `screenshot.mjs`: it leaves `isMobile`
+  off, because that flag switches HA to its narrow, sidebar-collapsed layout, which is not the
+  layout a desktop window of the same width has. `--touch` adds the phone emulation, `--mobile`
+  is the whole iPhone 15 descriptor.
+- `--locale de-DE` decides the language only while the **profile's** language is unset (HA then
+  falls back to the browser's); a profile that names a language wins over the flag — set it over
+  WS as under "Screenshot the setup and options screens".
+- [Windows/Git Bash] prefix the command with `MSYS_NO_PATHCONV=1` when you pass `--path /haventory`.
+
 ### Drive the import sheet
 
 `drive_import.mjs` puts a backup document through the card's own Import UI — overflow menu →
@@ -619,7 +656,8 @@ The full gate, with the numbers kept next to it, is the sibling `/test-haventory
 
 The harness has its own unit cover for the parts that decide where a run looks and which
 instance it looks at: `card_views.mjs` (which views hold the card, which URL addresses them,
-what `--path` and `--dashboard` asked for, which `.env` wins) and `surfaces.mjs`, whose
+what `--path` and `--dashboard` asked for, which `.env` wins), `probe.mjs` (which actions
+run in which order, and which screen a measurement was taken on) and `surfaces.mjs`, whose
 tables are checked about themselves — every selector a desktop surface asserts **absent** has
 to be one a narrow surface asserts present, so a typo cannot leave a `hidden` check passing
 vacuously. No HA and no dependency beyond Node:
@@ -698,8 +736,9 @@ destructive clean-start mode), then `Online smoke test completed successfully.`
   back to the browser language whenever the profile has none — so with the profile cleared
   the whole UI, HAventory included, still comes up German and a screenshot proves nothing
   about which language a string came from. Name it: `screenshot.mjs --locale en-US`, or set
-  the profile language over WS (see "Screenshot the setup and options screens"). The other
-  harnesses do not take `--locale`, so drive them by setting the profile.
+  the profile language over WS (see "Screenshot the setup and options screens"). Only
+  `screenshot.mjs` and `probe.mjs` take `--locale`; drive the others by setting the
+  profile.
 - **`HA_CONTAINER` turns `smoke_online.sh` destructive**: when set, the script
   `rm -f`s `haventory_store` inside that container and restarts HA before testing —
   all dev items/locations are gone. Leave it unset unless you *want* a wiped store.

--- a/.claude/skills/run-haventory/probe.mjs
+++ b/.claude/skills/run-haventory/probe.mjs
@@ -1,0 +1,421 @@
+// DOM probe: open an HAventory surface in the real Home Assistant frontend,
+// drive it, and read the DOM back as JSON.
+//
+// screenshot.mjs answers "what does it look like"; this answers "what are the
+// numbers" — the rect a chip really occupies, the computed style a rule really
+// produced, the state a component really holds. It logs in the same way
+// (the long-lived token injected into `hassTokens` before any page script runs)
+// and takes the same shape of arguments, so a measurement and a screenshot of
+// the same screen are two commands that differ in one flag.
+//
+// Usage (from the skill dir, .claude/skills/run-haventory/):
+//   node probe.mjs [--path <ha-url-path>] [--element <selector>]
+//                  [--mobile | --viewport <WxH> [--touch]]
+//                  [--locale <bcp47>] [--dark] [--settle <ms>]
+//                  [--search <text>] [--click <selector>] [--tap <selector>]
+//                  [--fill '<selector>=><value>'] [--press <key>] [--wait <ms>]
+//                  [--eval '<js expression>'] [--out <file.png>] [--full]
+//                  [--help|-h]
+//
+// Defaults: the sidebar panel (`/haventory`, root `haventory-panel`) at
+// 1280x900 with no touch. `--element haventory-card` without a `--path` asks
+// card_views.mjs which dashboard view holds the card, the same as every other
+// harness.
+//
+// --search/--click/--tap/--fill/--press/--wait run in the order given on the
+// command line, so a probe can search, open a row and then measure it. --eval
+// always runs last, once the page has settled.
+//
+// --eval takes ONE JavaScript expression (not statements) and may `await`. Two
+// helpers are in scope: deepQuery(sel) / deepQueryAll(sel) walk every open
+// shadow root, which ordinary `querySelector` will not cross. The value has to
+// survive `JSON.stringify` — return `el.getBoundingClientRect().toJSON()` or a
+// plain object of numbers, never a DOM node. Injecting a `<style>` into a
+// shadow root from here is how a CSS hypothesis is tried on the running card
+// before it is written into the source.
+//
+// The JSON result is the only thing on stdout; the resolved target, the actions
+// and any console error go to stderr, so `node probe.mjs --eval … | jq` works.
+//
+// Viewport, deliberately unlike screenshot.mjs: --viewport alone changes the
+// window size and nothing else. Playwright's `isMobile` makes Home Assistant
+// switch to its narrow, sidebar-collapsed layout, which is a different layout
+// from a desktop window of the same width — measuring one while meaning the
+// other is the mistake this split exists to prevent. --touch adds the phone
+// emulation, --mobile is the whole iPhone 15 descriptor.
+//
+// Reads HA_BASE_URL / HA_TOKEN from the environment or the repo-root .env.
+// [Windows/Git Bash] prefix the command with MSYS_NO_PATHCONV=1: `--path
+// /haventory` is exactly the leading-slash value Git Bash rewrites.
+
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { cardPath, haConfig } from "./card_views.mjs";
+
+const skillDir = path.dirname(fileURLToPath(import.meta.url));
+
+const PANEL_PATH = "/haventory";
+const MOBILE_DEVICE = "iPhone 15";
+const DEFAULT_VIEWPORT = { width: 1280, height: 900 };
+const DEFAULT_SETTLE_MS = 2500;
+const FILL_SEPARATOR = "=>";
+
+/** Flags that drive the page, in command-line order. */
+export const ACTION_FLAGS = new Set(["--search", "--click", "--tap", "--fill", "--press", "--wait"]);
+const VALUE_FLAGS = new Set(["--path", "--element", "--viewport", "--locale", "--settle", "--eval", "--out"]);
+const BOOLEAN_FLAGS = new Set(["--mobile", "--touch", "--dark", "--full", "--help", "-h"]);
+
+/** Every flag the parser accepts; the usage block above is held to it by a test. */
+export const KNOWN_FLAGS = new Set([...VALUE_FLAGS, ...ACTION_FLAGS, ...BOOLEAN_FLAGS]);
+
+export const USAGE = [
+  "node probe.mjs [--path <ha-url-path>] [--element <selector>]",
+  "               [--mobile | --viewport <WxH> [--touch]]",
+  "               [--locale <bcp47>] [--dark] [--settle <ms>]",
+  "               [--search <text>] [--click <selector>] [--tap <selector>]",
+  "               [--fill '<selector>=><value>'] [--press <key>] [--wait <ms>]",
+  "               [--eval '<js expression>'] [--out <file.png>] [--full]",
+  "               [--help|-h]",
+  "",
+  "Defaults: the sidebar panel (/haventory, root haventory-panel) at 1280x900,",
+  "no touch. --element haventory-card with no --path asks card_views.mjs where",
+  "the card is. Actions run in the order typed; --eval runs last and prints its",
+  "JSON to stdout, everything else to stderr.",
+  "",
+  "In --eval, deepQuery(sel)/deepQueryAll(sel) walk every open shadow root, the",
+  "expression may await, and the value must survive JSON.stringify.",
+  "",
+  "  node probe.mjs --eval 'deepQuery(\"hv-list\").getBoundingClientRect().toJSON()'",
+  "  node probe.mjs --mobile --element haventory-card --search projector \\",
+  "                 --tap '[data-testid=\"row-secondary\"]' --out row.png",
+].join("\n");
+
+const asMilliseconds = (flag, raw) => {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${flag} needs a number of milliseconds (got "${raw}")`);
+  }
+  return value;
+};
+
+/** `WxH` as a Playwright viewport, or an error naming the form it wanted. */
+export function parseViewport(raw) {
+  const match = /^(\d+)x(\d+)$/.exec(raw);
+  if (!match) throw new Error(`--viewport expects WxH, e.g. 390x844 (got "${raw}")`);
+  return { width: Number(match[1]), height: Number(match[2]) };
+}
+
+/**
+ * The command line as options plus an ordered action list.
+ *
+ * Anything the parser does not know is an error rather than a default: a
+ * mistyped `--elment` used to leave the run waiting on the default root and
+ * then time out with a message about that root, which says nothing about the
+ * typo that caused it.
+ */
+export function parseArgs(argv) {
+  const options = {
+    path: null,
+    element: "haventory-panel",
+    viewport: null,
+    locale: null,
+    dark: false,
+    mobile: false,
+    touch: false,
+    full: false,
+    settle: DEFAULT_SETTLE_MS,
+    evalExpr: null,
+    out: null,
+  };
+  const actions = [];
+
+  if (argv.includes("--help") || argv.includes("-h")) return { help: true, options, actions };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    let value = null;
+    if (ACTION_FLAGS.has(flag) || VALUE_FLAGS.has(flag)) {
+      value = argv[i + 1];
+      if (value === undefined) throw new Error(`${flag} needs a value`);
+      i += 1;
+    }
+
+    if (ACTION_FLAGS.has(flag)) {
+      if (flag === "--wait") asMilliseconds(flag, value);
+      if (flag === "--fill" && !value.includes(FILL_SEPARATOR)) {
+        throw new Error(`--fill needs '<selector>${FILL_SEPARATOR}<value>' (got "${value}")`);
+      }
+      actions.push({ kind: flag.slice(2), value });
+    } else if (flag === "--path") options.path = value;
+    else if (flag === "--element") options.element = value;
+    else if (flag === "--viewport") options.viewport = parseViewport(value);
+    else if (flag === "--locale") options.locale = value;
+    else if (flag === "--settle") options.settle = asMilliseconds(flag, value);
+    else if (flag === "--eval") options.evalExpr = value;
+    else if (flag === "--out") options.out = value;
+    else if (BOOLEAN_FLAGS.has(flag)) options[flag.slice(2)] = true;
+    else throw new Error(`unknown argument "${flag}"`);
+  }
+
+  return { help: false, options, actions };
+}
+
+/**
+ * The path a root element is reached at without a `--path`, or null when the
+ * instance has to be asked (card_views.mjs owns every dashboard URL).
+ */
+export function defaultPathFor(element) {
+  return /haventory-card/.test(element) ? null : PANEL_PATH;
+}
+
+/**
+ * Playwright context options for the emulation the flags asked for, plus the
+ * label that says which screen the numbers came from.
+ *
+ * `devices` is passed in rather than imported so this stays testable without a
+ * browser install.
+ */
+export function buildContextOptions(options, devices) {
+  // HA's service worker activates 30-90 s into a fresh context and reloads the
+  // page, which kills the JS execution context mid-run. Blocking it costs one
+  // harmless `navigator.serviceWorker` console error from HA's own bundle.
+  let contextOptions = {
+    viewport: { ...DEFAULT_VIEWPORT },
+    serviceWorkers: "block",
+    colorScheme: options.dark ? "dark" : "light",
+  };
+  let label = `desktop ${DEFAULT_VIEWPORT.width}x${DEFAULT_VIEWPORT.height} (no touch)`;
+
+  if (options.mobile) {
+    const descriptor = devices[MOBILE_DEVICE];
+    if (!descriptor) throw new Error(`Playwright has no "${MOBILE_DEVICE}" device descriptor`);
+    contextOptions = { ...descriptor, ...contextOptions, viewport: { ...descriptor.viewport } };
+    label = `${MOBILE_DEVICE} ${descriptor.viewport.width}x${descriptor.viewport.height} (touch)`;
+  } else if (options.viewport) {
+    contextOptions.viewport = { ...options.viewport };
+    if (options.touch) {
+      contextOptions.hasTouch = true;
+      contextOptions.isMobile = true;
+    }
+    label = `${options.viewport.width}x${options.viewport.height} (${options.touch ? "touch" : "no touch"})`;
+  }
+
+  // Chromium takes the host's locale, and HA falls back to the browser language
+  // whenever the profile has none — so on a German host every surface comes up
+  // German with nothing set. Naming the language only decides anything while
+  // the profile's own language is unset; a profile that names one wins.
+  if (options.locale) contextOptions.locale = options.locale;
+
+  return { contextOptions, label };
+}
+
+/** What a broken `--eval` says: the message and the expression, no stack. */
+export function describeEvalFailure(expr, error) {
+  const message = String(error?.message ?? error).split("\n")[0];
+  const shown = expr.length > 200 ? `${expr.slice(0, 200)}…` : expr;
+  return `--eval failed: ${message}\n  expression: ${shown}`;
+}
+
+// --- the run --------------------------------------------------------------
+
+// Runs in the page. `deepQueryAll` walks open shadow roots because a selector
+// never crosses a shadow boundary on its own, and every HAventory component
+// lives inside one.
+const evaluateInPage = (expr) => {
+  const deepQueryAll = (sel, root = document) => {
+    const out = [];
+    const walk = (node) => {
+      if (!node) return;
+      if (node.querySelectorAll) for (const el of node.querySelectorAll(sel)) out.push(el);
+      const kids = node.querySelectorAll ? node.querySelectorAll("*") : [];
+      for (const el of kids) if (el.shadowRoot) walk(el.shadowRoot);
+    };
+    walk(root);
+    return out;
+  };
+  const deepQuery = (sel, root = document) => deepQueryAll(sel, root)[0] ?? null;
+  // eslint-disable-next-line no-new-func
+  const fn = new Function("deepQuery", "deepQueryAll", `return (async () => (${expr}))();`);
+  return fn(deepQuery, deepQueryAll);
+};
+
+async function runActions(page, actions, { rootElement, touchEnabled }) {
+  for (const action of actions) {
+    if (action.kind === "search") {
+      // The card's list search is [data-testid="search-input"]; the full view
+      // and the panel own a different box, each with a placeholder that starts
+      // with the localized word for "search".
+      const search = page
+        .locator(
+          `${rootElement} [data-testid="search-input"], ${rootElement} input[type="search"], ` +
+            `${rootElement} input[placeholder^="Search"], ${rootElement} input[placeholder^="Suche"]`,
+        )
+        .first();
+      await search.waitFor({ state: "visible", timeout: 10000 });
+      await search.fill(action.value);
+      await page.waitForTimeout(1500); // debounce + round trip through the WS filter
+    } else if (action.kind === "click" || action.kind === "tap") {
+      const target = page.locator(action.value).first();
+      await target.waitFor({ state: "visible", timeout: 10000 });
+      if (touchEnabled && action.kind === "tap") await target.tap();
+      else await target.click();
+      await page.waitForTimeout(400);
+    } else if (action.kind === "fill") {
+      const at = action.value.indexOf(FILL_SEPARATOR);
+      const selector = action.value.slice(0, at);
+      const text = action.value.slice(at + FILL_SEPARATOR.length);
+      const field = page.locator(selector).first();
+      await field.waitFor({ state: "visible", timeout: 10000 });
+      await field.fill(text);
+      await page.waitForTimeout(300);
+    } else if (action.kind === "press") {
+      await page.keyboard.press(action.value);
+      await page.waitForTimeout(300);
+    } else if (action.kind === "wait") {
+      await page.waitForTimeout(Number(action.value));
+    }
+    console.error(`[probe] ${action.kind}: ${action.value}`);
+  }
+}
+
+async function main() {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`probe.mjs: ${error.message}`);
+    console.error("node probe.mjs --help lists the flags.");
+    process.exit(2);
+  }
+  if (parsed.help) {
+    console.log(USAGE);
+    return;
+  }
+  const { options, actions } = parsed;
+
+  const { base, token } = haConfig(); // prints the [target] line
+  if (!token) {
+    console.error("Missing HA_TOKEN (env or repo-root .env)");
+    process.exit(2);
+  }
+
+  // Imported here rather than at the top so `--help` and the argument errors
+  // work in a checkout that has never installed the browser, and so the pure
+  // half of this file can be unit-tested without one.
+  let chromium;
+  let devices;
+  try {
+    ({ chromium, devices } = await import("playwright"));
+  } catch {
+    console.error("probe.mjs: playwright is not installed in the skill dir.");
+    console.error("  cd .claude/skills/run-haventory && npm install --no-audit --no-fund && npx playwright install chromium");
+    process.exit(2);
+  }
+  let contextOptions;
+  let label;
+  try {
+    ({ contextOptions, label } = buildContextOptions(options, devices));
+  } catch (error) {
+    console.error(`probe.mjs: ${error.message}`);
+    process.exit(2);
+  }
+  const touchEnabled = Boolean(contextOptions.hasTouch);
+  const rootElement = options.element;
+  const urlPath = options.path ?? defaultPathFor(rootElement) ?? (await cardPath("column"));
+
+  // `hasTouch` alone leaves `'ontouchstart' in window` false, so code that
+  // feature-detects touch that way would take the desktop path.
+  const browser = await chromium.launch({ args: touchEnabled ? ["--touch-events=enabled"] : [] });
+  const context = await browser.newContext(contextOptions);
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+
+  // The HA frontend trusts hassTokens if `expires` is in the future; the
+  // long-lived token works as access_token and clientId must be `${origin}/`.
+  // HA's own dark mode is independent of the OS colour scheme — it reads the
+  // `selectedTheme` entry — so a dark probe sets both.
+  await page.addInitScript(
+    ([hassUrl, accessToken, dark]) => {
+      localStorage.setItem(
+        "hassTokens",
+        JSON.stringify({
+          access_token: accessToken,
+          token_type: "Bearer",
+          refresh_token: "unused-long-lived",
+          expires_in: 1800,
+          expires: Date.now() + 365 * 24 * 3600 * 1000,
+          hassUrl,
+          clientId: hassUrl + "/",
+        }),
+      );
+      if (dark) localStorage.setItem("selectedTheme", JSON.stringify({ dark: true }));
+    },
+    [base, token, options.dark],
+  );
+
+  console.error(`[probe] ${base}${urlPath} root=${rootElement} [${label}, scheme=${contextOptions.colorScheme}]`);
+  await page.goto(base + urlPath, { waitUntil: "domcontentloaded" });
+  if (page.url().includes("/auth/authorize")) {
+    console.error("Redirected to the login page — hassTokens injection was rejected. Is HA_TOKEN valid?");
+    await browser.close();
+    process.exit(1);
+  }
+
+  try {
+    await page.waitForSelector(rootElement, { timeout: 30000 });
+  } catch {
+    // A root that never appears has two very different causes — the wrong root
+    // for this path, or a page whose bundle never loaded — so name both, and
+    // hand over the console.
+    console.error(`Timed out waiting for "${rootElement}" on ${urlPath}.`);
+    console.error('The sidebar panel is "haventory-panel"; a dashboard card is "haventory-card".');
+    for (const e of consoleErrors.slice(0, 10)) console.error(`  ${e}`);
+    await browser.close();
+    process.exit(1);
+  }
+  await page.waitForTimeout(options.settle); // let the root's WS subscription deliver data
+
+  try {
+    await runActions(page, actions, { rootElement, touchEnabled });
+  } catch (error) {
+    console.error(`probe.mjs: ${String(error?.message ?? error).split("\n")[0]}`);
+    await browser.close();
+    process.exit(1);
+  }
+
+  if (options.evalExpr) {
+    let result;
+    try {
+      result = await page.evaluate(evaluateInPage, options.evalExpr);
+    } catch (error) {
+      console.error(describeEvalFailure(options.evalExpr, error));
+      await browser.close();
+      process.exit(1);
+    }
+    console.log(JSON.stringify(result ?? null, null, 2));
+  }
+
+  if (options.out) {
+    const outFile = path.resolve(skillDir, options.out);
+    await page.screenshot({ path: outFile, fullPage: options.full });
+    console.error(`screenshot: ${outFile}`);
+  }
+
+  // HA's own bundle logs a service-worker complaint on every blocked context;
+  // it says nothing about the surface under the probe.
+  const filtered = consoleErrors.filter((e) => !/addEventListener|serviceWorker/.test(e));
+  if (filtered.length) {
+    console.error(`browser console errors (${filtered.length}):`);
+    for (const e of filtered.slice(0, 8)) console.error(`  ${e}`);
+  }
+  await browser.close();
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/.claude/skills/run-haventory/probe.test.mjs
+++ b/.claude/skills/run-haventory/probe.test.mjs
@@ -1,0 +1,170 @@
+// Unit cover for the parts of probe.mjs that decide what a probe run does.
+//
+// The run itself needs a browser and a real Home Assistant, but everything it
+// decides before opening one is pure: which actions run and in which order,
+// which viewport the numbers were measured at, what a broken `--eval` says.
+// A mistake in any of that reports a measurement of the wrong screen, which is
+// worse than no measurement — so those parts are held here.
+//
+// Run: node --test   (from .claude/skills/run-haventory/)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import {
+  KNOWN_FLAGS,
+  USAGE,
+  buildContextOptions,
+  defaultPathFor,
+  describeEvalFailure,
+  parseArgs,
+} from "./probe.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Enough of a Playwright device descriptor for the context builder; the real
+// map comes from playwright, which these tests deliberately do not need.
+const DEVICES = {
+  "iPhone 15": {
+    viewport: { width: 393, height: 659 },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+    userAgent: "Mozilla/5.0 (iPhone)",
+  },
+};
+
+// --- what runs, and in which order ----------------------------------------
+
+test("actions keep the order they were typed in", () => {
+  const { actions } = parseArgs(["--search", "sponge", "--tap", "#a", "--wait", "500", "--click", "#b"]);
+  assert.deepEqual(actions, [
+    { kind: "search", value: "sponge" },
+    { kind: "tap", value: "#a" },
+    { kind: "wait", value: "500" },
+    { kind: "click", value: "#b" },
+  ]);
+});
+
+test("a value that looks like a flag is a value, not a second action", () => {
+  const { actions, options } = parseArgs(["--fill", "#q=>--tap", "--eval", "1 + 1"]);
+  assert.deepEqual(actions, [{ kind: "fill", value: "#q=>--tap" }]);
+  assert.equal(options.evalExpr, "1 + 1");
+});
+
+test("an action flag with nothing after it is refused", () => {
+  assert.throws(() => parseArgs(["--tap"]), /--tap/);
+});
+
+test("a mistyped flag is refused rather than silently ignored", () => {
+  // `--elment haventory-panel` used to fall through to the default root and
+  // then time out for a reason the message never mentioned.
+  assert.throws(() => parseArgs(["--elment", "haventory-panel"]), /--elment/);
+  assert.throws(() => parseArgs(["haventory-panel"]), /haventory-panel/);
+});
+
+test("--wait and --settle insist on a number", () => {
+  assert.throws(() => parseArgs(["--wait", "soon"]), /--wait/);
+  assert.throws(() => parseArgs(["--settle", "a while"]), /--settle/);
+  assert.equal(parseArgs(["--settle", "400"]).options.settle, 400);
+});
+
+test("--fill insists on the selector=>value form", () => {
+  assert.throws(() => parseArgs(["--fill", "#q"]), /--fill/);
+});
+
+test("--viewport insists on WxH", () => {
+  assert.throws(() => parseArgs(["--viewport", "390"]), /WxH|390x844/);
+  assert.deepEqual(parseArgs(["--viewport", "390x844"]).options.viewport, { width: 390, height: 844 });
+});
+
+test("--help wins over everything else on the line", () => {
+  assert.equal(parseArgs(["--help", "--eval", "boom"]).help, true);
+  assert.equal(parseArgs(["-h"]).help, true);
+});
+
+// --- which screen the numbers came from -----------------------------------
+
+test("the default is a stated desktop viewport with the service worker blocked", () => {
+  const { contextOptions, label } = buildContextOptions(parseArgs([]).options, DEVICES);
+  assert.deepEqual(contextOptions.viewport, { width: 1280, height: 900 });
+  assert.equal(contextOptions.serviceWorkers, "block");
+  assert.ok(!contextOptions.hasTouch);
+  assert.equal(contextOptions.colorScheme, "light");
+  assert.match(label, /1280x900/);
+});
+
+test("--mobile takes the iPhone 15 descriptor, touch and all", () => {
+  const { contextOptions, label } = buildContextOptions(parseArgs(["--mobile"]).options, DEVICES);
+  assert.deepEqual(contextOptions.viewport, DEVICES["iPhone 15"].viewport);
+  assert.equal(contextOptions.hasTouch, true);
+  assert.equal(contextOptions.isMobile, true);
+  assert.match(label, /iPhone 15/);
+});
+
+test("--viewport measures the desktop layout unless --touch asks for a phone", () => {
+  // HA switches to its narrow, sidebar-collapsed layout on `isMobile`, so a
+  // measurement of the desktop layout at a narrow window must not set it.
+  const plain = buildContextOptions(parseArgs(["--viewport", "900x800"]).options, DEVICES);
+  assert.deepEqual(plain.contextOptions.viewport, { width: 900, height: 800 });
+  assert.ok(!plain.contextOptions.hasTouch);
+  assert.ok(!plain.contextOptions.isMobile);
+
+  const touched = buildContextOptions(parseArgs(["--viewport", "900x800", "--touch"]).options, DEVICES);
+  assert.equal(touched.contextOptions.hasTouch, true);
+  assert.equal(touched.contextOptions.isMobile, true);
+});
+
+test("--dark and --locale reach the context", () => {
+  const { contextOptions } = buildContextOptions(
+    parseArgs(["--dark", "--locale", "de-DE"]).options,
+    DEVICES,
+  );
+  assert.equal(contextOptions.colorScheme, "dark");
+  assert.equal(contextOptions.locale, "de-DE");
+});
+
+test("the panel is its own path, and the card is asked about", () => {
+  assert.equal(defaultPathFor("haventory-panel"), "/haventory");
+  assert.equal(defaultPathFor("haventory-card"), null);
+  assert.equal(defaultPathFor('haventory-card [data-testid="row-secondary"]'), null);
+});
+
+// --- a run that fails says why --------------------------------------------
+
+test("a failing --eval names the message and the expression, not a stack", () => {
+  const error = new TypeError("Cannot read properties of null (reading 'getBoundingClientRect')");
+  error.stack = `${error.name}: ${error.message}\n    at eval (evaluate:1:1)\n    at run (probe.mjs:1:1)`;
+  const said = describeEvalFailure("deepQuery('.hv-area-chip').getBoundingClientRect()", error);
+  assert.match(said, /Cannot read properties of null/);
+  assert.match(said, /hv-area-chip/);
+  assert.doesNotMatch(said, /\n\s+at /);
+});
+
+// --- the usage block is the documentation ---------------------------------
+
+test("the usage block names every flag the parser takes", () => {
+  for (const name of KNOWN_FLAGS) {
+    assert.ok(USAGE.includes(name), `${name} is parsed but missing from the usage block`);
+  }
+});
+
+test("--help prints the usage and exits 0 without a token", () => {
+  const run = spawnSync(process.execPath, [path.join(here, "probe.mjs"), "--help"], {
+    encoding: "utf8",
+    env: { ...process.env, HA_TOKEN: "", HA_BASE_URL: "", HAVENTORY_IGNORE_ENV_FILE: "1" },
+  });
+  assert.equal(run.status, 0, run.stderr);
+  assert.match(run.stdout, /node probe\.mjs/);
+  assert.match(run.stdout, /--eval/);
+});
+
+test("SKILL.md documents the probe with a runnable example", () => {
+  const skill = readFileSync(path.join(here, "SKILL.md"), "utf8");
+  assert.match(skill, /node probe\.mjs[^\n]*--eval/);
+  assert.match(skill, /--locale/);
+});


### PR DESCRIPTION
## What was wrong

The V0.7.1 sweep wrote a Playwright DOM probe to measure the card on the running instance —
the rect a chip really occupies, the width a heading really needs — and left it untracked in
a worktree. Nothing in the skill mentioned it, so the next session that needs a measurement
writes it again. It also had none of the conventions the other harnesses keep: no `--help`,
no usage block, a mistyped flag silently fell through to a default and then timed out on the
default root, and a failing `--eval` came out as a raw Playwright stack.

## What changed

`.claude/skills/run-haventory/probe.mjs` is now tracked and brought up to the other
harnesses' conventions. It stays a separate script — `screenshot.mjs` answers what a surface
looks like, this one answers what its numbers are — and takes the same shape of arguments:
same login, `--path`/`--element`/`--mobile`/`--viewport`/`--locale`/`--dark`, the same actions
in the order typed (`--search`, `--click`/`--tap`, `--fill`, `--press`, `--wait`), plus
`--eval '<expression>'` with `deepQuery`/`deepQueryAll` shadow-root walkers in scope, and an
optional `--out` screenshot of the state the actions left behind.

- A header usage block and `--help`, both working without a token and without an installed
  browser: Playwright is imported only once a run is really starting, and the message for a
  missing one names the install command.
- An unknown or valueless flag is refused by name (`--elment` used to leave the run waiting
  on the default root and time out with a message about that root), `--viewport` insists on
  `WxH`, `--wait`/`--settle` on a number, `--fill` on `<selector>=><value>`.
- `--viewport` alone only resizes the window. `isMobile` switches Home Assistant to its
  narrow, sidebar-collapsed layout, which is not the layout a desktop window of that width
  has, so a desktop measurement must not set it; `--touch` adds the phone emulation and
  `--mobile` is the whole iPhone 15 descriptor. The default is a stated 1280x900.
- The `[target]` line prints before anything runs, the JSON result is the only thing on
  stdout (so `| jq` works), and a failing `--eval` reports its message and the expression
  rather than a stack. `--element haventory-card` with no `--path` asks `card_views.mjs`
  where the card is, like every other card-driving harness.
- `SKILL.md` gains the section next to the screenshot one — three examples, the shadow-root
  and JSON rules, the viewport difference, and the rule that `--locale` only decides anything
  while the profile's language is unset. The harness unit-cover paragraph names the probe,
  and the locale gotcha no longer claims `screenshot.mjs` is the only harness taking the flag.

## How it was tested

`probe.test.mjs` holds the pure half — action order, a value that looks like a flag, every
refusal above, the emulation each flag builds, the default path per root element, the eval
failure text, `--help` as a real subprocess with no token, and the usage block against the
flag list. Red before the change (the module had no exports at all), green after.

```
cd .claude/skills/run-haventory
node --check probe.mjs && node probe.mjs --help
node --test        # 54 pass / 0 fail (37 before)
```

The run half needs a browser and an instance; the session drives it live against the clean
container.

## Follow-ups

- `screenshot.mjs` and `probe.mjs` now carry two copies of the `hassTokens` init script and
  of the console-error filter. A shared `login.mjs` would hold one copy, and is a change to
  the screenshot harness this PR deliberately does not make.
- `--eval` takes one expression, not statements. A multi-statement probe has to be written as
  an IIFE; supporting a statement body would need a second `new Function` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
