### PR TITLE
refactor(models): filter_items as a predicate list

### DIFF
--- a/custom_components/haventory/models.py
+++ b/custom_components/haventory/models.py
@@ -1770,19 +1770,32 @@ def today_local_date() -> str:
     return dt_util.now().date().isoformat()
 
 
+def _date_passed(item: Item, field: str, today: str, *, inclusive: bool) -> bool:
+    """Whether the item's ``field`` date has come round by ``today``.
+
+    The one test behind the five named below, which are its five (field,
+    inclusive) pairs. An item carrying no date on that field is never counted.
+    Both sides are YYYY-MM-DD, which compares correctly as text. An empty
+    ``today`` reads the instance's current local date, and reads it only for an
+    item that has a date to compare — callers walking many items fill it in
+    once rather than paying for the clock per item.
+    """
+
+    value: str | None = getattr(item, field)
+    if not value:
+        return False
+    day = today or today_local_date()
+    return value <= day if inclusive else value < day
+
+
 def item_is_overdue(item: Item, *, today: str = "") -> bool:
     """Return True when the item's due date has passed.
 
     A due date only exists while an item is checked out (see
     ``validate_due_date_rules``), so this needs no separate checked-out test.
-    Both sides are YYYY-MM-DD, which compares correctly as text. ``today``
-    defaults to the instance's current local date; callers filtering many items
-    pass it in once rather than re-reading the clock per item.
     """
 
-    if not item.due_date:
-        return False
-    return item.due_date < (today or today_local_date())
+    return _date_passed(item, "due_date", today, inclusive=False)
 
 
 def item_is_due(item: Item, *, today: str = "") -> bool:
@@ -1795,22 +1808,17 @@ def item_is_due(item: Item, *, today: str = "") -> bool:
     ``item_inspection_is_due`` has to ``item_inspection_is_overdue``.
     """
 
-    if not item.due_date:
-        return False
-    return item.due_date <= (today or today_local_date())
+    return _date_passed(item, "due_date", today, inclusive=True)
 
 
 def item_inspection_is_overdue(item: Item, *, today: str = "") -> bool:
     """Return True when the item is past the date it was next due for inspection.
 
     Independent of the check-out state: an inspection is a fact about the item,
-    not about a borrowing, so this walks any item that carries a date. Same
-    text comparison and same ``today`` convention as ``item_is_overdue``.
+    not about a borrowing, so this walks any item that carries a date.
     """
 
-    if not item.inspection_date:
-        return False
-    return item.inspection_date < (today or today_local_date())
+    return _date_passed(item, "inspection_date", today, inclusive=False)
 
 
 def item_inspection_is_due(item: Item, *, today: str = "") -> bool:
@@ -1823,9 +1831,7 @@ def item_inspection_is_due(item: Item, *, today: str = "") -> bool:
     items whose date is today, and every overdue item is also due.
     """
 
-    if not item.inspection_date:
-        return False
-    return item.inspection_date <= (today or today_local_date())
+    return _date_passed(item, "inspection_date", today, inclusive=True)
 
 
 def item_reminder_is_due(item: Item, *, today: str = "") -> bool:
@@ -1837,9 +1843,7 @@ def item_reminder_is_due(item: Item, *, today: str = "") -> bool:
     date the household said to be reminded on.
     """
 
-    if not item.reminder_date:
-        return False
-    return item.reminder_date <= (today or today_local_date())
+    return _date_passed(item, "reminder_date", today, inclusive=True)
 
 
 def _parse_location_selection(location_ids: Sequence[str]) -> list[uuid.UUID]:
@@ -1864,10 +1868,13 @@ def _parse_location_selection(location_ids: Sequence[str]) -> list[uuid.UUID]:
 def _item_matches_locations(
     item: Item, needles: Sequence[uuid.UUID], include_subtree: bool
 ) -> bool:
-    """True when the item sits in — or under — any of the selected locations."""
+    """True when the item sits in — or under — any of the selected locations.
 
