### PR TITLE
test: one setup per phacc file, one helper per online smoke, and the phacc twins

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -5,7 +5,7 @@ import {
   makeItem,
   makeMockHass,
   mountComponent,
-  mountStore,
+  mountHost,
   q,
   settle,
   stubViewport,
@@ -32,15 +32,11 @@ function loc(id: string, name: string, parentId: string | null = null): Location
 }
 
 async function mountShell(opts: { items?: Item[]; locations?: Location[]; mobile?: boolean } = {}) {
-  const { hass, store } = await mountStore({
-    items: opts.items ?? [],
-    locations: opts.locations ?? [],
-  });
-  const { el, sr } = await mountComponent<HVCardShell>('hv-card-shell', {
-    store,
-    forceMobile: opts.mobile ?? false,
-  });
-  return { el, store, hass, sr };
+  return mountHost<HVCardShell>(
+    'hv-card-shell',
+    { items: opts.items ?? [], locations: opts.locations ?? [] },
+    { forceMobile: opts.mobile ?? false },
+  );
 }
 
 describe('hv-card-shell: header', () => {

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,5 +1,5 @@
 import './hv-full-view';
-import { componentCss, makeItem, mountComponent, mountStore, q, settle, stubViewport } from '../test.utils';
+import { componentCss, makeItem, mountHost, q, settle, stubViewport } from '../test.utils';
 import { deepActiveElement, deepFocusables } from '../ui/dialog-focus';
 import { discardPrompt } from '../ui/discard';
 import { toIsoDate } from '../ui/relative-time';
@@ -32,16 +32,15 @@ async function mount(
     narrow?: boolean;
   } = {},
 ) {
-  const { hass, store } = await mountStore({
-    items: opts.items ?? [],
-    locations: opts.locations ?? [],
-    areas: opts.areas ?? [],
-    ...(opts.statuses ? { statuses: opts.statuses } : {}),
-  });
-  const { el, sr } = await mountComponent<HVFullView>(
+  return mountHost<HVFullView>(
     'hv-full-view',
     {
-      store,
+      items: opts.items ?? [],
+      locations: opts.locations ?? [],
+      areas: opts.areas ?? [],
+      ...(opts.statuses ? { statuses: opts.statuses } : {}),
+    },
+    {
       columns: ['quantity', 'category'],
       ...(opts.embedded ? { embedded: true } : {}),
       ...(opts.narrow ? { narrow: true } : {}),
@@ -49,7 +48,6 @@ async function mount(
     },
     { renders: 2 },
   );
-  return { el, store, hass, sr };
 }
 
 describe('hv-full-view: phone-width app bar', () => {

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1,6 +1,6 @@
 import { setLanguage } from '../i18n';
 import './hv-organize-dialog';
-import { all, componentCss, makeItem, mountComponent, mountStore, q, settle } from '../test.utils';
+import { all, componentCss, makeItem, mountHost, q, settle } from '../test.utils';
 // The clipboard itself is `ui/clipboard`'s own test; what the dialog owes is
 // asking the helper and believing its answer, which needs both answers.
 vi.mock('../ui/clipboard', async (importOriginal) => ({
@@ -44,18 +44,17 @@ async function mount(
     mobile?: boolean;
   } = {},
 ) {
-  const { hass, store } = await mountStore({
-    items: opts.items ?? [],
-    locations: opts.locations ?? [],
-    areas: opts.areas ?? AREAS,
-    ...(opts.statuses ? { statuses: opts.statuses } : {}),
-  });
-  const { el, sr } = await mountComponent<HVOrganizeDialog>(
+  return mountHost<HVOrganizeDialog>(
     'hv-organize-dialog',
-    { store, tab: opts.tab ?? 'locations', mobile: opts.mobile ?? false, open: true },
+    {
+      items: opts.items ?? [],
+      locations: opts.locations ?? [],
+      areas: opts.areas ?? AREAS,
+      ...(opts.statuses ? { statuses: opts.statuses } : {}),
+    },
+    { tab: opts.tab ?? 'locations', mobile: opts.mobile ?? false, open: true },
     { renders: 2 },
   );
-  return { el, store, hass, sr };
 }
 
 /** jsdom lays out no shadow DOM, so geometry is asserted on the stylesheet. */

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -1127,6 +1127,25 @@ export async function mountStore(config: MockConfig = {}): Promise<{
   return { hass, store };
 }
 
+/**
+ * Mount one of the host components over a store of its own.
+ *
+ * `hv-card-shell`, `hv-full-view` and `hv-organize-dialog` each take a `store`
+ * property and are asserted against both halves, so their specs need the store
+ * and the mock hass back alongside the element. The two things a caller varies
+ * are the dataset the store answers with and the host's own properties.
+ */
+export async function mountHost<T extends HTMLElement>(
+  tag: string,
+  config: MockConfig = {},
+  props: Partial<T> = {},
+  options: MountOptions = {},
+): Promise<Mounted<T> & { store: Store; hass: MockHass }> {
+  const { hass, store } = await mountStore(config);
+  const { el, sr } = await mountComponent<T>(tag, { ...props, store }, options);
+  return { el, store, hass, sr };
+}
+
 /** The first match for a selector, from an element's shadow root or from a root itself. */
 export function q<T extends Element = HTMLElement>(
   root: Element | DocumentFragment,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,11 +319,9 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
 
         def __init__(self) -> None:
             self.static_paths: list = []
-            self.static_path_calls = 0
             self.views: list = []
 
         async def async_register_static_paths(self, configs) -> None:
-            self.static_path_calls += 1
             for config in configs:
                 if any(existing.url_path == config.url_path for existing in self.static_paths):
                     raise RuntimeError(f"Duplicate static path: {config.url_path}")
@@ -1010,9 +1008,6 @@ def _install_offline_ha_stubs() -> None:  # noqa: PLR0915 - flat, intentional st
             require_admin=require_admin,
             config_panel_domain=config_panel_domain,
         )
-        # Every call, not just the ones that stick: a test asserting "registered
-        # exactly once" needs the attempts, which the registry alone cannot show.
-        hass.data.setdefault("__panel_registrations__", []).append(frontend_url_path)
 
     ha_panel_custom.async_register_panel = async_register_panel
     sys.modules["homeassistant.components.panel_custom"] = ha_panel_custom

--- a/tests/date_helpers.py
+++ b/tests/date_helpers.py
@@ -1,0 +1,22 @@
+"""Dates a test writes relative to the household's own day.
+
+Every date-derived answer the integration gives — the item predicates, the
+`filter_items` flags, the repository counts, the subscription matcher — is
+measured against `dt_util.now()` in the instance's time zone
+(`models.today_local_date`). A test that writes "yesterday" or "tomorrow" has to
+measure from that same clock: `datetime.now(UTC)` is a second, different reading
+that disagrees with it for the hours a local day and a UTC one differ by, and
+also whenever midnight falls between the test's reading and the integration's.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.util import dt as dt_util
+
+
+def day_offset(days: int) -> str:
+    """A calendar date `days` from today in the instance's zone, as YYYY-MM-DD."""
+
+    return (dt_util.now().date() + timedelta(days=days)).isoformat()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,7 +21,18 @@ collide.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+from custom_components.haventory.const import DOMAIN
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from homeassistant.core import HomeAssistant
+
+    SetupEntry = Callable[..., Awaitable[MockConfigEntry]]
 
 
 @pytest.fixture(autouse=True)
@@ -34,3 +45,27 @@ def _auto_enable_custom_integrations(enable_custom_integrations):
     """
 
     yield
+
+
+@pytest.fixture
+def setup_entry(hass: HomeAssistant) -> SetupEntry:
+    """Bring the integration up from a config entry, as Home Assistant does.
+
+    ``hass.config_entries.async_setup`` rather than ``async_setup_entry``: only
+    the registry path moves the entry through its states, forwards the
+    platforms and lets a later reload or unload address it by ``entry_id``.
+    The returned entry is what those tests need afterwards.
+
+    Setting up is a step inside a test, not a precondition of one, so this is a
+    factory rather than an autouse fixture — several tests fill `hass_storage`,
+    monkeypatch a module or listen on the bus before the entry may load.
+    """
+
+    async def _setup(options: dict | None = None) -> MockConfigEntry:
+        entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory", options=options or {})
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        return entry
+
+    return _setup

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -34,7 +34,6 @@ from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from PIL import Image, ImageDraw
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
 
 # A real, if minimal, PNG: an 8x8 greyscale image. The backend sniffs the
@@ -54,14 +53,6 @@ PDF_BYTES = (
     b"trailer<</Root 1 0 R>>\n"
     b"%%EOF\n"
 )
-
-
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
 
 
 async def _upload(client, content: bytes = PNG_BYTES, filename: str = "drill.png") -> str:
@@ -211,11 +202,11 @@ async def _attach(
 
 
 async def test_a_real_png_round_trips_through_upload_and_the_view(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """Upload, attach, then GET the same bytes back with an image content type."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -254,7 +245,7 @@ async def test_a_real_png_round_trips_through_upload_and_the_view(
 
 
 async def test_size_thumb_serves_a_real_webp_tile_and_writes_it_once(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """The whole `?size=thumb` path against the real encoder.
 
@@ -265,7 +256,7 @@ async def test_size_thumb_serves_a_real_webp_tile_and_writes_it_once(
     """
 
     photo = _photograph()
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -311,7 +302,7 @@ async def test_size_thumb_serves_a_real_webp_tile_and_writes_it_once(
 
 
 async def test_a_transparent_picture_keeps_its_alpha_through_the_view(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """A logo or a screenshot saved as a transparent PNG keeps its background.
 
@@ -321,7 +312,7 @@ async def test_a_transparent_picture_keeps_its_alpha_through_the_view(
     """
 
     logo = _transparent_logo()
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -348,7 +339,7 @@ async def test_a_transparent_picture_keeps_its_alpha_through_the_view(
 
 
 async def test_a_picture_the_decoder_refuses_serves_the_original(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """Fail open, with a file that really does defeat the decoder.
 
@@ -358,7 +349,7 @@ async def test_a_picture_the_decoder_refuses_serves_the_original(
     still render, and the page is slower rather than broken.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -374,12 +365,12 @@ async def test_a_picture_the_decoder_refuses_serves_the_original(
 
 
 async def test_an_unknown_size_is_refused_rather_than_generated(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """One accepted value: the parameter selects a derived form, it does not let
     a caller ask the server to render whatever size it likes."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -392,11 +383,11 @@ async def test_an_unknown_size_is_refused_rather_than_generated(
 
 
 async def test_a_manual_asked_for_as_a_thumbnail_serves_the_pdf(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """Fail open: there is no tile of a PDF, and the answer is the document."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -414,6 +405,7 @@ async def test_the_upload_handle_is_consumed_off_the_event_loop(
     hass_client: ClientSessionGenerator,
     hass_ws_client,
     upload_teardowns: list[tuple[int, Path]],
+    setup_entry,
 ) -> None:
     """Every byte of the temp directory's teardown is paid by a worker thread.
 
@@ -422,7 +414,7 @@ async def test_the_upload_handle_is_consumed_off_the_event_loop(
     photos, which is the case the feature exists for.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -447,7 +439,7 @@ async def test_the_upload_handle_is_consumed_off_the_event_loop(
 
 
 async def test_a_consumed_handle_cannot_be_used_again(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """The upload is destroyed with the command, so the second call is a 404.
 
@@ -456,7 +448,7 @@ async def test_a_consumed_handle_cannot_be_used_again(
     retry a handle that can never come back.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -483,10 +475,11 @@ async def test_the_media_view_refuses_an_unauthenticated_request(
     hass_client: ClientSessionGenerator,
     hass_client_no_auth: ClientSessionGenerator,
     hass_ws_client,
+    setup_entry,
 ) -> None:
     """An inventory photo is as private as the inventory it belongs to."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -510,11 +503,11 @@ async def test_the_media_view_refuses_an_unauthenticated_request(
 
 
 async def test_an_id_no_metadata_claims_is_a_404(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """The handler resolves files from stored metadata, never from the URL."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -531,10 +524,11 @@ async def test_a_non_image_is_refused_and_leaves_nothing_behind(
     hass_client: ClientSessionGenerator,
     hass_ws_client,
     upload_teardowns: list[tuple[int, Path]],
+    setup_entry,
 ) -> None:
     """SVG carries script and the view serves it from the Home Assistant origin."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -565,9 +559,9 @@ async def test_a_non_image_is_refused_and_leaves_nothing_behind(
 
 
 async def test_deleting_the_item_deletes_its_files(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -599,11 +593,11 @@ async def test_deleting_the_item_deletes_its_files(
 
 
 async def test_a_bulk_delete_deletes_the_item_files(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """The card's bulk bar and the organize dialog delete through `items/bulk`."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -630,11 +624,11 @@ async def test_a_bulk_delete_deletes_the_item_files(
 
 
 async def test_the_item_delete_service_deletes_the_item_files(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """Only this mode dispatches a service: the offline stub has no registry."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -651,7 +645,7 @@ async def test_the_item_delete_service_deletes_the_item_files(
 
 
 async def test_setup_sweeps_a_file_no_metadata_references(
-    hass: HomeAssistant, hass_storage: dict
+    hass: HomeAssistant, hass_storage: dict, setup_entry
 ) -> None:
     """A store restored without its media, or a save that never landed."""
 
@@ -665,13 +659,13 @@ async def test_setup_sweeps_a_file_no_metadata_references(
     orphan.parent.mkdir(parents=True, exist_ok=True)
     orphan.write_bytes(PNG_BYTES)
 
-    await _setup(hass)
+    await setup_entry()
 
     assert not orphan.exists()
 
 
 async def test_setup_sweeps_a_tile_an_earlier_encoder_generation_wrote(
-    hass: HomeAssistant, hass_storage: dict
+    hass: HomeAssistant, hass_storage: dict, setup_entry
 ) -> None:
     """An install upgraded across a change to the encode.
 
@@ -717,7 +711,7 @@ async def test_setup_sweeps_a_tile_an_earlier_encoder_generation_wrote(
     stale = original.with_name(f"{attachment_id}.thumb.webp")
     stale.write_bytes(b"RIFF\x24\x00\x00\x00WEBP\x00\x00\x00\x00")
 
-    await _setup(hass)
+    await setup_entry()
 
     assert not stale.exists()
     assert original.read_bytes() == PNG_BYTES
@@ -728,7 +722,7 @@ async def test_setup_sweeps_a_tile_an_earlier_encoder_generation_wrote(
 
 
 async def test_a_v5_store_boots_to_v6_with_both_backfills(
-    hass: HomeAssistant, hass_storage: dict, hass_ws_client
+    hass: HomeAssistant, hass_storage: dict, hass_ws_client, setup_entry
 ) -> None:
     """One step for the milestone: statuses seeded, attachments backfilled.
 
@@ -749,7 +743,7 @@ async def test_a_v5_store_boots_to_v6_with_both_backfills(
         },
     }
 
-    await _setup(hass)
+    await setup_entry()
 
     persisted = hass_storage[STORAGE_KEY]["data"]
     assert persisted["schema_version"] == CURRENT_SCHEMA_VERSION
@@ -770,7 +764,7 @@ async def test_a_v5_store_boots_to_v6_with_both_backfills(
 
 
 async def test_a_pdf_round_trips_as_a_manual_and_can_be_retitled(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """The document half of the same path: kind, sniffed type, and the title.
 
@@ -780,7 +774,7 @@ async def test_a_pdf_round_trips_as_a_manual_and_can_be_retitled(
     a response header no offline test has a transport for.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws, "Dishwasher")
@@ -850,7 +844,7 @@ async def test_a_pdf_round_trips_as_a_manual_and_can_be_retitled(
 
 
 async def test_only_a_name_versioned_url_may_be_cached(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """A retitle rewrites the served name for a URL that did not change.
 
@@ -861,7 +855,7 @@ async def test_only_a_name_versioned_url_may_be_cached(
     signature lives, which is not a window anyone waits out.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)
@@ -895,11 +889,11 @@ async def test_only_a_name_versioned_url_may_be_cached(
 
 
 async def test_a_pdf_is_refused_as_a_picture(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_ws_client, setup_entry
 ) -> None:
     """The allow-list is per kind, so the picture strip cannot fill with PDFs."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_client()
     ws = await hass_ws_client(hass)
     item = await _create_item(ws)

--- a/tests/integration/test_calendar.py
+++ b/tests/integration/test_calendar.py
@@ -15,17 +15,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 ENTITY_ID = "calendar.haventory"
-
-
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
 
 
 async def _create(hass: HomeAssistant, **payload) -> dict:
@@ -38,10 +29,11 @@ async def _create(hass: HomeAssistant, **payload) -> dict:
 
 async def test_the_calendar_takes_the_reserved_entity_id_and_a_constant_unique_id(
     hass: HomeAssistant,
+    setup_entry,
 ) -> None:
     """`calendar.haventory` is the name the repository reserved for this entity."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     registry = er.async_get(hass)
     entity = registry.async_get(ENTITY_ID)
@@ -56,8 +48,8 @@ async def test_the_calendar_takes_the_reserved_entity_id_and_a_constant_unique_i
     assert state.attributes["friendly_name"] == "HAventory"
 
 
-async def test_it_joins_the_same_device_as_the_sensors(hass: HomeAssistant) -> None:
-    entry = await _setup(hass)
+async def test_it_joins_the_same_device_as_the_sensors(hass: HomeAssistant, setup_entry) -> None:
+    entry = await setup_entry()
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
@@ -68,16 +60,18 @@ async def test_it_joins_the_same_device_as_the_sensors(hass: HomeAssistant) -> N
     assert entity.device_id == device.id
 
 
-async def test_an_empty_inventory_reports_no_event(hass: HomeAssistant) -> None:
-    await _setup(hass)
+async def test_an_empty_inventory_reports_no_event(hass: HomeAssistant, setup_entry) -> None:
+    await setup_entry()
 
     assert hass.states.get(ENTITY_ID).state == "off"
 
 
-async def test_async_get_events_projects_both_dated_fields(hass: HomeAssistant) -> None:
+async def test_async_get_events_projects_both_dated_fields(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """The range read a calendar dashboard performs."""
 
-    await _setup(hass)
+    await setup_entry()
     today = dt_util.now().date()
     due = today + timedelta(days=3)
     inspection = today + timedelta(days=5)
@@ -101,7 +95,9 @@ async def test_async_get_events_projects_both_dated_fields(hass: HomeAssistant) 
     assert projected[0]["end"] == (due + timedelta(days=1)).isoformat()
 
 
-async def test_the_summaries_are_written_in_the_servers_language(hass: HomeAssistant) -> None:
+async def test_the_summaries_are_written_in_the_servers_language(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """Both surfaces the text reaches, in German: the event a calendar card
     lists and the `message` attribute a notification automation templates.
 
@@ -110,7 +106,7 @@ async def test_the_summaries_are_written_in_the_servers_language(hass: HomeAssis
     """
 
     hass.config.language = "de"
-    await _setup(hass)
+    await setup_entry()
 
     today = dt_util.now().date()
     await _create(hass, name="Leiter", checked_out=True, due_date=today.isoformat())
@@ -134,7 +130,9 @@ async def test_the_summaries_are_written_in_the_servers_language(hass: HomeAssis
     ]
 
 
-async def test_checking_an_item_out_due_today_turns_the_calendar_on(hass: HomeAssistant) -> None:
+async def test_checking_an_item_out_due_today_turns_the_calendar_on(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """A mutation repaints the entity with no polling and no time travel.
 
     `on` means an event is running now, which for an all-day occurrence means
@@ -142,7 +140,7 @@ async def test_checking_an_item_out_due_today_turns_the_calendar_on(hass: HomeAs
     covers the other half.
     """
 
-    await _setup(hass)
+    await setup_entry()
     assert hass.states.get(ENTITY_ID).state == "off"
 
     item = await _create(hass, name="Ladder")
@@ -165,11 +163,12 @@ async def test_checking_an_item_out_due_today_turns_the_calendar_on(hass: HomeAs
 
 async def test_an_upcoming_date_is_announced_while_the_state_stays_off(
     hass: HomeAssistant,
+    setup_entry,
 ) -> None:
     """Home Assistant's `on` is "happening now", so a future date announces itself
     through the attributes an automation's template reads."""
 
-    await _setup(hass)
+    await setup_entry()
     due = dt_util.now().date() + timedelta(days=2)
 
     item = await _create(hass, name="Ladder")
@@ -187,8 +186,8 @@ async def test_an_upcoming_date_is_announced_while_the_state_stays_off(
     assert state.attributes["start_time"].startswith(due.isoformat())
 
 
-async def test_the_reported_event_is_the_nearest_one(hass: HomeAssistant) -> None:
-    await _setup(hass)
+async def test_the_reported_event_is_the_nearest_one(hass: HomeAssistant, setup_entry) -> None:
+    await setup_entry()
     today = dt_util.now().date()
 
     await _create(hass, name="Boiler", inspection_date=(today + timedelta(days=90)).isoformat())
@@ -197,10 +196,10 @@ async def test_the_reported_event_is_the_nearest_one(hass: HomeAssistant) -> Non
     assert hass.states.get(ENTITY_ID).attributes["message"] == "Smoke alarm inspection"
 
 
-async def test_a_past_date_is_not_reported_as_upcoming(hass: HomeAssistant) -> None:
+async def test_a_past_date_is_not_reported_as_upcoming(hass: HomeAssistant, setup_entry) -> None:
     """Overdue is a count, not a calendar state: the day is gone."""
 
-    await _setup(hass)
+    await setup_entry()
     yesterday = dt_util.now().date() - timedelta(days=1)
 
     await _create(hass, name="Extinguisher", inspection_date=yesterday.isoformat())
@@ -212,8 +211,8 @@ async def test_a_past_date_is_not_reported_as_upcoming(hass: HomeAssistant) -> N
     assert "message" not in state.attributes
 
 
-async def test_unload_removes_the_entity(hass: HomeAssistant) -> None:
-    entry = await _setup(hass)
+async def test_unload_removes_the_entity(hass: HomeAssistant, setup_entry) -> None:
+    entry = await setup_entry()
     assert hass.states.get(ENTITY_ID) is not None
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -223,7 +222,9 @@ async def test_unload_removes_the_entity(hass: HomeAssistant) -> None:
     assert state is None or state.state == "unavailable"
 
 
-async def test_a_location_rename_reaches_the_calendar_at_once(hass: HomeAssistant) -> None:
+async def test_a_location_rename_reaches_the_calendar_at_once(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """The event description is the item's stored path, held in a cached state.
 
     Nothing invalidated that state on a rename, so `calendar.haventory` kept
@@ -232,7 +233,7 @@ async def test_a_location_rename_reaches_the_calendar_at_once(hass: HomeAssistan
     attribute to say where the item is.
     """
 
-    await _setup(hass)
+    await setup_entry()
     garage = (
         await hass.services.async_call(
             DOMAIN, "location_create", {"name": "Garage"}, blocking=True, return_response=True

--- a/tests/integration/test_config_entry.py
+++ b/tests/integration/test_config_entry.py
@@ -39,14 +39,6 @@ from homeassistant.data_entry_flow import FlowResultType, InvalidData
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
-
-
 async def _subscribe(client, sub_id: int, topic: str = "items") -> None:
     """Open one topic subscription and assert the backend accepted it."""
 
@@ -81,7 +73,7 @@ async def test_config_entry_setup_and_unload(hass: HomeAssistant) -> None:
 
 
 async def test_unloaded_entry_leaves_the_ws_api_refusing(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """An entry that owns nothing serves nothing — the reload window, held open.
 
@@ -89,7 +81,7 @@ async def test_unloaded_entry_leaves_the_ws_api_refusing(
     what it meets mid-reload.
     """
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Screwdriver"})
@@ -119,11 +111,11 @@ async def test_unloaded_entry_leaves_the_ws_api_refusing(
 
 
 async def test_disabled_entry_refuses_like_a_removed_one(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """Disabling is the case with no setup coming to end it."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
 
     await hass.config_entries.async_set_disabled_by(entry.entry_id, ConfigEntryDisabler.USER)
@@ -137,7 +129,7 @@ async def test_disabled_entry_refuses_like_a_removed_one(
 
 
 async def test_reload_tells_an_open_subscriber_and_lets_it_re_subscribe(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The whole loop a dashboard left open goes through, over one connection.
 
@@ -149,7 +141,7 @@ async def test_reload_tells_an_open_subscriber_and_lets_it_re_subscribe(
 
     first_sub, second_sub = 10, 12
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
     await _subscribe(client, first_sub)
 
@@ -188,10 +180,10 @@ async def test_reload_tells_an_open_subscriber_and_lets_it_re_subscribe(
     assert event["event"]["item"]["name"] == "After"
 
 
-async def test_reload_keeps_the_inventory(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_reload_keeps_the_inventory(hass: HomeAssistant, hass_ws_client, setup_entry) -> None:
     """Teardown flushes and setup reads it back, so a reload loses nothing."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})
     assert (await client.receive_json())["success"] is True
@@ -206,11 +198,11 @@ async def test_reload_keeps_the_inventory(hass: HomeAssistant, hass_ws_client) -
 
 
 async def test_removed_entry_leaves_the_ws_api_refusing(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """A dashboard left open cannot go on reading or writing a removed inventory."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Screwdriver"})
@@ -235,18 +227,18 @@ async def test_removed_entry_leaves_the_ws_api_refusing(
 
 
 async def test_re_adding_a_removed_entry_restores_the_inventory(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """Removal keeps the store file, so adding the integration again brings it back."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Screwdriver"})
     assert (await client.receive_json())["success"] is True
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
-    await _setup(hass)
+    await setup_entry()
 
     await client.send_json({"id": 2, "type": "haventory/item/list"})
     listed = await client.receive_json()
@@ -255,7 +247,7 @@ async def test_re_adding_a_removed_entry_restores_the_inventory(
 
 
 async def test_the_options_flow_stores_a_pill_choice_the_card_then_reads(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The pill picker is a real selector, and only real HA applies it.
 
@@ -265,7 +257,7 @@ async def test_the_options_flow_stores_a_pill_choice_the_card_then_reads(
     what `haventory/config` then reports to the card.
     """
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/config"})
@@ -297,10 +289,12 @@ async def test_the_options_flow_stores_a_pill_choice_the_card_then_reads(
     assert after["result"]["quick_filters"] == ["low_stock", "overdue"]
 
 
-async def test_the_options_flow_refuses_a_pill_it_does_not_offer(hass: HomeAssistant) -> None:
+async def test_the_options_flow_refuses_a_pill_it_does_not_offer(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """A name outside the five is rejected by the form, not stored and dropped later."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     flow = await hass.config_entries.options.async_init(entry.entry_id)
     with pytest.raises(InvalidData):

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -19,7 +19,6 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     CLIENT_ID,
-    MockConfigEntry,
     async_capture_events,
     async_fire_time_changed,
 )
@@ -28,22 +27,14 @@ LOW_THRESHOLD = 3
 CREATED_QUANTITY = 2
 
 
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
-
-
 def _data(events: list[Event]) -> list[dict[str, Any]]:
     return [dict(e.data) for e in events]
 
 
-async def test_a_service_call_reaches_a_bus_listener(hass: HomeAssistant) -> None:
+async def test_a_service_call_reaches_a_bus_listener(hass: HomeAssistant, setup_entry) -> None:
     """`hass.bus.async_listen` sees `haventory_item_changed` from a service."""
 
-    await _setup(hass)
+    await setup_entry()
     captured = async_capture_events(hass, EVENT_ITEM_CHANGED)
 
     await hass.services.async_call(
@@ -61,9 +52,9 @@ async def test_a_service_call_reaches_a_bus_listener(hass: HomeAssistant) -> Non
 
 
 async def test_a_websocket_mutation_reaches_a_bus_listener(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
-    await _setup(hass)
+    await setup_entry()
     captured = async_capture_events(hass, EVENT_ITEM_CHANGED)
     client = await hass_ws_client(hass)
 
@@ -74,10 +65,10 @@ async def test_a_websocket_mutation_reaches_a_bus_listener(
     assert [p["action"] for p in _data(captured)] == ["created"]
 
 
-async def test_low_stock_fires_entered_and_cleared(hass: HomeAssistant) -> None:
+async def test_low_stock_fires_entered_and_cleared(hass: HomeAssistant, setup_entry) -> None:
     """The transition an automation triggers on, both ways, from a service call."""
 
-    await _setup(hass)
+    await setup_entry()
     captured = async_capture_events(hass, EVENT_LOW_STOCK)
 
     created = await hass.services.async_call(
@@ -106,7 +97,7 @@ async def test_low_stock_fires_entered_and_cleared(hass: HomeAssistant) -> None:
     assert [p["action"] for p in _data(captured)] == ["entered", "cleared"]
 
 
-async def test_a_real_automation_triggers_on_low_stock(hass: HomeAssistant) -> None:
+async def test_a_real_automation_triggers_on_low_stock(hass: HomeAssistant, setup_entry) -> None:
     """The story #218 promises, through HA's automation engine rather than a listener.
 
     An event trigger with an `action: entered` filter, and a template that reads
@@ -114,7 +105,7 @@ async def test_a_real_automation_triggers_on_low_stock(hass: HomeAssistant) -> N
     not just as a dict this integration happens to fire.
     """
 
-    await _setup(hass)
+    await setup_entry()
     assert await async_setup_component(
         hass,
         "automation",
@@ -162,10 +153,12 @@ async def test_a_real_automation_triggers_on_low_stock(hass: HomeAssistant) -> N
     assert [dict(e.data) for e in fired] == [{"item": "Batteries", "quantity": 1}]
 
 
-async def test_a_restart_re_announces_nothing(hass: HomeAssistant, hass_storage) -> None:
+async def test_a_restart_re_announces_nothing(
+    hass: HomeAssistant, hass_storage, setup_entry
+) -> None:
     """Setting up against a store that already holds low items fires no event."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     await hass.services.async_call(
         DOMAIN,
         "item_create",
@@ -186,7 +179,7 @@ async def test_a_restart_re_announces_nothing(hass: HomeAssistant, hass_storage)
 
 
 async def test_a_status_reassignment_reaches_the_bus_once_per_item(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """A bulk rewrite is still a set of item edits, and each one is announced.
 
@@ -196,7 +189,7 @@ async def test_a_status_reassignment_reaches_the_bus_once_per_item(
     set moved underneath it.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json(
@@ -283,7 +276,7 @@ async def _events_before_a_ping(client: Any, ping_id: int) -> list[dict[str, Any
 
 
 async def test_the_counts_roll_over_at_the_instances_midnight(
-    hass: HomeAssistant, hass_ws_client: Any, hass_admin_user: Any, freezer: Any
+    hass: HomeAssistant, hass_ws_client: Any, hass_admin_user: Any, freezer: Any, setup_entry
 ) -> None:
     """#584: an open subscription hears the day turn, with nothing mutated.
 
@@ -296,7 +289,7 @@ async def test_the_counts_roll_over_at_the_instances_midnight(
     await hass.config.async_set_time_zone(NZ_ZONE)
     freezer.move_to(NZ_LATE_EVENING)
 
-    await _setup(hass)
+    await setup_entry()
     client = await _frozen_clock_client(hass, hass_ws_client, hass_admin_user)
     await _subscribe_stats(client)
 
@@ -328,14 +321,14 @@ async def test_the_counts_roll_over_at_the_instances_midnight(
 
 
 async def test_an_unloaded_entry_announces_no_rollover(
-    hass: HomeAssistant, hass_ws_client: Any, hass_admin_user: Any, freezer: Any
+    hass: HomeAssistant, hass_ws_client: Any, hass_admin_user: Any, freezer: Any, setup_entry
 ) -> None:
     """The tracker goes with the entry, or it broadcasts counts nothing owns."""
 
     await hass.config.async_set_time_zone(NZ_ZONE)
     freezer.move_to(NZ_LATE_EVENING)
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await _frozen_clock_client(hass, hass_ws_client, hass_admin_user)
     await _subscribe_stats(client)
 

--- a/tests/integration/test_frontend.py
+++ b/tests/integration/test_frontend.py
@@ -17,7 +17,6 @@ from custom_components.haventory.const import (
     CONF_CARD_TITLE,
     CONF_SIDEBAR_PANEL_ENABLED,
     DEFAULT_CARD_TITLE,
-    DOMAIN,
     PANEL_ELEMENT_NAME,
     PANEL_ICON,
     PANEL_URL_PATH,
@@ -25,7 +24,6 @@ from custom_components.haventory.const import (
 from homeassistant.components import frontend
 from homeassistant.config_entries import ConfigEntryDisabler
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
 
 CARD_PATH = "/haventory_static/haventory-card.js"
@@ -42,14 +40,6 @@ needs_bundle = pytest.mark.skipif(
     not BUNDLE.is_file(),
     reason="card bundle not built (npm run build in cards/haventory-card)",
 )
-
-
-async def _setup(hass: HomeAssistant, options: dict | None = None) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory", options=options or {})
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
 
 
 def test_the_frontend_wheel_matches_what_this_ha_release_asks_for() -> None:
@@ -69,14 +59,14 @@ def test_the_frontend_wheel_matches_what_this_ha_release_asks_for() -> None:
 
 @needs_bundle
 async def test_bundle_is_served_without_cache_control(
-    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator, setup_entry
 ) -> None:
     """The static route serves the real bytes, and leaves revalidation on.
 
     A `Cache-Control` header here is the old `/local` failure mode: the browser
     keeps a stale card for as long as the header says, whatever the server has.
     """
-    await _setup(hass)
+    await setup_entry()
 
     response = await (await hass_client_no_auth()).get(CARD_PATH)
 
@@ -87,13 +77,13 @@ async def test_bundle_is_served_without_cache_control(
 
 
 @needs_bundle
-async def test_both_loaders_get_the_same_url(hass: HomeAssistant) -> None:
+async def test_both_loaders_get_the_same_url(hass: HomeAssistant, setup_entry) -> None:
     """One URL string, registered twice — the browser module map dedupes it.
 
     Two *different* URLs for the same module evaluate it twice, and the second
     `customElements.define("haventory-card", ...)` throws.
     """
-    await _setup(hass)
+    await setup_entry()
 
     module_urls = hass.data[frontend.DATA_EXTRA_MODULE_URL].urls
     resources = hass.data["lovelace"].resources.async_items()
@@ -106,14 +96,14 @@ async def test_both_loaders_get_the_same_url(hass: HomeAssistant) -> None:
 
 @needs_bundle
 async def test_reload_registers_the_static_route_once(
-    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator, setup_entry
 ) -> None:
     """aiohttp rejects a duplicate route, so a reload must not attempt one.
 
     The failure this guards is not cosmetic: an unguarded second registration
     raises out of `async_setup_entry` and leaves the entry in a retry loop.
     """
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
@@ -122,9 +112,9 @@ async def test_reload_registers_the_static_route_once(
 
 
 @needs_bundle
-async def test_unload_hands_back_the_module_url(hass: HomeAssistant) -> None:
+async def test_unload_hands_back_the_module_url(hass: HomeAssistant, setup_entry) -> None:
     """Unload takes the module URL out of the frontend's set; the route stays."""
-    entry = await _setup(hass)
+    entry = await setup_entry()
     assert hass.data[frontend.DATA_EXTRA_MODULE_URL].urls
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -134,14 +124,16 @@ async def test_unload_hands_back_the_module_url(hass: HomeAssistant) -> None:
 
 
 @needs_bundle
-async def test_removal_deletes_the_card_resource_and_module_url(hass: HomeAssistant) -> None:
+async def test_removal_deletes_the_card_resource_and_module_url(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """Removal takes both loaders back through the real resource collection.
 
     The offline suite asserts this against a mock collection; only the real
     `ResourceStorageCollection.async_delete_item` proves the id we hand it is
     the one it stores.
     """
-    entry = await _setup(hass)
+    entry = await setup_entry()
     resources = hass.data["lovelace"].resources
     assert [r for r in resources.async_items() if r["url"].startswith(CARD_PATH)]
 
@@ -154,7 +146,7 @@ async def test_removal_deletes_the_card_resource_and_module_url(hass: HomeAssist
 
 @needs_bundle
 async def test_removal_leaves_the_static_route_serving(
-    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator, setup_entry
 ) -> None:
     """aiohttp cannot drop a route, so a re-add must not register a second one.
 
@@ -162,17 +154,19 @@ async def test_removal_leaves_the_static_route_serving(
     losing it turns the next setup into the duplicate registration that leaves
     the entry in a retry loop.
     """
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
-    await _setup(hass)
+    await setup_entry()
 
     assert (await (await hass_client_no_auth()).get(CARD_PATH)).status == HTTP_OK
 
 
 @needs_bundle
-async def test_the_sidebar_panel_lands_in_the_real_panel_registry(hass: HomeAssistant) -> None:
+async def test_the_sidebar_panel_lands_in_the_real_panel_registry(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """`panel_custom` puts a real `Panel` in `hass.data`, built the way HA builds them.
 
     The offline suite asserts this against a stub of `async_register_panel`;
@@ -185,7 +179,7 @@ async def test_the_sidebar_panel_lands_in_the_real_panel_registry(hass: HomeAssi
     for; a key HA chose for itself is not drift and must not fail the scheduled
     run against a newer core.
     """
-    await _setup(hass)
+    await setup_entry()
 
     panel = hass.data[frontend.DATA_PANELS][PANEL_URL_PATH]
 
@@ -206,7 +200,9 @@ async def test_the_sidebar_panel_lands_in_the_real_panel_registry(hass: HomeAssi
 
 
 @needs_bundle
-async def test_a_reload_leaves_the_same_panel_object_in_place(hass: HomeAssistant) -> None:
+async def test_a_reload_leaves_the_same_panel_object_in_place(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """A browser standing on `/haventory` is sent away the moment the panel goes.
 
     Identity rather than presence: a remove-then-register inside the reload
@@ -214,7 +210,7 @@ async def test_a_reload_leaves_the_same_panel_object_in_place(hass: HomeAssistan
     the panel-update event that moves the browser. Only the real `frontend`
     component has that registry, so the offline suite cannot see this.
     """
-    entry = await _setup(hass)
+    entry = await setup_entry()
     panel = hass.data[frontend.DATA_PANELS][PANEL_URL_PATH]
 
     assert await hass.config_entries.async_reload(entry.entry_id)
@@ -224,13 +220,15 @@ async def test_a_reload_leaves_the_same_panel_object_in_place(hass: HomeAssistan
 
 
 @needs_bundle
-async def test_an_unload_on_its_own_keeps_the_sidebar_panel(hass: HomeAssistant) -> None:
+async def test_an_unload_on_its_own_keeps_the_sidebar_panel(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """The half of a reload the panel has to survive, asserted on its own.
 
     A reload is an unload followed by a setup; if the unload took the panel, the
     setup could only put a new one back and the page would be gone either way.
     """
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -241,6 +239,7 @@ async def test_an_unload_on_its_own_keeps_the_sidebar_panel(hass: HomeAssistant)
 @needs_bundle
 async def test_a_rename_replaces_the_panel_without_the_overwriting_error(
     hass: HomeAssistant,
+    setup_entry,
 ) -> None:
     """`async_register_built_in_panel` raises on a path already taken.
 
@@ -249,7 +248,7 @@ async def test_a_rename_replaces_the_panel_without_the_overwriting_error(
     listener, the sidebar keeps the old name, and nothing about it reaches the
     user.
     """
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     hass.config_entries.async_update_entry(entry, options={CONF_CARD_TITLE: "Pantry"})
     await hass.async_block_till_done()
@@ -260,13 +259,15 @@ async def test_a_rename_replaces_the_panel_without_the_overwriting_error(
 
 
 @needs_bundle
-async def test_a_disabled_entry_gives_the_sidebar_panel_back(hass: HomeAssistant) -> None:
+async def test_a_disabled_entry_gives_the_sidebar_panel_back(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """A disabled entry stays unloaded, so its sidebar entry opens nothing.
 
     Home Assistant sets `disabled_by` before it unloads; that ordering is what
     the unload path reads, and it is real-core behaviour a stub cannot vouch for.
     """
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     assert await hass.config_entries.async_set_disabled_by(entry.entry_id, ConfigEntryDisabler.USER)
     await hass.async_block_till_done()
@@ -275,9 +276,11 @@ async def test_a_disabled_entry_gives_the_sidebar_panel_back(hass: HomeAssistant
 
 
 @needs_bundle
-async def test_removing_the_entry_gives_the_sidebar_panel_back(hass: HomeAssistant) -> None:
+async def test_removing_the_entry_gives_the_sidebar_panel_back(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """The other end: nothing is coming back to serve the page it opens."""
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
@@ -286,9 +289,9 @@ async def test_removing_the_entry_gives_the_sidebar_panel_back(hass: HomeAssista
 
 
 @needs_bundle
-async def test_an_opted_out_entry_registers_no_panel(hass: HomeAssistant) -> None:
+async def test_an_opted_out_entry_registers_no_panel(hass: HomeAssistant, setup_entry) -> None:
     """The toggle is honoured at setup, and takes nothing else down with it."""
-    await _setup(hass, {CONF_SIDEBAR_PANEL_ENABLED: False})
+    await setup_entry({CONF_SIDEBAR_PANEL_ENABLED: False})
 
     assert PANEL_URL_PATH not in hass.data[frontend.DATA_PANELS]
     assert hass.data[frontend.DATA_EXTRA_MODULE_URL].urls

--- a/tests/integration/test_import_export.py
+++ b/tests/integration/test_import_export.py
@@ -8,24 +8,15 @@ is reproduced — the real-HA counterpart to the offline round-trip unit test.
 
 from __future__ import annotations
 
-from custom_components.haventory.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-
-async def _setup(hass: HomeAssistant) -> None:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
 
 
 async def test_export_then_import_into_emptied_instance(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """Export, empty the instance, import the document, and verify data returns."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
     quantity = 3
 
@@ -90,11 +81,11 @@ async def test_export_then_import_into_emptied_instance(
 
 
 async def test_import_preview_reports_errors_without_mutating(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """A structurally invalid document is reported, not applied."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     bad_document = {
@@ -123,7 +114,7 @@ async def test_import_preview_reports_errors_without_mutating(
 
 
 async def test_import_preview_name_collision_survives_the_wire(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The warning entry serializes through the real result envelope.
 
@@ -131,7 +122,7 @@ async def test_import_preview_name_collision_survives_the_wire(
     unmodified, so only the real command layer proves the payload survives it.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -12,24 +12,15 @@ import logging
 
 from custom_components.haventory.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
 
 
 async def test_a_service_mutation_logs_a_greppable_persist_line(
-    hass: HomeAssistant, caplog
+    hass: HomeAssistant, caplog, setup_entry
 ) -> None:
     """`grep persist_complete` on a user's log finds the line, and its timing."""
 
     caplog.set_level(logging.DEBUG, logger="custom_components.haventory.storage")
-    await _setup(hass)
+    await setup_entry()
 
     await hass.services.async_call(DOMAIN, "item_create", {"name": "Torch"}, blocking=True)
     await hass.async_block_till_done()
@@ -45,7 +36,7 @@ async def test_a_service_mutation_logs_a_greppable_persist_line(
 
 
 async def test_a_refusal_logs_the_operation_it_refused(
-    hass: HomeAssistant, hass_ws_client, caplog
+    hass: HomeAssistant, hass_ws_client, caplog, setup_entry
 ) -> None:
     """The other half: a rejection says which command it was, in the message.
 
@@ -54,7 +45,7 @@ async def test_a_refusal_logs_the_operation_it_refused(
     reading the log can see it.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
     caplog.clear()
     caplog.set_level(logging.WARNING, logger="custom_components.haventory.ws")
@@ -70,12 +61,12 @@ async def test_a_refusal_logs_the_operation_it_refused(
 
 
 async def test_the_setup_line_carries_the_numbers_a_boot_is_diagnosed_from(
-    hass: HomeAssistant, caplog
+    hass: HomeAssistant, caplog, setup_entry
 ) -> None:
     """The line an operator reads first after a start-up that looks wrong."""
 
     caplog.set_level(logging.DEBUG, logger="custom_components.haventory")
-    await _setup(hass)
+    await setup_entry()
 
     health = [r.getMessage() for r in caplog.records if "Storage health" in r.getMessage()]
 

--- a/tests/integration/test_reminders.py
+++ b/tests/integration/test_reminders.py
@@ -11,12 +11,10 @@ from __future__ import annotations
 import uuid
 from datetime import timedelta
 
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.runtime import find_runtime
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, STORAGE_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 CALENDAR = "calendar.haventory"
 PLAIN_ITEM_ID = str(uuid.uuid4())
@@ -58,22 +56,14 @@ def _v7_store_data() -> dict:
     }
 
 
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
-
-
 async def test_a_v7_store_boots_to_the_current_version_with_the_fields_backfilled(
-    hass: HomeAssistant, hass_storage: dict
+    hass: HomeAssistant, hass_storage: dict, setup_entry
 ) -> None:
     """The upgrade an existing install takes, against a real `Store`."""
 
     hass_storage[STORAGE_KEY] = {"version": 1, "key": STORAGE_KEY, "data": _v7_store_data()}
 
-    await _setup(hass)
+    await setup_entry()
 
     persisted = hass_storage[STORAGE_KEY]["data"]
     assert persisted["schema_version"] == CURRENT_SCHEMA_VERSION == REMINDER_SCHEMA_VERSION
@@ -91,11 +81,11 @@ async def test_a_v7_store_boots_to_the_current_version_with_the_fields_backfille
 
 
 async def test_a_reminder_set_over_websocket_survives_a_reload(
-    hass: HomeAssistant, hass_storage: dict, hass_ws_client
+    hass: HomeAssistant, hass_storage: dict, hass_ws_client, setup_entry
 ) -> None:
     """Stored state, not runtime state: it has to come back off disk."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "HVAC filter"})
@@ -123,11 +113,11 @@ async def test_a_reminder_set_over_websocket_survives_a_reload(
 
 
 async def test_a_recurring_reminder_draws_its_next_occurrences_on_the_calendar(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The story the issue tells, read back through the calendar's own service."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
     anchor = dt_util.now().date() + timedelta(days=1)
 
@@ -163,9 +153,9 @@ async def test_a_recurring_reminder_draws_its_next_occurrences_on_the_calendar(
 
 
 async def test_bumping_moves_the_series_and_the_calendar_with_it(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
     anchor = dt_util.now().date()
 
@@ -197,11 +187,11 @@ async def test_bumping_moves_the_series_and_the_calendar_with_it(
 
 
 async def test_an_interval_with_no_anchor_is_refused_by_the_real_dispatch(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The offline stub cannot see HA's own schema validation ahead of the handler."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "HVAC filter"})
@@ -222,7 +212,7 @@ async def test_an_interval_with_no_anchor_is_refused_by_the_real_dispatch(
 
 
 async def test_an_evening_bump_west_of_greenwich_keeps_the_calendar_day(
-    hass: HomeAssistant, hass_ws_client, freezer
+    hass: HomeAssistant, hass_ws_client, freezer, setup_entry
 ) -> None:
     """The moment the two day boundaries disagree, pinned.
 
@@ -234,7 +224,7 @@ async def test_an_evening_bump_west_of_greenwich_keeps_the_calendar_day(
     """
 
     await hass.config.async_set_time_zone("America/Los_Angeles")
-    await _setup(hass)
+    await setup_entry()
     # After the client has authenticated: the token the fixture mints is checked
     # against the wall clock, and a frozen one is outside its window.
     client = await hass_ws_client(hass)
@@ -262,7 +252,7 @@ async def test_an_evening_bump_west_of_greenwich_keeps_the_calendar_day(
 
 
 async def test_a_v8_store_gains_an_anchor_for_every_reminder_it_holds(
-    hass: HomeAssistant, hass_storage: dict
+    hass: HomeAssistant, hass_storage: dict, setup_entry
 ) -> None:
     """The upgrade the release before this one leaves behind, through a real `Store`.
 
@@ -280,7 +270,7 @@ async def test_a_v8_store_gains_an_anchor_for_every_reminder_it_holds(
     data["items"][PLAIN_ITEM_ID]["reminder_interval"] = None
     hass_storage[STORAGE_KEY] = {"version": 1, "key": STORAGE_KEY, "data": data}
 
-    await _setup(hass)
+    await setup_entry()
 
     persisted = hass_storage[STORAGE_KEY]["data"]
     assert persisted["schema_version"] == CURRENT_SCHEMA_VERSION
@@ -292,7 +282,7 @@ async def test_a_v8_store_gains_an_anchor_for_every_reminder_it_holds(
 
 
 async def test_a_bumped_month_end_series_keeps_its_day_across_a_reload(
-    hass: HomeAssistant, hass_storage: dict, hass_ws_client
+    hass: HomeAssistant, hass_storage: dict, hass_ws_client, setup_entry
 ) -> None:
     """The whole point of the stored anchor, end to end and through a restart.
 
@@ -301,7 +291,7 @@ async def test_a_bumped_month_end_series_keeps_its_day_across_a_reload(
     from what was written.
     """
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Meter reading"})

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -41,14 +41,6 @@ def _local_day_offset(days: int) -> str:
     return (dt_util.now().date() + timedelta(days=days)).isoformat()
 
 
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
-
-
 def _sensor_entries(hass: HomeAssistant, entry: MockConfigEntry) -> list[er.RegistryEntry]:
     """Only this platform's entities — the entry also owns `calendar.haventory`."""
 
@@ -80,10 +72,10 @@ def _entity_id_for(hass: HomeAssistant, entry: MockConfigEntry, key: str) -> str
     )
 
 
-async def test_every_sensor_lands_on_one_device(hass: HomeAssistant) -> None:
+async def test_every_sensor_lands_on_one_device(hass: HomeAssistant, setup_entry) -> None:
     """One service device, one entity per catalog entry, `unique_id`s scoped to it."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     entries = _sensor_entries(hass, entry)
     assert len(entries) == len(SENSOR_DESCRIPTIONS)
@@ -107,14 +99,16 @@ async def test_every_sensor_lands_on_one_device(hass: HomeAssistant) -> None:
         assert not state.attributes["friendly_name"].endswith("HAventory ")
 
 
-async def test_items_total_moves_on_a_service_call_with_no_polling(hass: HomeAssistant) -> None:
+async def test_items_total_moves_on_a_service_call_with_no_polling(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """`haventory.item_create` repaints the sensor — the path that emitted nothing.
 
     No `async_update_entity`, no time travel: if the push were missing the state
     would still read 0 here.
     """
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     total = _entity_id_for(hass, entry, "items_total")
 
     assert hass.states.get(total).state == "0"
@@ -126,11 +120,11 @@ async def test_items_total_moves_on_a_service_call_with_no_polling(hass: HomeAss
 
 
 async def test_items_total_moves_on_a_websocket_mutation(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The other write path pushes the same way."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     total = _entity_id_for(hass, entry, "items_total")
     client = await hass_ws_client(hass)
 
@@ -141,8 +135,8 @@ async def test_items_total_moves_on_a_websocket_mutation(
     assert hass.states.get(total).state == "1"
 
 
-async def test_low_stock_sensor_tracks_the_threshold(hass: HomeAssistant) -> None:
-    entry = await _setup(hass)
+async def test_low_stock_sensor_tracks_the_threshold(hass: HomeAssistant, setup_entry) -> None:
+    entry = await setup_entry()
     low = _entity_id_for(hass, entry, "low_stock_count")
 
     created = await hass.services.async_call(
@@ -165,10 +159,10 @@ async def test_low_stock_sensor_tracks_the_threshold(hass: HomeAssistant) -> Non
     assert hass.states.get(low).state == "1"
 
 
-async def test_unload_removes_the_entities(hass: HomeAssistant) -> None:
+async def test_unload_removes_the_entities(hass: HomeAssistant, setup_entry) -> None:
     """An unloaded entry serves nothing, entities included."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     entity_ids = _entity_ids(hass, entry)
     assert entity_ids
 
@@ -181,10 +175,10 @@ async def test_unload_removes_the_entities(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("descriptor", SENSOR_DESCRIPTIONS, ids=lambda d: d.key)
-async def test_each_sensor_reports_its_count(hass: HomeAssistant, descriptor) -> None:
+async def test_each_sensor_reports_its_count(hass: HomeAssistant, descriptor, setup_entry) -> None:
     """Every entity reads its own key, so none of them is wired to the wrong one."""
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     repo = find_runtime(hass).repository
 
     entity_id = _entity_id_for(hass, entry, descriptor.key)
@@ -192,14 +186,16 @@ async def test_each_sensor_reports_its_count(hass: HomeAssistant, descriptor) ->
     assert hass.states.get(entity_id).state == str(repo.get_counts()[descriptor.key])
 
 
-async def test_an_item_due_back_today_is_due_and_not_overdue(hass: HomeAssistant) -> None:
+async def test_an_item_due_back_today_is_due_and_not_overdue(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """The two check-out sensors differ by exactly the items due back today.
 
     Driven through `item_check_out`, which is the only way a due date can exist,
     so the count is read off the same path a household uses.
     """
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     due = _entity_id_for(hass, entry, "checked_out_due_count")
     overdue = _entity_id_for(hass, entry, "overdue_count")
 
@@ -241,14 +237,16 @@ async def test_an_item_due_back_today_is_due_and_not_overdue(hass: HomeAssistant
     assert hass.states.get(overdue).state == "0"
 
 
-async def test_an_inspection_due_today_is_due_and_not_overdue(hass: HomeAssistant) -> None:
+async def test_an_inspection_due_today_is_due_and_not_overdue(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """The two inspection sensors differ by exactly the items due today.
 
     `due` includes today and `overdue` does not — the distinction the counts are
     named for, read off the entities a dashboard actually shows.
     """
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     due = _entity_id_for(hass, entry, "inspection_due_count")
     overdue = _entity_id_for(hass, entry, "inspection_overdue_count")
 
@@ -276,7 +274,7 @@ async def test_an_inspection_due_today_is_due_and_not_overdue(hass: HomeAssistan
 
 
 async def test_the_inspection_due_sensor_reads_the_instances_day(
-    hass: HomeAssistant, freezer
+    hass: HomeAssistant, freezer, setup_entry
 ) -> None:
     """The issue's reproduction, east of Greenwich (#568).
 
@@ -289,7 +287,7 @@ async def test_the_inspection_due_sensor_reads_the_instances_day(
     await hass.config.async_set_time_zone(NZ_ZONE)
     freezer.move_to(NZ_EARLY_MORNING)
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     due = _entity_id_for(hass, entry, "inspection_due_count")
 
     await hass.services.async_call(
@@ -302,7 +300,7 @@ async def test_the_inspection_due_sensor_reads_the_instances_day(
 
 
 async def test_the_inspection_due_sensor_rolls_over_at_the_instances_midnight(
-    hass: HomeAssistant, freezer
+    hass: HomeAssistant, freezer, setup_entry
 ) -> None:
     """A date-derived count rewrites on the rollover, with nothing mutated.
 
@@ -316,7 +314,7 @@ async def test_the_inspection_due_sensor_rolls_over_at_the_instances_midnight(
     await hass.config.async_set_time_zone(NZ_ZONE)
     freezer.move_to(NZ_LATE_EVENING)
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     due = _entity_id_for(hass, entry, "inspection_due_count")
 
     await hass.services.async_call(
@@ -333,7 +331,7 @@ async def test_the_inspection_due_sensor_rolls_over_at_the_instances_midnight(
 
 
 async def test_the_location_sensor_moves_on_a_location_mutation(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """A location create touches no item, and the count is still a sensor.
 
@@ -341,7 +339,7 @@ async def test_the_location_sensor_moves_on_a_location_mutation(
     reports the old figure until something happens to edit an item.
     """
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
     locations = _entity_id_for(hass, entry, "locations_total")
     client = await hass_ws_client(hass)
 

--- a/tests/integration/test_service_broadcast.py
+++ b/tests/integration/test_service_broadcast.py
@@ -14,21 +14,12 @@ import asyncio
 
 from custom_components.haventory.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 EVENT_WAIT_SECONDS = 5
 
 # Subscription ids, so an assertion can say which topic a frame arrived on.
 ITEMS_SUB = 10
 STATS_SUB = 11
-
-
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
 
 
 async def _subscribe(client, sub_id: int, topic: str) -> None:
@@ -59,11 +50,11 @@ async def _drain_events(client, count: int) -> list[dict]:
 
 
 async def test_item_create_service_delivers_items_and_counts(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """#450's acceptance, through the registry that actually dispatches."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
     await _subscribe(client, ITEMS_SUB, "items")
     await _subscribe(client, STATS_SUB, "stats")
@@ -84,11 +75,11 @@ async def test_item_create_service_delivers_items_and_counts(
 
 
 async def test_every_item_service_delivers_one_event_with_its_action(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """Every write path, not just the one the issue happened to name."""
 
-    await _setup(hass)
+    await setup_entry()
     created = await hass.services.async_call(
         DOMAIN, "item_create", {"name": "Widget"}, blocking=True, return_response=True
     )
@@ -115,11 +106,11 @@ async def test_every_item_service_delivers_one_event_with_its_action(
 
 
 async def test_location_services_deliver_locations_events(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The other half of "a `haventory.*` mutation reaches no subscriber"."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
     await _subscribe(client, 30, "locations")
 

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -27,14 +27,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 DUE_DATE = "2030-01-01"
 
 
-async def _setup(hass: HomeAssistant) -> Repository:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return find_runtime(hass).repository
-
-
 async def _call(hass: HomeAssistant, service: str, data: dict) -> None:
     await hass.services.async_call(DOMAIN, service, data, blocking=True)
     await hass.async_block_till_done()
@@ -52,10 +44,10 @@ def _only_item_id(repo: Repository) -> str:
     return str(items[0].id)
 
 
-async def test_all_services_are_registered(hass: HomeAssistant) -> None:
+async def test_all_services_are_registered(hass: HomeAssistant, setup_entry) -> None:
     """Setup registers the full ``haventory.*`` catalog."""
 
-    await _setup(hass)
+    await setup_entry()
 
     assert hass.services.async_services_for_domain(DOMAIN).keys() == {
         "item_create",
@@ -73,7 +65,7 @@ async def test_all_services_are_registered(hass: HomeAssistant) -> None:
     }
 
 
-async def test_every_service_dispatches_its_handler(hass: HomeAssistant) -> None:
+async def test_every_service_dispatches_its_handler(hass: HomeAssistant, setup_entry) -> None:
     """Calling each service through HA runs the handler and mutates the repository.
 
     One walk covers the whole catalog: a location is created, renamed and finally
@@ -82,7 +74,8 @@ async def test_every_service_dispatches_its_handler(hass: HomeAssistant) -> None
     handler to the executor instead of awaiting it.
     """
 
-    repo = await _setup(hass)
+    await setup_entry()
+    repo = find_runtime(hass).repository
 
     await _call(hass, "location_create", {"name": "Garage"})
     location_id = _only_location_id(repo)
@@ -132,11 +125,11 @@ async def test_every_service_dispatches_its_handler(hass: HomeAssistant) -> None
 
 
 async def test_service_call_persists_through_the_store(
-    hass: HomeAssistant, hass_storage: dict
+    hass: HomeAssistant, hass_storage: dict, setup_entry
 ) -> None:
     """A service mutation reaches the HA Store, not just the in-memory repository."""
 
-    await _setup(hass)
+    await setup_entry()
 
     await _call(hass, "item_create", {"name": "Flashlight", "quantity": 2})
 
@@ -144,10 +137,10 @@ async def test_service_call_persists_through_the_store(
     assert any(i["name"] == "Flashlight" for i in persisted["items"].values())
 
 
-async def test_service_call_surfaces_domain_errors(hass: HomeAssistant) -> None:
+async def test_service_call_surfaces_domain_errors(hass: HomeAssistant, setup_entry) -> None:
     """A repository error reaches the caller instead of being swallowed mid-dispatch."""
 
-    await _setup(hass)
+    await setup_entry()
 
     with pytest.raises(NotFoundError):
         await _call(hass, "item_update", {"item_id": "does-not-exist", "name": "Nope"})
@@ -176,10 +169,11 @@ async def test_service_call_after_removal_refuses(hass: HomeAssistant, hass_stor
     assert [i["name"] for i in hass_storage[STORAGE_KEY]["data"]["items"].values()] == ["Torch"]
 
 
-async def test_service_call_rejects_a_bad_payload(hass: HomeAssistant) -> None:
+async def test_service_call_rejects_a_bad_payload(hass: HomeAssistant, setup_entry) -> None:
     """HA validates against the registered schema before the handler runs."""
 
-    repo = await _setup(hass)
+    await setup_entry()
+    repo = find_runtime(hass).repository
 
     # ``item_create`` requires a name; the registered schema rejects the call.
     with pytest.raises(vol.Invalid):
@@ -193,14 +187,17 @@ async def test_service_call_rejects_a_bad_payload(hass: HomeAssistant) -> None:
     assert repo.get_counts()["items_total"] == 0
 
 
-async def test_services_answer_when_the_caller_asks_for_a_response(hass: HomeAssistant) -> None:
+async def test_services_answer_when_the_caller_asks_for_a_response(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """``return_response`` hands back the entity, so a script can chain calls.
 
     ``supports_response`` lives in the real service registry — the offline stub
     has none, so nothing about this classification is observable there.
     """
 
-    repo = await _setup(hass)
+    await setup_entry()
+    repo = find_runtime(hass).repository
 
     created = await hass.services.async_call(
         DOMAIN, "item_create", {"name": "Torch"}, blocking=True, return_response=True
@@ -236,10 +233,13 @@ async def test_services_answer_when_the_caller_asks_for_a_response(hass: HomeAss
     assert moved["item"]["version"] == created["item"]["version"] + 1
 
 
-async def test_a_caller_that_ignores_the_response_still_mutates(hass: HomeAssistant) -> None:
+async def test_a_caller_that_ignores_the_response_still_mutates(
+    hass: HomeAssistant, setup_entry
+) -> None:
     """``OPTIONAL`` means the pre-existing call shape keeps working unchanged."""
 
-    repo = await _setup(hass)
+    await setup_entry()
+    repo = find_runtime(hass).repository
 
     # No `return_response`: HA returns None and the mutation still lands.
     answer = await hass.services.async_call(DOMAIN, "item_create", {"name": "Torch"}, blocking=True)
@@ -249,11 +249,12 @@ async def test_a_caller_that_ignores_the_response_still_mutates(hass: HomeAssist
     assert repo.get_counts()["items_total"] == 1
 
 
-async def test_delete_answers_with_the_body_it_removed(hass: HomeAssistant) -> None:
+async def test_delete_answers_with_the_body_it_removed(hass: HomeAssistant, setup_entry) -> None:
     """The response is the item as it last stood, and the repository is empty after."""
 
     quantity = 3
-    repo = await _setup(hass)
+    await setup_entry()
+    repo = find_runtime(hass).repository
     await _call(hass, "item_create", {"name": "Torch", "quantity": quantity})
     item_id = _only_item_id(repo)
 
@@ -268,7 +269,7 @@ async def test_delete_answers_with_the_body_it_removed(hass: HomeAssistant) -> N
     assert repo.get_counts()["items_total"] == 0
 
 
-async def test_reminders_are_reachable_from_an_automation(hass: HomeAssistant) -> None:
+async def test_reminders_are_reachable_from_an_automation(hass: HomeAssistant, setup_entry) -> None:
     """The whole point of the service surface: a household can act on a reminder.
 
     Reminders shipped WebSocket-only, and no Home Assistant automation can send a
@@ -276,7 +277,7 @@ async def test_reminders_are_reachable_from_an_automation(hass: HomeAssistant) -
     automation-facing feature of the release, was unreachable from an automation.
     """
 
-    await _setup(hass)
+    await setup_entry()
 
     created = await hass.services.async_call(
         DOMAIN,

--- a/tests/integration/test_stale_files.py
+++ b/tests/integration/test_stale_files.py
@@ -20,11 +20,9 @@ from pathlib import Path
 
 import pytest
 from custom_components.haventory import stale_files
-from custom_components.haventory.const import DOMAIN
 from custom_components.haventory.runtime import find_runtime
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 RETIRED_MODULE = "reminders.py"
 
@@ -39,16 +37,8 @@ def install_dir(tmp_path: Path, monkeypatch) -> Path:
     return directory
 
 
-async def _setup(hass: HomeAssistant) -> MockConfigEntry:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    return entry
-
-
 async def test_setup_sweeps_a_retired_file_through_the_real_executor(
-    hass: HomeAssistant, install_dir: Path, monkeypatch
+    hass: HomeAssistant, install_dir: Path, monkeypatch, setup_entry
 ) -> None:
     """The upgrade case, end to end: the file is gone and the entry is loaded."""
 
@@ -56,7 +46,7 @@ async def test_setup_sweeps_a_retired_file_through_the_real_executor(
     left_behind = install_dir / RETIRED_MODULE
     left_behind.write_text("LEGACY = True\n", encoding="utf-8")
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     assert entry.state is ConfigEntryState.LOADED
     assert not left_behind.exists()
@@ -65,7 +55,7 @@ async def test_setup_sweeps_a_retired_file_through_the_real_executor(
 
 
 async def test_a_swept_path_that_escapes_the_package_is_refused_on_the_executor(
-    hass: HomeAssistant, install_dir: Path, monkeypatch, caplog
+    hass: HomeAssistant, install_dir: Path, monkeypatch, caplog, setup_entry
 ) -> None:
     """A typo in the list points into the operator's config tree; setup must not follow it."""
 
@@ -73,7 +63,7 @@ async def test_a_swept_path_that_escapes_the_package_is_refused_on_the_executor(
     outside = (install_dir / "../secrets.yaml").resolve()
     outside.write_text("token: secret\n", encoding="utf-8")
 
-    entry = await _setup(hass)
+    entry = await setup_entry()
 
     assert entry.state is ConfigEntryState.LOADED
     assert outside.read_text(encoding="utf-8") == "token: secret\n"

--- a/tests/integration/test_ws_errors.py
+++ b/tests/integration/test_ws_errors.py
@@ -15,24 +15,15 @@ either case is asserted here or nowhere.
 
 from __future__ import annotations
 
-from custom_components.haventory.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-
-async def _setup(hass: HomeAssistant) -> None:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
 
 
 async def test_the_error_context_reaches_the_client_intact(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """`data` arrives with the request fields the taxonomy promised, not just `op`."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/get", "item_id": "does-not-exist"})
@@ -44,7 +35,7 @@ async def test_the_error_context_reaches_the_client_intact(
 
 
 async def test_a_nested_error_payload_survives_the_wire(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The richest `data` there is: a list of objects, not a flat string map.
 
@@ -53,7 +44,7 @@ async def test_a_nested_error_payload_survives_the_wire(
     nesting on the way out would cost the whole message.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json(
@@ -78,7 +69,7 @@ async def test_a_nested_error_payload_survives_the_wire(
 
 
 async def test_home_assistants_own_refusal_carries_no_data_key(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """The counter-case: `data` is ours, not something every frame arrives with.
 
@@ -88,7 +79,7 @@ async def test_home_assistants_own_refusal_carries_no_data_key(
     to everything.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/get"})
@@ -100,7 +91,7 @@ async def test_home_assistants_own_refusal_carries_no_data_key(
 
 
 async def test_a_reused_frame_id_is_refused_before_the_command_runs(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """Real connections track `last_id`; the offline helpers dispatch each frame alone.
 
@@ -108,7 +99,7 @@ async def test_a_reused_frame_id_is_refused_before_the_command_runs(
     real client gets away with, and a card that did it would find out here.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 7, "type": "haventory/item/create", "name": "First"})
@@ -126,7 +117,7 @@ async def test_a_reused_frame_id_is_refused_before_the_command_runs(
 
 
 async def test_a_command_this_build_does_not_have_is_answered_not_ignored(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """What a newer card meets on an older backend: an answer it can branch on.
 
@@ -134,7 +125,7 @@ async def test_a_command_this_build_does_not_have_is_answered_not_ignored(
     a fine test failure and no description at all of what a client receives.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/teleport"})

--- a/tests/integration/test_ws_items.py
+++ b/tests/integration/test_ws_items.py
@@ -7,22 +7,13 @@ validation, dispatch, and the result envelope against the actual HA API.
 
 from __future__ import annotations
 
-from custom_components.haventory.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
-async def _setup(hass: HomeAssistant) -> None:
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title="HAventory")
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-
-async def test_ws_item_create_get_list(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_ws_item_create_get_list(hass: HomeAssistant, hass_ws_client, setup_entry) -> None:
     """Create an item, then fetch it by id and see it in the list."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     create_id, get_id, list_id = 1, 2, 3
@@ -63,7 +54,9 @@ async def test_ws_item_create_get_list(hass: HomeAssistant, hass_ws_client) -> N
     assert "Screwdriver" in names
 
 
-async def test_ws_rename_keeps_item_versions_valid(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_ws_rename_keeps_item_versions_valid(
+    hass: HomeAssistant, hass_ws_client, setup_entry
+) -> None:
     """A location rename must not spend the client's optimistic-concurrency token.
 
     The rename rewrites the item's derived ``location_path``; a client holding
@@ -72,7 +65,7 @@ async def test_ws_rename_keeps_item_versions_valid(hass: HomeAssistant, hass_ws_
     check wrong without anything failing.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/location/create", "name": "Garage"})
@@ -127,7 +120,7 @@ async def test_ws_rename_keeps_item_versions_valid(hass: HomeAssistant, hass_ws_
 
 
 async def test_ws_subscribe_accepts_area_id_and_refuses_unknown_keys(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """Real HA applies the subscribe schema; the offline stub stores it unapplied.
 
@@ -136,7 +129,7 @@ async def test_ws_subscribe_accepts_area_id_and_refuses_unknown_keys(
     against a real connection.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json(
@@ -158,10 +151,12 @@ async def test_ws_subscribe_accepts_area_id_and_refuses_unknown_keys(
     assert refused["success"] is False, refused
 
 
-async def test_ws_item_get_unknown_returns_error(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_ws_item_get_unknown_returns_error(
+    hass: HomeAssistant, hass_ws_client, setup_entry
+) -> None:
     """Fetching a missing item surfaces a structured error, not a crash."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/get", "item_id": "does-not-exist"})
@@ -170,7 +165,9 @@ async def test_ws_item_get_unknown_returns_error(hass: HomeAssistant, hass_ws_cl
     assert "error" in resp
 
 
-async def test_widened_frames_answer_validation_error(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_widened_frames_answer_validation_error(
+    hass: HomeAssistant, hass_ws_client, setup_entry
+) -> None:
     """The fields typed ``object`` reach the handler and answer through the guard.
 
     Home Assistant refuses a schema mismatch before ``ws_guard`` runs, so a
@@ -179,7 +176,7 @@ async def test_widened_frames_answer_validation_error(hass: HomeAssistant, hass_
     tell the two answers apart.
     """
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     frames = [
@@ -205,11 +202,11 @@ async def test_widened_frames_answer_validation_error(hass: HomeAssistant, hass_
 
 
 async def test_item_list_input_hardening_over_the_real_schema(
-    hass: HomeAssistant, hass_ws_client
+    hass: HomeAssistant, hass_ws_client, setup_entry
 ) -> None:
     """Unknown filter keys, unknown sort fields and bad cursors are refused."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})
@@ -242,10 +239,12 @@ async def test_item_list_input_hardening_over_the_real_schema(
     assert [i["name"] for i in listed["result"]["items"]] == ["Hammer"]
 
 
-async def test_duplicate_op_ids_reject_the_batch(hass: HomeAssistant, hass_ws_client) -> None:
+async def test_duplicate_op_ids_reject_the_batch(
+    hass: HomeAssistant, hass_ws_client, setup_entry
+) -> None:
     """Results are keyed by op_id, so a repeat has to fail the whole command."""
 
-    await _setup(hass)
+    await setup_entry()
     client = await hass_ws_client(hass)
 
     await client.send_json({"id": 1, "type": "haventory/item/create", "name": "Hammer"})

--- a/tests/lovelace_helpers.py
+++ b/tests/lovelace_helpers.py
@@ -1,0 +1,71 @@
+"""Stand-ins for Lovelace's two resource collections.
+
+Registering and taking back the card resource is written against a collection
+whose loading state the caller has to get right, and against a second one that
+cannot be written to at all. Both are modelled here, where the tests for the
+registration and for the removal can share them.
+
+* :class:`MockResourceCollection` is storage mode. ``stored`` is the backing
+  store; ``async_items`` reports nothing until something loads it, while every
+  mutation loads first — so code that reads before writing has to load for
+  itself or it sees an empty collection that is not empty.
+* :class:`MockYamlResourceCollection` is YAML mode: readable, with no mutation
+  API at all, which is why the card also goes out through the frontend's
+  extra-module URL.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class MockResourceCollection:
+    """Lovelace resources in storage mode: create, update and delete."""
+
+    def __init__(self, items: list[dict[str, Any]] | None = None, *, loaded: bool = True) -> None:
+        self.loaded = loaded
+        self.stored: list[dict[str, Any]] = list(items or [])
+        self.created: list[dict[str, Any]] = []
+        self.updated: list[tuple[str, dict[str, Any]]] = []
+        self.deleted: list[str] = []
+
+    def async_items(self) -> list[dict[str, Any]]:
+        return self.stored if self.loaded else []
+
+    async def async_load(self) -> None:
+        self.loaded = True
+
+    async def async_create_item(self, data: dict[str, Any]) -> dict[str, Any]:
+        self.loaded = True
+        self.created.append(data)
+        item = {"id": f"created_{len(self.created)}", **data}
+        self.stored.append(item)
+        return item
+
+    async def async_update_item(self, item_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        self.loaded = True
+        for item in self.stored:
+            if item.get("id") == item_id:
+                item.update(updates)
+                self.updated.append((item_id, updates))
+                return item
+        raise KeyError(item_id)
+
+    async def async_delete_item(self, item_id: str) -> None:
+        self.loaded = True
+        self.deleted.append(item_id)
+        self.stored = [item for item in self.stored if item.get("id") != item_id]
+
+
+class MockYamlResourceCollection:
+    """Lovelace resources in YAML mode: readable, with no mutation API."""
+
+    def __init__(self, items: list[dict[str, Any]] | None = None) -> None:
+        self.loaded = True
+        self.stored: list[dict[str, Any]] = list(items or [])
+
+    def async_items(self) -> list[dict[str, Any]]:
+        return self.stored
+
+    async def async_load(self) -> None:
+        pass

--- a/tests/online_helpers.py
+++ b/tests/online_helpers.py
@@ -1,0 +1,77 @@
+"""What every online smoke needs before it can say anything about HAventory.
+
+The smokes (``tests/*_online.py``) talk to a real Home Assistant over its own
+WebSocket API rather than to a stub, so each of them has to open a socket,
+authenticate, send frames under ids of its own making and pick its answer out of
+a stream that also carries events. That is the same four helpers every time.
+
+`HA_BASE_URL` and `HA_TOKEN` come from the environment — see
+``docs/developing.md``; a smoke runs only with ``RUN_ONLINE=1``, so nothing here
+is reached by the offline suite.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def ws_url_from_base(base_url: str) -> str:
+    """The WebSocket endpoint for an instance given by its HTTP base URL."""
+
+    base_url = base_url.rstrip("/")
+    if base_url.startswith("https://"):
+        return f"wss://{base_url[len('https://') :]}/api/websocket"
+    if base_url.startswith("http://"):
+        return f"ws://{base_url[len('http://') :]}/api/websocket"
+    return f"ws://{base_url}/api/websocket"
+
+
+async def open_ws() -> tuple[aiohttp.ClientSession, aiohttp.ClientWebSocketResponse]:
+    """Connect and authenticate, leaving the socket ready for the first command.
+
+    Home Assistant greets a new connection with ``auth_required`` and answers
+    the token with ``auth_ok``; both are read here so a caller's first
+    :func:`expect_result` is not handed one of them. The session comes back with
+    the socket because closing the socket alone leaks the connector.
+    """
+
+    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
+    token = os.environ.get("HA_TOKEN")
+    session = aiohttp.ClientSession()
+    ws = await session.ws_connect(ws_url_from_base(base))
+    _ = await ws.receive_json()
+    await ws.send_json({"type": "auth", "access_token": token})
+    _ = await ws.receive_json()
+    return session, ws
+
+
+async def expect_result(ws: aiohttp.ClientWebSocketResponse, expect_id: int) -> dict[str, Any]:
+    """Read until the ``result`` for one command id arrives, skipping everything else.
+
+    A connection that has subscribed carries event frames between the command
+    and its answer, and they are not this caller's.
+    """
+
+    while True:
+        msg = await ws.receive_json()
+        if isinstance(msg, dict) and msg.get("id") == expect_id and msg.get("type") == "result":
+            return msg
+
+
+def id_counter(start: int = 0) -> Callable[[], int]:
+    """A source of the strictly increasing message ids one connection needs."""
+
+    value = start
+
+    def _next() -> int:
+        nonlocal value
+        value += 1
+        return value
+
+    return _next

--- a/tests/runtime_helpers.py
+++ b/tests/runtime_helpers.py
@@ -10,6 +10,10 @@ nor a shape real Home Assistant has.
 * :func:`install_runtime` builds the runtime, attaches it to a stub entry and
   registers that entry. Defaults are an empty repository and a real
   `DomainStore`, which is what almost every test wants.
+* ``ws=True`` also registers the WebSocket commands, which setup does in the
+  same breath; :func:`ws_hass` is the whole opening move — a stub Home
+  Assistant with an entry loaded and the commands registered — for the many
+  files whose every test starts there.
 * ``state=`` is what makes the refusals testable: an entry that is not `LOADED`
   is exactly what a WebSocket command or a `haventory.*` service meets after an
   unload, a disable or a removal, and `loaded_runtime` refuses on it.
@@ -38,6 +42,7 @@ from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.runtime import HAventoryRuntime, find_runtime
 from custom_components.haventory.storage import DomainStore
+from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -53,6 +58,7 @@ def install_runtime(  # noqa: PLR0913 - one keyword per runtime field, all optio
     options: dict[str, Any] | None = None,
     state: Any = None,
     entry: Any = None,
+    ws: bool = False,
 ) -> HAventoryRuntime:
     """Register one HAventory entry carrying a runtime, and return the runtime."""
 
@@ -73,7 +79,21 @@ def install_runtime(  # noqa: PLR0913 - one keyword per runtime field, all optio
     entry.runtime_data = runtime
     hass.data.setdefault(DOMAIN, {})
     hass.config_entries.add(entry)
+    if ws:
+        ws_setup(hass)
     return runtime
+
+
+def ws_hass(**runtime_fields: Any) -> HomeAssistant:
+    """A Home Assistant with an entry loaded and the WebSocket commands registered.
+
+    Where every `ws_send` test starts. The keywords are `install_runtime`'s, so
+    a test that needs its own repository, store or limiter names it here.
+    """
+
+    hass = HomeAssistant()
+    install_runtime(hass, ws=True, **runtime_fields)
+    return hass
 
 
 def installed_entry(hass: HomeAssistant) -> Any:

--- a/tests/test_entry_removal_offline.py
+++ b/tests/test_entry_removal_offline.py
@@ -19,49 +19,12 @@ from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL, UrlManager
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from lovelace_helpers import MockResourceCollection, MockYamlResourceCollection
+
 CARD_URL = "/haventory_static/haventory-card.js"
 LOVELACE_KEY = "lovelace_data_key"
 # The versioned URL setup would have registered.
 CURRENT_CARD_URL = f"{CARD_URL}?v={INTEGRATION_VERSION}"
-
-
-class MockResourceCollection:
-    """Storage-mode Lovelace resource collection.
-
-    Mirrors the real collection where the caller has to get it right: `stored` is
-    the backing store, `async_items` sees only what a load has pulled into
-    memory, and `async_delete_item` pulls it in itself.
-    """
-
-    def __init__(self, items: list[dict[str, Any]] | None = None, *, loaded: bool = True) -> None:
-        self.loaded = loaded
-        self.stored: list[dict[str, Any]] = list(items or [])
-        self.deleted: list[str] = []
-
-    def async_items(self) -> list[dict[str, Any]]:
-        return self.stored if self.loaded else []
-
-    async def async_load(self) -> None:
-        self.loaded = True
-
-    async def async_delete_item(self, item_id: str) -> None:
-        self.loaded = True
-        self.deleted.append(item_id)
-        self.stored = [item for item in self.stored if item.get("id") != item_id]
-
-
-class MockYamlResourceCollection:
-    """YAML-mode collection: readable, with no mutation API."""
-
-    def __init__(self, items: list[dict[str, Any]] | None = None) -> None:
-        self.loaded = True
-        self.stored: list[dict[str, Any]] = list(items or [])
-
-    def async_items(self) -> list[dict[str, Any]]:
-        return self.stored
-
-    async def async_load(self) -> None:
-        pass
 
 
 def _import_with_lovelace(monkeypatch):

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -45,6 +45,8 @@ from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL, DATA_PANELS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from lovelace_helpers import MockResourceCollection, MockYamlResourceCollection
+
 STATIC_URL_PATH = "/haventory_static"
 CARD_PATH = f"{STATIC_URL_PATH}/haventory-card.js"
 # What both loaders and the panel receive, cache-buster and all.
@@ -62,63 +64,6 @@ def import_haventory(monkeypatch, lovelace_key: str):
     monkeypatch.setitem(sys.modules, "homeassistant.components.lovelace", lovelace_module)
     sys.modules.pop("custom_components.haventory", None)
     return importlib.import_module("custom_components.haventory")
-
-
-class MockResourceCollection:
-    """Mock Lovelace resource collection in storage mode (create/update/delete).
-
-    Mirrors where the real collection loads storage and where it does not:
-    `async_items` reports nothing until something loads it, while each mutation
-    method loads first — so a caller that reads before writing has to say so.
-    """
-
-    def __init__(self, items: list[dict[str, Any]] | None = None, *, loaded: bool = True):
-        self.loaded = loaded
-        self._items: list[dict[str, Any]] = list(items or [])
-        self.created: list[dict[str, Any]] = []
-        self.updated: list[tuple[str, dict[str, Any]]] = []
-        self.deleted: list[str] = []
-
-    def async_items(self) -> list[dict[str, Any]]:
-        return self._items if self.loaded else []
-
-    async def async_load(self):
-        self.loaded = True
-
-    async def async_create_item(self, data: dict[str, Any]) -> dict[str, Any]:
-        self.loaded = True
-        self.created.append(data)
-        item = {"id": f"created_{len(self.created)}", **data}
-        self._items.append(item)
-        return item
-
-    async def async_update_item(self, item_id: str, updates: dict[str, Any]) -> dict[str, Any]:
-        self.loaded = True
-        for item in self._items:
-            if item.get("id") == item_id:
-                item.update(updates)
-                self.updated.append((item_id, updates))
-                return item
-        raise KeyError(item_id)
-
-    async def async_delete_item(self, item_id: str) -> None:
-        self.loaded = True
-        self.deleted.append(item_id)
-        self._items = [item for item in self._items if item.get("id") != item_id]
-
-
-class MockYamlResourceCollection:
-    """Lovelace resources in YAML mode: readable, with no mutation API."""
-
-    def __init__(self, items: list[dict[str, Any]] | None = None):
-        self.loaded = True
-        self._items: list[dict[str, Any]] = list(items or [])
-
-    def async_items(self) -> list[dict[str, Any]]:
-        return self._items
-
-    async def async_load(self):
-        pass
 
 
 class MockLovelaceData:

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -28,13 +28,11 @@ import pytest
 from custom_components.haventory.const import (
     CONF_CARD_TITLE,
     CONF_SIDEBAR_PANEL_ENABLED,
-    DEFAULT_CARD_TITLE,
     INTEGRATION_VERSION,
     MEDIA_NAME_TOKEN_PARAM,
     MEDIA_SIZE_PARAM,
     MEDIA_SIZE_THUMB,
     MEDIA_URL_TEMPLATE,
-    PANEL_ELEMENT_NAME,
     PANEL_ICON,
     PANEL_URL_PATH,
     QUICK_FILTER_KEYS,
@@ -110,11 +108,6 @@ def registered_panel(hass: HomeAssistant) -> Any:
     return hass.data.get(DATA_PANELS, {}).get(PANEL_URL_PATH)
 
 
-def panel_registration_attempts(hass: HomeAssistant) -> list[str]:
-    """Every ``async_register_panel`` call, successful or not (see conftest)."""
-    return hass.data.get("__panel_registrations__", [])
-
-
 async def setup_frontend(hav_init, hass: HomeAssistant, entry: ConfigEntry) -> None:
     """The two frontend steps of ``async_setup_entry``, in the order it runs them."""
     await hav_init._register_frontend_module(hass)
@@ -146,71 +139,6 @@ def test_the_card_build_emits_a_single_file() -> None:
     config = (REPO_ROOT / "cards" / "haventory-card" / "vite.config.ts").read_text(encoding="utf-8")
 
     assert re.search(r"^\s*codeSplitting: false$", config, re.MULTILINE) is not None
-
-
-@pytest.mark.asyncio
-async def test_serves_the_bundle_directory_without_cache_headers(hav_init, tmp_path):
-    """The card directory is served at a fixed path, with revalidation left on.
-
-    `cache_headers=True` would stamp a long `max-age` and no revalidation, which
-    is how the old `/local` route kept browsers on a month-old bundle.
-    """
-    hass = make_hass()
-    hass.data["lovelace_data_key"] = MockLovelaceData()
-
-    await hav_init._register_frontend_module(hass)
-
-    assert len(hass.http.static_paths) == 1
-    config = hass.http.static_paths[0]
-    assert config.url_path == STATIC_URL_PATH
-    assert config.path == str(tmp_path / "www")
-    assert config.cache_headers is False
-
-
-@pytest.mark.asyncio
-async def test_registers_both_loaders_with_the_same_url(hav_init):
-    """One URL builder, two loaders — byte-identical, or the element defines twice."""
-    hass = make_hass()
-    lovelace_data = MockLovelaceData()
-    hass.data["lovelace_data_key"] = lovelace_data
-
-    await hav_init._register_frontend_module(hass)
-
-    expected = CURRENT_CARD_URL
-    assert [c["url"] for c in lovelace_data.resources.created] == [expected]
-    assert lovelace_data.resources.created[0]["res_type"] == "module"
-    assert extra_js_urls(hass) == {expected}
-
-
-@pytest.mark.asyncio
-async def test_static_path_is_registered_once_across_a_reload(hav_init):
-    """Setup → unload → setup registers the route once: aiohttp cannot take one back."""
-    hass = make_hass()
-    hass.data["lovelace_data_key"] = MockLovelaceData()
-
-    await hav_init._register_frontend_module(hass)
-    await hav_init.async_unload_entry(hass, ConfigEntry())
-    await hav_init._register_frontend_module(hass)
-
-    assert hass.http.static_path_calls == 1
-    assert len(hass.http.static_paths) == 1
-
-
-@pytest.mark.asyncio
-async def test_unload_hands_back_the_module_url_and_setup_restores_it(hav_init):
-    """The extra-module URL is entry-scoped state, unlike the static route."""
-    hass = make_hass()
-    hass.data["lovelace_data_key"] = MockLovelaceData()
-    expected = CURRENT_CARD_URL
-
-    await hav_init._register_frontend_module(hass)
-    assert extra_js_urls(hass) == {expected}
-
-    await hav_init.async_unload_entry(hass, ConfigEntry())
-    assert extra_js_urls(hass) == set()
-
-    await hav_init._register_frontend_module(hass)
-    assert extra_js_urls(hass) == {expected}
 
 
 @pytest.mark.asyncio
@@ -670,38 +598,6 @@ def test_every_status_colour_has_a_rule_in_the_chip_stylesheet() -> None:
 
 
 @pytest.mark.asyncio
-async def test_registers_the_sidebar_panel_against_the_card_bundle(hav_init):
-    """The panel is a custom panel loading the card bundle, named by the card title.
-
-    Its `module_url` is the string the extra-module loader got, character for
-    character: a second URL for the same module makes the browser evaluate the
-    bundle twice, and `defineCardElement` has nothing to say about a second
-    evaluation of itself.
-    """
-    hass = make_hass()
-
-    await setup_frontend(hav_init, hass, ConfigEntry())
-
-    expected_url = CURRENT_CARD_URL
-    panel = registered_panel(hass)
-    assert panel.component_name == "custom"
-    assert panel.frontend_url_path == PANEL_URL_PATH
-    assert panel.sidebar_title == DEFAULT_CARD_TITLE
-    assert panel.sidebar_icon == PANEL_ICON
-    assert panel.require_admin is False
-    assert panel.config == {
-        "title": DEFAULT_CARD_TITLE,
-        "_panel_custom": {
-            "name": PANEL_ELEMENT_NAME,
-            "embed_iframe": False,
-            "trust_external": False,
-            "module_url": expected_url,
-        },
-    }
-    assert extra_js_urls(hass) == {expected_url}
-
-
-@pytest.mark.asyncio
 async def test_applying_twice_over_registers_once(hav_init):
     """An options save that changes nothing about the panel must not touch it.
 
@@ -713,84 +609,13 @@ async def test_applying_twice_over_registers_once(hav_init):
     entry = ConfigEntry()
 
     await setup_frontend(hav_init, hass, entry)
+    panel = registered_panel(hass)
     await hav_init._async_apply_sidebar_panel(hass, entry)
 
     assert list(hass.data[DATA_PANELS]) == [PANEL_URL_PATH]
-    assert panel_registration_attempts(hass) == [PANEL_URL_PATH]
-
-
-@pytest.mark.asyncio
-async def test_a_reload_leaves_the_panel_in_place(hav_init):
-    """Setup → unload → setup, and the panel never leaves the registry.
-
-    The page a browser has open is what disappears with it, so the reload path
-    neither removes nor re-registers: it recognises the registration it already
-    has.
-    """
-    hass = make_hass()
-    entry = ConfigEntry()
-
-    await setup_frontend(hav_init, hass, entry)
-    panel = registered_panel(hass)
-
-    await hav_init.async_unload_entry(hass, entry)
+    # The same object, so the second pass neither replaced the registration nor
+    # took it away and put it back.
     assert registered_panel(hass) is panel
-
-    await setup_frontend(hav_init, hass, entry)
-
-    assert registered_panel(hass) is panel
-    assert panel_registration_attempts(hass) == [PANEL_URL_PATH]
-
-
-@pytest.mark.asyncio
-async def test_a_disabled_entry_takes_the_sidebar_entry_back(hav_init):
-    """A disabled entry stays unloaded, so its sidebar entry opens nothing."""
-    hass = make_hass()
-    entry = ConfigEntry(disabled_by="user")
-
-    await setup_frontend(hav_init, hass, entry)
-    assert registered_panel(hass) is not None
-
-    await hav_init.async_unload_entry(hass, entry)
-
-    assert registered_panel(hass) is None
-    assert hass.data[hav_init.DOMAIN].get("panel_state") is None
-
-
-@pytest.mark.asyncio
-async def test_removing_the_entry_takes_the_sidebar_entry_back(hav_init):
-    """Removal is the other end: nothing is coming back to serve the page."""
-    hass = make_hass()
-    entry = ConfigEntry()
-
-    await setup_frontend(hav_init, hass, entry)
-    await hav_init.async_unload_entry(hass, entry)
-    assert registered_panel(hass) is not None
-
-    await hav_init.async_remove_entry(hass, entry)
-
-    assert registered_panel(hass) is None
-    assert hass.data[hav_init.DOMAIN].get("panel_state") is None
-
-
-@pytest.mark.asyncio
-async def test_a_rename_across_a_reload_replaces_the_panel(hav_init):
-    """The recognised registration is the one that was made, not merely "a panel".
-
-    A title changed while the entry was unloaded still has to reach the sidebar,
-    which is the case a bare "is something registered?" check would miss.
-    """
-    hass = make_hass()
-    entry = ConfigEntry(options={CONF_CARD_TITLE: "Pantry"})
-
-    await setup_frontend(hav_init, hass, entry)
-    await hav_init.async_unload_entry(hass, entry)
-
-    entry.options[CONF_CARD_TITLE] = "Garage"
-    await setup_frontend(hav_init, hass, entry)
-
-    assert registered_panel(hass).sidebar_title == "Garage"
-    assert panel_registration_attempts(hass) == [PANEL_URL_PATH] * 2
 
 
 @pytest.mark.asyncio
@@ -829,19 +654,6 @@ async def test_renaming_the_card_renames_the_sidebar_entry(hav_init):
 
 
 @pytest.mark.asyncio
-async def test_an_explicit_opt_out_registers_no_panel(hav_init):
-    """Off in the options means off at setup too, not just on the toggle path."""
-    hass = make_hass()
-
-    await setup_frontend(hav_init, hass, ConfigEntry(options={CONF_SIDEBAR_PANEL_ENABLED: False}))
-
-    assert registered_panel(hass) is None
-    assert panel_registration_attempts(hass) == []
-    # The card itself is unaffected: only the sidebar entry is opted out of.
-    assert extra_js_urls(hass) == {CURRENT_CARD_URL}
-
-
-@pytest.mark.asyncio
 async def test_missing_panel_custom_degrades_to_a_debug_log(monkeypatch, tmp_path, caplog):
     """`panel_custom` is an internal component — treat its absence as our problem, not HA's."""
     monkeypatch.delitem(sys.modules, "homeassistant.components.panel_custom")
@@ -868,4 +680,3 @@ async def test_no_sidebar_panel_without_a_built_bundle(monkeypatch, tmp_path):
     await setup_frontend(hav_init, hass, ConfigEntry())
 
     assert registered_panel(hass) is None
-    assert panel_registration_attempts(hass) == []

--- a/tests/test_item_input_validation_offline.py
+++ b/tests/test_item_input_validation_offline.py
@@ -28,10 +28,8 @@ from custom_components.haventory.models import (
     ItemUpdate,
 )
 from custom_components.haventory.repository import Repository
-from custom_components.haventory.ws import setup as ws_setup
-from homeassistant.core import HomeAssistant
 
-from runtime_helpers import install_runtime
+from runtime_helpers import ws_hass
 from ws_helpers import ws_send
 
 # -----------------------------
@@ -103,16 +101,9 @@ def test_low_stock_threshold_rejects_bool() -> None:
 # -----------------------------
 
 
-def _make_hass() -> HomeAssistant:
-    hass = HomeAssistant()
-    install_runtime(hass)
-    ws_setup(hass)
-    return hass
-
-
 @pytest.mark.asyncio
 async def test_ws_create_non_text_category_is_validation_error_no_phantom() -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     res = await ws_send(hass, 1, "haventory/item/create", name="Widget", category=["oops"])
     assert res["success"] is False
     assert res["error"]["code"] == "validation_error"
@@ -125,7 +116,7 @@ async def test_ws_create_non_text_category_is_validation_error_no_phantom() -> N
 
 @pytest.mark.asyncio
 async def test_ws_set_quantity_bool_is_validation_error() -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     created = await ws_send(hass, 1, "haventory/item/create", name="Widget", quantity=1)
     item_id = created["result"]["id"]
 
@@ -152,7 +143,7 @@ async def test_a_refused_quantity_answers_alike_from_the_command_and_from_bulk()
     get a different one from the one it gets when it sends them singly.
     """
 
-    hass = _make_hass()
+    hass = ws_hass()
     missing = "00000000-0000-4000-8000-000000000000"
 
     single = await ws_send(hass, 1, "haventory/item/set_quantity", item_id=missing, quantity=-1)
@@ -185,7 +176,7 @@ async def test_an_item_id_of_the_wrong_type_names_the_field_on_both_surfaces() -
     author looking for a missing item instead.
     """
 
-    hass = _make_hass()
+    hass = ws_hass()
 
     single = await ws_send(hass, 1, "haventory/item/update", item_id=7, name="X")
     batch = await ws_send(
@@ -233,7 +224,7 @@ async def test_a_collection_field_given_a_bare_string_is_a_validation_error(
     the same code and the caller's own field name whichever command carried it.
     """
 
-    hass = _make_hass()
+    hass = ws_hass()
     created = await ws_send(hass, 1, "haventory/item/create", name="Widget", tags=["alpha"])
     item_id = created["result"]["id"]
 
@@ -269,7 +260,7 @@ async def test_a_reorder_still_refuses_a_list_naming_one_member_twice() -> None:
     normalizing it into a valid permutation would hide it.
     """
 
-    hass = _make_hass()
+    hass = ws_hass()
 
     res = await ws_send(hass, 1, "haventory/status/reorder", slugs=["ok", "ok", "missing"])
 
@@ -338,7 +329,7 @@ def test_create_accepts_at_the_cap_and_refuses_over_it(
 
 @pytest.mark.asyncio
 async def test_ws_create_over_a_cap_is_validation_error_no_phantom() -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     res = await ws_send(
         hass,
         1,

--- a/tests/test_models_filter_sort_offline.py
+++ b/tests/test_models_filter_sort_offline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
 
 import pytest
 from custom_components.haventory import models
@@ -22,6 +21,8 @@ from custom_components.haventory.models import (
     validate_item_filter,
     validate_sort,
 )
+
+from date_helpers import day_offset
 
 
 def _make_location(id: str, name: str, parent_id: str | None) -> Location:
@@ -285,21 +286,13 @@ async def test_filter_overdue_only() -> None:
     assert filter_items(every, ItemFilter(overdue_only=False)) == every
 
 
-def _utc_day_offset(days: int) -> str:
-    """A UTC calendar date `days` from today, as YYYY-MM-DD."""
-
-    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
-
-
 @pytest.mark.asyncio
 async def test_filter_inspection_overdue_only_is_strictly_before_today() -> None:
     """`inspection_overdue_only` keeps items whose next inspection is already past."""
 
-    yesterday = create_item_from_create(
-        {"name": "Yesterday", "inspection_date": _utc_day_offset(-1)}
-    )
-    today = create_item_from_create({"name": "Today", "inspection_date": _utc_day_offset(0)})
-    tomorrow = create_item_from_create({"name": "Tomorrow", "inspection_date": _utc_day_offset(1)})
+    yesterday = create_item_from_create({"name": "Yesterday", "inspection_date": day_offset(-1)})
+    today = create_item_from_create({"name": "Today", "inspection_date": day_offset(0)})
+    tomorrow = create_item_from_create({"name": "Tomorrow", "inspection_date": day_offset(1)})
     undated = create_item_from_create({"name": "Undated"})
     every = [yesterday, today, tomorrow, undated]
 
@@ -315,13 +308,13 @@ async def test_filter_inspection_overdue_only_is_strictly_before_today() -> None
 async def test_filter_inspection_overdue_is_independent_of_checkout() -> None:
     """An inspection is a fact about the item, so the two date filters are separate."""
 
-    shelved = create_item_from_create({"name": "Shelved", "inspection_date": _utc_day_offset(-1)})
+    shelved = create_item_from_create({"name": "Shelved", "inspection_date": day_offset(-1)})
     borrowed = create_item_from_create(
         {
             "name": "Borrowed",
             "checked_out": True,
-            "due_date": _utc_day_offset(-1),
-            "inspection_date": _utc_day_offset(30),
+            "due_date": day_offset(-1),
+            "inspection_date": day_offset(30),
         }
     )
     every = [shelved, borrowed]
@@ -339,13 +332,13 @@ async def test_filter_checked_out_due_only_counts_today() -> None:
     """`checked_out_due_only` is `overdue_only` plus the items due back today."""
 
     late = create_item_from_create(
-        {"name": "Late", "checked_out": True, "due_date": _utc_day_offset(-1)}
+        {"name": "Late", "checked_out": True, "due_date": day_offset(-1)}
     )
     today = create_item_from_create(
-        {"name": "Today", "checked_out": True, "due_date": _utc_day_offset(0)}
+        {"name": "Today", "checked_out": True, "due_date": day_offset(0)}
     )
     tomorrow = create_item_from_create(
-        {"name": "Tomorrow", "checked_out": True, "due_date": _utc_day_offset(1)}
+        {"name": "Tomorrow", "checked_out": True, "due_date": day_offset(1)}
     )
     undated = create_item_from_create({"name": "Out", "checked_out": True})
     home = create_item_from_create({"name": "Home"})
@@ -364,11 +357,9 @@ async def test_filter_checked_out_due_only_counts_today() -> None:
 async def test_filter_inspection_due_only_counts_today() -> None:
     """`inspection_due_only` is `inspection_overdue_only` plus today's inspections."""
 
-    yesterday = create_item_from_create(
-        {"name": "Yesterday", "inspection_date": _utc_day_offset(-1)}
-    )
-    today = create_item_from_create({"name": "Today", "inspection_date": _utc_day_offset(0)})
-    tomorrow = create_item_from_create({"name": "Tomorrow", "inspection_date": _utc_day_offset(1)})
+    yesterday = create_item_from_create({"name": "Yesterday", "inspection_date": day_offset(-1)})
+    today = create_item_from_create({"name": "Today", "inspection_date": day_offset(0)})
+    tomorrow = create_item_from_create({"name": "Tomorrow", "inspection_date": day_offset(1)})
     undated = create_item_from_create({"name": "Undated"})
     every = [yesterday, today, tomorrow, undated]
 
@@ -386,9 +377,9 @@ async def test_the_two_due_filters_ask_about_different_dates() -> None:
     """A due date is about a borrowing; an inspection date is about the item."""
 
     borrowed = create_item_from_create(
-        {"name": "Borrowed", "checked_out": True, "due_date": _utc_day_offset(0)}
+        {"name": "Borrowed", "checked_out": True, "due_date": day_offset(0)}
     )
-    shelved = create_item_from_create({"name": "Shelved", "inspection_date": _utc_day_offset(0)})
+    shelved = create_item_from_create({"name": "Shelved", "inspection_date": day_offset(0)})
     every = [borrowed, shelved]
 
     assert [x.name for x in filter_items(every, ItemFilter(checked_out_due_only=True))] == [

--- a/tests/test_repository_items_offline.py
+++ b/tests/test_repository_items_offline.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import base64
 import uuid
-from datetime import UTC, datetime, timedelta
 
 import pytest
 from custom_components.haventory.exceptions import ConflictError, NotFoundError, ValidationError
 from custom_components.haventory.models import ItemCreate, ItemFilter, ItemUpdate, Sort
 from custom_components.haventory.repository import CURSOR_MAX_LENGTH, Repository
+
+from date_helpers import day_offset
 
 TOTAL_ITEMS = 3
 BOOKS_TOTAL = 3
@@ -161,12 +162,6 @@ async def test_overdue_count_and_filter_track_check_in() -> None:
     assert repo.list_items(flt=ItemFilter(overdue_only=True))["items"] == []
 
 
-def _utc_day_offset(days: int) -> str:
-    """A UTC calendar date `days` from today, as YYYY-MM-DD."""
-
-    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
-
-
 @pytest.mark.asyncio
 async def test_checked_out_due_count_includes_today_where_overdue_does_not() -> None:
     """The two counts differ by exactly the items due back today.
@@ -176,9 +171,9 @@ async def test_checked_out_due_count_includes_today_where_overdue_does_not() -> 
     """
 
     repo = Repository()
-    repo.create_item(ItemCreate(name="Late Drill", checked_out=True, due_date=_utc_day_offset(-1)))
-    repo.create_item(ItemCreate(name="Today Drill", checked_out=True, due_date=_utc_day_offset(0)))
-    repo.create_item(ItemCreate(name="Soon Drill", checked_out=True, due_date=_utc_day_offset(1)))
+    repo.create_item(ItemCreate(name="Late Drill", checked_out=True, due_date=day_offset(-1)))
+    repo.create_item(ItemCreate(name="Today Drill", checked_out=True, due_date=day_offset(0)))
+    repo.create_item(ItemCreate(name="Soon Drill", checked_out=True, due_date=day_offset(1)))
     repo.create_item(ItemCreate(name="Out Drill", checked_out=True))
     repo.create_item(ItemCreate(name="Home Drill"))
 
@@ -200,10 +195,10 @@ async def test_checked_out_due_count_empties_on_check_in() -> None:
 
     repo = Repository()
     late = repo.create_item(
-        ItemCreate(name="Late Drill", checked_out=True, due_date=_utc_day_offset(-2))
+        ItemCreate(name="Late Drill", checked_out=True, due_date=day_offset(-2))
     )
     today = repo.create_item(
-        ItemCreate(name="Today Drill", checked_out=True, due_date=_utc_day_offset(0))
+        ItemCreate(name="Today Drill", checked_out=True, due_date=day_offset(0))
     )
     BOTH_DRILLS = 2
     assert repo.get_counts()["checked_out_due_count"] == BOTH_DRILLS
@@ -224,17 +219,17 @@ async def test_inspection_overdue_count_walks_the_whole_inventory() -> None:
     """`inspection_overdue_count` spans every item, not just the checked-out ones."""
 
     repo = Repository()
-    repo.create_item(ItemCreate(name="Ladder", inspection_date=_utc_day_offset(-1)))
+    repo.create_item(ItemCreate(name="Ladder", inspection_date=day_offset(-1)))
     repo.create_item(
         ItemCreate(
             name="Extinguisher",
             checked_out=True,
-            due_date=_utc_day_offset(7),
-            inspection_date=_utc_day_offset(-30),
+            due_date=day_offset(7),
+            inspection_date=day_offset(-30),
         )
     )
-    repo.create_item(ItemCreate(name="Harness", inspection_date=_utc_day_offset(0)))
-    repo.create_item(ItemCreate(name="Rope", inspection_date=_utc_day_offset(365)))
+    repo.create_item(ItemCreate(name="Harness", inspection_date=day_offset(0)))
+    repo.create_item(ItemCreate(name="Rope", inspection_date=day_offset(365)))
     repo.create_item(ItemCreate(name="Bucket"))
 
     counts = repo.get_counts()
@@ -255,11 +250,11 @@ async def test_inspection_overdue_count_follows_the_stored_date() -> None:
     """Rescheduling or clearing the date moves the item out of the population."""
 
     repo = Repository()
-    ladder = repo.create_item(ItemCreate(name="Ladder", inspection_date=_utc_day_offset(-1)))
+    ladder = repo.create_item(ItemCreate(name="Ladder", inspection_date=day_offset(-1)))
     assert repo.get_counts()["inspection_overdue_count"] == 1
 
     inspected = repo.update_item(
-        ladder.id, ItemUpdate(inspection_date=_utc_day_offset(365)), expected_version=ladder.version
+        ladder.id, ItemUpdate(inspection_date=day_offset(365)), expected_version=ladder.version
     )
     assert repo.get_counts()["inspection_overdue_count"] == 0
 
@@ -279,9 +274,9 @@ async def test_inspection_due_count_includes_today_where_overdue_does_not() -> N
     """
 
     repo = Repository()
-    repo.create_item(ItemCreate(name="Ladder", inspection_date=_utc_day_offset(-1)))
-    repo.create_item(ItemCreate(name="Harness", inspection_date=_utc_day_offset(0)))
-    repo.create_item(ItemCreate(name="Rope", inspection_date=_utc_day_offset(1)))
+    repo.create_item(ItemCreate(name="Ladder", inspection_date=day_offset(-1)))
+    repo.create_item(ItemCreate(name="Harness", inspection_date=day_offset(0)))
+    repo.create_item(ItemCreate(name="Rope", inspection_date=day_offset(1)))
     repo.create_item(ItemCreate(name="Bucket"))
 
     counts = repo.get_counts()
@@ -297,19 +292,19 @@ async def test_inspection_due_count_is_never_below_the_overdue_count() -> None:
     """Rescheduling moves an item between the two counts without inverting them."""
 
     repo = Repository()
-    ladder = repo.create_item(ItemCreate(name="Ladder", inspection_date=_utc_day_offset(-3)))
+    ladder = repo.create_item(ItemCreate(name="Ladder", inspection_date=day_offset(-3)))
     assert repo.get_counts()["inspection_due_count"] == 1
     assert repo.get_counts()["inspection_overdue_count"] == 1
 
     today = repo.update_item(
-        ladder.id, ItemUpdate(inspection_date=_utc_day_offset(0)), expected_version=ladder.version
+        ladder.id, ItemUpdate(inspection_date=day_offset(0)), expected_version=ladder.version
     )
     counts = repo.get_counts()
     assert counts["inspection_due_count"] == 1
     assert counts["inspection_overdue_count"] == 0
 
     later = repo.update_item(
-        today.id, ItemUpdate(inspection_date=_utc_day_offset(30)), expected_version=today.version
+        today.id, ItemUpdate(inspection_date=day_offset(30)), expected_version=today.version
     )
     assert repo.get_counts()["inspection_due_count"] == 0
 

--- a/tests/test_ws_areas_online.py
+++ b/tests/test_ws_areas_online.py
@@ -1,50 +1,11 @@
 import os
 import uuid
-from typing import Any
 
-import aiohttp
 import pytest
 
+from online_helpers import expect_result, id_counter, open_ws
+
 pytestmark = pytest.mark.online
-
-
-def _ws_url_from_base(base_url: str) -> str:
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    if base_url.startswith("http://"):
-        return f"ws://{base_url[len('http://') :]}/api/websocket"
-    return f"ws://{base_url}/api/websocket"
-
-
-async def _open_ws():
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
-    ws_url = _ws_url_from_base(base)
-    session = aiohttp.ClientSession()
-    ws = await session.ws_connect(ws_url)
-    _ = await ws.receive_json()
-    await ws.send_json({"type": "auth", "access_token": token})
-    _ = await ws.receive_json()
-    return session, ws
-
-
-async def _expect_result(ws: aiohttp.ClientWebSocketResponse, expect_id: int) -> dict[str, Any]:
-    while True:
-        msg = await ws.receive_json()
-        if isinstance(msg, dict) and msg.get("id") == expect_id and msg.get("type") == "result":
-            return msg
-
-
-def _id_counter(start: int = 0):
-    value = start
-
-    def _next() -> int:
-        nonlocal value
-        value += 1
-        return value
-
-    return _next
 
 
 @pytest.mark.asyncio
@@ -61,8 +22,8 @@ async def test_ws_areas_list_with_created_areas() -> None:
     if os.environ.get("HA_ALLOW_AREA_MUTATIONS") != "1":
         pytest.skip("HA_ALLOW_AREA_MUTATIONS!=1; skipping area creation online test")
 
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         # Create two unique areas via HA's area registry WS API
         suffix = uuid.uuid4().hex[:8]
@@ -72,7 +33,7 @@ async def test_ws_areas_list_with_created_areas() -> None:
         for nm in names:
             cid = next_id()
             await ws.send_json({"id": cid, "type": "config/area_registry/create", "name": nm})
-            created = await _expect_result(ws, cid)
+            created = await expect_result(ws, cid)
             if not created.get("success"):
                 pytest.skip("area_registry/create not available; skipping")
             cres = created.get("result") or {}
@@ -84,7 +45,7 @@ async def test_ws_areas_list_with_created_areas() -> None:
         # Call haventory/areas/list and ensure our areas are included by id or name
         qid = next_id()
         await ws.send_json({"id": qid, "type": "haventory/areas/list"})
-        got = await _expect_result(ws, qid)
+        got = await expect_result(ws, qid)
         if not got.get("success"):
             pytest.skip("haventory/areas/list not available; skipping")
         areas = (got.get("result") or {}).get("areas") or []
@@ -96,6 +57,6 @@ async def test_ws_areas_list_with_created_areas() -> None:
         for aid in area_ids:
             did = next_id()
             await ws.send_json({"id": did, "type": "config/area_registry/delete", "area_id": aid})
-            _ = await _expect_result(ws, did)
+            _ = await expect_result(ws, did)
         await ws.close()
         await session.close()

--- a/tests/test_ws_error_mapping_offline.py
+++ b/tests/test_ws_error_mapping_offline.py
@@ -25,16 +25,8 @@ from custom_components.haventory.ws import HANDLERS, UNEXPECTED_ERROR_MESSAGE
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-from runtime_helpers import install_runtime, repo_of
+from runtime_helpers import repo_of, ws_hass
 from ws_helpers import RecordingConn, ws_send
-
-
-def _make_hass(*, with_repo: bool = True) -> HomeAssistant:
-    hass = HomeAssistant()
-    if with_repo:
-        install_runtime(hass)
-    ws_setup(hass)
-    return hass
 
 
 def test_every_registered_command_is_guarded() -> None:
@@ -53,7 +45,7 @@ def test_every_registered_command_is_guarded() -> None:
 async def test_unexpected_exception_maps_to_unknown_error_without_leaking(monkeypatch) -> None:
     """Non-domain exceptions -> unknown_error with a generic message only."""
 
-    hass = _make_hass()
+    hass = ws_hass()
 
     def _boom(*_args: Any, **_kwargs: Any) -> dict:
         raise RuntimeError("SECRET-INTERNAL-DETAIL")
@@ -91,7 +83,10 @@ async def test_unexpected_exception_maps_to_unknown_error_without_leaking(monkey
 async def test_repo_dependent_commands_map_missing_repo_to_storage_error(type_: str) -> None:
     """Missing repository surfaces as storage_error, not an escaped exception."""
 
-    hass = _make_hass(with_repo=False)
+    # No runtime: the entry an unloaded, disabled or removed integration leaves.
+    hass = HomeAssistant()
+    ws_setup(hass)
+
     res = await ws_send(hass, 6, type_)
 
     assert res["success"] is False
@@ -100,7 +95,7 @@ async def test_repo_dependent_commands_map_missing_repo_to_storage_error(type_: 
 
 @pytest.mark.asyncio
 async def test_subscribe_bad_topic_maps_to_validation_error() -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     res = await ws_send(hass, 7, "haventory/subscribe", topic="nope")
 
     assert res["success"] is False
@@ -110,7 +105,7 @@ async def test_subscribe_bad_topic_maps_to_validation_error() -> None:
 
 @pytest.mark.asyncio
 async def test_unsubscribe_validates_subscription_id() -> None:
-    hass = _make_hass()
+    hass = ws_hass()
 
     res = await ws_send(hass, 8, "haventory/unsubscribe", subscription="abc")
     assert res["success"] is False
@@ -129,7 +124,7 @@ async def test_unsubscribe_validates_subscription_id() -> None:
 async def test_bulk_malformed_custom_fields_payload_fails_only_that_op() -> None:
     """A payload that would raise TypeError fails per-op as validation_error."""
 
-    hass = _make_hass()
+    hass = ws_hass()
     repo = repo_of(hass)
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
@@ -173,7 +168,7 @@ async def test_bulk_malformed_custom_fields_payload_fails_only_that_op() -> None
 async def test_bulk_payload_field_validation_errors() -> None:
     """Missing/typed-wrong per-op payload fields fail their own op only."""
 
-    hass = _make_hass()
+    hass = ws_hass()
     repo = repo_of(hass)
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
@@ -216,7 +211,7 @@ async def test_bulk_payload_field_validation_errors() -> None:
 async def test_bulk_unexpected_per_op_error_is_contained(monkeypatch) -> None:
     """An unexpected exception in one op yields per-op unknown_error only."""
 
-    hass = _make_hass()
+    hass = ws_hass()
     repo = repo_of(hass)
     item = repo.create_item({"name": "Widget", "quantity": 1})
 
@@ -256,7 +251,7 @@ async def test_bulk_unexpected_per_op_error_is_contained(monkeypatch) -> None:
 async def test_broadcast_failure_does_not_fail_the_command(monkeypatch) -> None:
     """A raising event sender must not turn a successful mutation into an error."""
 
-    hass = _make_hass()
+    hass = ws_hass()
     conn = RecordingConn()
     sub = await ws_send(hass, 100, "haventory/subscribe", conn=conn, topic="items")
     assert sub["success"] is True

--- a/tests/test_ws_logging_offline.py
+++ b/tests/test_ws_logging_offline.py
@@ -28,19 +28,12 @@ from custom_components.haventory.rate_limit import RateLimitConfig, RateLimiter
 from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-from runtime_helpers import install_runtime, repo_of, runtime_of
+from runtime_helpers import repo_of, runtime_of, ws_hass
 from ws_helpers import RecordingConn, ws_send
 
 WS_LOGGER = "custom_components.haventory.ws"
 SERVICES_LOGGER = "custom_components.haventory.services"
 RATE_LIMIT_LOGGER = "custom_components.haventory.rate_limit"
-
-
-def _make_hass(limiter: RateLimiter | None = None) -> HomeAssistant:
-    hass = HomeAssistant()
-    install_runtime(hass, rate_limiter=limiter)
-    ws_setup(hass)
-    return hass
 
 
 def _records(caplog, logger: str = WS_LOGGER) -> list[logging.LogRecord]:
@@ -60,7 +53,7 @@ def _only(caplog, logger: str = WS_LOGGER) -> logging.LogRecord:
 
 @pytest.mark.asyncio
 async def test_validation_error_logs_warning_without_traceback(caplog) -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
     res = await ws_send(hass, 1, "haventory/item/set_quantity", item_id="any", quantity=-1)
@@ -74,7 +67,7 @@ async def test_validation_error_logs_warning_without_traceback(caplog) -> None:
 
 @pytest.mark.asyncio
 async def test_not_found_logs_warning_without_traceback(caplog) -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
     res = await ws_send(
@@ -92,7 +85,7 @@ async def test_not_found_logs_warning_without_traceback(caplog) -> None:
 async def test_conflict_logs_warning_without_traceback(caplog) -> None:
     """A stale ``expected_version`` is an HTTP-409 equivalent, not a crash."""
 
-    hass = _make_hass()
+    hass = ws_hass()
     created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
@@ -125,7 +118,7 @@ async def test_rate_limited_logs_warning_without_traceback(caplog) -> None:
             global_events_burst=1000.0,
         )
     )
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     # One connection object across both sends: the limiter keys a bucket per
     # connection identity, so a second object would get a fresh budget.
     conn = RecordingConn()
@@ -152,7 +145,7 @@ async def test_rate_limited_logs_warning_without_traceback(caplog) -> None:
 async def test_storage_error_logs_error_with_traceback(caplog, monkeypatch) -> None:
     """The cause chain is the only record of what actually failed to write."""
 
-    hass = _make_hass()
+    hass = ws_hass()
 
     async def _raise(*_args: Any, **_kwargs: Any) -> None:
         raise StorageError("failed to persist repository")
@@ -173,7 +166,7 @@ async def test_storage_error_logs_error_with_traceback(caplog, monkeypatch) -> N
 async def test_unknown_error_logs_error_with_traceback(caplog, monkeypatch) -> None:
     """A non-domain exception has no vetted message, so the traceback is all there is."""
 
-    hass = _make_hass()
+    hass = ws_hass()
 
     def _boom(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError("kaboom")
@@ -270,7 +263,7 @@ async def test_a_retrying_client_leaves_no_tracebacks(caplog) -> None:
 async def test_a_real_storage_failure_still_logs_error_with_traceback(caplog, monkeypatch) -> None:
     """The quieter rule is scoped to the refusal, not to the code it maps to."""
 
-    hass = _make_hass()
+    hass = ws_hass()
 
     async def _raise(*_args: Any, **_kwargs: Any) -> None:
         raise StorageError("failed to persist repository")
@@ -309,7 +302,7 @@ async def test_service_not_loaded_refusal_logs_warning_without_traceback(caplog)
 
 @pytest.mark.asyncio
 async def test_bulk_conflict_logs_warning_without_traceback(caplog) -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
@@ -338,7 +331,7 @@ async def test_bulk_conflict_logs_warning_without_traceback(caplog) -> None:
 
 @pytest.mark.asyncio
 async def test_bulk_unexpected_error_logs_error_with_traceback(caplog, monkeypatch) -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
@@ -374,7 +367,7 @@ async def test_all_failed_bulk_logs_only_its_per_op_lines(caplog) -> None:
     log is already at its longest.
     """
 
-    hass = _make_hass()
+    hass = ws_hass()
     caplog.clear()
     caplog.set_level(logging.DEBUG, logger=WS_LOGGER)
 
@@ -399,7 +392,7 @@ async def test_all_failed_bulk_logs_only_its_per_op_lines(caplog) -> None:
 async def test_partly_successful_bulk_still_logs_its_summary(caplog) -> None:
     """The summary survives where it still says something: a batch that changed state."""
 
-    hass = _make_hass()
+    hass = ws_hass()
     created = await ws_send(hass, 1, "haventory/item/create", name="Widget")
     item_id = created["result"]["id"]
 
@@ -433,7 +426,7 @@ async def test_partly_successful_bulk_still_logs_its_summary(caplog) -> None:
 
 @pytest.mark.asyncio
 async def test_service_conflict_logs_warning_without_traceback(caplog) -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     repo = repo_of(hass)
     await services_mod.service_item_create(hass, {"name": "Widget"})
     item_id = str(repo.list_items()["items"][0].id)
@@ -456,7 +449,7 @@ async def test_service_conflict_logs_warning_without_traceback(caplog) -> None:
 async def test_service_schema_error_logs_warning_without_traceback(caplog) -> None:
     """``vol.Invalid`` is a validation rejection like any other."""
 
-    hass = _make_hass()
+    hass = ws_hass()
     caplog.set_level(logging.DEBUG, logger=SERVICES_LOGGER)
 
     with pytest.raises(vol.Invalid):
@@ -470,7 +463,7 @@ async def test_service_schema_error_logs_warning_without_traceback(caplog) -> No
 
 @pytest.mark.asyncio
 async def test_service_storage_error_logs_error_with_traceback(caplog, monkeypatch) -> None:
-    hass = _make_hass()
+    hass = ws_hass()
 
     async def _raise(*_args: Any, **_kwargs: Any) -> None:
         raise StorageError("failed to persist repository")

--- a/tests/test_ws_rate_limit_offline.py
+++ b/tests/test_ws_rate_limit_offline.py
@@ -43,11 +43,10 @@ from custom_components.haventory.rate_limit import (
 )
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION, DomainStore
 from custom_components.haventory.ws import RATE_LIMITED_MESSAGE
-from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from runtime_helpers import install_runtime, repo_of, runtime_of, setup_entry
+from runtime_helpers import install_runtime, repo_of, runtime_of, setup_entry, ws_hass
 from ws_helpers import RecordingConn, ws_send
 
 
@@ -67,13 +66,6 @@ def clock(monkeypatch) -> _FakeClock:
     fake = _FakeClock()
     monkeypatch.setattr(rate_limit_module, "_monotonic", fake)
     return fake
-
-
-def _make_hass(limiter: RateLimiter | None = None) -> HomeAssistant:
-    hass = HomeAssistant()
-    install_runtime(hass, rate_limiter=limiter)
-    ws_setup(hass)
-    return hass
 
 
 def _config(**overrides: Any) -> RateLimitConfig:
@@ -123,7 +115,7 @@ def test_token_bucket_rejects_non_positive_parameters() -> None:
 
 @pytest.mark.asyncio
 async def test_no_limiter_means_unlimited() -> None:
-    hass = _make_hass(limiter=None)
+    hass = ws_hass()
     conn = RecordingConn()
     for i in range(50):
         res = await ws_send(hass, i + 1, "haventory/ping", conn=conn)
@@ -133,7 +125,7 @@ async def test_no_limiter_means_unlimited() -> None:
 @pytest.mark.asyncio
 async def test_disabled_limiter_means_unlimited(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(enabled=False, commands_burst=1.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     conn = RecordingConn()
     for i in range(50):
         res = await ws_send(hass, i + 1, "haventory/ping", conn=conn)
@@ -154,7 +146,7 @@ def test_default_config_is_disabled() -> None:
 @pytest.mark.asyncio
 async def test_per_connection_command_limit(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(commands_per_second=1.0, commands_burst=2.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     conn_a = RecordingConn()
     conn_b = RecordingConn()
 
@@ -180,7 +172,7 @@ async def test_per_connection_command_limit(clock: _FakeClock) -> None:
 @pytest.mark.asyncio
 async def test_global_command_limit(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(global_commands_per_second=1.0, global_commands_burst=3.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
 
     conns = [RecordingConn() for _ in range(4)]
     outcomes = []
@@ -195,7 +187,7 @@ async def test_global_command_limit(clock: _FakeClock) -> None:
 @pytest.mark.asyncio
 async def test_rate_limited_command_does_not_execute(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(commands_burst=1.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     conn = RecordingConn()
 
     res = await ws_send(hass, 1, "haventory/item/create", conn=conn, name="First")
@@ -215,7 +207,7 @@ async def test_rate_limited_command_does_not_execute(clock: _FakeClock) -> None:
 @pytest.mark.asyncio
 async def test_per_connection_event_limit(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(events_per_second=1.0, events_burst=1.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     subscriber = RecordingConn()
     sub = await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items")
     assert sub["success"] is True
@@ -236,7 +228,7 @@ async def test_no_budget_consumed_without_matching_subscribers(clock: _FakeClock
     """Events nobody would receive must not consume the global event budget."""
 
     limiter = RateLimiter(_config(global_events_per_second=1.0, global_events_burst=1.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
 
     # No subscribers at all: nothing is consumed or counted.
     for _ in range(3):
@@ -267,7 +259,7 @@ async def test_one_event_consumes_one_token_across_multiple_subscriptions(
     """Two matching subscriptions on one connection share a single event token."""
 
     limiter = RateLimiter(_config(events_per_second=1.0, events_burst=1.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     conn = RecordingConn()
     assert (await ws_send(hass, 301, "haventory/subscribe", conn=conn, topic="items"))["success"]
     assert (await ws_send(hass, 302, "haventory/subscribe", conn=conn, topic="items"))["success"]
@@ -285,7 +277,7 @@ async def test_one_event_consumes_one_token_across_multiple_subscriptions(
 @pytest.mark.asyncio
 async def test_global_event_limit_drops_for_all_subscribers(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(global_events_per_second=1.0, global_events_burst=1.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     sub_a = RecordingConn()
     sub_b = RecordingConn()
     assert (await ws_send(hass, 100, "haventory/subscribe", conn=sub_a, topic="items"))["success"]
@@ -304,7 +296,7 @@ async def test_event_drop_does_not_fail_the_command(clock: _FakeClock) -> None:
     limiter = RateLimiter(
         _config(global_events_per_second=1.0, global_events_burst=1.0, commands_burst=1000.0)
     )
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     subscriber = RecordingConn()
     actor = RecordingConn()
     assert (await ws_send(hass, 100, "haventory/subscribe", conn=subscriber, topic="items"))[
@@ -329,7 +321,7 @@ async def test_event_drop_does_not_fail_the_command(clock: _FakeClock) -> None:
 @pytest.mark.asyncio
 async def test_health_exposes_rate_limit_counters(clock: _FakeClock) -> None:
     limiter = RateLimiter(_config(commands_burst=1.0))
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     conn = RecordingConn()
     assert (await ws_send(hass, 1, "haventory/ping", conn=conn))["success"] is True
     assert (await ws_send(hass, 2, "haventory/ping", conn=conn))["success"] is False
@@ -343,7 +335,7 @@ async def test_health_exposes_rate_limit_counters(clock: _FakeClock) -> None:
 
 @pytest.mark.asyncio
 async def test_health_reports_disabled_without_limiter() -> None:
-    hass = _make_hass(limiter=None)
+    hass = ws_hass()
     res = await ws_send(hass, 1, "haventory/health", conn=RecordingConn())
     assert res["success"] is True
     assert res["result"]["rate_limit"] == {
@@ -563,7 +555,7 @@ class _ConnWithSubscriptions(RecordingConn):
 
 @pytest.mark.asyncio
 async def test_close_cleanup_registers_in_conn_subscriptions() -> None:
-    hass = _make_hass()
+    hass = ws_hass()
     conn = _ConnWithSubscriptions()
     res = await ws_send(hass, 200, "haventory/subscribe", conn=conn, topic="items")
     assert res["success"] is True
@@ -582,7 +574,7 @@ async def test_rate_limit_state_cleanup_via_conn_subscriptions(clock: _FakeClock
     """Per-connection bucket state is dropped when real HA closes the conn."""
 
     limiter = RateLimiter(_config())
-    hass = _make_hass(limiter)
+    hass = ws_hass(rate_limiter=limiter)
     conn = _ConnWithSubscriptions()
     assert (await ws_send(hass, 1, "haventory/ping", conn=conn))["success"] is True
     assert conn in limiter._conn_states

--- a/tests/test_ws_reminders_offline.py
+++ b/tests/test_ws_reminders_offline.py
@@ -14,24 +14,16 @@ from __future__ import annotations
 from datetime import UTC, date, datetime, timedelta, timezone
 
 import pytest
-from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from runtime_helpers import install_runtime, repo_of
+from runtime_helpers import repo_of, ws_hass
 from ws_helpers import ws_send
 
 MONTHLY = {"unit": "months", "count": 3}
 _AFTER_ONE_EDIT = 2
 #: An arbitrary new quantity, standing in for any edit that is not the reminder.
 _EDITED_QUANTITY = 4
-
-
-def _hass() -> HomeAssistant:
-    hass = HomeAssistant()
-    install_runtime(hass)
-    ws_setup(hass)
-    return hass
 
 
 async def _item(hass: HomeAssistant, name: str = "HVAC filter") -> str:
@@ -52,7 +44,7 @@ def _freeze(monkeypatch, today: date) -> None:
 
 @pytest.mark.asyncio
 async def test_set_stores_the_anchor_and_the_interval() -> None:
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
 
     res = await ws_send(
@@ -76,7 +68,7 @@ async def test_set_stores_the_anchor_and_the_interval() -> None:
 async def test_set_without_an_interval_is_a_one_off() -> None:
     """An omitted interval means no recurrence, not "keep the stored one"."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -97,7 +89,7 @@ async def test_set_without_an_interval_is_a_one_off() -> None:
 
 @pytest.mark.asyncio
 async def test_clear_removes_both_halves() -> None:
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -119,7 +111,7 @@ async def test_clear_removes_both_halves() -> None:
 async def test_clear_on_an_item_with_no_reminder_succeeds() -> None:
     """Clearing is idempotent: the end state is what the caller asked for."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
 
     res = await ws_send(hass, 2, "haventory/reminder/clear", item_id=item_id)
@@ -132,7 +124,7 @@ async def test_clear_on_an_item_with_no_reminder_succeeds() -> None:
 async def test_bump_moves_a_due_reminder_on_by_one_interval() -> None:
     """The filter was changed today: the whole series moves with the anchor."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     anchor = _today()
     await ws_send(
@@ -155,7 +147,7 @@ async def test_bump_moves_a_due_reminder_on_by_one_interval() -> None:
 async def test_bump_from_a_long_past_anchor_lands_in_the_future() -> None:
     """A reminder nobody bumped for years does not advance to another past date."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -173,7 +165,7 @@ async def test_bump_from_a_long_past_anchor_lands_in_the_future() -> None:
 
 @pytest.mark.asyncio
 async def test_bump_refuses_an_item_with_no_reminder() -> None:
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
 
     res = await ws_send(hass, 2, "haventory/reminder/bump", item_id=item_id)
@@ -186,7 +178,7 @@ async def test_bump_refuses_an_item_with_no_reminder() -> None:
 async def test_bump_refuses_a_one_off() -> None:
     """There is no next occurrence to move to, and guessing one would invent a series."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(hass, 2, "haventory/reminder/set", item_id=item_id, reminder_date="2026-09-01")
 
@@ -200,7 +192,7 @@ async def test_bump_refuses_a_one_off() -> None:
 async def test_an_interval_with_no_anchor_is_refused() -> None:
     """Through `item/update`, the one path that can name the interval alone."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
 
     res = await ws_send(
@@ -215,7 +207,7 @@ async def test_an_interval_with_no_anchor_is_refused() -> None:
 async def test_clearing_the_anchor_of_a_recurring_reminder_is_refused() -> None:
     """The stored interval is what the update is validated against."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -245,7 +237,7 @@ async def test_clearing_the_anchor_of_a_recurring_reminder_is_refused() -> None:
 )
 @pytest.mark.asyncio
 async def test_an_unusable_interval_is_refused(interval: dict) -> None:
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
 
     res = await ws_send(
@@ -265,7 +257,7 @@ async def test_an_unusable_interval_is_refused(interval: dict) -> None:
 async def test_a_stale_expected_version_is_a_conflict() -> None:
     """Reminders take part in the same optimistic concurrency as every edit."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
 
     res = await ws_send(
@@ -289,7 +281,7 @@ async def test_bump_names_a_stored_anchor_it_cannot_read() -> None:
     at the field and at the way out rather than to report a crash.
     """
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -320,7 +312,7 @@ async def test_a_bump_counts_from_the_household_day_not_the_utc_one(monkeypatch)
     anywhere but UTC, so the zone has to be pinned here.
     """
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     # 18:00 on the 14th in Los Angeles is 02:00 on the 15th in UTC.
     evening_local = datetime(2026, 8, 14, 18, 0, tzinfo=timezone(timedelta(hours=-8)))
@@ -357,7 +349,7 @@ async def test_a_month_end_series_still_lands_on_the_31st_after_a_bump(monkeypat
     on the 30th — and February re-anchored it on the 28th — permanently.
     """
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     _freeze(monkeypatch, date(2026, 8, 15))
     await ws_send(
@@ -390,7 +382,7 @@ async def test_a_bump_through_february_skips_no_occurrence(monkeypatch) -> None:
     reminded in February.
     """
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     _freeze(monkeypatch, date(2027, 1, 20))
     await ws_send(
@@ -415,7 +407,7 @@ async def test_a_bump_through_february_skips_no_occurrence(monkeypatch) -> None:
 async def test_setting_a_date_re_anchors_the_series_on_it() -> None:
     """A household picking a date is saying where the series starts."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -444,7 +436,7 @@ async def test_setting_a_date_re_anchors_the_series_on_it() -> None:
 async def test_clearing_a_reminder_takes_the_anchor_with_it() -> None:
     """An anchor with no date names a series with no next occurrence."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -465,7 +457,7 @@ async def test_clearing_a_reminder_takes_the_anchor_with_it() -> None:
 async def test_a_bump_answers_conflict_on_a_stale_version() -> None:
     """It is an ordinary item edit, so it takes the same concurrency check."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     await ws_send(
         hass,
@@ -498,7 +490,7 @@ async def test_an_edit_that_resends_the_same_date_leaves_the_anchor_alone(monkey
     with nothing in the card showing it.
     """
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     _freeze(monkeypatch, date(2026, 1, 15))
     created = await ws_send(
@@ -551,7 +543,7 @@ async def test_the_cards_whole_save_payload_leaves_the_anchor_alone(monkeypatch)
     sends what the editor sends.
     """
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     _freeze(monkeypatch, date(2026, 1, 15))
     await ws_send(
@@ -597,7 +589,7 @@ async def test_the_cards_whole_save_payload_leaves_the_anchor_alone(monkeypatch)
 async def test_an_edit_that_moves_the_date_still_re_anchors() -> None:
     """Picking a new date is still saying where the series starts."""
 
-    hass = _hass()
+    hass = ws_hass()
     item_id = await _item(hass)
     created = await ws_send(
         hass,
@@ -643,7 +635,7 @@ async def _item_with_reminder(hass: HomeAssistant, name: str, date_str: str, msg
 async def test_items_sort_by_reminder_date() -> None:
     """Soonest first ascending, and an item with no reminder sorts last."""
 
-    hass = _hass()
+    hass = ws_hass()
     late = await _item_with_reminder(hass, "Water filter", "2027-03-01", 10)
     soon = await _item_with_reminder(hass, "Smoke detector", "2026-09-01", 20)
     none = await _item(hass, "Hammer")
@@ -660,7 +652,7 @@ async def test_items_sort_by_reminder_date() -> None:
 async def test_reminder_due_only_takes_today_and_leaves_the_future() -> None:
     """Today counts: a reminder names the day it is asking about."""
 
-    hass = _hass()
+    hass = ws_hass()
     today = _today().isoformat()
     past = await _item_with_reminder(hass, "Gutters", "2020-01-01", 10)
     now = await _item_with_reminder(hass, "Smoke detector", today, 20)
@@ -677,7 +669,7 @@ async def test_reminder_due_only_takes_today_and_leaves_the_future() -> None:
 async def test_stats_counts_the_reminders_that_have_come_round() -> None:
     """The count behind the quick-filter pill, on the same inclusive rule."""
 
-    hass = _hass()
+    hass = ws_hass()
     await _item_with_reminder(hass, "Gutters", "2020-01-01", 10)
     await _item_with_reminder(hass, "Smoke detector", _today().isoformat(), 20)
     await _item_with_reminder(hass, "Water filter", "2099-01-01", 30)
@@ -691,7 +683,7 @@ async def test_stats_counts_the_reminders_that_have_come_round() -> None:
 async def test_an_unknown_reminder_sort_field_is_still_refused() -> None:
     """The new key is additive; it does not open the vocabulary up."""
 
-    hass = _hass()
+    hass = ws_hass()
     await _item(hass)
 
     res = await ws_send(

--- a/tests/test_ws_reminders_offline.py
+++ b/tests/test_ws_reminders_offline.py
@@ -32,7 +32,9 @@ async def _item(hass: HomeAssistant, name: str = "HVAC filter") -> str:
 
 
 def _today() -> date:
-    return datetime.now(UTC).date()
+    """The day a bump counts from, read off the clock the bump itself reads."""
+
+    return dt_util.now().date()
 
 
 def _freeze(monkeypatch, today: date) -> None:

--- a/tests/test_ws_smoke_advanced_online.py
+++ b/tests/test_ws_smoke_advanced_online.py
@@ -1,8 +1,9 @@
 import os
-from typing import Any
 
 import aiohttp
 import pytest
+
+from online_helpers import expect_result, id_counter, open_ws
 
 pytestmark = pytest.mark.online
 
@@ -12,49 +13,10 @@ BASELINE_LOCATIONS_COUNT = 3
 AFTER_MIXED_ITEMS_COUNT = 2
 
 
-def _ws_url_from_base(base_url: str) -> str:
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    if base_url.startswith("http://"):
-        return f"ws://{base_url[len('http://') :]}/api/websocket"
-    return f"ws://{base_url}/api/websocket"
-
-
-async def _open_ws():
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
-    ws_url = _ws_url_from_base(base)
-    session = aiohttp.ClientSession()
-    ws = await session.ws_connect(ws_url)
-    _ = await ws.receive_json()
-    await ws.send_json({"type": "auth", "access_token": token})
-    _ = await ws.receive_json()
-    return session, ws
-
-
-async def _expect_result(ws: aiohttp.ClientWebSocketResponse, expect_id: int) -> dict[str, Any]:
-    while True:
-        msg = await ws.receive_json()
-        if isinstance(msg, dict) and msg.get("id") == expect_id and msg.get("type") == "result":
-            return msg
-
-
-def _id_counter(start: int = 0):
-    value = start
-
-    def _next() -> int:
-        nonlocal value
-        value += 1
-        return value
-
-    return _next
-
-
 async def _purge_items(ws: aiohttp.ClientWebSocketResponse, next_id) -> None:
     qid = next_id()
     await ws.send_json({"id": qid, "type": "haventory/item/list"})
-    lst = await _expect_result(ws, qid)
+    lst = await expect_result(ws, qid)
     items = (lst.get("result") or {}).get("items") or []
     for it in items:
         did = next_id()
@@ -66,13 +28,13 @@ async def _purge_items(ws: aiohttp.ClientWebSocketResponse, next_id) -> None:
                 "expected_version": int(it.get("version", 1)),
             }
         )
-        _ = await _expect_result(ws, did)
+        _ = await expect_result(ws, did)
 
 
 async def _purge_locations(ws: aiohttp.ClientWebSocketResponse, next_id) -> None:
     qid = next_id()
     await ws.send_json({"id": qid, "type": "haventory/location/list"})
-    lst = await _expect_result(ws, qid)
+    lst = await expect_result(ws, qid)
     locs = lst.get("result") or []
     locs_sorted = sorted(
         [loc for loc in locs if isinstance(loc, dict)],
@@ -84,7 +46,7 @@ async def _purge_locations(ws: aiohttp.ClientWebSocketResponse, next_id) -> None
         await ws.send_json(
             {"id": did, "type": "haventory/location/delete", "location_id": loc.get("id")}
         )
-        _ = await _expect_result(ws, did)
+        _ = await expect_result(ws, did)
 
 
 @pytest.mark.asyncio
@@ -101,8 +63,8 @@ async def _purge_locations(ws: aiohttp.ClientWebSocketResponse, next_id) -> None
 )
 async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0915
     """Phase 3: mixed-success bulk then all-failure bulk; verify stats and per-op outcomes."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         # Clean slate
         await _purge_items(ws, next_id)
@@ -111,12 +73,12 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
         # Create base locations: Garage, Pantry, Pantry/Shelf A
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/location/create", "name": "Garage"})
-        cre_g = await _expect_result(ws, cid)
+        cre_g = await expect_result(ws, cid)
         garage_id = str((cre_g.get("result") or {}).get("id"))
 
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/location/create", "name": "Pantry"})
-        cre_p = await _expect_result(ws, cid)
+        cre_p = await expect_result(ws, cid)
         pantry_id = str((cre_p.get("result") or {}).get("id"))
 
         cid = next_id()
@@ -128,7 +90,7 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
                 "parent_id": pantry_id,
             }
         )
-        cre_s = await _expect_result(ws, cid)
+        cre_s = await expect_result(ws, cid)
         shelf_a_id = str((cre_s.get("result") or {}).get("id"))
 
         # Create base items: Hammer@Garage(2), Apples@Pantry(5), Junk Screwdriver@Garage(1)
@@ -146,7 +108,7 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
                 "location_id": garage_id,
             }
         )
-        cre_h = await _expect_result(ws, iid)
+        cre_h = await expect_result(ws, iid)
         hammer_id = str((cre_h.get("result") or {}).get("id"))
 
         iid = next_id()
@@ -159,7 +121,7 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
                 "location_id": pantry_id,
             }
         )
-        cre_a = await _expect_result(ws, iid)
+        cre_a = await expect_result(ws, iid)
         apples_id = str((cre_a.get("result") or {}).get("id"))
 
         iid = next_id()
@@ -172,13 +134,13 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
                 "location_id": garage_id,
             }
         )
-        cre_j = await _expect_result(ws, iid)
+        cre_j = await expect_result(ws, iid)
         junk_id = str((cre_j.get("result") or {}).get("id"))
 
         # Baseline stats
         sid = next_id()
         await ws.send_json({"id": sid, "type": "haventory/stats"})
-        stats0 = await _expect_result(ws, sid)
+        stats0 = await expect_result(ws, sid)
         s0 = stats0.get("result", {})
         assert (
             s0.get("items_total") == BASELINE_ITEMS_COUNT
@@ -216,7 +178,7 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
                 ],
             }
         )
-        bulk = await _expect_result(ws, bid)
+        bulk = await expect_result(ws, bid)
         assert bulk.get("success") is True
         results = (bulk.get("result") or {}).get("results") or {}
 
@@ -235,7 +197,7 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
         # Stats after mixed: items decreased by 1, locations unchanged
         sid2 = next_id()
         await ws.send_json({"id": sid2, "type": "haventory/stats"})
-        stats1 = await _expect_result(ws, sid2)
+        stats1 = await expect_result(ws, sid2)
         s1 = stats1.get("result", {})
         assert (
             s1.get("items_total") == AFTER_MIXED_ITEMS_COUNT
@@ -268,7 +230,7 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
                 ],
             }
         )
-        bulk_bad = await _expect_result(ws, bid2)
+        bulk_bad = await expect_result(ws, bid2)
         assert bulk_bad.get("success") is True
         results_bad = (bulk_bad.get("result") or {}).get("results") or {}
         for key in ("b1", "b2", "b3", "b4"):
@@ -277,7 +239,7 @@ async def test_p3_bulk_operations_mixed_and_all_failure() -> None:  # noqa: PLR0
         # Verify counts unchanged vs post-mixed
         sid3 = next_id()
         await ws.send_json({"id": sid3, "type": "haventory/stats"})
-        stats2 = await _expect_result(ws, sid3)
+        stats2 = await expect_result(ws, sid3)
         s2 = stats2.get("result", {})
         assert s2.get("items_total") == s1.get("items_total") and s2.get(
             "locations_total"

--- a/tests/test_ws_smoke_online.py
+++ b/tests/test_ws_smoke_online.py
@@ -6,6 +6,8 @@ import aiohttp
 import pytest
 from custom_components.haventory.storage import CURRENT_SCHEMA_VERSION
 
+from online_helpers import expect_result, id_counter, open_ws, ws_url_from_base
+
 pytestmark = pytest.mark.online
 
 # Destructive online tests PURGE ALL HAventory data on the target instance.
@@ -27,48 +29,9 @@ def _unique(name: str) -> str:
     return f"{name} {uuid.uuid4().hex[:8]}"
 
 
-def _ws_url_from_base(base_url: str) -> str:
-    base_url = base_url.rstrip("/")
-    if base_url.startswith("https://"):
-        return f"wss://{base_url[len('https://') :]}/api/websocket"
-    if base_url.startswith("http://"):
-        return f"ws://{base_url[len('http://') :]}/api/websocket"
-    return f"ws://{base_url}/api/websocket"
-
-
 MAGIC_MIN_ADDED_LOCATIONS: int = 2
 EXPECTED_LOCATIONS_AFTER_CREATE: int = 2
 EXPECTED_FINAL_LOCATIONS: int = 2
-
-
-async def _open_ws():
-    base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
-    token = os.environ.get("HA_TOKEN")
-    ws_url = _ws_url_from_base(base)
-    session = aiohttp.ClientSession()
-    ws = await session.ws_connect(ws_url)
-    _ = await ws.receive_json()
-    await ws.send_json({"type": "auth", "access_token": token})
-    _ = await ws.receive_json()
-    return session, ws
-
-
-async def _expect_result(ws: aiohttp.ClientWebSocketResponse, expect_id: int) -> dict[str, Any]:
-    while True:
-        msg = await ws.receive_json()
-        if isinstance(msg, dict) and msg.get("id") == expect_id and msg.get("type") == "result":
-            return msg
-
-
-def _id_counter(start: int = 0):
-    value = start
-
-    def _next() -> int:
-        nonlocal value
-        value += 1
-        return value
-
-    return _next
 
 
 async def _find_location_id_by_name(
@@ -76,7 +39,7 @@ async def _find_location_id_by_name(
 ) -> str | None:
     qid = next_id()
     await ws.send_json({"id": qid, "type": "haventory/location/list"})
-    lst = await _expect_result(ws, qid)
+    lst = await expect_result(ws, qid)
     for loc in lst.get("result", []) or []:
         if isinstance(loc, dict) and loc.get("name") == name:
             return str(loc.get("id"))
@@ -91,7 +54,7 @@ async def _create_location(
     if parent_id is not None:
         payload["parent_id"] = parent_id
     await ws.send_json(payload)
-    res = await _expect_result(ws, cid)
+    res = await expect_result(ws, cid)
     assert res.get("success") is True, res
     return str(res["result"]["id"])
 
@@ -104,7 +67,7 @@ async def _delete_location_quiet(
         return
     did = next_id()
     await ws.send_json({"id": did, "type": "haventory/location/delete", "location_id": location_id})
-    _ = await _expect_result(ws, did)
+    _ = await expect_result(ws, did)
 
 
 @pytest.mark.asyncio
@@ -115,13 +78,13 @@ async def _delete_location_quiet(
 async def test_ws_areas_list_and_location_area_field_presence() -> None:
     """Verify areas/list shape and that location serialization includes area_id."""
 
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         # areas/list returns {areas: []}
         aid = next_id()
         await ws.send_json({"id": aid, "type": "haventory/areas/list"})
-        areas = await _expect_result(ws, aid)
+        areas = await expect_result(ws, aid)
         if not areas.get("success"):
             pytest.skip("areas/list not available in this HA runtime")
         assert isinstance((areas.get("result") or {}).get("areas"), list)
@@ -130,7 +93,7 @@ async def test_ws_areas_list_and_location_area_field_presence() -> None:
         cid = next_id()
         probe_name = _unique("AreaProbe")
         await ws.send_json({"id": cid, "type": "haventory/location/create", "name": probe_name})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         loc = cre.get("result") or {}
         assert "area_id" in loc and loc.get("area_id") is None
         # Clean up the probe location so the test leaves no trace
@@ -150,7 +113,7 @@ async def test_ws_ping_and_version() -> None:
     base = os.environ.get("HA_BASE_URL", "http://localhost:8123")
     token = os.environ.get("HA_TOKEN")
 
-    ws_url = _ws_url_from_base(base)
+    ws_url = ws_url_from_base(base)
 
     async with aiohttp.ClientSession() as session:
         async with session.ws_connect(ws_url) as ws:
@@ -187,8 +150,8 @@ async def test_ws_smoke_phase0_phase1_locations() -> None:  # noqa: PLR0915
     Preconditions:
     - Intended to run against a clean dataset (fresh storage) so Phase 0 stats are zero.
     """
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         # Purge any existing items/locations to ensure a clean dataset
         await _purge_items(ws, next_id)
@@ -196,19 +159,19 @@ async def test_ws_smoke_phase0_phase1_locations() -> None:  # noqa: PLR0915
 
         # Phase 0.1: ping
         await ws.send_json({"id": 101, "type": "haventory/ping", "echo": "hi"})
-        msg = await _expect_result(ws, 101)
+        msg = await expect_result(ws, 101)
         assert msg.get("success") is True  # scenario: WS echo should succeed
         assert msg.get("result", {}).get("echo") == "hi"  # expected: echo roundtrip
 
         # Phase 0.2: version and stats
         await ws.send_json({"id": 102, "type": "haventory/version"})
-        ver = await _expect_result(ws, 102)
+        ver = await expect_result(ws, 102)
         assert ver.get("success") is True  # scenario: version endpoint works
         vres = ver.get("result")
         assert isinstance(vres, dict) and vres.get("schema_version") == CURRENT_SCHEMA_VERSION
 
         await ws.send_json({"id": 103, "type": "haventory/stats"})
-        stats = await _expect_result(ws, 103)
+        stats = await expect_result(ws, 103)
         sres = stats.get("result", {})
         # Expect clean storage (script purges before running)
         assert sres.get("items_total") == 0  # scenario: no items initially
@@ -216,14 +179,14 @@ async def test_ws_smoke_phase0_phase1_locations() -> None:  # noqa: PLR0915
 
         # Phase 0.3: health
         await ws.send_json({"id": 104, "type": "haventory/health"})
-        health = await _expect_result(ws, 104)
+        health = await expect_result(ws, 104)
         hres = health.get("result", {})
         assert hres.get("healthy") is True  # expected: healthy on empty dataset
         assert hres.get("issues") == []  # expected: no issues
 
         # Phase 1.1: create root and child
         await ws.send_json({"id": 201, "type": "haventory/location/create", "name": "Garage"})
-        cre_g = await _expect_result(ws, 201)
+        cre_g = await expect_result(ws, 201)
         garage_id = cre_g.get("result", {}).get("id")
         assert isinstance(garage_id, str) and len(garage_id) > 0  # expected: UUID
 
@@ -235,12 +198,12 @@ async def test_ws_smoke_phase0_phase1_locations() -> None:  # noqa: PLR0915
                 "parent_id": garage_id,
             }
         )
-        cre_s = await _expect_result(ws, 202)
+        cre_s = await expect_result(ws, 202)
         shelf_id = cre_s.get("result", {}).get("id")
         assert isinstance(shelf_id, str) and len(shelf_id) > 0
 
         await ws.send_json({"id": 203, "type": "haventory/location/list"})
-        lst = await _expect_result(ws, 203)
+        lst = await expect_result(ws, 203)
         lres = lst.get("result")
         assert (
             isinstance(lres, list) and len(lres) >= MAGIC_MIN_ADDED_LOCATIONS
@@ -251,7 +214,7 @@ async def test_ws_smoke_phase0_phase1_locations() -> None:  # noqa: PLR0915
         assert shelf_entry.get("parent_id") == garage_id  # parent relation
 
         await ws.send_json({"id": 204, "type": "haventory/location/tree"})
-        tree = await _expect_result(ws, 204)
+        tree = await expect_result(ws, 204)
         tres = tree.get("result")
         assert isinstance(tres, list) and len(tres) >= 1
 
@@ -272,7 +235,7 @@ async def test_ws_smoke_phase0_phase1_locations() -> None:  # noqa: PLR0915
 
         # Stats should reflect exactly +2 locations after creation
         await ws.send_json({"id": 205, "type": "haventory/stats"})
-        stats_after_create = await _expect_result(ws, 205)
+        stats_after_create = await expect_result(ws, 205)
         s_after = stats_after_create.get("result", {})
         assert (
             s_after.get("locations_total") == EXPECTED_LOCATIONS_AFTER_CREATE
@@ -291,8 +254,8 @@ async def test_ws_smoke_phase0_phase1_locations() -> None:  # noqa: PLR0915
 )
 async def test_ws_location_rename() -> None:
     """Rename a test-created location (self-contained, cleans up after itself)."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     loc_id: str | None = None
     try:
         name = _unique("SmokeRename")
@@ -306,7 +269,7 @@ async def test_ws_location_rename() -> None:
                 "name": f"{name} Renamed",
             }
         )
-        upd = await _expect_result(ws, rid)
+        upd = await expect_result(ws, rid)
         assert upd.get("success") is True and upd["result"]["name"] == f"{name} Renamed"
     finally:
         await _delete_location_quiet(ws, next_id, loc_id)
@@ -321,8 +284,8 @@ async def test_ws_location_rename() -> None:
 )
 async def test_ws_location_create_basement() -> None:
     """Create and remove a root location (self-contained)."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     basement_id: str | None = None
     try:
         basement_id = await _create_location(ws, next_id, _unique("SmokeBasement"))
@@ -340,8 +303,8 @@ async def test_ws_location_create_basement() -> None:
 )
 async def test_ws_location_move_subtree() -> None:
     """Move a test-created subtree under another test-created root (self-contained)."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     garage_id: str | None = None
     basement_id: str | None = None
     try:
@@ -356,12 +319,12 @@ async def test_ws_location_move_subtree() -> None:
                 "new_parent_id": basement_id,
             }
         )
-        mv = await _expect_result(ws, mid)
+        mv = await expect_result(ws, mid)
         assert mv.get("success") is True
         # Verify via tree
         tid = next_id()
         await ws.send_json({"id": tid, "type": "haventory/location/tree"})
-        tree2 = await _expect_result(ws, tid)
+        tree2 = await expect_result(ws, tid)
         roots = tree2.get("result")
         assert isinstance(roots, list)
 
@@ -394,8 +357,8 @@ async def test_ws_location_move_subtree() -> None:
 )
 async def test_ws_location_move_subtree_negative_self() -> None:
     """Negative: cannot move a location under itself (self-contained)."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     garage_id: str | None = None
     try:
         garage_id = await _create_location(ws, next_id, _unique("SmokeSelfMove"))
@@ -408,7 +371,7 @@ async def test_ws_location_move_subtree_negative_self() -> None:
                 "new_parent_id": garage_id,
             }
         )
-        neg = await _expect_result(ws, nid)
+        neg = await expect_result(ws, nid)
         assert (
             neg.get("success") is False
             and (neg.get("error") or {}).get("code") == "validation_error"
@@ -426,8 +389,8 @@ async def test_ws_location_move_subtree_negative_self() -> None:
 )
 async def test_ws_location_move_subtree_negative_descendant() -> None:
     """Negative: cannot move a location under a descendant (self-contained)."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     garage_id: str | None = None
     shelf_id: str | None = None
     try:
@@ -444,7 +407,7 @@ async def test_ws_location_move_subtree_negative_descendant() -> None:
                 "new_parent_id": shelf_id,
             }
         )
-        neg2 = await _expect_result(ws, nid)
+        neg2 = await expect_result(ws, nid)
         assert (
             neg2.get("success") is False
             and (neg2.get("error") or {}).get("code") == "validation_error"
@@ -464,8 +427,8 @@ async def test_ws_location_move_subtree_negative_descendant() -> None:
 )
 async def test_ws_location_delete_leaf_and_get_not_found() -> None:
     """Delete a test-created leaf and verify get returns not_found (self-contained)."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     root_id: str | None = None
     try:
         root_id = await _create_location(ws, next_id, _unique("SmokeDelRoot"))
@@ -474,11 +437,11 @@ async def test_ws_location_delete_leaf_and_get_not_found() -> None:
         await ws.send_json(
             {"id": did, "type": "haventory/location/delete", "location_id": shelf_id}
         )
-        del_ack = await _expect_result(ws, did)
+        del_ack = await expect_result(ws, did)
         assert del_ack.get("success") is True
         gid = next_id()
         await ws.send_json({"id": gid, "type": "haventory/location/get", "location_id": shelf_id})
-        get_after = await _expect_result(ws, gid)
+        get_after = await expect_result(ws, gid)
         assert (
             get_after.get("success") is False
             and (get_after.get("error") or {}).get("code") == "not_found"
@@ -497,22 +460,22 @@ async def test_ws_location_delete_leaf_and_get_not_found() -> None:
 @destructive
 async def test_ws_final_stats_after_all_location_ops() -> None:
     """Final stats: expect 2 locations remaining (Basement + Garage West)."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         # Make this test independent: purge all locations, then create exactly two roots
         await _purge_locations(ws, next_id)
         # Create 'Basement'
         bid = next_id()
         await ws.send_json({"id": bid, "type": "haventory/location/create", "name": "Basement"})
-        _ = await _expect_result(ws, bid)
+        _ = await expect_result(ws, bid)
         # Create 'Garage West'
         gid = next_id()
         await ws.send_json({"id": gid, "type": "haventory/location/create", "name": "Garage West"})
-        _ = await _expect_result(ws, gid)
+        _ = await expect_result(ws, gid)
         fid = next_id()
         await ws.send_json({"id": fid, "type": "haventory/stats"})
-        stats_final = await _expect_result(ws, fid)
+        stats_final = await expect_result(ws, fid)
         s_final = stats_final.get("result", {})
         assert s_final.get("locations_total") == EXPECTED_FINAL_LOCATIONS  # Basement + Garage West
     finally:
@@ -532,7 +495,7 @@ L_SHELF_A = "Shelf A"
 async def _purge_items(ws: aiohttp.ClientWebSocketResponse, next_id) -> None:
     qid = next_id()
     await ws.send_json({"id": qid, "type": "haventory/item/list"})
-    lst = await _expect_result(ws, qid)
+    lst = await expect_result(ws, qid)
     items = (lst.get("result") or {}).get("items") or []
     for it in items:
         did = next_id()
@@ -544,13 +507,13 @@ async def _purge_items(ws: aiohttp.ClientWebSocketResponse, next_id) -> None:
                 "expected_version": int(it.get("version", 1)),
             }
         )
-        _ = await _expect_result(ws, did)
+        _ = await expect_result(ws, did)
 
 
 async def _purge_locations(ws: aiohttp.ClientWebSocketResponse, next_id) -> None:
     qid = next_id()
     await ws.send_json({"id": qid, "type": "haventory/location/list"})
-    lst = await _expect_result(ws, qid)
+    lst = await expect_result(ws, qid)
     locs = lst.get("result") or []
     # deepest-first by path length
     locs_sorted = sorted(
@@ -563,7 +526,7 @@ async def _purge_locations(ws: aiohttp.ClientWebSocketResponse, next_id) -> None
         await ws.send_json(
             {"id": did, "type": "haventory/location/delete", "location_id": loc.get("id")}
         )
-        _ = await _expect_result(ws, did)
+        _ = await expect_result(ws, did)
 
 
 async def _ensure_phase2_base(ws: aiohttp.ClientWebSocketResponse, next_id) -> dict[str, str]:
@@ -574,12 +537,12 @@ async def _ensure_phase2_base(ws: aiohttp.ClientWebSocketResponse, next_id) -> d
     # Create base locations: Garage, Workshop, Shelf A under Garage
     gid = next_id()
     await ws.send_json({"id": gid, "type": "haventory/location/create", "name": L_GARAGE})
-    cre_g = await _expect_result(ws, gid)
+    cre_g = await expect_result(ws, gid)
     garage_id = str((cre_g.get("result") or {}).get("id"))
 
     wid = next_id()
     await ws.send_json({"id": wid, "type": "haventory/location/create", "name": L_WORKSHOP})
-    cre_w = await _expect_result(ws, wid)
+    cre_w = await expect_result(ws, wid)
     workshop_id = str((cre_w.get("result") or {}).get("id"))
 
     sid = next_id()
@@ -591,7 +554,7 @@ async def _ensure_phase2_base(ws: aiohttp.ClientWebSocketResponse, next_id) -> d
             "parent_id": garage_id,
         }
     )
-    cre_s = await _expect_result(ws, sid)
+    cre_s = await expect_result(ws, sid)
     shelf_a_id = str((cre_s.get("result") or {}).get("id"))
 
     return {"garage": garage_id, "workshop": workshop_id, "shelfA": shelf_a_id}
@@ -605,15 +568,15 @@ async def _ensure_phase2_base(ws: aiohttp.ClientWebSocketResponse, next_id) -> d
 @destructive
 async def test_p2_item_create_defaults_and_rich() -> None:
     """Create default item and rich item with all optionals."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         ids = await _ensure_phase2_base(ws, next_id)
 
         # Default
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         assert cre.get("success") is True
         item = cre.get("result") or {}
         assert item.get("version") == 1 and item.get("quantity") == 1
@@ -633,7 +596,7 @@ async def test_p2_item_create_defaults_and_rich() -> None:
                 "location_id": ids["shelfA"],
             }
         )
-        rich = await _expect_result(ws, rid)
+        rich = await expect_result(ws, rid)
         ritem = rich.get("result") or {}
         TARGET_QTY_RICH = 3  # avoid magic numbers
         assert ritem.get("quantity") == TARGET_QTY_RICH and ritem.get("category") == "tools"
@@ -652,22 +615,22 @@ async def test_p2_item_create_defaults_and_rich() -> None:
 @destructive
 async def test_p2_item_get_update_delete_recreate() -> None:
     """Get, update (version++), delete (with expected), then re-create."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         _ = await _ensure_phase2_base(ws, next_id)
 
         # Create
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         item_id = cre["result"]["id"]
         ver = int(cre["result"]["version"])
 
         # Get
         gid = next_id()
         await ws.send_json({"id": gid, "type": "haventory/item/get", "item_id": item_id})
-        got = await _expect_result(ws, gid)
+        got = await expect_result(ws, gid)
         assert got.get("success") is True and got["result"]["id"] == item_id
 
         # Update name/description/category
@@ -683,7 +646,7 @@ async def test_p2_item_get_update_delete_recreate() -> None:
                 "category": "pro tools",
             }
         )
-        upd = await _expect_result(ws, uid)
+        upd = await expect_result(ws, uid)
         ver = int(upd["result"]["version"])
         assert upd["result"]["name"] == "Hammer Pro"
 
@@ -697,13 +660,13 @@ async def test_p2_item_get_update_delete_recreate() -> None:
                 "expected_version": ver,
             }
         )
-        del_ack = await _expect_result(ws, did)
+        del_ack = await expect_result(ws, did)
         assert del_ack.get("success") is True
 
         # Re-create for later tests
         rcid = next_id()
         await ws.send_json({"id": rcid, "type": "haventory/item/create", "name": "Hammer R"})
-        re = await _expect_result(ws, rcid)
+        re = await expect_result(ws, rcid)
         assert re.get("success") is True
     finally:
         await ws.close()
@@ -718,14 +681,14 @@ async def test_p2_item_get_update_delete_recreate() -> None:
 @destructive
 async def test_p2_item_move_between_locations() -> None:
     """Move item to Workshop; verify location_path and version bump."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         ids = await _ensure_phase2_base(ws, next_id)
         # Create item
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer R"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         item_id = cre["result"]["id"]
         ver = int(cre["result"]["version"])
 
@@ -740,7 +703,7 @@ async def test_p2_item_move_between_locations() -> None:
                 "expected_version": ver,
             }
         )
-        mv = await _expect_result(ws, mid)
+        mv = await expect_result(ws, mid)
         assert mv.get("success") is True and mv["result"]["location_id"] == ids["workshop"]
         assert (mv["result"].get("location_path") or {}).get("display_path") == L_WORKSHOP
     finally:
@@ -756,14 +719,14 @@ async def test_p2_item_move_between_locations() -> None:
 @destructive
 async def test_p2_quantity_operations() -> None:
     """Invalid set_quantity (-1) then adjust +2 and set=5."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         _ = await _ensure_phase2_base(ws, next_id)
         # Create item
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer R"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         item_id = cre["result"]["id"]
         ver = int(cre["result"]["version"])
 
@@ -778,7 +741,7 @@ async def test_p2_quantity_operations() -> None:
                 "expected_version": ver,
             }
         )
-        neg = await _expect_result(ws, sid)
+        neg = await expect_result(ws, sid)
         assert (
             neg.get("success") is False
             and (neg.get("error") or {}).get("code") == "validation_error"
@@ -795,7 +758,7 @@ async def test_p2_quantity_operations() -> None:
                 "expected_version": ver,
             }
         )
-        adj = await _expect_result(ws, aid)
+        adj = await expect_result(ws, aid)
         ver = int(adj["result"]["version"])
         QTY_AFTER_ADJUST = 3
         assert adj["result"]["quantity"] == QTY_AFTER_ADJUST
@@ -811,7 +774,7 @@ async def test_p2_quantity_operations() -> None:
                 "expected_version": ver,
             }
         )
-        setq = await _expect_result(ws, sid2)
+        setq = await expect_result(ws, sid2)
         TARGET_QTY_FINAL = 5
         assert setq["result"]["quantity"] == TARGET_QTY_FINAL
     finally:
@@ -827,14 +790,14 @@ async def test_p2_quantity_operations() -> None:
 @destructive
 async def test_p2_checkout_checkin_and_due_dates() -> None:
     """Check-out with due_date, check-in, then negative due_date without checked_out."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         _ = await _ensure_phase2_base(ws, next_id)
         # Create item
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer R"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         item_id = cre["result"]["id"]
         ver = int(cre["result"]["version"])
 
@@ -849,7 +812,7 @@ async def test_p2_checkout_checkin_and_due_dates() -> None:
                 "expected_version": ver,
             }
         )
-        co = await _expect_result(ws, coid)
+        co = await expect_result(ws, coid)
         ver = int(co["result"]["version"])
         assert co["result"]["checked_out"] is True
 
@@ -863,7 +826,7 @@ async def test_p2_checkout_checkin_and_due_dates() -> None:
                 "expected_version": ver,
             }
         )
-        ci = await _expect_result(ws, ciid)
+        ci = await expect_result(ws, ciid)
         ver = int(ci["result"]["version"])
         assert ci["result"]["checked_out"] is False
 
@@ -878,7 +841,7 @@ async def test_p2_checkout_checkin_and_due_dates() -> None:
                 "due_date": "2025-01-01",
             }
         )
-        neg = await _expect_result(ws, nid)
+        neg = await expect_result(ws, nid)
         assert (
             neg.get("success") is False
             and (neg.get("error") or {}).get("code") == "validation_error"
@@ -896,14 +859,14 @@ async def test_p2_checkout_checkin_and_due_dates() -> None:
 @destructive
 async def test_p2_tags_and_custom_fields() -> None:
     """Add/remove tags; set/unset custom fields; verify normalization and result."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         _ = await _ensure_phase2_base(ws, next_id)
         # Create item
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer R"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         item_id = cre["result"]["id"]
         ver = int(cre["result"]["version"])
 
@@ -918,7 +881,7 @@ async def test_p2_tags_and_custom_fields() -> None:
                 "tags": ["Tool", "TOOL", "garage"],
             }
         )
-        tadd = await _expect_result(ws, tid)
+        tadd = await expect_result(ws, tid)
         ver = int(tadd["result"]["version"])
         # Normalization preserves insertion order of unique, casefolded tags
         # Given ["Tool","TOOL","garage"] -> ["tool","garage"]
@@ -935,7 +898,7 @@ async def test_p2_tags_and_custom_fields() -> None:
                 "tags": ["tool"],
             }
         )
-        trem = await _expect_result(ws, rid)
+        trem = await expect_result(ws, rid)
         ver = int(trem["result"]["version"])
         # We removed 'tool', leaving 'garage'
         assert trem["result"]["tags"] == ["garage"]
@@ -952,7 +915,7 @@ async def test_p2_tags_and_custom_fields() -> None:
                 "unset": [],
             }
         )
-        cset = await _expect_result(ws, sid)
+        cset = await expect_result(ws, sid)
         ver = int(cset["result"]["version"])
         assert (cset["result"].get("custom_fields") or {}).get("color") == "red"
 
@@ -968,7 +931,7 @@ async def test_p2_tags_and_custom_fields() -> None:
                 "unset": ["weight"],
             }
         )
-        cunset = await _expect_result(ws, uid)
+        cunset = await expect_result(ws, uid)
         cf = cunset["result"].get("custom_fields") or {}
         assert "weight" not in cf and cf.get("color") == "red"
     finally:
@@ -984,14 +947,14 @@ async def test_p2_tags_and_custom_fields() -> None:
 @destructive
 async def test_p2_low_stock_threshold_and_stats() -> None:
     """Set threshold and cross it to verify low_stock_count in stats."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         _ = await _ensure_phase2_base(ws, next_id)
         # Create item quantity 5
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer R"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         item_id = cre["result"]["id"]
         ver = int(cre["result"]["version"])
 
@@ -1006,12 +969,12 @@ async def test_p2_low_stock_threshold_and_stats() -> None:
                 "low_stock_threshold": 3,
             }
         )
-        _ = await _expect_result(ws, tid)
+        _ = await expect_result(ws, tid)
 
         # stats before crossing
         sid = next_id()
         await ws.send_json({"id": sid, "type": "haventory/stats"})
-        s1 = await _expect_result(ws, sid)
+        s1 = await expect_result(ws, sid)
         assert (s1.get("result") or {}).get("low_stock_count") in {0, 1}
 
         # set quantity 2 => low stock
@@ -1025,11 +988,11 @@ async def test_p2_low_stock_threshold_and_stats() -> None:
                 "expected_version": ver + 1,
             }
         )
-        _ = await _expect_result(ws, qid)
+        _ = await expect_result(ws, qid)
 
         sid2 = next_id()
         await ws.send_json({"id": sid2, "type": "haventory/stats"})
-        s2 = await _expect_result(ws, sid2)
+        s2 = await expect_result(ws, sid2)
         assert (s2.get("result") or {}).get("low_stock_count") >= 1
 
         # raise to 5 => not low
@@ -1043,11 +1006,11 @@ async def test_p2_low_stock_threshold_and_stats() -> None:
                 "expected_version": (ver + 2),
             }
         )
-        _ = await _expect_result(ws, qid2)
+        _ = await expect_result(ws, qid2)
 
         sid3 = next_id()
         await ws.send_json({"id": sid3, "type": "haventory/stats"})
-        s3 = await _expect_result(ws, sid3)
+        s3 = await expect_result(ws, sid3)
         assert (s3.get("result") or {}).get("low_stock_count") == 0
     finally:
         await ws.close()
@@ -1062,8 +1025,8 @@ async def test_p2_low_stock_threshold_and_stats() -> None:
 @destructive
 async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
     """Exercise list filters, sorts, and cursor pagination."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         ids = await _ensure_phase2_base(ws, next_id)
         # Create items
@@ -1079,16 +1042,16 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
                 "location_id": ids["workshop"],
             }
         )
-        _ = await _expect_result(ws, rid)
+        _ = await expect_result(ws, rid)
 
         did = next_id()
         await ws.send_json({"id": did, "type": "haventory/item/create", "name": "Hammer"})
-        _ = await _expect_result(ws, did)
+        _ = await expect_result(ws, did)
 
         # q
         q1 = next_id()
         await ws.send_json({"id": q1, "type": "haventory/item/list", "filter": {"q": "hammer"}})
-        r1 = await _expect_result(ws, q1)
+        r1 = await expect_result(ws, q1)
         assert len((r1.get("result") or {}).get("items") or []) >= 1
 
         # tags_any
@@ -1096,7 +1059,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
         await ws.send_json(
             {"id": q2, "type": "haventory/item/list", "filter": {"tags_any": ["garage"]}}
         )
-        r2 = await _expect_result(ws, q2)
+        r2 = await expect_result(ws, q2)
         assert len((r2.get("result") or {}).get("items") or []) >= 1
 
         # tags_all
@@ -1104,7 +1067,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
         await ws.send_json(
             {"id": q3, "type": "haventory/item/list", "filter": {"tags_all": ["garage"]}}
         )
-        r3 = await _expect_result(ws, q3)
+        r3 = await expect_result(ws, q3)
         assert len((r3.get("result") or {}).get("items") or []) >= 1
 
         # category (none expected)
@@ -1112,7 +1075,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
         await ws.send_json(
             {"id": q4, "type": "haventory/item/list", "filter": {"category": "TOOLS"}}
         )
-        r4 = await _expect_result(ws, q4)
+        r4 = await expect_result(ws, q4)
         assert ((r4.get("result") or {}).get("items") or []) == []
 
         # checked_out
@@ -1120,7 +1083,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
         await ws.send_json(
             {"id": q5, "type": "haventory/item/list", "filter": {"checked_out": False}}
         )
-        r5 = await _expect_result(ws, q5)
+        r5 = await expect_result(ws, q5)
         assert len((r5.get("result") or {}).get("items") or []) >= 1
 
         # low_stock_only
@@ -1128,7 +1091,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
         await ws.send_json(
             {"id": q6, "type": "haventory/item/list", "filter": {"low_stock_only": True}}
         )
-        r6 = await _expect_result(ws, q6)
+        r6 = await expect_result(ws, q6)
         # May be zero depending on prior state
         assert ((r6.get("result") or {}).get("items") or []) in (
             [],
@@ -1144,7 +1107,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
                 "filter": {"location_id": ids["garage"], "include_subtree": True},
             }
         )
-        r7 = await _expect_result(ws, q7)
+        r7 = await expect_result(ws, q7)
         assert ((r7.get("result") or {}).get("items") or []) == []
 
         # area_id prefilter: expect zero until areas are wired to locations online (best-effort)
@@ -1156,14 +1119,14 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
                 "filter": {"area_id": "00000000-0000-4000-8000-000000000000"},
             }
         )
-        _ = await _expect_result(ws, q8a)
+        _ = await expect_result(ws, q8a)
 
         # sort by name asc
         q8 = next_id()
         await ws.send_json(
             {"id": q8, "type": "haventory/item/list", "sort": {"field": "name", "order": "asc"}}
         )
-        r8 = await _expect_result(ws, q8)
+        r8 = await expect_result(ws, q8)
         assert r8.get("success") is True
 
         # sort by quantity desc
@@ -1175,7 +1138,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
                 "sort": {"field": "quantity", "order": "desc"},
             }
         )
-        r9 = await _expect_result(ws, q9)
+        r9 = await expect_result(ws, q9)
         assert r9.get("success") is True
 
         # pagination: limit 1
@@ -1188,7 +1151,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
                 "limit": 1,
             }
         )
-        pg1 = await _expect_result(ws, q10)
+        pg1 = await expect_result(ws, q10)
         cursor = (pg1.get("result") or {}).get("next_cursor")
         if cursor:
             q11 = next_id()
@@ -1201,7 +1164,7 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
                     "cursor": cursor,
                 }
             )
-            _ = await _expect_result(ws, q11)
+            _ = await expect_result(ws, q11)
     finally:
         await ws.close()
         await session.close()
@@ -1215,14 +1178,14 @@ async def test_p2_list_filters_sorts_pagination() -> None:  # noqa: PLR0915
 @destructive
 async def test_p2_optimistic_concurrency_conflict() -> None:
     """Demonstrate conflict on stale expected_version with error envelope."""
-    session, ws = await _open_ws()
-    next_id = _id_counter()
+    session, ws = await open_ws()
+    next_id = id_counter()
     try:
         _ = await _ensure_phase2_base(ws, next_id)
         # Create item
         cid = next_id()
         await ws.send_json({"id": cid, "type": "haventory/item/create", "name": "Hammer R"})
-        cre = await _expect_result(ws, cid)
+        cre = await expect_result(ws, cid)
         item_id = cre["result"]["id"]
         ver_a = int(cre["result"]["version"])
 
@@ -1237,7 +1200,7 @@ async def test_p2_optimistic_concurrency_conflict() -> None:
                 "description": "bump",
             }
         )
-        good = await _expect_result(ws, uid)
+        good = await expect_result(ws, uid)
         ver_b = int(good["result"]["version"])
         assert ver_b == ver_a + 1
 
@@ -1252,7 +1215,7 @@ async def test_p2_optimistic_concurrency_conflict() -> None:
                 "name": "should conflict",
             }
         )
-        stale = await _expect_result(ws, sid)
+        stale = await expect_result(ws, sid)
         assert (
             stale.get("success") is False and (stale.get("error") or {}).get("code") == "conflict"
         )

--- a/tests/test_ws_storage_error_offline.py
+++ b/tests/test_ws_storage_error_offline.py
@@ -25,21 +25,16 @@ import pytest
 from custom_components.haventory.exceptions import StorageError
 from custom_components.haventory.repository import Repository
 from custom_components.haventory.storage import DomainStore
-from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 
-from runtime_helpers import install_runtime, runtime_of
+from runtime_helpers import runtime_of, ws_hass
 from ws_helpers import RecordingConn, ws_send
 
 
 def _make_hass() -> tuple[HomeAssistant, Repository, DomainStore]:
-    hass = HomeAssistant()
     repo = Repository()
-    install_runtime(hass, repository=repo)
-    store = DomainStore(hass)
-    runtime_of(hass).store = store
-    ws_setup(hass)
-    return hass, repo, store
+    hass = ws_hass(repository=repo)
+    return hass, repo, runtime_of(hass).store
 
 
 def _fail_next_save(monkeypatch: pytest.MonkeyPatch, store: DomainStore) -> None:

--- a/tests/test_ws_subscriptions_offline.py
+++ b/tests/test_ws_subscriptions_offline.py
@@ -13,7 +13,6 @@ Scenarios:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -24,6 +23,7 @@ from custom_components.haventory.ws import setup as ws_setup
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 
+from date_helpers import day_offset
 from runtime_helpers import install_runtime, runtime_of
 from ws_helpers import RecordingConn, ws_send
 
@@ -262,12 +262,6 @@ async def test_location_filters_subtree_and_direct_only() -> None:
     assert "item" not in delivered
 
 
-def _utc_day_offset(days: int) -> str:
-    """A UTC calendar date `days` from today, as YYYY-MM-DD."""
-
-    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
-
-
 @pytest.mark.asyncio
 async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
     """`inspection_overdue_only` narrows item events the same way `item/list` does."""
@@ -305,7 +299,7 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
         "haventory/item/create",
         conn=conn,
         name="Ladder",
-        inspection_date=_utc_day_offset(-1),
+        inspection_date=day_offset(-1),
     )
     assert late["success"] is True
     assert item_event_ids() == {SUB_ID_INSPECTION, SUB_ID_EVERYTHING}
@@ -319,7 +313,7 @@ async def test_inspection_overdue_filter_constrains_delivered_events() -> None:
         "haventory/item/create",
         conn=conn,
         name="Harness",
-        inspection_date=_utc_day_offset(0),
+        inspection_date=day_offset(0),
     )
     assert due_today["success"] is True
     assert item_event_ids() == {SUB_ID_EVERYTHING}


### PR DESCRIPTION
## Summary

Seven folds across the test tree, no behaviour change and no production line touched.

- **One `setup_entry` fixture** in `tests/integration/conftest.py` replaces the fourteen
  identical `_setup` helpers the phacc files each carried. It is a factory rather than an
  autouse fixture because several tests fill `hass_storage`, monkeypatch a module or open a
  bus listener before the entry may load. `test_services.py` read the repository off its own
  `_setup`; it asks `find_runtime` for it at the call site now.
- **`install_runtime(…, ws=True)` and `ws_hass()`** replace the six copies of "a stub Home
  Assistant, an entry with a runtime, the WebSocket commands registered" (five named
  `_make_hass`, one `_hass`). `test_ws_storage_error_offline.py` keeps a wrapper — its callers
  want the repository and the store too — and reads the store off the runtime instead of
  building a second one and swapping it in.
- **`tests/online_helpers.py`** holds the four helpers the three online smokes each carried
  byte-identical: the WebSocket URL from the base URL, connect-and-authenticate,
  read-until-this-id, and the message-id source.
- **`tests/date_helpers.day_offset`** replaces the three copies of `_utc_day_offset`. It reads
  `dt_util.now()` — the clock every answer it is checked against is measured from — instead of
  `datetime.now(UTC)`; the reminder spec's own `_today` now does too. That is the #586 shape:
  a test whose expected date comes from a second, different reading of the clock.
- **`tests/lovelace_helpers.py`** holds one storage-mode and one YAML-mode resource collection,
  where the registration tests and the removal tests each had their own.
- **`mountHost`** in the card's `test.utils.ts` replaces the `mountStore` → `mountComponent` →
  `{el, store, hass, sr}` sequence in the three store-backed host specs.
- **The ten offline twins** of `tests/integration/test_frontend.py` go, and with them the stub's
  log of every `async_register_panel` call, which real Home Assistant does not have.

Refs #230 (TESTS-T5, TESTS-T6)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## Counting

| | Lines |
| --- | ---: |
| Production removed | 0 |
| Test removed | 1,105 |
| Added | 809 |

`git diff --stat origin/main`: 38 files changed, 809 insertions(+), 1105 deletions(-). Nothing
under `custom_components/` or the card's non-test `src/` changed.

## What the twins were, and what is left

`tests/integration/test_frontend.py` runs on every pull request (`ci.yml`'s `integration` job)
and asserts these against a real Home Assistant, so the offline versions were a second, weaker
oracle for the same ten facts:

| Offline test dropped | phacc test that pins it |
| --- | --- |
| `test_serves_the_bundle_directory_without_cache_headers` | `test_bundle_is_served_without_cache_control` |
| `test_registers_both_loaders_with_the_same_url` | `test_both_loaders_get_the_same_url` |
| `test_static_path_is_registered_once_across_a_reload` | `test_reload_registers_the_static_route_once` |
| `test_unload_hands_back_the_module_url_and_setup_restores_it` | `test_unload_hands_back_the_module_url` |
| `test_registers_the_sidebar_panel_against_the_card_bundle` | `test_the_sidebar_panel_lands_in_the_real_panel_registry` |
| `test_a_reload_leaves_the_panel_in_place` | `test_a_reload_leaves_the_same_panel_object_in_place` |
| `test_a_disabled_entry_takes_the_sidebar_entry_back` | `test_a_disabled_entry_gives_the_sidebar_panel_back` |
| `test_removing_the_entry_takes_the_sidebar_entry_back` | `test_removing_the_entry_gives_the_sidebar_panel_back` |
| `test_a_rename_across_a_reload_replaces_the_panel` | `test_a_rename_replaces_the_panel_without_the_overwriting_error` |
| `test_an_explicit_opt_out_registers_no_panel` | `test_an_opted_out_entry_registers_no_panel` |

Kept, because nothing else can reach them: the cross-language pins (icon set, media route and
its parameters, status vocabularies, pills), the Lovelace resource migration, no bundle built,
no `http`, a refused route, and the panel toggle and rename through the options listener.

What a contributor loses is the ability to check those ten facts on a host that cannot run
phacc without Docker.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1333 passed, 27 skipped),
  `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`,
  `npx vitest run` (1917 passed, 67 files), `npm run build` — all green.
- [x] phacc (`scripts/test_integration.sh`, card built first): **153 passed in 14.69s**.
- The online smokes cannot run here (no live Home Assistant, `RUN_ONLINE` unset). Their fold is
  proven by import and collection — `pytest --collect-only` over the three files collects 22
  tests — plus the offline gate, which imports every one of them.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — this is a subtraction: tests are deleted or folded onto shared
  helpers, never rewritten to pass.
- [x] Docs updated where behavior changed — no behaviour changed; no file left
  `custom_components/haventory/`, so `RETIRED_PATHS` is unchanged, and no WS schema, error code
  or field moved.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
  `docs/data_shapes.md` in sync — no API change.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`,
  optimistic `version`).

## Decisions taken against drifted notes

- **The stub's `async_register_panel` stays; its `__panel_registrations__` log goes.** TESTS-T5
  lists the whole 60-line helper. Five panel tests with no phacc twin still need a
  `panel_custom` module — the options toggle, the live rename, a missing `panel_custom`, and no
  bundle built — and TESTS-T5 keeps them. What goes is the part real Home Assistant does not
  have: the log of every registration attempt. `test_applying_twice_over_registers_once` reads
  the registry instead, and the same `Panel` object after a second apply says the registration
  was neither replaced nor taken away and put back. `hass.http.static_path_calls` went the same
  way — its one reader was a dropped twin, and aiohttp's duplicate-route raise, which the stub
  keeps, is the real oracle.
- **Five `_make_hass` and one `_hass`, not six `_make_hass`.** M1's PR deleted
  `tests/test_ws_helpers_offline.py`, which held one of the six the audit counted.
  `tests/test_ws_reminders_offline.py`'s `_hass` is the same three lines under another name, so
  the count is six again and it is folded here.
- **`mountHost` serves three host specs, not four.** `haventory-panel.test.ts` is handed a
  `hass` and builds its own store; mounting it through `mountHost` would give it a second store
  nothing reads.
- **`test_ws_storage_error_offline.py` keeps a local `_make_hass`.** Its eight call sites want
  `(hass, repo, store)`; it is three lines over `ws_hass` now and is no longer a copy of
  anything.

## Follow-ups

- Sixty-five places in the offline suite still write `install_runtime(hass)` and
  `ws_setup(hass)` on two lines inside a test. The new `ws=` flag collapses each pair to one
  line, but those files are outside this package's list and the sweep is worth its own pass.
- `tests/integration/{test_areas,test_diagnostics,test_persistence,test_repairs}.py` build their
  entries inline with variations the `setup_entry` fixture does not cover (a setup expected to
  fail, custom `data`). Some of those inline blocks are the fixture verbatim and could move onto
  it.
- `tests/integration/test_sensor.py` has its own `_local_day_offset`, already reading
  `dt_util.now()`. It is the same four lines as `tests/date_helpers.day_offset`; a module both
  modes can import would be one more fold.

None of the three is filed: they are tidiness inside the test tree, not something a household
can meet.

## Handover

**1. Merged / left open** — this PR, for the M2 master to merge once its review is done.
Nothing here is left open for the owner.

**2. Test this by hand** — nothing. No user-visible surface, no stored data and no lifecycle
path changed; the ten dropped tests are covered by the phacc job CI runs on every pull request.

**3. Validate locally** — nothing. Every fold is pinned by a test that ran here: the offline
gate (1333 passed), the card gate (1917 passed) and `scripts/test_integration.sh` (153 passed).
The online smokes' fold is pinned by import and collection only, so the next session that has a
live Home Assistant can run `RUN_ONLINE=1 HA_BASE_URL=… HA_TOKEN=… uv run pytest -q -m online`
`[dev-ha]` and expect the same results as before this PR.

**4. Decisions taken against drifted notes** — see the section above: the stub keeps
`async_register_panel` and loses `__panel_registrations__`; five `_make_hass` plus one `_hass`
rather than six `_make_hass`; `mountHost` for three host specs, not four;
`test_ws_storage_error_offline.py` keeps a three-line local wrapper.

**5. Follow-ups** — the three named above, none filed.

**6. State left behind** — branch `claude/v0-8-0-m2-test-folds`; no assets branch; no Home
Assistant instance touched and no `.env` left in the worktree. Counting for this PR: production
removed 0, tests removed 1,105, added 809.
