### PR TITLE
refactor(card): delete the dead selection chain, the unused client methods and the unbound props

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -8,6 +8,7 @@ import {
   mountHost,
   q,
   settle,
+  stubElementWidth,
   stubViewport,
 } from '../test.utils';
 import { discardPrompt } from '../ui/discard';
@@ -31,13 +32,26 @@ function loc(id: string, name: string, parentId: string | null = null): Location
   };
 }
 
+// The shell measures its own element, so the two layouts are two widths. A
+// phone is 375px; 1280 is any dashboard column wider than the breakpoint.
+const PHONE_WIDTH = 375;
+const DESKTOP_WIDTH = 1280;
+
+let restoreWidth: (() => void) | null = null;
+
 async function mountShell(opts: { items?: Item[]; locations?: Location[]; mobile?: boolean } = {}) {
-  return mountHost<HVCardShell>(
-    'hv-card-shell',
-    { items: opts.items ?? [], locations: opts.locations ?? [] },
-    { forceMobile: opts.mobile ?? false },
-  );
+  restoreWidth?.();
+  restoreWidth = stubElementWidth(opts.mobile ? PHONE_WIDTH : DESKTOP_WIDTH);
+  return mountHost<HVCardShell>('hv-card-shell', {
+    items: opts.items ?? [],
+    locations: opts.locations ?? [],
+  });
 }
