### PR TITLE
refactor(storage): delete the debounced persist path nothing calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,9 @@ helpers assume a UTF-8 terminal. Develop on Windows through WSL2.
   concurrency** via the item `version` are invariants the rest of the code depends on.
   `location_path` is derived: no client writes it, and rewriting it must not touch an item's
   `version` or `updated_at` — a location rename is not an item edit.
-- **Persistence**: WS and service handlers save immediately, errors propagating as
-  `storage_error`; shutdown and unload flush immediately; debounced saves are for internal or
-  batch work only and go through `hass.async_create_background_task`.
+- **Persistence**: every write is awaited where it is made — WS and service handlers save
+  immediately, errors propagating as `storage_error`; shutdown and unload flush immediately.
+  There is one persist path and no scheduled one.
 - **Deleting or renaming a file inside `custom_components/haventory/`** means appending its old
   path to `RETIRED_PATHS` in the same PR — a HACS upgrade leaves it behind otherwise.
 - **Logging**: take the module logger from `logs.context_logger(__name__)`, never

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -83,7 +83,6 @@ from .storage import (
     DomainStore,
     async_backup_store,
     async_persist_immediate,
-    cancel_pending_persist,
     read_schema_version,
     schema_downgrade_message,
 )
@@ -503,13 +502,11 @@ async def _async_options_updated(hass: HomeAssistant, entry: HAventoryConfigEntr
 async def _async_flush_pending_writes(hass: HomeAssistant, *, op: str) -> None:
     """Write out whatever is still unsaved, before the state that holds it goes.
 
-    A pending debounce is cleared either way: with nothing loaded there is
-    nothing to write, and leaving the task scheduled would only fire it against
-    a repository that is on its way out.
+    With no runtime there is nothing to write: the repository the write would
+    read is already gone.
     """
 
     if find_runtime(hass) is None:
-        cancel_pending_persist(hass, op=op)
         return
 
     try:

--- a/custom_components/haventory/runtime.py
+++ b/custom_components/haventory/runtime.py
@@ -86,9 +86,6 @@ class HAventoryRuntime:
     # Serializes every write to the one store file. Per entry, because it guards
     # that entry's store and nothing else.
     persist_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    # The pending debounced write, cancelled by anything that is about to write
-    # itself or to take the repository away.
-    persist_task: asyncio.Task[None] | None = None
     subscriptions: dict[Any, dict[int, Subscription]] = field(default_factory=dict)
     # Which items were low when the last mutation was announced. Seeded at setup
     # so a restart re-announces nothing, and diffed after every mutation.

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -15,7 +15,6 @@ forward-only migrations when an older schema payload is encountered.
 
 from __future__ import annotations
 
-import asyncio
 import time
 from collections.abc import Mapping
 from copy import deepcopy
@@ -43,9 +42,6 @@ CURRENT_SCHEMA_VERSION: Final[int] = 9
 
 # Storage key under which the persisted dataset is saved
 STORAGE_KEY: Final[str] = "haventory_store"
-
-# Debounce delay for persistence operations (seconds)
-PERSIST_DEBOUNCE_DELAY: Final[float] = 1.0
 
 # How much of a corrupt ``schema_version`` the refusal quotes back. The value is
 # whatever the file holds, and the message reaches the config entry's error state
@@ -390,87 +386,13 @@ async def async_persist_repo(hass: HomeAssistant) -> None:
             raise StorageError("failed to persist repository") from exc
 
 
-def cancel_pending_persist(hass: HomeAssistant, *, op: str = "persist_cancel") -> None:
-    """Cancel a scheduled debounced persist, if one is pending.
-
-    Anything about to write itself — or about to take away the repository the
-    write would read — has to clear the pending task first, or it fires against
-    state that has moved on.
-    """
-    runtime = find_runtime(hass)
-    if runtime is None:
-        return
-
-    existing_task = runtime.persist_task
-    if existing_task is None or existing_task.done():
-        return
-
-    existing_task.cancel()
-    _LOGGER.debug(
-        "Cancelled pending persist task",
-        extra={"domain": DOMAIN, "op": op},
-    )
-
-
-async def async_request_persist(hass: HomeAssistant) -> None:
-    """Request a debounced persistence operation.
-
-    Cancels any pending persist task and schedules a new one — as a Home
-    Assistant tracked background task — after the debounce delay. This coalesces
-    rapid changes into a single persistence operation, reducing disk I/O while
-    maintaining data safety.
-
-    The debounce delay is PERSIST_DEBOUNCE_DELAY (1.0 seconds by default).
-    """
-    runtime = find_runtime(hass)
-    if runtime is None:
-        raise NotLoadedError("HAventory runtime not initialized; run integration setup")
-
-    cancel_pending_persist(hass, op="persist_debounce_cancel")
-
-    async def _delayed_persist() -> None:
-        """Execute persistence after debounce delay."""
-        try:
-            await asyncio.sleep(PERSIST_DEBOUNCE_DELAY)
-            await async_persist_repo(hass)
-        except asyncio.CancelledError:
-            # Task was cancelled, this is expected
-            _LOGGER.debug(
-                "Debounced persist task cancelled",
-                extra={"domain": DOMAIN, "op": "persist_debounce_cancelled"},
-            )
-        except Exception:  # pragma: no cover - defensive
-            _LOGGER.error(
-                "Debounced persist task failed",
-                extra={"domain": DOMAIN, "op": "persist_debounce_failed"},
-                exc_info=True,
-            )
-
-    _LOGGER.debug(
-        "Persist requested, debouncing",
-        extra={
-            "domain": DOMAIN,
-            "op": "persist_debounce_request",
-            "delay_s": PERSIST_DEBOUNCE_DELAY,
-        },
-    )
-
-    # Schedule through HA rather than asyncio directly: hass tracks the task and
-    # cancels/awaits it during shutdown, so a pending debounce cannot outlive the
-    # event loop.
-    runtime.persist_task = hass.async_create_background_task(
-        _delayed_persist(), name=f"{DOMAIN} debounced persist"
-    )
-
-
 async def async_persist_immediate(hass: HomeAssistant) -> None:
-    """Persist immediately, bypassing debounce.
+    """Persist from a path with no client waiting on the answer.
 
-    Cancels any pending debounced persist task and executes persistence
-    synchronously. Use this for critical paths like shutdown where we need
-    to ensure data is written to disk before the process exits.
+    The rewrite after a lossy load and the teardown flush both write through
+    here. Neither surfaces in a handler's reply, so this log line is what tells
+    an operator reading the log that the write was attempted at all.
     """
-    cancel_pending_persist(hass, op="persist_immediate_cancel")
 
     _LOGGER.debug(
         "Immediate persist requested",

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -839,9 +839,9 @@ def broadcast_counts(hass: HomeAssistant) -> None:
 async def _persist_repo(hass: HomeAssistant) -> None:
     """Write the repository to disk, propagating failure to the caller.
 
-    Uses immediate persistence so storage errors reach clients: debounced
-    persistence (``async_request_persist``) swallows errors in background tasks,
-    breaking the ``@ws_guard`` error mapping contract.
+    The write is awaited rather than handed to a background task, because that
+    is what puts a storage failure in front of ``@ws_guard`` and so in the
+    client's reply as ``storage_error``.
 
     **Every mutation handler awaits this before it broadcasts or replies.** That
     ordering is the whole guarantee an event carries: a subscriber that receives

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -204,7 +204,6 @@ uniquely-named item and deletes it (best-effort cleanup even on failure).
   - **WebSocket / service handlers**: immediate saves via `async_persist_repo` — storage
     errors propagate to clients as `storage_error`.
   - **Shutdown/unload**: immediate save via `async_persist_immediate`.
-  - **Debounced saves**: `async_request_persist` for batch/internal operations only.
   - **Concurrency**: all persist paths use `asyncio.Lock` to serialize writes.
 - Repository generation counter increments on every state modification (optimistic locking/debugging).
 - WebSocket-first CRUD via `homeassistant.components.websocket_api` decorators.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1086,15 +1086,3 @@ else:
         pass
 
     _install_offline_ha_stubs()
-
-    # Pytest fixtures for testing
-
-    # Import project storage module after HA stubs are installed
-    import pytest
-    from custom_components.haventory import storage as storage_mod
-
-    @pytest.fixture
-    def immediate_persist(monkeypatch):
-        """Fixture that makes persistence immediate instead of debounced for faster tests."""
-        # Replace async_request_persist with async_persist_repo to make it immediate
-        monkeypatch.setattr(storage_mod, "async_request_persist", storage_mod.async_persist_repo)

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -2,21 +2,12 @@
 
 Confirms a mutation is written through Home Assistant's ``Store`` backend and can
 be read back by a fresh store instance — the real serialize/deserialize path,
-not the offline in-memory stub.
-
-The debounced write is here for a sharper reason. ``async_request_persist``
-schedules through ``hass.async_create_background_task`` precisely so Home
-Assistant holds the task and cancels it at shutdown; the offline stub forwards
-that call to a plain ``asyncio`` task, which nothing tracks, so the property the
-scheduling exists for is the one offline tests cannot see.
+not the offline in-memory stub. The unload flush and the reload after it are
+here because only a real core sequences an entry's teardown around them.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-
-from custom_components.haventory import storage as storage_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import (
@@ -24,20 +15,9 @@ from custom_components.haventory.storage import (
     STORAGE_KEY,
     DomainStore,
     async_persist_immediate,
-    async_request_persist,
 )
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-# Short enough that a test can wait it out, long enough that the assertion
-# taken before it elapses is not a race. The debounce rides ``asyncio.sleep``
-# rather than Home Assistant's clock helpers, so ``async_fire_time_changed``
-# would not move it — a real, shortened delay is the honest way to drive it.
-SHORT_DEBOUNCE = 0.05
-
-# Longer than any of these tests take, so a debounce scheduled with it can only
-# end by being cancelled — never by firing on its own.
-UNREACHABLE_DEBOUNCE = 300.0
 
 
 async def test_store_write_and_reload_roundtrip(hass: HomeAssistant, hass_storage: dict) -> None:
@@ -119,76 +99,3 @@ async def test_setup_after_unload_reads_back_what_the_flush_wrote(
     assert second_runtime is not first_runtime
     names = [item.name for item in second_runtime.repository.list_items()["items"]]
     assert names == ["Across the reload"]
-
-
-async def test_a_debounced_persist_lands_in_the_store_only_after_its_window(
-    hass: HomeAssistant, hass_storage: dict, monkeypatch
-) -> None:
-    """The window is a window: nothing is written until it elapses, then it is.
-
-    A debounce that wrote immediately would pass every "the data is on disk"
-    assertion while coalescing nothing, so both halves are asserted here.
-    """
-
-    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", SHORT_DEBOUNCE)
-
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Straight onto the repository, so only the debounce can carry it to disk.
-    find_runtime(hass).repository.create_item({"name": "Debounced"})
-    await async_request_persist(hass)
-
-    pending = find_runtime(hass).persist_task
-    assert pending is not None
-    # Home Assistant is holding it. That is what makes shutdown cancel and await
-    # the task instead of destroying it while pending, and it is exactly what
-    # the offline stub's untracked `asyncio.create_task` cannot show.
-    assert pending in hass._background_tasks
-
-    assert STORAGE_KEY not in hass_storage
-
-    await asyncio.sleep(SHORT_DEBOUNCE * 4)
-
-    assert pending.done()
-    stored = hass_storage[STORAGE_KEY]["data"]
-    assert [item["name"] for item in stored["items"].values()] == ["Debounced"]
-
-
-async def test_the_unload_flush_beats_a_debounce_that_has_not_fired(
-    hass: HomeAssistant, hass_storage: dict, monkeypatch, caplog
-) -> None:
-    """Teardown writes the mutation and leaves no task behind to write it again.
-
-    With a debounce this long the only way the item reaches the store is the
-    teardown flush, and the only way the task can be finished afterwards is
-    cancellation — so a green run says both happened, in that order.
-    """
-
-    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", UNREACHABLE_DEBOUNCE)
-    caplog.set_level(logging.DEBUG, logger="custom_components.haventory.storage")
-
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    find_runtime(hass).repository.create_item({"name": "Flushed past the debounce"})
-    await async_request_persist(hass)
-    pending = find_runtime(hass).persist_task
-    assert pending is not None
-
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Finished, without having reached the end of a five-minute sleep. The task
-    # swallows its own cancellation and returns normally, so the log line is
-    # what names the way it ended.
-    assert pending.done()
-    assert pending.exception() is None
-    assert any("op=persist_immediate_cancel" in record.getMessage() for record in caplog.records)
-
-    stored = hass_storage[STORAGE_KEY]["data"]
-    assert [item["name"] for item in stored["items"].values()] == ["Flushed past the debounce"]

--- a/tests/test_diagnostics_offline.py
+++ b/tests/test_diagnostics_offline.py
@@ -84,7 +84,6 @@ async def test_the_payload_answers_shape_questions() -> None:
         "card_title",
         "low_stock_ids",
         "persist_lock",
-        "persist_task",
         "quick_filters",
         "rate_limiter",
         "repository",

--- a/tests/test_entry_removal_refusal_offline.py
+++ b/tests/test_entry_removal_refusal_offline.py
@@ -1,9 +1,9 @@
 """Offline tests: once the config entry is removed, the API refuses.
 
 Home Assistant cannot unregister a WebSocket command, so the ``haventory/*``
-commands keep listening after the integration is gone. Removal drops the loaded
-runtime — store, repository, limiter, subscriptions, any pending write — which
-is what turns "still listening" into "refuses", instead of a dashboard left open
+commands keep listening after the integration is gone. Removal writes out what is
+unsaved and then drops the loaded runtime — store, repository, limiter,
+subscriptions — which turns "still listening" into "refuses", instead of a dashboard left open
 going on reading and writing an inventory nothing owns any more.
 
 These tests call ``async_remove_entry`` without ``async_unload_entry`` first.
@@ -16,11 +16,9 @@ ordering against a real core.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 import pytest
-from custom_components.haventory import storage as storage_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.runtime import find_runtime
@@ -120,9 +118,7 @@ async def test_removal_stops_persistence(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_removal_flushes_before_dropping(monkeypatch) -> None:
-    """A debounced write pending at removal lands, and then fires no second time."""
-
-    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
+    """What the repository holds and the store does not is written out at removal."""
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
@@ -135,18 +131,11 @@ async def test_removal_flushes_before_dropping(monkeypatch) -> None:
     monkeypatch.setattr(store, "async_save", _record)
 
     repo_of(hass).create_item({"name": "Unsaved"})
-    await storage_mod.async_request_persist(hass)
-    pending = runtime_of(hass).persist_task
 
     await remove_entry(hass, entry)
 
-    assert len(saved) == 1, "removal writes the pending state out"
+    assert len(saved) == 1, "removal writes the unsaved state out"
     assert [item["name"] for item in saved[0]["items"].values()] == ["Unsaved"]
-
-    await asyncio.sleep(0.2)
-
-    assert pending.cancelled() or pending.done()
-    assert len(saved) == 1, "the cancelled debounce never fired against a dropped store"
 
 
 @pytest.mark.asyncio

--- a/tests/test_entry_unload_refusal_offline.py
+++ b/tests/test_entry_unload_refusal_offline.py
@@ -17,12 +17,10 @@ WebSocket, against a real core.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 import pytest
 from custom_components.haventory import services as services_mod
-from custom_components.haventory import storage as storage_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import NotLoadedError
@@ -119,9 +117,7 @@ async def test_unload_keeps_the_static_route_flag() -> None:
 
 @pytest.mark.asyncio
 async def test_unload_flushes_before_dropping(monkeypatch) -> None:
-    """A debounced write pending at unload lands, and then fires no second time."""
-
-    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
+    """What the repository holds and the store does not is written out at unload."""
 
     hass = HomeAssistant()
     entry = await _setup_entry(hass)
@@ -134,18 +130,11 @@ async def test_unload_flushes_before_dropping(monkeypatch) -> None:
     monkeypatch.setattr(store, "async_save", _record)
 
     repo_of(hass).create_item({"name": "Unsaved"})
-    await storage_mod.async_request_persist(hass)
-    pending = runtime_of(hass).persist_task
 
     await unload_entry(hass, entry)
 
-    assert len(saved) == 1, "unload writes the pending state out"
+    assert len(saved) == 1, "unload writes the unsaved state out"
     assert [item["name"] for item in saved[0]["items"].values()] == ["Unsaved"]
-
-    await asyncio.sleep(0.2)
-
-    assert pending.cancelled() or pending.done()
-    assert len(saved) == 1, "the cancelled debounce never fired against a dropped store"
 
 
 @pytest.mark.asyncio

--- a/tests/test_stale_files_offline.py
+++ b/tests/test_stale_files_offline.py
@@ -163,9 +163,7 @@ async def test_nothing_retired_touches_no_files_at_all() -> None:
 
 
 @pytest.mark.asyncio
-async def test_setup_entry_sweeps_the_retired_paths(
-    install_dir: Path, monkeypatch, immediate_persist
-) -> None:
+async def test_setup_entry_sweeps_the_retired_paths(install_dir: Path, monkeypatch) -> None:
     """The sweep is wired into setup, which is the only thing that runs it."""
     stale = install_dir / "reminders.py"
     stale.write_text("LEGACY = True\n", encoding="utf-8")

--- a/tests/test_storage_concurrency_offline.py
+++ b/tests/test_storage_concurrency_offline.py
@@ -1,7 +1,7 @@
-"""Tests for storage concurrency, locking, and debouncing.
+"""Tests for storage concurrency and locking.
 
-Verifies that the persistence layer correctly handles concurrent operations,
-prevents race conditions, and properly debounces rapid changes.
+Verifies that the persistence layer serializes writes to the one store file and
+survives concurrent mutations.
 """
 
 import asyncio
@@ -9,45 +9,12 @@ import logging
 from unittest.mock import AsyncMock
 
 import pytest
-from custom_components.haventory import storage as storage_mod
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.models import ItemCreate, ItemUpdate
 from custom_components.haventory.repository import Repository
-from custom_components.haventory.storage import (
-    PERSIST_DEBOUNCE_DELAY,
-    DomainStore,
-    async_persist_immediate,
-    async_persist_repo,
-    async_request_persist,
-)
-from custom_components.haventory.ws import setup as ws_setup
+from custom_components.haventory.storage import DomainStore, async_persist_repo
 from homeassistant.core import HomeAssistant
 
-from runtime_helpers import install_runtime, runtime_of
-from ws_helpers import ws_send
-
-# Named constants for test assertions
-RAPID_MUTATION_COUNT = 3
-
-
-class _TrackedTaskHass(HomeAssistant):
-    """hass double that records the background tasks it is handed.
-
-    Mirrors ``HomeAssistant.async_create_background_task``'s signature so the
-    debounced persist path is driven through the same call it makes against a
-    real core, and keeps every scheduled task addressable for assertions. It
-    subclasses the stub rather than standing alone because the persist path
-    resolves its runtime through `hass.config_entries`.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.background_tasks: list[tuple[str, asyncio.Task]] = []
-
-    def async_create_background_task(self, target, name, eager_start=True):
-        task = asyncio.create_task(target, name=name)
-        self.background_tasks.append((name, task))
-        return task
+from runtime_helpers import install_runtime
 
 
 @pytest.mark.asyncio
@@ -77,185 +44,6 @@ async def test_persist_lock_prevents_concurrent_saves():
 
     # Verify operations were serialized (each completes before next starts)
     assert save_order == ["start", "end", "start", "end", "start", "end"]
-
-
-@pytest.mark.asyncio
-async def test_debounce_coalesces_rapid_changes():
-    """Rapid persist requests are coalesced into a single save operation."""
-    hass = _TrackedTaskHass()
-
-    # Create mock store that counts save calls
-    mock_store = AsyncMock(spec=DomainStore)
-    save_count = []
-
-    async def count_save(data):
-        save_count.append(1)
-
-    mock_store.async_save = count_save
-
-    # Create repository and store
-    repo = Repository()
-    install_runtime(hass, repository=repo, store=mock_store)
-
-    # Request multiple rapid persists
-    for _ in range(10):
-        await async_request_persist(hass)
-        await asyncio.sleep(0.01)  # 10ms between requests
-
-    # Wait for debounce delay plus buffer
-    await asyncio.sleep(PERSIST_DEBOUNCE_DELAY + 0.2)
-
-    # Should have only saved once (all requests coalesced)
-    assert len(save_count) == 1
-
-
-@pytest.mark.asyncio
-async def test_debounce_cancels_pending_task():
-    """New persist request cancels previous pending task."""
-    hass = _TrackedTaskHass()
-
-    mock_store = AsyncMock(spec=DomainStore)
-    mock_store.async_save = AsyncMock()
-
-    repo = Repository()
-    install_runtime(hass, repository=repo, store=mock_store)
-
-    # Request first persist
-    await async_request_persist(hass)
-    first_task = runtime_of(hass).persist_task
-    assert first_task is not None
-    assert not first_task.done()
-
-    # Request second persist before first completes
-    await asyncio.sleep(0.1)  # Wait a bit but not full delay
-    await async_request_persist(hass)
-    second_task = runtime_of(hass).persist_task
-
-    # Give time for cancellation to propagate
-    await asyncio.sleep(0.01)
-
-    # First task should be cancelled or done
-    assert first_task.cancelled() or first_task.done()
-    assert second_task is not first_task
-
-
-@pytest.mark.asyncio
-async def test_immediate_persist_bypasses_debounce():
-    """Immediate persist cancels pending debounced task and saves immediately."""
-    hass = _TrackedTaskHass()
-
-    mock_store = AsyncMock(spec=DomainStore)
-    save_times = []
-
-    async def record_save(data):
-        save_times.append(asyncio.get_event_loop().time())
-
-    mock_store.async_save = record_save
-
-    repo = Repository()
-    install_runtime(hass, repository=repo, store=mock_store)
-
-    # Request debounced persist
-    start_time = asyncio.get_event_loop().time()
-    await async_request_persist(hass)
-
-    # Immediately request immediate persist
-    await asyncio.sleep(0.1)
-    await async_persist_immediate(hass)
-
-    # Should have saved immediately, not after debounce delay
-    elapsed = save_times[0] - start_time
-    assert elapsed < PERSIST_DEBOUNCE_DELAY
-
-
-@pytest.mark.asyncio
-async def test_debounce_schedules_ha_tracked_background_task(monkeypatch):
-    """The debounced persist is scheduled through hass, not asyncio directly.
-
-    A task handed to Home Assistant is cancelled and awaited on shutdown; a bare
-    asyncio task is not, so the scheduling call itself is the contract here.
-    """
-    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
-
-    hass = _TrackedTaskHass()
-    saved: list[dict] = []
-
-    async def record_save(data):
-        saved.append(data)
-
-    mock_store = AsyncMock(spec=DomainStore)
-    mock_store.async_save = record_save
-    repo = Repository()
-    repo.create_item(ItemCreate(name="Tracked"))
-    install_runtime(hass, repository=repo, store=mock_store)
-
-    await async_request_persist(hass)
-
-    assert len(hass.background_tasks) == 1
-    name, task = hass.background_tasks[0]
-    assert DOMAIN in name
-    assert runtime_of(hass).persist_task is task
-
-    await asyncio.sleep(0.2)
-
-    assert task.done()
-    assert len(saved) == 1
-    assert len(saved[0]["items"]) == 1
-
-
-@pytest.mark.asyncio
-async def test_debounce_coalesces_across_tracked_tasks(monkeypatch):
-    """Every request gets its own tracked task, but only the last one persists."""
-    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
-
-    hass = _TrackedTaskHass()
-    saved: list[dict] = []
-
-    async def record_save(data):
-        saved.append(data)
-
-    mock_store = AsyncMock(spec=DomainStore)
-    mock_store.async_save = record_save
-    install_runtime(hass, repository=Repository(), store=mock_store)
-
-    for _ in range(RAPID_MUTATION_COUNT):
-        await async_request_persist(hass)
-        await asyncio.sleep(0.01)
-
-    await asyncio.sleep(0.2)
-
-    assert len(hass.background_tasks) == RAPID_MUTATION_COUNT
-    assert all(task.done() for _, task in hass.background_tasks)
-    assert len(saved) == 1
-
-
-@pytest.mark.asyncio
-async def test_debounced_tracked_task_reports_failure_without_raising(monkeypatch, caplog):
-    """A failing debounced persist is logged inside the task, never propagated.
-
-    The tracked task belongs to Home Assistant once scheduled, so a storage
-    failure has to surface as a log record rather than as a task exception.
-    """
-    caplog.set_level(logging.ERROR)
-    monkeypatch.setattr(storage_mod, "PERSIST_DEBOUNCE_DELAY", 0.05)
-
-    hass = _TrackedTaskHass()
-
-    async def refuse_save(_data):
-        raise OSError("disk went away")
-
-    failing_store = AsyncMock(spec=DomainStore)
-    failing_store.async_save = refuse_save
-    install_runtime(hass, store=failing_store)
-
-    await async_request_persist(hass)
-    _, task = hass.background_tasks[0]
-
-    await asyncio.sleep(0.2)
-
-    assert task.done()
-    assert task.exception() is None
-    assert any("Debounced persist task failed" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -331,59 +119,3 @@ async def test_persist_with_timing_logs(caplog):
     assert any("Repository persisted successfully" in rec.message for rec in caplog.records)
     # Check that elapsed_ms is in the extra dict of at least one record
     assert any(hasattr(rec, "elapsed_ms") for rec in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_debounce_request_logs(caplog):
-    """Debounced persist requests log appropriately."""
-    caplog.set_level(logging.DEBUG)
-
-    hass = _TrackedTaskHass()
-
-    mock_store = AsyncMock(spec=DomainStore)
-    mock_store.async_save = AsyncMock()
-
-    repo = Repository()
-    install_runtime(hass, repository=repo, store=mock_store)
-
-    await async_request_persist(hass)
-
-    # Check for debounce logs
-    assert any("Persist requested, debouncing" in rec.message for rec in caplog.records)
-
-
-# -----------------------------------------------------------------------------
-# Integration test: verify WS handlers use immediate persistence for error propagation
-# -----------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_ws_mutations_use_immediate_persistence(monkeypatch):
-    """WS mutations use immediate persistence to ensure storage errors propagate.
-
-    Verifies that each WS mutation triggers an immediate persist (async_persist_repo),
-    not debounced persistence. This ensures @ws_guard can catch and report StorageError.
-    """
-    hass = HomeAssistant()
-    repo = Repository()
-    install_runtime(hass, repository=repo)
-    store = DomainStore(hass)
-    runtime_of(hass).store = store
-    ws_setup(hass)
-
-    # Track calls to async_persist_repo (immediate)
-    immediate_calls: list[bool] = []
-
-    async def track_immediate(h):
-        immediate_calls.append(True)
-
-    monkeypatch.setattr(storage_mod, "async_persist_repo", track_immediate)
-
-    # Execute multiple WS mutations
-    await ws_send(hass, 1, "haventory/item/create", name="Item 1")
-    await ws_send(hass, 2, "haventory/item/create", name="Item 2")
-    await ws_send(hass, 3, "haventory/item/create", name="Item 3")
-
-    # Each WS mutation should trigger an immediate persist
-    assert len(immediate_calls) == RAPID_MUTATION_COUNT
-    assert len(immediate_calls) > 0, "WS must use immediate persistence for error propagation"


### PR DESCRIPTION
## Summary

`async_request_persist` had no caller inside `custom_components/`. Every WebSocket and service mutation awaits `async_persist_repo` directly, and the two teardown paths write through `async_persist_immediate`, so the scheduled write existed only to be tested. This deletes it and everything that was there to hold it up.

Production: `PERSIST_DEBOUNCE_DELAY`, `cancel_pending_persist`, `async_request_persist`, `HAventoryRuntime.persist_task` and `storage.py`'s `import asyncio`. `_async_flush_pending_writes` becomes "write if there is a runtime" — the cancel-and-return branch had nothing left to cancel. `async_persist_immediate` stays: it has two callers (the rewrite after a lossy load and the teardown flush) and its debug line is what names those writes in the log; its docstring no longer describes itself as the opposite of a debounce, and `ws.py`'s `_persist_repo` docstring now says why the write is awaited rather than what the deleted function did with errors.

Tests: the six debounce cases and `_TrackedTaskHass` in `test_storage_concurrency_offline.py`, `test_debounce_request_logs`, and `test_ws_mutations_use_immediate_persistence` (it asserted that WS does not use a path that no longer exists); the two phacc debounce tests and the module docstring paragraph justifying them; the `immediate_persist` fixture and its one consumer's parameter; the `persist_task` key in the diagnostics expectation. The two refusal tests keep their flush half and stage the unsaved state on the repository instead of on a pending task — the store still has to receive exactly one write carrying the item, which is what they were about.

Docs: `docs/developing.md`'s "Debounced saves" line and CLAUDE.md's persistence convention lose the debounce clause. No WebSocket schema, error code or field moves, so `docs/backend_api_contract.md` and `docs/data_shapes.md` are unchanged. No file leaves `custom_components/haventory/`, so `RETIRED_PATHS` is unchanged.

Refs #230 (item 3), BE-LIFE-L1, TESTS-T2.

## Counting

| | lines |
| --- | --- |
| production removed | 93 |
| test lines removed | 413 |
| lines added | 27 |

(`git diff --stat`: 13 files changed, 27 insertions, 510 deletions; the remaining 4 removed lines are `CLAUDE.md` and `docs/developing.md`.)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` — 1329 passed, 26 skipped; `uv run ruff check .` — All checks passed; `uv run ruff format --check .` — 188 files already formatted; `uv run mypy` — Success: no issues found in 26 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` — 70 files, 1941 passed, `npm run build` — clean
- [x] phacc (`scripts/test_integration.sh`, card built first): **153 passed in 20.66s** — the two deleted debounce tests are the difference from 155; `test_the_unload_flush_reaches_the_store_it_is_giving_up` and `test_setup_after_unload_reads_back_what_the_flush_wrote` are the ones that matter here and stay green.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — this is a cut, so its tests are deleted or have their debounce half removed; none was rewritten to pass.
- [x] Docs updated where behavior changed (`docs/developing.md`, `CLAUDE.md`).
- [x] WebSocket API unchanged, so `ws.py`, `docs/backend_api_contract.md` and `docs/data_shapes.md` stay in sync.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Decisions taken against drifted notes

- BE-LIFE-L1 lists `async_persist_immediate` among what goes, with its two callers moved onto `async_persist_repo`. The plan's §6.M1 PR 1, written a day later, says it stays where it has callers. Kept, per the plan: the two callers are the writes no client is waiting on, and the `persist_immediate_request` debug line is the only thing that marks them in the log. Its docstring is rewritten so it no longer names the debounce.

## Follow-ups

- `scripts/stress_test.py` counts `Persist requested, debouncing` and `Cancelled pending persist task` into `debounce_requests` / `debounce_cancels`, and scenario 1 is titled "Debounce Validation" with an "expected 1-3 persists" line. Those counters already read zero today, because nothing in production has requested a debounced write for some time, so this PR changes nothing there. Not filed: the docs/scripts audit on #230 already marks `scripts/stress_test.py` **cut — superseded** by `.claude/skills/test-haventory/stress.py`, which is M6's package.

## Handover

1. **Merged / left open** — this PR, for the M1 master to merge once CI is green.
2. **Test this by hand** — nothing. No user-visible surface moves: no WebSocket command, service, card string or stored payload changes.
3. **Validate locally** — nothing new to click through; the behaviour this touches is pinned by `tests/integration/test_persistence.py::test_the_unload_flush_reaches_the_store_it_is_giving_up` and `::test_setup_after_unload_reads_back_what_the_flush_wrote`. If a step is wanted anyway: `[dev-ha]` deploy this branch, edit an item, restart Home Assistant from Developer Tools, and the edit is still there; `[log]` nothing at ERROR carrying `haventory` across the restart.
4. **Decisions taken against drifted notes** — the `async_persist_immediate` line above.
5. **Follow-ups** — `scripts/stress_test.py`'s debounce metrics, above; not filed.
6. **State left behind** — branch `claude/v0-8-0-m1-debounced-persist`, one commit, nothing stacked on it. No assets branch. Counting for this PR: 93 production lines removed, 413 test lines removed, 27 added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L8sdndwVjV3JGfckyMBh5y)_