-    if not needles:
-        return True
+    An empty selection keeps nothing, which is what a selection of only
+    unparsable ids has always meant: the filter names locations, and none of
+    them is this item's.
+    """
+
     if not item.location_id:
         return False
     for needle in needles:
@@ -1876,6 +1883,143 @@ def _item_matches_locations(
         if include_subtree and item.location_path.id_path and needle in item.location_path.id_path:
             return True
     return False
+
+
+#: The filter keys these two tables read, spelled out so a table entry is
+#: checked against ``ItemFilter`` rather than against a plain string.
+DateFilterKey = Literal[
+    "overdue_only",
+    "checked_out_due_only",
+    "inspection_overdue_only",
+    "inspection_due_only",
+    "reminder_due_only",
+]
+TimestampBoundKey = Literal["updated_after", "created_after", "updated_before", "created_before"]
+
+#: The five date filters, each with the item field it reads and whether today
+#: itself counts. A ``*_due_only`` key counts it because a due date names the
+#: day something is being asked for; an ``*overdue*`` key does not, so a pair
+#: over one field differs by exactly the items dated today.
+_DATE_FILTERS: Final[tuple[tuple[DateFilterKey, str, bool], ...]] = (
+    ("overdue_only", "due_date", False),
+    ("checked_out_due_only", "due_date", True),
+    ("inspection_overdue_only", "inspection_date", False),
+    ("inspection_due_only", "inspection_date", True),
+    ("reminder_due_only", "reminder_date", True),
+)
+
+#: The four timestamp bounds, each with the item field it reads and which side
+#: of the bound the item must fall on. Read in this order, which is the order a
+#: filter carrying more than one malformed bound is refused in.
+_TIMESTAMP_BOUNDS: Final[tuple[tuple[TimestampBoundKey, str, bool], ...]] = (
+    ("updated_after", "updated_at", True),
+    ("created_after", "created_at", True),
+    ("updated_before", "updated_at", False),
+    ("created_before", "created_at", False),
+)
+
+
+def _date_predicate(field: str, today: str, *, inclusive: bool) -> Callable[[Item], bool]:
+    """One date filter, bound to the field and the day it measures against."""
+
+    def passes(item: Item) -> bool:
+        return _date_passed(item, field, today, inclusive=inclusive)
+
+    return passes
+
+
+def _bound_predicate(field: str, bound: str, *, after: bool) -> Callable[[Item], bool]:
+    """One timestamp filter, bound to the field and the bound it compares to.
+
+    Canonical fixed-width 'Z' timestamps compare lexicographically, so an item
+    costs no parsing here — only the bound itself was parsed, once, to refuse a
+    malformed one.
+    """
+
+    def passes(item: Item) -> bool:
+        value: str = getattr(item, field)
+        return value > bound if after else value < bound
+
+    return passes
+
+
+def _timestamp_predicates(flt: ItemFilter) -> list[Callable[[Item], bool]]:
+    """The timestamp filters a filter carries, refusing a malformed bound.
+
+    A bound the filter names as null is no filter at all; one it names as empty
+    is not a timestamp to parse but is still compared against, which is what
+    keeps ``updated_before: ""`` meaning what it has always meant.
+    """
+
+    predicates: list[Callable[[Item], bool]] = []
+    for key, attr, after in _TIMESTAMP_BOUNDS:
+        bound = flt.get(key)
+        if bound is None:
+            continue
+        if bound:
+            _parse_iso8601_utc(bound, field_name=key)
+        predicates.append(_bound_predicate(attr, bound, after=after))
+    return predicates
+
+
+def _filter_predicates(
+    flt: ItemFilter, *, known_statuses: Collection[str]
+) -> list[Callable[[Item], bool]]:
+    """The tests a filter asks for, one per key it carries.
+
+    Built once for the whole query, so a key the filter leaves out costs an item
+    nothing, and what a key needs parsed — the status, the location ids, the
+    timestamp bounds, the day — is parsed here rather than against every
+    candidate. A malformed value is refused here too, in the order the keys are
+    read below, so a filter that cannot be honoured raises before any item is
+    walked. ``q`` is appended last because it is the only test that normalizes
+    text: the cheap ones drop what they can before it runs.
+    """
+
+    predicates: list[Callable[[Item], bool]] = []
+
+    q = (flt.get("q") or "").strip()
+    tags_any = selected_tags(flt, "tags_any")
+    if tags_any:
+        predicates.append(lambda item: any(tag in item.tags for tag in tags_any))
+    tags_all = selected_tags(flt, "tags_all")
+    if tags_all:
+        predicates.append(lambda item: all(tag in item.tags for tag in tags_all))
+    categories = set(selected_categories(flt))
+    if categories:
+        predicates.append(lambda item: (item.category or "").strip().casefold() in categories)
+    if "status" in flt:
+        status = validate_item_status(flt["status"], known_statuses=known_statuses)
+        predicates.append(lambda item: item.status == status)
+    checked_out = flt.get("checked_out")
+    if checked_out is not None:
+        wanted = bool(checked_out)
+        predicates.append(lambda item: item.checked_out == wanted)
+    if flt.get("low_stock_only"):
+        predicates.append(item_is_low_stock)
+    if flt.get("orphaned_only"):
+        predicates.append(lambda item: item.location_id is None)
+
+    dated = [(attr, inclusive) for key, attr, inclusive in _DATE_FILTERS if flt.get(key)]
+    if dated:
+        # One clock read for the whole query, and only when a date filter is on.
+        today = today_local_date()
+        predicates.extend(
+            _date_predicate(attr, today, inclusive=inclusive) for attr, inclusive in dated
+        )
+
+    location_ids = selected_location_ids(flt)
+    if location_ids:
+        # Parsed once for the whole query rather than once per candidate item.
+        needles = _parse_location_selection(location_ids)
+        include_subtree = bool(flt.get("include_subtree"))
+        predicates.append(lambda item: _item_matches_locations(item, needles, include_subtree))
+
+    predicates.extend(_timestamp_predicates(flt))
+
+    if q:
+        predicates.append(lambda item: _item_matches_q(item, q))
+    return predicates
 
 
 def filter_items(
@@ -1907,138 +2051,20 @@ def filter_items(
       optionally includes descendants (by prefix of id_path), one flag for all
     - updated_after/created_after: ISO-8601 UTC with 'Z', strictly greater-than
     - updated_before/created_before: ISO-8601 UTC with 'Z', strictly less-than
+
+    Each key the filter carries becomes one test, built once by
+    :func:`_filter_predicates`; an item is walked against those and no others,
+    and stops at the first one it fails.
     """
 
     if not flt:
         return list(items)
 