+
+afterEach(() => {
+  restoreWidth?.();
+  restoreWidth = null;
+});
 
 describe('hv-card-shell: header', () => {
   it('shows the configured heading and the live stat badges', async () => {
@@ -534,10 +548,8 @@ describe('hv-card-shell: list and footer', () => {
     // Deliberately not `mountStore`: the skeleton is what shows before the
     // first list resolves, so this store must not be initialised.
     const store = new Store(makeMockHass({ items: [] }), { retryBaseMs: 0 });
-    const { el } = await mountComponent<HVCardShell>('hv-card-shell', {
-      store,
-      forceMobile: false,
-    });
+    restoreWidth = stubElementWidth(DESKTOP_WIDTH);
+    const { el } = await mountComponent<HVCardShell>('hv-card-shell', { store });
 
     const list = q(el, 'hv-list')!;
     expect(list.shadowRoot?.querySelector('[data-testid="list-skeleton"]')).toBeTruthy();

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -316,8 +316,6 @@ export class HVCardShell extends LitElement {
   /** Required. The shell subscribes to it itself — see `connectedCallback`. */
   @property({ attribute: false }) store!: Store;
   @property({ type: String }) heading = DEFAULT_CARD_TITLE;
-  /** Force a layout instead of measuring; `null` measures. */
-  @property({ attribute: false }) forceMobile: boolean | null = null;
   /**
    * Which quick-filter pills this dashboard offers, or `null` for all of them.
    * Passed on to the full view unchanged — one vocabulary on both surfaces.
@@ -431,7 +429,6 @@ export class HVCardShell extends LitElement {
       this._storeUnsub = this.store.state.onChange(() => this.requestUpdate());
       this._searchDraft = this.store.state.value.filters.q;
     }
-    if (changed.has('forceMobile')) this.responsive.setForced(this.forceMobile);
     // Reflect the mode so child selectors and :host([mobile]) rules apply.
     this.toggleAttribute('mobile', this.mobile);
     this._syncPinnedItem();

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -593,21 +593,41 @@ describe('hv-list-row: the phone line’s pieces', () => {
   });
 });
 
-describe('hv-list-row: selection mode', () => {
-  it('swaps row navigation for a checkbox', async () => {
-    const el = await mount({ id: 'item-1' }, { selectable: true });
-    const seen = captured(el, ['open-item', 'toggle-select']);
+/*
+ * Bulk selection lives on the full view's `hv-data-table`, which draws its own
+ * checkbox column. The card's list has one job — open the item — so a row here
+ * navigates on click and draws nothing that would claim otherwise, whatever a
+ * host sets on it.
+ */
+describe('hv-list-row: one job per row', () => {
+  it('opens the item on click and offers the hover actions', async () => {
+    const el = await mount({ id: 'item-1' });
+    const seen = captured(el, ['open-item']);
 
-    expect(q(el, '[data-testid="row-select"]')).toBeTruthy();
-    expect(q(el, '[data-testid="row-edit"]')).toBe(null);
+    expect(q(el, '[data-testid="row-edit"]')).toBeTruthy();
+    expect(q(el, '[data-testid="row-select"]')).toBe(null);
 
     (q(el, '[data-testid="list-row"]') as HTMLElement).click();
-    expect(seen).toEqual(['toggle-select']);
+    expect(seen).toEqual(['open-item']);
   });
 
-  it('reflects the selected state on the checkbox', async () => {
-    const el = await mount({ id: 'item-1' }, { selectable: true, selected: true });
-    expect(q(el, '[data-testid="row-select"]')?.getAttribute('aria-checked')).toBe('true');
+  it('renders no pending chip beside the ones a row does draw', async () => {
+    // The store applies a write to the row and rolls it back on refusal, so
+    // there is no second "in flight" state for a chip to name. The type line
+    // is the other half: a property no host binds draws nothing, and a test
+    // that only looked at the output would not notice one coming back.
+    const el = await mount({
+      id: 'item-1',
+      checked_out: true,
+      quantity: 0,
+      low_stock_threshold: 5,
+    });
+
+    expect(q(el, '[data-testid="row-checked-out"]')).toBeTruthy();
+    expect(q(el, '[data-testid="row-pending"]')).toBe(null);
+
+    const noPendingProp: Extract<keyof HVListRow, 'pending'> extends never ? true : never = true;
+    expect(noPendingProp).toBe(true);
   });
 });
 

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -111,9 +111,6 @@ export class HVListRow extends LitElement {
       .row:hover:not(.touch) {
         background: var(--hv-row-hover);
       }
-      .row.selected {
-        background: var(--hv-row-hover);
-      }
       .names {
         flex: 1;
         min-width: 0;
@@ -400,33 +397,6 @@ export class HVListRow extends LitElement {
         padding: 0 18px;
         font-size: 13.5px;
       }
-      .box {
-        flex: none;
-        display: inline-grid;
-        place-items: center;
-        width: 16px;
-        height: 16px;
-        border-radius: 3px;
-        border: 1.5px solid var(--hv-text-tertiary);
-        background: none;
-        color: #fff;
-        padding: 0;
-      }
-      .box.on {
-        background: var(--hv-primary-dark);
-        border-color: var(--hv-primary-dark);
-      }
-      /* A 16px box is far too small for a thumb. Tapping the row toggles the
-         same selection, so an oversized hit area here can only ever agree with
-         what is underneath it — no visual change needed. */
-      :host([mobile]) .box {
-        position: relative;
-      }
-      :host([mobile]) .box::after {
-        content: '';
-        position: absolute;
-        inset: calc((var(--hv-tap-min, 16px) - 16px) / -2);
-      }
     `,
   ];
 
@@ -434,11 +404,6 @@ export class HVListRow extends LitElement {
   @property({ type: Boolean, reflect: true }) mobile = false;
   /** HA areas, to name the one the item's location resolves to. */
   @property({ attribute: false }) areas: AreaRef[] = [];
-  /** Selection mode: show a checkbox and suppress row navigation. */
-  @property({ type: Boolean }) selectable = false;
-  @property({ type: Boolean }) selected = false;
-  /** Show the optimistic-write "pending" chip. */
-  @property({ type: Boolean }) pending = false;
   /** Picture access; null means the row shows no thumbnail. */
   /** The status vocabulary from `haventory/config`; the built-ins stand in
    * until it answers. */
@@ -668,33 +633,15 @@ export class HVListRow extends LitElement {
 
     return html`
       <div
-        class="row ${this.mobile ? 'touch' : ''} ${this.selected ? 'selected' : ''}"
+        class="row ${this.mobile ? 'touch' : ''}"
         role="row"
         tabindex="0"
         aria-label=${t('hv.row.label', { name: item.name })}
         data-testid="list-row"
         data-item-id=${item.id}
         @keydown=${this._onKeydown}
-        @click=${() => {
-          if (this.selectable) this._emit('toggle-select');
-          else this._emit('open-item');
-        }}
+        @click=${() => this._emit('open-item')}
       >
-        ${this.selectable
-          ? html`<button
-              class="box ${this.selected ? 'on' : ''}"
-              role="checkbox"
-              aria-checked=${String(this.selected)}
-              aria-label=${t('hv.row.select', { name: item.name })}
-              data-testid="row-select"
-              @click=${(e: Event) => {
-                e.stopPropagation();
-                this._emit('toggle-select');
-              }}
-            >
-              ${this.selected ? icon('check', 13) : null}
-            </button>`
-          : null}
         ${this._renderThumb()}
         <span class="names">
           <span class="name-line">
@@ -751,9 +698,6 @@ export class HVListRow extends LitElement {
                       >`}
           </span>
         </span>
-        ${this.pending
-          ? html`<span class="hv-chip warning" data-testid="row-pending">${t('hv.row.pending')}</span>`
-          : null}
         ${!this.mobile && low
           ? html`<span class="hv-chip warning" data-testid="row-low" aria-label=${t('hv.term.lowStock')}
               >${t('hv.term.low')}</span
@@ -777,36 +721,34 @@ export class HVListRow extends LitElement {
               ${t('hv.term.inspectionDue')}
             </span>`
           : null}
-        ${this.selectable
-          ? null
-          : html`<span class="hover-actions">
-              <button
-                data-testid="row-edit"
-                aria-label=${t('hv.row.editNamed', { name: item.name })}
-                title=${t('hv.row.editItem')}
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  this._emit('edit');
-                }}
-              >
-                ${icon('pencil', 18)}
-              </button>
-              <hv-overflow-menu
-                data-testid="row-menu"
-                label=${t('hv.row.actionsFor', { name: item.name })}
-                .entries=${rowMenuEntries(item)}
-                @click=${(e: Event) => e.stopPropagation()}
-                @select=${(e: CustomEvent) => {
-                  e.stopPropagation();
-                  const { id } = e.detail as { id: string };
-                  // The check-out flow needs somewhere to anchor its popover.
-                  const anchor = (
-                    this.shadowRoot?.querySelector('[data-testid="row-menu"]') as HTMLElement | null
-                  )?.getBoundingClientRect();
-                  this._emit('row-action', { action: id, anchor });
-                }}
-              ></hv-overflow-menu>
-            </span>`}
+        <span class="hover-actions">
+          <button
+            data-testid="row-edit"
+            aria-label=${t('hv.row.editNamed', { name: item.name })}
+            title=${t('hv.row.editItem')}
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              this._emit('edit');
+            }}
+          >
+            ${icon('pencil', 18)}
+          </button>
+          <hv-overflow-menu
+            data-testid="row-menu"
+            label=${t('hv.row.actionsFor', { name: item.name })}
+            .entries=${rowMenuEntries(item)}
+            @click=${(e: Event) => e.stopPropagation()}
+            @select=${(e: CustomEvent) => {
+              e.stopPropagation();
+              const { id } = e.detail as { id: string };
+              // The check-out flow needs somewhere to anchor its popover.
+              const anchor = (
+                this.shadowRoot?.querySelector('[data-testid="row-menu"]') as HTMLElement | null
+              )?.getBoundingClientRect();
+              this._emit('row-action', { action: id, anchor });
+            }}
+          ></hv-overflow-menu>
+        </span>
         ${this._renderStepper()}
       </div>
     `;

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -404,10 +404,10 @@ export class HVListRow extends LitElement {
   @property({ type: Boolean, reflect: true }) mobile = false;
   /** HA areas, to name the one the item's location resolves to. */
   @property({ attribute: false }) areas: AreaRef[] = [];
-  /** Picture access; null means the row shows no thumbnail. */
   /** The status vocabulary from `haventory/config`; the built-ins stand in
    * until it answers. */
   @property({ attribute: false }) statuses: StatusDefinition[] | null = null;
+  /** Picture access; null means the row shows no thumbnail. */
   @property({ attribute: false }) media: MediaBindings | null = null;
 
   private readonly _urls = new MediaUrls(this);

--- a/cards/haventory-card/src/components/hv-list.ts
+++ b/cards/haventory-card/src/components/hv-list.ts
@@ -10,6 +10,12 @@ import type { AreaRef, Item, StatusDefinition } from '../store/types';
 import type { MediaBindings } from '../ui/media';
 import './hv-list-row';
 
+/**
+ * Placeholder rows drawn while the first page is in flight. Enough to fill the
+ * scroller's default cap, so the list does not visibly grow when the real rows
+ * land.
+ */
+const SKELETON_ROWS = 5;
 
 /**
  * The standard card's list: skeletons while loading, a named empty state, rows,
@@ -32,6 +38,7 @@ export class HVList extends LitElement {
       .scroller {
         overflow-y: auto;
         overscroll-behavior: contain;
+        max-height: var(--hv-list-max-height, 420px);
       }
       /*
        * A refetch keeps the rows it already has, so the only thing left to say
@@ -80,9 +87,6 @@ export class HVList extends LitElement {
         color: var(--hv-text-secondary);
         border-top: 1px solid var(--hv-row-divider);
       }
-      :host(:not([fill])) .scroller {
-        max-height: var(--hv-list-max-height, 420px);
-      }
       /*
        * The inline editor renders inside this same scroller and is roughly
        * 720px tall, so the compact cap buried its Save/Cancel row and the
@@ -90,17 +94,8 @@ export class HVList extends LitElement {
        * form — as the design shows — but stays bounded so a long row list
        * cannot run away with the page.
        */
-      :host(:not([fill])[editing]) .scroller {
+      :host([editing]) .scroller {
         max-height: var(--hv-list-editing-max-height, min(80dvh, 760px));
-      }
-      :host([fill]) {
-        display: flex;
-        flex-direction: column;
-        min-height: 0;
-      }
-      :host([fill]) .scroller {
-        flex: 1;
-        min-height: 0;
       }
       .empty {
         display: grid;
@@ -158,7 +153,6 @@ export class HVList extends LitElement {
   ];
 
   @property({ attribute: false }) items: Item[] = [];
-  @property({ type: Boolean, reflect: true }) fill = false;
   @property({ type: Boolean }) mobile = false;
   /** HA areas, forwarded to each row so it can name the item's area. */
   @property({ attribute: false }) areas: AreaRef[] = [];
@@ -167,13 +161,9 @@ export class HVList extends LitElement {
   /** The status vocabulary from `haventory/config`; passed through to each row. */
   @property({ attribute: false }) statuses: StatusDefinition[] | null = null;
   @property({ type: Boolean }) loading = false;
-  @property({ type: Boolean }) selectable = false;
-  @property({ attribute: false }) selection: Set<string> = new Set();
-  @property({ attribute: false }) pendingIds: Set<string> = new Set();
   @property({ type: String }) emptyKind: EmptyKind = 'no-items';
   /** Location name for the "Nothing in X" empty state. */
   @property({ type: String }) emptyLocationName: string | null = null;
-  @property({ type: Number }) skeletonRows = 5;
   /**
    * Inline editing: the host supplies a template and says which row it belongs
    * to. Passing a callback rather than editor props keeps this component from
@@ -254,7 +244,7 @@ export class HVList extends LitElement {
     if (this.loading && !this.items.length && !editorOpen) {
       return html`<div class="scroller" data-testid="list-skeleton" aria-busy="true">
         ${Array.from(
-          { length: this.skeletonRows },
+          { length: SKELETON_ROWS },
           () => html`<div class="skeleton-row">
             <div class="bar" style="width: 55%"></div>
             <div class="bar short" style="width: 38%"></div>
@@ -295,9 +285,6 @@ export class HVList extends LitElement {
                   .areas=${this.areas}
                   .media=${this.media}
                   ?mobile=${this.mobile}
-                  ?selectable=${this.selectable}
-                  ?selected=${this.selection.has(it.id)}
-                  ?pending=${this.pendingIds.has(it.id)}
                 ></hv-list-row>`,
         )}
       </div>

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -220,9 +220,7 @@ export const de: Record<TranslationKey, string> = {
   'hv.list.noLongerMatches': 'Passt nicht mehr zu den aktuellen Filtern',
 
   'hv.row.label': 'Gegenstand {name}',
-  'hv.row.select': '{name} auswählen',
   'hv.row.hasDocument': 'Hat ein Dokument',
-  'hv.row.pending': 'Ausstehend',
   'hv.row.decreaseQuantity': 'Menge verringern',
   'hv.row.increaseQuantity': 'Menge erhöhen',
   'hv.row.editItem': 'Gegenstand bearbeiten',

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -189,7 +189,6 @@ export const de: Record<TranslationKey, string> = {
   'hv.term.id': 'ID',
   'hv.term.due': 'fällig {date}',
   'hv.term.overdueOn': 'Überfällig · {date}',
-  'hv.term.checkedOutUntil': 'Ausgeliehen · fällig {date}',
   'hv.term.inspectionDueOn': 'Prüfung fällig · {date}',
 
   'hv.card.badge.low': '{count} niedrig',
@@ -406,7 +405,6 @@ export const de: Record<TranslationKey, string> = {
 
   'hv.cardEditor.title': 'Titel',
 
-  'hv.action.apply': 'Anwenden',
   'hv.action.set': 'Setzen',
   'hv.action.done': 'Fertig',
   'hv.action.rename': 'Umbenennen',

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -213,7 +213,6 @@ export const en = {
   'hv.term.id': 'ID',
   'hv.term.due': 'due {date}',
   'hv.term.overdueOn': 'Overdue · {date}',
-  'hv.term.checkedOutUntil': 'Checked out · due {date}',
   'hv.term.inspectionDueOn': 'Inspection due · {date}',
 
   // hv-card-shell — the card's own header, search row and sheets.
@@ -435,7 +434,6 @@ export const en = {
   'hv.cardEditor.title': 'Title',
 
   // Shared, added by the second component batch.
-  'hv.action.apply': 'Apply',
   'hv.action.set': 'Set',
   'hv.action.done': 'Done',
   'hv.action.rename': 'Rename',

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -247,9 +247,7 @@ export const en = {
 
   // hv-list-row.
   'hv.row.label': 'Item {name}',
-  'hv.row.select': 'Select {name}',
   'hv.row.hasDocument': 'Has a document',
-  'hv.row.pending': 'Pending',
   'hv.row.decreaseQuantity': 'Decrease quantity',
   'hv.row.increaseQuantity': 'Increase quantity',
   'hv.row.editItem': 'Edit item',

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Store } from './store';
 import { makeMockHass, makeItem } from '../test.utils';
+import type { StoreState } from './types';
 
 /**
  * Let queued microtasks and any zero-delay timers run.
@@ -1014,5 +1015,24 @@ describe('Store', () => {
 
     expect(store.state.value.errorQueue.length).toBeGreaterThan(0);
     expect(store.state.value.items.find((i) => i.id === '1')?.reminder_date).toBe('2026-08-31');
+  });
+
+  /*
+   * An optimistic write shows its result on the row itself and rolls that row
+   * back when the call is refused, so no surface has a second, per-operation
+   * "in flight" state to draw. A register of open writes would therefore be
+   * written on every mutator and read by nobody — the type line is what keeps
+   * it from coming back unnoticed, since a field nothing reads costs no test.
+   */
+  it('keeps no register of writes in flight', async () => {
+    const hass = makeMockHass({ items: [makeItem({ id: '1', name: 'A' })] });
+    const store = new Store(hass);
+    await store.init();
+
+    await store.updateItem('1', { name: 'B' });
+
+    const noPendingOps: Extract<keyof StoreState, 'pendingOps'> extends never ? true : never = true;
+    expect(noPendingOps).toBe(true);
+    expect(Object.keys(store.state.value)).not.toContain('pendingOps');
   });
 });

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -400,7 +400,6 @@ export class Store {
       loading: true,
       filters: defaultFilters(),
       selection: new Set<string>(),
-      pendingOps: new Map(),
       errorQueue: [],
       areasCache: null,
       locationTreeCache: null,
@@ -1477,8 +1476,6 @@ export class Store {
 
   // ---------- Optimistic writes ----------
   async createItem(input: ItemCreate) {
-    const opId = `create:${Date.now()}`;
-    this.state.value.pendingOps.set(opId, { kind: 'create' });
     try {
       const created = await this.run(() => this.ws.createItem(input));
       // Insert optimistically already covered by items event; ensure presence
@@ -1486,15 +1483,10 @@ export class Store {
       this.stateObs.set({ items });
     } catch (err) {
       this.pushError(err);
-    } finally {
-      this.state.value.pendingOps.delete(opId);
-      this.stateObs.set({ pendingOps: new Map(this.state.value.pendingOps) });
     }
   }
 
   async updateItem(itemId: string, changes: ItemUpdate, expectedVersion?: number) {
-    const opId = `update:${itemId}:${Date.now()}`;
-    this.state.value.pendingOps.set(opId, { kind: 'update', itemId });
     const before = this.state.value.items.find((i) => i.id === itemId);
     if (before) {
       const optimistic: Item = { ...before, ...changes } as Item;
@@ -1507,15 +1499,10 @@ export class Store {
       // Capture conflict context for actionable retry
       this.pushError(err, { itemId, changes });
       if (before) this.applyOptimistic(before);
-    } finally {
-      this.state.value.pendingOps.delete(opId);
-      this.stateObs.set({ pendingOps: new Map(this.state.value.pendingOps) });
     }
   }
 
   async deleteItem(itemId: string, expectedVersion?: number) {
-    const opId = `delete:${itemId}:${Date.now()}`;
-    this.state.value.pendingOps.set(opId, { kind: 'delete', itemId });
     const before = this.state.value.items.find((i) => i.id === itemId);
     if (before) this.removeById(itemId);
     try {
@@ -1523,9 +1510,6 @@ export class Store {
     } catch (err) {
       this.pushError(err);
       if (before) this.applyOptimistic(before);
-    } finally {
-      this.state.value.pendingOps.delete(opId);
-      this.stateObs.set({ pendingOps: new Map(this.state.value.pendingOps) });
     }
   }
 

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -737,7 +737,6 @@ export interface StoreState {
   loading: boolean;
   filters: StoreFilters;
   selection: Set<string>;
-  pendingOps: Map<string, { kind: string; itemId?: string }>;
   errorQueue: ErrorEntry[];
   areasCache: AreasListResult | null;
   locationTreeCache: LocationTreeNode[] | null;

--- a/cards/haventory-card/src/store/ws.test.ts
+++ b/cards/haventory-card/src/store/ws.test.ts
@@ -88,19 +88,6 @@ describe('WSClient payload shaping', () => {
     expect(hass.sent[0]).toEqual({ type: 'haventory/item/list', filter: { q: 'drill' }, limit: 50 });
   });
 
-  it('sends only the custom-field halves that were provided', async () => {
-    const hass = makeSpyHass();
-    const ws = new WSClient(hass);
-
-    await ws.updateCustomFields('i1', { a: 1 }, undefined);
-    await ws.updateCustomFields('i2', undefined, ['b']);
-
-    expect(hass.sent[0]).toHaveProperty('set', { a: 1 });
-    expect(hass.sent[0]).not.toHaveProperty('unset');
-    expect(hass.sent[1]).toHaveProperty('unset', ['b']);
-    expect(hass.sent[1]).not.toHaveProperty('set');
-  });
-
   it('omits parent_id and area_id on create unless they were passed', async () => {
     // `undefined` means "not asked"; an explicit null means "top level" / "no
     // area", so the two cannot collapse into one check.

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -21,7 +21,6 @@ import type {
   ListItemsResult,
   Location,
   LocationTreeNode,
-  ScalarValue,
   Sort,
   StatsCounts,
   StatusColorValue,
@@ -40,10 +39,6 @@ export class WSClient {
   }
 
   // ---------- Utility ----------
-  ping(echo?: unknown) {
-    return callWS<{ echo: unknown; ts: string }>(this.hass, { type: 'haventory/ping', echo });
-  }
-
   version() {
     return callWS<VersionInfo>(this.hass, { type: 'haventory/version' });
   }
@@ -153,38 +148,6 @@ export class WSClient {
 
   moveItem(itemId: string, locationId: string | null, expectedVersion?: number) {
     const payload: Record<string, unknown> = { type: 'haventory/item/move', item_id: itemId, location_id: locationId };
-    if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return callWS<Item>(this.hass, payload);
-  }
-
-  /**
-   * Additive tag edit. Preferred over sending the whole `tags` array through
-   * item/update, which loses a concurrent edit made by another client.
-   */
-  addTags(itemId: string, tags: string[], expectedVersion?: number) {
-    const payload: Record<string, unknown> = { type: 'haventory/item/add_tags', item_id: itemId, tags };
-    if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return callWS<Item>(this.hass, payload);
-  }
-
-  removeTags(itemId: string, tags: string[], expectedVersion?: number) {
-    const payload: Record<string, unknown> = { type: 'haventory/item/remove_tags', item_id: itemId, tags };
-    if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
-    return callWS<Item>(this.hass, payload);
-  }
-
-  updateCustomFields(
-    itemId: string,
-    set: Record<string, ScalarValue> | undefined,
-    unset: string[] | undefined,
-    expectedVersion?: number,
-  ) {
-    const payload: Record<string, unknown> = {
-      type: 'haventory/item/update_custom_fields',
-      item_id: itemId,
-    };
-    if (set) payload.set = set;
-    if (unset) payload.unset = unset;
     if (typeof expectedVersion === 'number') payload.expected_version = expectedVersion;
     return callWS<Item>(this.hass, payload);
   }
@@ -329,10 +292,6 @@ export class WSClient {
     if (parentId !== undefined) msg.parent_id = parentId;
     if (areaId !== undefined) msg.area_id = areaId;
     return callWS<Location>(this.hass, msg);
-  }
-
-  getLocation(locationId: string) {
-    return callWS<Location>(this.hass, { type: 'haventory/location/get', location_id: locationId });
   }
 
   /**

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -394,12 +394,6 @@ export function makeMockHass(initial?: MockConfig): MockHass {
         case 'haventory/location/list': {
           return locations as unknown as T;
         }
-        case 'haventory/location/get': {
-          const locationId = String((msg as any).location_id);
-          const loc = locations.find((l) => l.id === locationId);
-          if (!loc) throw { code: 'not_found', message: 'location not found' };
-          return loc as unknown as T;
-        }
         case 'haventory/location/update': {
           const locationId = String((msg as any).location_id);
           const loc = locations.find((l) => l.id === locationId);

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -1056,6 +1056,32 @@ export function stubViewport(matches: boolean): () => void {
   };
 }
 
+/**
+ * Stand in a `ResizeObserver` that reports one width, and hand back the restore.
+ *
+ * `ResponsiveController` decides the card's mobile mode from the element's own
+ * measured width, and jsdom lays nothing out — its observer would never call
+ * back, leaving every card at the unmeasured default. The stub answers the
+ * moment a target is observed, which is inside `hostConnected`, so the first
+ * render already draws the mode the width implies. Install it before mounting
+ * and call the restore afterwards.
+ */
+export function stubElementWidth(width: number): () => void {
+  const original = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    constructor(private readonly callback: ResizeObserverCallback) {}
+    observe(target: Element) {
+      const entry = { target, contentRect: { width } } as unknown as ResizeObserverEntry;
+      this.callback([entry], this as unknown as ResizeObserver);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  return () => {
+    globalThis.ResizeObserver = original;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Component-test harness
 // ---------------------------------------------------------------------------

--- a/cards/haventory-card/src/ui/media.test.ts
+++ b/cards/haventory-card/src/ui/media.test.ts
@@ -383,7 +383,6 @@ describe('MediaUrls', () => {
     await Promise.resolve();
 
     expect(urls.get('item-1', 'att-1')).toBeNull();
-    expect(urls.failed('item-1', 'att-1')).toBe(true);
     // And it does not keep retrying on every render.
     urls.get('item-1', 'att-1');
     expect(signer.sign).toHaveBeenCalledTimes(1);
@@ -405,15 +404,19 @@ describe('MediaUrls', () => {
     await Promise.resolve();
     await Promise.resolve();
 
+    // The read above found the URL lapsed and asked again, which is the point:
+    // a refresh that failed is not remembered as "no URL is coming" the way a
+    // first signing that failed is.
     expect(urls.get('item-1', 'att-1')).toBe('/first');
-    expect(urls.failed('item-1', 'att-1')).toBe(false);
+    signer.resolve('/second');
+    await Promise.resolve();
+    expect(urls.get('item-1', 'att-1')).toBe('/second');
   });
 
   it('signs nothing at all without a signer', () => {
     const urls = new MediaUrls(host());
 
     expect(urls.get('item-1', 'att-1')).toBeNull();
-    expect(urls.failed('item-1', 'att-1')).toBe(false);
   });
 
   it('reports a reference whose file is gone, so nothing offers a dead link', async () => {

--- a/cards/haventory-card/src/ui/media.ts
+++ b/cards/haventory-card/src/ui/media.ts
@@ -249,9 +249,9 @@ interface Entry {
  *
  * `get` is synchronous because that is what a template can use: it returns the
  * URL when there is a live one, and otherwise starts the signing request and
- * returns null, asking the host to re-render once the answer lands. `failed`
- * separates "not yet" from "will not" so the caller can draw a placeholder
- * rather than an image element that can only break.
+ * returns null, asking the host to re-render once the answer lands. A signing
+ * that failed is remembered on the entry, so the next render is answered from
+ * it rather than asking again for a URL that is not coming.
  */
 export class MediaUrls {
   private readonly host: MediaHost;
@@ -315,11 +315,6 @@ export class MediaUrls {
     // browser has the image cached and swapping to a placeholder mid-view would
     // be a worse answer than a URL that is briefly stale.
     return entry?.url ?? null;
-  }
-
-  /** True when signing this attachment failed, so no URL is coming. */
-  failed(itemId: string, attachmentId: string, variant?: MediaVariant): boolean {
-    return this.entries.get(urlKey(itemId, attachmentId, variant))?.failed === true;
   }
 
   /**

--- a/cards/haventory-card/src/ui/responsive.test.ts
+++ b/cards/haventory-card/src/ui/responsive.test.ts
@@ -49,22 +49,6 @@ describe('ResponsiveController', () => {
     expect(host.updates).toBe(2); // mobile → desktop
   });
 
-  it('honours a forced mode and restores measurement when cleared', () => {
-    const host = makeHost();
-    const c = new ResponsiveController(host as never);
-    c.setWidth(900);
-
-    c.setForced(true);
-    expect(c.mobile).toBe(true);
-    expect(host.updates).toBe(1);
-
-    c.setForced(true); // idempotent
-    expect(host.updates).toBe(1);
-
-    c.setForced(null);
-    expect(c.mobile).toBe(false);
-  });
-
   it('accepts a custom breakpoint', () => {
     const host = makeHost();
     const c = new ResponsiveController(host as never, 420);

--- a/cards/haventory-card/src/ui/responsive.ts
+++ b/cards/haventory-card/src/ui/responsive.ts
@@ -73,17 +73,16 @@ export class ViewportNarrow implements ReactiveController {
  * Drives the card's mobile/desktop mode from its own rendered width.
  *
  * Media queries are unreliable inside HA dashboards — a card can be narrow in a
- * wide viewport — so the handoff asks for element-based detection. `ResizeObserver`
- * is used rather than `@container` because jsdom implements neither container
- * queries nor layout, and this way tests can drive the mode deterministically via
- * `setWidth()`, or pin it with `setForced()`.
+ * wide viewport — so the handoff asks for element-based detection.
+ * `ResizeObserver` is used rather than `@container` because jsdom implements
+ * neither container queries nor layout, so a test can stand an observer in that
+ * reports the width it wants and the mode is decided the way it is in a browser.
  */
 export class ResponsiveController implements ReactiveController {
   private readonly host: ReactiveControllerHost & Element;
   private readonly breakpoint: number;
   private observer?: ResizeObserver;
   private width = 0;
-  private forced: boolean | null = null;
 
   constructor(host: ReactiveControllerHost & Element, breakpoint: number = MOBILE_BREAKPOINT) {
     this.host = host;
@@ -93,22 +92,10 @@ export class ResponsiveController implements ReactiveController {
 
   /** True when the card should render its mobile layout. */
   get mobile(): boolean {
-    if (this.forced !== null) return this.forced;
     return this.width > 0 && this.width <= this.breakpoint;
   }
 
-  /**
-   * Pin the mode regardless of measured width; `null` restores measurement.
-   * `hv-card-shell` feeds this from its own `forceMobile` property, so a test
-   * can pin either layout.
-   */
-  setForced(value: boolean | null): void {
-    if (this.forced === value) return;
-    this.forced = value;
-    this.host.requestUpdate();
-  }
-
-  /** Feed a measured width in. Called by the observer, and directly by tests. */
+  /** The one way in for a measured width. */
   setWidth(width: number): void {
     const before = this.mobile;
     this.width = width;

--- a/cards/haventory-card/src/ui/tokens.ts
+++ b/cards/haventory-card/src/ui/tokens.ts
@@ -68,7 +68,6 @@ export const tokens = css`
     --hv-error: var(--error-color, light-dark(#c62828, #ef5350));
     --hv-error-bg: light-dark(#fdecea, rgba(198, 40, 40, 0.14));
     --hv-error-deep: light-dark(#8b1f1a, #ef9a9a);
-    --hv-error-border: light-dark(#e6a9a4, rgba(239, 83, 80, 0.7));
     --hv-error-soft: light-dark(#c62828, #ef9a9a);
 
     /* Success */

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -717,8 +717,9 @@ Things jsdom cannot do, and how the tests handle it:
 
 - **No CSS evaluation in shadow DOM** — tests assert the hook a stylesheet keys off (e.g.
   the reflected `mobile` attribute), never a computed style.
-- **No layout** — `ResponsiveController` is driven through `setWidth()` / `setForced()`
-  rather than a real `ResizeObserver`.
+- **No layout** — `ResponsiveController` is driven by `stubElementWidth()`, a `ResizeObserver`
+  that answers with the width the test names, so the mode is decided the way it is in a
+  browser.
 - **No real drag and drop** — jsdom builds a `DragEvent` with no `DataTransfer` behind it,
   so the editor's file-drop tests carry a plain-object `dataTransfer` and assert the
   routing (which kind each dropped file becomes) rather than the browser's drag machinery.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -496,7 +496,7 @@ Holds all app state in a small observable (`createObservable`), fetches over `WS
 applies optimistic writes with rollback.
 
 **State** (`StoreState`): `items`, `cursor`, `total`, `loading`, `filters`, `selection`,
-`pendingOps`, `errorQueue`, `areasCache`, `locationTreeCache`, `locationsFlatCache`,
+`errorQueue`, `areasCache`, `locationTreeCache`, `locationsFlatCache`,
 `statsCounts`, `healthCache`, `versionInfo`, `distinctValuesCache`, `connected`, `degraded`.
 
 **Notable methods**


### PR DESCRIPTION
## Summary

The card's dead-code cut for V0.8.0 §6.M3, PR 1 — FE-STORE-S1/S2, FE-LISTS-L1/L8, FE-SHELLS-C7. Nothing here changes what a user sees; every target is either unreachable from any production path or a production API only a test called.

Refs #231

What goes:

- **`StoreState.pendingOps`** — seeded once, written in three `finally` blocks, read by nothing. An optimistic write shows its result on the row and rolls that row back when the call is refused, so no surface has a second per-operation state to draw. The `docs/frontend_architecture.md` state list drops it too.
- **Five `WSClient` methods** — `ping`, `addTags`, `removeTags`, `updateCustomFields`, `getLocation`. Tag and custom-field edits reach the backend through `items/bulk`, so the mock keeps its `item/add_tags`, `item/remove_tags` and `item/update_custom_fields` cases (the bulk handler dispatches them); only `location/get` goes. The backend commands themselves stay — `docs/backend_api_contract.md` describes a server surface, and the card not using one is not a reason to retire it.
- **The list's selection mode.** `hv-list`'s one host is `hv-card-shell`, which binds none of `selectable`, `selection`, `pendingIds`, `fill` or `skeletonRows`. So `hv-list-row`'s whole selection half is unreachable: the three props, the `.row.selected` rule, the 27 lines of `.box` CSS, the checkbox, the `toggle-select` emissions nothing listens for, the pending chip, and the gate that hid the hover actions behind it. Bulk selection lives on the full view's `hv-data-table`, which keeps its own checkbox column and its live `toggle-select` — untouched here. `fill` was never set, so the `:host(:not([fill]))` half is the branch that runs and the scroller's cap moves onto `.scroller`; `skeletonRows` becomes the constant it always was.
- **`hv-card-shell.forceMobile` and `ResponsiveController.setForced`** — a production property and a controller method that existed only because jsdom lays nothing out, so the shell's tests had no width to give it.
- **`MediaUrls.failed()`, `--hv-error-border`**, and four i18n names: `hv.row.select` and `hv.row.pending` (they die with the selection mode) plus `hv.term.checkedOutUntil` and `hv.action.apply` (#542's two already-unread names). All four go from both dictionaries and nothing else in them changes.

### The test-harness swap, in place of `forceMobile`

`stubElementWidth(width)` in `test.utils.ts` stands in a `ResizeObserver` that answers the moment a target is observed — which is inside `hostConnected`, so the first render already draws the mode the width implies. `hv-card-shell.test.ts` mounts at 375px or 1280px instead of pinning a boolean. **This is a harness swap, not a loosened assertion**: every assertion in that file is unchanged, and setting the phone constant to a desktop width fails 23 of its cases, so the width is really what decides the layout now.

`ui/media.test.ts` loses two `urls.failed(...)` assertions that restated the line above them. The third stood for "a refresh that failed is not remembered as *no URL is coming*", which the test now says in what the next read returns — a stronger observation than the accessor gave it.

### Two pins added

- `hv-list-row.test.ts` — a row opens the item it names and draws no `row-pending` chip beside the ones it does draw.
- `store.test.ts` — the store keeps no register of writes in flight.

Each carries a type line — an `Extract` of the removed name out of the type's keys, asserted to be `never` — as well as the rendered/runtime half, because a property no host binds and a state field nothing reads both cost zero failing tests when they come back. Both lines were checked in the failing direction: re-adding the field or the property makes `tsc --noEmit` fail.

### Counting

| | lines |
|---|---|
| Production removed | 210 |
| Test removed | 57 |
| Added | 155 |

`git diff --stat origin/main...HEAD`: 19 files, 155 insertions, 267 deletions. `hv-list-row.ts`'s 89 removed / 31 added is inflated by re-indenting the hover-actions block once its `selectable ? null :` wrapper went.

### Keeping #632 mergeable

PR #632 (the rate-limiter removal) is open on eight of the same files. Every target here sits outside its hunks, and nothing was reformatted, re-commented or re-imported near them.

```
$ git merge-tree --write-tree HEAD origin/claude/v0-8-0-m2-rate-limiter
3098496029b7a0ae8dbc633b209f5f60905a2756
$ echo $?
0
```

One tree OID, no conflict lines, exit 0 — against `a337dad`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

Both gates green before each of the six commits.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1333 passed, 27 skipped · `uv run ruff check .` → All checks passed · `uv run ruff format --check .` → 192 files already formatted · `uv run mypy` → no issues in 26 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean · `npm run typecheck` clean · `npx vitest run` → 67 files, 1916 tests passed · `npm run build` → 727.76 kB

`scripts/test_integration.sh` not required: nothing under `custom_components/` or `tests/integration/` changes (the built bundle there is git-ignored).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix: …`).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`README.md`, `docs/backend_api_contract.md`, `docs/data_shapes.md`).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

No WS schema, error code or field moves — the five client methods that go were calls the card never made, and the backend keeps every command. `docs/frontend_architecture.md` changes twice: the `StoreState` field list, and the testing note that named `setForced()`.

## Screenshots (card / UI changes)

None — no visible change. The three states a screenshot would show (a hovered row's actions, the list's skeleton, the phone row) are covered by the card gate, and the master's live check after this PR is the browser confirmation.

## Decisions taken against drifted notes

1. **`hv-location-tree`'s `allLabel` / `allIcon` were not cut.** FE-L5 and the §6.M3 text call them unbound; they are bound today — `hv-organize-dialog.ts:1368` sets `allLabel`, `hv-item-editor.ts:1518-1519` sets both. Left alone.
2. **`toggle-select` is not dead everywhere.** `hv-full-view` binds `@toggle-select` on `hv-data-table`, whose `selectable` is driven by its own selecting state. Only `hv-list-row`'s emissions and `hv-list`'s forwarding go; `hv-data-table` is untouched.
3. **`MediaUrls.failed()` was still dead, and is cut.** The re-check asked for: the `failed` *field* on the cache entry is live, but it is `get()` that reads it — a signing that failed is answered from the entry instead of asked for again. The missing-picture state comes from `presence()`, not from `failed`. The *method* had zero callers outside `media.test.ts`, so the package's condition held. The class docstring, which claimed a caller drew a placeholder off it, is corrected rather than left wrong.
4. **The `healthCache` / `refreshHealth` chain is untouched**, as instructed — #632 still routes it to the diagnostics panel (`host-surfaces.ts:364`). Named under Follow-ups instead.
5. **`hv-list`'s `fill` and `skeletonRows` went with the three props #231 names** — same dead chain, per FE-L1, and the issue's estimate is short by that much.

## Follow-ups

- **`ui/media.ts`'s `Entry.failed`** is now read in exactly one place (`get()`). It is live and correct; a later pass could fold it into the `pending` check, but there is nothing to fix. Not filed.
- **`StoreState.selection`** sits beside the field this PR removed and is a set of ids the store seeds — unlike `pendingOps` it is genuinely read (the full view's bulk selection), so it stays. Recorded so the next reader does not re-derive it. Not filed.
- **The `healthCache` / `refreshHealth` chain** is close to dead on the card side once the diagnostics panel is the only consumer. Out of scope here and owned by #632's aftermath; the M1 backend health cut is what decides it. Not filed.
- **`en.ts`'s "Shared, added by the second component batch."** is comment archaeology sitting beside a line this PR edits. Left for §6.M3's PR 2, which is the comment sweep. Not filed.

## Handover

**1. Merged / left open** — this PR, for the M3 master to squash-merge once CI is green. Nothing is left open for the owner here; #632 stays the owner's, and this branch is proven mergeable under it.

**2. Test this by hand** — `[owner]` nothing specific. No text, layout or backend surface moves, and the German dictionary loses only keys English lost with it.

**3. Validate locally**
1. `[browser]` Open the card on a desktop dashboard and hover a row: the pencil and the ⋮ appear, the ⋮ opens, and its entries act as before. This is the one path the deleted `selectable ? null :` gate stood in front of.
2. `[browser]` Click a row: the item opens (inline editor on desktop, detail sheet on a phone). No checkbox appears anywhere on the card's list.
3. `[browser]` Load the card with a slow backend, or before the first list resolves: five skeleton rows, and the scroller still caps at its usual height rather than running to the page's bottom.
4. `[browser]` Open the item editor on the desktop card: the form gets the taller cap and its Save/Cancel row is reachable — the `:host([editing])` branch after the `[fill]` collapse.
5. `[browser]` At a phone width, the card renders its mobile layout — the measured-width path, which no longer has a forced mode behind it.

**4. Decisions taken against drifted notes** — the five above.

**5. Follow-ups** — the four above, none filed; none clears the real-world bar.

**6. State left behind** — branch `claude/v0-8-0-m3-dead-code`, six commits, no assets branch, no HA instance touched. Counting for this session: production removed 210 · test removed 57 · added 155.
