### PR TITLE
refactor(repository): one chain walk, from_dict on the models, and the small copies

### DIFF
--- a/custom_components/haventory/import_export.py
+++ b/custom_components/haventory/import_export.py
@@ -649,19 +649,12 @@ def _recompute_paths(
     ``None`` when a reference is broken (with ``errors`` populated).
     """
 
-    loc_objs: dict[str, Location] = {}
-    for lid, d in locations.items():
-        loc_objs[lid] = Location(
-            id=parse_uuid4(str(d["id"]), field_name="location.id"),
-            parent_id=(
-                parse_uuid4(str(d["parent_id"]), field_name="location.parent_id")
-                if d.get("parent_id") is not None
-                else None
-            ),
-            name=str(d["name"]),
-            area_id=str(d["area_id"]) if d.get("area_id") is not None else None,
-            path=EMPTY_LOCATION_PATH,
-        )
+    # The path a document carries is dropped rather than read: it is recomputed
+    # below from the names and parent links this import is about to store, and a
+    # hand-edited one would otherwise decide whether the document loads at all.
+    loc_objs: dict[str, Location] = {
+        lid: Location.from_dict({**d, "path": None}) for lid, d in locations.items()
+    }
 
     # Recompute location paths (also validates parent references resolve).
     out_locations: dict[str, Any] = {}
@@ -671,18 +664,7 @@ def _recompute_paths(
         except ValidationError as exc:
             errors.append(_err(f"locations[{lid}].parent_id", str(exc)))
             return None
-        out_locations[lid] = {
-            "id": str(obj.id),
-            "name": obj.name,
-            "parent_id": str(obj.parent_id) if obj.parent_id is not None else None,
-            "area_id": obj.area_id,
-            "path": {
-                "id_path": [str(x) for x in path.id_path],
-                "name_path": list(path.name_path),
-                "display_path": path.display_path,
-                "sort_key": path.sort_key,
-            },
-        }
+        out_locations[lid] = {**obj.to_dict(), "path": path.to_dict()}
 
     out_items: dict[str, Any] = {}
     for iid, d in items.items():
@@ -693,17 +675,11 @@ def _recompute_paths(
             )
             return None
         if loc_id is not None:
-            lp = build_location_path_from_map(
+            location_path = build_location_path_from_map(
                 parse_uuid4(str(loc_id), field_name="item.location_id"), locations_by_id=loc_objs
-            )
-            location_path = {
-                "id_path": [str(x) for x in lp.id_path],
-                "name_path": list(lp.name_path),
-                "display_path": lp.display_path,
-                "sort_key": lp.sort_key,
-            }
+            ).to_dict()
         else:
-            location_path = {"id_path": [], "name_path": [], "display_path": "", "sort_key": ""}
+            location_path = EMPTY_LOCATION_PATH.to_dict()
         entry = dict(d)
         entry["tags"] = normalize_tags(d.get("tags") or [])
         entry["custom_fields"] = dict(d.get("custom_fields") or {})

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -94,6 +94,32 @@ class LocationPath:
             "sort_key": self.sort_key,
         }
 
+    @classmethod
+    def from_dict(cls, data: object) -> LocationPath:
+        """Read back what ``to_dict`` wrote, tolerating an absent nesting.
+
+        ``sort_key`` is backfilled from ``display_path`` when the payload
+        carries none: stores written before it was persisted have to sort
+        alongside the ones that were, and it is derived, so recomputing it
+        costs nothing but the read.
+
+        An entry of ``id_path`` that is not a UUID v4 raises: the id path is
+        what a subtree filter matches on, so a row carrying a broken one is
+        corrupt rather than merely old.
+        """
+
+        raw = data if isinstance(data, Mapping) else {}
+        display = str(raw.get("display_path", ""))
+        return cls(
+            id_path=[
+                parse_uuid4(str(entry), field_name="path.id_path")
+                for entry in (raw.get("id_path") or [])
+            ],
+            name_path=list(raw.get("name_path") or []),
+            display_path=display,
+            sort_key=str(raw.get("sort_key", "")) or normalize_text_for_sort(display),
+        )
+
 
 EMPTY_LOCATION_PATH = LocationPath(id_path=[], name_path=[], display_path="", sort_key="")
 
@@ -142,6 +168,34 @@ class Location:
             "area_id": str(self.area_id) if self.area_id is not None else None,
             "path": self.path.to_dict(),
         }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], *, fallback_id: str | None = None) -> Location:
+        """Read back what ``to_dict`` wrote, refusing a row no write path wrote.
+
+        ``fallback_id`` is the key the row was stored under, used when the row
+        itself carries no ``id``.
+
+        The name goes through :func:`validate_required_name` rather than
+        ``str()``: a missing key would read as ``""`` and a stored ``null`` as
+        the literal ``"None"``, putting a location in memory that no write path
+        would accept. Raising here is what lets a load drop the row and report
+        it instead.
+        """
+
+        parent_id = data.get("parent_id")
+        area_id = data.get("area_id")
+        return cls(
+            id=parse_uuid4(str(data.get("id", fallback_id)), field_name="location.id"),
+            parent_id=(
+                parse_uuid4(str(parent_id), field_name="location.parent_id")
+                if parent_id is not None
+                else None
+            ),
+            name=validate_required_name(data.get("name")),
+            area_id=str(area_id) if area_id is not None else None,
+            path=LocationPath.from_dict(data.get("path")),
+        )
 
 
 @dataclass
@@ -289,6 +343,68 @@ class Item:
             "location_path": self.location_path.to_dict(),
             "attachments": [serialize_attachment_meta(meta) for meta in self.attachments],
         }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Mapping[str, Any],
+        *,
+        known_statuses: Collection[str] = ITEM_STATUSES,
+        fallback_id: str | None = None,
+    ) -> Item:
+        """Read back what ``to_dict`` wrote, refusing a row no write path wrote.
+
+        ``fallback_id`` is the key the row was stored under, used when the row
+        itself carries no ``id``. ``known_statuses`` has to be the live set:
+        passing the built-ins while the store defines more would rewrite every
+        item on a custom status to the default.
+
+        Absent fields read as the value the build that introduced them writes
+        for an item that has none, so a store written by an older build loads
+        without a migration touching every row. What is *not* tolerated is a
+        malformed value: an unreadable name, id or attachment entry is a corrupt
+        row, and raising is what lets a load drop it and report it.
+        """
+
+        location_id = data.get("location_id")
+        created_at = _coerce_canonical_ts(data.get("created_at"))
+        return cls(
+            id=parse_uuid4(str(data.get("id", fallback_id)), field_name="item.id"),
+            name=validate_required_name(data.get("name")),
+            description=data.get("description"),
+            quantity=int(data.get("quantity", 0)),
+            status=coerce_item_status(data.get("status"), known_statuses=known_statuses),
+            checked_out=bool(data.get("checked_out", False)),
+            due_date=data.get("due_date"),
+            inspection_date=data.get("inspection_date"),
+            reminder_date=data.get("reminder_date"),
+            # Equal to the date for any reminder nobody has bumped, which is
+            # what a store written before the anchor existed carries.
+            reminder_anchor=load_reminder_anchor(
+                data.get("reminder_anchor"), reminder_date=data.get("reminder_date")
+            ),
+            reminder_interval=load_reminder_interval(data.get("reminder_interval")),
+            location_id=(
+                parse_uuid4(str(location_id), field_name="item.location_id")
+                if location_id is not None
+                else None
+            ),
+            tags=list(data.get("tags", []) or []),
+            category=data.get("category"),
+            low_stock_threshold=data.get("low_stock_threshold"),
+            custom_fields=dict(data.get("custom_fields", {}) or {}),
+            # Timestamps compare lexicographically for sort and range filters,
+            # so a missing, null or non-canonical one is backfilled rather than
+            # carried: the alternative is a row that sorts arbitrarily.
+            created_at=created_at,
+            updated_at=_coerce_canonical_ts(data.get("updated_at"), fallback=created_at),
+            version=int(data.get("version", 1)),
+            location_path=LocationPath.from_dict(data.get("location_path")),
+            # Tolerant of absence and of a non-list value (both read as none),
+            # but not of a malformed *entry*: dropping one would lose the only
+            # reference to a file on disk, which the orphan sweep then deletes.
+            attachments=load_attachments(data.get("attachments")),
+        )
 
 
 class ItemCreate(TypedDict, total=False):
@@ -1549,6 +1665,21 @@ def is_canonical_utc_timestamp(ts: object) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _coerce_canonical_ts(value: object, *, fallback: str | None = None) -> str:
+    """Return a canonical UTC timestamp, backfilling non-canonical input.
+
+    Item timestamps compare lexicographically for sort and range filters, so on
+    load any missing / null / corrupt value is replaced with a canonical one
+    (the fallback when it is itself canonical, otherwise the current time).
+    """
+
+    if isinstance(value, str) and is_canonical_utc_timestamp(value):
+        return value
+    if fallback is not None and is_canonical_utc_timestamp(fallback):
+        return fallback
+    return iso_utc_now()
 
 
 def _parse_iso8601_utc(ts: str, *, field_name: str) -> datetime:

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 import unicodedata
 import uuid
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, Final, Literal, NotRequired, TypedDict
@@ -1224,6 +1224,57 @@ def load_reminder_interval(value: object) -> ReminderInterval | None:
         return None
 
 
+def walk_location_chain(
+    start_id: str | uuid.UUID, *, locations_by_id: Mapping[str, Location]
+) -> Iterator[Location]:
+    """Yield the locations from ``start_id`` upwards, the node itself first.
+
+    The one walk up the parent chain. It ends without raising on a parent id no
+    location carries, on an id it has already yielded, and at
+    ``LOCATION_GUARD_MAX_STEPS``: a hand-edited or corrupt store can close a
+    chain into a loop, and the item-index path walks it on every mutation, so
+    the walk has to end by itself rather than throw there.
+
+    A caller that needs the whole chain therefore cannot read a short answer as
+    a complete one — :func:`location_chain_to_root` is that caller's version.
+    """
+
+    cursor: str | None = str(start_id)
+    seen: set[str] = set()
+    while cursor is not None and cursor not in seen and len(seen) < LOCATION_GUARD_MAX_STEPS:
+        location = locations_by_id.get(cursor)
+        if location is None:
+            return
+        seen.add(cursor)
+        yield location
+        cursor = str(location.parent_id) if location.parent_id is not None else None
+
+
+def location_chain_to_root(
+    leaf_id: str | uuid.UUID, *, locations_by_id: Mapping[str, Location]
+) -> list[Location]:
+    """The chain root→leaf, or a ``ValidationError`` naming what stopped it.
+
+    A chain that does not reach a root is refused rather than shortened,
+    because what is built from it is the denormalized path stored on the node
+    and on every item under it: a partial chain would store a display path
+    missing its leading names.
+    """
+
+    chain = list(walk_location_chain(leaf_id, locations_by_id=locations_by_id))
+    if not chain:
+        raise ValidationError("location_id must reference an existing location")
+    last_parent = chain[-1].parent_id
+    if last_parent is not None:
+        if len(chain) >= LOCATION_GUARD_MAX_STEPS or str(last_parent) in {
+            str(node.id) for node in chain
+        }:
+            raise ValidationError("location graph too deep or cyclic")
+        raise ValidationError("location_id must reference an existing location chain")
+    chain.reverse()
+    return chain
+
+
 def build_location_path(location_chain: list[Location]) -> LocationPath:
     """Build a denormalized LocationPath from a chain ordered root->leaf."""
 
@@ -1239,34 +1290,17 @@ def build_location_path(location_chain: list[Location]) -> LocationPath:
 
 
 def build_location_path_from_map(
-    leaf_location_id: uuid.UUID, *, locations_by_id: dict[str, Location]
+    leaf_location_id: str | uuid.UUID, *, locations_by_id: Mapping[str, Location]
 ) -> LocationPath:
-    """Follow parent links to build LocationPath given a leaf location ID.
+    """The denormalized path of one location, given the map it lives in.
 
-    Raises ValidationError if the leaf ID is unknown.
+    Raises ``ValidationError`` when the leaf id is unknown or the chain above
+    it never reaches a root.
     """
 
-    # locations_by_id is keyed by string UUIDs
-    leaf_key = str(leaf_location_id)
-    if leaf_key not in locations_by_id:
-        raise ValidationError("location_id must reference an existing location")
-
-    chain: list[Location] = []
-    cursor_id: uuid.UUID | None = leaf_location_id
-    guard = 0
-    while cursor_id:
-        guard += 1
-        if guard > LOCATION_GUARD_MAX_STEPS:  # pragma: no cover - degenerate cycles
-            raise ValidationError("location graph too deep or cyclic")
-        location = locations_by_id.get(str(cursor_id))
-        if location is None:
-            # Broken link in chain
-            raise ValidationError("location_id must reference an existing location chain")
-        chain.append(location)
-        cursor_id = location.parent_id
-    # We collected leaf->root; reverse to root->leaf
-    chain.reverse()
-    return build_location_path(chain)
+    return build_location_path(
+        location_chain_to_root(leaf_location_id, locations_by_id=locations_by_id)
+    )
 
 
 # -----------------------------

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -96,28 +96,32 @@ class LocationPath:
 
     @classmethod
     def from_dict(cls, data: object) -> LocationPath:
-        """Read back what ``to_dict`` wrote, tolerating an absent nesting.
+        """Read back what ``to_dict`` wrote; ``None`` reads as the empty path.
 
         ``sort_key`` is backfilled from ``display_path`` when the payload
         carries none: stores written before it was persisted have to sort
         alongside the ones that were, and it is derived, so recomputing it
         costs nothing but the read.
 
-        An entry of ``id_path`` that is not a UUID v4 raises: the id path is
-        what a subtree filter matches on, so a row carrying a broken one is
-        corrupt rather than merely old.
+        What is refused is a value of the wrong shape — anything present that
+        is not an object, and an ``id_path`` entry that is not a UUID v4. A row
+        carrying one of those is corrupt rather than merely old, and refusing
+        is what lets a load drop it and report it.
         """
 
-        raw = data if isinstance(data, Mapping) else {}
-        display = str(raw.get("display_path", ""))
+        if data is None:
+            return cls(id_path=[], name_path=[], display_path="", sort_key="")
+        if not isinstance(data, Mapping):
+            raise ValidationError("a location path must be an object")
+        display = str(data.get("display_path", ""))
         return cls(
             id_path=[
                 parse_uuid4(str(entry), field_name="path.id_path")
-                for entry in (raw.get("id_path") or [])
+                for entry in (data.get("id_path") or [])
             ],
-            name_path=list(raw.get("name_path") or []),
+            name_path=list(data.get("name_path") or []),
             display_path=display,
-            sort_key=str(raw.get("sort_key", "")) or normalize_text_for_sort(display),
+            sort_key=str(data.get("sort_key", "")) or normalize_text_for_sort(display),
         )
 
 

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -169,11 +169,10 @@ def _parse_reminder_date(value: str, field: str) -> date:
 class Repository:
     """In-memory repository maintaining indexes and providing operations.
 
-    Notes:
-        - Only items carry a ``version`` for optimistic concurrency in Phase 1.
-        - Location changes that affect denormalized item ``location_path``
-          will update impacted items via ``apply_item_update`` to increment
-          their version and ``updated_at`` timestamps.
+    Only items carry a ``version``, and only an item edit moves it. A location
+    rename or move rewrites the denormalized ``location_path`` of every item
+    under it and leaves both ``version`` and ``updated_at`` alone —
+    ``_update_items_location_paths_for_locations`` says what that protects.
     """
 
     # -----------------------------
@@ -703,34 +702,32 @@ class Repository:
                 self._items_in_subtree[loc_id] = in_subtree
 
     def _add_item_to_subtree_index(self, item: Item) -> None:
+        """Put an item in its own location's bucket and in every ancestor's."""
+
         if not item.location_id:
             return
 
         item_key = str(item.id)
         loc_key = str(item.location_id)
-
-        # Add to direct location
-        self._add_to_bucket(self._items_in_subtree, loc_key, item_key)
-
-        # Add to all ancestors
-        for anc in self._get_ancestors(loc_key):
-            self._add_to_bucket(self._items_in_subtree, anc, item_key)
+        for key in (loc_key, *self._get_ancestors(loc_key)):
+            self._add_to_bucket(self._items_in_subtree, key, item_key)
 
     def _remove_item_from_subtree_index(self, item: Item) -> None:
+        """Take an item out of the buckets ``_add_item_to_subtree_index`` put it in.
+
+        The chain is walked again rather than remembered per item: what has to
+        be undone is where the item *was*, and the caller passes the item as it
+        was, so the two walks agree as long as the tree between them has not
+        moved — and a tree that moves rebuilds this index wholesale.
+        """
+
         if not item.location_id:
             return
 
         item_key = str(item.id)
         loc_key = str(item.location_id)
-
-        # Remove from direct location
-        self._remove_from_bucket(self._items_in_subtree, loc_key, item_key)
-
-        # Remove from all ancestors
-        # Optimization: if we moved the item, we called unindex then index.
-        # This naive removal walks up.
-        for anc in self._get_ancestors(loc_key):
-            self._remove_from_bucket(self._items_in_subtree, anc, item_key)
+        for key in (loc_key, *self._get_ancestors(loc_key)):
+            self._remove_from_bucket(self._items_in_subtree, key, item_key)
 
     def _rebuild_paths_for_subtree(self, root_id: str) -> None:
         """Recompute ``Location.path`` for the subtree rooted at ``root_id``.
@@ -747,14 +744,14 @@ class Repository:
     def _update_items_location_paths_for_locations(self, affected_location_ids: set[str]) -> None:
         """Refresh ``location_path`` for items under any of the given locations.
 
-        Fast path for subtree renames/moves. All items in one location share
-        that location's (already recomputed) ``path``, so the only thing that
-        changes per item is the denormalized ``location_path``. Everything else
-        is either untouched (location/category/tag/checkout/low-stock buckets,
-        name sort keys) or rebuilt wholesale by the caller via
-        ``_rebuild_location_hierarchy_indexes`` (subtree index). The effective
-        area is re-resolved once per location and items are re-bucketed only
-        when it actually changed.
+        Fast path for subtree renames and moves. All items in one location
+        share that location's already recomputed ``path``, so the only thing
+        that changes per item is the denormalized ``location_path``. Everything
+        else is either untouched (the location, category, tag, check-out and
+        low-stock buckets) or rebuilt wholesale by the caller through
+        ``_rebuild_location_hierarchy_indexes`` (the subtree index). The
+        effective area is re-resolved once per location and items are
+        re-bucketed only when it actually changed.
 
         ``version`` and ``updated_at`` deliberately stay put. ``location_path``
         is derived from the location tree — no client can write it — so its

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -27,7 +27,6 @@ from .logs import context_logger
 from .models import (
     DEFAULT_ITEM_STATUS,
     EMPTY_LOCATION_PATH,
-    LOCATION_GUARD_MAX_STEPS,
     AttachmentMeta,
     Item,
     ItemCreate,
@@ -38,6 +37,7 @@ from .models import (
     StatusDefinition,
     apply_item_update,
     build_location_path,
+    build_location_path_from_map,
     create_item_from_create,
     date_sort_key,
     filter_items,
@@ -47,6 +47,7 @@ from .models import (
     item_is_low_stock,
     item_is_overdue,
     item_reminder_is_due,
+    location_chain_to_root,
     location_sort_key,
     monotonic_timestamp_after,
     new_uuid4,
@@ -63,6 +64,7 @@ from .models import (
     validate_location_name,
     validate_status_definition,
     validate_status_slug,
+    walk_location_chain,
 )
 
 LOGGER = context_logger(__name__)
@@ -431,18 +433,9 @@ class Repository:
         stores ``None``.
         """
 
-        cursor: str | None = location_key
-        guard = 0
-        while cursor is not None:
-            guard += 1
-            if guard > LOCATION_GUARD_MAX_STEPS:  # pragma: no cover - degenerate
-                return None
-            loc = self._locations_by_id.get(cursor)
-            if loc is None:
-                return None
+        for loc in walk_location_chain(location_key, locations_by_id=self._locations_by_id):
             if loc.area_id is not None:
                 return str(loc.area_id)
-            cursor = str(loc.parent_id) if loc.parent_id is not None else None
         return None
 
     def _reindex_item_replacement(self, old: Item, new: Item) -> None:
@@ -497,19 +490,17 @@ class Repository:
         raise ValidationError("area_id must be a string or null")
 
     def _find_location_root(self, location_key: str) -> str:
-        """Walk up the parent chain to find the root location id."""
-        cursor: str | None = location_key
+        """The id at the top of the tree ``location_key`` sits in.
+
+        A chain ending on a parent id no location carries answers with that id
+        rather than with the last node that does exist: it is the id the tree
+        claims as its root, and every caller looks the answer up in a map and
+        tolerates a miss.
+        """
+
         root_key = location_key
-        guard = 0
-        while cursor is not None:
-            guard += 1
-            if guard > LOCATION_GUARD_MAX_STEPS:  # pragma: no cover - degenerate
-                break
-            root_key = cursor
-            loc = self._locations_by_id.get(cursor)
-            if loc is None:
-                break
-            cursor = str(loc.parent_id) if loc.parent_id is not None else None
+        for loc in walk_location_chain(location_key, locations_by_id=self._locations_by_id):
+            root_key = str(loc.parent_id) if loc.parent_id is not None else str(loc.id)
         return root_key
 
     def _propagate_area_to_root(self, location_key: str, area_id: str | None) -> set[str]:
@@ -651,35 +642,20 @@ class Repository:
         return result
 
     def _get_ancestors(self, location_id: str) -> list[str]:
-        """Return list of ancestor location IDs from parent up to root.
+        """The ancestor ids of a location, from its parent up to the root.
 
-        A hand-edited or corrupt store can carry a cyclic ``parent_id`` chain,
-        which this walk would otherwise follow forever — during setup, since
-        ``load_state`` reaches it once per item. The visited set is what bounds the
-        walk to the size of the cycle; the step ceiling its four siblings cite is
-        the backstop for a chain that is merely absurdly deep. Breaking rather than
-        raising matches ``_find_location_root``, because
-        ``_remove_item_from_subtree_index`` walks the same chain on the mutation
-        path and must not learn to throw.
+        Empty for a root, and bounded rather than endless for a chain a corrupt
+        store has closed into a loop — the shared walk stops on an id it has
+        already passed. That it does not raise is what the subtree index needs:
+        ``_remove_item_from_subtree_index`` walks the same chain on every item
+        mutation.
         """
-        ancestors: list[str] = []
-        visited: set[str] = {location_id}
-        cursor: str | None = location_id
-        guard = 0
-        while cursor:
-            guard += 1
-            if guard > LOCATION_GUARD_MAX_STEPS:  # pragma: no cover - degenerate
-                break
-            loc = self._locations_by_id.get(cursor)
-            if not loc or not loc.parent_id:
-                break
-            parent_key = str(loc.parent_id)
-            if parent_key in visited:
-                break
-            visited.add(parent_key)
-            ancestors.append(parent_key)
-            cursor = parent_key
-        return ancestors
+
+        return [
+            str(loc.parent_id)
+            for loc in walk_location_chain(location_id, locations_by_id=self._locations_by_id)
+            if loc.parent_id is not None
+        ]
 
     def _unrooted_location_ids(self) -> tuple[tuple[str, ...], tuple[str, ...]]:
         """Split the locations that never reach a root into members and descendants.
@@ -839,23 +815,8 @@ class Repository:
                     queue.append(cid)
 
         for loc_id in to_fix:
-            loc = loc_map[loc_id]
-            # Build chain root->loc by following parent links in the given locations map
-            chain: list[Location] = []
-            cursor_id: str | None = loc_id
-            guard = 0
-            while cursor_id is not None:
-                guard += 1
-                if guard > LOCATION_GUARD_MAX_STEPS:  # defensive; should never happen
-                    raise ValidationError("location graph too deep or cyclic")
-                node = loc_map.get(cursor_id)
-                if node is None:  # pragma: no cover - corrupted map
-                    raise ValidationError("location_id must reference an existing location chain")
-                chain.append(node)
-                cursor_id = str(node.parent_id) if node.parent_id is not None else None
-            chain.reverse()
-            new_path = build_location_path(chain)
-            loc_map[loc_id] = replace(loc, path=new_path)
+            new_path = build_location_path_from_map(loc_id, locations_by_id=loc_map)
+            loc_map[loc_id] = replace(loc_map[loc_id], path=new_path)
 
     def _update_items_location_paths_for_locations(self, affected_location_ids: set[str]) -> None:
         """Refresh ``location_path`` for items under any of the given locations.
@@ -1696,37 +1657,23 @@ class Repository:
 
         new_id = new_uuid4()
         new_key = str(new_id)
-        # Build path using parent chain plus new node
-        chain: list[Location] = []
-        if parent_key is not None:
-            # Build parent chain root->parent
-            cursor: str | None = parent_key
-            guard = 0
-            lineage: list[Location] = []
-            while cursor is not None:
-                guard += 1
-                if guard > LOCATION_GUARD_MAX_STEPS:  # pragma: no cover - degenerate
-                    raise ValidationError("location graph too deep or cyclic")
-                node = self._locations_by_id.get(cursor)
-                if node is None:
-                    raise ValidationError("parent_id must reference an existing location")
-                lineage.append(node)
-                cursor = str(node.parent_id) if node.parent_id is not None else None
-            lineage.reverse()
-            chain.extend(lineage)
+        lineage = (
+            location_chain_to_root(parent_key, locations_by_id=self._locations_by_id)
+            if parent_key is not None
+            else []
+        )
 
-        # New locations never store area_id directly - it's always on root
-        # Area will be propagated to root after creation if specified
+        # An area is stored on the root of a tree and inherited by everything
+        # under it, so a new node never carries one of its own; a requested area
+        # is propagated up after the node exists.
         new_loc = Location(
             id=new_id,
             parent_id=parsed_parent,
             name=name,
-            area_id=None,  # Don't set area directly on new location
+            area_id=None,
             path=EMPTY_LOCATION_PATH,
         )
-        chain.append(new_loc)
-        new_path = build_location_path(chain)
-        new_loc = replace(new_loc, path=new_path)
+        new_loc = replace(new_loc, path=build_location_path([*lineage, new_loc]))
 
         self._add_location(new_loc)
 

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -16,7 +16,7 @@ import copy
 import json
 import uuid
 from collections import deque
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from datetime import date
 from typing import Any, TypedDict, TypeVar
@@ -200,15 +200,11 @@ class Repository:
         # Area indexes
         self._locations_by_area_id: dict[str, set[str]] = {}
         self._items_by_area_id: dict[str, set[str]] = {}
-        # Cached name sort keys
-        self._name_sort_key_by_item_id: dict[str, str] = {}
-
         # Location tree indexes
         self._children_ids_by_parent_id: dict[str | None, set[str]] = {}
 
-        # Location Hierarchy Indexes (O(1) subtree lookup)
-        self._location_descendants: dict[str, set[str]] = {}  # loc_id -> all descendant ids
-        self._items_in_subtree: dict[str, set[str]] = {}  # loc_id -> all item ids in subtree
+        # O(1) subtree lookup: loc_id -> every item id in that subtree
+        self._items_in_subtree: dict[str, set[str]] = {}
 
         # What the last load_state could not make sense of; empty on a fresh repo.
         self._last_load_report = LoadReport()
@@ -380,7 +376,7 @@ class Repository:
             self._checked_out_item_ids.add(item_key)
 
         # low stock
-        if self._is_low_stock(item):
+        if item_is_low_stock(item):
             self._low_stock_item_ids.add(item_key)
 
         # location direct membership
@@ -391,9 +387,6 @@ class Repository:
             eff_area_id = self.effective_area_id(str(item.location_id))
             if eff_area_id is not None:
                 self._add_to_bucket(self._items_by_area_id, eff_area_id, item_key)
-
-        # cached sort key for name
-        self._name_sort_key_by_item_id[item_key] = normalize_text_for_sort(item.name)
 
         # Update subtree index
         self._add_item_to_subtree_index(item)
@@ -419,8 +412,6 @@ class Repository:
             # Remove from any area buckets (area could have changed since indexing)
             self._remove_item_from_all_area_buckets(item_key)
 
-        self._name_sort_key_by_item_id.pop(item_key, None)
-
         # Remove from subtree index
         self._remove_item_from_subtree_index(item)
 
@@ -428,14 +419,14 @@ class Repository:
         self._items_by_id.pop(item_key, None)
 
     def _remove_item_from_all_area_buckets(self, item_key: str) -> None:
-        # Defensive: remove an item id from every area bucket
-        for area_key in list(self._items_by_area_id.keys()):
-            s = self._items_by_area_id.get(area_key)
-            if not s:
-                continue
-            s.discard(item_key)
-            if not s:
-                self._items_by_area_id.pop(area_key, None)
+        """Drop an item from every area bucket.
+
+        The item's own area is derived from a tree that may since have moved,
+        so the bucket it is in cannot be worked out from the item alone.
+        """
+
+        for area_key in list(self._items_by_area_id):
+            self._remove_from_bucket(self._items_by_area_id, area_key, item_key)
 
     def effective_area_id(self, location_key: str) -> str | None:
         """Return the area a location sits in, walking ancestors to find it.
@@ -455,12 +446,15 @@ class Repository:
         return None
 
     def _reindex_item_replacement(self, old: Item, new: Item) -> None:
-        # Efficiently reindex by removing old and adding new
+        """Swap one item for its successor across every index.
+
+        In this order: unindexing ends by dropping the id from the primary
+        store, so indexing the replacement first would leave the repository
+        without it.
+        """
+
         self._unindex_item(old)
         self._index_item(new)
-
-    def _is_low_stock(self, item: Item) -> bool:
-        return item_is_low_stock(item)
 
     # -----------------------------
     # Internal helpers — locations
@@ -577,22 +571,15 @@ class Repository:
             self._locations_by_area_id.setdefault(str(loc.area_id), set()).add(str(loc.id))
 
     def _remove_location(self, loc: Location) -> None:
-        self._locations_by_id.pop(str(loc.id), None)
+        key = str(loc.id)
+        self._locations_by_id.pop(key, None)
         parent_key: str | None = str(loc.parent_id) if loc.parent_id is not None else None
-        children = self._children_ids_by_parent_id.get(parent_key)
-        if children is not None:
-            children.discard(str(loc.id))
-            if not children:
-                self._children_ids_by_parent_id.pop(parent_key, None)
-        # Remove dedicated children bucket if any
-        self._children_ids_by_parent_id.pop(str(loc.id), None)
-        # area index
+        self._remove_from_bucket(self._children_ids_by_parent_id, parent_key, key)
+        # The node's own children bucket, empty by now: deletion refuses a
+        # location that still has children.
+        self._children_ids_by_parent_id.pop(key, None)
         if loc.area_id is not None:
-            s = self._locations_by_area_id.get(str(loc.area_id))
-            if s is not None:
-                s.discard(str(loc.id))
-                if not s:
-                    self._locations_by_area_id.pop(str(loc.area_id), None)
+            self._remove_from_bucket(self._locations_by_area_id, str(loc.area_id), key)
 
     def _update_location_area_index(
         self, *, location_key: str, old_area: str | None, new_area: str | None
@@ -600,13 +587,9 @@ class Repository:
         """Maintain the locations-by-area index for a single location id."""
 
         if old_area is not None:
-            s = self._locations_by_area_id.get(old_area)
-            if s is not None:
-                s.discard(location_key)
-                if not s:
-                    self._locations_by_area_id.pop(old_area, None)
+            self._remove_from_bucket(self._locations_by_area_id, old_area, location_key)
         if new_area is not None:
-            self._locations_by_area_id.setdefault(new_area, set()).add(location_key)
+            self._add_to_bucket(self._locations_by_area_id, new_area, location_key)
 
     def _collect_descendant_ids(self, root_id: str) -> set[str]:
         """Collect all descendant location IDs (excluding the root itself)."""
@@ -705,32 +688,19 @@ class Repository:
         )
 
     def _rebuild_location_hierarchy_indexes(self) -> None:
-        """Rebuild location-based hierarchy indexes from scratch."""
-        self._location_descendants.clear()
+        """Rebuild the subtree index from scratch.
+
+        A location with no items under it gets no entry: an empty bucket reads
+        the same as an absent one everywhere the index is consulted.
+        """
+
         self._items_in_subtree.clear()
-
-        # Build descendants map
         for loc_id in self._locations_by_id:
-            descendants = self._collect_descendant_ids(loc_id)
-            if descendants:
-                self._location_descendants[loc_id] = descendants
-
-        # Build items in subtree map
-        # For each location, gather items from itself and all descendants
-        for loc_id in self._locations_by_id:
-            subtree_ids = {loc_id}
-            if loc_id in self._location_descendants:
-                subtree_ids.update(self._location_descendants[loc_id])
-
-            # Aggregate items
-            all_items: set[str] = set()
-            for sub_id in subtree_ids:
-                s = self._items_by_location_id.get(sub_id)
-                if s:
-                    all_items.update(s)
-
-            if all_items:
-                self._items_in_subtree[loc_id] = all_items
+            in_subtree: set[str] = set()
+            for sub_id in (loc_id, *self._collect_descendant_ids(loc_id)):
+                in_subtree.update(self._items_by_location_id.get(sub_id, ()))
+            if in_subtree:
+                self._items_in_subtree[loc_id] = in_subtree
 
     def _add_item_to_subtree_index(self, item: Item) -> None:
         if not item.location_id:
@@ -1317,7 +1287,7 @@ class Repository:
         # handed to _paginate rather than left as a local rearrangement.
         low_stock_first = bool(flt and flt.get("low_stock_first"))
         if low_stock_first:
-            sorted_items.sort(key=lambda it: not self._is_low_stock(it))
+            sorted_items.sort(key=lambda it: not item_is_low_stock(it))
 
         # Normalize sort for cursor tracking
         if sort is None:
@@ -1355,12 +1325,16 @@ class Repository:
         """Aggregate counts for ``haventory/stats``, ``haventory/health`` and events.
 
         ``status_counts`` covers every defined slug, including the default one
-        the index deliberately does not bucket. The two legacy
-        ``missing_count`` / ``needs_repair_count`` keys stay beside it: one
-        shape serves all three surfaces, and dropping them would move the card
-        in the same release that widens the vocabulary.
+        the index deliberately does not bucket. ``missing_count`` and
+        ``needs_repair_count`` name two of those slugs a second time, on their
+        own keys, because the card reads them there.
+
+        One ``today`` serves every date count, so a call that spans midnight
+        answers about one day rather than two.
         """
 
+        today = today_local_date()
+        items = self._items_by_id.values()
         items_with_location = sum(len(ids) for ids in self._items_by_location_id.values())
         flagged_total = sum(len(ids) for ids in self._status_to_item_ids.values())
         status_counts = {
@@ -1375,11 +1349,25 @@ class Repository:
             "items_total": len(self._items_by_id),
             "low_stock_count": len(self._low_stock_item_ids),
             "checked_out_count": len(self._checked_out_item_ids),
-            "overdue_count": self._count_overdue(),
-            "checked_out_due_count": self._count_checked_out_due(),
-            "inspection_overdue_count": self._count_inspection_overdue(),
-            "inspection_due_count": self._count_inspection_due(),
-            "reminder_due_count": self._count_reminder_due(),
+            "overdue_count": self._count(
+                self._checked_out_items(), lambda it: item_is_overdue(it, today=today)
+            ),
+            # A superset of the one above: the two differ by exactly the items
+            # due back today, the relation the inspection pair also has.
+            "checked_out_due_count": self._count(
+                self._checked_out_items(), lambda it: item_is_due(it, today=today)
+            ),
+            "inspection_overdue_count": self._count(
+                items, lambda it: item_inspection_is_overdue(it, today=today)
+            ),
+            "inspection_due_count": self._count(
+                items, lambda it: item_inspection_is_due(it, today=today)
+            ),
+            # Today counts: a reminder names the day it is asking about, so an
+            # item reminding today is one the household still has to act on.
+            "reminder_due_count": self._count(
+                items, lambda it: item_reminder_is_due(it, today=today)
+            ),
             "missing_count": len(self._status_to_item_ids.get("missing", set())),
             "needs_repair_count": len(self._status_to_item_ids.get("needs_repair", set())),
             "status_counts": status_counts,
@@ -1387,75 +1375,29 @@ class Repository:
             "no_location_count": len(self._items_by_id) - items_with_location,
         }
 
-    def _count_overdue(self) -> int:
-        """Count items whose due date has passed.
+    def _count(self, population: Iterable[Item], matches: Callable[[Item], bool]) -> int:
+        """How many of ``population`` the predicate keeps.
 
-        Deliberately not indexed: "overdue" moves with the calendar, so an index
-        would go stale at midnight with no mutation to invalidate it. A due date
-        only exists on a checked-out item, so the walk is over that set rather
-        than the whole inventory.
+        None of the five date counts is indexed, and none can be: each answer
+        moves with the calendar, so a bucket would go stale at midnight with no
+        mutation to invalidate it.
         """
 
-        today = today_local_date()
-        return sum(
-            1
+        return sum(1 for item in population if matches(item))
+
+    def _checked_out_items(self) -> Iterator[Item]:
+        """The checked-out items themselves.
+
+        A due date only exists on a checked-out item, so the two counts about
+        one walk this set rather than the whole inventory. An inspection or
+        reminder date is independent of any check-out, so those three do not.
+        """
+
+        return (
+            item
             for iid in self._checked_out_item_ids
-            if (it := self._items_by_id.get(iid)) is not None and item_is_overdue(it, today=today)
+            if (item := self._items_by_id.get(iid)) is not None
         )
-
-    def _count_checked_out_due(self) -> int:
-        """Count items that are due back, today included.
-
-        Unindexed and over the checked-out set, for the same two reasons as
-        ``_count_overdue``. This is a superset of it: the two differ by exactly
-        the items due back today, the same relation ``_count_inspection_due``
-        has to ``_count_inspection_overdue``.
-        """
-
-        today = today_local_date()
-        return sum(
-            1
-            for iid in self._checked_out_item_ids
-            if (it := self._items_by_id.get(iid)) is not None and item_is_due(it, today=today)
-        )
-
-    def _count_inspection_overdue(self) -> int:
-        """Count items past the date they were next due for inspection.
-
-        Unindexed for the same reason as ``_count_overdue`` — the answer moves
-        with the calendar, and no mutation invalidates it at midnight. The walk
-        covers the whole inventory rather than a subset: an inspection date is
-        independent of any check-out, so any item can carry one.
-        """
-
-        today = today_local_date()
-        return sum(
-            1 for it in self._items_by_id.values() if item_inspection_is_overdue(it, today=today)
-        )
-
-    def _count_inspection_due(self) -> int:
-        """Count items whose inspection is being asked for, today included.
-
-        Unindexed for the same reason as the two above. This is a superset of
-        ``_count_inspection_overdue``: it walks the same population and the two
-        differ by exactly the items whose inspection date is today.
-        """
-
-        today = today_local_date()
-        return sum(
-            1 for it in self._items_by_id.values() if item_inspection_is_due(it, today=today)
-        )
-
-    def _count_reminder_due(self) -> int:
-        """Count items whose reminder has come round.
-
-        Unindexed for the same reason as the two above, and today counts: a
-        reminder names the day it is asking about, so an item reminding today is
-        one the household still has to act on.
-        """
-
-        today = today_local_date()
-        return sum(1 for it in self._items_by_id.values() if item_reminder_is_due(it, today=today))
 
     def count_matching_by_location(self, flt: ItemFilter | None = None) -> dict[str | None, int]:
         """Count filter matches grouped by the item's own location.
@@ -1822,9 +1764,7 @@ class Repository:
         field = sort.get("field")
         order = sort.get("order", "desc")
         if field == "name":
-            return self._name_sort_key_by_item_id.get(str(item.id)) or normalize_text_for_sort(
-                item.name
-            )
+            return normalize_text_for_sort(item.name)
         if field == "quantity":
             return int(item.quantity)
         # The three date fields differ only in which date they read, so they are
@@ -1868,7 +1808,7 @@ class Repository:
 
     def _low_stock_group(self, item: Item) -> int:
         """Which low_stock_first block an item sits in: 0 low-stock, 1 the rest."""
-        return 0 if self._is_low_stock(item) else 1
+        return 0 if item_is_low_stock(item) else 1
 
     def _paginate(
         self,
@@ -2094,9 +2034,7 @@ class Repository:
         self._items_by_location_id = {}
         self._locations_by_area_id = {}
         self._items_by_area_id = {}
-        self._name_sort_key_by_item_id = {}
         self._children_ids_by_parent_id = {}
-        self._location_descendants = {}
         self._items_in_subtree = {}
 
     def _load_statuses(self, raw: object) -> None:

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -19,7 +19,7 @@ from collections import deque
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from datetime import date
-from typing import Any, TypedDict
+from typing import Any, TypedDict, TypeVar
 
 from .calendar_projection import next_occurrence_after
 from .exceptions import ConflictError, NotFoundError, ValidationError
@@ -68,6 +68,11 @@ from .models import (
 )
 
 LOGGER = context_logger(__name__)
+
+
+#: What an index bucket is keyed by. A string for every item index; the location
+#: tree's children index adds ``None`` for the roots.
+_BucketKey = TypeVar("_BucketKey", str, str | None)
 
 
 class PageResult(TypedDict):
@@ -331,15 +336,26 @@ class Repository:
     # Internal helpers — indexing
     # -----------------------------
 
-    def _add_to_bucket(self, bucket: dict[str, set[str]], key: str, item_id: str) -> None:
-        bucket.setdefault(key, set()).add(item_id)
+    def _add_to_bucket(
+        self, bucket: dict[_BucketKey, set[str]], key: _BucketKey, member: str
+    ) -> None:
+        bucket.setdefault(key, set()).add(member)
 
-    def _remove_from_bucket(self, bucket: dict[str, set[str]], key: str, item_id: str) -> None:
-        s = bucket.get(key)
-        if not s:
+    def _remove_from_bucket(
+        self, bucket: dict[_BucketKey, set[str]], key: _BucketKey, member: str
+    ) -> None:
+        """Drop a member, and the bucket with it when that empties it.
+
+        An empty bucket is indistinguishable from an absent one everywhere it
+        is read, so leaving one behind would grow the index by every key the
+        inventory has ever used.
+        """
+
+        members = bucket.get(key)
+        if not members:
             return
-        s.discard(item_id)
-        if not s:
+        members.discard(member)
+        if not members:
             bucket.pop(key, None)
 
     def _index_item(self, item: Item) -> None:
@@ -578,42 +594,6 @@ class Repository:
                 if not s:
                     self._locations_by_area_id.pop(str(loc.area_id), None)
 
-    def _stage_location_update(
-        self,
-        *,
-        loc: Location,
-        updated_name: str,
-        target_parent_id: uuid.UUID | None,
-        parent_changed: bool,
-        target_area: str | None,
-    ) -> tuple[dict[str, Location], dict[str | None, set[str]], Location]:
-        """Create staged maps with the proposed location update applied.
-
-        Returns (staged_locations_by_id, staged_children_by_parent, new_loc).
-        """
-
-        staged_locations_by_id: dict[str, Location] = dict(self._locations_by_id)
-        staged_children_by_parent: dict[str | None, set[str]] = {
-            k: set(v) for k, v in self._children_ids_by_parent_id.items()
-        }
-
-        new_loc = replace(loc, name=updated_name, parent_id=target_parent_id, area_id=target_area)
-        key = str(loc.id)
-        staged_locations_by_id[key] = new_loc
-
-        if parent_changed:
-            # Remove from old parent's children in staged map
-            old_parent = str(loc.parent_id) if loc.parent_id is not None else None
-            if old_parent in staged_children_by_parent:
-                staged_children_by_parent[old_parent].discard(key)
-                if not staged_children_by_parent[old_parent]:
-                    staged_children_by_parent.pop(old_parent)
-            # Add to new parent's children bucket in staged map
-            parent_key: str | None = str(target_parent_id) if target_parent_id is not None else None
-            staged_children_by_parent.setdefault(parent_key, set()).add(key)
-
-        return staged_locations_by_id, staged_children_by_parent, new_loc
-
     def _update_location_area_index(
         self, *, location_key: str, old_area: str | None, new_area: str | None
     ) -> None:
@@ -782,41 +762,17 @@ class Repository:
         for anc in self._get_ancestors(loc_key):
             self._remove_from_bucket(self._items_in_subtree, anc, item_key)
 
-    def _rebuild_paths_for_subtree(
-        self,
-        root_id: str,
-        *,
-        locations_by_id: dict[str, Location] | None = None,
-        children_ids_by_parent_id: dict[str | None, set[str]] | None = None,
-    ) -> None:
-        """Recompute ``Location.path`` for a subtree rooted at ``root_id``.
+    def _rebuild_paths_for_subtree(self, root_id: str) -> None:
+        """Recompute ``Location.path`` for the subtree rooted at ``root_id``.
 
-        If ``locations_by_id`` and/or ``children_ids_by_parent_id`` are provided,
-        the computation mutates those maps instead of the repository's live maps.
+        Reads the live maps, so a move writes the new parent link first and
+        calls this second — a path built from the old link would be stored on
+        the node and denormalized onto every item under it.
         """
 
-        loc_map = locations_by_id if locations_by_id is not None else self._locations_by_id
-        child_map = (
-            children_ids_by_parent_id
-            if children_ids_by_parent_id is not None
-            else self._children_ids_by_parent_id
-        )
-
-        to_fix = [root_id]
-        # Collect descendants using the provided child map
-        queue = deque([root_id])
-        visited: set[str] = set()
-        while queue:
-            current = queue.popleft()
-            for cid in child_map.get(current, set()):
-                if cid not in visited:
-                    visited.add(cid)
-                    to_fix.append(cid)
-                    queue.append(cid)
-
-        for loc_id in to_fix:
-            new_path = build_location_path_from_map(loc_id, locations_by_id=loc_map)
-            loc_map[loc_id] = replace(loc_map[loc_id], path=new_path)
+        for loc_id in (root_id, *self._collect_descendant_ids(root_id)):
+            new_path = build_location_path_from_map(loc_id, locations_by_id=self._locations_by_id)
+            self._locations_by_id[loc_id] = replace(self._locations_by_id[loc_id], path=new_path)
 
     def _update_items_location_paths_for_locations(self, affected_location_ids: set[str]) -> None:
         """Refresh ``location_path`` for items under any of the given locations.
@@ -1750,29 +1706,26 @@ class Repository:
         parsed_area, area_change_requested = self._parse_area_change(area_id, loc.area_id)
         name_changed = updated_name != loc.name
 
-        # Validate move invariants if changing parent
+        # Everything that can refuse the move has refused it by here, so the
+        # tree is rewritten in place: the parent link first, then the paths that
+        # are derived from it.
         if parent_changed:
             self._validate_parent_move(location_key=key, target_parent_id=target_parent_id)
+            self._remove_from_bucket(
+                self._children_ids_by_parent_id,
+                str(loc.parent_id) if loc.parent_id is not None else None,
+                key,
+            )
+            self._add_to_bucket(
+                self._children_ids_by_parent_id,
+                str(target_parent_id) if target_parent_id is not None else None,
+                key,
+            )
 
-        # For staging, don't change area on this location - area propagates to root
-        staged_locations_by_id, staged_children_by_parent, _ = self._stage_location_update(
-            loc=loc,
-            updated_name=updated_name,
-            target_parent_id=target_parent_id,
-            parent_changed=parent_changed,
-            target_area=loc.area_id,  # Keep current area in staging; propagation happens after
-        )
-
-        # Attempt to rebuild paths against staged maps; if this fails, nothing is committed
-        self._rebuild_paths_for_subtree(
-            key,
-            locations_by_id=staged_locations_by_id,
-            children_ids_by_parent_id=staged_children_by_parent,
-        )
-
-        # Commit: swap in staged structures atomically
-        self._children_ids_by_parent_id = staged_children_by_parent
-        self._locations_by_id = staged_locations_by_id
+        # The area is left as it stands: it belongs to the root of a tree, and
+        # a requested change is propagated there once the node has moved.
+        self._locations_by_id[key] = replace(loc, name=updated_name, parent_id=target_parent_id)
+        self._rebuild_paths_for_subtree(key)
 
         # Update affected items (now that live maps are consistent)
         affected = {key}

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -34,26 +34,19 @@ from .models import (
     ItemFilter,
     ItemUpdate,
     Location,
-    LocationPath,
     Sort,
     StatusDefinition,
     apply_item_update,
     build_location_path,
-    coerce_item_status,
     create_item_from_create,
     date_sort_key,
     filter_items,
-    is_canonical_utc_timestamp,
-    iso_utc_now,
     item_inspection_is_due,
     item_inspection_is_overdue,
     item_is_due,
     item_is_low_stock,
     item_is_overdue,
     item_reminder_is_due,
-    load_attachments,
-    load_reminder_anchor,
-    load_reminder_interval,
     location_sort_key,
     monotonic_timestamp_after,
     new_uuid4,
@@ -68,7 +61,6 @@ from .models import (
     sort_items,
     today_local_date,
     validate_location_name,
-    validate_required_name,
     validate_status_definition,
     validate_status_slug,
 )
@@ -113,20 +105,6 @@ def _log_dropped_overflow(op: str, dropped: int) -> None:
             "dropped_logged": LOAD_DROP_LOG_LIMIT,
         },
     )
-
-
-def _coerce_canonical_ts(value: object, *, fallback: str | None = None) -> str:
-    """Return a canonical UTC timestamp, backfilling non-canonical input.
-
-    Item timestamps compare lexicographically for sort/range filters, so on
-    load any missing / null / corrupt value is replaced with a canonical one
-    (the fallback when it is itself canonical, otherwise the current time).
-    """
-    if isinstance(value, str) and is_canonical_utc_timestamp(value):
-        return value
-    if fallback is not None and is_canonical_utc_timestamp(fallback):
-        return fallback
-    return iso_utc_now()
 
 
 @dataclass(frozen=True)
@@ -2145,42 +2123,7 @@ class Repository:
         if isinstance(locations, dict):
             for loc_id, loc_data in locations.items():
                 try:
-                    path_obj = loc_data.get("path", {}) if isinstance(loc_data, dict) else {}
-                    path = LocationPath(
-                        id_path=[
-                            parse_uuid4(str(x), field_name="path.id_path")
-                            for x in list(path_obj.get("id_path", []) or [])
-                        ],
-                        name_path=list(path_obj.get("name_path", []) or []),
-                        display_path=str(path_obj.get("display_path", "")),
-                        # Backfill for stores written before sort_key was
-                        # persisted (pre-WP4): derive it from display_path.
-                        sort_key=str(path_obj.get("sort_key", ""))
-                        or normalize_text_for_sort(str(path_obj.get("display_path", ""))),
-                    )
-                    loc = Location(
-                        id=parse_uuid4(str(loc_data.get("id", loc_id)), field_name="location.id"),
-                        parent_id=(
-                            parse_uuid4(
-                                str(loc_data.get("parent_id")), field_name="location.parent_id"
-                            )
-                            if loc_data.get("parent_id") is not None
-                            else None
-                        ),
-                        # Not `str(...)`: a missing key would read as "" and a
-                        # stored `null` as the literal "None", both of them rows
-                        # no write path could have produced. Raising here drops
-                        # the row into the load report, which is what the
-                        # corrupt-store repair is built on.
-                        name=validate_required_name(loc_data.get("name")),
-                        area_id=(
-                            str(loc_data.get("area_id"))
-                            if loc_data.get("area_id") is not None
-                            else None
-                        ),
-                        path=path,
-                    )
-                    self._add_location(loc)
+                    self._add_location(Location.from_dict(loc_data, fallback_id=str(loc_id)))
                 except (
                     AttributeError,
                     TypeError,
@@ -2208,75 +2151,11 @@ class Repository:
         if isinstance(items, dict):
             for item_id, item_data in items.items():
                 try:
-                    lp = (item_data or {}).get("location_path", {})
-                    location_path = LocationPath(
-                        id_path=[
-                            parse_uuid4(str(x), field_name="location_path.id_path")
-                            for x in list(lp.get("id_path", []) or [])
-                        ],
-                        name_path=list(lp.get("name_path", []) or []),
-                        display_path=str(lp.get("display_path", "")),
-                        # Backfill for stores written before sort_key was
-                        # persisted (pre-WP4): derive it from display_path.
-                        sort_key=str(lp.get("sort_key", ""))
-                        or normalize_text_for_sort(str(lp.get("display_path", ""))),
+                    self._index_item(
+                        Item.from_dict(
+                            item_data, known_statuses=known_statuses, fallback_id=str(item_id)
+                        )
                     )
-                    item = Item(
-                        id=parse_uuid4(str(item_data.get("id", item_id)), field_name="item.id"),
-                        # See the location above: an unreadable name is a
-                        # corrupt row, not an item called "" or "None".
-                        name=validate_required_name(item_data.get("name")),
-                        description=item_data.get("description"),
-                        quantity=int(item_data.get("quantity", 0)),
-                        # Stores written before the field existed carry no
-                        # status; they read as the default rather than failing.
-                        status=coerce_item_status(
-                            item_data.get("status"), known_statuses=known_statuses
-                        ),
-                        checked_out=bool(item_data.get("checked_out", False)),
-                        due_date=item_data.get("due_date"),
-                        inspection_date=item_data.get("inspection_date"),
-                        # Absent on every store written before v8, and read as
-                        # none there — which is exactly what migrate_7_to_8
-                        # writes, so the two paths agree. The anchor is the same
-                        # story one version later: absent before v9, and equal to
-                        # the date for any reminder nobody has bumped.
-                        reminder_date=item_data.get("reminder_date"),
-                        reminder_anchor=load_reminder_anchor(
-                            item_data.get("reminder_anchor"),
-                            reminder_date=item_data.get("reminder_date"),
-                        ),
-                        reminder_interval=load_reminder_interval(
-                            item_data.get("reminder_interval")
-                        ),
-                        location_id=(
-                            parse_uuid4(
-                                str(item_data.get("location_id")), field_name="item.location_id"
-                            )
-                            if item_data.get("location_id") is not None
-                            else None
-                        ),
-                        tags=list(item_data.get("tags", []) or []),
-                        category=item_data.get("category"),
-                        low_stock_threshold=item_data.get("low_stock_threshold"),
-                        custom_fields=dict(item_data.get("custom_fields", {}) or {}),
-                        # Timestamps compare lexicographically for sort/filter,
-                        # so any non-canonical value (missing / null / corrupt /
-                        # hand-edited import) is backfilled with a canonical one.
-                        created_at=_coerce_canonical_ts(item_data.get("created_at")),
-                        updated_at=_coerce_canonical_ts(
-                            item_data.get("updated_at"),
-                            fallback=_coerce_canonical_ts(item_data.get("created_at")),
-                        ),
-                        version=int(item_data.get("version", 1)),
-                        location_path=location_path,
-                        # Tolerant of absence and of a non-list value (both read
-                        # as none), but not of a malformed *entry*: dropping one
-                        # would lose the only reference to a file on disk, which
-                        # the orphan sweep would then delete.
-                        attachments=load_attachments(item_data.get("attachments")),
-                    )
-                    self._index_item(item)
                 except (
                     AttributeError,
                     TypeError,

--- a/tests/test_models_offline.py
+++ b/tests/test_models_offline.py
@@ -43,6 +43,7 @@ from custom_components.haventory.models import (
     validate_optional_date,
     validate_status_definition,
     validate_tags,
+    walk_location_chain,
 )
 
 UUID4_RE = re.compile(
@@ -158,6 +159,48 @@ async def test_denormalized_location_path_generation() -> None:
     # And lookup via map works from leaf
     path2 = build_location_path_from_map(uuid.UUID(leaf_id), locations_by_id=by_id)
     assert path2.display_path == path.display_path
+
+
+def test_the_chain_walk_ends_on_a_loop_instead_of_following_it() -> None:
+    """A store edited into a cycle must not cost the walk more than the cycle.
+
+    Every walk up the parent chain shares this one, including the ones the
+    item-index path takes on each mutation, so a loop has to end the walk
+    rather than spin in it.
+    """
+
+    first_id = new_uuid4_str()
+    second_id = new_uuid4_str()
+    by_id = {
+        first_id: _make_location(first_id, "First", second_id),
+        second_id: _make_location(second_id, "Second", first_id),
+    }
+
+    walked = list(walk_location_chain(first_id, locations_by_id=by_id))
+
+    assert [loc.name for loc in walked] == ["First", "Second"]
+
+
+@pytest.mark.parametrize(
+    ("parent_id", "message"),
+    [
+        (None, "existing location chain"),
+        ("cycle", "too deep or cyclic"),
+    ],
+)
+def test_a_chain_that_reaches_no_root_is_refused(parent_id: str | None, message: str) -> None:
+    """A path is stored on every item under the node, so a partial one is refused.
+
+    The two ways a chain fails to reach a root are named apart: a parent no
+    location carries, and a parent the walk has already passed.
+    """
+
+    leaf_id = new_uuid4_str()
+    missing_id = new_uuid4_str()
+    leaf = _make_location(leaf_id, "Bin 3", missing_id if parent_id is None else leaf_id)
+
+    with pytest.raises(ValidationError, match=message):
+        build_location_path_from_map(leaf_id, locations_by_id={leaf_id: leaf})
 
 
 @pytest.mark.asyncio

--- a/tests/test_repository_locations_offline.py
+++ b/tests/test_repository_locations_offline.py
@@ -79,33 +79,6 @@ async def test_move_to_root_and_disallow_self_parent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_location_is_atomic_when_path_rebuild_fails(monkeypatch) -> None:
-    """Path rebuild failure does not leave partial parent/name/path changes."""
-
-    repo = Repository()
-    a = repo.create_location(name="A")
-    b = repo.create_location(name="B", parent_id=a.id)
-
-    old_b = repo.get_location(b.id)
-    old_children = {k: set(v) for k, v in repo._children_ids_by_parent_id.items()}
-    old_paths = {lid: loc.path.display_path for lid, loc in repo._locations_by_id.items()}
-
-    def boom(*args, **kwargs) -> None:
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(repo, "_rebuild_paths_for_subtree", boom)
-
-    with pytest.raises(RuntimeError):
-        repo.update_location(b.id, name="B2", new_parent_id=None)
-
-    # No state should have changed
-    assert repo.get_location(b.id).name == old_b.name
-    assert repo.get_location(b.id).parent_id == old_b.parent_id
-    assert {k: set(v) for k, v in repo._children_ids_by_parent_id.items()} == old_children
-    assert {lid: loc.path.display_path for lid, loc in repo._locations_by_id.items()} == old_paths
-
-
-@pytest.mark.asyncio
 async def test_location_item_counts_and_no_location_count() -> None:
     """Per-location direct/subtree counts and the orphan count track item moves."""
 

--- a/tests/test_serialized_shapes_offline.py
+++ b/tests/test_serialized_shapes_offline.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from custom_components.haventory.exceptions import ValidationError
 from custom_components.haventory.import_export import build_export_document
 from custom_components.haventory.models import EMPTY_LOCATION_PATH, Item, Location, LocationPath
 from custom_components.haventory.repository import Repository
@@ -181,6 +182,18 @@ def test_a_row_that_carries_no_path_reads_as_the_empty_one() -> None:
     location = Location.from_dict({"id": str(uuid.uuid4()), "name": "Garage"})
 
     assert location.path == EMPTY_LOCATION_PATH
+
+
+@pytest.mark.parametrize("broken", ["garbage", 7, []])
+def test_a_path_of_the_wrong_shape_is_refused(broken: object) -> None:
+    """Absent is old; present and not an object is corrupt.
+
+    The load path turns this refusal into a dropped row named in the report,
+    rather than an entity carrying a path no write path could have written.
+    """
+
+    with pytest.raises(ValidationError):
+        LocationPath.from_dict(broken)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_serialized_shapes_offline.py
+++ b/tests/test_serialized_shapes_offline.py
@@ -1,4 +1,4 @@
-"""One ``to_dict()`` per model, and the three shapes that come off it.
+"""One ``to_dict()`` per model, the way back off it, and the three shapes.
 
 An item is serialized for three places, and they are not the same shape:
 
@@ -11,7 +11,8 @@ An item is serialized for three places, and they are not the same shape:
 Held together here rather than in the three modules that emit them: the fields
 were hand-written three times and drifted, and the way that drift shows up is a
 restore that quietly loses something, or a card that reads a key from one
-surface and not another.
+surface and not another. ``from_dict`` is the fourth place the field list is
+written out, which is why the inverse is asserted here too.
 
 ``tests/fixtures/stored_payload.json`` is the golden document. It was generated
 from the serializers as they stood before they were consolidated, so what the
@@ -151,6 +152,35 @@ def test_a_changed_entity_breaks_the_golden_comparison(collection: str) -> None:
     entity["name"] = f"{entity['name']} (edited)"
 
     assert dumped(Repository.from_state(payload).export_state()) != golden_text()
+
+
+# --------------------------------------------------------------------------- #
+# The way back
+# --------------------------------------------------------------------------- #
+
+
+def test_every_stored_field_reads_back_into_the_model() -> None:
+    """``from_dict`` is the inverse of ``to_dict``, field for field.
+
+    The load path and the import path both build their models through it, so a
+    field one half of the pair learns and the other does not is a field a
+    restart drops without saying so.
+    """
+    payload = golden_payload()
+    known = frozenset(payload["statuses"])
+    item = next(entry for entry in payload["items"].values() if entry["name"] == "Cordless drill")
+    location = next(entry for entry in payload["locations"].values() if entry["name"] == "Bin 3")
+
+    assert Item.from_dict(item, known_statuses=known).to_dict() == item
+    assert Location.from_dict(location).to_dict() == location
+
+
+def test_a_row_that_carries_no_path_reads_as_the_empty_one() -> None:
+    """The nesting may be absent altogether — an import document leaves it out."""
+
+    location = Location.from_dict({"id": str(uuid.uuid4()), "name": "Garage"})
+
+    assert location.path == EMPTY_LOCATION_PATH
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

The last of §6.M1's repository work: BE-REPO-3, -4, -5, -6 and -8 from the
[2026-08-22 measurement on #230](https://github.com/chrreiter/HAventory/issues/230#issuecomment-5381712066).
Five copies of the same walk, one staged copy of two whole maps, two hand-written copies of the
model field lists, five counts that were one expression each, and three comments that told the
reader about the past instead of about the code.

- **One walk up the parent chain** (BE-REPO-3). `effective_area_id`, `_find_location_root`,
  `_get_ancestors`, the lineage `create_location` builds and the chain `_rebuild_paths_for_subtree`
  rebuilds each carried their own copy of the step ceiling and their own answer to a chain that
  closes into a loop. They now share `walk_location_chain`, which stops on an id it has already
  passed, and `location_chain_to_root`, which refuses a chain that reaches no root and names which
  of the two ways it failed. `build_location_path_from_map` — the helper two of the five were
  duplicating — is now written on those two, so the codebase holds one such loop.
- **A location update applied in place** (BE-REPO-4). `update_location` copied the whole location
  map and the whole children index, applied the change to the copies, rebuilt the subtree's paths
  against them and swapped them in. `_validate_parent_move` runs first, and after it the parent
  exists and is neither the node nor one of its descendants, so neither exception the rebuild can
  raise is reachable in a tree. `_rebuild_paths_for_subtree` loses the two optional map parameters
  that existed only for the staged copies.
- **`from_dict` beside `to_dict`** (BE-REPO-5), on `Item`, `Location` and `LocationPath`.
  `load_state` and `import_export._recompute_paths` stop building the models field by field, and
  the two `LocationPath` dict literals in the import path become `to_dict()` calls. The `sort_key`
  backfill lives once. `load_state` keeps its per-row `try`/`except`, so the `LoadReport` contract
  is untouched — `test_load_report_offline.py` is green and unedited.
- **One count, and the copies around the buckets** (BE-REPO-6). Five `_count_*` helpers → `_count`
  plus a named predicate per line; three places that inlined `_remove_from_bucket`'s
  discard-and-drop-empty dance now call it; the cached name sort key (one reader, which recomputed
  on a miss anyway) and the descendants map (filled and read inside one method) are gone;
  `_is_low_stock` was an alias for the models predicate.
- **Comments that state the constraint** (BE-REPO-8). The class docstring said a location change
  updates impacted items "to increment their version and `updated_at`" — the opposite of the
  invariant the rest of the codebase depends on. The "pre-WP4" pair collapses into one line on
  `LocationPath.from_dict`. The subtree-index removal narrated the call sequence that reaches it.
  `get_counts` no longer calls two live contract fields "legacy" or explains a past release.

No file left `custom_components/haventory/`, so `RETIRED_PATHS` is unchanged. No WS schema, error
code or payload field moved, so `docs/backend_api_contract.md` and `docs/data_shapes.md` are
unchanged.

Refs #230

## Counting

| | lines |
|---|---|
| Production removed | 544 |
| Test removed | 29 |
| Added | 491 |

From `git diff origin/main --numstat`: `repository.py` −485/+199, `models.py` −25/+194,
`import_export.py` −34/+10, tests −29/+88. Net −82; the production net is −141, and the difference
is the load block that moved out of `repository.py` into the two `from_dict`s.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1357 passed, 27 skipped**;
  `uv run ruff check .` → All checks passed; `uv run ruff format --check .` → 189 files already
  formatted; `uv run mypy` → Success: no issues found in 26 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
  `npx vitest run` → **67 files, 1917 passed**, `npm run build` → 732.88 kB.
- [x] phacc (`scripts/test_integration.sh`, card built first): **153 passed in 16.51s** —
  `[ OK ] Integration tests OK`.

### Tests

Five tests were added and one was deleted.

- `test_every_stored_field_reads_back_into_the_model`,
  `test_a_row_that_carries_no_path_reads_as_the_empty_one` and
  `test_a_path_of_the_wrong_shape_is_refused` (`tests/test_serialized_shapes_offline.py`) —
  `from_dict` is the fourth place the field list is written out, so the file that holds the other
  three against each other holds the inverse too.
- `test_the_chain_walk_ends_on_a_loop_instead_of_following_it` and
  `test_a_chain_that_reaches_no_root_is_refused` (`tests/test_models_offline.py`) — the shared
  walk's two stop conditions, which is the part of BE-REPO-3 the issue called medium risk.
- `test_update_location_is_atomic_when_path_rebuild_fails`
  (`tests/test_repository_locations_offline.py`) is **deleted, not rewritten**, per the subtraction
  rule. It monkeypatched `_rebuild_paths_for_subtree` into raising `RuntimeError`, which is the
  failure the staged maps existed for; with the staging gone there is nothing left for it to
  assert that validation does not already exclude.

The autouse index-invariant oracle (`tests/repository_invariants.py`, PR 8) runs after every test
over every repository built, so it covered each of these commits as they landed.

The last commit is a correction found by diffing the load path against `main` rather than by a
failing test: the first cut of `LocationPath.from_dict` read *anything* that was not an object as
the empty path, so a stored `location_path` of `"garbage"` loaded with no path instead of being
dropped and named in the `LoadReport`. Absent is old; present and the wrong shape is corrupt. The
third new test above is the pin.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — no behaviour changed; see "Differences" below.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md`
      in sync — none in this PR.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`,
      optimistic `version`).

## Differences a reader should check rather than assume

Four places where the collapse could not be byte-identical. None is reachable from a store or a
document this integration wrote itself.

1. **`_get_ancestors` on a chain that loops.** The old walk stopped *before* recording the id that
   closes the loop; the shared walk stops *after*, so the returned list can carry that id (and
   therefore a repeat). Its two callers add to and remove from the same buckets, and both are
   idempotent, so the index is identical either way — and a cyclic location makes setup refuse to
   load at all.
2. **`create_location` with a broken ancestor above a parent that exists.** The message changes
   from "parent_id must reference an existing location" to "location_id must reference an existing
   location chain" / "location graph too deep or cyclic", which is what every other chain builder
   already answers.
3. **`build_location_path_from_map` on a cyclic map** now answers after the cycle rather than after
   10,000 steps. Same message, same refusal.
4. **A location name in an import document** is now trimmed, because `Location.from_dict` runs it
   through `validate_required_name` — which is what `load_state` already did to the same field, and
   what the interactive write path does. Only a hand-authored document with padded names differs.

`get_counts` also reads `today_local_date()` once instead of five times, so a call that straddles
midnight now answers about one day rather than two.

## Screenshots (card / UI changes)

None — no card file is touched.

## Handover

1. **Merged / left open** — this PR, left open for the M1 master to review and squash-merge; it is
   the last of §6.M1's nine.
2. **Test this by hand** — `[owner]` nothing specific. The one path no test reaches is a store the
   owner's own install has grown: loading it should produce the same counts and the same location
   tree as before, which the diagnostics panel shows at a glance.
3. **Validate locally**
   1. `[dev-ha]` deploy this branch and reload the entry from Settings → Devices & services.
      Expected: the entry reloads, the item and location counts are what they were.
   2. `[browser]` rename a location that has a subtree and items in it. Expected: every descendant
      path and every item's location line update, and the items keep their positions in a
      "recently updated" sort — the rename must not restamp them.
   3. `[browser]` move a subtree under another node, then move it back. Expected: paths follow both
      ways; no item's version changes (visible as no concurrency error on a subsequent edit).
   4. `[browser]` set an area on a location deep in a tree. Expected: the area lands on the tree's
      root and every item under it reports it.
   5. `[browser]` export the inventory, then import the document back. Expected: valid, and the
      report classifies every entity as unchanged.
   6. `[log]` nothing at ERROR carrying `haventory` through all of the above.
4. **Decisions taken against drifted notes**
   - BE-REPO-6(e) lists three one-line wrappers. Only `_is_low_stock` went. `_low_stock_group`
     encodes the 0/1 block convention `_tuple_cmp` compares on, and inlining it at its two call
     sites would need that convention spelled out twice. `_reindex_item_replacement` has three
     callers and a required order — unindexing ends by dropping the id from the primary store, so
     indexing first would leave the repository without the item — which is now its docstring
     instead of the comment that restated the two calls below it.
   - BE-REPO-3's suggested `_chain(loc_key, loc_map) -> list[Location]` became a generator in
     `models.py` plus a raising list builder beside it. `models.py` owns
     `LOCATION_GUARD_MAX_STEPS`, `Location` and the path builders, and putting the walk there is
     what let `build_location_path_from_map` — the sixth copy of the loop, which the issue notes
     two of the five were duplicating — be written on it rather than left standing.
   - BE-REPO-8 also lists the `get_counts` "legacy" sentence; it is fixed here because the
     surrounding method was being rewritten for BE-REPO-6(a) anyway. The `#225` forward pointer at
     `LoadReport` stays, as the issue asks.
5. **Follow-ups** — `tests/test_repository_roundtrip_offline.py`'s
   `test_legacy_store_without_sort_key_is_backfilled_on_load` still says "Pre-WP4 stores" in its
   docstring. Not filed: it is a one-line wording fix in a file this PR does not otherwise touch,
   and M6's docs pass is where it belongs.
6. **State left behind** — branch `claude/v0-8-0-m1-repo-copies`, six commits, no assets branch,
   no HA instance touched. Counting for this PR: 544 production lines removed, 29 test lines
   removed, 491 added.
