### PR TITLE
refactor(repository): the scan answers q; delete the text index

### DIFF
--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -481,8 +481,9 @@ def normalize_search_text(text: str) -> str:
     """Normalize text for search matching (lowercase, strip accents).
 
     Uses NFKD normalization to separate accents from characters, then keeps only ASCII.
-    Shared by the repository search indexes and the post-filter in ``_item_matches_q``
-    so both layers agree on what "case-insensitive, accent-insensitive" means.
+    What ``_item_matches_q`` reads both the query and the item's text through, so
+    "case-insensitive, accent-insensitive" means one thing on both sides of the
+    comparison.
     """
 
     if not text:

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -14,13 +14,12 @@ import base64
 import binascii
 import copy
 import json
-import re
 import uuid
 from collections import deque
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from datetime import date
-from typing import Any, NamedTuple, TypedDict
+from typing import Any, TypedDict
 
 from .calendar_projection import next_occurrence_after
 from .exceptions import ConflictError, NotFoundError, ValidationError
@@ -58,7 +57,6 @@ from .models import (
     location_sort_key,
     monotonic_timestamp_after,
     new_uuid4,
-    normalize_search_text,
     normalize_text_for_sort,
     parse_uuid4,
     require_string_list,
@@ -76,21 +74,6 @@ from .models import (
 )
 
 LOGGER = context_logger(__name__)
-
-
-class _TextTokens(NamedTuple):
-    """Cached text-index tokens for one item, split by source.
-
-    ``base_*`` tokens derive from name/description/category/tags; ``path_*``
-    tokens derive from the denormalized ``location_path.display_path``. The
-    split lets subtree moves update only the path-derived buckets.
-    """
-
-    base_words: frozenset[str]
-    path_words: frozenset[str]
-    name_prefixes: frozenset[str]
-    base_trigrams: frozenset[str]
-    path_trigrams: frozenset[str]
 
 
 class PageResult(TypedDict):
@@ -116,9 +99,6 @@ class InternalIndexes(TypedDict):
 
 # Sentinel for optional args that distinguish "not provided" from explicit None
 UNSET: object = object()
-
-TRIGRAM_MIN_LEN = 3
-PREFIX_MIN_LEN = 2
 
 #: Longest pagination cursor this build will even attempt to decode. A cursor is
 #: base64 of a small JSON object this repository minted itself, so anything
@@ -252,14 +232,6 @@ class Repository:
         self._items_by_area_id: dict[str, set[str]] = {}
         # Cached name sort keys
         self._name_sort_key_by_item_id: dict[str, str] = {}
-
-        # Text Indices
-        self._word_to_item_ids: dict[str, set[str]] = {}
-        self._name_prefix_to_item_ids: dict[str, set[str]] = {}
-        self._trigram_to_item_ids: dict[str, set[str]] = {}
-        # Per-item cached tokens so clearing/delta-updating the text indexes
-        # never has to re-derive tokens from the item fields.
-        self._item_text_tokens: dict[str, _TextTokens] = {}
 
         # Location tree indexes
         self._children_ids_by_parent_id: dict[str | None, set[str]] = {}
@@ -460,9 +432,6 @@ class Repository:
         # Update subtree index
         self._add_item_to_subtree_index(item)
 
-        # Update text search index
-        self._index_item_text(item)
-
         # Increment generation on state modification
         self._increment_generation()
 
@@ -491,9 +460,6 @@ class Repository:
 
         # Remove from subtree index
         self._remove_item_from_subtree_index(item)
-
-        # Remove from text search index
-        self._clear_item_text_index(item)
 
         # Finally, drop from primary store
         self._items_by_id.pop(item_key, None)
@@ -544,199 +510,6 @@ class Repository:
 
     def _is_low_stock(self, item: Item) -> bool:
         return item_is_low_stock(item)
-
-    def _normalize_for_search(self, text: str) -> str:
-        """Normalize text for search indexing (lowercase, strip accents).
-
-        Delegates to :func:`models.normalize_search_text` so the index path and the
-        ``filter_items`` post-filter always agree on normalization.
-        """
-        return normalize_search_text(text)
-
-    def _extract_trigrams(self, text: str) -> set[str]:
-        """Extract 3-character trigrams from normalized text."""
-        if len(text) < TRIGRAM_MIN_LEN:
-            return set()
-        return {text[i : i + TRIGRAM_MIN_LEN] for i in range(len(text) - (TRIGRAM_MIN_LEN - 1))}
-
-    def _tokenize(self, text: str) -> list[str]:
-        """Normalize and split text into indexable words."""
-        norm = self._normalize_for_search(text)
-        if not norm:
-            return []
-        return [w for w in re.split(r"[^a-z0-9]", norm) if w]
-
-    def _compute_path_tokens(self, display_path: str) -> tuple[frozenset[str], frozenset[str]]:
-        """Return (words, trigrams) derived from a location display path."""
-        words = self._tokenize(display_path)
-        trigrams: set[str] = set()
-        for w in words:
-            trigrams |= self._extract_trigrams(w)
-        return frozenset(words), frozenset(trigrams)
-
-    def _compute_text_tokens(self, item: Item) -> _TextTokens:
-        """Derive the full token record for an item's text indexes."""
-        base_words: set[str] = set()
-        base_trigrams: set[str] = set()
-        for text in (item.name, item.description or "", item.category or "", *item.tags):
-            for w in self._tokenize(text):
-                base_words.add(w)
-                base_trigrams |= self._extract_trigrams(w)
-
-        # Prefixes are indexed per word of the name only.
-        name_prefixes: set[str] = set()
-        for w in self._tokenize(item.name):
-            for i in range(PREFIX_MIN_LEN, len(w) + 1):
-                name_prefixes.add(w[:i])
-
-        path_words, path_trigrams = self._compute_path_tokens(item.location_path.display_path)
-        return _TextTokens(
-            base_words=frozenset(base_words),
-            path_words=path_words,
-            name_prefixes=frozenset(name_prefixes),
-            base_trigrams=frozenset(base_trigrams),
-            path_trigrams=path_trigrams,
-        )
-
-    def _index_item_text(self, item: Item) -> None:
-        """Build text indexes for an item and cache its token record."""
-        item_key = str(item.id)
-        tokens = self._compute_text_tokens(item)
-        self._item_text_tokens[item_key] = tokens
-
-        for prefix in tokens.name_prefixes:
-            self._add_to_bucket(self._name_prefix_to_item_ids, prefix, item_key)
-        for w in tokens.base_words | tokens.path_words:
-            self._add_to_bucket(self._word_to_item_ids, w, item_key)
-        for t in tokens.base_trigrams | tokens.path_trigrams:
-            self._add_to_bucket(self._trigram_to_item_ids, t, item_key)
-
-    def _clear_item_text_index(self, item: Item) -> None:
-        """Remove item from text bucket indexes using its cached tokens."""
-        item_key = str(item.id)
-        tokens = self._item_text_tokens.pop(item_key, None)
-        if tokens is None:  # pragma: no cover - defensive fallback
-            tokens = self._compute_text_tokens(item)
-
-        for prefix in tokens.name_prefixes:
-            self._remove_from_bucket(self._name_prefix_to_item_ids, prefix, item_key)
-        for w in tokens.base_words | tokens.path_words:
-            self._remove_from_bucket(self._word_to_item_ids, w, item_key)
-        for t in tokens.base_trigrams | tokens.path_trigrams:
-            self._remove_from_bucket(self._trigram_to_item_ids, t, item_key)
-
-    def _apply_path_token_delta(
-        self,
-        item_key: str,
-        tokens: _TextTokens,
-        new_path_words: frozenset[str],
-        new_path_trigrams: frozenset[str],
-    ) -> None:
-        """Update text buckets for a path-only change using set deltas.
-
-        A bucket entry must exist iff the token is in ``base | path``: a token
-        leaving the path is only removed when the base does not also carry it,
-        and a token joining the path is only added when the base did not
-        already index it.
-        """
-        for w in tokens.path_words - new_path_words:
-            if w not in tokens.base_words:
-                self._remove_from_bucket(self._word_to_item_ids, w, item_key)
-        for w in new_path_words - tokens.path_words:
-            if w not in tokens.base_words:
-                self._add_to_bucket(self._word_to_item_ids, w, item_key)
-
-        for t in tokens.path_trigrams - new_path_trigrams:
-            if t not in tokens.base_trigrams:
-                self._remove_from_bucket(self._trigram_to_item_ids, t, item_key)
-        for t in new_path_trigrams - tokens.path_trigrams:
-            if t not in tokens.base_trigrams:
-                self._add_to_bucket(self._trigram_to_item_ids, t, item_key)
-
-        self._item_text_tokens[item_key] = tokens._replace(
-            path_words=new_path_words, path_trigrams=new_path_trigrams
-        )
-
-    def _get_candidates_for_word(self, word: str) -> set[str]:
-        """Get candidate item IDs for a single search word using strict OR logic."""
-        word_candidates = self._word_to_item_ids.get(word)
-        prefix_candidates = self._name_prefix_to_item_ids.get(word)
-
-        matches = set()
-        if word_candidates:
-            matches.update(word_candidates)
-        if prefix_candidates:
-            matches.update(prefix_candidates)
-
-        if not matches and len(word) >= TRIGRAM_MIN_LEN:
-            trigrams = self._extract_trigrams(word)
-            if trigrams:
-                trigram_candidates: list[set[str]] = []
-                for t in trigrams:
-                    ts = self._trigram_to_item_ids.get(t)
-                    if ts:
-                        trigram_candidates.append(ts)
-
-                if trigram_candidates:
-                    fuzzy_matches = set(trigram_candidates[0])
-                    for other in trigram_candidates[1:]:
-                        fuzzy_matches.intersection_update(other)
-                    matches.update(fuzzy_matches)
-
-        return matches
-
-    def _text_index_covers_query(self, query: str) -> bool:
-        """Return True when the text index can answer ``query`` without false negatives.
-
-        ``_item_matches_q`` matches a query word anywhere inside an item's text,
-        mid-word included. The index only reaches that far through trigrams, so a
-        word shorter than ``TRIGRAM_MIN_LEN`` is reachable only where it happens to
-        start a name word — "wi" finds "Wine" and never "Kiwi". A query with no
-        indexable word at all (punctuation only) is outside the index entirely.
-
-        For those queries the index is a lossy filter rather than a pre-filter, and
-        callers must let the ``filter_items`` scan answer instead. Tokenizes exactly
-        as ``_search_by_text`` does, so the two always agree on the word boundaries
-        the judgement is made over.
-        """
-
-        words = self._tokenize(query)
-        return bool(words) and all(len(w) >= TRIGRAM_MIN_LEN for w in words)
-
-    def _search_by_text(self, query: str) -> set[str]:
-        """Return item IDs matching the query using indexes.
-
-        Per query word, candidates come from exact word matches, name-prefix
-        matches, and (only when both miss) a trigram fallback — see
-        ``_get_candidates_for_word``. Multi-word queries intersect the per-word
-        candidate sets.
-        """
-        norm_query = self._normalize_for_search(query)
-        if not norm_query:
-            return set()
-
-        # Split into words
-        query_words = [w for w in re.split(r"[^a-z0-9]", norm_query) if w]
-        if not query_words:
-            return set()
-
-        # Strategy: Intersection of candidates for each word
-        candidate_sets: list[set[str]] = []
-
-        for word in query_words:
-            matches = self._get_candidates_for_word(word)
-            if not matches:
-                return set()
-            candidate_sets.append(matches)
-
-        if not candidate_sets:
-            return set()
-
-        result = set(candidate_sets[0])
-        for other in candidate_sets[1:]:
-            result.intersection_update(other)
-
-        return result
 
     # -----------------------------
     # Internal helpers — locations
@@ -1152,11 +925,10 @@ class Repository:
         """Refresh ``location_path`` for items under any of the given locations.
 
         Fast path for subtree renames/moves. All items in one location share
-        that location's (already recomputed) ``path``, and only two things
-        change per item: the denormalized ``location_path`` and the
-        path-derived text tokens. Everything else is either untouched
-        (location/category/tag/checkout/low-stock buckets, name sort keys) or
-        rebuilt wholesale by the caller via
+        that location's (already recomputed) ``path``, so the only thing that
+        changes per item is the denormalized ``location_path``. Everything else
+        is either untouched (location/category/tag/checkout/low-stock buckets,
+        name sort keys) or rebuilt wholesale by the caller via
         ``_rebuild_location_hierarchy_indexes`` (subtree index). The effective
         area is re-resolved once per location and items are re-bucketed only
         when it actually changed.
@@ -1181,7 +953,6 @@ class Repository:
                 continue
 
             new_path = loc.path
-            new_path_words, new_path_trigrams = self._compute_path_tokens(new_path.display_path)
 
             # All items of a location live in the same area bucket; probe once.
             item_id_list = list(item_ids)
@@ -1199,13 +970,6 @@ class Repository:
                 updated = copy.copy(old_item)
                 updated.location_path = new_path
                 self._items_by_id[item_id] = updated
-
-                tokens = self._item_text_tokens.get(item_id)
-                if tokens is None:  # pragma: no cover - defensive fallback
-                    self._clear_item_text_index(old_item)
-                    self._index_item_text(updated)
-                else:
-                    self._apply_path_token_delta(item_id, tokens, new_path_words, new_path_trigrams)
 
                 if area_changed:
                     if old_area is not None:
@@ -1560,6 +1324,11 @@ class Repository:
         available indexes (category, tags, location, etc.).
         Returns None if no selective index applies.
         Returns empty list if indexes prove no items match.
+
+        ``q`` is not one of them. It matches anywhere inside an item's text,
+        mid-word included, which a bucket keyed by whole words or by fixed-length
+        fragments cannot narrow without dropping matches the contract promises —
+        so ``filter_items`` answers ``q`` over whatever this hands it.
         """
         if not flt:
             return None
@@ -1576,19 +1345,6 @@ class Repository:
                 if not s:
                     return []
                 candidate_sets.append(s)
-
-        # 0. Text Search Index (q)
-        # A pre-filter, authoritative only over the queries the index covers
-        # (``_text_index_covers_query``). Where it does not, ``q`` contributes no
-        # candidate set and the ``filter_items`` post-filter decides on its own —
-        # an index miss there means "cannot tell", not "no match".
-        q = (flt.get("q") or "").strip()
-        if q and self._text_index_covers_query(q):
-            has_indexed_filter = True
-            text_matches = self._search_by_text(q)
-            if not text_matches:
-                return []
-            candidate_sets.append(text_matches)
 
         # 2. Location Index
         # A multi-select unions its buckets, the way tags_any does below; the
@@ -2640,16 +2396,12 @@ class Repository:
         self._tags_to_item_ids = {}
         self._category_to_item_ids = {}
         self._status_to_item_ids = {}
-        self._word_to_item_ids = {}
-        self._name_prefix_to_item_ids = {}
-        self._trigram_to_item_ids = {}
         self._checked_out_item_ids = set()
         self._low_stock_item_ids = set()
         self._items_by_location_id = {}
         self._locations_by_area_id = {}
         self._items_by_area_id = {}
         self._name_sort_key_by_item_id = {}
-        self._item_text_tokens = {}
         self._children_ids_by_parent_id = {}
         self._location_descendants = {}
         self._items_in_subtree = {}

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -269,7 +269,9 @@ counts items at the node or any descendant (so it is always >= the direct count)
 ### Filters and sorting
 
 - ItemFilter:
-  - `q?: string` (case-insensitive; name, description, tags, location display path)
+  - `q?: string` (case- and accent-insensitive substring match, mid-word included; every
+    word of the query must appear in one of name, description, category, tags or the
+    location display path)
   - `tags_any?: string[]` (a value that is not a list of strings is a `validation_error`)
   - `tags_all?: string[]` (same rule)
   - `category?: string`

--- a/tests/test_repository_move_reindex_offline.py
+++ b/tests/test_repository_move_reindex_offline.py
@@ -1,10 +1,10 @@
 """Offline tests for the fast-path item reindexing on subtree moves.
 
-The subtree move/rename path updates items via path-token deltas instead of a
-full unindex/index cycle. These tests pin the invariants that must survive:
+The subtree move/rename path rewrites each item's denormalized
+``location_path`` in place instead of running a full unindex/index cycle.
+These tests pin the invariants that must survive:
 
 - text search agrees with the denormalized path after moves/renames
-- the text indexes stay byte-identical to a from-scratch rebuild
 - rewriting the derived ``location_path`` leaves ``version`` and ``updated_at``
   alone, so optimistic-concurrency tokens held by clients stay valid
 - effective-area buckets follow the subtree to its new ancestry
@@ -62,21 +62,6 @@ async def test_search_follows_location_rename() -> None:
     assert {i.name for i in res["items"]} == {"Hammer", "Garage opener"}
     res = repo.list_items(flt=ItemFilter(q="alpha"))
     assert res["items"] == []
-
-
-@pytest.mark.asyncio
-async def test_text_indexes_match_fresh_rebuild_after_moves() -> None:
-    """Delta-maintained text indexes must equal a from-scratch rebuild."""
-    repo, t = _build_tree()
-
-    repo.update_location(t["shelf"].id, new_parent_id=t["attic"].id)
-    repo.update_location(t["shelf"].id, name="Rack Beta")
-    repo.update_location(t["shelf"].id, new_parent_id=t["garage"].id)
-
-    rebuilt = Repository.from_state(repo.export_state())
-    assert repo._word_to_item_ids == rebuilt._word_to_item_ids
-    assert repo._trigram_to_item_ids == rebuilt._trigram_to_item_ids
-    assert repo._name_prefix_to_item_ids == rebuilt._name_prefix_to_item_ids
 
 
 @pytest.mark.asyncio

--- a/tests/test_repository_search_benchmark_offline.py
+++ b/tests/test_repository_search_benchmark_offline.py
@@ -1,0 +1,95 @@
+"""Timing floor for a `q` list at a size no household reaches.
+
+Opt-in with ``ASSERT_BUDGETS=1``: a wall-clock assertion on a shared CI runner
+fails for reasons that have nothing to do with the code, so the gate never runs
+it and a person measuring the search path asks for it by name.
+
+    ASSERT_BUDGETS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q -s \\
+        tests/test_repository_search_benchmark_offline.py
+
+The number this defends is the cost of answering ``q`` by scanning every item —
+five fields per item through ``normalize_search_text`` — which is what
+``list_items`` does once no index pre-filters ``q``.
+"""
+
+import os
+import time
+
+import pytest
+from custom_components.haventory.models import ItemCreate
+from custom_components.haventory.repository import Repository
+
+#: Items seeded before the query is timed. Five times the largest inventory the
+#: release testing plan drives, so the measurement carries headroom over any
+#: household this ships to.
+BENCHMARK_ITEM_COUNT = 10_000
+
+#: What one `q` list must stay under at that size, in seconds. A search runs
+#: while a person waits on a card, so the ceiling is a human one, not a
+#: machine one.
+Q_LIST_BUDGET_SECONDS = 0.5
+
+#: Timed passes; the fastest is reported, because a slower pass measures the
+#: host's other work rather than this code.
+TIMED_PASSES = 5
+
+#: Every fifth item is a "Widget", so the query returns a fifth of the
+#: inventory: an answer big enough that building it is part of what is timed.
+_NAME_STEMS = ("Widget", "Bracket", "Cable", "Fastener", "Gasket")
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ASSERT_BUDGETS") != "1",
+    reason="wall-clock assertion; opt in with ASSERT_BUDGETS=1",
+)
+
+
+def _seeded_repository(count: int) -> Repository:
+    """A repository holding ``count`` items spread over a small location tree.
+
+    Every text field ``q`` reads is populated — name, description, category,
+    tags and, through the location, the denormalized display path — so the scan
+    pays for all five rather than for a name alone.
+    """
+
+    repo = Repository()
+    warehouse = repo.create_location(name="Warehouse")
+    shelves = [
+        repo.create_location(name=f"Shelf {n}", parent_id=str(warehouse.id)) for n in range(20)
+    ]
+    for n in range(count):
+        stem = _NAME_STEMS[n % len(_NAME_STEMS)]
+        repo.create_item(
+            ItemCreate(
+                name=f"{stem} {n}",
+                description=f"Spare {stem.lower()} kept for the {n % 7}th bench",
+                category=f"Category {n % 11}",
+                tags=[f"tag{n % 13}", "spare"],
+                location_id=str(shelves[n % len(shelves)].id),
+            )
+        )
+    return repo
+
+
+def test_q_list_stays_under_budget() -> None:
+    """One `q` list over 10,000 items answers inside the budget."""
+
+    repo = _seeded_repository(BENCHMARK_ITEM_COUNT)
+    expected_matches = BENCHMARK_ITEM_COUNT // len(_NAME_STEMS)
+
+    timings: list[float] = []
+    for _ in range(TIMED_PASSES):
+        start = time.perf_counter()
+        page = repo.list_items(flt={"q": "Widget"})
+        timings.append(time.perf_counter() - start)
+        assert page["total"] == expected_matches
+
+    best = min(timings)
+    print(
+        f"\nq='Widget' over {BENCHMARK_ITEM_COUNT} items: "
+        f"best {best:.3f}s of {TIMED_PASSES} passes "
+        f"(budget {Q_LIST_BUDGET_SECONDS:.3f}s, {expected_matches} matches)"
+    )
+    assert best < Q_LIST_BUDGET_SECONDS, (
+        f"q list took {best:.3f}s over {BENCHMARK_ITEM_COUNT} items, "
+        f"budget is {Q_LIST_BUDGET_SECONDS:.3f}s"
+    )

--- a/tests/test_repository_search_offline.py
+++ b/tests/test_repository_search_offline.py
@@ -1,4 +1,10 @@
-"""Offline tests for repository text search (Phase 2.4)."""
+"""Offline tests for repository text search.
+
+``q`` is a substring test: every word of the normalized query must appear
+somewhere in the normalized name, description, category, tags or location
+display path of an item. These tests are what that contract means in cases a
+faster shortcut over words or fragments would get wrong.
+"""
 
 import pytest
 from custom_components.haventory.repository import Repository
@@ -56,15 +62,11 @@ async def test_text_search_prefix_autocomplete() -> None:
 
 
 @pytest.mark.asyncio
-async def test_text_search_fuzzy_matching() -> None:
-    """Text search provides basic typo tolerance via trigrams."""
+async def test_text_search_matches_inside_a_word() -> None:
+    """A fragment that starts no word still matches the word holding it."""
     repo = Repository()
     i1 = repo.create_item({"name": "Battery AA"})
 
-    # Substring search via trigrams (not a prefix)
-    # "atter" exists within "Battery"
-
-    # "atter" -> att, tte, ter. All are in "Battery".
     results = repo.list_items(flt={"q": "atter"})["items"]
     assert len(results) == 1
     assert results[0].id == i1.id
@@ -72,18 +74,11 @@ async def test_text_search_fuzzy_matching() -> None:
 
 @pytest.mark.asyncio
 async def test_text_search_accent_insensitive_end_to_end() -> None:
-    """Accent-insensitive search works through list_items (index + post-filter).
-
-    Regression: the index normalized accents (NFKD) but the filter_items
-    post-filter only casefolded, so "cafe" found the candidate in the index
-    and then discarded it — list_items returned nothing for unaccented queries
-    against accented content.
-    """
+    """An unaccented query finds accented content through ``list_items``."""
     repo = Repository()
     i1 = repo.create_item({"name": "Probe Café"})
     repo.create_item({"name": "Plain Mug"})
 
-    # Unaccented query vs accented content (the previously broken direction)
     for query in ("cafe", "CAFE", "Cafe"):
         results = repo.list_items(flt={"q": query})["items"]
         assert len(results) == 1, f"q={query!r} should match 'Probe Café'"
@@ -130,13 +125,11 @@ async def test_text_search_multi_word_and_logic() -> None:
 
 @pytest.mark.asyncio
 async def test_text_search_short_fragment_matches_mid_word() -> None:
-    """A fragment shorter than a trigram still matches mid-word.
+    """A one- or two-character fragment matches mid-word like any other.
 
-    Regression: the text index was authoritative for ``q``, so a two-character
-    fragment that starts no word found no word bucket, no name-prefix bucket and
-    no trigram fallback (which needs three characters) — and the empty index
-    result was reported as "no match" instead of falling through to the scan that
-    implements the documented substring contract.
+    The contract is a substring test over the item's text, so query length
+    carries no meaning of its own — a fragment too short to be a word is
+    answered exactly like a long one.
     """
     repo = Repository()
     i1 = repo.create_item({"name": "Kiwi"})
@@ -146,7 +139,6 @@ async def test_text_search_short_fragment_matches_mid_word() -> None:
     assert len(results) == 1
     assert results[0].id == i1.id
 
-    # One character is below the prefix floor as well, so no index reaches it.
     results = repo.list_items(flt={"q": "w"})["items"]
     assert len(results) == 1
     assert results[0].id == i1.id
@@ -154,12 +146,10 @@ async def test_text_search_short_fragment_matches_mid_word() -> None:
 
 @pytest.mark.asyncio
 async def test_short_fragment_matches_beyond_the_word_starts_it_hits() -> None:
-    """A short fragment returns mid-word matches alongside the word-start ones.
+    """A fragment returns mid-word matches alongside the word-start ones.
 
-    The name-prefix index is built from two characters up, so "wi" *does* find
-    "Wine" — a non-empty index result that is still missing "Kiwi". Treating a
-    non-empty result as complete would leave the bug alive whenever the inventory
-    happens to hold a word starting with the fragment.
+    "wi" starts "Wine" and sits inside "Kiwi"; both are matches, and an answer
+    holding only the word-start one is the shape a word-keyed shortcut produces.
     """
     repo = Repository()
     kiwi = repo.create_item({"name": "Kiwi"})
@@ -171,54 +161,92 @@ async def test_short_fragment_matches_beyond_the_word_starts_it_hits() -> None:
 
 
 @pytest.mark.asyncio
-async def test_short_fragment_falls_through_while_long_one_stays_indexed() -> None:
-    """Only queries the index cannot cover give up the indexed path.
-
-    ``_get_filtered_candidates`` returning ``None`` means "scan everything";
-    returning a list means the index narrowed the field. The fall-through must be
-    confined to sub-trigram fragments, or the fast path is disabled for every
-    search.
-    """
-    repo = Repository()
-    repo.create_item({"name": "Kiwi"})
-    repo.create_item({"name": "Hammer"})
-
-    assert repo._get_filtered_candidates({"q": "wi"}) is None
-    assert repo._get_filtered_candidates({"q": "w"}) is None
-
-    # Three characters reach the trigram fallback, so the index stays in charge.
-    candidates = repo._get_filtered_candidates({"q": "iwi"})
-    assert candidates is not None
-    assert [c.name for c in candidates] == ["Kiwi"]
-
-    # An indexed query that genuinely matches nothing still short-circuits.
-    assert repo._get_filtered_candidates({"q": "zzz"}) == []
-
-
-@pytest.mark.asyncio
-async def test_short_fragment_still_uses_the_other_indexes() -> None:
-    """Dropping ``q`` from the index pre-filter leaves the sibling indexes intact."""
+async def test_a_q_filter_still_narrows_by_its_siblings() -> None:
+    """``q`` alongside an indexed filter answers over that filter's candidates."""
     repo = Repository()
     kiwi = repo.create_item({"name": "Kiwi", "category": "Fruit"})
     repo.create_item({"name": "Kiwi Box", "category": "Storage"})
-
-    candidates = repo._get_filtered_candidates({"q": "wi", "category": "Fruit"})
-    assert candidates is not None
-    assert [c.id for c in candidates] == [kiwi.id]
 
     results = repo.list_items(flt={"q": "wi", "category": "Fruit"})["items"]
     assert [x.id for x in results] == [kiwi.id]
 
 
 @pytest.mark.asyncio
-async def test_punctuation_only_query_falls_through_to_the_scan() -> None:
-    """A query with no indexable word is outside the index, not proof of no match."""
+async def test_punctuation_only_query_is_matched_literally() -> None:
+    """Punctuation is text like any other, not a query with nothing in it."""
     repo = Repository()
     i1 = repo.create_item({"name": "Wow!!!"})
     repo.create_item({"name": "Hammer"})
 
-    assert repo._get_filtered_candidates({"q": "!!!"}) is None
-
     results = repo.list_items(flt={"q": "!!!"})["items"]
     assert len(results) == 1
     assert results[0].id == i1.id
+
+
+@pytest.mark.asyncio
+async def test_mid_word_match_survives_a_word_start_hit_elsewhere() -> None:
+    """A fragment that is one item's whole word still matches inside others.
+
+    The answer is a substring test per item, so what any other item is called
+    cannot decide whether this one matches.
+    """
+    repo = Repository()
+    light = repo.create_item({"name": "Light"})
+    flashlight = repo.create_item({"name": "Flashlight"})
+    repo.create_item({"name": "Hammer"})
+
+    results = repo.list_items(flt={"q": "light"})["items"]
+    assert {x.id for x in results} == {light.id, flashlight.id}
+
+
+@pytest.mark.asyncio
+async def test_accented_query_matches_unaccented_content() -> None:
+    """Accents are stripped on both sides, so either spelling finds the other."""
+    repo = Repository()
+    plain = repo.create_item({"name": "Cafe Sign"})
+    repo.create_item({"name": "Plain Mug"})
+
+    for query in ("café", "CAFÉ", "Café"):
+        results = repo.list_items(flt={"q": query})["items"]
+        assert [x.id for x in results] == [plain.id], f"q={query!r} should match 'Cafe Sign'"
+
+
+@pytest.mark.asyncio
+async def test_multi_word_query_ands_across_fields_and_the_path() -> None:
+    """Each query word may land in a different field, and all of them must land."""
+    repo = Repository()
+    shelf = repo.create_location(name="Basement Shelf")
+    match = repo.create_item(
+        {
+            "name": "Torch",
+            "description": "Spare emergency lamp",
+            "category": "Tools",
+            "tags": ["camping"],
+            "location_id": str(shelf.id),
+        }
+    )
+    repo.create_item({"name": "Torch", "description": "Spare emergency lamp"})
+
+    # name + description + tag + category + display path, one word from each.
+    results = repo.list_items(flt={"q": "torch emergency camping tools basement"})["items"]
+    assert [x.id for x in results] == [match.id]
+
+    # A word no field carries drops the item, however many of the others match.
+    results = repo.list_items(flt={"q": "torch attic"})["items"]
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_a_query_that_normalizes_away_narrows_nothing() -> None:
+    """A query that ASCII folding empties matches every item.
+
+    ``normalize_search_text`` keeps only what NFKD can render as ASCII, so a
+    query written in a script without word boundaries — Japanese here — reduces
+    to no words at all, and a filter with no words to test excludes nobody.
+    """
+    repo = Repository()
+    battery = repo.create_item({"name": "電池ケース"})
+    hammer = repo.create_item({"name": "Hammer"})
+
+    results = repo.list_items(flt={"q": "電池"})["items"]
+    assert {x.id for x in results} == {battery.id, hammer.id}


### PR DESCRIPTION
## Summary

`q` was answered twice. `_get_filtered_candidates` consulted a word / name-prefix / trigram
index first, and then `filter_items` applied `_item_matches_q` to every item that survived — so
the buckets could only ever narrow the answer the scan would have given, never widen it. This
deletes them: the buckets, the per-item token cache, the path-token delta that kept them in step
through a subtree move, and the `q` step of `_get_filtered_candidates`. The cheap tag / category /
location / status / area buckets stay exactly as they are.

One shape of that narrowing was wrong, and is fixed here — see "The behaviour half" below.

Closes #623
Refs #230 (item 1, BE-REPO-1)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## The measurement, before and after

The 0.5 s budget the issue names came from a benchmark test that is no longer in the tree, so the
first commit puts one back: `tests/test_repository_search_benchmark_offline.py` seeds 10,000 items
across 20 locations — name, description, category, tags and a denormalized display path each
populated — and times `list_items(flt={"q": "Widget"})`, which returns a fifth of them. It is
opt-in with `ASSERT_BUDGETS=1`, because a wall-clock assertion on a shared runner fails for
reasons that have nothing to do with this code.

```
ASSERT_BUDGETS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q -s \
    tests/test_repository_search_benchmark_offline.py
```

| | best of 5 passes | budget |
|---|---|---|
| before the cut (index answers `q`) | **0.010 s** | 0.5 s |
| after the cut (scan answers `q`) | **0.020 s** | 0.5 s |

Twice the cost of the indexed path, 25x under the ceiling, at five times the largest inventory
the release testing plan drives. The write side moved the other way: the same test file's total
wall clock, which is dominated by seeding those 10,000 items, went from 1.86 s to 0.81 s, because
a create or an update no longer tokenizes five fields and touches three bucket maps. The offline
suite went from 6.6 s to 4.6 s for the same reason.

## The behaviour half

The cut is not behaviour-neutral in one direction, and the direction is a fix.

`_get_candidates_for_word` reached a mid-word match only through its trigram fallback, and ran
that fallback **only when the word bucket and the name-prefix bucket both missed**. So as soon as
any one item had the query as a whole word or as the start of a name word, every *other* item
carrying the query inside a word was dropped — and `_text_index_covers_query` called a
three-character query covered, so the short answer was treated as authoritative and the scan never
saw the missing items.

An inventory holding **Light** and **Flashlight**: `q="light"` returned Light alone. Delete the
item called Light and the same query returns both. Which item is in the store decided whether
another item was findable. Same for Screw/Unscrew, Case/Suitcase, Box/Toolbox. Filed as #623 and
closed by this PR; `test_mid_word_match_survives_a_word_start_hit_elsewhere` is the pin, and it is
the one new test that fails on `main`.

This is the second half of what #230 item 1 predicted — #220 fixed the sub-trigram fragments in
0.3.1 by letting them fall through to the scan; this removes the short-circuit for the rest.

## Tests

The five fall-through tests from #220's fix are the oracle, because they ask `list_items` what it
returns rather than asking the index what it holds. Four of them keep every assertion they had and
pass unchanged over both trees; two of those four had a docstring naming a bucket, rewritten to
state the contract instead, and were renamed for the same reason. What went:

- the six `_get_filtered_candidates({"q": …})` assertions — they name a pre-filter that no longer
  exists. `test_short_fragment_falls_through_while_long_one_stays_indexed` held four of them and
  nothing else, so the fifth fall-through test goes with them; the other two keep their
  `list_items` assertions and lose only the private-accessor half.
- `test_text_indexes_match_fresh_rebuild_after_moves` — the three-dict comparison against a
  rebuilt repository, with no dicts left to compare. What it was really guarding, that search
  agrees with the display path after a move and a rename, is still pinned by the two tests above
  it in that module.

What is new, all of it asserting results:

- `test_mid_word_match_survives_a_word_start_hit_elsewhere` — Light / Flashlight, above.
- `test_accented_query_matches_unaccented_content` — `q="café"` finds an item called `Cafe`. The
  existing test covered the other direction only.
- `test_multi_word_query_ands_across_fields_and_the_path` — one query word each in name,
  description, tag, category and the location display path; and one word no field carries drops
  the item.
- `test_a_query_that_normalizes_away_narrows_nothing` — a Japanese item name (`電池ケース`) with
  `電池` as the query. `normalize_search_text` keeps only what NFKD renders as ASCII, so the query
  reduces to no words, and a filter with no words to test excludes nobody: every item comes back.
  Identical before and after the cut — the scan always answered this one — and written down
  because it is the contract for a script without word boundaries. See Follow-ups.

Docstrings that named the buckets were rewritten to state the contract instead, in
`repository.py`, `models.normalize_search_text`, and the two test modules.

## Counting

| | lines |
|---|---|
| production removed (`custom_components/`) | 260 |
| test lines removed | 79 |
| lines added | 203 (95 the opt-in benchmark, 92 in the two rewritten test modules, 16 production and docs) |

`repository.py`: 2,700 → 2,452 lines.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1358 passed, 27 skipped**;
  `uv run ruff check .` → All checks passed; `uv run ruff format --check .` → 189 files already
  formatted; `uv run mypy` → Success: no issues found in 27 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`
  (**68 files, 1924 passed**), `npm run build` — untouched by this PR, run because the card is
  built before phacc.
- [x] phacc (`scripts/test_integration.sh`, card built first): **153 passed in 20.35s**.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge cases).
- [x] Docs updated where behavior changed — `docs/data_shapes.md`'s `q` line now states the
  contract the scan implements (substring, mid-word included, and `category` among the fields it
  reads, which it always did).
- [x] No WebSocket schema, error code or field moves here.
- [x] Essential invariants preserved: search stays case- and accent-insensitive (and gains the
  mid-word matches it promised), `location_path` is still rewritten without touching `version` or
  `updated_at` — `test_repository_move_reindex_offline.py` still pins that — and optimistic
  concurrency is untouched.

## Follow-ups

- **A query in a script without word boundaries matches every item.** `normalize_search_text`
  drops everything NFKD cannot render as ASCII, so `q="電池"` normalizes to the empty string and
  `_item_matches_q` returns `True` for every item; an item named only in Japanese or Chinese is
  likewise unreachable by any query. Unchanged by this PR — the scan always answered it this way —
  and now written down in `test_a_query_that_normalizes_away_narrows_nothing`. Not filed: the
  shipped dictionaries are English and German, and a fix means changing what normalization means
  for every language at once, which is a decision rather than a bug fix. Worth an issue if the
  project takes a CJK language.
- `list_items` still materializes the whole filtered, sorted list before slicing a page. At 10,000
  items with `q` that is the 0.020 s above, so nothing to do now; noted because the scan is the
  only thing standing between a query and the item map.

## Handover

1. **Merged / left open** — this PR, for the M1 master to squash-merge once CI is green. Nothing
   left open for the owner.
2. **Test this by hand** — nothing that needs a phone, a German reader or the owner's own store.
   The behaviour change is a backend search result, pinned by tests.
3. **Validate locally** —
   1. `[dev-ha]` deploy this branch, create items named `Light` and `Flashlight`.
   2. `[browser]` search `light` in the card → **both** rows are listed. On `main` only `Light` is.
   3. `[browser]` search `caf` and `café` against an item named `Cafe` → both find it.
   4. `[dev-ha]` with ~2,000 seeded items: search, filter, sort, a subtree move and a location
      rename all answer as before, and search after the move follows the new display path.
   5. `[log]` nothing at ERROR carrying `haventory` through any of it.
4. **Decisions taken against drifted notes** — the issue comment counts the five fall-through
   tests as removable ("they pass trivially or become redundant"); the plan's PR 7 keeps them as
   the oracle, and that is what happened — four were kept and pass unchanged, and the fifth held
   nothing but assertions about the deleted pre-filter. The comment's "~249 LOC removed" measured
   `b878bfe`; the tree at `f1f6d9b` gave 258 from `repository.py`.
5. **Follow-ups** — above: the CJK normalization gap (not filed, with the reason) and the
   materialize-then-slice note (not filed). The behaviour fix earned #623, closed here.
6. **State left behind** — branch `claude/v0-8-0-m1-text-index`, two commits. No assets branch, no
   HA instance touched. Counting for this session: production removed 260 · tests removed 79 ·
   added 203.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L8sdndwVjV3JGfckyMBh5y)_