### PR TITLE
refactor(init): the manifest is already a constant; the /local path never shipped; the unreachable checks

### DIFF
--- a/.claude/skills/run-haventory/SKILL.md
+++ b/.claude/skills/run-haventory/SKILL.md
@@ -626,10 +626,8 @@ uv run python .claude/skills/run-haventory/lifecycle_probe.py all --yes
 ```
 
 `resources` sets the Lovelace resource to each shape a restart can find — hand-pinned
-`?v=<hash>`, stale `?v=<old version>`, bare URL, plus the two legacy
-`/local/haventory/haventory-card.js` shapes an install predating the integration-served
-bundle carries — restarts, and asserts one entry survives **under the original resource
-id**; a second entry would load the card module twice and the second
+`?v=<hash>`, stale `?v=<old version>`, bare URL, a URL carrying a second query parameter
+— restarts, and asserts one entry survives **under the original resource id**; a second entry would load the card module twice and the second
 `customElements.define` would throw. `downgrade` writes a higher `schema_version`
 into the store and asserts the entry lands in `setup_error` (not `setup_retry` — retrying
 cannot teach this build a newer schema) with the payload untouched. `entry` removes the

--- a/.claude/skills/run-haventory/lifecycle_probe.py
+++ b/.claude/skills/run-haventory/lifecycle_probe.py
@@ -203,10 +203,7 @@ async def check_resources() -> list[Result]:
             ("pinned", "/haventory_static/haventory-card.js?v=deadbeefcafe"),
             ("stale", "/haventory_static/haventory-card.js?v=0.0.0"),
             ("bare", "/haventory_static/haventory-card.js"),
-            # Installs predating the move of the bundle into the integration
-            # package: the entry must migrate in place, not gain a sibling.
-            ("legacy", "/local/haventory/haventory-card.js"),
-            ("legacy-versioned", "/local/haventory/haventory-card.js?v=0.0.1"),
+            ("query", "/haventory_static/haventory-card.js?v=1&foo=bar"),
         ]
         for label, url in variants:
             ws = await connect(session)

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -97,12 +97,6 @@ _CARD_BUNDLE_PATH = _WWW_DIR / _CARD_FILENAME
 _STATIC_URL_PATH = "/haventory_static"
 _CARD_URL_PATH = f"{_STATIC_URL_PATH}/{_CARD_FILENAME}"
 
-# Installs predating the move loaded the card from a copy in the config `www/`
-# tree. That copy goes away with the integration, so such an entry is ours to
-# rewrite rather than somebody else's resource to leave alone.
-_LEGACY_CARD_URL_PATH = "/local/haventory/haventory-card.js"
-_CARD_URL_PATHS = frozenset({_CARD_URL_PATH, _LEGACY_CARD_URL_PATH})
-
 # hass.data[DOMAIN] keys that outlive a config entry: the static route cannot be
 # unregistered, and the module URL has to be removed as the exact string it was
 # registered under.
@@ -590,13 +584,11 @@ def _points_at_card(resource_url: Any) -> bool:
     Compare paths, not whole URLs: a resource carries a cache-busting `?v=`
     query, and matching the full string would treat a versioned entry as
     somebody else's resource and register a second one for the same module — the
-    card then loads twice and the second `customElements.define` throws. The
-    legacy `/local` path counts as ours for the same reason: an install that
-    predates the move must end up with one entry, not two.
+    card then loads twice and the second `customElements.define` throws.
     """
     if not isinstance(resource_url, str):
         return False
-    return urlsplit(resource_url).path in _CARD_URL_PATHS
+    return urlsplit(resource_url).path == _CARD_URL_PATH
 
 
 async def _async_lovelace_resources(hass: HomeAssistant, *, op: str) -> Any:

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -6,7 +6,6 @@ the core data structures in hass.data.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from pathlib import Path
@@ -18,7 +17,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.loader import async_get_integration
 
 try:
     from homeassistant.components.lovelace import LOVELACE_DATA
@@ -62,6 +60,7 @@ from .const import (
     DEFAULT_CARD_TITLE,
     DEFAULT_SIDEBAR_PANEL_ENABLED,
     DOMAIN,
+    INTEGRATION_VERSION,
     ISSUE_CORRUPT_SCHEMA_VERSION,
     ISSUE_CORRUPT_STORE,
     ISSUE_SCHEMA_DOWNGRADE,
@@ -89,8 +88,6 @@ from .storage import (
 from .subscriptions import notify_backend_unavailable
 
 LOGGER = context_logger(__name__)
-
-_MANIFEST_PATH = Path(__file__).with_name("manifest.json")
 
 # The card bundle ships inside the integration package — the only tree HACS
 # copies for an integration-category repo — and is served from there.
@@ -570,62 +567,21 @@ async def async_remove_entry(hass: HomeAssistant, _entry: ConfigEntry) -> None:
     await _async_teardown_entry(hass, op="remove", release_panel=True)
 
 
-def _read_manifest_version() -> str:
-    """Parse the version out of the shipped manifest file. Blocks — run it in the executor."""
-    try:
-        manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
-    except OSError, ValueError:
-        return ""
-    raw = manifest.get("version")
-    return raw if isinstance(raw, str) else ""
-
-
-async def _async_manifest_version(hass: HomeAssistant) -> str:
-    """Version this integration declares, or `""` when it cannot be determined.
-
-    Home Assistant parses `manifest.json` when it loads the integration and keeps
-    the result, so the version is already in memory. Reading the file here instead
-    would be blocking I/O on the event loop, which HA's loop protection reports as
-    a warning with a full stack trace on every startup. The executor read is the
-    fallback for the case where the loader has no manifest to hand us.
-    """
-    try:
-        integration = await async_get_integration(hass, DOMAIN)
-        raw = integration.manifest.get("version")
-    except Exception:
-        LOGGER.debug(
-            "Integration manifest unavailable from the loader; reading the file instead",
-            extra={"domain": DOMAIN, "op": "frontend_register"},
-        )
-    else:
-        if isinstance(raw, str) and raw:
-            return raw
-
-    try:
-        return await hass.async_add_executor_job(_read_manifest_version)
-    except Exception:
-        LOGGER.debug(
-            "Could not read the integration manifest; registering the card unversioned",
-            extra={"domain": DOMAIN, "op": "frontend_register", "path": str(_MANIFEST_PATH)},
-        )
-        return ""
-
-
-async def _async_card_url(hass: HomeAssistant) -> str:
+def _card_url() -> str:
     """The one URL both frontend loaders receive, versioned as `?v=`.
 
     The bundle is served without a `Cache-Control` header, so a browser — or the
     companion app's webview, which is harder to clear — falls back to *heuristic*
     freshness and may hold a long-unchanged bundle for days after an update,
     running an old card against a new backend. A version bump is a new URL, which
-    no cache can satisfy. Falls back to the bare path if the version cannot be
-    determined, since a missing cache-buster must not stop the card from loading
-    at all.
+    no cache can satisfy.
+
+    `INTEGRATION_VERSION` is the version `manifest.json` declares — the two are
+    rewritten together by release-please and held equal by
+    `tests/test_release_version_consistency.py` — so the string is the shipped
+    one without asking the loader or the filesystem for it.
     """
-    version = await _async_manifest_version(hass)
-    if not version:
-        return _CARD_URL_PATH
-    return f"{_CARD_URL_PATH}?v={quote(version, safe='')}"
+    return f"{_CARD_URL_PATH}?v={quote(INTEGRATION_VERSION, safe='')}"
 
 
 def _points_at_card(resource_url: Any) -> bool:
@@ -705,7 +661,7 @@ async def _async_register_static_path(hass: HomeAssistant) -> bool:
         # cache_headers=False: no Cache-Control, so the browser revalidates and
         # picks up a rebuild that did not change the version — which is every
         # rebuild during development. The `?v=` on the URL covers the other
-        # direction (see _async_card_url).
+        # direction (see _card_url).
         await register([StaticPathConfig(_STATIC_URL_PATH, str(_WWW_DIR), cache_headers=False)])
     except Exception:
         # ERROR, not WARNING: this return short-circuits both card loaders below,
@@ -878,7 +834,7 @@ async def _async_apply_sidebar_panel(hass: HomeAssistant, entry: ConfigEntry) ->
     title = _resolve_card_title(entry)
     # The exact string both card loaders receive: a second URL for the same
     # module defeats the browser's module map and defines the element twice.
-    url = await _async_card_url(hass)
+    url = _card_url()
     wanted = (title, url)
 
     if bucket.get(_PANEL_STATE_KEY) == wanted:
@@ -1067,14 +1023,14 @@ async def _register_frontend_module(hass: HomeAssistant) -> None:
     if not await _async_register_static_path(hass):
         return
 
-    url = await _async_card_url(hass)
+    url = _card_url()
     _register_extra_js_url(hass, url)
     await _async_register_lovelace_resource(hass, url)
 
 
 async def _unregister_frontend_module(hass: HomeAssistant) -> None:
     """Take back both frontend registrations for the card."""
-    _remove_extra_js_url(hass, await _async_card_url(hass))
+    _remove_extra_js_url(hass, _card_url())
 
     resources = await _async_lovelace_resources(hass, op="frontend_unregister")
     if resources is None:

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -1141,7 +1141,7 @@ def _corrupt_store_message(report: LoadReport, *, store_key: str) -> str:
 
 
 def _log_storage_health(payload: dict[str, Any], *, schema_version: int) -> None:
-    """Log storage health summary after validation.
+    """Log what the store came back with, once it has come back.
 
     Always DEBUG, whatever the counts. An empty store is what every fresh
     install and every household that cleared its inventory boots with, and HA

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -82,8 +82,6 @@ from .storage import (
     DomainStore,
     async_backup_store,
     async_persist_immediate,
-    read_schema_version,
-    schema_downgrade_message,
 )
 from .subscriptions import notify_backend_unavailable
 
@@ -219,7 +217,6 @@ async def _async_load_repository(
 
     try:
         payload = await store.async_load()
-        _validate_storage_payload(payload, schema_version=store.schema_version)
         _log_storage_health(payload, schema_version=store.schema_version)
     except SchemaDowngradeError as exc:
         LOGGER.error(
@@ -1164,28 +1161,6 @@ def _corrupt_store_message(report: LoadReport, *, store_key: str) -> str:
         f"Removing and re-adding the integration will not help: it leaves the file "
         f"exactly as it is, so setup stops here again."
     )
-
-
-def _validate_storage_payload(payload: dict[str, Any], *, schema_version: int) -> None:
-    """Validate loaded storage payload shape and version."""
-
-    if not isinstance(payload, dict):
-        raise StorageError("storage payload is not a dict")
-
-    stored_version = read_schema_version(payload, missing=-1)
-    if stored_version > int(schema_version):
-        raise SchemaDowngradeError(
-            schema_downgrade_message(
-                stored_version=stored_version, supported_version=int(schema_version)
-            )
-        )
-    if stored_version != int(schema_version):
-        raise StorageError("storage payload schema_version mismatch")
-
-    items = payload.get("items")
-    locations = payload.get("locations")
-    if not isinstance(items, dict) or not isinstance(locations, dict):
-        raise StorageError("storage payload missing required collections")
 
 
 def _log_storage_health(payload: dict[str, Any], *, schema_version: int) -> None:

--- a/custom_components/haventory/__init__.py
+++ b/custom_components/haventory/__init__.py
@@ -80,7 +80,6 @@ from .storage import (
     CURRENT_SCHEMA_VERSION,
     STORAGE_KEY,
     DomainStore,
-    async_backup_store,
     async_persist_immediate,
 )
 from .subscriptions import notify_backend_unavailable
@@ -153,7 +152,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HAventoryConfigEntry) ->
 
     # A load that had to leave rows behind has to reach the file, or the next
     # restart meets the same rows and refuses all over again.
-    await _async_settle_lossy_load(hass, store, repository)
+    await _async_settle_lossy_load(hass, repository)
 
     # Whatever the previous boot left in Settings → Repairs described a store this
     # one just read, so none of it is true any more.
@@ -294,9 +293,7 @@ async def _async_load_repository(
     return repository
 
 
-async def _async_settle_lossy_load(
-    hass: HomeAssistant, store: DomainStore, repository: Repository
-) -> None:
+async def _async_settle_lossy_load(hass: HomeAssistant, repository: Repository) -> None:
     """Write the store back the way it was just read, when rows had to be dropped.
 
     A lossy load leaves the unreadable rows on disk, so the refusal and its card
@@ -304,32 +301,12 @@ async def _async_settle_lossy_load(
     repair would hold only until the household restarts Home Assistant, and the
     copy it took would be the only sign it ever ran.
 
-    A copy is taken here as well as in the repair flow, so no path can write the
-    readable remainder over the file while the rows it left out exist nowhere. It
-    is the same raw copy under the same key: the store has not changed since the
-    flow took its own, so the second write is the same bytes.
+    The rows this overwrites are in that copy: a load reaches here only with the
+    lossy-load option set, and `repairs.py` sets it after its own raw copy of the
+    store succeeded and withdraws the offer when it does not.
     """
 
     if not repository.last_load_report.has_corruption:
-        return
-
-    try:
-        copied = await async_backup_store(hass, source_key=store.key)
-    except Exception:  # pragma: no cover - defensive
-        LOGGER.exception(
-            "Failed to copy the HAventory store aside after loading it with unreadable rows",
-            extra={"domain": DOMAIN, "op": "settle_lossy_load"},
-        )
-        copied = False
-    if not copied:
-        # Leaving the file as it is keeps the rows recoverable, at the price of
-        # meeting the same refusal on the next restart. The alternative writes
-        # the only copy of them away.
-        LOGGER.error(
-            "Loaded a store with unreadable rows but could not copy it aside, so it "
-            "was left as it is; the same rows will stop the next start-up",
-            extra={"domain": DOMAIN, "op": "settle_lossy_load"},
-        )
         return
 
     await async_persist_immediate(hass)

--- a/custom_components/haventory/storage.py
+++ b/custom_components/haventory/storage.py
@@ -51,8 +51,7 @@ _MAX_REPORTED_VERSION_CHARS: Final[int] = 60
 
 
 # Every top-level collection the stored payload carries, in one place because
-# three call sites have to agree about the set: `_empty_payload`, `async_load`'s
-# backfill, and `async_save`'s.
+# every payload this module hands out or writes has to agree about the set.
 #
 # The load path is wider than the save path by construction — `async_load` keeps
 # whatever the file holds, while a save writes exactly what
@@ -61,6 +60,30 @@ _MAX_REPORTED_VERSION_CHARS: Final[int] = 60
 # the first save afterwards, with nothing logged. `tests/test_storage_offline.py`
 # pins `export_state()` to this tuple so that mistake fails a test instead.
 STORE_COLLECTIONS: Final[tuple[str, ...]] = ("items", "locations", "statuses")
+
+# The collections `Repository.from_state` walks by key. A stored value of another
+# type there is corruption the load path names rather than crashes on; the rest
+# of `STORE_COLLECTIONS` is checked by the repository as it reads each row.
+_REQUIRED_COLLECTIONS: Final[tuple[str, ...]] = ("items", "locations")
+
+
+def _normalized(payload: Mapping[str, Any], *, schema_version: int) -> dict[str, Any]:
+    """A copy of ``payload`` carrying every collection, defaulting the absent ones.
+
+    What the payload holds wins, extra keys included: a store written by a build
+    that knew a key this one does not has to survive the trip, and be handed back
+    unchanged.
+
+    The copy is one level deep on purpose. The collections underneath are handed
+    over, not duplicated — the save path's caller builds them fresh on every call
+    and keeps no reference, and a deep copy of a thousand items measured longer
+    than building the payload and encoding it put together.
+    """
+
+    normalized: dict[str, Any] = {"schema_version": schema_version}
+    normalized.update({name: {} for name in STORE_COLLECTIONS})
+    normalized.update(payload)
+    return normalized
 
 
 def _empty_payload() -> dict[str, Any]:
@@ -71,27 +94,14 @@ def _empty_payload() -> dict[str, Any]:
     an absent ``statuses`` section means everywhere else.
     """
 
-    payload: dict[str, Any] = {"schema_version": CURRENT_SCHEMA_VERSION}
-    payload.update({name: {} for name in STORE_COLLECTIONS})
-    payload["statuses"] = {
-        slug: serialize_status_definition(definition)
-        for slug, definition in seed_status_definitions().items()
-    }
-    return payload
-
-
-def schema_downgrade_message(*, stored_version: int, supported_version: int) -> str:
-    """Build the refusal shown when stored data outranks this build.
-
-    Shared by the storage layer and setup validation so both refusal paths tell
-    the user the same thing.
-    """
-
-    return (
-        f"stored data uses schema version {stored_version}, which is newer than this "
-        f"build supports ({supported_version}); HAventory will not downgrade it. "
-        "Upgrade HAventory to a version that understands this data, or restore a backup "
-        "taken with this version. The stored data was left unchanged."
+    return _normalized(
+        {
+            "statuses": {
+                slug: serialize_status_definition(definition)
+                for slug, definition in seed_status_definitions().items()
+            }
+        },
+        schema_version=CURRENT_SCHEMA_VERSION,
     )
 
 
@@ -197,6 +207,10 @@ class DomainStore:
 
         Returns a copy of the data to prevent external mutation of the cached
         object inside the storage layer.
+
+        The payload comes back stamped with this build's schema version, whether
+        it was migrated to get there or already carried it, so what the caller
+        reads never disagrees with the store it came from.
         """
 
         raw = await self._store.async_load()
@@ -207,33 +221,25 @@ class DomainStore:
         from_version = read_schema_version(raw, missing=0) if isinstance(raw, dict) else 0
 
         if from_version != self._schema_version:
-            migrated = await self.async_migrate_if_needed(raw)
-            return deepcopy(migrated)
+            data = await self.async_migrate_if_needed(raw)
+        else:
+            data = _normalized(
+                raw if isinstance(raw, dict) else {}, schema_version=self._schema_version
+            )
 
-        # Ensure required keys exist (older stubs or external mutations)
-        data: dict[str, Any] = {"schema_version": self._schema_version}
-        data.update({name: {} for name in STORE_COLLECTIONS})
-        if isinstance(raw, dict):
-            data.update(raw)
+        # A hand-edited file can hold anything under these keys, and the
+        # repository walks them as maps of rows.
+        for name in _REQUIRED_COLLECTIONS:
+            if not isinstance(data.get(name), dict):
+                raise StorageError(f"storage payload {name} is not a mapping")
         return deepcopy(data)
 
     async def async_save(self, data: dict[str, Any]) -> None:
-        """Persist the dataset, ensuring schema_version is up to date.
+        """Persist the dataset, ensuring schema_version is up to date."""
 
-        The copy is one level deep: enough that the defaults below land on this
-        method's dict rather than the caller's, and no deeper. The collections
-        underneath are handed over, not duplicated — ``Repository.export_state``
-        builds every one of them fresh on each call and keeps no reference, so a
-        deep copy would rebuild the whole dataset a second time on the event
-        loop for nothing. At a thousand items that copy measured longer than
-        building the payload and encoding it put together, and it grows with the
-        inventory the way both of those do.
-        """
-
-        payload = dict(data) if isinstance(data, dict) else {}
-        payload.setdefault("schema_version", self._schema_version)
-        for name in STORE_COLLECTIONS:
-            payload.setdefault(name, {})
+        payload = _normalized(
+            data if isinstance(data, dict) else {}, schema_version=self._schema_version
+        )
         await self._store.async_save(payload)
 
     async def async_migrate_if_needed(self, raw: dict[str, Any]) -> dict[str, Any]:
@@ -265,11 +271,7 @@ class DomainStore:
         from_version = read_schema_version(raw, missing=0)
         to_version = self._schema_version
         if from_version == to_version:
-            # Normalize missing keys even when versions match
-            normalized: dict[str, Any] = {"schema_version": to_version}
-            normalized.update({name: {} for name in STORE_COLLECTIONS})
-            normalized.update(raw)
-            return normalized
+            return _normalized(raw, schema_version=to_version)
 
         if from_version > to_version:
             # Migrations are forward-only, so a newer payload would pass through
@@ -286,7 +288,10 @@ class DomainStore:
                 },
             )
             raise SchemaDowngradeError(
-                schema_downgrade_message(stored_version=from_version, supported_version=to_version)
+                f"stored data uses schema version {from_version}, which is newer than this "
+                f"build supports ({to_version}); HAventory will not downgrade it. "
+                "Upgrade HAventory to a version that understands this data, or restore a "
+                "backup taken with this version. The stored data was left unchanged."
             )
 
         try:
@@ -317,13 +322,14 @@ class DomainStore:
                 },
             )
             raise StorageError("storage migration returned non-dict payload")
-        # Guarantee required fields and version
-        for name in STORE_COLLECTIONS:
-            migrated.setdefault(name, {})
+        # The version is this build's, not whatever the last step left behind: a
+        # payload saved under a version it does not carry is one nothing can read
+        # back correctly.
         migrated["schema_version"] = to_version
+        normalized = _normalized(migrated, schema_version=to_version)
 
-        await self._store.async_save(migrated)
-        return migrated
+        await self._store.async_save(normalized)
+        return normalized
 
 
 async def async_persist_repo(hass: HomeAssistant) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ import asyncio
 import dataclasses
 import datetime
 import functools
-import json
 import os
 import sys
 import tempfile
@@ -355,9 +354,6 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             self.config_entries = _ConfigEntries()
             self.services = _Services()
             self.http = _Http()
-            # What was handed to a worker thread, in order. A test telling an
-            # event-loop file read apart from an offloaded one reads this.
-            self.executor_jobs: list = []
 
         def async_create_background_task(self, target, name, eager_start=True):
             """Stand in for HA's tracked-task helper; the real one also cancels on shutdown."""
@@ -369,7 +365,6 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             Running the callable on a genuine worker thread keeps the offline suite
             honest about what does and does not touch the event loop thread.
             """
-            self.executor_jobs.append(target)
             return await asyncio.get_running_loop().run_in_executor(None, target, *args)
 
     class ServiceCall:  # type: ignore[override]
@@ -1114,49 +1109,6 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
     ha_diagnostics.REDACTED = REDACTED
     ha_diagnostics.async_redact_data = async_redact_data
     sys.modules["homeassistant.components.diagnostics"] = ha_diagnostics
-
-    # homeassistant.loader
-    ha_loader = types.ModuleType("homeassistant.loader")
-
-    _SHIPPED_MANIFEST = json.loads(
-        (ROOT / "custom_components" / "haventory" / "manifest.json").read_text(encoding="utf-8")
-    )
-
-    class IntegrationNotFound(Exception):  # type: ignore[override]
-        def __init__(self, domain: str) -> None:
-            super().__init__(f"Integration '{domain}' not found.")
-            self.domain = domain
-
-    class Integration:  # type: ignore[override]
-        def __init__(self, domain: str, manifest: dict) -> None:
-            self.domain = domain
-            self.manifest = manifest
-
-    async def async_get_integration(hass: HomeAssistant, domain: str):  # type: ignore[override]
-        """Hand back the manifest HA parsed at load time, doing no file I/O.
-
-        Tests override per-hass through ``hass.data["__integration_manifests__"]``;
-        mapping a domain to None makes the lookup raise, the way it does in real HA
-        for an integration that is not installed.
-        """
-        overrides = getattr(hass, "data", None)
-        if isinstance(overrides, dict) and domain in (
-            overrides.get("__integration_manifests__") or {}
-        ):
-            manifest = overrides["__integration_manifests__"][domain]
-        elif domain == _SHIPPED_MANIFEST.get("domain"):
-            manifest = _SHIPPED_MANIFEST
-        else:
-            manifest = None
-
-        if manifest is None:
-            raise IntegrationNotFound(domain)
-        return Integration(domain, manifest)
-
-    ha_loader.IntegrationNotFound = IntegrationNotFound
-    ha_loader.Integration = Integration
-    ha_loader.async_get_integration = async_get_integration
-    sys.modules["homeassistant.loader"] = ha_loader
 
 
 if _INTEGRATION_MODE:

--- a/tests/test_entry_removal_offline.py
+++ b/tests/test_entry_removal_offline.py
@@ -8,29 +8,21 @@ inventory, so a re-add restores the data.
 from __future__ import annotations
 
 import importlib
-import json
 import sys
 import types
-from pathlib import Path
 from typing import Any
 
 import pytest
+from custom_components.haventory.const import INTEGRATION_VERSION
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
 from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL, UrlManager
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 CARD_URL = "/haventory_static/haventory-card.js"
-# What installs from before the bundle moved into the package registered.
-LEGACY_CARD_URL = "/local/haventory/haventory-card.js"
 LOVELACE_KEY = "lovelace_data_key"
-
-
-def current_card_url() -> str:
-    """The versioned URL setup would have registered, from the shipped manifest."""
-    manifest = Path(__file__).resolve().parents[1] / "custom_components" / "haventory"
-    version = json.loads((manifest / "manifest.json").read_text(encoding="utf-8"))["version"]
-    return f"{CARD_URL}?v={version}"
+# The versioned URL setup would have registered.
+CURRENT_CARD_URL = f"{CARD_URL}?v={INTEGRATION_VERSION}"
 
 
 class MockResourceCollection:
@@ -117,9 +109,9 @@ async def test_remove_entry_removes_the_frontend_module_url(monkeypatch) -> None
     """The extra-module URL goes too, or the frontend keeps requesting a dead asset."""
 
     hav_init = _import_with_lovelace(monkeypatch)
-    resources = MockResourceCollection([{"id": "haventory", "url": current_card_url()}])
+    resources = MockResourceCollection([{"id": "haventory", "url": CURRENT_CARD_URL}])
     hass = _hass_with_resources(
-        resources, module_urls=[current_card_url(), "/other_static/other-card.js"]
+        resources, module_urls=[CURRENT_CARD_URL, "/other_static/other-card.js"]
     )
 
     await hav_init.async_remove_entry(hass, ConfigEntry())
@@ -148,9 +140,6 @@ async def test_remove_entry_removes_the_module_url_recorded_at_setup(monkeypatch
         f"{CARD_URL}?v=38b725595b78",
         f"{CARD_URL}?v=1&foo=bar",
         f"{CARD_URL}#frag",
-        # An install that never got past the legacy `/local` URL.
-        LEGACY_CARD_URL,
-        f"{LEGACY_CARD_URL}?v=0.0.1",
     ],
 )
 async def test_remove_entry_deletes_versioned_card_resource(monkeypatch, registered_url) -> None:

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -20,7 +20,6 @@ import json
 import logging
 import re
 import sys
-import threading
 import types
 from pathlib import Path
 from typing import Any
@@ -30,6 +29,7 @@ from custom_components.haventory.const import (
     CONF_CARD_TITLE,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
+    INTEGRATION_VERSION,
     MEDIA_NAME_TOKEN_PARAM,
     MEDIA_SIZE_PARAM,
     MEDIA_SIZE_THUMB,
@@ -47,19 +47,11 @@ from homeassistant.core import HomeAssistant
 
 STATIC_URL_PATH = "/haventory_static"
 CARD_PATH = f"{STATIC_URL_PATH}/haventory-card.js"
+# What both loaders and the panel receive, cache-buster and all.
+CURRENT_CARD_URL = f"{CARD_PATH}?v={INTEGRATION_VERSION}"
 # Where installs from before the bundle moved into the package loaded it from.
 LEGACY_CARD_PATH = "/local/haventory/haventory-card.js"
 REPO_ROOT = Path(__file__).resolve().parents[1]
-MANIFEST_PATH = REPO_ROOT / "custom_components" / "haventory" / "manifest.json"
-
-# Distinguishes "leave the loader stub at its default (the shipped manifest)" from
-# "register None", which makes the lookup raise the way an absent integration does.
-_NO_OVERRIDE = object()
-
-
-def manifest_version() -> str:
-    """Version the shipped manifest declares, read independently of the module under test."""
-    return str(json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["version"])
 
 
 def import_haventory(monkeypatch, lovelace_key: str):
@@ -138,21 +130,15 @@ class MockLovelaceData:
         self.resources = MockResourceCollection() if resources is None else resources
 
 
-def make_hass(*, manifest: Any = _NO_OVERRIDE) -> HomeAssistant:
+def make_hass() -> HomeAssistant:
     """Hass stub with the frontend's URL manager in place.
 
     The manager is created by the frontend component's own setup, which nothing
     here runs — so a test that wants the extra-module loader to work has to put
     one there, and one that does not gets the KeyError a bare hass gives.
-
-    `manifest` seeds what the loader hands back for the `haventory` domain: omit it
-    for the shipped manifest, pass a dict to choose the version, pass None to make
-    the lookup fail the way it does for an integration HA has not loaded.
     """
     hass = HomeAssistant()
     hass.data[DATA_EXTRA_MODULE_URL] = UrlManager()
-    if manifest is not _NO_OVERRIDE:
-        hass.data["__integration_manifests__"] = {"haventory": manifest}
     return hass
 
 
@@ -190,23 +176,6 @@ async def setup_frontend(hav_init, hass: HomeAssistant, entry: ConfigEntry) -> N
     """The two frontend steps of ``async_setup_entry``, in the order it runs them."""
     await hav_init._register_frontend_module(hass)
     await hav_init._async_apply_sidebar_panel(hass, entry)
-
-
-def track_manifest_reads(monkeypatch) -> list[int]:
-    """Record the thread of every `Path.read_text` call from here on.
-
-    HA's blocking-call protection flags exactly this call when it happens on the
-    event loop thread, and answers it with a stack trace on every startup.
-    """
-    threads: list[int] = []
-    real_read_text = Path.read_text
-
-    def tracking_read_text(self, *args, **kwargs):
-        threads.append(threading.get_ident())
-        return real_read_text(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "read_text", tracking_read_text)
-    return threads
 
 
 @pytest.fixture
@@ -264,7 +233,7 @@ async def test_registers_both_loaders_with_the_same_url(hav_init):
 
     await hav_init._register_frontend_module(hass)
 
-    expected = f"{CARD_PATH}?v={manifest_version()}"
+    expected = CURRENT_CARD_URL
     assert [c["url"] for c in lovelace_data.resources.created] == [expected]
     assert lovelace_data.resources.created[0]["res_type"] == "module"
     assert extra_js_urls(hass) == {expected}
@@ -289,7 +258,7 @@ async def test_unload_hands_back_the_module_url_and_setup_restores_it(hav_init):
     """The extra-module URL is entry-scoped state, unlike the static route."""
     hass = make_hass()
     hass.data["lovelace_data_key"] = MockLovelaceData()
-    expected = f"{CARD_PATH}?v={manifest_version()}"
+    expected = CURRENT_CARD_URL
 
     await hav_init._register_frontend_module(hass)
     assert extra_js_urls(hass) == {expected}
@@ -364,107 +333,22 @@ async def test_a_failed_static_route_logs_at_error(hav_init, caplog):
 
 
 @pytest.mark.asyncio
-async def test_registered_url_carries_the_manifest_version(monkeypatch, tmp_path):
-    """The `?v=` value comes from the loaded manifest, not from a constant in the code."""
-    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    install_bundle(monkeypatch, hav_init, tmp_path)
-    hass = make_hass(manifest={"domain": "haventory", "version": "9.9.9"})
-    lovelace_data = MockLovelaceData()
-    hass.data["lovelace_data_key"] = lovelace_data
+async def test_registered_url_carries_the_integration_version(hav_init):
+    """The `?v=` value is the version this build declares.
 
-    await hav_init._register_frontend_module(hass)
-
-    assert [c["url"] for c in lovelace_data.resources.created] == [f"{CARD_PATH}?v=9.9.9"]
-    assert extra_js_urls(hass) == {f"{CARD_PATH}?v=9.9.9"}
-
-
-@pytest.mark.asyncio
-async def test_the_loaded_manifest_is_read_without_touching_the_filesystem(monkeypatch, tmp_path):
-    """The version comes out of memory: no file read at all, on the loop or off it.
-
-    Home Assistant already parsed `manifest.json` when it loaded the integration.
-    Reading it again during `async_setup_entry` runs on the event loop thread,
-    where HA's loop protection answers it with a stack-trace warning on every
-    startup, so the registered URL must not depend on a file read.
+    `INTEGRATION_VERSION` and `manifest.json` are rewritten together by
+    release-please and held equal by `tests/test_release_version_consistency.py`,
+    so the constant is the shipped version and the URL needs no second source
+    for it.
     """
-    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    install_bundle(monkeypatch, hav_init, tmp_path)
-    hass = make_hass(manifest={"domain": "haventory", "version": "9.9.9"})
-    lovelace_data = MockLovelaceData()
-    hass.data["lovelace_data_key"] = lovelace_data
-    read_threads = track_manifest_reads(monkeypatch)
-
-    await hav_init._register_frontend_module(hass)
-
-    assert [c["url"] for c in lovelace_data.resources.created] == [f"{CARD_PATH}?v=9.9.9"]
-    assert read_threads == []
-    assert hass.executor_jobs == []
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "manifest",
-    [
-        # Domain unknown to the loader, which raises rather than returning.
-        None,
-        # Loaded, but carrying nothing usable as a version.
-        {"domain": "haventory"},
-        {"domain": "haventory", "version": ""},
-        {"domain": "haventory", "version": 9},
-    ],
-)
-async def test_falls_back_to_reading_the_manifest_off_the_loop(monkeypatch, tmp_path, manifest):
-    """No version from the loader => read the file, but in the executor."""
-    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    install_bundle(monkeypatch, hav_init, tmp_path)
-    manifest_file = tmp_path / "manifest.json"
-    manifest_file.write_text(
-        json.dumps({"domain": "haventory", "version": "8.8.8"}), encoding="utf-8"
-    )
-    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", manifest_file)
-
-    hass = make_hass(manifest=manifest)
-    lovelace_data = MockLovelaceData()
-    hass.data["lovelace_data_key"] = lovelace_data
-    read_threads = track_manifest_reads(monkeypatch)
-
-    await hav_init._register_frontend_module(hass)
-
-    assert [c["url"] for c in lovelace_data.resources.created] == [f"{CARD_PATH}?v=8.8.8"]
-    assert hass.executor_jobs == [hav_init._read_manifest_version]
-    assert read_threads and threading.get_ident() not in read_threads
-
-
-@pytest.mark.asyncio
-async def test_registers_bare_url_when_manifest_version_unavailable(monkeypatch, tmp_path):
-    """Neither source yields a version => unversioned URL, rather than a failed setup."""
-    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    install_bundle(monkeypatch, hav_init, tmp_path)
-    monkeypatch.setattr(hav_init, "_MANIFEST_PATH", tmp_path / "no-such-manifest.json")
-
-    hass = make_hass(manifest=None)
+    hass = make_hass()
     lovelace_data = MockLovelaceData()
     hass.data["lovelace_data_key"] = lovelace_data
 
     await hav_init._register_frontend_module(hass)
 
-    assert [c["url"] for c in lovelace_data.resources.created] == [CARD_PATH]
-    assert extra_js_urls(hass) == {CARD_PATH}
-
-
-@pytest.mark.asyncio
-async def test_registers_bare_url_when_no_executor_is_available(monkeypatch, tmp_path):
-    """A hass without an executor still registers the card, just without `?v=`."""
-    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    install_bundle(monkeypatch, hav_init, tmp_path)
-    hass = make_hass(manifest=None)
-    monkeypatch.delattr(HomeAssistant, "async_add_executor_job")
-    lovelace_data = MockLovelaceData()
-    hass.data["lovelace_data_key"] = lovelace_data
-
-    await hav_init._register_frontend_module(hass)
-
-    assert [c["url"] for c in lovelace_data.resources.created] == [CARD_PATH]
+    assert [c["url"] for c in lovelace_data.resources.created] == [CURRENT_CARD_URL]
+    assert extra_js_urls(hass) == {CURRENT_CARD_URL}
 
 
 # --------------------------------------------------------------------------- #
@@ -490,13 +374,13 @@ async def test_migrates_a_legacy_local_resource_in_place(monkeypatch, tmp_path, 
     """
     hav_init = import_haventory(monkeypatch, "lovelace_data_key")
     install_bundle(monkeypatch, hav_init, tmp_path)
-    hass = make_hass(manifest={"domain": "haventory", "version": "9.9.9"})
+    hass = make_hass()
     resources = MockResourceCollection([{"id": "legacy", "url": registered_url, "type": "module"}])
     hass.data["lovelace_data_key"] = MockLovelaceData(resources)
 
     await hav_init._register_frontend_module(hass)
 
-    expected = f"{CARD_PATH}?v=9.9.9"
+    expected = CURRENT_CARD_URL
     assert resources.created == []
     assert resources.updated == [("legacy", {"res_type": "module", "url": expected})]
     assert [i["url"] for i in resources.async_items()] == [expected]
@@ -507,7 +391,7 @@ async def test_migrates_a_legacy_local_resource_in_place(monkeypatch, tmp_path, 
 async def test_reregistration_at_the_same_version_is_idempotent(hav_init):
     """Entry already at the current `?v=` => nothing is created and nothing is written."""
     hass = make_hass()
-    current_url = f"{CARD_PATH}?v={manifest_version()}"
+    current_url = CURRENT_CARD_URL
     resources = MockResourceCollection([{"id": "existing", "url": current_url, "type": "module"}])
     hass.data["lovelace_data_key"] = MockLovelaceData(resources)
 
@@ -538,7 +422,7 @@ async def test_updates_existing_entry_when_the_version_changed(
     """A stale entry for the card is rewritten in place, never duplicated."""
     hav_init = import_haventory(monkeypatch, "lovelace_data_key")
     install_bundle(monkeypatch, hav_init, tmp_path)
-    hass = make_hass(manifest={"domain": "haventory", "version": "9.9.9"})
+    hass = make_hass()
     resources = MockResourceCollection(
         [{"id": "existing", "url": registered_url, "type": "module"}]
     )
@@ -546,7 +430,7 @@ async def test_updates_existing_entry_when_the_version_changed(
 
     await hav_init._register_frontend_module(hass)
 
-    expected = f"{CARD_PATH}?v=9.9.9"
+    expected = CURRENT_CARD_URL
     assert resources.created == []
     assert resources.updated == [("existing", {"res_type": "module", "url": expected})]
     assert [i["url"] for i in resources.async_items()] == [expected]
@@ -562,8 +446,8 @@ async def test_collapses_duplicate_card_resources(monkeypatch, tmp_path):
     """A legacy entry beside a current one is one element definition too many."""
     hav_init = import_haventory(monkeypatch, "lovelace_data_key")
     install_bundle(monkeypatch, hav_init, tmp_path)
-    hass = make_hass(manifest={"domain": "haventory", "version": "9.9.9"})
-    expected = f"{CARD_PATH}?v=9.9.9"
+    hass = make_hass()
+    expected = CURRENT_CARD_URL
     resources = MockResourceCollection(
         [
             {"id": "current", "url": expected, "type": "module"},
@@ -589,7 +473,7 @@ async def test_finds_the_existing_entry_in_an_unloaded_collection(hav_init):
     two resources for one module — the second `customElements.define` throws.
     """
     hass = make_hass()
-    current_url = f"{CARD_PATH}?v={manifest_version()}"
+    current_url = CURRENT_CARD_URL
     resources = MockResourceCollection(
         [{"id": "existing", "url": current_url, "type": "module"}], loaded=False
     )
@@ -632,7 +516,7 @@ async def test_registers_alongside_unrelated_resources(hav_init):
 
     await hav_init._register_frontend_module(hass)
 
-    assert [c["url"] for c in resources.created] == [f"{CARD_PATH}?v={manifest_version()}"]
+    assert [c["url"] for c in resources.created] == [CURRENT_CARD_URL]
     assert resources.updated == []
     assert resources.deleted == []
 
@@ -649,7 +533,7 @@ async def test_yaml_mode_loads_the_card_through_the_module_url(hav_init, registe
     await hav_init._register_frontend_module(hass)
 
     assert resources.async_items() == items
-    assert extra_js_urls(hass) == {f"{CARD_PATH}?v={manifest_version()}"}
+    assert extra_js_urls(hass) == {CURRENT_CARD_URL}
 
 
 @pytest.mark.asyncio
@@ -660,7 +544,7 @@ async def test_registers_the_module_url_when_lovelace_is_not_initialized(hav_ini
     # hass.data["lovelace_data_key"] is NOT set - simulates Lovelace not initialized
     await hav_init._register_frontend_module(hass)
 
-    assert extra_js_urls(hass) == {f"{CARD_PATH}?v={manifest_version()}"}
+    assert extra_js_urls(hass) == {CURRENT_CARD_URL}
 
 
 @pytest.mark.asyncio
@@ -671,7 +555,7 @@ async def test_skips_when_resources_is_none(hav_init):
 
     await hav_init._register_frontend_module(hass)
 
-    assert extra_js_urls(hass) == {f"{CARD_PATH}?v={manifest_version()}"}
+    assert extra_js_urls(hass) == {CURRENT_CARD_URL}
 
 
 # --------------------------------------------------------------------------- #
@@ -694,9 +578,7 @@ async def test_missing_frontend_component_degrades_gracefully(monkeypatch, tmp_p
     await hav_init._register_frontend_module(hass)
     await hav_init.async_unload_entry(hass, ConfigEntry())
 
-    assert [c["url"] for c in lovelace_data.resources.created] == [
-        f"{CARD_PATH}?v={manifest_version()}"
-    ]
+    assert [c["url"] for c in lovelace_data.resources.created] == [CURRENT_CARD_URL]
 
 
 @pytest.mark.asyncio
@@ -710,9 +592,7 @@ async def test_frontend_without_a_url_manager_degrades_gracefully(hav_init):
     await hav_init._register_frontend_module(hass)
     await hav_init.async_unload_entry(hass, ConfigEntry())
 
-    assert [c["url"] for c in lovelace_data.resources.created] == [
-        f"{CARD_PATH}?v={manifest_version()}"
-    ]
+    assert [c["url"] for c in lovelace_data.resources.created] == [CURRENT_CARD_URL]
 
 
 # --------------------------------------------------------------------------- #
@@ -892,7 +772,7 @@ async def test_registers_the_sidebar_panel_against_the_card_bundle(hav_init):
 
     await setup_frontend(hav_init, hass, ConfigEntry())
 
-    expected_url = f"{CARD_PATH}?v={manifest_version()}"
+    expected_url = CURRENT_CARD_URL
     panel = registered_panel(hass)
     assert panel.component_name == "custom"
     assert panel.frontend_url_path == PANEL_URL_PATH
@@ -1048,7 +928,7 @@ async def test_an_explicit_opt_out_registers_no_panel(hav_init):
     assert registered_panel(hass) is None
     assert panel_registration_attempts(hass) == []
     # The card itself is unaffected: only the sidebar entry is opted out of.
-    assert extra_js_urls(hass) == {f"{CARD_PATH}?v={manifest_version()}"}
+    assert extra_js_urls(hass) == {CURRENT_CARD_URL}
 
 
 @pytest.mark.asyncio

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -49,8 +49,6 @@ STATIC_URL_PATH = "/haventory_static"
 CARD_PATH = f"{STATIC_URL_PATH}/haventory-card.js"
 # What both loaders and the panel receive, cache-buster and all.
 CURRENT_CARD_URL = f"{CARD_PATH}?v={INTEGRATION_VERSION}"
-# Where installs from before the bundle moved into the package loaded it from.
-LEGACY_CARD_PATH = "/local/haventory/haventory-card.js"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -357,37 +355,6 @@ async def test_registered_url_carries_the_integration_version(hav_init):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "registered_url",
-    [
-        LEGACY_CARD_PATH,
-        f"{LEGACY_CARD_PATH}?v=0.0.1",
-        f"{LEGACY_CARD_PATH}?v=38b725595b78",
-    ],
-)
-async def test_migrates_a_legacy_local_resource_in_place(monkeypatch, tmp_path, registered_url):
-    """An install predating the move ends up with one entry, on the new URL.
-
-    A second entry alongside the legacy one would load the card module twice and
-    the second `customElements.define` would throw; the legacy one left alone
-    would 404 once the copy under the config `www/` tree is gone.
-    """
-    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    install_bundle(monkeypatch, hav_init, tmp_path)
-    hass = make_hass()
-    resources = MockResourceCollection([{"id": "legacy", "url": registered_url, "type": "module"}])
-    hass.data["lovelace_data_key"] = MockLovelaceData(resources)
-
-    await hav_init._register_frontend_module(hass)
-
-    expected = CURRENT_CARD_URL
-    assert resources.created == []
-    assert resources.updated == [("legacy", {"res_type": "module", "url": expected})]
-    assert [i["url"] for i in resources.async_items()] == [expected]
-    assert extra_js_urls(hass) == {expected}
-
-
-@pytest.mark.asyncio
 async def test_reregistration_at_the_same_version_is_idempotent(hav_init):
     """Entry already at the current `?v=` => nothing is created and nothing is written."""
     hass = make_hass()
@@ -442,16 +409,14 @@ async def test_updates_existing_entry_when_the_version_changed(
 
 
 @pytest.mark.asyncio
-async def test_collapses_duplicate_card_resources(monkeypatch, tmp_path):
-    """A legacy entry beside a current one is one element definition too many."""
-    hav_init = import_haventory(monkeypatch, "lovelace_data_key")
-    install_bundle(monkeypatch, hav_init, tmp_path)
+async def test_collapses_duplicate_card_resources(hav_init):
+    """A second entry for the card is one element definition too many."""
     hass = make_hass()
     expected = CURRENT_CARD_URL
     resources = MockResourceCollection(
         [
             {"id": "current", "url": expected, "type": "module"},
-            {"id": "legacy", "url": LEGACY_CARD_PATH, "type": "module"},
+            {"id": "stale", "url": f"{CARD_PATH}?v=0.0.1", "type": "module"},
         ]
     )
     hass.data["lovelace_data_key"] = MockLovelaceData(resources)
@@ -459,7 +424,7 @@ async def test_collapses_duplicate_card_resources(monkeypatch, tmp_path):
     await hav_init._register_frontend_module(hass)
 
     assert resources.created == []
-    assert resources.deleted == ["legacy"]
+    assert resources.deleted == ["stale"]
     assert [i["url"] for i in resources.async_items()] == [expected]
 
 
@@ -522,7 +487,7 @@ async def test_registers_alongside_unrelated_resources(hav_init):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("registered_url", [None, LEGACY_CARD_PATH, f"{CARD_PATH}?v=0.0.0"])
+@pytest.mark.parametrize("registered_url", [None, f"{CARD_PATH}?v=0.0.0"])
 async def test_yaml_mode_loads_the_card_through_the_module_url(hav_init, registered_url):
     """YAML resources are read-only — which is exactly what the extra-module URL is for."""
     hass = make_hass()

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -530,45 +530,10 @@ async def test_a_lossy_load_rewrites_the_store_it_could_not_fully_read(monkeypat
     }
     raw_store = HAStore(hass, DomainStore.HA_STORE_VERSION, key)
     await raw_store.async_save(deepcopy(payload))
-    backup = HAStore(hass, DomainStore.HA_STORE_VERSION, CORRUPT_BACKUP_STORAGE_KEY)
-    await backup.async_remove()
-
-    try:
-        await setup_entry(hass, entry)
-
-        written = await raw_store.async_load()
-        assert set(written["items"]) == {"11111111-1111-4111-8111-111111111111"}
-        # The rows that just left the store are in the copy, which is what makes
-        # rewriting it something other than deleting them.
-        assert set((await backup.async_load())["items"]) == set(payload["items"])
-    finally:
-        # The stub's backing dict is module-global, so a copy left under the real
-        # key would outlive this test.
-        await backup.async_remove()
-
-
-@pytest.mark.asyncio
-async def test_a_lossy_load_that_cannot_be_copied_leaves_the_store_alone(
-    monkeypatch, caplog
-) -> None:
-    """No copy, no rewrite: the rows stay recoverable at the price of one more refusal."""
-
-    hass = HomeAssistant()
-    entry = ConfigEntry(options={CONF_ALLOW_LOSSY_LOAD: True})
-    key = "test_init_lossy_load_no_copy"
-    monkeypatch.setattr(haven_init, "STORAGE_KEY", key)
-
-    payload = _corrupt_payload()
-    raw_store = HAStore(hass, DomainStore.HA_STORE_VERSION, key)
-    await raw_store.async_save(deepcopy(payload))
-
-    async def _no_copy(_hass, **_kwargs):  # type: ignore[no-untyped-def]
-        return False
-
-    monkeypatch.setattr(haven_init, "async_backup_store", _no_copy)
-    caplog.set_level(logging.ERROR)
 
     await setup_entry(hass, entry)
 
-    assert await raw_store.async_load() == payload
-    assert any("could not copy it aside" in record.message for record in caplog.records)
+    # What the copy the repair flow took holds is asserted where that flow can
+    # actually run: `tests/integration/test_repairs.py`.
+    written = await raw_store.async_load()
+    assert set(written["items"]) == {"11111111-1111-4111-8111-111111111111"}

--- a/tests/test_init_offline.py
+++ b/tests/test_init_offline.py
@@ -100,22 +100,6 @@ async def test_setup_entry_logs_populated_storage_at_debug(monkeypatch, caplog) 
 
 
 @pytest.mark.asyncio
-async def test_setup_entry_invalid_version_raises(monkeypatch) -> None:
-    """Schema version mismatch triggers ConfigEntryNotReady."""
-
-    hass = HomeAssistant()
-    entry = ConfigEntry()
-
-    async def _bad_load(self):  # type: ignore[no-untyped-def]
-        return {"schema_version": 0, "items": {}, "locations": {}}
-
-    monkeypatch.setattr(DomainStore, "async_load", _bad_load)
-
-    with pytest.raises(ConfigEntryNotReady):
-        await haven_init.async_setup_entry(hass, entry)
-
-
-@pytest.mark.asyncio
 async def test_setup_entry_refuses_newer_schema_and_leaves_store_intact(monkeypatch) -> None:
     """Data written by a newer build aborts setup permanently and is never rewritten."""
 
@@ -145,22 +129,6 @@ async def test_setup_entry_refuses_newer_schema_and_leaves_store_intact(monkeypa
 
     assert await raw_store.async_load() == pre_payload
     assert "repository" not in hass.data[haven_init.DOMAIN]
-
-
-@pytest.mark.asyncio
-async def test_validate_storage_payload_reports_newer_version_specifically() -> None:
-    """A newer payload reaching validation is refused with the downgrade message."""
-
-    payload = {
-        "schema_version": CURRENT_SCHEMA_VERSION + 2,
-        "items": {},
-        "locations": {},
-    }
-
-    with pytest.raises(SchemaDowngradeError) as excinfo:
-        haven_init._validate_storage_payload(payload, schema_version=CURRENT_SCHEMA_VERSION)
-
-    assert str(CURRENT_SCHEMA_VERSION + 2) in str(excinfo.value)
 
 
 @pytest.mark.asyncio
@@ -196,32 +164,23 @@ async def test_setup_entry_refuses_corrupt_schema_version_and_leaves_store_intac
 
 
 @pytest.mark.asyncio
-async def test_validate_storage_payload_rejects_a_numeric_string_version() -> None:
-    """``"5"`` is corruption, not the current version — validation must not coerce it."""
+async def test_setup_entry_retries_on_a_collection_of_the_wrong_type(monkeypatch) -> None:
+    """A stored ``items`` that is not a mapping stops setup rather than half-loading.
 
-    payload = {
-        "schema_version": str(CURRENT_SCHEMA_VERSION),
-        "items": {},
-        "locations": {},
-    }
-
-    with pytest.raises(CorruptSchemaVersionError) as excinfo:
-        haven_init._validate_storage_payload(payload, schema_version=CURRENT_SCHEMA_VERSION)
-
-    assert repr(str(CURRENT_SCHEMA_VERSION)) in str(excinfo.value)
-
-
-@pytest.mark.asyncio
-async def test_setup_entry_invalid_collections_raise(monkeypatch) -> None:
-    """Non-dict collections trigger ConfigEntryNotReady."""
+    ConfigEntryNotReady, not ConfigEntryError: a file in that state was written
+    by something other than this integration, and a restore in the background is
+    a fix a retry would pick up.
+    """
 
     hass = HomeAssistant()
     entry = ConfigEntry()
+    key = "test_init_collection_wrong_type"
+    monkeypatch.setattr(haven_init, "STORAGE_KEY", key)
 
-    async def _bad_load(self):  # type: ignore[no-untyped-def]
-        return {"schema_version": CURRENT_SCHEMA_VERSION, "items": [], "locations": {}}
-
-    monkeypatch.setattr(DomainStore, "async_load", _bad_load)
+    raw_store = HAStore(hass, DomainStore.HA_STORE_VERSION, key)
+    await raw_store.async_save(
+        {"schema_version": CURRENT_SCHEMA_VERSION, "items": [], "locations": {}}
+    )
 
     with pytest.raises(ConfigEntryNotReady):
         await haven_init.async_setup_entry(hass, entry)
@@ -384,7 +343,10 @@ async def test_a_newer_store_also_reaches_settings_repairs(monkeypatch) -> None:
     entry = ConfigEntry()
 
     async def _newer(self):  # type: ignore[no-untyped-def]
-        return {"schema_version": CURRENT_SCHEMA_VERSION + 1, "items": {}, "locations": {}}
+        raise SchemaDowngradeError(
+            f"stored data uses schema version {CURRENT_SCHEMA_VERSION + 1}, which is newer "
+            f"than this build supports ({CURRENT_SCHEMA_VERSION})"
+        )
 
     monkeypatch.setattr(DomainStore, "async_load", _newer)
 


### PR DESCRIPTION
## Summary

Four cuts in the lifecycle modules, none of them user-visible. The ids are the ones the
[2026-08-22 measurement comment on #230](https://github.com/chrreiter/HAventory/issues/230) uses.

**L4 — the card URL's version is already a constant.** `_async_card_url` asked HA's loader for
the manifest and fell back to an executor file read, so `_read_manifest_version`,
`_async_manifest_version` and `_MANIFEST_PATH` existed to reach a string `INTEGRATION_VERSION`
already holds: release-please rewrites the two together and
`tests/test_release_version_consistency.py` fails when they disagree, and `ws.py` has served the
constant as `haventory/version` all along. The URL is byte-identical, so `_card_url` is sync and
its three call sites stop awaiting it; its fallback to the bare path went with the readers,
since a constant is always there.

**L5 — the `/local` path never shipped.** `_LEGACY_CARD_URL_PATH` matched a Lovelace resource
pointing at `/local/haventory/haventory-card.js`. The bundle moved into the integration package
in `ea8d038`, which `git tag --contains` reports as v0.1.0, so no tagged release ever served that
path and only an untagged pre-0.1.0 checkout could hold such a resource. `_points_at_card` now
compares against the one served path.

**L7a — the checks the load path already makes, and one normalizer.**
`_validate_storage_payload` ran *after* `DomainStore.async_load`, which either returns
`_empty_payload()`, raises for a store a newer schema wrote, or stamps its own version — so the
payload it saw always carried this build's version and its two version branches could not fire
from setup. What they refuse is refused inside `DomainStore` and pinned there by
`tests/test_storage_offline.py`. The one reachable check — `items` and `locations` are maps of
rows, which a hand-edited file need not hold — moves into `async_load` beside the normalisation
it guards, and setup still answers it with `ConfigEntryNotReady` through the `StorageError` it
already maps. The `STORE_COLLECTIONS` defaults were written out at four sites in two spellings;
`_normalized(payload, schema_version=…)` is the one they share, with the payload still winning
over the defaults everywhere, extra keys included. `schema_downgrade_message` had one caller left
and is inlined into it word for word.

**L7b — one raw copy before a lossy load, not two.** `_async_settle_lossy_load` copied the store
aside under the same key `repairs.py` had just copied it to, and its own docstring said the
second write was the same bytes. A load reaches settle only with `CONF_ALLOW_LOSSY_LOAD` set,
that option is set in exactly one place, and the flow that sets it withdraws the offer when its
own copy fails — so the copy is already on disk, holding the rows the rewrite drops. The refusal
branch goes with it: the one that can still refuse is the flow's.

Refs #230

## Counting

| | lines |
|---|---|
| production removed | 178 (`__init__.py` 121, `storage.py` 57) |
| test lines removed | 346 (`test_frontend_registration.py` 189, `test_init_offline.py` 93, `conftest.py` 48, `test_entry_removal_offline.py` 16) |
| lines added | 146 (production 84, tests 59, skill harness 3) |

`git diff --shortstat origin/main...HEAD`: 8 files changed, 146 insertions(+), 532 deletions(-).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1338 passed, 27 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (26 source files, no issues)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (67 files, 1917 tests passed), `npm run build`
- [x] phacc, card built first — `scripts/test_integration.sh`: **`153 passed in 14.82s`**

`tests/integration/test_repairs.py` is the gate for the backup cut, and it is in that run:
`test_a_corrupt_row_offers_a_fix_that_backs_up_reloads_and_clears` still finds the dropped row in
`haventory_store_corrupt_backup` after the flow, and
`test_the_repair_survives_a_restart_with_no_mutation_in_between` still finds the store rewritten
without it and no refusal on the restart.

### What moved on the test side

- The four tests that drove the loader and the executor read go, and
  `test_registered_url_carries_the_manifest_version` stays as
  `test_registered_url_carries_the_integration_version`, comparing the registered URL against the
  constant. `test_migrates_a_legacy_local_resource_in_place` goes with the `/local` path.
- `test_collapses_duplicate_card_resources` keeps testing the collapse, with a stale `?v=` entry
  as the duplicate instead of the retired legacy URL — the self-healing it pins is untouched.
- `test_setup_entry_invalid_version_raises` and the two direct `_validate_storage_payload` tests
  go: the first monkeypatched `async_load` into returning a payload that method cannot return,
  and the other two re-tested what `test_storage_offline.py` pins on `DomainStore`.
  `test_setup_entry_invalid_collections_raise` becomes
  `test_setup_entry_retries_on_a_collection_of_the_wrong_type` and seeds a real store instead of
  patching the load.
- The stub's `async_get_integration` and its `hass.executor_jobs` recorder lose their last
  readers and go; the stub is that much closer to real HA, which records neither.
- `.claude/skills/run-haventory`'s lifecycle probe loses its two `/local` variants: it would
  otherwise assert an entry gets rewritten that the integration now leaves alone.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — a cut's tests are deleted or moved, never rewritten to pass; the two rewritten ones (the collections check, the duplicate collapse) test the same production behaviour through a path that still exists.
- [x] Docs updated where behavior changed — none did; no doc names the manifest read, the `/local` path or the second copy.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS schema, error code or field moved.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Follow-ups

- `async_persist_immediate` (`storage.py`) is now a one-line wrapper around `async_persist_repo`
  whose only reason to exist is its DEBUG line; its two callers are the settle rewrite and the
  teardown flush. Not filed: it is a comment-sized finding, and M1's debounce cut already looked
  at this function.
- `DomainStore.async_save` writes `schema_version` first now rather than appending it after the
  caller's keys, so the key order inside `.storage/haventory_store` changes on the next write.
  Nothing reads the file by key order. Not filed.

## Handover

1. **Merged / left open** — this PR is for the M2 master to merge once CI is green; nothing in
   the package stacks on it.
2. **Test this by hand** — nothing `[owner]`-only. The card is byte-identical and no string
   changed, so nothing `[German]` or `[phone]`.
3. **Validate locally**
   1. `[dev-ha]` deploy the branch and restart; over WS, `lovelace/resources` shows exactly one
      HAventory entry and its URL ends `?v=<INTEGRATION_VERSION>` (`0.7.1` on this branch) — the
      same string the sidebar panel's `module_url` carries.
   2. `[browser]` open a dashboard with the card and `/haventory`: both load, and the browser's
      network tab shows one request for `haventory-card.js`, not two.
   3. `[log]` grep the start-up log for a loop-protection stack trace naming `manifest.json` —
      there is none to find now, and there was none before either; the point is that the read is
      gone rather than merely offloaded.
   4. `[dev-ha]` optional, only if the store is worth breaking: hand-edit an item row into
      something unreadable, restart, press **Fix** in Repairs, restart again — the entry comes up
      both times and `haventory_store_corrupt_backup` holds the broken row.
4. **Decisions taken against drifted notes** — the measurement comment sizes L7's dict-type check
   as "moves into `async_load` as ~4 lines"; it landed as a loop over `("items", "locations")`
   with its own message per collection, since one message naming both read as if both were
   wrong. It also lists five `STORE_COLLECTIONS` default sites while the plan text says four —
   all five are now `_normalized`.
5. **Follow-ups** — the two above, neither filed.
6. **State left behind** — branch `claude/v0-8-0-m2-init-leftovers`, no assets branch, no HA
   instance touched. Counting for this PR: 178 production lines removed, 346 test lines removed,
   146 added.
