### PR TITLE
refactor(models): every field rule written once

### DIFF
--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 import re
 import unicodedata
 import uuid
-from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from typing import Any, Final, Literal, NotRequired, TypedDict
 
 from homeassistant.util import dt as dt_util
@@ -661,11 +662,11 @@ def validate_required_name(value: object) -> str:
     return value.strip()
 
 
-def validate_location_name(name: str) -> str:
-    """Validate a location name and return a trimmed value.
+def validate_write_name(name: object) -> str:
+    """Validate a name a client wrote and return a trimmed value.
 
-    The write path's rule: what the load path requires, plus the length cap the
-    load path deliberately does not apply.
+    The write path's rule, for an item and a location alike: what the load path
+    requires, plus the length cap the load path deliberately does not apply.
     """
 
     trimmed = validate_required_name(name)
@@ -1359,14 +1360,222 @@ def validate_quantity(value: object) -> int:
     return value
 
 
-def _validate_item_core_fields(name: str, quantity: int, low_stock_threshold: int | None) -> None:
-    if len(validate_required_name(name)) > NAME_MAX_LENGTH:
-        raise ValidationError(f"name must be at most {NAME_MAX_LENGTH} characters")
-    validate_quantity(quantity)
-    if low_stock_threshold is not None and (
-        not _is_int_not_bool(low_stock_threshold) or low_stock_threshold < 0
-    ):
+@dataclass(frozen=True, slots=True)
+class _ItemWrite:
+    """One item write in progress, as the field rules see it.
+
+    ``draft`` is what the write starts from and what the rules fill in: the
+    field defaults on a create, a copy of the stored item on an update. A cap
+    that refuses *growth* reads the value the item already carries off the same
+    draft, so on a create — where the defaults are empty — it is an absolute
+    cap, and neither path needs a rule of its own.
+    """
+
+    draft: Item
+    payload: Mapping[str, Any]
+    creating: bool
+    locations_by_id: dict[str, Location] | None
+    known_statuses: Collection[str]
+
+
+def _write_name(write: _ItemWrite) -> None:
+    """Required on a create; a null on an update leaves the stored name alone.
+
+    The field is non-nullable and the card's editor sends every field it holds,
+    so a null has to read as "this write does not name the name".
+    """
+
+    value = write.payload.get("name")
+    if value is None and not write.creating:
+        return
+    # Type before shape: the command schemas type `name` as `object` so a wrong
+    # type is answered here as `validation_error` rather than by an HA-core
+    # schema rejection, and a `.strip()` on a non-string would leave through
+    # `unknown_error` instead of naming the field.
+    write.draft.name = validate_write_name(value)
+
+
+def _write_optional_text(write: _ItemWrite, *, key: str, max_length: int) -> None:
+    """One nullable free-text field, held to its cap against what is stored.
+
+    ``key`` names the payload field and the item's attribute, which are the same
+    word for every field written this way.
+    """
+
+    if key not in write.payload:
+        return
+    value = write.payload[key]
+    _validate_optional_text(value, key, max_length=max_length, previous=getattr(write.draft, key))
+    setattr(write.draft, key, value)
+
+
+def _write_quantity(write: _ItemWrite) -> None:
+    # Type before use, for the same reason `name` is checked before `.strip()`:
+    # the command schema types `quantity` as `object`, and arithmetic over a
+    # non-integer routes to `unknown_error` instead of naming the field.
+    if "quantity" in write.payload:
+        write.draft.quantity = validate_quantity(write.payload["quantity"])
+
+
+def _write_status(write: _ItemWrite) -> None:
+    if "status" in write.payload:
+        write.draft.status = validate_item_status(
+            write.payload["status"], known_statuses=write.known_statuses
+        )
+
+
+def _write_checkout(write: _ItemWrite) -> None:
+    """The checkout flag and its due date, holding the pair's rule across both.
+
+    Judged on what the write leaves behind rather than on the keys it carries,
+    so a write that sends the item home without naming the date is refused
+    rather than leaving a due date on an item nobody has out.
+    """
+
+    draft = write.draft
+    if "checked_out" in write.payload:
+        draft.checked_out = bool(write.payload["checked_out"])
+    if "due_date" in write.payload:
+        draft.due_date = write.payload["due_date"]
+    draft.due_date = validate_due_date_rules(checked_out=draft.checked_out, due_date=draft.due_date)
+
+
+def _write_inspection_date(write: _ItemWrite) -> None:
+    if "inspection_date" in write.payload:
+        write.draft.inspection_date = validate_optional_date(
+            write.payload["inspection_date"], field_name="inspection_date"
+        )
+
+
+def _write_reminder(write: _ItemWrite) -> None:
+    """Apply either half of the reminder, holding the pair's rule across both.
+
+    A write naming only one of the two is validated against the item's other
+    half, so clearing the date of a recurring reminder is refused rather than
+    leaving an interval with nothing to count from.
+
+    Writing a *different* date re-anchors the series on it: the payloads carry
+    no anchor of their own, deliberately, because a household picking a date is
+    saying where the series starts. Re-sending the date the item already carries
+    says nothing, so it must not move the anchor — the card's editor puts every
+    field in every payload, changed or not, and re-anchoring on presence alone
+    would let an ordinary save walk a month-end series off its day one short
+    month at a time. `Repository.bump_reminder` is the one path that moves the
+    date and keeps the anchor, which is what makes a bumped month-end series stay
+    on its own day.
+    """
+
+    payload = write.payload
+    draft = write.draft
+    if "reminder_date" not in payload and "reminder_interval" not in payload:
+        return
+    previous_reminder_date = draft.reminder_date
+    date_value = payload["reminder_date"] if "reminder_date" in payload else draft.reminder_date
+    interval_value = (
+        payload["reminder_interval"] if "reminder_interval" in payload else draft.reminder_interval
+    )
+    draft.reminder_date, draft.reminder_interval = validate_reminder_rules(
+        reminder_date=date_value, reminder_interval=interval_value
+    )
+    if "reminder_date" in payload and draft.reminder_date != previous_reminder_date:
+        draft.reminder_anchor = draft.reminder_date
+    elif draft.reminder_date is None:
+        # The interval was cleared alongside a date that was already absent, or
+        # the pair rule left nothing behind. An anchor without a date names a
+        # series with no next occurrence.
+        draft.reminder_anchor = None
+
+
+def _write_location(write: _ItemWrite) -> None:
+    """Place the item, and keep its denormalized path in step with the tree.
+
+    The path is rebuilt on every write rather than only on the one that names a
+    location, so an item whose stored path predates a rename higher up carries
+    the current one from its next edit onwards.
+    """
+
+    draft = write.draft
+    locations_by_id = write.locations_by_id
+    if "location_id" in write.payload:
+        raw = write.payload["location_id"]
+        location_id: uuid.UUID | None = None
+        if raw is not None:
+            location_id = parse_uuid4(raw, field_name="location_id")
+            if locations_by_id is None or str(location_id) not in locations_by_id:
+                raise ValidationError("location_id must reference an existing location")
+        draft.location_id = location_id
+
+    if draft.location_id is not None and locations_by_id:
+        draft.location_path = build_location_path_from_map(
+            draft.location_id, locations_by_id=locations_by_id
+        )
+    elif draft.location_id is None:
+        draft.location_path = EMPTY_LOCATION_PATH
+
+
+def _write_tags(write: _ItemWrite) -> None:
+    if "tags" in write.payload:
+        write.draft.tags = validate_tags(write.payload["tags"], previous=write.draft.tags)
+
+
+def _write_low_stock_threshold(write: _ItemWrite) -> None:
+    if "low_stock_threshold" not in write.payload:
+        return
+    threshold = write.payload["low_stock_threshold"]
+    if threshold is not None and (not _is_int_not_bool(threshold) or threshold < 0):
         raise ValidationError("low_stock_threshold must be an integer >= 0 or null")
+    write.draft.low_stock_threshold = threshold
+
+
+def _write_custom_fields(write: _ItemWrite) -> None:
+    """Patch the map by key — a create names it whole, an update by halves.
+
+    The key cap bounds the item, not the patch: a two-key patch onto an item
+    already at the limit is what would otherwise walk past it. Judged on the
+    result of the whole write, and only when the write grew the map — so an item
+    that predates the cap can still be edited down.
+    """
+
+    draft = write.draft
+    set_key = "custom_fields" if write.creating else "custom_fields_set"
+    to_set = write.payload.get(set_key)
+    to_unset = require_string_list(
+        write.payload.get("custom_fields_unset"), field_name="custom_fields_unset"
+    )
+    before = len(draft.custom_fields)
+    if to_set is not None:
+        validate_custom_fields(to_set, previous=draft.custom_fields, field_name=set_key)
+        draft.custom_fields = {**draft.custom_fields, **to_set}
+    if to_unset:
+        draft.custom_fields = {
+            k: v for k, v in draft.custom_fields.items() if k not in set(to_unset)
+        }
+    after = len(draft.custom_fields)
+    if after > CUSTOM_FIELDS_MAX_KEYS and after > before:
+        raise ValidationError(f"custom_fields must have at most {CUSTOM_FIELDS_MAX_KEYS} keys")
+
+
+#: Every item field a client writes, and the rule that writes it. A create and
+#: an update walk this one table in this one order, so each field's type, cap
+#: and binding to its neighbours is written once and refuses the same value with
+#: the same message whichever command carried it. A rule reads the keys it owns
+#: off the payload and leaves the draft as it is when the write names none of
+#: them, which is what makes the same walk serve a full create and a one-field
+#: patch.
+_ITEM_FIELD_RULES: Final[tuple[Callable[[_ItemWrite], None], ...]] = (
+    _write_name,
+    partial(_write_optional_text, key="description", max_length=DESCRIPTION_MAX_LENGTH),
+    _write_quantity,
+    _write_status,
+    _write_checkout,
+    _write_inspection_date,
+    _write_reminder,
+    _write_location,
+    _write_tags,
+    partial(_write_optional_text, key="category", max_length=CATEGORY_MAX_LENGTH),
+    _write_low_stock_threshold,
+    _write_custom_fields,
+)
 
 
 def create_item_from_create(
@@ -1387,226 +1596,23 @@ def create_item_from_create(
         A fully-populated Item instance with defaults applied.
     """
 
