### PR TITLE
fix(media): remove an item's attachment directory once its last file is gone

### DIFF
--- a/custom_components/haventory/media.py
+++ b/custom_components/haventory/media.py
@@ -328,10 +328,40 @@ def _read_head_blocking(source: Path) -> tuple[bytes, int]:
         return handle.read(SNIFF_BYTES), size
 
 
-def _delete_blocking(targets: Iterable[Path]) -> None:
-    """Unlink each path that is present. Blocks — run it in the executor."""
+def _prune_emptied_blocking(root: Path, directories: Iterable[Path]) -> None:
+    """Remove each directory the caller has just emptied. Blocks — executor only.
 
+    ``rmdir`` is the whole check: a directory still holding something — an
+    operator's own file, or a tile from an encoder generation this build cannot
+    name — refuses to go, so nothing has to recognise that file first. Any other
+    refusal (a file being served at that instant, a mount point) leaves the
+    directory where it is, which costs an inert directory and nothing else.
+
+    ``root`` is where the next upload is written and is never a candidate; only
+    a directory under it is, and one resolving elsewhere is skipped for the same
+    reason the sweep re-checks every file.
+    """
+
+    resolved_root = root.resolve()
+    for directory in directories:
+        resolved = directory.resolve()
+        if resolved_root not in resolved.parents:
+            continue
+        try:
+            resolved.rmdir()
+        except OSError:
+            continue
+
+
+def _delete_blocking(root: Path, targets: Iterable[Path]) -> None:
+    """Unlink each path that is present, then drop what that empties.
+
+    Blocks — run it in the executor.
+    """
+
+    emptied: set[Path] = set()
     for target in targets:
+        emptied.add(target.parent)
         try:
             target.unlink()
         except FileNotFoundError:
@@ -344,15 +374,17 @@ def _delete_blocking(targets: Iterable[Path]) -> None:
                 extra={"domain": DOMAIN, "op": "attachment_delete", "path": str(target)},
                 exc_info=True,
             )
+    _prune_emptied_blocking(root, emptied)
 
 
 def _sweep_blocking(root: Path, referenced: frozenset[str]) -> list[str]:
     """Delete every file under ``root`` no metadata claims. Blocks — executor only.
 
-    Files only, and only ones resolving inside ``root``: ``rglob`` follows a
+    Files first, and only ones resolving inside ``root``: ``rglob`` follows a
     symlinked directory, so an unchecked candidate could name a file anywhere in
-    the config tree. Empty directories are left behind — they are inert, and an
-    operator's own file may sit in one.
+    the config tree. A directory this sweep has itself emptied then goes with
+    them; one that was already empty is left alone, so an operator who made a
+    directory here keeps it.
     """
 
     if not root.is_dir():
@@ -360,6 +392,7 @@ def _sweep_blocking(root: Path, referenced: frozenset[str]) -> list[str]:
 
     resolved_root = root.resolve()
     removed: list[str] = []
+    emptied: set[Path] = set()
     for candidate in root.rglob("*"):
         if not candidate.is_file():
             continue
@@ -382,6 +415,8 @@ def _sweep_blocking(root: Path, referenced: frozenset[str]) -> list[str]:
             )
             continue
         removed.append(str(resolved))
+        emptied.add(resolved.parent)
+    _prune_emptied_blocking(root, emptied)
     return removed
 
 