-    q = (flt.get("q") or "").strip()
-    tags_any = selected_tags(flt, "tags_any")
-    tags_all = selected_tags(flt, "tags_all")
-    categories = set(selected_categories(flt))
-    status = (
-        validate_item_status(flt["status"], known_statuses=known_statuses)
-        if "status" in flt
-        else None
-    )
-    checked_out = flt.get("checked_out") if "checked_out" in flt else None
-    low_stock_only = bool(flt.get("low_stock_only")) if "low_stock_only" in flt else False
-    orphaned_only = bool(flt.get("orphaned_only")) if "orphaned_only" in flt else False
-    overdue_only = bool(flt.get("overdue_only")) if "overdue_only" in flt else False
-    checked_out_due_only = (
-        bool(flt.get("checked_out_due_only")) if "checked_out_due_only" in flt else False
-    )
-    inspection_overdue_only = (
-        bool(flt.get("inspection_overdue_only")) if "inspection_overdue_only" in flt else False
-    )
-    inspection_due_only = (
-        bool(flt.get("inspection_due_only")) if "inspection_due_only" in flt else False
-    )
-    reminder_due_only = bool(flt.get("reminder_due_only")) if "reminder_due_only" in flt else False
-    location_ids = selected_location_ids(flt)
-    include_subtree = bool(flt.get("include_subtree")) if "include_subtree" in flt else False
-    updated_after = flt.get("updated_after") if "updated_after" in flt else None
-    created_after = flt.get("created_after") if "created_after" in flt else None
-    updated_before = flt.get("updated_before") if "updated_before" in flt else None
-    created_before = flt.get("created_before") if "created_before" in flt else None
-
-    # Validate filter bounds (raises ValidationError for malformed input).
-    for bound, name in (
-        (updated_after, "updated_after"),
-        (created_after, "created_after"),
-        (updated_before, "updated_before"),
-        (created_before, "created_before"),
-    ):
-        if bound:
-            _parse_iso8601_utc(bound, field_name=name)
-    # Parsed once for the whole query, beside the bounds, rather than once per
-    # candidate item. A selection that parses to nothing keeps its old meaning:
-    # it selects nothing, rather than falling through to "no location filter".
-    location_needles = _parse_location_selection(location_ids)
-    if location_ids and not location_needles:
-        return []
-    # One clock read for the whole query, and only when a date predicate is on.
-    date_predicates = (
-        overdue_only,
-        checked_out_due_only,
-        inspection_overdue_only,
-        inspection_due_only,
-        reminder_due_only,
-    )
-    today = today_local_date() if any(date_predicates) else ""
-
-    predicates_active = (
-        bool(q)
-        or bool(tags_any)
-        or bool(tags_all)
-        or bool(categories)
-        or status is not None
-        or checked_out is not None
-        or low_stock_only
-        or orphaned_only
-        or any(date_predicates)
-        or bool(location_ids)
-        or updated_after is not None
-        or created_after is not None
-        or updated_before is not None
-        or created_before is not None
-    )
-    if not predicates_active:
-        # e.g. flt only carries presentation hints such as low_stock_first
+    predicates = _filter_predicates(flt, known_statuses=known_statuses)
+    if not predicates:
+        # A filter carrying only presentation hints, such as low_stock_first.
         return list(items)