-    # Type before shape: the command schema types `name` as `object` so a wrong
-    # type answers `validation_error` rather than an HA-core schema rejection,
-    # and `.strip()` on a non-string would reach that route as `unknown_error`.
-    # `validate_required_name` checks the type first for that reason, and
-    # returns the trimmed value this stores.
-    name = validate_required_name(payload.get("name"))
-    description = payload.get("description")
-    # Type before use, for the same reason `name` is checked before `.strip()`:
-    # the command schema types `quantity` as `object`, and arithmetic over a
-    # non-integer routes to `unknown_error` instead of naming the field.
-    quantity = validate_quantity(payload.get("quantity", 1))
-    status = validate_item_status(
-        payload.get("status", DEFAULT_ITEM_STATUS), known_statuses=known_statuses
-    )
-    checked_out = bool(payload.get("checked_out", False))
-    due_date = payload.get("due_date")
-    inspection_date = payload.get("inspection_date")
-    location_id_raw = payload.get("location_id")
-    tags = validate_tags(payload.get("tags"))
-    category = payload.get("category")
-    low_stock_threshold = payload.get("low_stock_threshold")
-    custom_fields = payload.get("custom_fields", {})
-
-    _validate_optional_text(description, "description", max_length=DESCRIPTION_MAX_LENGTH)
-    _validate_optional_text(category, "category", max_length=CATEGORY_MAX_LENGTH)
-    _validate_item_core_fields(name, quantity, low_stock_threshold)
-    validate_custom_fields(custom_fields)
-    normalized_due_date = validate_due_date_rules(checked_out=checked_out, due_date=due_date)
-    normalized_inspection_date = validate_optional_date(
-        inspection_date, field_name="inspection_date"
-    )
-    normalized_reminder_date, reminder_interval = validate_reminder_rules(
-        reminder_date=payload.get("reminder_date"),
-        reminder_interval=payload.get("reminder_interval"),
-    )
-
-    location_id: uuid.UUID | None = None
-    if location_id_raw is not None:
-        location_id = parse_uuid4(location_id_raw, field_name="location_id")
-        if locations_by_id is None or str(location_id) not in locations_by_id:
-            raise ValidationError("location_id must reference an existing location")
-
     created_ts = iso_utc_now()
