### PR TITLE
refactor(ws): one door for every broadcast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ Each module documents its own traps; this is the map to which file to open.
 - `storage.py` — HA `Store`, schema versioning, serialized writes, and the refusal to read a
   store a newer schema wrote. `migrations.py` is forward-only and **idempotent**.
 - `ws.py` — the primary API surface: CRUD, the four subscription topics, and `ws_guard`.
+- `subscriptions.py` — the subscription registry and the fan-out that writes events on the
+  wire; `events.py` holds the doors every write path announces through, one per topic, and
+  is the only module that calls the broadcaster.
 - `services.py` / `services.yaml` — `haventory.*`; read the registration comment before changing
   how a handler is bound.
 - `stale_files.py` — `RETIRED_PATHS`, swept on setup because a HACS upgrade never deletes.

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -86,6 +86,7 @@ from .storage import (
     read_schema_version,
     schema_downgrade_message,
 )
+from .subscriptions import notify_backend_unavailable
 
 LOGGER = context_logger(__name__)
 
@@ -507,7 +508,7 @@ async def _async_teardown_entry(hass: HomeAssistant, *, op: str, release_panel: 
 
     await _async_flush_pending_writes(hass, op=op)
 
-    ws_mod.notify_backend_unavailable(hass)
+    notify_backend_unavailable(hass)
 
     # Hand back the frontend module URL; setup re-adds it on the next load. The
     # static route stays, along with the flag that records it: aiohttp cannot

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -1,23 +1,25 @@
 """Announcing a mutation — to WebSocket subscribers, to the bus, to the sensors.
 
-One call per mutation path covers all three. Every path — WebSocket handler,
-`haventory.*` service, bulk operation, import — calls `notify_mutation` after
-its durable write, which broadcasts the `items` event to subscribed clients,
-fires `haventory_item_changed` on the bus, diffs the low-stock set to fire
-`haventory_low_stock`, dispatches the signal the sensors repaint on, and
-broadcasts the fresh `stats` counts. A command that rewrites many items at once
-calls `notify_bulk_mutation` instead: one `items` event and one counts event for
-the batch, a bus event per item, one diff and one repaint.
+Every write path announces itself through one of the doors here, and each door
+covers all three surfaces at once. A path that reached `subscriptions.py`
+directly would tell a card what it never told the bus, so the two would disagree
+about the same edit.
 
-That the two surfaces are one call is the point rather than a convenience: they
-were two, and every `haventory.*` service call reached the bus and no subscriber
-at all, so a card left open showed a stale list until something made it re-list.
-
-A location mutation calls `notify_location_mutation`, which broadcasts the
-`locations` event and the counts and repaints, but announces nothing on the bus —
-no item changed, only the tree the items are counted and pathed against.
-`notify_location_changed` is the repaint on its own, for the paths that have
-already broadcast.
+- `notify_mutation`, after the durable write of one item: it broadcasts the
+  `items` event, fires `haventory_item_changed` on the bus, diffs the low-stock
+  set to fire `haventory_low_stock`, dispatches the signal the sensors repaint
+  on, and broadcasts the fresh `stats` counts.
+- `notify_bulk_mutation`, for a command that rewrote many items: one `items`
+  event and one counts event for the batch, a bus event per item, one diff and
+  one repaint.
+- `notify_dataset_replaced`, for an import: a `reloaded` event on both item
+  topics, and no per-row announcement anywhere.
+- `notify_location_mutation`, which broadcasts the `locations` event and the
+  counts and repaints, but announces nothing on the bus — no item changed, only
+  the tree the items are counted and pathed against. `notify_location_changed`
+  is the repaint on its own, for the paths that have already broadcast.
+- `notify_status_mutation`, for the status vocabulary: the `statuses` topic and
+  nothing else, because a label is neither an item nor a count.
 
 Bus events bypass the rate limiter: it budgets WebSocket subscription traffic,
 and these are internal to Home Assistant. The WebSocket half charged here is
@@ -204,6 +206,22 @@ def notify_bulk_mutation(
         )
 
 
+def notify_dataset_replaced(hass: HomeAssistant) -> None:
+    """Announce that the whole dataset was rewritten, after the persist.
+
+    One `reloaded` event per topic and no per-item announcement at all: an
+    import replaces items and locations wholesale, and both an automation and a
+    card want one signal rather than one per row. Passing no item to
+    ``notify_mutation`` leaves it the rest of its job — the low-stock diff still
+    runs, so a restock done by import announces itself, the sensors repaint, and
+    the counts go out.
+    """
+
+    broadcast_event(hass, topic="items", action="reloaded", payload=None)
+    broadcast_event(hass, topic="locations", action="reloaded", payload=None)
+    notify_mutation(hass, action="reloaded")
+
+
 def notify_location_mutation(
     hass: HomeAssistant,
     *,
@@ -254,6 +272,30 @@ def notify_location_changed(hass: HomeAssistant) -> None:
             "Failed to repaint after a location change",
             extra={"domain": DOMAIN, "op": "notify_location_changed"},
         )
+
+
+def notify_status_mutation(
+    hass: HomeAssistant,
+    *,
+    action: str,
+    status: dict[str, Any] | None = None,
+    statuses: list[dict[str, Any]] | None = None,
+) -> None:
+    """Announce a change to the status vocabulary, after the persist.
+
+    The `statuses` topic alone. A status is a label items may carry: defining,
+    renaming or removing one moves no item, no count and nothing an entity
+    renders, so there is nothing to fire on the bus and nothing to repaint. A
+    delete that reassigns the items off the slug announces those beside this
+    call, as the ordinary bulk item mutation they are.
+
+    ``statuses`` carries the whole vocabulary for a reorder, which is the one
+    action that describes the list rather than an entry of it; ``status``
+    carries the single entry for the rest.
+    """
+
+    payload = {"statuses": statuses} if statuses is not None else {"status": status}
+    broadcast_event(hass, topic="statuses", action=action, payload=payload)
 
 
 def _fire_item_changed(hass: HomeAssistant, action: str, item: dict[str, Any]) -> None:

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -54,12 +54,6 @@ from .subscriptions import broadcast_counts, broadcast_event
 
 LOGGER = context_logger(__name__)
 
-# The WebSocket items vocabulary, reused verbatim: an automation and a card
-# client describe the same mutation with the same word.
-ITEM_ACTIONS: frozenset[str] = frozenset(
-    {"created", "updated", "moved", "quantity_changed", "checked_out", "checked_in", "deleted"}
-)
-
 
 def seed_low_stock_snapshot(hass: HomeAssistant) -> None:
     """Record which items are low at setup, so a restart re-announces nothing.

--- a/custom_components/haventory/events.py
+++ b/custom_components/haventory/events.py
@@ -48,6 +48,7 @@ from .const import (
 from .logs import context_logger
 from .models import iso_utc_now
 from .runtime import HAventoryRuntime, find_runtime
+from .subscriptions import broadcast_counts, broadcast_event
 
 LOGGER = context_logger(__name__)
 
@@ -56,29 +57,6 @@ LOGGER = context_logger(__name__)
 ITEM_ACTIONS: frozenset[str] = frozenset(
     {"created", "updated", "moved", "quantity_changed", "checked_out", "checked_in", "deleted"}
 )
-
-
-def _broadcast_event(
-    hass: HomeAssistant, *, topic: str, action: str, payload: dict[str, Any] | None = None
-) -> None:
-    """Hand one event to the WebSocket broadcaster.
-
-    The import is function-local because `ws.py` imports this module at its own
-    module scope; at module scope here the two would be a cycle. Python caches
-    the module, so every call after the first is a dictionary lookup.
-    """
-
-    from .ws import broadcast_event  # noqa: PLC0415 - the cycle, see above
-
-    broadcast_event(hass, topic=topic, action=action, payload=payload)
-
-
-def _broadcast_counts(hass: HomeAssistant) -> None:
-    """Hand the fresh counts to the WebSocket broadcaster. Local import as above."""
-
-    from .ws import broadcast_counts  # noqa: PLC0415 - the cycle, see above
-
-    broadcast_counts(hass)
 
 
 def seed_low_stock_snapshot(hass: HomeAssistant) -> None:
@@ -117,7 +95,7 @@ def async_track_day_rollover(hass: HomeAssistant) -> Callable[[], None]:
     @callback
     def _rollover(_now: datetime) -> None:
         try:
-            _broadcast_counts(hass)
+            broadcast_counts(hass)
         except Exception:
             # Best-effort, as every announcement here is, and for a sharper
             # reason: an exception escaping into the tracker can take the next
@@ -165,7 +143,7 @@ def notify_mutation(
             return
 
         if item is not None:
-            _broadcast_event(hass, topic="items", action=action, payload={"item": item})
+            broadcast_event(hass, topic="items", action=action, payload={"item": item})
             _fire_item_changed(hass, action, item)
 
         _fire_low_stock_transitions(hass, runtime, item=item)
@@ -173,7 +151,7 @@ def notify_mutation(
         async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
 
         if counts:
-            _broadcast_counts(hass)
+            broadcast_counts(hass)
     except Exception:  # pragma: no cover - defensive
         LOGGER.exception(
             "Failed to notify a mutation",
@@ -184,7 +162,7 @@ def notify_mutation(
 def notify_counts(hass: HomeAssistant) -> None:
     """Broadcast the counts alone, for a batch that suppressed them per row."""
 
-    _broadcast_counts(hass)
+    broadcast_counts(hass)
 
 
 def notify_bulk_mutation(
@@ -208,7 +186,7 @@ def notify_bulk_mutation(
         # One `items` event for the batch, carrying no row: a subscriber is
         # being told its list is stale, not which rows moved, and a payload per
         # row would be a whole inventory on the wire.
-        _broadcast_event(hass, topic="items", action=action, payload=None)
+        broadcast_event(hass, topic="items", action=action, payload=None)
 
         for item in items:
             _fire_item_changed(hass, action, item)
@@ -218,7 +196,7 @@ def notify_bulk_mutation(
         _fire_low_stock_transitions(hass, runtime, item=None)
 
         async_dispatcher_send(hass, SIGNAL_INVENTORY_CHANGED)
-        _broadcast_counts(hass)
+        broadcast_counts(hass)
     except Exception:  # pragma: no cover - defensive
         LOGGER.exception(
             "Failed to notify a bulk mutation",
@@ -246,10 +224,10 @@ def notify_location_mutation(
     `locations_total` and every `location_path` stay exactly as they were.
     """
 
-    _broadcast_event(hass, topic="locations", action=action, payload={"location": location})
+    broadcast_event(hass, topic="locations", action=action, payload={"location": location})
     if repaint:
         notify_location_changed(hass)
-    _broadcast_counts(hass)
+    broadcast_counts(hass)
 
 
 def notify_location_changed(hass: HomeAssistant) -> None:

--- a/custom_components/haventory/runtime.py
+++ b/custom_components/haventory/runtime.py
@@ -48,8 +48,9 @@ if TYPE_CHECKING:
 class Subscription(TypedDict, total=False):
     """One open `haventory/subscribe`, as the broadcaster matches it.
 
-    Lives here rather than in `ws.py` because the registry holding these is a
-    field of the runtime, and typing that field from `ws.py` would be a cycle.
+    Lives here rather than in `subscriptions.py` because the registry holding
+    these is a field of the runtime, and typing that field from the module that
+    reads the registry would be a cycle.
     """
 
     topic: str

--- a/custom_components/haventory/subscriptions.py
+++ b/custom_components/haventory/subscriptions.py
@@ -1,0 +1,400 @@
+"""The subscription registry and the fan-out that writes events onto the wire.
+
+`haventory/subscribe` records a topic and its filters against the connection
+that asked; every announcement is matched against those filters here and written
+to the connections that want it. The registry itself is a field of the runtime,
+so it goes when the config entry does.
+
+This module is the wire, not the announcement. `events.py` holds the doors a
+mutation calls — one per topic — and imports this at module scope; nothing here
+imports `events.py` or `ws.py` back. A handler that broadcast from here directly
+would reach subscribers without firing the bus event and repainting the entities
+beside them, which is the split `events.py` exists to prevent.
+
+Delivery is best-effort by contract: a broadcast runs after the mutation is
+persisted, so a failure on one connection must not reach the client whose
+command succeeded, nor stop the fan-out reaching the others.
+"""
+
+from __future__ import annotations
+
+import functools
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .logs import context_logger
+from .models import today_local_date
+from .runtime import Subscription, find_runtime, loaded_runtime
+
+LOGGER = context_logger(__name__)
+
+
+# -----------------------------
+# The registry
+# -----------------------------
+
+
+def open_subscriptions(
+    hass: HomeAssistant,
+) -> dict[websocket_api.ActiveConnection, dict[int, Subscription]]:
+    """The open subscriptions, or an empty map when no runtime holds any.
+
+    A regular dict rather than a WeakKeyDictionary, because HA's
+    `ActiveConnection` does not support weak references; cleanup is the close
+    callback registered in `_register_close_listener`. That callback fires when
+    the *connection* closes, which can be long after the entry went — so this
+    resolves without the loaded check and answers `{}` rather than raising out
+    of a close callback.
+    """
+
+    runtime = find_runtime(hass)
+    if runtime is None:
+        return {}
+    return cast(
+        "dict[websocket_api.ActiveConnection, dict[int, Subscription]]", runtime.subscriptions
+    )
+
+
+def register_subscription(
+    hass: HomeAssistant,
+    conn: websocket_api.ActiveConnection,
+    sub_id: int,
+    sub: Subscription,
+) -> None:
+    """Record one open subscription and arm both teardown paths for it."""
+
+    open_subscriptions(hass).setdefault(conn, {})[sub_id] = sub
+    _register_close_listener(hass, conn)
+    _register_framework_unsub(hass, conn, sub_id)
+
+
+def unregister_subscription(
+    hass: HomeAssistant, conn: websocket_api.ActiveConnection, sub_id: int
+) -> bool:
+    """Drop one subscription on the client's request; True when it was open."""
+
+    subs_all = open_subscriptions(hass)
+    removed = False
+    subs_for_conn = subs_all.get(conn)
+    if subs_for_conn:
+        removed = subs_for_conn.pop(sub_id, None) is not None
+        if not subs_for_conn:
+            subs_all.pop(conn, None)
+    # Keep HA's own subscription registry in sync with this explicit teardown.
+    _unregister_framework_unsub(conn, sub_id)
+    return removed
+
+
+def _cleanup_subscriptions_for_conn(hass: HomeAssistant, conn: object) -> None:
+    """Remove all subscriptions for a given connection."""
+
+    subs_all = open_subscriptions(hass)
+    subs_all.pop(cast("websocket_api.ActiveConnection", conn), None)
+
+
+def _drop_subscription(hass: HomeAssistant, conn: object, sub_id: int) -> None:
+    """Remove a single subscription from the per-connection bucket.
+
+    Registered as the zero-arg teardown callback in HA's ``connection.subscriptions``
+    registry (see ``_register_framework_unsub``). Safe to call repeatedly and after
+    the connection bucket has already been cleaned up.
+    """
+
+    subs_all = open_subscriptions(hass)
+    subs_for_conn = subs_all.get(cast("websocket_api.ActiveConnection", conn))
+    if subs_for_conn is None:
+        return
+    subs_for_conn.pop(sub_id, None)
+    if not subs_for_conn:
+        subs_all.pop(cast("websocket_api.ActiveConnection", conn), None)
+
+
+def _register_framework_unsub(
+    hass: HomeAssistant, conn: websocket_api.ActiveConnection, sub_id: int
+) -> None:
+    """Register the subscription teardown in HA's own subscription registry.
+
+    ``ActiveConnection.subscriptions`` maps a message id to a zero-arg unsubscribe
+    callback, and HA core's generic ``unsubscribe_events`` command pops-and-calls
+    it. The frontend's ``subscribeMessage`` lifecycle tears down via exactly that
+    command, so without an entry here HA core replies ``not_found``
+    ("Subscription not found.") on every teardown — surfacing as an unhandled
+    rejection in the card. Registering the id makes the standard lifecycle work.
+    """
+
+    conn.subscriptions[sub_id] = functools.partial(_drop_subscription, hass, conn, sub_id)
+
+
+def _unregister_framework_unsub(conn: websocket_api.ActiveConnection, sub_id: int) -> None:
+    """Drop the HA-registry entry for a subscription torn down via our own command.
+
+    Keeps ``haventory/unsubscribe`` and HA core's ``unsubscribe_events`` symmetric so
+    a subscription removed through the dedicated command leaves no stale callback in
+    ``connection.subscriptions``.
+    """
+
+    conn.subscriptions.pop(sub_id, None)
+
+
+def _register_close_listener(hass: HomeAssistant, conn: websocket_api.ActiveConnection) -> None:
+    """Have the connection drop its subscriptions when it closes.
+
+    ``ActiveConnection.subscriptions`` holds zero-arg callbacks Home Assistant
+    invokes on disconnect, so registering there is what keeps a client that
+    vanishes from leaking subscription state.
+
+    Idempotency is derived from the state itself, not stamped on the connection:
+    real HA's ``ActiveConnection`` is ``__slots__``-based (no ``__dict__``), so a
+    ``conn._haventory_close_registered = True`` marker would raise
+    ``AttributeError`` on every subscribe. The ``"haventory/cleanup"`` key — a
+    string, which cannot collide with HA's integer subscription ids — is the
+    marker instead, and ``_cleanup_subscriptions_for_conn`` is idempotent.
+    """
+
+    if "haventory/cleanup" not in conn.subscriptions:
+        conn.subscriptions["haventory/cleanup"] = functools.partial(
+            _cleanup_subscriptions_for_conn, hass, conn
+        )
+
+
+# -----------------------------
+# Matching
+# -----------------------------
+
+
+def _subscription_location_ids(sub: Subscription) -> list[str]:
+    """The locations a subscription is scoped to, scalar and list unioned.
+
+    The same union rule ``models.selected_location_ids`` applies to an
+    ``ItemFilter``, kept here because a subscription is not one: it carries a
+    payload matcher, not a query.
+    """
+
+    selection: list[str] = []
+    scalar = sub.get("location_id")
+    if scalar:
+        selection.append(str(scalar).strip())
+    for raw in sub.get("location_ids") or []:
+        value = str(raw).strip()
+        if value and value not in selection:
+            selection.append(value)
+    return [value for value in selection if value]
+
+
+def _payload_inspection_is_overdue(item: dict[str, Any]) -> bool:
+    """Whether a serialized item is past its next-inspection date.
+
+    The matcher is handed the event payload rather than the stored ``Item``, so
+    it cannot call ``item_inspection_is_overdue`` — but it must agree with it,
+    and with ``inspection_overdue_only`` on ``item/list``. Same comparison and
+    the same clock: YYYY-MM-DD text, strictly before the instance's local day.
+    """
+
+    date = item.get("inspection_date")
+    if not isinstance(date, str) or not date:
+        return False
+    return date < today_local_date()
+
+
+def _item_matches_filter(item: dict[str, Any], sub: Subscription) -> bool:
+    if sub.get("inspection_overdue_only") and not _payload_inspection_is_overdue(item):
+        return False
+    # Read the area off the payload rather than resolving it from the repository:
+    # the matcher runs once per subscription per event, and `serialize_item` has
+    # already walked the location ancestry to compute the same value. An item with
+    # no location carries `effective_area_id: None`, which matches no area filter.
+    area_filter = sub.get("area_id")
+    if area_filter and item.get("effective_area_id") != area_filter:
+        return False
+    loc_filters = _subscription_location_ids(sub)
+    if not loc_filters:
+        return True
+    include_subtree = bool(sub.get("include_subtree", True))
+    if include_subtree:
+        # Match if any selected id is anywhere in the id_path
+        path = item.get("location_path", {}).get("id_path", [])
+        return any(loc in path for loc in loc_filters)
+    # Direct-only
+    return item.get("location_id") in loc_filters
+
+
+def _location_matches_filter(location: dict[str, Any], sub: Subscription) -> bool:
+    loc_filters = _subscription_location_ids(sub)
+    if not loc_filters:
+        return True
+    include_subtree = bool(sub.get("include_subtree", True))
+    if include_subtree:
+        # If subtree, match if this location is a selected one or under one
+        path = location.get("path", {}).get("id_path", [])
+        return any(loc in path or location.get("id") == loc for loc in loc_filters)
+    # Direct-only: only the exact locations
+    return location.get("id") in loc_filters
+
+
+def _collect_event_deliveries(
+    hass: HomeAssistant, topic: str, payload: dict[str, Any] | None
+) -> list[tuple[websocket_api.ActiveConnection, list[int]]]:
+    """Return (connection, subscription ids) pairs the event would reach.
+
+    Snapshots the subscription registry to avoid mutation issues.
+    """
+    item_obj = (payload or {}).get("item") if payload else None
+    location_obj = (payload or {}).get("location") if payload else None
+
+    deliveries: list[tuple[websocket_api.ActiveConnection, list[int]]] = []
+    for conn, subs in list(open_subscriptions(hass).items()):
+        sub_ids: list[int] = []
+        for sub_id, sub in list(subs.items()):
+            if sub.get("topic") != topic:
+                continue
+            if (
+                topic == "items"
+                and item_obj is not None
+                and not _item_matches_filter(item_obj, sub)
+            ):
+                continue
+            if (
+                topic == "locations"
+                and location_obj is not None
+                and not _location_matches_filter(location_obj, sub)
+            ):
+                continue
+            sub_ids.append(sub_id)
+        if sub_ids:
+            deliveries.append((conn, sub_ids))
+    return deliveries
+
+
+# -----------------------------
+# The fan-out
+# -----------------------------
+
+
+def _now_ts() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _send_event_message(
+    conn: websocket_api.ActiveConnection, subscription_id: int, event_payload: dict[str, Any]
+) -> None:
+    # One dead connection must not stop the fan-out reaching the others, so the
+    # failure is logged here rather than raised into the broadcast loop.
+    try:
+        conn.send_message({"id": subscription_id, "type": "event", "event": event_payload})
+    except Exception:  # pragma: no cover - defensive logging only
+        LOGGER.debug(
+            "Failed to send WS event message",
+            extra={"domain": DOMAIN, "op": "send_event", "subscription_id": subscription_id},
+            exc_info=True,
+        )
+
+
+def broadcast_event(
+    hass: HomeAssistant,
+    *,
+    topic: str,
+    action: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Deliver one event to every subscription that asked for it.
+
+    Called from `events.py`, which announces the same mutation on the bus and to
+    the entities in the same breath, so no write path can reach one surface and
+    miss the others.
+    """
+
+    # Broadcasts are best-effort: they run after a mutation has been applied and
+    # persisted, so a broadcast failure must never turn the originating command
+    # into an error.
+    try:
+        event: dict[str, Any] = {
+            "domain": DOMAIN,
+            "topic": topic,
+            "action": action,
+            "ts": _now_ts(),
+        }
+        if payload:
+            event.update(payload)
+
+        # Collect matching deliveries first so budgets are only consumed for
+        # events somebody would actually receive.
+        deliveries = _collect_event_deliveries(hass, topic, payload)
+        if not deliveries:
+            return
+
+        # The limiter is resolved without the loaded check: a broadcast can run
+        # during teardown, while the entry is no longer `LOADED`.
+        runtime = find_runtime(hass)
+        limiter = runtime.rate_limiter if runtime is not None else None
+        if limiter is not None and not limiter.allow_event_broadcast():
+            # Global event budget exhausted: drop this event entirely.
+            return
+
+        for conn, sub_ids in deliveries:
+            # One event delivered to a connection consumes one token,
+            # regardless of how many of its subscriptions match.
+            if limiter is not None and not limiter.allow_event_send(conn):
+                continue
+            for sub_id in sub_ids:
+                _send_event_message(conn, sub_id, event)
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.exception(
+            "Failed to broadcast WS event",
+            extra={"domain": DOMAIN, "op": "broadcast_event", "topic": topic, "action": action},
+        )
+
+
+def broadcast_counts(hass: HomeAssistant) -> None:
+    """Send the whole counts object on the `stats` topic."""
+
+    try:
+        counts_payload = loaded_runtime(hass).repository.get_counts()
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.exception(
+            "Failed to broadcast counts", extra={"domain": DOMAIN, "op": "broadcast_counts"}
+        )
+        return
+    broadcast_event(
+        hass,
+        topic="stats",
+        action="counts",
+        payload={"counts": counts_payload},
+    )
+
+
+# Action every open subscription receives when the config entry serving it goes
+# away. A subscription is bound to a WebSocket connection, which outlives the
+# entry, so without it nothing on the wire marks the end: no further event ever
+# arrives and a client cannot tell that from an inventory nobody is editing.
+BACKEND_UNAVAILABLE_ACTION = "unavailable"
+
+
+def notify_backend_unavailable(hass: HomeAssistant) -> None:
+    """Tell every open subscription that it has stopped delivering.
+
+    Teardown calls this while the registry is still populated; the subscriptions
+    themselves go with the rest of the runtime immediately after.
+
+    The one announcement that is not a mutation, so it is written here rather
+    than through a door in `events.py`: nothing changed, no entity repaints, and
+    it ignores the rate limiter. A connection whose event budget happened to be
+    spent would otherwise be the one client left believing its topics are still
+    live.
+    """
+
+    for conn, subs in list(open_subscriptions(hass).items()):
+        for sub_id, sub in list(subs.items()):
+            _send_event_message(
+                conn,
+                sub_id,
+                {
+                    "domain": DOMAIN,
+                    "topic": sub.get("topic"),
+                    "action": BACKEND_UNAVAILABLE_ACTION,
+                    "ts": _now_ts(),
+                },
+            )

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -2,6 +2,10 @@
 
 Implements CRUD and helper commands for items and locations.
 Adheres to the envelope: input {id, type, ...payload}, output result_message/error_message.
+
+Handlers only. A mutation announces itself through a door in `events.py`, which
+covers the bus and the entities as well as the wire; the subscription registry
+and the fan-out behind that door are `subscriptions.py`.
 """
 
 from __future__ import annotations

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -62,7 +62,6 @@ from .models import (
     new_uuid4,
     normalize_string_list,
     serialize_status_definition,
-    today_local_date,
     validate_attachment_meta,
     validate_item_filter,
     validate_sort,
@@ -72,6 +71,7 @@ from .repository import UNSET, Repository
 from .runtime import Subscription, find_runtime, loaded_runtime
 from .serialization import serialize_item, serialize_location
 from .storage import CURRENT_SCHEMA_VERSION
+from .subscriptions import broadcast_event, register_subscription, unregister_subscription
 
 LOGGER = context_logger(__name__)
 
@@ -476,329 +476,6 @@ def _execute_item_op(
     return handler(hass, payload)
 
 
-# -----------------------------
-# Subscriptions & Events
-# -----------------------------
-
-
-def _subscription_location_ids(sub: Subscription) -> list[str]:
-    """The locations a subscription is scoped to, scalar and list unioned.
-
-    The same union rule ``models.selected_location_ids`` applies to an
-    ``ItemFilter``, kept here because a subscription is not one: it carries a
-    payload matcher, not a query.
-    """
-
-    selection: list[str] = []
-    scalar = sub.get("location_id")
-    if scalar:
-        selection.append(str(scalar).strip())
-    for raw in sub.get("location_ids") or []:
-        value = str(raw).strip()
-        if value and value not in selection:
-            selection.append(value)
-    return [value for value in selection if value]
-
-
-def _subs_bucket(
-    hass: HomeAssistant,
-) -> dict[websocket_api.ActiveConnection, dict[int, Subscription]]:
-    """The open subscriptions, or an empty map when no runtime holds any.
-
-    A regular dict rather than a WeakKeyDictionary, because HA's
-    `ActiveConnection` does not support weak references; cleanup is the close
-    callback registered in `_register_close_listener`. That callback fires when
-    the *connection* closes, which can be long after the entry went — so this
-    resolves without the loaded check and answers `{}` rather than raising out
-    of a close callback.
-    """
-
-    runtime = find_runtime(hass)
-    if runtime is None:
-        return {}
-    return cast(
-        "dict[websocket_api.ActiveConnection, dict[int, Subscription]]", runtime.subscriptions
-    )
-
-
-def _cleanup_subscriptions_for_conn(hass: HomeAssistant, conn: object) -> None:
-    """Remove all subscriptions for a given connection."""
-
-    subs_all = _subs_bucket(hass)
-    subs_all.pop(cast("websocket_api.ActiveConnection", conn), None)
-
-
-def _drop_subscription(hass: HomeAssistant, conn: object, sub_id: int) -> None:
-    """Remove a single subscription from the per-connection bucket.
-
-    Registered as the zero-arg teardown callback in HA's ``connection.subscriptions``
-    registry (see ``_register_framework_unsub``). Safe to call repeatedly and after
-    the connection bucket has already been cleaned up.
-    """
-
-    subs_all = _subs_bucket(hass)
-    subs_for_conn = subs_all.get(cast("websocket_api.ActiveConnection", conn))
-    if subs_for_conn is None:
-        return
-    subs_for_conn.pop(sub_id, None)
-    if not subs_for_conn:
-        subs_all.pop(cast("websocket_api.ActiveConnection", conn), None)
-
-
-def _register_framework_unsub(
-    hass: HomeAssistant, conn: websocket_api.ActiveConnection, sub_id: int
-) -> None:
-    """Register the subscription teardown in HA's own subscription registry.
-
-    ``ActiveConnection.subscriptions`` maps a message id to a zero-arg unsubscribe
-    callback, and HA core's generic ``unsubscribe_events`` command pops-and-calls
-    it. The frontend's ``subscribeMessage`` lifecycle tears down via exactly that
-    command, so without an entry here HA core replies ``not_found``
-    ("Subscription not found.") on every teardown — surfacing as an unhandled
-    rejection in the card. Registering the id makes the standard lifecycle work.
-    """
-
-    conn.subscriptions[sub_id] = functools.partial(_drop_subscription, hass, conn, sub_id)
-
-
-def _unregister_framework_unsub(conn: websocket_api.ActiveConnection, sub_id: int) -> None:
-    """Drop the HA-registry entry for a subscription torn down via our own command.
-
-    Keeps ``haventory/unsubscribe`` and HA core's ``unsubscribe_events`` symmetric so
-    a subscription removed through the dedicated command leaves no stale callback in
-    ``connection.subscriptions``.
-    """
-
-    conn.subscriptions.pop(sub_id, None)
-
-
-def _register_close_listener(hass: HomeAssistant, conn: websocket_api.ActiveConnection) -> None:
-    """Have the connection drop its subscriptions when it closes.
-
-    ``ActiveConnection.subscriptions`` holds zero-arg callbacks Home Assistant
-    invokes on disconnect, so registering there is what keeps a client that
-    vanishes from leaking subscription state.
-
-    Idempotency is derived from the state itself, not stamped on the connection:
-    real HA's ``ActiveConnection`` is ``__slots__``-based (no ``__dict__``), so a
-    ``conn._haventory_close_registered = True`` marker would raise
-    ``AttributeError`` on every subscribe. The ``"haventory/cleanup"`` key — a
-    string, which cannot collide with HA's integer subscription ids — is the
-    marker instead, and ``_cleanup_subscriptions_for_conn`` is idempotent.
-    """
-
-    if "haventory/cleanup" not in conn.subscriptions:
-        conn.subscriptions["haventory/cleanup"] = functools.partial(
-            _cleanup_subscriptions_for_conn, hass, conn
-        )
-
-
-def _now_ts() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-def _send_event_message(
-    conn: websocket_api.ActiveConnection, subscription_id: int, event_payload: dict[str, Any]
-) -> None:
-    # One dead connection must not stop the fan-out reaching the others, so the
-    # failure is logged here rather than raised into the broadcast loop.
-    try:
-        conn.send_message({"id": subscription_id, "type": "event", "event": event_payload})
-    except Exception:  # pragma: no cover - defensive logging only
-        LOGGER.debug(
-            "Failed to send WS event message",
-            extra={"domain": DOMAIN, "op": "send_event", "subscription_id": subscription_id},
-            exc_info=True,
-        )
-
-
-def _payload_inspection_is_overdue(item: dict[str, Any]) -> bool:
-    """Whether a serialized item is past its next-inspection date.
-
-    The matcher is handed the event payload rather than the stored ``Item``, so
-    it cannot call ``item_inspection_is_overdue`` — but it must agree with it,
-    and with ``inspection_overdue_only`` on ``item/list``. Same comparison and
-    the same clock: YYYY-MM-DD text, strictly before the instance's local day.
-    """
-
-    date = item.get("inspection_date")
-    if not isinstance(date, str) or not date:
-        return False
-    return date < today_local_date()
-
-
-def _item_matches_filter(item: dict[str, Any], sub: Subscription) -> bool:
-    if sub.get("inspection_overdue_only") and not _payload_inspection_is_overdue(item):
-        return False
-    # Read the area off the payload rather than resolving it from the repository:
-    # the matcher runs once per subscription per event, and `serialize_item` has
-    # already walked the location ancestry to compute the same value. An item with
-    # no location carries `effective_area_id: None`, which matches no area filter.
-    area_filter = sub.get("area_id")
-    if area_filter and item.get("effective_area_id") != area_filter:
-        return False
-    loc_filters = _subscription_location_ids(sub)
-    if not loc_filters:
-        return True
-    include_subtree = bool(sub.get("include_subtree", True))
-    if include_subtree:
-        # Match if any selected id is anywhere in the id_path
-        path = item.get("location_path", {}).get("id_path", [])
-        return any(loc in path for loc in loc_filters)
-    # Direct-only
-    return item.get("location_id") in loc_filters
-
-
-def _location_matches_filter(location: dict[str, Any], sub: Subscription) -> bool:
-    loc_filters = _subscription_location_ids(sub)
-    if not loc_filters:
-        return True
-    include_subtree = bool(sub.get("include_subtree", True))
-    if include_subtree:
-        # If subtree, match if this location is a selected one or under one
-        path = location.get("path", {}).get("id_path", [])
-        return any(loc in path or location.get("id") == loc for loc in loc_filters)
-    # Direct-only: only the exact locations
-    return location.get("id") in loc_filters
-
-
-def _collect_event_deliveries(
-    hass: HomeAssistant, topic: str, payload: dict[str, Any] | None
-) -> list[tuple[websocket_api.ActiveConnection, list[int]]]:
-    """Return (connection, subscription ids) pairs the event would reach.
-
-    Snapshots the subscription registry to avoid mutation issues.
-    """
-    item_obj = (payload or {}).get("item") if payload else None
-    location_obj = (payload or {}).get("location") if payload else None
-
-    deliveries: list[tuple[websocket_api.ActiveConnection, list[int]]] = []
-    for conn, subs in list(_subs_bucket(hass).items()):
-        sub_ids: list[int] = []
-        for sub_id, sub in list(subs.items()):
-            if sub.get("topic") != topic:
-                continue
-            if (
-                topic == "items"
-                and item_obj is not None
-                and not _item_matches_filter(item_obj, sub)
-            ):
-                continue
-            if (
-                topic == "locations"
-                and location_obj is not None
-                and not _location_matches_filter(location_obj, sub)
-            ):
-                continue
-            sub_ids.append(sub_id)
-        if sub_ids:
-            deliveries.append((conn, sub_ids))
-    return deliveries
-
-
-def broadcast_event(
-    hass: HomeAssistant,
-    *,
-    topic: str,
-    action: str,
-    payload: dict[str, Any] | None = None,
-) -> None:
-    """Deliver one event to every subscription that asked for it.
-
-    Public because `events.py` calls it: a mutation announces itself to
-    subscribers and to the Home Assistant bus in one call, so no write path can
-    reach one surface and miss the other.
-    """
-
-    # Broadcasts are best-effort: they run after a mutation has been applied and
-    # persisted, so a broadcast failure must never turn the originating command
-    # into an error.
-    try:
-        event: dict[str, Any] = {
-            "domain": DOMAIN,
-            "topic": topic,
-            "action": action,
-            "ts": _now_ts(),
-        }
-        if payload:
-            event.update(payload)
-
-        # Collect matching deliveries first so budgets are only consumed for
-        # events somebody would actually receive.
-        deliveries = _collect_event_deliveries(hass, topic, payload)
-        if not deliveries:
-            return
-
-        limiter = _rate_limiter(hass)
-        if limiter is not None and not limiter.allow_event_broadcast():
-            # Global event budget exhausted: drop this event entirely.
-            return
-
-        for conn, sub_ids in deliveries:
-            # One event delivered to a connection consumes one token,
-            # regardless of how many of its subscriptions match.
-            if limiter is not None and not limiter.allow_event_send(conn):
-                continue
-            for sub_id in sub_ids:
-                _send_event_message(conn, sub_id, event)
-    except Exception:  # pragma: no cover - defensive
-        LOGGER.exception(
-            "Failed to broadcast WS event",
-            extra={"domain": DOMAIN, "op": "broadcast_event", "topic": topic, "action": action},
-        )
-
-
-# Action every open subscription receives when the config entry serving it goes
-# away. A subscription is bound to a WebSocket connection, which outlives the
-# entry, so without it nothing on the wire marks the end: no further event ever
-# arrives and a client cannot tell that from an inventory nobody is editing.
-BACKEND_UNAVAILABLE_ACTION = "unavailable"
-
-
-def notify_backend_unavailable(hass: HomeAssistant) -> None:
-    """Tell every open subscription that it has stopped delivering.
-
-    Teardown calls this while the registry is still populated; the subscriptions
-    themselves go with the rest of the runtime immediately after.
-
-    Deliberately not routed through ``broadcast_event``: this is a lifecycle
-    signal rather than inventory traffic, so it ignores the rate limiter. A
-    connection whose event budget happened to be spent would otherwise be the one
-    client left believing its topics are still live.
-    """
-
-    for conn, subs in list(_subs_bucket(hass).items()):
-        for sub_id, sub in list(subs.items()):
-            _send_event_message(
-                conn,
-                sub_id,
-                {
-                    "domain": DOMAIN,
-                    "topic": sub.get("topic"),
-                    "action": BACKEND_UNAVAILABLE_ACTION,
-                    "ts": _now_ts(),
-                },
-            )
-
-
-def broadcast_counts(hass: HomeAssistant) -> None:
-    """Send the whole counts object on the `stats` topic. Public for `events.py`."""
-
-    try:
-        counts_payload = _repo(hass).get_counts()
-    except Exception:  # pragma: no cover - defensive
-        LOGGER.exception(
-            "Failed to broadcast counts", extra={"domain": DOMAIN, "op": "broadcast_counts"}
-        )
-        return
-    broadcast_event(
-        hass,
-        topic="stats",
-        action="counts",
-        payload={"counts": counts_payload},
-    )
-
-
 async def _persist_repo(hass: HomeAssistant) -> None:
     """Write the repository to disk, propagating failure to the caller.
 
@@ -831,7 +508,7 @@ async def _persist_repo(hass: HomeAssistant) -> None:
 async def ws_ping(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    result = {"echo": msg.get("echo"), "ts": _now_ts()}
+    result = {"echo": msg.get("echo"), "ts": datetime.now(UTC).isoformat()}
     conn.send_message(websocket_api.result_message(msg.get("id", 0), result))
 
 
@@ -990,14 +667,7 @@ async def ws_subscribe(
         sub["include_subtree"] = bool(msg.get("include_subtree"))
     if "inspection_overdue_only" in msg:
         sub["inspection_overdue_only"] = bool(msg.get("inspection_overdue_only"))
-    sub_id = int(msg.get("id", 0))
-    subs_all = _subs_bucket(hass)
-    subs_for_conn = subs_all.setdefault(conn, {})
-    subs_for_conn[sub_id] = sub
-    _register_close_listener(hass, conn)
-    # Let HA core's generic `unsubscribe_events` (the path the frontend uses) tear
-    # this subscription down cleanly, instead of replying "Subscription not found".
-    _register_framework_unsub(hass, conn, sub_id)
+    register_subscription(hass, conn, int(msg.get("id", 0)), sub)
     LOGGER.debug(
         "Subscribed",
         extra={
@@ -1025,15 +695,7 @@ async def ws_unsubscribe(
         sub_id = int(sub_id_raw)
     except ValueError:
         raise ValidationError("subscription must be an integer") from None
-    subs_all = _subs_bucket(hass)
-    removed = False
-    subs_for_conn = subs_all.get(conn)
-    if subs_for_conn:
-        removed = subs_for_conn.pop(sub_id, None) is not None
-        if not subs_for_conn:
-            subs_all.pop(conn, None)
-    # Keep HA's own subscription registry in sync with this explicit teardown.
-    _unregister_framework_unsub(conn, sub_id)
+    removed = unregister_subscription(hass, conn, sub_id)
     LOGGER.debug(
         "Unsubscribed",
         extra={

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -39,8 +39,10 @@ from .const import (
 from .events import (
     notify_bulk_mutation,
     notify_counts,
+    notify_dataset_replaced,
     notify_location_mutation,
     notify_mutation,
+    notify_status_mutation,
 )
 from .exceptions import (
     ConflictError,
@@ -71,7 +73,7 @@ from .repository import UNSET, Repository
 from .runtime import Subscription, find_runtime, loaded_runtime
 from .serialization import serialize_item, serialize_location
 from .storage import CURRENT_SCHEMA_VERSION
-from .subscriptions import broadcast_event, register_subscription, unregister_subscription
+from .subscriptions import register_subscription, unregister_subscription
 
 LOGGER = context_logger(__name__)
 
@@ -98,8 +100,9 @@ def _require_loaded(hass: HomeAssistant) -> None:
 def _rate_limiter(hass: HomeAssistant) -> RateLimiter | None:
     """The configured rate limiter, or None when limiting is off.
 
-    Resolved without the loaded check: the broadcaster charges this budget, and
-    a broadcast can run during teardown.
+    Resolved without the loaded check: the guard charges a command's token
+    before it has asked whether an entry is loaded at all, so a refusal costs
+    the same whichever answer the command was heading for.
     """
 
     runtime = find_runtime(hass)
@@ -1773,7 +1776,7 @@ async def ws_status_create(
     created = repo.create_status(doc)
     serialized = serialize_status_definition(created)
     await _persist_repo(hass)
-    broadcast_event(hass, topic="statuses", action="created", payload={"status": serialized})
+    notify_status_mutation(hass, action="created", status=serialized)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1804,7 +1807,7 @@ async def ws_status_update(
     updated = repo.update_status(msg["slug"], changes)
     serialized = serialize_status_definition(updated)
     await _persist_repo(hass)
-    broadcast_event(hass, topic="statuses", action="updated", payload={"status": serialized})
+    notify_status_mutation(hass, action="updated", status=serialized)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1825,7 +1828,7 @@ async def ws_status_reorder(
     ordered = repo.reorder_statuses(list(msg["slugs"]))
     serialized = [serialize_status_definition(d) for d in ordered]
     await _persist_repo(hass)
-    broadcast_event(hass, topic="statuses", action="reordered", payload={"statuses": serialized})
+    notify_status_mutation(hass, action="reordered", statuses=serialized)
     conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
 
 
@@ -1852,7 +1855,7 @@ async def ws_status_delete(
     removed, reassigned = repo.delete_status(msg["slug"], reassign_to=msg.get("reassign_to"))
     serialized = serialize_status_definition(removed)
     await _persist_repo(hass)
-    broadcast_event(hass, topic="statuses", action="deleted", payload={"status": serialized})
+    notify_status_mutation(hass, action="deleted", status=serialized)
     if reassigned:
         # Two topics on purpose: one card is showing the vocabulary, another is
         # showing the items that just moved underneath it — that second topic is
@@ -2033,15 +2036,7 @@ async def ws_import_execute(
     await media_mod.async_sweep_orphans(hass, repo.iter_attachments())
 
     # Tell every subscriber the dataset was replaced wholesale.
-    broadcast_event(hass, topic="items", action="reloaded", payload=None)
-    broadcast_event(hass, topic="locations", action="reloaded", payload=None)
-    # No per-item bus event and no per-item `items` event — an import rewrites
-    # the dataset, and both an automation and a card want one signal rather than
-    # one per row, which is what the two `reloaded` events above are. Passing no
-    # item leaves `notify_mutation` the rest of its job: the low-stock diff still
-    # runs, so a restock done by import announces itself, the sensors repaint,
-    # and the counts go out.
-    notify_mutation(hass, action="reloaded")
+    notify_dataset_replaced(hass)
     # And the shopping list explicitly, because that diff is the only bus signal
     # a wholesale swap produces: a document that renames items or changes their
     # quantities without moving the low-stock set fires nothing at all.

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -1,6 +1,6 @@
 ## HAventory WebSocket API Contract
 
-This document specifies the WebSocket message envelope, error taxonomy, command catalog, and event delivery semantics implemented by `custom_components/haventory/ws.py`.
+This document specifies the WebSocket message envelope, error taxonomy, command catalog, and event delivery semantics implemented by `custom_components/haventory/ws.py`, with the subscription registry and the event fan-out in `custom_components/haventory/subscriptions.py`.
 
 ### Envelope
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ module = [
   "haventory.runtime",
   "haventory.serialization",
   "haventory.storage",
+  "haventory.subscriptions",
   "haventory.ws",
 ]
 disallow_any_generics = true

--- a/tests/test_entry_removal_refusal_offline.py
+++ b/tests/test_entry_removal_refusal_offline.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 
 import pytest
+from custom_components.haventory import subscriptions as subs_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.runtime import find_runtime
@@ -185,7 +186,7 @@ async def test_removal_drops_live_subscriptions() -> None:
     await remove_entry(hass, entry)
     conn.messages.clear()
 
-    ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
 
     assert conn.messages == []
     assert hass.data[DOMAIN].get("subscriptions") in (None, {})

--- a/tests/test_entry_unload_refusal_offline.py
+++ b/tests/test_entry_unload_refusal_offline.py
@@ -21,6 +21,7 @@ import logging
 
 import pytest
 from custom_components.haventory import services as services_mod
+from custom_components.haventory import subscriptions as subs_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.exceptions import NotLoadedError
@@ -197,7 +198,7 @@ async def test_unload_drops_live_subscriptions() -> None:
     await unload_entry(hass, entry)
     conn.messages.clear()
 
-    ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
 
     assert conn.messages == []
     assert hass.data[DOMAIN].get("subscriptions") in (None, {})
@@ -230,7 +231,7 @@ async def test_teardown_signal_outranks_the_event_budget() -> None:
     # Drain the global budget, then prove an ordinary broadcast is now dropped.
     assert limiter.allow_event_broadcast() is True
     conn.messages.clear()
-    ws_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload={"item": {"id": "x"}})
     assert conn.messages == []
 
     await unload_entry(hass, entry)

--- a/tests/test_events_offline.py
+++ b/tests/test_events_offline.py
@@ -520,7 +520,7 @@ async def test_a_failing_rollover_broadcast_is_logged_rather_than_raised(
     def _boom(_hass: HomeAssistant) -> None:
         raise RuntimeError("no counts today")
 
-    monkeypatch.setattr(events_mod, "_broadcast_counts", _boom)
+    monkeypatch.setattr(events_mod, "broadcast_counts", _boom)
 
     action(None)
 

--- a/tests/test_events_offline.py
+++ b/tests/test_events_offline.py
@@ -14,6 +14,7 @@ Scenarios:
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import pytest
 from custom_components.haventory import events as events_mod
@@ -528,3 +529,25 @@ async def test_a_failing_rollover_broadcast_is_logged_rather_than_raised(
     assert [r.levelno for r in records] == [logging.ERROR]
     assert records[0].op == "day_rollover"
     assert records[0].exc_info is not None
+
+
+def test_nothing_but_events_py_reaches_the_broadcaster() -> None:
+    """One door: a write path announces through here, or subscribers hear nothing.
+
+    A module calling `subscriptions.broadcast_event` itself would reach a card
+    without firing the bus event, diffing the low-stock set or repainting the
+    entities beside it, so the same edit would look different depending on which
+    surface was watching. Read from the source rather than by importing: several
+    modules pull in Home Assistant packages the offline stubs do not provide.
+    """
+
+    package = Path(events_mod.__file__).parent
+    offenders = []
+    for path in sorted(package.glob("*.py")):
+        if path.name in {"events.py", "subscriptions.py"}:
+            continue
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if "broadcast_event(" in line or "broadcast_counts(" in line:
+                offenders.append(f"{path.name}:{number}: {line.strip()}")
+
+    assert offenders == [], "announce through events.py: it covers the bus and the entities too"

--- a/tests/test_events_offline.py
+++ b/tests/test_events_offline.py
@@ -37,7 +37,7 @@ from runtime_helpers import (
     unload_entry,
     unload_runtime,
 )
-from ws_helpers import RecordingConn, ws_send
+from ws_helpers import ITEM_ACTIONS, RecordingConn, ws_send
 
 LOW_THRESHOLD = 3
 # One create, then the reassignment's edit.
@@ -90,7 +90,7 @@ async def test_every_websocket_item_mutation_reaches_the_bus() -> None:
 
     fired = hass.bus.events_of(EVENT_ITEM_CHANGED)
     assert len(fired) == len(commands) + 1
-    assert {e["action"] for e in fired} <= events_mod.ITEM_ACTIONS
+    assert {e["action"] for e in fired} <= ITEM_ACTIONS
     assert fired[0]["action"] == "created"
     assert fired[-1]["action"] == "deleted"
     assert {e["item_id"] for e in fired} == {item_id}
@@ -226,7 +226,7 @@ def test_an_emptied_bucket_is_a_no_op() -> None:
     assert hass.bus.events_of(EVENT_LOW_STOCK) == []
 
 
-@pytest.mark.parametrize("action", sorted(events_mod.ITEM_ACTIONS))
+@pytest.mark.parametrize("action", sorted(ITEM_ACTIONS))
 def test_every_action_in_the_vocabulary_fires(action: str) -> None:
     hass, repo = _hass()
     _item, serialized = _create(repo, hass, name="Widget")

--- a/tests/test_local_day_offline.py
+++ b/tests/test_local_day_offline.py
@@ -33,7 +33,7 @@ from custom_components.haventory.models import (
 )
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.serialization import serialize_item
-from custom_components.haventory.ws import _item_matches_filter
+from custom_components.haventory.subscriptions import _item_matches_filter
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 

--- a/tests/test_runtime_offline.py
+++ b/tests/test_runtime_offline.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pytest
 from custom_components.haventory import storage as storage_mod
+from custom_components.haventory import subscriptions as subs_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.exceptions import NotLoadedError
 from custom_components.haventory.runtime import find_runtime, loaded_runtime
@@ -120,15 +121,15 @@ async def test_a_close_callback_after_teardown_is_a_no_op() -> None:
     conn = RecordingConn()
 
     assert (await ws_send(hass, 1, "haventory/subscribe", conn=conn, topic="items"))["success"]
-    assert ws_mod._subs_bucket(hass)
+    assert subs_mod.open_subscriptions(hass)
 
     unload_runtime(hass)
 
     # Both callbacks, on a hass with no runtime left to look one up in.
-    ws_mod._drop_subscription(hass, conn, 1)
-    ws_mod._cleanup_subscriptions_for_conn(hass, conn)
+    subs_mod._drop_subscription(hass, conn, 1)
+    subs_mod._cleanup_subscriptions_for_conn(hass, conn)
 
-    assert ws_mod._subs_bucket(hass) == {}
+    assert subs_mod.open_subscriptions(hass) == {}
 
 
 @pytest.mark.asyncio
@@ -143,6 +144,6 @@ async def test_a_broadcast_after_teardown_reaches_nobody_and_raises_nothing() ->
     conn.messages.clear()
 
     unload_runtime(hass)
-    ws_mod.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
 
     assert conn.events() == []

--- a/tests/test_service_broadcast_offline.py
+++ b/tests/test_service_broadcast_offline.py
@@ -29,7 +29,7 @@ from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
 from runtime_helpers import install_runtime
-from ws_helpers import RecordingConn, ws_send
+from ws_helpers import ITEM_ACTIONS, RecordingConn, ws_send
 
 _BULK_ROWS = 3
 
@@ -107,7 +107,7 @@ async def test_every_item_service_delivers_its_own_action() -> None:
         await handler(hass, payload)
 
     assert _actions(conn, "items") == [action for _h, _p, action in calls]
-    assert {a for a in _actions(conn, "items")} <= events_mod.ITEM_ACTIONS
+    assert {a for a in _actions(conn, "items")} <= ITEM_ACTIONS
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_effective_area_offline.py
+++ b/tests/test_ws_effective_area_offline.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
-from custom_components.haventory.ws import _item_matches_filter
+from custom_components.haventory.subscriptions import _item_matches_filter
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 

--- a/tests/test_ws_error_mapping_offline.py
+++ b/tests/test_ws_error_mapping_offline.py
@@ -19,6 +19,7 @@ import json
 from typing import Any
 
 import pytest
+from custom_components.haventory import subscriptions as subs_mod
 from custom_components.haventory import ws as ws_module
 from custom_components.haventory.ws import HANDLERS, UNEXPECTED_ERROR_MESSAGE
 from custom_components.haventory.ws import setup as ws_setup
@@ -263,7 +264,7 @@ async def test_broadcast_failure_does_not_fail_the_command(monkeypatch) -> None:
     def _boom(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError("broadcast down")
 
-    monkeypatch.setattr(ws_module, "_send_event_message", _boom)
+    monkeypatch.setattr(subs_mod, "_send_event_message", _boom)
 
     res = await ws_send(hass, 101, "haventory/item/create", conn=conn, name="Widget")
     assert res["success"] is True

--- a/tests/test_ws_items_offline.py
+++ b/tests/test_ws_items_offline.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+from custom_components.haventory import events as events_mod
 from custom_components.haventory import media as media_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.repository import Repository
@@ -512,7 +513,7 @@ async def test_attachment_add_announces_the_item_as_updated(upload, monkeypatch)
     created = await ws_send(hass, 1, "haventory/item/create", name="Drill")
     broadcasts: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        ws_mod,
+        events_mod,
         "broadcast_event",
         lambda _hass, *, topic, action, payload=None: broadcasts.append((topic, action)),
     )

--- a/tests/test_ws_rate_limit_offline.py
+++ b/tests/test_ws_rate_limit_offline.py
@@ -19,7 +19,7 @@ import pytest
 import voluptuous as vol
 from custom_components.haventory import _async_options_updated
 from custom_components.haventory import rate_limit as rate_limit_module
-from custom_components.haventory import ws as ws_module
+from custom_components.haventory import subscriptions as subs_mod
 from custom_components.haventory.config_flow import (
     SECTION_RATE_LIMIT,
     SECTION_TODO,
@@ -220,13 +220,13 @@ async def test_per_connection_event_limit(clock: _FakeClock) -> None:
     sub = await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items")
     assert sub["success"] is True
 
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     assert len(subscriber.events()) == 1
     assert limiter.dropped_events == 1
 
     clock.advance(1.0)
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     delivered_after_refill = 2
     assert len(subscriber.events()) == delivered_after_refill
 
@@ -240,7 +240,7 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
 
     # No subscribers at all: nothing is consumed or counted.
     for _ in range(3):
-        ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+        subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     assert limiter.dropped_events == 0
 
     # A subscriber on another topic does not consume the budget either.
@@ -248,7 +248,7 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
     assert (await ws_send(hass, 99, "haventory/subscribe", conn=other, topic="locations"))[
         "success"
     ]
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     assert limiter.dropped_events == 0
 
     # The budget is still intact for the first real delivery.
@@ -256,7 +256,7 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
     assert (await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items"))[
         "success"
     ]
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     assert len(subscriber.events()) == 1
 
 
@@ -272,11 +272,11 @@ async def test_one_event_consumes_one_token_across_multiple_subscriptions(
     assert (await ws_send(hass, 301, "haventory/subscribe", conn=conn, topic="items"))["success"]
     assert (await ws_send(hass, 302, "haventory/subscribe", conn=conn, topic="items"))["success"]
 
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     # Both subscriptions receive the event; only one token was spent.
     assert {m["id"] for m in conn.messages if m["type"] == "event"} == {301, 302}
 
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     delivered_before_drop = 2  # both subscriptions got the FIRST event only
     assert len(conn.events()) == delivered_before_drop
     assert limiter.dropped_events == 1
@@ -291,8 +291,8 @@ async def test_global_event_limit_drops_for_all_subscribers(clock: _FakeClock) -
     assert (await ws_send(hass, 100, "haventory/subscribe", conn=sub_a, topic="items"))["success"]
     assert (await ws_send(hass, 101, "haventory/subscribe", conn=sub_b, topic="items"))["success"]
 
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
-    ws_module.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
+    subs_mod.broadcast_event(hass, topic="items", action="created", payload=None)
     # First event reached both; second was dropped globally.
     assert len(sub_a.events()) == 1
     assert len(sub_b.events()) == 1

--- a/tests/test_ws_statuses_offline.py
+++ b/tests/test_ws_statuses_offline.py
@@ -15,6 +15,7 @@ for to flag something and find it again.
 from __future__ import annotations
 
 import pytest
+from custom_components.haventory import events as events_mod
 from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DEFAULT_STATUS_COLOR, DEFAULT_STATUS_ICON
 from custom_components.haventory.ws import setup as ws_setup
@@ -42,7 +43,10 @@ def _record_broadcasts(monkeypatch) -> list[Broadcast]:
     def fake(hass, *, topic, action, payload=None):
         seen.append((topic, action, payload))
 
+    # The status handlers broadcast on their own; the item half of a reassigning
+    # delete travels through `events.py`.
     monkeypatch.setattr(ws_mod, "broadcast_event", fake)
+    monkeypatch.setattr(events_mod, "broadcast_event", fake)
     return seen
 
 

--- a/tests/test_ws_statuses_offline.py
+++ b/tests/test_ws_statuses_offline.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import pytest
 from custom_components.haventory import events as events_mod
-from custom_components.haventory import ws as ws_mod
 from custom_components.haventory.const import DEFAULT_STATUS_COLOR, DEFAULT_STATUS_ICON
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
@@ -43,9 +42,6 @@ def _record_broadcasts(monkeypatch) -> list[Broadcast]:
     def fake(hass, *, topic, action, payload=None):
         seen.append((topic, action, payload))
 
-    # The status handlers broadcast on their own; the item half of a reassigning
-    # delete travels through `events.py`.
-    monkeypatch.setattr(ws_mod, "broadcast_event", fake)
     monkeypatch.setattr(events_mod, "broadcast_event", fake)
     return seen
 

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -19,7 +19,7 @@ from typing import Any
 import pytest
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
-from custom_components.haventory.ws import _subs_bucket, broadcast_event
+from custom_components.haventory.subscriptions import broadcast_event, open_subscriptions
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
@@ -164,12 +164,12 @@ async def test_subscriptions_cleanup_on_connection_close() -> None:
     conn = RecordingConn()
     await ws_send(hass, 901, "haventory/subscribe", conn=conn, topic="items")
 
-    subs = _subs_bucket(hass)
+    subs = open_subscriptions(hass)
     assert subs.get(conn)
 
     conn.close()
 
-    assert conn not in _subs_bucket(hass)
+    assert conn not in open_subscriptions(hass)
 
 
 @pytest.mark.asyncio
@@ -729,7 +729,7 @@ async def test_framework_unsubscribe_events_tears_down_subscription() -> None:
     # Emulate core ``unsubscribe_events``: the id is found -> success (no not_found).
     assert conn.core_unsubscribe_events(sub_id) is True
     assert sub_id not in conn.subscriptions
-    assert conn not in _subs_bucket(hass)  # our bucket was cleaned up too
+    assert conn not in open_subscriptions(hass)  # our bucket was cleaned up too
 
     # No further deliveries after teardown.
     conn.messages.clear()
@@ -754,7 +754,7 @@ async def test_dedicated_unsubscribe_clears_framework_registry() -> None:
     res = await ws_send(hass, 602, "haventory/unsubscribe", conn=conn, subscription=sub_id)
     assert res["success"] is True
     assert sub_id not in conn.subscriptions
-    assert conn not in _subs_bucket(hass)
+    assert conn not in open_subscriptions(hass)
 
 
 @pytest.mark.asyncio
@@ -793,9 +793,9 @@ async def test_subscribe_on_slotted_connection_never_stamps_attribute() -> None:
 
     # Both subscriptions are live in our bucket, and the disconnect path
     # (subscriptions.values()) tears them all down without drift.
-    assert _subs_bucket(hass).get(conn)
+    assert open_subscriptions(hass).get(conn)
     conn.close()
-    assert conn not in _subs_bucket(hass)
+    assert conn not in open_subscriptions(hass)
 
     # Sanity: the stub really is slotted like real HA (rejects arbitrary attrs).
     with pytest.raises(AttributeError):

--- a/tests/ws_helpers.py
+++ b/tests/ws_helpers.py
@@ -31,6 +31,15 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 
+# The item-action vocabulary `docs/backend_api_contract.md` documents for both
+# surfaces — the `items` topic and `haventory_item_changed` — so a test can hold
+# either to the same words. `reloaded` is not one of them: it says the dataset
+# moved wholesale, carries no item and fires nothing on the bus.
+ITEM_ACTIONS: frozenset[str] = frozenset(
+    {"created", "updated", "moved", "quantity_changed", "checked_out", "checked_in", "deleted"}
+)
+
+
 class WsHandler(Protocol):
     """What the stub registry stores: a dispatchable, command-tagged coroutine."""
 


### PR DESCRIPTION
## Summary

Every broadcast now leaves through one door. The subscription registry and the event fan-out move out of `ws.py` into `subscriptions.py`, which `events.py` imports at module scope — so the two function-local imports that dodged the import cycle go, and with them the comments that documented it. `events.py` gains the two doors its module docstring was already claiming to cover: `notify_status_mutation` for the four `status/*` handlers, and `notify_dataset_replaced` for `import/execute`'s pair of `reloaded` broadcasts. No handler calls the broadcaster itself any more, and a source sweep in `tests/test_events_offline.py` keeps it that way.

`ws.py` is a handler module now: 2,470 lines down to 2,131. `ITEM_ACTIONS` had no production reader and moves to `tests/ws_helpers.py`, where the two tests that hold the bus and the wire to the same words take it from.

No behaviour change. Same topics, same actions, same payloads, same order — `notify_dataset_replaced` broadcasts `items/reloaded`, then `locations/reloaded`, then runs `notify_mutation(action="reloaded")` exactly as the import handler did inline. The existing subscription, event, status, import and teardown tests are the oracle and none of their assertions moved; what changed in them is which module a `monkeypatch.setattr` or an import names.

§6.M1 PR 3 of `dev/V0_8_0_implementation.md`, BE-WS-C5 in the 2026-08-22 measurement comment on #230 (items 4 and 10 of the issue body).

Refs #230

## Counting

| | Lines |
|---|---|
| Production removed (`custom_components/`) | 415 |
| Test lines removed | 38 |
| Lines added (all files) | 572 |

`git diff --numstat origin/main HEAD`. The move is not a net subtraction: `ws.py` loses 357 lines and `subscriptions.py` carries 400, the difference being its module docstring, its two section banners and the `register_subscription` / `unregister_subscription` pair that takes the bucket writes out of the two handlers. `events.py` grows by 14 net — two doors and their docstrings, less the two shims, the cycle comments, the history paragraph and `ITEM_ACTIONS`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1320 passed, 26 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (26 source files, no issues)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (68 files, 1924 tests), `npm run build` — untouched by this PR, run before each commit
- [x] phacc (`scripts/test_integration.sh`, card built first): **`153 passed in 20.59s`**

New test: `test_nothing_but_events_py_reaches_the_broadcaster` sweeps the package source and fails if any module other than `events.py` and `subscriptions.py` calls `broadcast_event` / `broadcast_counts`. It is what keeps the one door single.

`haventory.subscriptions` joins the per-module strict-mypy list in `pyproject.toml`, so the moved code is held to the same typing it had inside `haventory.ws`.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (the sweep above; every existing subscription/event/status/import test passes unchanged in substance).
- [x] Docs updated where behavior changed — no behaviour changed; `docs/backend_api_contract.md`'s opening line and CLAUDE.md's file map name the module the registry moved to.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no schema, error code or field moved, so `data_shapes.md` is untouched.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).
- [x] No file was removed from `custom_components/haventory/`, so `RETIRED_PATHS` is unchanged.

## Screenshots (card / UI changes)

None — backend only.

## Follow-ups

- `_rate_limiter` in `ws.py` is now read by `ws_guard` and `ws_health` only; its docstring says why it skips the loaded check for those two. M2's rate-limiter PR removes both readers, so nothing is filed.
- `notify_backend_unavailable` stays outside the door on purpose: it is a lifecycle signal, not a mutation, and it ignores the rate limiter so a client whose event budget is spent still learns its topics stopped. The sweep test above allows it because it writes on the connection directly rather than through the broadcaster.

## Handover

1. **Merged / left open** — this PR, for the master to merge after its review.
2. **Test this by hand** — nothing `[phone]`, `[German]` or `[owner]`-only: no user-facing text, no card change, no stored shape.
3. **Validate locally**
   1. `[dev-ha]` Deploy the branch and open two browser tabs on the panel. Edit an item in one; the other repaints without a reload — the `items` and `stats` events still arrive.
   2. `[browser]` In tab A, create a status and then rename it. Tab B's status vocabulary updates without a reload — the `statuses` topic still delivers.
   3. `[dev-ha]` Import a document over `haventory/import/execute`; an open card re-lists rather than patching rows — both `reloaded` events still arrive.
   4. `[HA settings]` Reload the config entry from Settings → Devices & services with a card open. The card reports live updates paused, then re-subscribes — the teardown notice still reaches every open subscription.
   5. `[log]` Nothing at ERROR carrying `haventory` in any of the above; `custom_components.haventory.subscriptions` is the logger name for a failed delivery now, not `...ws`.
4. **Decisions taken against drifted notes** — the audit suggested "keep a re-export or update imports" for the tests that import `broadcast_event` from `ws`; a re-export would be a second door, so the eleven test modules name the owning module instead. The audit's line numbers are from `b878bfe` and were not used; symbols were grepped.
5. **Follow-ups** — the two above, neither filed: one dies with M2's rate-limiter cut, the other is a deliberate exception the code documents.
6. **State left behind** — branch `claude/v0-8-0-m1-broadcast-door`, no assets branch, no HA instance touched. Counting for this PR: production removed 415 · tests removed 38 · added 572.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L8sdndwVjV3JGfckyMBh5y)_