### PR TITLE
refactor(ws): one tail for every single-item mutation

### DIFF
--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -1149,11 +1149,27 @@ def _validate_optional_text(
         raise ValidationError(f"{field_name} must be at most {max_length} characters")
 
 
+def validate_quantity(value: object) -> int:
+    """Return the quantity, or refuse the value with the one message there is.
+
+    Public because a caller that holds an unvalidated quantity before it holds
+    an item — `haventory/item/set_quantity` and the `items/bulk` row of the same
+    kind — checks the value first, so a payload that is wrong about both is
+    answered on the value rather than on the id.
+
+    Spelled out rather than through ``_is_int_not_bool`` so the comparison and
+    the return narrow to ``int``.
+    """
+
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValidationError("quantity must be an integer >= 0")
+    return value
+
+
 def _validate_item_core_fields(name: str, quantity: int, low_stock_threshold: int | None) -> None:
     if len(validate_required_name(name)) > NAME_MAX_LENGTH:
         raise ValidationError(f"name must be at most {NAME_MAX_LENGTH} characters")
-    if not _is_int_not_bool(quantity) or quantity < 0:
-        raise ValidationError("quantity must be an integer >= 0")
+    validate_quantity(quantity)
     if low_stock_threshold is not None and (
         not _is_int_not_bool(low_stock_threshold) or low_stock_threshold < 0
     ):
@@ -1185,14 +1201,10 @@ def create_item_from_create(
     # returns the trimmed value this stores.
     name = validate_required_name(payload.get("name"))
     description = payload.get("description")
-    # Type before conversion, for the same reason `name` is checked before
-    # `.strip()`: the command schema types `quantity` as `object`, and `int()`
-    # over a non-numeric string raises `ValueError`, which routes to
-    # `unknown_error` instead of naming the field.
-    raw_quantity = payload.get("quantity", 1)
-    if not _is_int_not_bool(raw_quantity):
-        raise ValidationError("quantity must be an integer >= 0")
-    quantity = int(raw_quantity)
+    # Type before use, for the same reason `name` is checked before `.strip()`:
+    # the command schema types `quantity` as `object`, and arithmetic over a
+    # non-integer routes to `unknown_error` instead of naming the field.
+    quantity = validate_quantity(payload.get("quantity", 1))
     status = validate_item_status(
         payload.get("status", DEFAULT_ITEM_STATUS), known_statuses=known_statuses
     )
@@ -1277,10 +1289,7 @@ def _update_name_and_description(new_item: Item, update: ItemUpdate) -> None:
 
 def _update_quantity(new_item: Item, update: ItemUpdate) -> None:
     if "quantity" in update:
-        q = update["quantity"]
-        if not _is_int_not_bool(q) or q < 0:
-            raise ValidationError("quantity must be an integer >= 0")
-        new_item.quantity = q
+        new_item.quantity = validate_quantity(update["quantity"])
 
 
 def _update_status(new_item: Item, update: ItemUpdate, known_statuses: Collection[str]) -> None:

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -505,6 +505,33 @@ async def _persist_repo(hass: HomeAssistant) -> None:
     await storage_mod.async_persist_repo(hass)
 
 
+async def _mutate_item(
+    hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any], kind: str
+) -> None:
+    """Run one item operation and answer for it: write, free, announce, reply.
+
+    The command's fields are the op's payload — the envelope's `id` and `type`
+    are all that is stripped — so a command and the `items/bulk` row naming the
+    same `kind` reach the repository through one function and answer alike.
+    """
+
+    payload = {k: v for k, v in msg.items() if k not in {"id", "type"}}
+    serialized, action = _execute_item_op(hass, kind, payload)
+    await _persist_repo(hass)
+
+    # `deleted` is the action `_op_item_delete` alone returns, so it names
+    # exactly the body whose files nothing references any more — and exactly the
+    # command that answers `null`, its body being a pre-delete snapshot for the
+    # `items/deleted` event rather than a row the caller could read back.
+    deleted = action == "deleted"
+    if deleted:
+        await media_mod.async_delete_item_files(hass, [serialized])
+    notify_mutation(hass, action=action, item=serialized)
+    conn.send_message(
+        websocket_api.result_message(msg.get("id", 0), None if deleted else serialized)
+    )
+
+
 # -----------------------------
 # Utility commands
 # -----------------------------
@@ -798,18 +825,7 @@ async def ws_item_get(
 async def ws_item_update(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    item_id = msg["item_id"]
-    expected = msg.get("expected_version")
-    update = cast(
-        "ItemUpdate",
-        {k: v for k, v in msg.items() if k not in {"id", "type", "item_id", "expected_version"}},
-    )
-    updated = _repo(hass).update_item(item_id, update, expected_version=expected)
-    serialized = serialize_item(hass, updated)
-    action = "moved" if "location_id" in update else "updated"
-    await _persist_repo(hass)
-    notify_mutation(hass, action=action, item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_update")
 
 
 @websocket_api.websocket_command(
@@ -824,15 +840,7 @@ async def ws_item_update(
 async def ws_item_delete(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    item_id = msg["item_id"]
-    repo = _repo(hass)
-    before = repo.get_item(item_id)
-    serialized_before = serialize_item(hass, before)
-    repo.delete_item(item_id, expected_version=msg.get("expected_version"))
-    await _persist_repo(hass)
-    await media_mod.async_delete_item_files(hass, [serialized_before])
-    notify_mutation(hass, action="deleted", item=serialized_before)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), None))
+    await _mutate_item(hass, conn, msg, "item_delete")
 
 
 @websocket_api.websocket_command(
@@ -848,15 +856,7 @@ async def ws_item_delete(
 async def ws_item_adjust_quantity(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    # The schema types `delta` as `object`, so the integer check lives here and
-    # answers `validation_error` rather than an HA-core schema rejection.
-    item = _repo(hass).adjust_quantity(
-        msg["item_id"], _payload_int(msg, "delta"), expected_version=msg.get("expected_version")
-    )
-    serialized = serialize_item(hass, item)
-    await _persist_repo(hass)
-    notify_mutation(hass, action="quantity_changed", item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_adjust_quantity")
 
 
 @websocket_api.websocket_command(
@@ -872,20 +872,7 @@ async def ws_item_adjust_quantity(
 async def ws_item_set_quantity(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    # Validated here, not in the schema: `quantity` is typed `object` so a wrong
-    # type answers `validation_error` instead of an HA-core schema rejection,
-    # and validating upfront keeps the answer about the quantity even when the
-    # item id is also bad.
-    qty = _payload_int(msg, "quantity")
-    if qty < 0:
-        raise ValidationError("quantity must be an integer >= 0")
-    item = _repo(hass).set_quantity(
-        msg["item_id"], qty, expected_version=msg.get("expected_version")
-    )
-    serialized = serialize_item(hass, item)
-    await _persist_repo(hass)
-    notify_mutation(hass, action="quantity_changed", item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_set_quantity")
 
 
 @websocket_api.websocket_command(
@@ -901,15 +888,7 @@ async def ws_item_set_quantity(
 async def ws_item_check_out(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    item = _repo(hass).check_out(
-        msg["item_id"],
-        due_date=msg.get("due_date"),
-        expected_version=msg.get("expected_version"),
-    )
-    serialized = serialize_item(hass, item)
-    await _persist_repo(hass)
-    notify_mutation(hass, action="checked_out", item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_check_out")
 
 
 @websocket_api.websocket_command(
@@ -924,11 +903,7 @@ async def ws_item_check_out(
 async def ws_item_check_in(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    item = _repo(hass).check_in(msg["item_id"], expected_version=msg.get("expected_version"))
-    serialized = serialize_item(hass, item)
-    await _persist_repo(hass)
-    notify_mutation(hass, action="checked_in", item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_check_in")
 
 
 async def _apply_reminder(
@@ -1048,18 +1023,7 @@ async def ws_reminder_bump(
 async def ws_item_add_tags(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    serialized, action = _execute_item_op(
-        hass,
-        "item_add_tags",
-        {
-            "item_id": msg["item_id"],
-            "expected_version": msg.get("expected_version"),
-            "tags": msg.get("tags"),
-        },
-    )
-    await _persist_repo(hass)
-    notify_mutation(hass, action=action, item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_add_tags")
 
 
 @websocket_api.websocket_command(
@@ -1075,18 +1039,7 @@ async def ws_item_add_tags(
 async def ws_item_remove_tags(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    serialized, action = _execute_item_op(
-        hass,
-        "item_remove_tags",
-        {
-            "item_id": msg["item_id"],
-            "expected_version": msg.get("expected_version"),
-            "tags": msg.get("tags"),
-        },
-    )
-    await _persist_repo(hass)
-    notify_mutation(hass, action=action, item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_remove_tags")
 
 
 @websocket_api.websocket_command(
@@ -1103,19 +1056,7 @@ async def ws_item_remove_tags(
 async def ws_item_update_custom_fields(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    serialized, action = _execute_item_op(
-        hass,
-        "item_update_custom_fields",
-        {
-            "item_id": msg["item_id"],
-            "expected_version": msg.get("expected_version"),
-            "set": msg.get("set"),
-            "unset": msg.get("unset"),
-        },
-    )
-    await _persist_repo(hass)
-    notify_mutation(hass, action=action, item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_update_custom_fields")
 
 
 @websocket_api.websocket_command(
@@ -1131,18 +1072,7 @@ async def ws_item_update_custom_fields(
 async def ws_item_set_low_stock_threshold(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    serialized, action = _execute_item_op(
-        hass,
-        "item_set_low_stock_threshold",
-        {
-            "item_id": msg["item_id"],
-            "expected_version": msg.get("expected_version"),
-            "low_stock_threshold": msg.get("low_stock_threshold"),
-        },
-    )
-    await _persist_repo(hass)
-    notify_mutation(hass, action=action, item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_set_low_stock_threshold")
 
 
 @websocket_api.websocket_command(
@@ -1351,18 +1281,7 @@ async def ws_item_attachment_reorder(
 async def ws_item_move(
     hass: HomeAssistant, conn: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    serialized, action = _execute_item_op(
-        hass,
-        "item_move",
-        {
-            "item_id": msg["item_id"],
-            "expected_version": msg.get("expected_version"),
-            "location_id": msg.get("location_id"),
-        },
-    )
-    await _persist_repo(hass)
-    notify_mutation(hass, action=action, item=serialized)
-    conn.send_message(websocket_api.result_message(msg.get("id", 0), serialized))
+    await _mutate_item(hass, conn, msg, "item_move")
 
 
 @websocket_api.websocket_command(

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -150,7 +150,14 @@ def _error_envelope(
     return {"id": iden, "type": "result", "success": False, "error": error}
 
 
-def _error_message(_id: int, exc: Exception, *, context: dict[str, Any]) -> dict[str, Any]:
+def _log_rejection(exc: Exception, context: dict[str, Any]) -> tuple[str, str]:
+    """Log one refused call at the level its code earns, and say what the wire carries.
+
+    The severity, the traceback and the message a client is given are decided
+    here for a whole command and for one row of a batch alike, so a rejection
+    reads the same in the log whichever of the two carried it.
+    """
+
     code = error_code(exc)
     LOGGER.log(
         log_severity(code, exc),
@@ -158,7 +165,12 @@ def _error_message(_id: int, exc: Exception, *, context: dict[str, Any]) -> dict
         extra={"domain": DOMAIN, **(context or {})},
         exc_info=log_exc_info(code, exc),
     )
-    return _error_envelope(_id, code, str(exc), context or None)
+    return code, str(exc)
+
+
+def _error_message(_id: int, exc: Exception, *, context: dict[str, Any]) -> dict[str, Any]:
+    code, message = _log_rejection(exc, context)
+    return _error_envelope(_id, code, message, context or None)
 
 
 # -----------------------------
@@ -304,6 +316,48 @@ def _validate_bulk_ops(operations: Any) -> list[dict[str, Any]]:
             raise ValidationError("operation.payload must be an object")
         validated.append({"op_id": normalized_op_id, "kind": str(kind), "payload": payload})
     return validated
+
+
+#: The payload fields a rejected bulk row names, the way `ws_guard`'s
+#: `context_fields` name a command's. One list for every kind, because a row
+#: carries whichever of them its own kind takes.
+_BULK_OP_CONTEXT_FIELDS = (
+    "item_id",
+    "expected_version",
+    "location_id",
+    "due_date",
+    "quantity",
+    "delta",
+    "low_stock_threshold",
+    "tags",
+    "set",
+    "unset",
+)
+
+
+def _bulk_op_error(
+    op_id: str, kind: str, payload: dict[str, Any], exc: Exception
+) -> dict[str, object]:
+    """Map one refused row to the verdict the caller reads under its `op_id`.
+
+    Built from the same two pieces `ws_guard` builds a whole command's answer
+    from, so a row and a command say the same thing about the same failure: one
+    rejected row is classified on its own code — a stale version inside a batch
+    is no more of a fault than it is on its own — and anything that is not a
+    domain error answers the generic message with its details left in the log.
+    """
+
+    context = _context_from_msg("items_bulk_op_failed", payload, _BULK_OP_CONTEXT_FIELDS)
+    context["op_id"] = op_id
+    context["kind"] = kind
+    if isinstance(exc, ValidationError | NotFoundError | ConflictError | StorageError):
+        code, message = _log_rejection(exc, context)
+    else:
+        LOGGER.exception(
+            "Unexpected error in a bulk operation", extra={"domain": DOMAIN, **context}
+        )
+        code, message = "unknown_error", UNEXPECTED_ERROR_MESSAGE
+    return {"success": False, "error": {"code": code, "message": message, "context": context}}
 
 
 def _payload_item_id(payload: dict[str, Any]) -> str:
@@ -1306,69 +1360,12 @@ async def ws_items_bulk(
         payload = op["payload"]
         try:
             serialized, action = _execute_item_op(hass, kind, payload)
+        except Exception as exc:
+            # Whatever it was, it fails its own row and no other.
+            results[op_id] = _bulk_op_error(op_id, kind, payload, exc)
+        else:
             results[op_id] = {"success": True, "result": serialized}
             successful_ops.append((op_id, serialized, action))
-        except (ValidationError, NotFoundError, ConflictError, StorageError) as exc:
-            # Log error with full context for debugging
-            ctx = {
-                "op_id": op_id,
-                "kind": kind,
-                "error": str(exc),
-            }
-            for k in (
-                "item_id",
-                "expected_version",
-                "location_id",
-                "due_date",
-                "quantity",
-                "delta",
-                "low_stock_threshold",
-                "tags",
-                "set",
-                "unset",
-            ):
-                if k in payload:
-                    ctx[k] = payload.get(k)
-
-            # One rejected op is classified on its own code, not on the batch:
-            # a stale version inside a bulk is no more of a fault than it is
-            # on its own.
-            code = error_code(exc)
-            LOGGER.log(
-                log_severity(code, exc),
-                "Bulk operation failed, continuing with remaining ops",
-                extra={
-                    "domain": DOMAIN,
-                    "op": "items_bulk_op_failed",
-                    **ctx,
-                },
-                exc_info=log_exc_info(code, exc),
-            )
-
-            results[op_id] = {
-                "success": False,
-                "error": {"code": code, "message": str(exc), "context": ctx},
-            }
-        except Exception:
-            # A malformed payload must fail only its own op, never the batch,
-            # and internal details stay out of the client-visible message.
-            LOGGER.exception(
-                "Bulk operation failed unexpectedly, continuing with remaining ops",
-                extra={
-                    "domain": DOMAIN,
-                    "op": "items_bulk_op_failed",
-                    "op_id": op_id,
-                    "kind": kind,
-                },
-            )
-            results[op_id] = {
-                "success": False,
-                "error": {
-                    "code": "unknown_error",
-                    "message": UNEXPECTED_ERROR_MESSAGE,
-                    "context": {"op_id": op_id, "kind": kind},
-                },
-            }
 
     # Only a batch that changed something writes or announces anything. An
     # all-failed batch deliberately logs no summary of its own: each op already

--- a/custom_components/haventory/ws.py
+++ b/custom_components/haventory/ws.py
@@ -70,6 +70,7 @@ from .models import (
     serialize_status_definition,
     validate_attachment_meta,
     validate_item_filter,
+    validate_quantity,
     validate_sort,
 )
 from .rate_limit import RateLimiter
@@ -378,9 +379,11 @@ def _op_item_set_quantity(
     hass: HomeAssistant, payload: dict[str, Any]
 ) -> tuple[dict[str, Any], str]:
     repo = _repo(hass)
+    # The quantity before the item id: a payload wrong about both is answered on
+    # the value, which is the answer both this op's callers give.
+    quantity = validate_quantity(payload.get("quantity"))
     item_id = _payload_item_id(payload)
-    qty = _payload_int(payload, "quantity")
-    updated = repo.set_quantity(item_id, qty, expected_version=payload.get("expected_version"))
+    updated = repo.set_quantity(item_id, quantity, expected_version=payload.get("expected_version"))
     return serialize_item(hass, updated), "quantity_changed"
 
 

--- a/docs/backend_api_contract.md
+++ b/docs/backend_api_contract.md
@@ -34,6 +34,7 @@ Guarantees (every `haventory/*` command is wrapped by the same guard):
 
 - Domain errors carry the exception message plus structured `data` context (`op` and selected request fields).
 - Any unexpected (non-domain) exception maps to `unknown_error` with the fixed message `"unexpected error; see Home Assistant logs"` and `data` context. Exception text and stack traces never reach the client; the full traceback goes to the server log only.
+- A single-item command and the `items/bulk` row naming the same `kind` run one operation, so one payload gets one answer from both. A value the payload is wrong about — a `quantity` that is not an integer `>= 0`, an `item_id` that is not a non-empty string — is refused before the item is looked up, and so answers `validation_error` even when the id names nothing.
 - In `haventory/items/bulk`, a failing operation (including an unexpectedly malformed **payload**) fails only its own per-op result; the remaining operations still run and successful ones persist. Note the batch **envelope** is validated first: a structurally malformed operation *entry* (non-object entry, missing/invalid `op_id`, non-string `kind`, non-object `payload`) cannot be reported per-op and rejects the whole command with `validation_error`.
 
 Transport-level errors produced by Home Assistant itself (before a handler runs) are outside this taxonomy and can also be observed by clients: `invalid_format` (request failed the command's voluptuous schema) and `unknown_command` (integration not loaded or unknown `type`).

--- a/scripts/stress_test.py
+++ b/scripts/stress_test.py
@@ -256,7 +256,9 @@ class DockerLogMonitor:
                 self.metrics.persist_timestamps.append(("complete", ts))
             elif "Failed to persist repository" in line or "persist_failed" in line:
                 self.metrics.persist_failures += 1
-            elif "Bulk operation failed" in line:
+            elif "items_bulk_op_failed" in line:
+                # The structured `op` rather than the sentence: a refused row is
+                # logged with the reason as its message, whatever that reason is.
                 self.metrics.bulk_op_failures += 1
 
 

--- a/tests/test_delete_surfaces_offline.py
+++ b/tests/test_delete_surfaces_offline.py
@@ -1,0 +1,84 @@
+"""Every surface that deletes an item frees its files through the same call.
+
+Three of them remove an item: `haventory/item/delete`, an `item_delete` row of
+`haventory/items/bulk`, and the `haventory.item_delete` service. Each one is
+asserted here against `media.async_delete_item_files` rather than against the
+files on disk, because what makes a fourth surface safe is going through that
+one call — a test per caller is what let the bulk path ship without it.
+
+Ordering, and what a failed write frees, stay with each caller's own tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from custom_components.haventory import media as media_mod
+from custom_components.haventory import services as services_mod
+from custom_components.haventory.models import AttachmentMeta, iso_utc_now, new_uuid4
+from custom_components.haventory.repository import Repository
+from custom_components.haventory.ws import setup as ws_setup
+from homeassistant.core import HomeAssistant
+
+from runtime_helpers import install_runtime
+from ws_helpers import ws_send
+
+Surface = Callable[[HomeAssistant, str], Awaitable[None]]
+
+
+async def _command(hass: HomeAssistant, item_id: str) -> None:
+    res = await ws_send(hass, 1, "haventory/item/delete", item_id=item_id)
+    assert res["success"] is True
+
+
+async def _bulk_row(hass: HomeAssistant, item_id: str) -> None:
+    res = await ws_send(
+        hass,
+        1,
+        "haventory/items/bulk",
+        operations=[{"op_id": "d", "kind": "item_delete", "payload": {"item_id": item_id}}],
+    )
+    assert res["result"]["results"]["d"]["success"] is True
+
+
+async def _service(hass: HomeAssistant, item_id: str) -> None:
+    await services_mod.service_item_delete(hass, {"item_id": item_id})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "surface",
+    [_command, _bulk_row, _service],
+    ids=["item/delete", "items/bulk", "service"],
+)
+async def test_a_delete_frees_the_items_files_through_one_call(
+    surface: Surface, monkeypatch
+) -> None:
+    hass = HomeAssistant()
+    repo = Repository()
+    install_runtime(hass, repository=repo)
+    ws_setup(hass)
+    item = repo.create_item({"name": "Drill"})
+    repo.add_attachment(
+        item.id,
+        AttachmentMeta(
+            id=new_uuid4(),
+            kind="picture",
+            filename="photo.png",
+            mime="image/png",
+            size=16,
+            uploaded_at=iso_utc_now(),
+        ),
+    )
+
+    freed: list[list[str]] = []
+
+    async def _spy(_hass, bodies):  # type: ignore[no-untyped-def]
+        freed.append([str(body.get("id")) for body in bodies])
+
+    monkeypatch.setattr(media_mod, "async_delete_item_files", _spy)
+
+    await surface(hass, str(item.id))
+
+    assert freed == [[str(item.id)]]

--- a/tests/test_item_input_validation_offline.py
+++ b/tests/test_item_input_validation_offline.py
@@ -4,7 +4,10 @@ Regression coverage for the PR #91 review:
 - non-scalar category/description are rejected before indexing, so a bad value
   can never leave a durable partially-indexed phantom item;
 - boolean quantity/delta/low_stock_threshold are rejected consistently on the
-  single-command paths (matching the bulk validator), never stored as a bool.
+  single-command paths (matching the bulk validator), never stored as a bool;
+- a value the model refuses is refused before the item is looked up, so
+  `haventory/item/set_quantity` and the `items/bulk` row of the same kind answer
+  one payload with one code.
 """
 
 from __future__ import annotations
@@ -138,6 +141,40 @@ async def test_ws_set_quantity_bool_is_validation_error() -> None:
     got = await ws_send(hass, 4, "haventory/item/get", item_id=item_id)
     assert got["result"]["quantity"] == 1
     assert got["result"]["quantity"] is not True
+
+
+@pytest.mark.asyncio
+async def test_a_refused_quantity_answers_alike_from_the_command_and_from_bulk() -> None:
+    """The value is checked before the item is looked up, on both surfaces.
+
+    A payload that is wrong about the quantity *and* names an item that is not
+    there has two possible answers, and a caller that batches its edits must not
+    get a different one from the one it gets when it sends them singly.
+    """
+
+    hass = _make_hass()
+    missing = "00000000-0000-4000-8000-000000000000"
+
+    single = await ws_send(hass, 1, "haventory/item/set_quantity", item_id=missing, quantity=-1)
+    batch = await ws_send(
+        hass,
+        2,
+        "haventory/items/bulk",
+        operations=[
+            {
+                "op_id": "a",
+                "kind": "item_set_quantity",
+                "payload": {"item_id": missing, "quantity": -1},
+            }
+        ],
+    )
+
+    assert single["success"] is False
+    assert single["error"]["code"] == "validation_error"
+    row = batch["result"]["results"]["a"]
+    assert row["success"] is False
+    assert row["error"]["code"] == single["error"]["code"]
+    assert row["error"]["message"] == single["error"]["message"]
 
 
 # -----------------------------

--- a/tests/test_item_input_validation_offline.py
+++ b/tests/test_item_input_validation_offline.py
@@ -5,9 +5,9 @@ Regression coverage for the PR #91 review:
   can never leave a durable partially-indexed phantom item;
 - boolean quantity/delta/low_stock_threshold are rejected consistently on the
   single-command paths (matching the bulk validator), never stored as a bool;
-- a value the model refuses is refused before the item is looked up, so
-  `haventory/item/set_quantity` and the `items/bulk` row of the same kind answer
-  one payload with one code.
+- a value the payload is wrong about is refused before the item is looked up, so
+  a single-item command and the `items/bulk` row of the same kind answer one
+  payload with one code.
 """
 
 from __future__ import annotations
@@ -167,6 +167,32 @@ async def test_a_refused_quantity_answers_alike_from_the_command_and_from_bulk()
                 "payload": {"item_id": missing, "quantity": -1},
             }
         ],
+    )
+
+    assert single["success"] is False
+    assert single["error"]["code"] == "validation_error"
+    row = batch["result"]["results"]["a"]
+    assert row["success"] is False
+    assert row["error"]["code"] == single["error"]["code"]
+    assert row["error"]["message"] == single["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_an_item_id_of_the_wrong_type_names_the_field_on_both_surfaces() -> None:
+    """`item_id` is typed `object` in the schema, so the handler is what names it.
+
+    A number where an id belongs is a client bug, and `not_found` sends its
+    author looking for a missing item instead.
+    """
+
+    hass = _make_hass()
+
+    single = await ws_send(hass, 1, "haventory/item/update", item_id=7, name="X")
+    batch = await ws_send(
+        hass,
+        2,
+        "haventory/items/bulk",
+        operations=[{"op_id": "a", "kind": "item_update", "payload": {"item_id": 7, "name": "X"}}],
     )
 
     assert single["success"] is False


### PR DESCRIPTION
## Summary

Eleven single-item WebSocket commands each carried their own copy of the same
tail — run the operation, persist, announce, reply. Six of those copies were
inline twins of the `_op_item_*` entry `haventory/items/bulk` dispatches to, and
five more rebuilt a payload dict out of the frame they had just been handed.
`_mutate_item` is that tail once; each handler is now its schema, its guard and
one line, and a command and the bulk row naming the same `kind` reach the
repository through one function.

`media.async_delete_item_files` moves into that tail, so the rule #592 put in
one place is now reached from one place on the WebSocket side, and the test its
follow-up asked for lands with it: all three delete surfaces asserted against
that one call, once, instead of a test per caller.

`ws_items_bulk`'s per-row error mapping was a hand-built version of what
`ws_guard` already does for a whole command; it now uses the same two pieces.

Refs #230 (items 4 and 6 of its 2026-08-22 comment: BE-WS-C1, BE-WS-C7), refs #565.

## Two answers move, and what they are

Both are the collapse making a command answer the way its bulk row already
answers — or the other way round where the model's answer is the contract.

| Payload | Before, `item/*` | Before, `items/bulk` | After, both |
|---|---|---|---|
| `{item_id: <unknown id>, quantity: -1}` | `validation_error` | `not_found` | `validation_error` |
| `{item_id: 7, name: "X"}` (id not a string) | `not_found` | `validation_error` | `validation_error` |

The first is the asymmetry the audit recorded: `ws_item_set_quantity` pre-checked
`quantity < 0` with a message copied from `models.py`, and `_op_item_set_quantity`
did not check at all, so the batch looked the item up first. The rule now lives in
`models.validate_quantity` — one function replacing the three copies create, update
and the core-field check each carried — and the op runs it before the lookup.

The second follows from the same ordering: `_payload_item_id` refuses a
non-string id, which the eleven commands did not do for themselves. Both are
what `docs/backend_api_contract.md` already says about an `object`-typed field:
the handler names the value rather than letting the id decide the code. The
contract gains one sentence saying it for the pair of surfaces at once;
`docs/data_shapes.md` needed nothing — no shape moved, only which code answers a
value the shape already forbade (`quantity?: number>=0` was and stays the
documented type).

## Counting

| | Lines |
|---|---|
| Production removed (`custom_components/`) | 198 |
| Test lines removed | 1 |
| Lines added | 278 |

`git diff --stat` against `main`: `models.py` +23 −14, `ws.py` +103 −184,
`backend_api_contract.md` +1, `scripts/stress_test.py` +3 −1,
`test_delete_surfaces_offline.py` +84, `test_item_input_validation_offline.py`
+64 −1. Production net −72; the added test lines are the delete-surface
assertion and the two answers-alike cases.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1325
  passed, 26 skipped** (5 new; `main` collects 1320). `uv run ruff check .` → All
  checks passed. `uv run ruff format --check .` → 187 files already formatted.
  `uv run mypy` → Success: no issues found in 26 source files.
- [x] In-process (phacc), card built first: `bash scripts/test_integration.sh` →
  **153 passed in 20.23s** — `[ OK ] Integration tests OK`.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck`
  clean, `npx vitest run` → 68 files, 1924 passed, `npm run build` → 745.77 kB.
  No card file is touched; run because the card is built for phacc anyway.

Each of the four commits was gate-green on its own. The two behaviour commits
were seen failing first: `test_a_refused_quantity_answers_alike_from_the_command_and_from_bulk`
fails with `assert 'not_found' == 'validation_error'` before the quantity fix,
and `test_an_item_id_of_the_wrong_type_names_the_field_on_both_surfaces` fails
the same way with `ws.py` alone stashed. The delete-surface test was seen failing
by dropping the `async_delete_item_files` call out of the tail, which reddens the
`item/delete` case and leaves the other two green — the shape of the bug #592
fixed.

The eleven collapsed handlers needed no test change at all, which is what says
the cut is a cut: `test_ws_items_offline.py`, `test_ws_bulk_offline.py`,
`test_ws_error_mapping_offline.py` (which monkeypatches `_op_item_update`, so the
dispatch table stays resolved per call), `test_ws_guard_offline.py` and
`test_ws_logging_offline.py` all pass untouched.

New tests:

- `tests/test_delete_surfaces_offline.py` — one parametrized case over
  `haventory/item/delete`, an `item_delete` row of `haventory/items/bulk` and
  `haventory.item_delete`, each asserted against `media.async_delete_item_files`
  with the deleted body. Ordering and what a failed write frees stay with each
  caller's own tests; this one holds the rule a fourth surface would have to meet.
- `tests/test_item_input_validation_offline.py` — the two answers-alike cases in
  the table above.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
  `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved.

## Decisions taken against drifted notes

- **`_mutate_item` takes no `counts` parameter.** The plan's signature has
  `counts=True`, but none of the eleven table-shaped commands suppresses the
  counts event — the two that do (`attachment/update`, `attachment/reorder`) are
  not table-shaped and keep their own bodies. A parameter with one possible value
  is what this milestone removes, so it is not written; a later caller that needs
  it adds it with its reason.
- **The bulk row reuses `_context_from_msg` and the logging half of
  `_error_message`.** That half is now `_log_rejection`, which returns the
  `(code, message)` pair the wire carries. Calling `_error_message` itself would
  have meant building a whole error envelope under a fake frame id in order to
  read two fields back out of it.
- **The `set_quantity` rule went into `models.validate_quantity` rather than
  staying restated in `ws.py`.** The plan says the pre-check goes because it
  restates the model; moving it into the op would only have moved the
  restatement. `models.py` is edited for that one function, which replaces three
  copies of the same rule and its message.
- **`scripts/stress_test.py` is edited** (one line): it counted refused bulk rows
  by matching the fixed sentence that log line used to carry. The line now
  carries the reason as its message, so the script matches the structured
  `items_bulk_op_failed` instead.

## Follow-ups

- `scripts/stress_test.py` still counts `Persist requested, debouncing` and
  `Cancelled pending persist task`, log lines PR #617 deleted, so its debounce
  metrics are permanently zero. Not filed: the maintained stress driver is
  `.claude/skills/test-haventory/stress.py`, and this one is a dev script whose
  sweep belongs with whatever revisits the skills.
- `_payload_int` now has one caller left (`_op_item_adjust_quantity`); BE-WS-C6
  retires it along with the `object`-typing pass.
- The row error envelope calls its context `context` while every command-level
  envelope calls it `data`. One name would be better, but the card reads neither
  (it reads `code` and `message` off a row), so the change is a wire rename with
  no reader — worth doing only when something else moves that envelope.

## Handover

1. **Merged / left open** — this PR is left open for the master to squash-merge
   once CI is green; nothing here needs the owner. CI on `ada45ea`: all 12 checks
   green, `integration` and `backend (3.14)` included.
2. **Test this by hand** — nothing `[phone]`, `[German]` or `[owner]`-only: no
   card file, no string, no dictionary is touched.
3. **Validate locally**
   1. `[dev-ha]` Deploy the branch and reload the entry. `[HA settings]`
      Developer Tools → Actions → `haventory.item_delete` on an item carrying a
      picture; the file under `<config>/haventory/attachments/<item_id>/` is gone
      and the response envelope is unchanged.
   2. `[browser]` In the card, edit an item, move it, adjust and set its
      quantity, check it out and back in, add and remove a tag, and change its
      low-stock threshold; each still answers and each still repaints a second
      open tab. These are the eleven collapsed commands.
   3. `[browser]` Select several items in the bulk bar and delete them; their
      pictures are gone from disk, and a row refused on a stale version keeps
      its own.
   4. `[log]` Nothing at ERROR carrying `haventory` through any of the above; a
      refused bulk row logs at WARNING with `op=items_bulk_op_failed` and the
      reason as its message.
4. **Decisions taken against drifted notes** — the four above.
5. **Follow-ups** — the three above, none filed.
6. **State left behind** — branch `claude/v0-8-0-m1-mutation-tail`, no assets
   branch, no `.env` written, no Home Assistant instance touched. Counting for
   this PR: 198 production lines removed, 1 test line removed, 278 added.