-    location_path = (
-        build_location_path_from_map(location_id, locations_by_id=locations_by_id)
-        if location_id is not None and locations_by_id
-        else EMPTY_LOCATION_PATH
+    # The draft carries the field defaults, and a rule the payload does not
+    # reach leaves them where they are — so "the value the item already has" is
+    # empty here and every cap is absolute. `name` is the one field with no
+    # usable default, and its rule refuses a payload that omits it.
+    draft = Item(id=new_uuid4(), name="", created_at=created_ts, updated_at=created_ts)
+    write = _ItemWrite(
+        draft=draft,
+        payload=payload,
+        creating=True,
+        locations_by_id=locations_by_id,
+        known_statuses=known_statuses,
     )
+    for rule in _ITEM_FIELD_RULES:
+        rule(write)
 
-    item = Item(
-        id=new_uuid4(),
-        name=name,
-        description=description,
-        quantity=quantity,
-        status=status,
-        checked_out=checked_out,
-        due_date=normalized_due_date,
-        inspection_date=normalized_inspection_date,
-        reminder_date=normalized_reminder_date,
-        # Setting a reminder is saying where its series starts, so the anchor
-        # follows the date. Only a bump moves one without the other.
-        reminder_anchor=normalized_reminder_date,
-        reminder_interval=reminder_interval,
-        location_id=location_id,
-        tags=tags,
-        category=category,
-        low_stock_threshold=low_stock_threshold,
-        custom_fields=custom_fields,
-        created_at=created_ts,
-        updated_at=created_ts,
-        version=1,
-        location_path=location_path,
-    )
-
-    return item
-
-
-def _update_name_and_description(new_item: Item, update: ItemUpdate) -> None:
-    if "name" in update and update["name"] is not None:
-        trimmed = validate_required_name(update["name"])
-        if len(trimmed) > NAME_MAX_LENGTH:
-            raise ValidationError(f"name must be at most {NAME_MAX_LENGTH} characters")
-        new_item.name = trimmed
-    if "description" in update:
-        _validate_optional_text(
-            update["description"],
-            "description",
-            max_length=DESCRIPTION_MAX_LENGTH,
-            previous=new_item.description,
-        )
-        new_item.description = update["description"]
-
-
-def _update_quantity(new_item: Item, update: ItemUpdate) -> None:
-    if "quantity" in update:
-        new_item.quantity = validate_quantity(update["quantity"])
-
-
-def _update_status(new_item: Item, update: ItemUpdate, known_statuses: Collection[str]) -> None:
-    if "status" in update:
-        new_item.status = validate_item_status(update["status"], known_statuses=known_statuses)
-
-
-def _update_checkout_and_due_date(new_item: Item, update: ItemUpdate) -> None:
-    checked_out = new_item.checked_out
-    due_date_val = new_item.due_date
-    if "checked_out" in update:
-        checked_out = bool(update["checked_out"])
-    if "due_date" in update:
-        due_date_val = update["due_date"]
-    new_item.checked_out = checked_out
-    new_item.due_date = validate_due_date_rules(checked_out=checked_out, due_date=due_date_val)
-
-
-def _update_inspection_date(new_item: Item, update: ItemUpdate) -> None:
-    if "inspection_date" in update:
-        new_item.inspection_date = validate_optional_date(
-            update["inspection_date"], field_name="inspection_date"
-        )
-
-
-def _update_reminder(new_item: Item, update: ItemUpdate) -> None:
-    """Apply either half of the reminder, holding the pair's rule across both.
-
-    An update naming only one of the two is validated against the item's stored
-    other half, so clearing the date of a recurring reminder is refused rather
-    than leaving an interval with nothing to count from.
-
-    Writing a *different* date re-anchors the series on it: `ItemUpdate` carries
-    no anchor of its own, deliberately, because a household picking a date is
-    saying where the series starts. Re-sending the date the item already carries
-    says nothing, so it must not move the anchor — the card's editor puts every
-    field in every payload, changed or not, and re-anchoring on presence alone
-    would let an ordinary save walk a month-end series off its day one short
-    month at a time. `Repository.bump_reminder` is the one path that moves the
-    date and keeps the anchor, which is what makes a bumped month-end series stay
-    on its own day.
-    """
-
-    if "reminder_date" not in update and "reminder_interval" not in update:
-        return
-    previous_reminder_date = new_item.reminder_date
-    date_value = update["reminder_date"] if "reminder_date" in update else new_item.reminder_date
-    interval_value = (
-        update["reminder_interval"] if "reminder_interval" in update else new_item.reminder_interval
-    )
-    new_item.reminder_date, new_item.reminder_interval = validate_reminder_rules(
-        reminder_date=date_value, reminder_interval=interval_value
-    )
-    if "reminder_date" in update and new_item.reminder_date != previous_reminder_date:
-        new_item.reminder_anchor = new_item.reminder_date
-    elif new_item.reminder_date is None:
-        # The interval was cleared alongside a date that was already absent, or
-        # the pair rule left nothing behind. An anchor without a date names a
-        # series with no next occurrence.
-        new_item.reminder_anchor = None
-
-
-def _update_location_and_path(
-    new_item: Item, update: ItemUpdate, locations_by_id: dict[str, Location] | None
-) -> None:
-    if "location_id" in update:
-        loc_raw = update["location_id"]
-        loc_id: uuid.UUID | None = None
-        if loc_raw is not None:
-            parsed = parse_uuid4(loc_raw, field_name="location_id")
-            if locations_by_id is None or str(parsed) not in locations_by_id:
-                raise ValidationError("location_id must reference an existing location")
-            loc_id = parsed
-        new_item.location_id = loc_id
-
-    # Recompute location_path if we have a mapping and a location_id
-    if new_item.location_id is not None and locations_by_id:
-        new_item.location_path = build_location_path_from_map(
-            new_item.location_id, locations_by_id=locations_by_id
-        )
-    elif new_item.location_id is None:
-        new_item.location_path = EMPTY_LOCATION_PATH
-
-
-def _update_tags_category_threshold(new_item: Item, update: ItemUpdate) -> None:
-    if "tags" in update:
-        new_item.tags = validate_tags(update.get("tags"), previous=new_item.tags)
-    if "category" in update:
-        _validate_optional_text(
-            update["category"],
-            "category",
-            max_length=CATEGORY_MAX_LENGTH,
-            previous=new_item.category,
-        )
-        new_item.category = update["category"]
-    if "low_stock_threshold" in update:
-        thr = update["low_stock_threshold"]
-        if thr is not None and (not _is_int_not_bool(thr) or thr < 0):
-            raise ValidationError("low_stock_threshold must be an integer >= 0 or null")
-        new_item.low_stock_threshold = thr
-
-
-def _update_custom_fields(new_item: Item, update: ItemUpdate) -> None:
-    to_set = update.get("custom_fields_set")
-    to_unset = require_string_list(
-        update.get("custom_fields_unset"), field_name="custom_fields_unset"
-    )
-    before = len(new_item.custom_fields)
-    if to_set is not None:
-        validate_custom_fields(
-            to_set, previous=new_item.custom_fields, field_name="custom_fields_set"
-        )
-        new_item.custom_fields = {**new_item.custom_fields, **to_set}
-    if to_unset:
-        new_item.custom_fields = {
-            k: v for k, v in new_item.custom_fields.items() if k not in set(to_unset)
-        }
-    # The key cap bounds the item, not the patch: a two-key patch onto an item
-    # already at the limit is what would otherwise walk past it. Judged on the
-    # result of the whole call, and only when the call grew the map — so an item
-    # that predates the cap can still be edited down.
-    after = len(new_item.custom_fields)
-    if after > CUSTOM_FIELDS_MAX_KEYS and after > before:
-        raise ValidationError(f"custom_fields must have at most {CUSTOM_FIELDS_MAX_KEYS} keys")
+    return draft
 
 
 def apply_item_update(
@@ -1619,16 +1625,15 @@ def apply_item_update(
     """Apply an update payload to an Item and return a new updated instance."""
 
     new_item = replace(item)  # shallow copy
-
-    _update_name_and_description(new_item, update)
-    _update_quantity(new_item, update)
-    _update_status(new_item, update, known_statuses)
-    _update_checkout_and_due_date(new_item, update)
-    _update_inspection_date(new_item, update)
-    _update_reminder(new_item, update)
-    _update_location_and_path(new_item, update, locations_by_id)
-    _update_tags_category_threshold(new_item, update)
-    _update_custom_fields(new_item, update)
+    write = _ItemWrite(
+        draft=new_item,
+        payload=update,
+        creating=False,
+        locations_by_id=locations_by_id,
+        known_statuses=known_statuses,
+    )
+    for rule in _ITEM_FIELD_RULES:
+        rule(write)
 
     # Ensure updated_at is strictly monotonic to avoid equality within same second
     new_item.updated_at = monotonic_timestamp_after(item.updated_at)

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -560,12 +560,6 @@ def new_uuid4() -> uuid.UUID:
     return uuid.uuid4()
 
 
-def new_uuid4_str() -> str:
-    """Generate a hyphenated UUID v4 string."""
-
-    return str(new_uuid4())
-
-
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
@@ -1362,9 +1356,8 @@ class _ItemWrite:
 
     ``draft`` is what the write starts from and what the rules fill in: the
     field defaults on a create, a copy of the stored item on an update. A cap
-    that refuses *growth* reads the value the item already carries off the same
-    draft, so on a create — where the defaults are empty — it is an absolute
-    cap, and neither path needs a rule of its own.
+    that refuses *growth* reads what the item already carries off that same
+    draft, which on a create is empty — so one rule serves both paths.
     """
 
     draft: Item
@@ -1394,8 +1387,7 @@ def _write_name(write: _ItemWrite) -> None:
 def _write_optional_text(write: _ItemWrite, *, key: str, max_length: int) -> None:
     """One nullable free-text field, held to its cap against what is stored.
 
-    ``key`` names the payload field and the item's attribute, which are the same
-    word for every field written this way.
+    ``key`` names the payload field and the item's attribute alike.
     """
 
     if key not in write.payload:
@@ -1423,9 +1415,9 @@ def _write_status(write: _ItemWrite) -> None:
 def _write_checkout(write: _ItemWrite) -> None:
     """The checkout flag and its due date, holding the pair's rule across both.
 
-    Judged on what the write leaves behind rather than on the keys it carries,
-    so a write that sends the item home without naming the date is refused
-    rather than leaving a due date on an item nobody has out.
+    Judged on what the write leaves behind rather than on the keys it names, so
+    sending the item home without clearing the date is refused rather than
+    leaving a due date on an item nobody has out.
     """
 
     draft = write.draft
@@ -1485,9 +1477,9 @@ def _write_reminder(write: _ItemWrite) -> None:
 def _write_location(write: _ItemWrite) -> None:
     """Place the item, and keep its denormalized path in step with the tree.
 
-    The path is rebuilt on every write rather than only on the one that names a
-    location, so an item whose stored path predates a rename higher up carries
-    the current one from its next edit onwards.
+    The path is rebuilt on every write, not only on one that names a location:
+    an item whose stored path predates a rename higher up carries the current
+    one from its next edit onwards.
     """
 
     draft = write.draft
@@ -1552,12 +1544,11 @@ def _write_custom_fields(write: _ItemWrite) -> None:
 
 
 #: Every item field a client writes, and the rule that writes it. A create and
-#: an update walk this one table in this one order, so each field's type, cap
-#: and binding to its neighbours is written once and refuses the same value with
-#: the same message whichever command carried it. A rule reads the keys it owns
-#: off the payload and leaves the draft as it is when the write names none of
-#: them, which is what makes the same walk serve a full create and a one-field
-#: patch.
+#: an update walk this one table in this one order, so a field's type, cap and
+#: binding to its neighbours is written once and refuses the same value with the
+#: same message whichever command carried it. A rule leaves the draft as it
+#: stands when the write names none of its keys, which is what lets the one walk
+#: serve a full create and a one-field patch.
 _ITEM_FIELD_RULES: Final[tuple[Callable[[_ItemWrite], None], ...]] = (
     _write_name,
     partial(_write_optional_text, key="description", max_length=DESCRIPTION_MAX_LENGTH),
@@ -1582,14 +1573,8 @@ def create_item_from_create(
 ) -> Item:
     """Create a validated Item from an ItemCreate payload.
 
-    Args:
-        payload: Input fields from the client.
-        locations_by_id: Optional map of locations used to validate location_id and
-            construct a denormalized location_path when provided.
-        known_statuses: The live status slugs to validate ``status`` against.
-
-    Returns:
-        A fully-populated Item instance with defaults applied.
+    ``locations_by_id`` is the map ``location_id`` is checked against and the
+    denormalized path is built from; ``known_statuses`` is the live status set.
     """
 
     created_ts = iso_utc_now()

--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -378,7 +378,9 @@ class Item:
             name=validate_required_name(data.get("name")),
             description=data.get("description"),
             quantity=int(data.get("quantity", 0)),
-            status=coerce_item_status(data.get("status"), known_statuses=known_statuses),
+            status=validate_item_status(
+                data.get("status"), known_statuses=known_statuses, default=DEFAULT_ITEM_STATUS
+            ),
             checked_out=bool(data.get("checked_out", False)),
             due_date=data.get("due_date"),
             inspection_date=data.get("inspection_date"),
@@ -919,9 +921,12 @@ def validate_due_date_rules(*, checked_out: bool, due_date: str | None) -> str |
 
 
 def validate_item_status(
-    value: object, *, known_statuses: Collection[str] = ITEM_STATUSES
+    value: object,
+    *,
+    known_statuses: Collection[str] = ITEM_STATUSES,
+    default: ItemStatus | None = None,
 ) -> ItemStatus:
-    """Validate an item status against the live set and return it.
+    """Return ``value`` when it is one of the live statuses, or refuse it.
 
     Status is non-nullable: an item always has one, so ``None`` is rejected the
     same as any other unknown value ("ok" is the way to clear a flagged state).
@@ -929,29 +934,20 @@ def validate_item_status(
     ``known_statuses`` is an explicit parameter rather than module-level mutable
     state: the default keeps every caller that has no repository to ask meaning
     what it has always meant, and nothing global needs resetting between tests.
-    """
 
-    if isinstance(value, str) and value in known_statuses:
-        return value
-    raise ValidationError(f"status must be one of: {', '.join(sorted(known_statuses))}")
-
-
-def coerce_item_status(
-    value: object, *, known_statuses: Collection[str] = ITEM_STATUSES
-) -> ItemStatus:
-    """Return ``value`` when it is a known status, otherwise the default.
-
-    The tolerant twin of :func:`validate_item_status`, for loading persisted
-    payloads: a store written before the field existed (or hand-edited into an
-    unknown value) reads as "ok" rather than failing the whole item. Callers
+    ``default`` is what a load path passes to read a stored payload tolerantly:
+    a store written before the field existed (or hand-edited into an unknown
+    value) reads as that status rather than failing the whole item. A caller
     loading a store MUST pass the definitions that store carries — with the
-    built-ins alone, every custom status would be silently rewritten to "ok" on
-    the first restart after the upgrade that introduced it.
+    built-ins alone, every custom status would be silently rewritten to the
+    default on the first restart after the upgrade that introduced it.
     """
 
     if isinstance(value, str) and value in known_statuses:
         return value
-    return DEFAULT_ITEM_STATUS
+    if default is not None:
+        return default
+    raise ValidationError(f"status must be one of: {', '.join(sorted(known_statuses))}")
 
 
 def validate_status_slug(value: object) -> str:

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -61,9 +61,9 @@ from .models import (
     serialize_status_definition,
     sort_items,
     today_local_date,
-    validate_location_name,
     validate_status_definition,
     validate_status_slug,
+    validate_write_name,
     walk_location_chain,
 )
 
@@ -1530,7 +1530,7 @@ class Repository:
         parent_id: str | uuid.UUID | None = None,
         area_id: str | None = None,
     ) -> Location:
-        name = validate_location_name(name)
+        name = validate_write_name(name)
         # Parse/normalize parent id once at ingress using shared helper
         parsed_parent: uuid.UUID | None
         if parent_id is None:
@@ -1638,7 +1638,7 @@ class Repository:
         # Validate inputs first (no mutation yet)
         updated_name = loc.name
         if name is not None:
-            updated_name = validate_location_name(name)
+            updated_name = validate_write_name(name)
 
         parent_changed, target_parent_id = self._parse_new_parent(new_parent_id, loc.parent_id)
         # Parse area but don't use target_area directly - we propagate to root

--- a/custom_components/haventory/repository.py
+++ b/custom_components/haventory/repository.py
@@ -1948,7 +1948,7 @@ class Repository:
         # and is gone, and the item `version` field — which is persisted — is
         # what optimistic concurrency runs on.
 
-        # Statuses BEFORE the item loop, or ``coerce_item_status`` would see
+        # Statuses BEFORE the item loop, or the tolerant status read would see
         # only the built-ins and rewrite every item on a custom status to "ok"
         # — silently, on the first restart after the upgrade that added it. An
         # absent or unreadable section means the built-ins, which is what a

--- a/tests/test_item_status_offline.py
+++ b/tests/test_item_status_offline.py
@@ -21,7 +21,6 @@ from custom_components.haventory.models import (
     ItemCreate,
     ItemUpdate,
     apply_item_update,
-    coerce_item_status,
     create_item_from_create,
     filter_items,
     validate_item_status,
@@ -78,14 +77,14 @@ def test_update_without_status_keeps_it() -> None:
     assert updated.status == "needs_repair"
 
 
-def test_validate_and_coerce_helpers() -> None:
+def test_the_strict_and_the_tolerant_read_of_a_status() -> None:
     assert validate_item_status("missing") == "missing"
     with pytest.raises(ValidationError):
         validate_item_status("bogus")
-    assert coerce_item_status("needs_repair") == "needs_repair"
-    assert coerce_item_status(None) == "ok"
-    assert coerce_item_status("bogus") == "ok"
-    assert coerce_item_status(7) == "ok"
+    assert validate_item_status("needs_repair", default=DEFAULT_ITEM_STATUS) == "needs_repair"
+    assert validate_item_status(None, default=DEFAULT_ITEM_STATUS) == "ok"
+    assert validate_item_status("bogus", default=DEFAULT_ITEM_STATUS) == "ok"
+    assert validate_item_status(7, default=DEFAULT_ITEM_STATUS) == "ok"
 
 
 def test_filter_items_by_status() -> None:
@@ -301,12 +300,14 @@ def test_validate_accepts_a_slug_in_the_live_set_and_rejects_one_outside_it() ->
         validate_item_status("missing", known_statuses=live)
 
 
-def test_coerce_keeps_a_custom_slug_and_still_maps_garbage_to_ok() -> None:
+def test_the_tolerant_read_keeps_a_custom_slug_and_still_maps_garbage_to_ok() -> None:
     live = {"ok", "lent_out"}
 
-    assert coerce_item_status("lent_out", known_statuses=live) == "lent_out"
-    assert coerce_item_status("who_knows", known_statuses=live) == DEFAULT_ITEM_STATUS
-    assert coerce_item_status(None, known_statuses=live) == DEFAULT_ITEM_STATUS
+    tolerant = {"known_statuses": live, "default": DEFAULT_ITEM_STATUS}
+
+    assert validate_item_status("lent_out", **tolerant) == "lent_out"
+    assert validate_item_status("who_knows", **tolerant) == DEFAULT_ITEM_STATUS
+    assert validate_item_status(None, **tolerant) == DEFAULT_ITEM_STATUS
 
 
 def test_the_default_set_is_still_the_built_ins() -> None:

--- a/tests/test_models_filter_sort_offline.py
+++ b/tests/test_models_filter_sort_offline.py
@@ -18,7 +18,6 @@ from custom_components.haventory.models import (
     build_location_path,
     create_item_from_create,
     filter_items,
-    new_uuid4_str,
     sort_items,
     validate_item_filter,
     validate_sort,
@@ -35,9 +34,9 @@ def _make_location(id: str, name: str, parent_id: str | None) -> Location:
 
 
 def _build_locations() -> tuple[dict[str, Location], Location, Location, Location]:
-    root_id = new_uuid4_str()
-    mid_id = new_uuid4_str()
-    leaf_id = new_uuid4_str()
+    root_id = str(uuid.uuid4())
+    mid_id = str(uuid.uuid4())
+    leaf_id = str(uuid.uuid4())
     root = _make_location(root_id, "Garage", None)
     mid = _make_location(mid_id, "Shelf A", root_id)
     leaf = _make_location(leaf_id, "Bin 3", mid_id)
@@ -201,7 +200,7 @@ async def test_filter_location_id_with_and_without_subtree() -> None:
 
     # Unknown location id → empty result (no error)
     empty = filter_items(
-        [at_root, at_mid, at_leaf], ItemFilter(location_id=new_uuid4_str(), include_subtree=True)
+        [at_root, at_mid, at_leaf], ItemFilter(location_id=str(uuid.uuid4()), include_subtree=True)
     )
     assert empty == []
 
@@ -664,7 +663,7 @@ async def test_filter_location_ids_unions_the_selection() -> None:
 @pytest.mark.asyncio
 async def test_include_subtree_is_one_flag_for_the_whole_location_selection() -> None:
     by_id, _root, mid, leaf = _build_locations()
-    other = _make_location(new_uuid4_str(), "Cellar", None)
+    other = _make_location(str(uuid.uuid4()), "Cellar", None)
     by_id[str(other.id)] = other
     other.path = build_location_path([other])
 
@@ -751,7 +750,7 @@ def test_validate_item_filter_accepts_the_multi_select_keys() -> None:
     declared there — no second list to extend."""
 
     assert {"categories", "location_ids"} <= set(ItemFilter.__annotations__)
-    validate_item_filter({"categories": ["Tools"], "location_ids": [new_uuid4_str()]})
+    validate_item_filter({"categories": ["Tools"], "location_ids": [str(uuid.uuid4())]})
 
 
 # -----------------------------
@@ -771,7 +770,7 @@ def _located(name: str, chain: list[Location]) -> Item:
 @pytest.mark.asyncio
 async def test_sort_by_location_orders_on_the_denormalized_path() -> None:
     by_id, root, mid, leaf = _build_locations()
-    cellar = _make_location(new_uuid4_str(), "Cellar", None)
+    cellar = _make_location(str(uuid.uuid4()), "Cellar", None)
     cellar.path = build_location_path([cellar])
     by_id[str(cellar.id)] = cellar
 
@@ -819,7 +818,7 @@ async def test_unlocated_items_stay_last_behind_a_non_latin_location_name() -> N
     folds to a character well above the "~" the date rule uses.
     """
 
-    accented = _make_location(new_uuid4_str(), "Éclairage", None)
+    accented = _make_location(str(uuid.uuid4()), "Éclairage", None)
     accented.path = build_location_path([accented])
     filed = _located("Filed", [accented])
     loose = create_item_from_create({"name": "Loose"})

--- a/tests/test_models_offline.py
+++ b/tests/test_models_offline.py
@@ -34,7 +34,6 @@ from custom_components.haventory.models import (
     load_attachments,
     load_reminder_interval,
     monotonic_timestamp_after,
-    new_uuid4_str,
     seed_status_definitions,
     serialize_attachment_meta,
     serialize_reminder_interval,
@@ -133,9 +132,9 @@ def test_a_tag_list_is_normalized_and_a_null_clears() -> None:
 @pytest.mark.asyncio
 async def test_denormalized_location_path_generation() -> None:
     # Build a simple 3-level location chain and ensure display/sort paths
-    root_id = new_uuid4_str()
-    mid_id = new_uuid4_str()
-    leaf_id = new_uuid4_str()
+    root_id = str(uuid.uuid4())
+    mid_id = str(uuid.uuid4())
+    leaf_id = str(uuid.uuid4())
     root = _make_location(root_id, "Garage", None)
     mid = _make_location(mid_id, "Shelf A", root_id)
     leaf = _make_location(leaf_id, "Bin 3", mid_id)
@@ -169,8 +168,8 @@ def test_the_chain_walk_ends_on_a_loop_instead_of_following_it() -> None:
     rather than spin in it.
     """
 
-    first_id = new_uuid4_str()
-    second_id = new_uuid4_str()
+    first_id = str(uuid.uuid4())
+    second_id = str(uuid.uuid4())
     by_id = {
         first_id: _make_location(first_id, "First", second_id),
         second_id: _make_location(second_id, "Second", first_id),
@@ -195,8 +194,8 @@ def test_a_chain_that_reaches_no_root_is_refused(parent_id: str | None, message:
     location carries, and a parent the walk has already passed.
     """
 
-    leaf_id = new_uuid4_str()
-    missing_id = new_uuid4_str()
+    leaf_id = str(uuid.uuid4())
+    missing_id = str(uuid.uuid4())
     leaf = _make_location(leaf_id, "Bin 3", missing_id if parent_id is None else leaf_id)
 
     with pytest.raises(ValidationError, match=message):
@@ -206,7 +205,7 @@ def test_a_chain_that_reaches_no_root_is_refused(parent_id: str | None, message:
 @pytest.mark.asyncio
 async def test_invalid_location_reference() -> None:
     # Invalid: location_id unknown → ValidationError
-    fake_id = new_uuid4_str()
+    fake_id = str(uuid.uuid4())
     with pytest.raises(ValidationError):
         create_item_from_create(
             {"name": "Glue", "location_id": fake_id, "checked_out": True, "due_date": "2024-01-02"},
@@ -354,7 +353,7 @@ def test_an_absent_optional_date_is_not_a_refusal() -> None:
 
 def _attachment_doc(**overrides) -> dict:
     doc = {
-        "id": new_uuid4_str(),
+        "id": str(uuid.uuid4()),
         "kind": "picture",
         "filename": "photo.png",
         "mime": "image/png",

--- a/tests/test_repository_roundtrip_offline.py
+++ b/tests/test_repository_roundtrip_offline.py
@@ -114,7 +114,7 @@ def _payload_with_custom_status() -> dict:
 def test_a_custom_status_survives_load_export_load() -> None:
     """The loader-ordering trap.
 
-    `coerce_item_status` maps an unknown value to "ok". Definitions therefore
+    the tolerant status read maps an unknown value to "ok". Definitions therefore
     have to load before the item loop, or the first restart after the upgrade
     that introduced a custom status silently rewrites every item carrying it.
     """


### PR DESCRIPTION
## Summary

An item's fields were validated twice: once inline in `create_item_from_create`, once in one of the nine `_update_*` helpers. The two copies had drifted into different shapes for the same rule — the name cap written three times, the threshold check twice, the growth caps reading `previous` in create and update by different routes.

They are now one ordered table of per-field rules that a create and an update walk alike:

- `_ItemWrite` carries the draft the rules fill in — the field defaults on a create, a copy of the stored item on an update. Every cap that refuses *growth* reads what the item already carries off that same draft, so on a create it is an absolute cap and no second shape is needed.
- The nine `_update_*` helpers and the inline create body become twelve rules in `_ITEM_FIELD_RULES`, one per field or per bound pair (`checked_out`/`due_date`, the reminder's date and interval, `location_id` and its denormalized path).
- `validate_location_name` becomes `validate_write_name`: trim plus `NAME_MAX_LENGTH` is the write path's name rule for an item and a location alike, and it was written three times.
- `validate_item_status` and `coerce_item_status` were the same four lines twice, differing in the last one. One function with `default=`: a write path passes none and gets the refusal, a load path passes the status an unreadable stored value should read as.
- `new_uuid4_str` had zero production callers; the fifteen test call sites take `str(uuid.uuid4())`.

No message text changed and the update path answers byte-identically. Verified against the pre-change implementation with a throwaway differential harness (both implementations imported side by side, outcomes compared field by field): every single-field create, every single-field update over five base items with and without a location map, the grandfathered pre-cap cases, and the reminder-anchor paths all match. The one difference the harness found is noted under Follow-ups.

Refs #230 (BE-MODELS-C3), §6.M2 PR 1.

## Counting

| | lines |
|---|---:|
| production removed | 238 |
| test removed | 30 |
| added | 253 |

`git diff --stat` against `origin/main`. The net is small because each rule now carries in one place the constraint the two inline copies encoded between them: the executable statements in the create/update/status region go from 134 to 107 (`ast`, docstrings excluded), and `models.py` from 2144 to 2130 lines.

## Type of change

- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1357 passed, 27 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all clean
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (67 files, 1917 tests passed), `npm run build`
- [x] phacc (`scripts/test_integration.sh`, card built first): **153 passed in 16.88s**

No test was rewritten to pass. The test edits are the twin's call sites moving onto the merged function, two test names that said "coerce", and `new_uuid4_str()` becoming `str(uuid.uuid4())`.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added/updated — a cut changes no behaviour, so the existing suite is the pin (the sixteen date-message cases from #590, `test_item_input_validation_offline.py`'s cap and grandfathering cases, `test_item_status_offline.py`)
- [x] Docs updated where behavior changed — none: no WS schema, error code or field moved, so `docs/backend_api_contract.md` and `docs/data_shapes.md` are untouched
- [x] WebSocket API changes keep `ws.py` and the two contract docs in sync — no API change
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path` rebuilt on every write, optimistic `version`)
- [x] No file removed from `custom_components/haventory/`, so `RETIRED_PATHS` is unchanged

## Decisions taken against drifted notes

- **The second `CUSTOM_FIELDS_MAX_KEYS` check stays.** The #230 comment (§2.1) reads it as re-applying what `validate_custom_fields` already did. It does not: the check inside `validate_custom_fields` bounds the *patch*, this one bounds the *merged map*. A two-key patch onto an item at 49 keys passes the first and is caught by the second, which is what `test_an_item_over_the_custom_field_cap_may_not_grow_further` pins. Dropping it would let an item walk past the cap one patch at a time. It is now written once, in the one rule that owns the field.
- **`validate_optional_date(value, *, field_name)` and the `field_name` on `normalize_date_yyyy_mm_dd` were already in the tree** (#590), so the twin date validators and the "due_date must be…" wording defect that C3 also listed are not part of this PR.

## Follow-ups

- A create payload that is wrong about **two** fields at once can now name the other one of them in its single refusal. The two paths validated in different orders (create checked `location_id` last, an update checks it before tags and category), and one table has one order — the update path's, which is byte-identical. Every message text is unchanged and each refusal is true of the payload, so this is not filed: an API contract names codes and texts, not which of two invalid fields wins the race.

## Handover

1. **Merged / left open** — this PR, for the M2 master to merge once CI is green.
2. **Test this by hand** — nothing. No user-visible surface, no dictionary key, no stored shape moves.
3. **Validate locally** — nothing: pinned by `tests/test_item_input_validation_offline.py`, `tests/test_models_offline.py`, `tests/test_item_status_offline.py` and the phacc run above.
4. **Decisions taken against drifted notes** — the two above.
5. **Follow-ups** — the create multi-error ordering note above; not filed.
6. **State left behind** — branch `claude/v0-8-0-m2-field-rules`, no assets branch, no HA instance touched. Counting: production removed 238 · tests removed 30 · added 253.
