### PR TITLE
fix(card): drop the phone row's area pill whole instead of slicing it

### DIFF
--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -502,6 +502,97 @@ describe('hv-list-row: mobile affordances', () => {
   });
 });
 
+// An ellipsis only ever replaces text, and the area pill in the middle of this
+// line is an atomic box: a checked-out row with an overdue date left it no room
+// and it was cut where the edge fell — "Living Ro" — while every other row on
+// the same screen elided its path with a "…".
+describe('hv-list-row: the phone line’s pieces', () => {
+  const deepPath = {
+    id_path: [],
+    name_path: [],
+    display_path: 'Workshop / Parts Cabinet / Drawer A / Small Bin',
+    sort_key: '',
+  };
+  const garage = [{ id: 'area-workshop', name: 'Garage' }];
+
+  it('lays the line out as lead, area and tail, reading as it always did', async () => {
+    const el = await mount(
+      {
+        checked_out: true,
+        due_date: '2000-01-02',
+        category: 'Tools',
+        effective_area_id: 'area-workshop',
+        location_path: deepPath,
+      },
+      { mobile: true, areas: garage },
+    );
+    const secondary = q(el, '[data-testid="row-secondary"]');
+    const pieces = [...(secondary?.children ?? [])];
+
+    expect(pieces.map((piece) => piece.getAttribute('data-testid'))).toEqual([
+      'row-lead',
+      'row-area',
+      'row-tail',
+    ]);
+    expect(pieces[0].textContent).toBe('Overdue · due Jan 2, 2000');
+    expect(pieces[1].querySelector('[data-testid="area-chip"]')?.textContent).toContain('Garage');
+    expect(pieces[2].textContent).toBe('… › Small Bin · Tools');
+    expect(secondary?.textContent).toContain('Overdue · due Jan 2, 2000 · ');
+  });
+
+  // The separator rides with whatever follows the lead, so a line that drops
+  // that piece drops the dot with it rather than ending on one.
+  it('gives the separator to the piece that follows the lead', async () => {
+    const withArea = await mount(
+      { checked_out: true, due_date: '2000-01-02', category: null, effective_area_id: 'area-workshop', location_path: deepPath },
+      { mobile: true, areas: garage },
+    );
+    expect(q(withArea, '[data-testid="row-lead"]')?.textContent).toBe('Overdue · due Jan 2, 2000');
+    expect(q(withArea, '[data-testid="row-area"]')?.textContent?.startsWith(' · ')).toBe(true);
+    expect(q(withArea, '[data-testid="row-tail"]')?.textContent).toBe('… › Small Bin');
+
+    const noArea = await mount(
+      { checked_out: true, due_date: '2000-01-02', category: null, location_path: deepPath },
+      { mobile: true },
+    );
+    expect(q(noArea, '[data-testid="row-area"]')).toBe(null);
+    expect(q(noArea, '[data-testid="row-tail"]')?.textContent).toBe(' · Workshop › … › Small Bin');
+  });
+
+  it('leads with nothing on a row that is only where the item is', async () => {
+    const el = await mount(
+      { category: null, effective_area_id: 'area-workshop', location_path: deepPath },
+      { mobile: true, areas: garage },
+    );
+    const secondary = q(el, '[data-testid="row-secondary"]');
+
+    expect(q(el, '[data-testid="row-lead"]')).toBe(null);
+    // No lead to separate it from, so the pill opens the line as it always did.
+    expect(q(el, '[data-testid="row-area"]')?.textContent?.startsWith(' · ')).toBe(false);
+    expect(secondary?.textContent).toContain('… › Small Bin');
+  });
+
+  // jsdom lays nothing out, so the rules are what can be asserted here; the
+  // measurement is a live one.
+  it('caps the line at its first row of pieces, and drops what does not fit whole', () => {
+    const css = componentCss('hv-list-row');
+
+    expect(css).toMatch(/:host\(\[mobile\]\) \.secondary \{[^}]*flex-wrap: wrap/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.secondary \{[^}]*max-height: 24px/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.secondary \{[^}]*overflow: hidden/);
+    // What keeps the cap honest: the wrapped row starts far below the first, so
+    // a dropped piece cannot show its top edge under the text.
+    expect(css).toMatch(/:host\(\[mobile\]\) \.secondary \{[^}]*row-gap: 200px/);
+    // The lead elides in place; the tail takes what is left and elides in that.
+    expect(css).toMatch(/:host\(\[mobile\]\) \.secondary > \.lead \{[^}]*text-overflow: ellipsis/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.secondary > \.tail \{[^}]*flex: 1 1 0/);
+    expect(css).toMatch(/:host\(\[mobile\]\) \.secondary > \.tail \{[^}]*min-width: 4ch/);
+    // The pill is no longer spaced by a margin of its own — the row's gap does
+    // it, and a margin would double it.
+    expect(css).not.toMatch(/:host\(\[mobile\]\) \.secondary \.hv-area-chip \{[^}]*margin-right/);
+  });
+});
+
 describe('hv-list-row: selection mode', () => {
   it('swaps row navigation for a checkbox', async () => {
     const el = await mount({ id: 'item-1' }, { selectable: true });

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -26,6 +26,7 @@ import {
   pictures,
 } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
+import type { TemplateResult } from 'lit';
 import type { AreaRef, Item, StatusDefinition } from '../store/types';
 import './hv-overflow-menu';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
@@ -205,17 +206,78 @@ export class HVListRow extends LitElement {
       .secondary.hv-chip-line {
         display: flex;
       }
-      /* The wide row's area pill, inside a line that is a text run rather than a
-         row of chips. The fill is what separates the area from the path after
-         it: as plain text in the same colour and weight, a root location named
-         after its own area printed the word twice with a single space between
-         them and nothing to say which was which.
+      /*
+       * The phone line: pieces on a row, capped at the first row of them.
+       *
+       * An ellipsis only ever replaces text, and the area pill in the middle of
+       * this line is an atomic box — inside one elided text run it was cut where
+       * the edge fell, so a row leading with an overdue loan ended in half a
+       * room name with nothing to say it had been cut. As flex items the pieces
+       * are placed whole or not at all: the lead elides in place, and a pill or
+       * tail the line cannot afford wraps onto a second row.
+       *
+       * That second row is what the cap hides, and the row-gap is what makes the
+       * cap safe: it pushes the wrapped pieces far below the first row, so the
+       * cap only has to clear the tallest piece instead of matching whatever
+       * line-height the line inherits. A line with nothing to drop keeps its own
+       * height, so a row without an area does not grow to meet the cap. 24px
+       * clears the pill, which is the tallest thing here — 11.5px of text at
+       * 1.4, plus its padding and border.
+       */
+      :host([mobile]) .secondary {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        align-content: flex-start;
+        column-gap: 6px;
+        row-gap: 200px;
+        max-height: 24px;
+        overflow: hidden;
+      }
+      /* First on the line and never wrapped away: what the row is flagged with
+         is why the line is being read at all. It elides only when it alone
+         outruns the line. */
+      :host([mobile]) .secondary > .lead {
+        flex: 0 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      /* The pill and the " · " that introduces it travel as one piece, so a line
+         with no room for the pill drops the separator with it rather than ending
+         on a dot. Those two spaces are the piece's own text, and white-space:
+         pre is what keeps them — a flex item's leading and trailing spaces are
+         dropped otherwise.
 
-         The margin is the gap the wide line gets from its flex layout. The line
-         itself stays a block with inline content, because text-overflow does not
-         apply to a flex container and the path tail has to keep its ellipsis. */
-      :host([mobile]) .secondary .hv-area-chip {
-        margin-right: 6px;
+         The pill's fill is what separates the area from the path after it: as
+         plain text in the same colour and weight, a root location named after
+         its own area printed the word twice with a single space between them and
+         nothing to say which was which. */
+      :host([mobile]) .secondary > .area {
+        display: flex;
+        align-items: center;
+        flex: 0 1 auto;
+        min-width: 0;
+        white-space: pre;
+      }
+      /* A room name long enough to outrun the whole line elides inside the pill
+         rather than being cut at the line's edge — the shared chip rule elides
+         the label, and reaching it needs the pill to be allowed to shrink, which
+         that rule holds at flex: none for the rows of chips elsewhere. */
+      :host([mobile]) .secondary > .area > .hv-area-chip {
+        flex: 0 1 auto;
+        min-width: 0;
+      }
+      /* Takes what the pieces before it leave and elides inside it; below the
+         floor it wraps away instead, because two characters of a location name
+         and an ellipsis name nothing. */
+      :host([mobile]) .secondary > .tail {
+        flex: 1 1 0;
+        min-width: 4ch;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       /* The path elides; the chip ahead of it does not. */
       .secondary.hv-chip-line > .hv-chip-line-text {
@@ -243,10 +305,10 @@ export class HVListRow extends LitElement {
         color: var(--hv-warn);
         font-weight: 500;
       }
+      /* Only ever drawn on the phone line, which is a flex row — so the space
+         after it is that row's gap, and a margin of its own would double it. */
       .dot {
-        display: inline-block;
-        vertical-align: middle;
-        margin-right: 6px;
+        flex: none;
         width: 6px;
         height: 6px;
         border-radius: 50%;
@@ -535,6 +597,31 @@ export class HVListRow extends LitElement {
     `;
   }
 
+  /**
+   * The phone row's second line, as up to three pieces: what the row leads
+   * with, the area pill, and the location tail.
+   *
+   * Three elements rather than one run of text, because an ellipsis only
+   * replaces text and the pill between them is an atomic box — see the
+   * `:host([mobile]) .secondary` rule for what the pieces buy. The " · " that
+   * introduces whichever piece follows the lead sits inside that piece, so a
+   * line that drops it drops the separator with it; a line that has no lead
+   * opens on the pill, which is how it always read.
+   */
+  private _mobileSecondary(lead: TemplateResult | null, area: string | null, tail: string) {
+    return html`${lead === null
+      ? null
+      : html`<span class="lead" data-testid="row-lead">${lead}</span>`}${area === null
+      ? null
+      : html`<span class="area" data-testid="row-area"
+          >${lead === null ? '' : ' · '}${renderAreaChip(area)}</span
+        >`}${tail
+      ? html`<span class="tail" data-testid="row-tail"
+          >${lead !== null && area === null ? ' · ' : ''}${tail}</span
+        >`
+      : null}`;
+  }
+
   render() {
     const item = this.item;
     if (!item) return null;
@@ -555,7 +642,6 @@ export class HVListRow extends LitElement {
     const mobileLead = elideMobilePath(areaMark, parts.path);
     const mobileTail = [mobileLead.rest, item.category].filter(Boolean).join(' · ');
     const hasMobileSecondary = Boolean(mobileLead.area || mobileTail);
-    const mobileSecondary = html`${renderAreaChip(mobileLead.area)}${mobileTail}`;
     // The tooltip carries the *unelided* path: on a phone the middle of it is
     // dropped on purpose, and this is where the whole thing can still be read.
     const secondaryFull = [pathTitle(parts), item.category].filter(Boolean).join(' · ');
@@ -632,20 +718,34 @@ export class HVListRow extends LitElement {
               ? html`<span class="dot" data-testid="row-low-dot"></span>`
               : null}
             ${this.mobile && item.checked_out
-              ? html`${overdue ? t('hv.term.overdue') : t('hv.term.checkedOut')}${item.due_date
-                  ? ` · ${t('hv.term.due', { date: formatDate(item.due_date) })}`
-                  : ''}${hasMobileSecondary ? html` · ${mobileSecondary}` : ''}`
+              ? this._mobileSecondary(
+                  html`${overdue ? t('hv.term.overdue') : t('hv.term.checkedOut')}${item.due_date
+                    ? ` · ${t('hv.term.due', { date: formatDate(item.due_date) })}`
+                    : ''}`,
+                  mobileLead.area,
+                  mobileTail,
+                )
               : this.mobile && flagged
-                ? html`<span data-testid="row-status">${statusLabel(status, this.statuses)}</span>${hasMobileSecondary
-                    ? html` · ${mobileSecondary}`
-                    : ''}`
+                ? this._mobileSecondary(
+                    html`<span data-testid="row-status">${statusLabel(status, this.statuses)}</span>`,
+                    mobileLead.area,
+                    mobileTail,
+                  )
                 : this.mobile && inspectionDue
-                  ? html`<span data-testid="row-inspection-due">${t('hv.term.inspectionDue')}</span> ·
-                      ${formatDate(item.inspection_date)}`
+                  ? // The one phone line that says nothing about where the item
+                    // is: the chore and its date take all of it.
+                    this._mobileSecondary(
+                      html`<span data-testid="row-inspection-due">${t('hv.term.inspectionDue')}</span> ·
+                        ${formatDate(item.inspection_date)}`,
+                      null,
+                      '',
+                    )
                   : this.mobile
-                    ? hasMobileSecondary
-                      ? mobileSecondary
-                      : t('hv.term.noLocation')
+                    ? this._mobileSecondary(
+                        null,
+                        mobileLead.area,
+                        hasMobileSecondary ? mobileTail : t('hv.term.noLocation'),
+                      )
                     : html`${renderAreaChip(areaMark)}<span class="hv-chip-line-text"
                         >${secondary || t('hv.term.noLocation')}</span
                       >`}

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -364,6 +364,15 @@ mark is the separator, and it costs the line about what that separator cost. An 
 that itself contains ` › ` splits into two segments and comes back unmarked, which reads as
 the line always did rather than marking the wrong words.
 
+That line is three elements rather than one run of text — the lead the row is flagged with,
+the pill, and the path tail. An ellipsis only ever replaces text, and the pill is an atomic
+box: on a checked-out row with an overdue date the line ran out of room beside *Check in*
+and the pill was cut mid-word, while every other row on the screen elided its path with a
+"…". As flex items on a wrapping row capped at its first line, a piece that does not fit
+wraps out of sight and is dropped whole instead. The " · " that introduces whichever piece
+follows the lead sits inside that piece, so a line that drops the piece drops the separator
+with it rather than ending on a dot.
+
 Both live in `ui/location-path.ts`, because `hv-data-table` writes the same line: its
 `narrow` property — the phone breakpoint, handed down by `hv-full-view`, which is the only
 thing that can read a media query on the table's behalf — swaps the wrapping location cell


### PR DESCRIPTION
## What was wrong

On the card's narrow branch a row's second line was one run of text with the area pill in
the middle of it, elided with `text-overflow: ellipsis`. An ellipsis only ever replaces
text, and the pill is an atomic inline box: a checked-out row that leads with "Overdue ·
due Aug 10 · " leaves it no room next to *Check in*, so it was cut where the line's edge
fell — "Living Ro" — while every other row on the same screen elided its path with a "…".
The flagged branch ("Needs repair · [pill] path") has the same shape.

## What changed

`hv-list-row`'s phone line is now up to three pieces — the lead the row is flagged with
(`row-lead`), the area pill (`row-area`) and the path tail (`row-tail`) — laid out as flex
items on a wrapping row capped at its first line:

- the lead is first and never wraps away; it elides only when it alone outruns the line,
- the pill is placed whole or wraps onto the second line, which the cap hides,
- the tail takes what is left and elides in it, or wraps away below a 4ch floor.

The visible characters are what they were: the " · " that introduces whichever piece
follows the lead rides inside that piece, so a line that drops the piece drops the
separator with it rather than ending on a dot. The pill's `margin-right` and the low-stock
dot's give way to the row's `column-gap`. The wide row's line is untouched.

Two details differ from the plan's sketch, both to keep the row's height where it is:

- the cap is made safe by a large `row-gap` rather than by pinning the line's
  `line-height` to the pill's height. The gap pushes the wrapped pieces far below the first
  line, so the cap only has to clear the tallest piece (24px, the pill: 11.5px of text at
  1.4 plus its padding and border) instead of forcing every phone line — including the rows
  with no area at all — to grow to that height.
- the pill piece may shrink rather than being held at `flex: none`, so a room name long
  enough to outrun the whole line elides inside the pill (the shared chip rule's own
  elision) instead of being cut at the line's edge.

## How it was tested

`cards/haventory-card`: `npx eslint .`, `npm run typecheck`, `npx vitest run` (1938 passed),
`npm run build`. Four new cases in `hv-list-row.test.ts`, red before the change and green
after: the checked-out line renders lead, pill and tail as separate children in that order
with today's text; the separator belongs to the piece after the lead, and to the tail when
there is no pill; a line with no lead opens on the pill; and the mobile line's CSS declares
the wrap, the cap, the row-gap and the pieces' own elision. jsdom lays nothing out, so the
measurement at 390px — pill fully inside the line or hidden below it, row height unchanged,
a deep path still ending in "…", the same in German — is a live check.

## Follow-ups

- The `.dot` low-stock mark is only ever drawn on this line, so its rule now assumes the
  flex row. If a wide row ever grows one, it needs its own spacing again.

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