-
-    filtered: list[Item] = []
-    for it in items:
-        matches_q = (not q) or _item_matches_q(it, q)
-        matches_any = (not tags_any) or any(tag in it.tags for tag in tags_any)
-        matches_all = (not tags_all) or all(tag in it.tags for tag in tags_all)
-        matches_category = (not categories) or (
-            (it.category or "").strip().casefold() in categories
-        )
-        matches_status = (status is None) or (it.status == status)
-        matches_checked = (checked_out is None) or (it.checked_out == bool(checked_out))
-        matches_low_stock = (not low_stock_only) or item_is_low_stock(it)
-        matches_orphaned = (not orphaned_only) or (it.location_id is None)
-        matches_overdue = (not overdue_only) or item_is_overdue(it, today=today)
-        matches_due = (not checked_out_due_only) or item_is_due(it, today=today)
-        matches_inspection_overdue = (not inspection_overdue_only) or item_inspection_is_overdue(
-            it, today=today
-        )
-        matches_inspection_due = (not inspection_due_only) or item_inspection_is_due(
-            it, today=today
-        )
-        matches_reminder = (not reminder_due_only) or item_reminder_is_due(it, today=today)
-        matches_location = _item_matches_locations(it, location_needles, include_subtree)
-        # Canonical fixed-width 'Z' timestamps compare lexicographically, so no
-        # per-item parsing is needed (the filter bound was validated above).
-        matches_updated = ((updated_after is None) or (it.updated_at > updated_after)) and (
-            (updated_before is None) or (it.updated_at < updated_before)
-        )
-        matches_created = ((created_after is None) or (it.created_at > created_after)) and (
-            (created_before is None) or (it.created_at < created_before)
-        )
-        ok = (
-            matches_q
-            and matches_any
-            and matches_all
-            and matches_category
-            and matches_status
-            and matches_checked
-            and matches_low_stock
-            and matches_orphaned
-            and matches_overdue
-            and matches_due
-            and matches_inspection_overdue
-            and matches_inspection_due
-            and matches_reminder
-            and matches_location
-            and matches_updated
-            and matches_created
-        )
-        if ok:
-            filtered.append(it)
-
-    return filtered
+    return [item for item in items if all(passes(item) for passes in predicates)]
 
 
 #: What an item with no location sorts under in ascending order.
@@ -2086,6 +2112,10 @@ def sort_items(items: Iterable[Item], sort: Sort | None = None) -> list[Item]:
     name sorting is case-insensitive using normalize_text_for_sort.
     due_date / inspection_date place undated items last in both orders, and
     location does the same for items filed nowhere.