@@ -440,7 +475,8 @@ async def async_delete_attachments(
     """Delete the files named by each (item id, attachment) pair.
 
     A removed picture takes its row tile with it; `_delete_blocking` passes over
-    one that was never made.
+    one that was never made, and removes the item's directory when the pair was
+    the last thing in it.
     """
 
     root = media_root(hass)
@@ -456,7 +492,7 @@ async def async_delete_attachments(
         except ValidationError:  # pragma: no cover - ids come from validated metadata
             continue
     if targets:
-        await hass.async_add_executor_job(_delete_blocking, targets)
+        await hass.async_add_executor_job(_delete_blocking, root, targets)
 
 
 async def async_delete_item_files(hass: HomeAssistant, items: Iterable[Mapping[str, Any]]) -> None:
@@ -485,7 +521,7 @@ async def async_delete_item_files(hass: HomeAssistant, items: Iterable[Mapping[s
 async def async_sweep_orphans(
     hass: HomeAssistant, pairs: Iterable[tuple[str, AttachmentMeta]]
 ) -> tuple[str, ...]:
-    """Remove media files no metadata references.
+    """Remove media files no metadata references, and what that empties.
 
     Its own module rather than ``stale_files``: that one is deliberately
     confined to the integration package directory and refuses anything resolving

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -217,6 +217,8 @@ rewritten in full on every mutation, so base64 content would multiply every save
   the config directory so HA backups carry them, and outside both the integration package
   (which HACS replaces on upgrade) and `<config>/www` (which is `/local`, unauthenticated).
   They are served only through the authenticated view; see `backend_api_contract.md`.
+  An item's directory is removed once its last file is deleted; one that still holds
+  anything — a file you put there yourself — is kept.
 - Caps: 10 pictures and 10 manuals per item, 8 MB per file. `haventory/config` reports all
   of them so a picker can refuse early.
 - A picture also has a **row tile**: `?size=thumb` on the media route serves a 256px WebP

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -593,6 +593,9 @@ async def test_deleting_the_item_deletes_its_files(
     assert deleted["success"] is True, deleted
 
     assert not path.exists()
+    # The file was the last one in it, so the item's directory goes too.
+    assert not path.parent.exists()
+    assert media.media_root(hass).is_dir()
 
 
 async def test_a_bulk_delete_deletes_the_item_files(

--- a/tests/test_media_offline.py
+++ b/tests/test_media_offline.py
@@ -18,6 +18,7 @@ Scenarios:
 - the sweep refuses a path resolving outside the media root
 - a tile names the encoder generation that wrote it, and the sweep removes the
   tiles an earlier generation left behind
+- an item's directory goes with its last file, and one holding anything else stays
 - a tile keeps the transparency its source had, where there is a decoder to
   look at the bytes with
 """
@@ -615,6 +616,108 @@ async def test_deleting_an_attachment_takes_its_thumbnail_with_it(monkeypatch) -
 
     assert not thumb.exists()
     assert not media.attachment_path(root, str(item.id), str(meta.id), meta.mime).exists()
+
+
+# -----------------------------
+# The item's directory
+# -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleting_the_last_attachment_takes_the_item_directory(monkeypatch) -> None:
+    """A picture is two files, and the directory goes when the second one does."""
+
+    hass = HomeAssistant()
+    _, item, meta = await _stored_picture(hass)
+    monkeypatch.setattr(media, "_encode_thumbnail_blocking", _stub_encoder([]))
+    root = media.media_root(hass)
+    thumb = await media.async_thumbnail(hass, root=root, item_id=str(item.id), meta=meta)
+    assert thumb is not None and thumb.is_file()
+    directory = thumb.parent
+
+    await media.async_delete_attachments(hass, [(str(item.id), meta)])
+
+    assert not directory.exists()
+    assert root.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_a_directory_that_still_holds_an_attachment_is_kept() -> None:
+    """Removing one of two attachments empties nothing."""
+
+    hass = HomeAssistant()
+    item_id = str(new_uuid4())
+    root = media.media_root(hass)
+    going, staying = _meta(), _meta()
+    going_path = media.attachment_path(root, item_id, str(going.id), going.mime)
+    staying_path = media.attachment_path(root, item_id, str(staying.id), staying.mime)
+    going_path.parent.mkdir(parents=True, exist_ok=True)
+    going_path.write_bytes(PNG_BYTES)
+    staying_path.write_bytes(PNG_BYTES)
+
+    await media.async_delete_attachments(hass, [(item_id, going)])
+
+    assert not going_path.exists()
+    assert staying_path.is_file()
+    assert staying_path.parent.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_a_directory_holding_a_file_of_the_operators_own_is_kept() -> None:
+    """`rmdir` is the whole check: a directory that still holds something
+    refuses to go, so nothing has to recognise the file first."""
+
+    hass = HomeAssistant()
+    item_id = str(new_uuid4())
+    meta = _meta()
+    root = media.media_root(hass)
+    path = media.attachment_path(root, item_id, str(meta.id), meta.mime)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(PNG_BYTES)
+    theirs = path.parent / "where-the-receipt-is.txt"
+    theirs.write_text("filing cabinet, second drawer", encoding="utf-8")
+
+    await media.async_delete_attachments(hass, [(item_id, meta)])
+
+    assert not path.exists()
+    assert theirs.is_file()
+    assert path.parent.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_takes_a_directory_it_emptied_of_an_old_generation_tile() -> None:
+    """A tile the current encoder cannot name outlives the delete that emptied
+    the directory around it, so the next setup takes the pair."""
+
+    hass = HomeAssistant()
+    root = media.media_root(hass)
+    directory = root / str(new_uuid4())
+    directory.mkdir(parents=True)
+    stale = directory / f"{new_uuid4()}{FIRST_GENERATION_SUFFIX}"
+    stale.write_bytes(WEBP_BYTES)
+
+    removed = await media.async_sweep_orphans(hass, [])
+
+    assert removed == (str(stale.resolve()),)
+    assert not directory.exists()
+    assert root.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_leaves_the_media_root_itself_where_it_is() -> None:
+    """The root is where the next upload is written, and an orphan sitting
+    directly in it is not an item's directory."""
+
+    hass = HomeAssistant()
+    root = media.media_root(hass)
+    root.mkdir(parents=True, exist_ok=True)
+    orphan = root / "loose.png"
+    orphan.write_bytes(PNG_BYTES)
+
+    removed = await media.async_sweep_orphans(hass, [])
+
+    assert removed == (str(orphan.resolve()),)
+    assert root.is_dir()
 
 
 def test_referenced_paths_names_both_files_for_a_picture_and_one_for_a_manual() -> None:


### PR DESCRIPTION
## Summary

`<config>/haventory/attachments/<item_id>/` outlived the item it belonged to: the delete
paths unlinked files and stopped there, so every item that ever carried a photo or a manual
left one empty directory behind for good. #333 recorded that as a decision to make rather
than a defect; this takes its **option 2**.

- `_delete_blocking` now finishes by `rmdir`-ing the directories its unlinks left empty, and
  `_sweep_blocking` does the same for a directory the setup sweep has itself just emptied.
  Both go through one `_prune_emptied_blocking(root, directories)`, in the executor with
  every other filesystem call.
- The `rmdir` is the whole guard. A directory that still holds anything — a file the
  operator put there, a tile from an encoder generation this build cannot name — refuses to
  be removed, so nothing has to recognise that file first; that is exactly the case the old
  `_sweep_blocking` docstring protected by leaving every directory alone. Any other refusal
  (a file being served at that instant, a mount point) leaves the directory where it was,
  which is where it was before this PR.
- "Last file" counts the row tile beside a picture: `async_delete_attachments` already
  unlinks the original and the tile as a pair, so the directory goes when the pair does.
  A directory kept because an old-generation tile was still in it is emptied and removed by
  the next setup sweep — that tile is the sweep's orphan.
- The media root itself is never a candidate, and neither is a directory resolving outside
  it: only a directory under the root is pruned.

`docs/data_shapes.md`'s on-disk-layout bullet gains the one sentence a user reading their
config directory needs. No WebSocket schema, error code or field moves.

Closes #333

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → **1343 passed, 27 skipped**;
  `uv run ruff check .` → All checks passed; `uv run ruff format --check .` → 189 files already
  formatted; `uv run mypy` → no issues in 26 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`
  → **1917 passed (67 files)**, `npm run build` → built (card untouched by this PR; built so
  the phacc frontend cases run).
- [x] phacc (`scripts/test_integration.sh`, native Linux): **153 passed in 14.36s**.

Five new offline cases in `tests/test_media_offline.py`:

| case | expectation |
| --- | --- |
| delete the last attachment (picture + its tile) | the item's directory is gone, the root stays |
| delete one of two attachments | the directory stays |
| delete the attachment beside a file of the operator's own | the directory and their file stay |
| sweep a directory holding only an old-generation tile | tile and directory both gone |
| sweep an orphan sitting directly under the media root | file gone, the root stays |

`tests/integration/test_attachments.py::test_deleting_the_item_deletes_its_files` gains two
assertions, so the same behaviour is pinned once through the real delete surface in HA.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed (`docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and
  `docs/data_shapes.md` in sync — no WS change here.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`,
  optimistic `version`).

## Counting

`git diff --numstat origin/main...HEAD`

| | lines |
| --- | --- |
| production lines removed | 8 |
| test lines removed | 0 |
| lines added | 152 |

This PR is the behaviour change §6.M2 carries, not a cut — the numbers are here for the
session's running total.

## Follow-ups

- `README.md` (the "Nothing is resized or thumbnailed on the server" bullet, and its closing
  "Lists still load the stored file at full size") describes the integration before row
  tiles: `?size=thumb` writes a 256px WebP beside the picture when Pillow is importable, and
  the list reads that. Not fixed here — out of this PR's scope, and §6.M6 owns the docs
  pass. Named rather than filed: it is one paragraph for that sweep to rewrite.

## Handover

1. **Merged / left open** — this PR is for the M2 master to merge once CI is green; nothing
   in the package stacks on it.
2. **Test this by hand** — `[owner]` nothing specific to this change beyond the local steps
   below; no phone-, German- or store-shaped surface is touched.
3. **Validate locally**
   1. `[dev-ha]` deploy the branch, add a photo to an item, open the list so the row tile is
      encoded, then delete the item → no directory left under
      `/config/haventory/attachments/`, and `attachments/` itself still there.
   2. `[dev-ha]` put a file of your own (`notes.txt`) into an item's attachment directory,
      delete that item → the directory and your file are still there, the item's own files
      are gone.
   3. `[dev-ha]` with that stray file still in place, restart HA → the sweep removes it (a
      file no metadata claims, which is its behaviour since before this PR) and the
      now-emptied directory goes with it. A stray file dropped beside a **live** item's
      attachments is swept the same way at the next restart, and that directory stays,
      because the item's own files are still in it.
   4. `[log]` no warning from any step: a refused `rmdir` is silent by design. Step 3 logs
      the sweep's usual info line counting the files it removed; directories are not counted
      in it.
4. **Decisions taken against drifted notes** — the issue's option 2 says
   "`_delete_blocking` gains one `rmdir`"; the sweep needs the same call, so the two share
   `_prune_emptied_blocking` rather than repeating it. `_delete_blocking` takes the media
   root as its first argument now, so the containment check is made against a root the
   function was handed rather than inferred from a path.
5. **Follow-ups** — the README paragraph above, named and not filed.
6. **State left behind** — branch `claude/v0-8-0-m2-media-rmdir`; no assets branch; no HA
   instance touched; `.venv-integration/` provisioned by `scripts/test_integration.sh` in
   the worktree. Counting for this PR: production removed 8 · tests removed 0 · added 152.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YN6wQcqZD9UGhcDjXmVb8L)_