+
+    Orders, it does not validate: :func:`validate_sort` refuses an unknown field
+    or order at the WebSocket boundary, which is where a client's typo has to be
+    named. A field this does not know falls to the default ordering.
     """
 
     result = list(items)
@@ -2101,11 +2131,6 @@ def sort_items(items: Iterable[Item], sort: Sort | None = None) -> list[Item]:
 
     field = sort.get("field")
     order = sort.get("order")
-    if field not in SORT_FIELDS:
-        raise ValidationError(f"sort.field must be one of: {', '.join(sorted(SORT_FIELDS))}")
-    if order not in SORT_ORDERS:
-        raise ValidationError("sort.order must be 'asc' or 'desc'")
-
     reverse = order == "desc"
     # Stable sort: primary key, then id asc tie-break
     result.sort(key=lambda x: str(x.id))

--- a/tests/test_models_filter_sort_offline.py
+++ b/tests/test_models_filter_sort_offline.py
@@ -513,15 +513,6 @@ async def test_sort_by_inspection_date_nulls_last_both_orders() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sort_invalid_inputs_raise() -> None:
-    items = [create_item_from_create({"name": "A"})]
-    with pytest.raises(ValidationError):
-        sort_items(items, Sort(field="bogus", order="asc"))  # type: ignore[arg-type]
-    with pytest.raises(ValidationError):
-        sort_items(items, Sort(field="name", order="ascending"))  # type: ignore[arg-type]
-
-
-@pytest.mark.asyncio
 async def test_filter_then_sort_pipeline() -> None:
     a = create_item_from_create({"name": "B", "tags": ["x"]})
     b = create_item_from_create({"name": "A", "tags": ["y"]})
@@ -585,19 +576,6 @@ def test_validate_sort_accepts_the_vocabulary_and_rejects_the_rest() -> None:
         validate_sort({"by": "name", "order": "asc"})
     with pytest.raises(ValidationError, match=r"sort must be an object"):
         validate_sort("name")
-
-
-def test_validate_sort_agrees_with_sort_items() -> None:
-    """The two must not drift: both read the same allowed-field set."""
-
-    for field_name in SORT_FIELDS:
-        sort_items([], Sort(field=field_name, order="asc"))  # type: ignore[typeddict-item]
-
-    with pytest.raises(ValidationError):
-        sort_items(
-            [create_item_from_create({"name": "Widget"})],
-            {"field": "colour", "order": "asc"},  # type: ignore[typeddict-item]
-        )
 
 
 # -----------------------------


### PR DESCRIPTION
## Summary

`filter_items` decided sixteen things about every item, whichever ones the filter actually asked
for. Fourteen `bool(flt.get("x")) if "x" in flt else False` reads, a seventeen-line disjunction
whose only job was to notice that none of them was on, and then sixteen booleans computed eagerly
per item and `and`ed afterwards — `q`, the only test that normalizes text, among them.

The keys a filter carries now become a list of predicates, built once per query by
`_filter_predicates`. An item is walked against those and no others, and stops at the first one it
fails. `q` is appended last, so a cheap flag drops what it can before any text is normalized.

Also here:

- The five `item_*_is_*` predicates are the five `(field, inclusive)` pairs of one `_date_passed`.
  The five public names stay as one-liners, and `today` stays a parameter the caller fills once per
  query from `today_local_date()` — `models.py` still reads no `hass`.
- Two small tables replace two hand-written runs: `_DATE_FILTERS` (five keys) and
  `_TIMESTAMP_BOUNDS` (four bounds, in the order a filter carrying more than one malformed bound is
  refused in).
- `sort_items` no longer re-checks the field and order that `validate_sort` already refused at the
  WebSocket boundary.
- `_item_matches_locations` loses its `if not needles: return True` guard: the predicate is built
  only when the filter names locations, so an empty parsed selection now selects nothing by
  reading its own loop rather than through a second early return in `filter_items`.

Refs #230 (BE-MODELS-C4, and item 1's scan — `_item_matches_q` applied by `filter_items` is still
the declared contract).

### Behaviour

None. Every value the old function read, it reads in the same order, so a filter carrying more than
one malformed value is refused by the same one; a location selection that parses to no id still
matches nothing; `updated_before: ""` still keeps nothing and `updated_after: ""` still keeps
everything; a filter carrying only presentation hints (`low_stock_first`) still returns the whole
population.

The one caller-visible edge is `sort_items` called directly with a field or order outside the
vocabulary: it now orders by the default instead of raising. No production caller can reach that —
`ws.py` calls `validate_sort` first, and `import_export.py` and `calendar.py` pass no sort at all.

### Benchmark (`ASSERT_BUDGETS=1`, 10,000 items, best of 5 passes)

`tests/test_repository_search_benchmark_offline.py`, run back to back on the same host:

| | before this PR | after this PR |
|---|---:|---:|
| `q` list through `repo.list_items` | 0.013 s | 0.012–0.014 s |

Unchanged, as expected: with `q` alone there is nothing to short-circuit *to*, and the fifteen other
booleans the old loop computed per item are cheap next to `normalize_search_text`. Where the
predicate order pays is a query that carries a flag as well, measured against `filter_items`
directly over the same 10,000 items so the repository's index pre-filter does not narrow the
population first:

| query | before | after |
|---|---:|---:|
| `{"q": "Widget"}` | 0.0127 s | 0.0128 s |
| `{"q": "Widget", "category": "Category 3", "checked_out": False}` | 0.0139 s | 0.0046 s |
| `{"category": "Category 3"}` | 0.0035 s | 0.0035 s |

Adding a flag to a `q` list used to make it strictly more work; it now makes it three times less.
Budget (0.5 s) is untouched, and item 1's 0.012 s figure still holds.

### Counting

| | lines |
|---|---:|
| production removed | 154 |
| test removed | 22 |
| added | 179 |

From `git diff --stat` against `origin/main`: `models.py` 179 insertions / 154 deletions,
`tests/test_models_filter_sort_offline.py` 0 / 22. The insertions are the predicate builder, the two
factories, the two tables and their notes; `filter_items` itself goes from 154 lines to 15.

`repository.py`'s five `_count_*` are named by the plan as part of this cut and were already
collapsed by #626 — they are `self._count(population, predicate)` calls over the same five public
predicates, so they ride `_date_passed` from this PR without an edit. Nothing left to remove there.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1355 passed, 27 skipped**;
      `uv run ruff check .` → All checks passed; `uv run ruff format --check .` → 189 files already
      formatted; `uv run mypy` → Success: no issues found in 26 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → **67 files, 1917 tests passed**, `npm run build` → built in 228 ms
- [x] phacc (`scripts/test_integration.sh`, card built first): **`153 passed in 14.48s` — `[ OK ]
      Integration tests OK`**

`tests/test_models_filter_sort_offline.py` is the pin for the semantics and passes unchanged apart
from the two deletions below — that whole file, and the WebSocket item/list tests, went green on the
first run of the rewritten function.

### The two deleted tests

Both pinned only the duplicate re-check inside `sort_items`, and the refusal a caller actually sees
stays pinned where it is answered:

- `test_sort_invalid_inputs_raise` — a bad field and a bad order. Both are asserted against
  `validate_sort` by `test_validate_sort_accepts_the_vocabulary_and_rejects_the_rest` (`sort.field`
  for `colour`, `sort.order` for `sideways`), and on the wire by
  `tests/test_ws_items_offline.py::test_item_list_refuses_an_unknown_sort_field`.
- `test_validate_sort_agrees_with_sort_items` — its loop over `SORT_FIELDS` sorted an **empty**
  list, which `sort_items` returns before it reads `field` at all, so that half asserted nothing;
  the rest was the same duplicate raise. It never proved every `SORT_FIELDS` member has a branch —
  the chain's `else` has always absorbed one that does not, before this PR as after it.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — a cut: no test rewritten to pass, two deleted with the duplicate they
      pinned, the rest left alone.
- [x] Docs updated where behavior changed — none: no schema, error code or field moves, so
      `docs/backend_api_contract.md` and `docs/data_shapes.md` are unchanged.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and `docs/data_shapes.md`
      in sync — no WS change.
- [x] Essential invariants preserved (case-insensitive search through the same `_item_matches_q`,
      denormalized `location_path` read by the same subtree test, optimistic `version` untouched).

## Screenshots (card / UI changes)

None — no card change.

## Follow-ups

- The `q` + flag short-circuit is not pinned by a benchmark case. A committed one would want a
  narrowing key the repository does **not** index, and category, status, `tags_any`,
  `checked_out: true`, `low_stock_only` and location are all indexed — so the case that shows the
  gain is not the case a household runs. Named, not filed: a performance property, not a
  correctness one.
- `subscriptions._payload_inspection_is_overdue` is still the third copy of
  `item_inspection_is_overdue`, over the serialized dict rather than the `Item`. Its docstring says
  why it cannot call the shared one, and the plan puts it elsewhere. Not filed.

## Handover

1. **Merged / left open** — this PR, for the master to merge once CI is green. Nothing stacks on it
   inside M2 except PR 3, which touches the same file.
2. **Test this by hand** — nothing. No user-facing string, no lifecycle, no card change.
3. **Validate locally** — nothing new: the filter and sort semantics are pinned by
   `tests/test_models_filter_sort_offline.py` (unchanged apart from the two deletions above) and by
   the WebSocket `item/list` tests. If the master is driving its own HA anyway: `[dev-ha]` an
   `item/list` with `filter: {"q": "…", "low_stock_only": true}` and one with
   `sort: {"field": "colour", "order": "asc"}` — the first answers as before, the second still comes
   back `validation_error`.
4. **Decisions taken against drifted notes** — the plan's "`repository.py`'s `_count_*` collapse
   onto the same predicates" was already done by #626; they ride the new `_date_passed` unedited.
   The plan offered "drop the re-validation in `sort_items` **or** drop `validate_sort`"; §6.M2 PR 2
   picks the former, which is what this does.
5. **Follow-ups** — the two above, neither filed.
6. **State left behind** — branch `claude/v0-8-0-m2-predicate-list`; no assets branch; no HA
   instance touched. Counting for this PR: production removed 154 · tests removed 22 · added 179.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YN6wQcqZD9UGhcDjXmVb8L)_