### PR TITLE
docs(card): comments that state the rule, not the measurement

### DIFF
--- a/cards/haventory-card/src/components/hv-bulk-bar.test.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.test.ts
@@ -287,7 +287,7 @@ describe('describeFailure', () => {
     expect(describeFailure(failure('a', 'not_found'))).toContain('Nicht gefunden');
     expect(describeFailure(failure('a', 'storage_error'))).toContain('Nicht gespeichert');
     // The backend's own sentence rides through untranslated inside the card's
-    // frame, which is what #190's notes settle for `validation_error`.
+    // frame: for `validation_error` only the frame is a card string.
     expect(describeFailure(failure('a', 'validation_error', 'quantity must be >= 0'))).toBe(
       'Abgelehnt – quantity must be >= 0',
     );

--- a/cards/haventory-card/src/components/hv-bulk-bar.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.ts
@@ -530,7 +530,7 @@ export function describeFailure(failure: BulkFailure): string {
       return t('hv.bulk.failure.notFound');
     case 'validation_error':
       // The backend's own sentence, framed by the card's — the message text
-      // itself is not translated, as #190's notes settle.
+      // itself is not translated.
       return t('hv.bulk.failure.rejected', { message });
     case 'storage_error':
       return t('hv.bulk.failure.storage');

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -832,10 +832,9 @@ describe('hv-card-shell: narrow header', () => {
     expect(sr.querySelector('[data-testid="badge-low"]')).toBeTruthy();
   });
 
-  // Checked-out used to be desktop-only, on the theory that a phone had no room
-  // for a third badge. It does, now that the badges have a row to themselves —
-  // and that row is a filter toggle a phone user could not otherwise reach
-  // without opening the filter sheet.
+  // The badges have a row of their own, so a phone has room for a third — and
+  // that row is a filter toggle a phone user cannot otherwise reach without
+  // opening the filter sheet.
   it('badges checked-out on a phone too, and wraps if the row runs out', async () => {
     const { sr } = await mountShell({ items: [makeItem({ id: '1', checked_out: true })], mobile: true });
     const badge = sr.querySelector('[data-testid="badge-out"]');
@@ -1269,10 +1268,10 @@ describe('hv-card-shell: inline editing', () => {
 });
 
 // Typing in the search box, toggling a filter and changing the sort all run
-// through `Store.setFilters`. It used to blank the item list, which sent
-// `hv-list` into its skeleton branch and replaced the scroller the open form
-// lives in — the element was rebuilt from the stored item and everything typed
-// into it was gone, while the form still looked open.
+// through `Store.setFilters`, and none of them may blank the item list: that
+// sends `hv-list` into its skeleton branch and replaces the scroller the open
+// form lives in, so the form is rebuilt from the stored item and everything
+// typed into it is gone while it still looks open.
 describe('hv-card-shell: the open editor survives a refetch', () => {
   const list = (sr: ShadowRoot) => sr.querySelector('hv-list') as HTMLElement;
   const editor = (sr: ShadowRoot) =>
@@ -1713,7 +1712,7 @@ describe('hv-card-shell: full view', () => {
   it('keeps the expand toggle on a narrow card, where only "select items" led there', async () => {
     // "mobile" means the *card* is narrow, not the screen: a narrow card in a
     // wide dashboard is exactly when the full view is worth opening, and the
-    // only route to it used to be the overflow menu's "Select items".
+    // expand toggle is the route there, since the footer link is desktop-only.
     const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })], mobile: true });
     expect(sr.querySelector('[data-testid="open-full-view"]'), 'footer link stays desktop-only').toBe(null);
 
@@ -1821,10 +1820,10 @@ describe('hv-card-shell: full view', () => {
 });
 
 // A dialog is `position: fixed`, so it is laid out against the window and not
-// against the card that opened it. Feeding it the card's measured width put the
-// organize dialog in its full-bleed phone page on a desktop monitor, from every
+// against the card that opened it. Fed the card's measured width, the organize
+// dialog takes its full-bleed phone page on a desktop monitor from every
 // surface — a card in a dashboard column is 300–500px wide, and expanding it
-// changed nothing because the measured element was still the card underneath.
+// changes nothing, because the measured element is still the card underneath.
 describe('hv-card-shell: host dialogs follow the viewport, not the card', () => {
   const HOSTED = ['host-columns', 'host-confirm', 'host-organize', 'host-import', 'host-diagnostics'];
 

--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -406,10 +406,10 @@ describe('hv-data-table: the checked-out chip names an overdue loan', () => {
 });
 
 // Both chips are unshrinkable, so on a row carrying both they take 138px of the
-// 250px name track and leave 112px of name — about sixteen characters, measured
-// on a real instance at the table's floor width and again at 390px, where the
-// same cell is pinned. Dropping one is what buys the name back; which one to
-// drop is the choice the phone row already makes on its single line.
+// 250px name track and leave 112px of name — about sixteen characters, at the
+// table's floor width and at 390px alike, where the same cell is pinned.
+// Dropping one is what buys the name back; which one to drop is the choice the
+// phone row already makes on its single line.
 describe('hv-data-table: the name cell picks one chip', () => {
   const bothWays = { quantity: 1, low_stock_threshold: 5 };
 
@@ -648,8 +648,8 @@ describe('hv-data-table: sorting', () => {
 });
 
 describe('hv-data-table: inspection column', () => {
-  // The header used to read "Inspected", past tense, over a date the rest of
-  // the card treats as the next one due.
+  // The column holds the next inspection due, not the last one done, and heads
+  // itself the way the rest of the card names that date.
   it('heads the column with the date it holds', async () => {
     const el = await mount([{ id: '1' }], { columns: ['inspection_date'] });
     expect(q(el, '[data-field="inspection_date"]')?.textContent?.trim()).toBe('Next inspection');

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -71,11 +71,10 @@ export class HVDataTable extends LitElement {
            Sideways because the column template has a hard minimum — about
            1366px for the default set, 1414px with the selection column — and a
            grid whose tracks do not fit overflows its own box rather than
-           shrinking. With overflow visible that spilled content was simply
-           clipped by the shell: at 375px the rows measured clientWidth 634
-           against scrollWidth 854, and the Tags, Due and Updated columns could
-           not be reached by any gesture. Scrolling keeps whichever columns the
-           user chose rather than quietly dropping them on small screens.
+           shrinking. With overflow visible the shell clips what spills, and on
+           a phone the rightmost columns cannot be reached by any gesture.
+           Scrolling keeps whichever columns the user chose rather than quietly
+           dropping them on small screens.
 
            Vertically here rather than on the row group, because a sticky cell
            resolves its offsets against the nearest scroll container: with the

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -261,8 +261,8 @@ describe('hv-detail-sheet: read view', () => {
     expect(facts.find((f) => f.dataset.key === 'inspection')?.textContent).toContain('Not set');
   });
 
-  // The row used to read "Last inspected" while the editor's field called the
-  // same value an inspection date — two readings of one stored date.
+  // The stored date is the next inspection due, and the row names it the way
+  // the editor's field does — one value, one reading.
   it('names the inspection fact for the date it holds', async () => {
     const el = await mount({ inspection_date: '2099-03-04' });
     const fact = all(el, '[data-testid="sheet-fact"]').find((f) => f.dataset.key === 'inspection');
@@ -284,9 +284,9 @@ describe('hv-detail-sheet: read view', () => {
     }
   });
 
-  // The sheet used to mark the smaller thing and leave the bigger one plain: an
-  // amber Next inspection fact directly under a Due fact in ordinary black, on
-  // an item whose chip above already said "Overdue".
+  // Marking the inspection fact and leaving Due plain marks the smaller thing:
+  // an amber Next inspection directly under a Due fact in ordinary black, on an
+  // item whose chip above already says "Overdue".
   it('marks a Due date that has passed, the way the inspection fact beneath it is marked', async () => {
     const el = await mount({ checked_out: true, due_date: '2020-01-01' });
     const due = all(el, '[data-testid="sheet-fact"]').find((f) => f.dataset.key === 'due');
@@ -604,8 +604,8 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     );
   });
 
-  // Every cancel in the card is composed. Backing out of the date step used to
-  // reach the host as "the sheet closed" and took the item down with it.
+  // Every cancel in the card is composed, so backing out of the date step must
+  // not reach the host as "the sheet closed" and take the item down with it.
   it('keeps the sheet up when the check-out date step is backed out of', async () => {
     const el = await mount({ id: '1', name: 'A' });
     let cancels = 0;
@@ -1086,7 +1086,7 @@ describe('hv-detail-sheet: documents', () => {
 
     const open = all(el, '[data-testid="sheet-document-open"]')[0] as HTMLAnchorElement;
     // Versioned by the served name, so a retitle cannot be answered from the
-    // browser's cache with the filename this document used to carry.
+    // browser's cache with the filename the document carried before it.
     expect(open.getAttribute('href')).toBe(
       `/api/haventory/media/i-1/m-1?${MEDIA_NAME_TOKEN_PARAM}=${attachmentNameToken(docs()[0])}&authSig=test`,
     );

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -1004,10 +1004,10 @@ export class HVDetailSheet extends LitElement {
           this._mode = 'read';
         }}
         @delete-item=${(e: Event) => {
-          // The form has a Delete of its own, and this sheet is the only host
-          // that never forwarded it — so the button sat there doing nothing.
-          // Re-emitted as `request-delete`, the same event the read view's
-          // Delete sends, so the host confirms it exactly once either way.
+          // The form has a Delete of its own, and this sheet has to forward it
+          // or the button does nothing. Re-emitted as `request-delete`, the
+          // same event the read view's Delete sends, so the host confirms it
+          // exactly once either way.
           e.stopPropagation();
           this._emit('request-delete');
         }}

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -627,13 +627,11 @@ export class HVDetailSheet extends LitElement {
   /**
    * The picture strip, or nothing at all when the item has none.
    *
-   * Each figure is a button: tapping one opens the lightbox, which is the only
-   * way to see a photo at a useful size on a phone.
-   *
-   * A picture whose file the backend cannot find is drawn as missing rather
-   * than handed to an `<img>` that can only draw the browser's broken-image
-   * glyph — the same reason the document rows below probe, and the same state a
-   * restore without the media directory puts every photo in.
+   * Each figure is a button: tapping one opens the lightbox, the only way to
+   * see a photo at a useful size on a phone. A picture whose file the backend
+   * cannot find is drawn as missing rather than handed to an `<img>` that can
+   * only show the browser's broken-image glyph — the state a restore without
+   * the media directory puts every photo in, and why the document rows probe.
    */
   private _renderGallery(item: Item) {
     const shots = pictures(item.attachments);
@@ -678,10 +676,9 @@ export class HVDetailSheet extends LitElement {
    * Each row is an anchor to the signed media URL rather than a button that
    * opens one: the URL has to be on the element before the tap, or the popup
    * blocker eats the new tab a handler would open after awaiting a signature.
-   *
    * A reference whose file the backend cannot find is shown as missing instead
-   * of as a link that leads to a 404 — a JSON export carries the metadata and
-   * not the bytes, so a fresh install genuinely can hold one.
+   * of as a link to a 404 — a JSON export carries the metadata and not the
+   * bytes, so a fresh install genuinely can hold one.
    */
   private _renderDocuments(item: Item) {
     const docs = manuals(item.attachments);

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.ts
@@ -37,11 +37,9 @@ export class HVDiagnosticsPanel extends LitElement {
       /*
        * The single implicit track of a centring grid is auto-sized, and an
        * auto track takes the width its item asks for — 470px — however narrow
-       * the container is. The panel's own max-width: 100% then resolved
-       * against that 470px track and never clamped, so on a 390px screen the
-       * dialog stayed 470 wide: the third tile, the fact values and the Close
-       * button all hung off the right edge, unreachable (the wrap measured
-       * scrollWidth 494 against clientWidth 390).
+       * the container is. The panel's own max-width: 100% resolves against
+       * that track and never clamps, so on a phone the dialog stays 470 wide
+       * and its right edge hangs off the screen, out of reach.
        *
        * A minmax(0, 1fr) track is the container's width instead, which is what
        * gives the percentage something to bite on. Rows get the same treatment

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -733,8 +733,9 @@ describe('hv-filter-panel: footer and staging', () => {
     expect(el.working.categories).toEqual([]);
   });
 
-  // Clearing used to go straight to the store: the list behind the sheet
-  // reloaded while every control in the sheet kept its old value.
+  // Clearing stages like every other edit in the sheet: sent straight to the
+  // store, the list behind the sheet reloads while every control in the sheet
+  // keeps its old value.
   it('clears the staged draft, not the applied filters', async () => {
     const el = await mount(
       { categories: ['Hardware'], tags: ['metric'], lowStockOnly: true },
@@ -781,8 +782,9 @@ describe('hv-filter-panel: footer and staging', () => {
 
 describe('hv-filter-panel: native control affordances', () => {
 
-  // The drawn chevron used to be a sibling of a select only as wide as its own
-  // text, so clicking the arrow — the obvious target — did nothing at all.
+  // The drawn chevron sits over a select that fills the field: beside a select
+  // only as wide as its own text, clicking the arrow — the obvious target —
+  // does nothing at all.
   it('lets the select own the whole field, chevron included', async () => {
     const el = await mount();
     for (const testid of ['filter-sort-field', 'filter-area']) {
@@ -799,9 +801,9 @@ describe('hv-filter-panel: native control affordances', () => {
 });
 
 describe('hv-filter-panel: changed', () => {
-  // Two bare date inputs side by side are indistinguishable: the only labels
-  // used to be screen-reader-only, so a sighted user could not tell which one
-  // filtered on updated and which on created.
+  // Two bare date inputs side by side are indistinguishable: with the labels
+  // screen-reader-only, a sighted user cannot tell which one filters on updated
+  // and which on created.
   it('labels each date filter visibly, not only for screen readers', async () => {
     const el = await mount();
 

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -56,14 +56,12 @@ const DATE_KEYS = {
  * Every filter the backend accepts, in one panel — and the same set as a staged
  * bottom-sheet body on mobile.
  *
- * Two pairs are deliberately kept apart because the backend treats them
- * differently: "Low stock" is a filter (`low_stock_only`) while "Low stock
- * first" is an ordering hint (`low_stock_first`), and tags are one selection
- * with an any/all mode that routes to `tags_any` or `tags_all`.
- *
- * Desktop applies each change immediately. Mobile stages edits locally and
- * reports the live match count on the apply button, so the user sees the
- * consequence before committing.
+ * Two pairs stay apart because the backend treats them differently: "Low stock"
+ * is a filter (`low_stock_only`) while "Low stock first" is an ordering hint
+ * (`low_stock_first`), and tags are one selection with an any/all mode routing
+ * to `tags_any` or `tags_all`. Desktop applies each change immediately; mobile
+ * stages edits and prices the apply button, so the consequence is visible
+ * before it is committed.
  */
 @customElement('hv-filter-panel')
 export class HVFilterPanel extends LitElement {
@@ -180,13 +178,11 @@ export class HVFilterPanel extends LitElement {
         font: inherit;
       }
       /*
-       * The comparison is a button, not a caption: it says which field this row
-       * is about *and* which way the comparison runs, and clicking it flips the
-       * direction.
-       *
-       * It carries its own outline and fill against the field's, which is the
-       * smallest treatment that reads as a control at rest — a hover-only
-       * affordance never arrives on a touch screen at all.
+       * The comparison is a button, not a caption: it says which field the row
+       * is about and which way the comparison runs, and clicking it flips the
+       * direction. Its own outline and fill against the field's is the smallest
+       * treatment that reads as a control at rest — a hover-only affordance
+       * never arrives on a touch screen at all.
        */
       .field .direction {
         white-space: nowrap;
@@ -260,15 +256,13 @@ export class HVFilterPanel extends LitElement {
         font-weight: 500;
       }
       /*
-       * A "Show only" row is a chip in another shape, and carries the chip class
-       * to say so: it holds the same filter the wider panel draws as a chip and
-       * announces the same way, so it takes the chip's outline and on-state
-       * rather than restating those tokens — a row that paints a checkbox while
-       * announcing a toggle describes two widgets. Only what a full-width row
-       * needs on top of a chip lives here.
-       *
-       * Five of these stack under "Show only" in the sheet, and pills each sized
-       * to their own label leave that column with a ragged right edge.
+       * A "Show only" row is a chip in another shape and carries the chip class
+       * to say so: same filter, same announcement, so it takes the chip's
+       * outline and on-state rather than restating those tokens — a row that
+       * paints a checkbox while announcing a toggle describes two widgets. Only
+       * what a full-width row needs on top of a chip lives here: five stack
+       * under "Show only" in the sheet, and pills each sized to their own label
+       * leave that column with a ragged right edge.
        */
       :host([mobile]) .check {
         box-sizing: border-box;
@@ -348,11 +342,9 @@ export class HVFilterPanel extends LitElement {
   @property({ type: Boolean, reflect: true }) mobile = false;
   /**
    * Whole-inventory stat counts, which price both the "Show only" rows and the
-   * status chips.
-   *
-   * Every facet in this panel carries a number, so a user can see what a filter
-   * is worth before applying it. Null until the first `haventory/stats` answer
-   * arrives, and then each tally is drawn only where the payload prices it.
+   * status chips, so a user can see what a filter is worth before applying it.
+   * Null until the first `haventory/stats` answer arrives, and then each tally
+   * is drawn only where the payload prices it.
    */
   @property({ attribute: false }) counts: StatsCounts | null = null;
 
@@ -461,13 +453,12 @@ export class HVFilterPanel extends LitElement {
   /**
    * A labelled on/off filter row.
    *
-   * Its state is `aria-pressed`, not a checkbox role: every filter toggle in the
-   * card announces as a pressed toggle button — the app bars' stat pills, the
-   * sidebar's facet rows, this panel's chips — and the "Show only" facets render
-   * as rows here and as chips on a wider screen, so a single facet would
-   * otherwise change vocabulary with the viewport it is read on. The row is
-   * painted to match: it takes the chip's on state, so what the row draws and
-   * what it announces describe the same widget.
+   * Its state is `aria-pressed`, not a checkbox role: every filter toggle in
+   * the card announces as a pressed toggle button, and the "Show only" facets
+   * render as rows here and as chips on a wider screen, so one facet would
+   * otherwise change vocabulary with the viewport it is read on. The row takes
+   * the chip's on state to match, so what it draws and what it announces are
+   * one widget.
    */
   private _renderCheckbox(
     label: string,
@@ -797,10 +788,9 @@ export class HVFilterPanel extends LitElement {
    * The stored item status, as one single-select chip row.
    *
    * Single-select because the backend filter takes exactly one status, and each
-   * chip carries the tone its household picked. Every chip is priced the same
-   * way, so a user choosing what to filter by can see which statuses are worth
-   * filtering by — a backend too old to price them all leaves the rest bare
-   * rather than guessing.
+   * chip carries the tone its household picked. Every chip is priced, so what a
+   * status is worth is visible before it is picked; a backend too old to price
+   * them all leaves the rest bare rather than guessing.
    */
   private _renderStatusGroup() {
     const f = this.working;

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -109,7 +109,8 @@ describe('hv-full-view: phone-width app bar', () => {
   });
 
   it('keeps Clear selection on screen', async () => {
-    // It measured 380..490 in a 375px viewport before the bar could wrap.
+    // The bar does not wrap, so at 375px only the tighter step keeps it on
+    // screen.
     const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
     el.startSelecting = true;
     el.open = false;
@@ -952,9 +953,9 @@ describe('hv-full-view: sidebar status', () => {
     expect(tallies(sr)).toEqual(['1', '1', '2']);
   });
 
-  // The audit's fixture in miniature: custom slugs used to inherit "everything
-  // that is not missing or needs_repair", so an empty status claimed the whole
-  // inventory and then showed no rows when it was clicked.
+  // Each slug is priced on its own: inheriting "everything that is not missing
+  // or needs_repair" lets an empty status claim the whole inventory and then
+  // show no rows when it is clicked.
   it('prices a household vocabulary per slug, including one nothing carries', async () => {
     const statuses: StatusDefinition[] = [
       { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
@@ -1052,7 +1053,7 @@ describe('hv-full-view: context bar and table', () => {
     await settle(el);
     const crumb = q(sr, '[data-testid="full-breadcrumb"]')?.textContent?.replace(/\s+/g, ' ');
     expect(crumb).toContain('garage › Shelf A');
-    // One item is one item — the crumb used to say "1 items".
+    // One item is one item, not "1 items".
     expect(crumb).toContain('1 item');
   });
 
@@ -1074,9 +1075,9 @@ describe('hv-full-view: context bar and table', () => {
     expect(crumb?.textContent?.replace(/\s+/g, ' ')).toContain('garage › Shelf A');
   });
 
-  // Browsing into a root named after its own room used to write the room twice:
-  // "Kitchen  Kitchen › Pantry". The crumb elides like every other surface that
-  // marks an area, and the pairing stays in the title.
+  // Browsing into a root named after its own room must not write the room
+  // twice — "Kitchen  Kitchen › Pantry". The crumb elides like every other
+  // surface that marks an area, and the pairing stays in the title.
   it('drops the area mark when the crumb already opens with the area name', async () => {
     const kitchen = { ...loc('kitchen', 'Kitchen'), area_id: 'area-kitchen' };
     const pantry: Location = {
@@ -1173,14 +1174,14 @@ describe('hv-full-view: context bar and table', () => {
       expect(button.getAttribute('aria-label')).toBe('Organize');
       button.click();
 
-      // No tab named: Organize opens where it always did, on Locations.
+      // No tab named: Organize opens on its default, Locations.
       expect(seen).toEqual([{ id: 'organize' }]);
       el.remove();
     }
   });
 
-  // The same sentence the card's footer prints — the two used to phrase one
-  // fact two ways, and neither named what it was counting.
+  // The same sentence the card's footer prints: one fact, one phrasing, and it
+  // names what it is counting.
   it('counts loaded rows against the filtered total, in the words the card uses', async () => {
     const items = Array.from({ length: 60 }, (_, i) => makeItem({ id: `i${i}` }));
     const { el, store, sr } = await mount({ items });
@@ -1241,9 +1242,9 @@ describe('hv-full-view: empty table', () => {
 
   it('waits for the fetch instead of blaming the filters for the gap', async () => {
     // Changing a filter clears the rows and asks for the next page, so between
-    // the two the table has nothing to show and no answer yet. It used to fill
-    // that gap with "No items match these filters" and a Clear all button,
-    // against a filter nothing had been counted for.
+    // the two the table has nothing to show and no answer yet. Filling that gap
+    // with "No items match these filters" and a Clear all button blames a
+    // filter nothing has been counted for.
     const { el, store, sr } = await mount({ items: [makeItem({ id: '1', name: 'Wood Glue' })] });
     store.setFilters({ q: 'wood' });
     await el.updateComplete;
@@ -2114,8 +2115,8 @@ describe('hv-full-view: selection and bulk actions', () => {
     expect([...store.state.value.selection]).toEqual(['2']);
   });
 
-  // Bulk check-out used to fire on the press with no due date at all, so a
-  // batch could never go overdue while a single row was always asked.
+  // A batch is asked for a due date exactly as a single row is: firing on the
+  // press with no date means a bulk check-out can never go overdue.
   describe('bulk check-out asks for a due date, once', () => {
     async function selectTwoAndCheckOut() {
       const items = [makeItem({ id: '1' }), makeItem({ id: '2' })];

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -369,14 +369,13 @@ export class HVFullView extends LitElement {
        * Above the phone breakpoint — the complement of NARROW_QUERY, whose own
        * block below owns everything at or under it.
        *
-       * The search box has a floor here, or each pill added would come out of
-       * it: with all six showing it collapsed to "Search all 1(" in a 1024px
-       * content area. The bar used to take a second line instead, which read
-       * as a fix until an ordinary laptop hit it — at 1280px in German the ⋮
-       * went down on its own and left a 44px band of empty blue under the
-       * pills. So the row stays whole and two things give before it does: the
-       * pill strip scrolls, and the two steps below trade away what can be
-       * read from an icon.
+       * The search box has a floor here, or every pill added comes out of it
+       * until there is no room left to read the query in. Wrapping onto a
+       * second line is not the alternative: in German at 1280px the ⋮ goes
+       * down on its own and leaves a band of empty blue under the pills. So
+       * the row stays whole and two things give before it does: the pill strip
+       * scrolls, and the two steps below trade away what can be read from an
+       * icon.
        */
       @media (min-width: 701px) {
         .appbar .search {
@@ -463,7 +462,7 @@ export class HVFullView extends LitElement {
         grid-template-columns: 264px 1fr;
         min-height: 0;
       }
-      /* Now reachable from a narrow card, so it can land on a phone-width
+      /* Reachable from a narrow card, so it can land on a phone-width
          viewport: there is no room for a 264px tree beside the table, and the
          app bar's search and filters still cover navigation.
 
@@ -630,8 +629,8 @@ export class HVFullView extends LitElement {
         border: none;
         background: none;
         color: var(--hv-chip-text);
-        /* 2px of padding measured 17px tall, which is a poor target even for a
-           mouse; there is room for this in a 264px column. */
+        /* Tighter padding than this leaves a target too short to hit even with
+           a mouse, and a 264px column has room for it. */
         padding: 4px 10px;
         font: 400 11.5px var(--hv-font);
         min-height: var(--hv-tap-min, auto);
@@ -1629,10 +1628,10 @@ export class HVFullView extends LitElement {
   /**
    * Which way multiple selected tags combine, in the sidebar that selects them.
    *
-   * The sidebar accumulated tags but said nothing about the mode governing them,
-   * so a filter set to "all" in the filter panel silently kept applying to every
-   * tag picked here. Only shown from the second tag on, since that is when any
-   * and all start meaning different things.
+   * The mode is the filter panel's, and it keeps applying to every tag picked
+   * here, so the sidebar has to show it rather than let "all" work unseen. Only
+   * shown from the second tag on, since that is when any and all start meaning
+   * different things.
    */
   private _renderTagsMode(mode: 'any' | 'all') {
     return html`<span class="segmented" role="radiogroup" aria-label=${t('hv.filter.tagMatchMode')}>

--- a/cards/haventory-card/src/components/hv-import-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.test.ts
@@ -444,8 +444,8 @@ describe('hv-import-sheet: summary', () => {
     expect(el.open).toBe(false);
   });
 
-  // Issue #439: a locations-only document used to complete with every number on
-  // the screen at zero, because the sentence had no slot for location updates.
+  // The result sentence has a slot for location updates, or a locations-only
+  // document completes with every number on the screen at zero.
   it('reports a locations-only import instead of a row of zeros', async () => {
     const s = summary();
     s.items = { total: 0, add: 0, update: 0, conflict: 0, unchanged: 0 };

--- a/cards/haventory-card/src/components/hv-import-sheet.ts
+++ b/cards/haventory-card/src/components/hv-import-sheet.ts
@@ -12,12 +12,10 @@ import { copyText } from '../ui/clipboard';
 import type { ImportBucketCounts, ImportPolicy, ImportPreview, ImportSummary } from '../store/types';
 
 // Every policy decides one thing: what happens to an item the file and the
-// inventory both have — "both have" meaning the same id, never the same name, so
-// an item rebuilt by hand carries a fresh id and is added alongside the file's
-// copy rather than matched to it. Each description names the id as the match key,
-// because "matching" on its own reads as matching by name. None of the policies
-// deletes anything — an item absent from the file is always left alone — so each
-// description says so too, because "Replace" on its own reads like a
+// inventory both have — the same id, never the same name, so an item rebuilt by
+// hand carries a fresh id and is added alongside the file's copy. Each
+// description names the id as the match key and says that nothing is deleted:
+// "matching" alone reads as matching by name, and "Replace" alone reads like a
 // whole-inventory swap.
 /**
  * How many name clashes are listed individually before the block switches to a
@@ -30,9 +28,9 @@ const WARNING_LIST_LIMIT = 5;
  * What the execute button promises to write.
  *
  * It names both kinds because either can be the whole document: a backup
- * restored onto a hand-rebuilt tree writes locations and no items. The
- * breakdown into added and updated is left to the count tables directly above,
- * which carry it for both kinds; repeating it here would need four numbers.
+ * restored onto a hand-rebuilt tree writes locations and no items. Added and
+ * updated are left to the count tables above, which carry both kinds; here they
+ * would take four numbers.
  */
 function importButtonLabel(itemWrites: number, locationWrites: number): string {
   const parts: string[] = [];
@@ -47,10 +45,8 @@ function importButtonLabel(itemWrites: number, locationWrites: number): string {
  * What the completed import did, as one sentence.
  *
  * Every dimension that moved is named and every dimension that did not is
- * dropped, so a locations-only document reports its location updates instead
- * of a row of zeros — the run that motivated this reported "Imported 0 new,
- * updated 0" after doing exactly what its preview promised. An import that
- * changed nothing says so in words rather than in numbers.
+ * dropped, so a locations-only document reports its location updates instead of
+ * a row of zeros. An import that changed nothing says so in words, not numbers.
  */
 export function importSummaryLine(summary: ImportSummary): string {
   const added: string[] = [];
@@ -97,10 +93,10 @@ function policyTitle(id: ImportPolicy): string {
 /**
  * Restore from a backup.
  *
- * The server-side dry run is mandatory and stays that way: nothing is written
- * until the preview has been seen. An invalid document comes back as a
- * structured list of JSON paths rather than counts, so that gets its own state
- * instead of being flattened into "import failed".
+ * The server-side dry run is mandatory: nothing is written until the preview
+ * has been seen. An invalid document comes back as a structured list of JSON
+ * paths rather than counts, so it gets a state of its own instead of being
+ * flattened into "import failed".
  */
 @customElement('hv-import-sheet')
 export class HVImportSheet extends LitElement {

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -498,13 +498,14 @@ describe('hv-item-editor: saving', () => {
     expect(cancels).toBe(1);
   });
 
-  // The hint used to print ⌘↵ on every platform, naming a key a PC keyboard does
-  // not have. jsdom reports no Apple platform, so this is the fallback branch.
+  // The hint names no key the keyboard in front of the user lacks — ⌘↵ on a PC
+  // names nothing. jsdom reports no Apple platform, so this is the fallback
+  // branch.
   it('names the save chord for the keyboard it can actually detect', async () => {
     const el = await mount(makeItem({ id: '1', name: 'A' }));
     const hint = q(el, '[data-testid="editor-key-hint"]')?.textContent ?? '';
-    // Esc no longer discards: it asks whenever there is typing to lose, exactly
-    // as Cancel and the ✕ do, so the hint stops promising the old outcome.
+    // Esc asks whenever there is typing to lose, exactly as Cancel and the ✕
+    // do, so the hint promises closing and not discarding.
     expect(hint).toContain('Esc closes');
     expect(hint).toContain('Ctrl+Enter saves');
     expect(hint).not.toContain('⌘');
@@ -523,8 +524,8 @@ describe('hv-item-editor: saving', () => {
     expect(saves).toHaveLength(1);
   });
 
-  // The auto margin that holds Cancel and Save against the right edge used to
-  // ride on the hint, so hiding the hint dropped them back beside Delete.
+  // The auto margin that holds Cancel and Save against the right edge rides on
+  // a spacer of its own: on the hint, hiding the hint drops them beside Delete.
   it('keeps Cancel and Save off the left edge once the hint is gone', async () => {
     const el = await mount(makeItem({ id: '1', name: 'A' }), { mobile: true });
     const kids = [...(q(el, '.actions')?.children ?? [])];
@@ -559,11 +560,10 @@ describe('hv-item-editor: saving', () => {
     }
   });
 
-  // Three buttons in one row, three shapes: measured at a 390px viewport in the
-  // expanded view, Delete was 93x44 with a 1px border and a 999px radius, Cancel
-  // beside it 64x44 borderless with an 8px radius, and Delete's 12.5px/400 text
-  // matched neither. The card's other destructive actions — the detail sheet's
-  // own Delete item, the organize dialog's Delete — are all borderless red.
+  // Three buttons in one row take one shape: a bordered pill beside two
+  // borderless buttons reads as a third. The card's other destructive actions —
+  // the detail sheet's own Delete item, the organize dialog's Delete — are all
+  // borderless red.
   it('styles Delete like every other destructive action in the card', async () => {
     const el = await mount(makeItem({ id: '1', name: 'A' }));
     expect([...(q(el, '[data-testid="editor-delete"]')?.classList ?? [])]).toEqual([
@@ -1105,8 +1105,8 @@ describe('hv-item-editor: opening', () => {
   });
 });
 
-// Escape-to-close-a-dropdown is muscle memory; here it used to cost the whole
-// form, dropdown and typing together.
+// Escape-to-close-a-dropdown is muscle memory, so one Escape closes the
+// dropdown and not the form and the typing with it.
 describe('hv-item-editor: Escape takes back one thing at a time', () => {
   const esc = (el: HVItemEditor, from?: HTMLElement) =>
     (from ?? (q(el, '[data-testid="item-editor"]') as HTMLElement)).dispatchEvent(
@@ -1880,8 +1880,8 @@ describe('hv-item-editor: opening a document', () => {
 
 /**
  * The state an import onto a fresh machine leaves every picture in — the export
- * carries the metadata and not the bytes. A photo used to get the browser's
- * broken-image glyph here while its manual sibling got the chip.
+ * carries the metadata and not the bytes. A photo whose file is gone gets the
+ * same chip its manual sibling gets, not the browser's broken-image glyph.
  */
 describe('hv-item-editor: a picture whose file is gone', () => {
   afterEach(() => {

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -96,10 +96,9 @@ const MORE_FIELDS_ID = 'editor-more-fields';
 /**
  * One file the picker is working through, and how it ended up.
  *
- * A failed entry keeps the `File` itself so Retry can send exactly what was
- * picked. Without it the user would have to find the file again — and on a
- * phone that means retaking the photo, because the original came from the
- * camera and was never on disk.
+ * A failed entry keeps the `File` itself so Retry sends exactly what was
+ * picked; without it the user has to find the file again, and on a phone that
+ * means retaking a photo the camera never wrote to disk.
  */
 interface UploadEntry {
   id: string;
@@ -133,12 +132,11 @@ function errorText(err: unknown, fallback = t('hv.editor.upload.failed')): strin
  * The one edit surface: the inline expander, the full view and the mobile sheet.
  *
  * The row expands in place and the location tree opens *inside* the form, so
- * picking a location never stacks a second modal over the edit surface.
- *
- * Every editable field lives here: name, description, quantity, low-stock
- * threshold, category (with suggestions), tags, location, checked-out plus due
- * date, inspection date and typed custom fields. On mobile the rarely-touched
- * half collapses behind one "More fields" disclosure rather than being dropped.
+ * picking a location never stacks a second modal over the edit surface. Every
+ * editable field lives here: name, description, quantity, low-stock threshold,
+ * category (with suggestions), tags, location, checked-out plus due date,
+ * inspection date and typed custom fields — on mobile the rarely-touched half
+ * collapses behind one "More fields" disclosure rather than being dropped.
  */
 @customElement('hv-item-editor')
 export class HVItemEditor extends LitElement {
@@ -211,13 +209,12 @@ export class HVItemEditor extends LitElement {
         grid-column: span 1;
       }
       /* Packed to the top rather than sharing out the row's surplus. A grid
-         item stretches by default, so a cell holding a label and a control grew
-         to whatever the tallest cell in the row needed — the Description
-         textarea — and its two auto rows split the difference between them.
-         That is why the status select came out taller than an input and shorter
-         than the textarea beside it: exactly the midpoint. The same hazard is
-         guarded inside the boxes on the state row, which are stretched on
-         purpose; this closes it at the top. */
+         item stretches by default, so a cell holding a label and a control
+         takes the height of the tallest cell in the row — the Description
+         textarea — and its two auto rows split the difference, leaving a select
+         taller than an input and shorter than the textarea beside it. The boxes
+         on the state row are stretched on purpose and close the same hazard
+         inside themselves. */
       .cell {
         display: grid;
         align-content: start;
@@ -225,13 +222,11 @@ export class HVItemEditor extends LitElement {
         min-width: 0;
       }
       /* Checked out and Due date are two halves of one fact; Next inspection is
-         unrelated to both. The boxes below carry that split visually, so the
-         three fields are never read as three peer settings of the same kind.
-
-         Both boxes take the height of the taller one. Left to size themselves
-         they never agreed — one carries a note, the other three offset chips —
-         and a row of two boxes of different heights reads as four stacked
-         pieces rather than two. */
+         unrelated to both, and the boxes below carry that split visually so the
+         three are never read as three peer settings. Both boxes take the height
+         of the taller one: sized to themselves they disagree — one carries a
+         note, the other three offset chips — and two boxes of different heights
+         read as four stacked pieces rather than two. */
       .state {
         display: grid;
         /* Even halves. At 2fr/1fr the inspection box was narrow enough that its
@@ -302,13 +297,11 @@ export class HVItemEditor extends LitElement {
       /*
        * The button and the due date share a row by construction, not by
        * matching heights: three named rows, and column 1 of the label row is
-       * simply empty because the button carries no label of its own. Aligning
-       * the two halves by hand instead only moved the dead air — top-aligned
-       * put the button level with the *label* opposite it, bottom-aligned put
-       * the gap between the caption and the first control.
-       *
-       * The note spans the box: it says what state both controls are in, not
-       * just the field above it.
+       * empty because the button carries no label of its own. Aligning the two
+       * halves by hand only moves the dead air — top-aligned puts the button
+       * level with the *label* opposite it, bottom-aligned puts the gap between
+       * the caption and the first control. The note spans the box: it says what
+       * state both controls are in, not just the field above it.
        */
       .checkout-body {
         grid-template-columns: 1fr 1fr;
@@ -493,16 +486,15 @@ export class HVItemEditor extends LitElement {
         padding: 4px 0;
       }
       /* The category list is the one holder that must NOT take part in the
-         layout. In flow it grew its own grid cell, which grew the row, which
-         stretched the Location button beside it to ~130px — the form visibly
-         came apart every time the suggestions opened. The location tree below
-         is the opposite case: it is meant to push the form open, so it keeps
-         the in-flow rule above.
+         layout: in flow it grows its own grid cell, which grows the row and
+         stretches the Location button beside it, so the form comes apart every
+         time the suggestions open. The location tree below is the opposite case
+         and keeps the in-flow rule above — it is meant to push the form open.
 
-         Fixed rather than absolute, because the expanded view puts the whole
-         form inside an editor-holder that is max-height 70dvh with
-         overflow-y auto, and an absolute list would be clipped by it. Same
-         technique the checkout popover and the overflow menu already use. */
+         Fixed rather than absolute: the expanded view puts the whole form
+         inside an editor-holder that is max-height 70dvh with overflow-y auto,
+         and an absolute list would be clipped by it. Same technique the
+         checkout popover and the overflow menu use. */
       .list-holder.floating {
         position: fixed;
         margin-top: 0;
@@ -746,15 +738,13 @@ export class HVItemEditor extends LitElement {
         font: 400 12px var(--hv-font);
         color: var(--hv-text-secondary);
       }
-      /* The id is not read, it is pasted — printed in full and offered to one
-         tap: user-select: all takes the whole uuid from a single click or
-         long-press, which is the copy route left when the browser has no
-         clipboard API (Home Assistant over plain http:// is not a secure
-         context). A uuid carries no space to break at, so it is allowed to
-         break anywhere rather than push the button off a phone's row.
-         A row of its own above the actions, never a fourth control inside
-         them: that row is Delete, Cancel and Save, and at 375px the three of
-         them have 343px to spend. */
+      /* The id is not read, it is pasted: user-select: all takes the whole uuid
+         from a single click or long-press, which is the copy route left when
+         the browser has no clipboard API (Home Assistant over plain http:// is
+         not a secure context). A uuid carries no space to break at, so it may
+         break anywhere rather than push the button off a phone's row — and it
+         takes a row of its own above Delete, Cancel and Save, which have 343px
+         to spend at 375px. */
       .id-row {
         display: flex;
         align-items: center;
@@ -771,13 +761,11 @@ export class HVItemEditor extends LitElement {
         user-select: all;
       }
       /* Delete is hv-text-button danger from the shared sheet — the same
-         borderless red every other destructive action in the card uses (the
-         detail sheet's own Delete item, the organize dialog's Delete).
-         The row is Delete, Cancel and Save, and only three labels wide: at
-         375px it has 343px to spend, which German's full "Gegenstand löschen"
-         overruns by 9px and drops Save onto a line of its own. That is why the
-         narrow branch shows the bare verb; wrap stays as the last resort for a
-         language longer still. */
+         borderless red every other destructive action in the card uses. The row
+         is Delete, Cancel and Save, and only three labels wide: at 375px it has
+         343px, which German's full "Gegenstand löschen" overruns by 9px and
+         drops Save onto a line of its own. Hence the bare verb on the narrow
+         branch; wrap is the last resort for a language longer still. */
       .actions {
         display: flex;
         align-items: center;
@@ -790,13 +778,12 @@ export class HVItemEditor extends LitElement {
          scrolling — a phone sheet, the card's list, and the expanded view,
          which caps the form at 70dvh. The editor answers that itself rather
          than each host growing a pinned footer of its own.
-         Sticky goes on the wrapping cell rather than on .actions: an element
-         only sticks within its containing block, and .actions' parent is
-         exactly as tall as .actions, so it would have had nowhere to move.
-         The cell's containing block is the form grid, which is tall.
-         The negative side margins and the matching padding bleed the opaque
-         bar out to the form's edges — .grid's 18px side padding would otherwise
-         leave the rows it covers showing in two strips either side of it. */
+         Sticky goes on the wrapping cell, not on .actions: an element sticks
+         only within its containing block, and .actions' parent is exactly as
+         tall as .actions, while the cell's is the tall form grid. The negative
+         side margins and matching padding bleed the opaque bar out to the
+         form's edges, which .grid's 18px side padding would otherwise leave
+         showing in two strips either side of it. */
       .actions-cell {
         position: sticky;
         bottom: -14px;
@@ -1280,12 +1267,11 @@ export class HVItemEditor extends LitElement {
    * The form belongs to an item *id*, not to one `item` object.
    *
    * Every host re-binds `.item` from a fresh lookup on each store broadcast, so
-   * an upload finishing — or anyone editing the same row elsewhere — hands this
-   * component a new object for the item the user is still typing into.
-   * Rebuilding on that would throw away everything typed since the last save,
-   * so the reset is keyed on the id: a different one (including the null→id hop
-   * a create makes the moment it saves) is a different form, and everything
-   * else is a refresh the open form absorbs.
+   * an upload finishing — or anyone editing the same row elsewhere — hands the
+   * form a new object for the item being typed into, and rebuilding on that
+   * throws away everything typed since the last save. Keyed on the id, a
+   * different one (including the null→id hop a create makes when it saves) is a
+   * different form; everything else is a refresh the open form absorbs.
    */
   protected willUpdate() {
     this._urls.configure(this.media?.sign ?? null);
@@ -1822,19 +1808,17 @@ export class HVItemEditor extends LitElement {
   /**
    * The checkout, and the one date that is not part of it.
    *
-   * A due date is half of the checkout — it only means anything while an item
+   * A due date is half of the checkout — it means something only while an item
    * is out, which is why it is disabled otherwise and why `commonFields()`
-   * nulls it on save. The inspection date is unrelated to any of that: it is
-   * when the item is next due for inspection, and it stands whether or not
-   * anyone has borrowed it. Laid out as three equal thirds of a row they read
-   * as three settings of the same kind, so the two boxes below carry the
-   * distinction visually, on both widths.
+   * nulls it on save; the inspection date stands whether or not anyone has
+   * borrowed it. As three equal thirds of a row the fields read as three
+   * settings of one kind, so the two boxes below carry the distinction on both
+   * widths.
    *
-   * The state itself is a button rather than a switch. A switch says "this is
-   * a property of the item, set it either way"; checking something out is an
-   * act, so it matches the detail sheet — same words, same icons, so the two
-   * surfaces cannot teach different things. It still writes
-   * `checkedOut` into the form model rather than firing the WS command: this
+   * The state is a button, not a switch: a switch says "a property of the item,
+   * set it either way", and checking out is an act. Same words and icons as the
+   * detail sheet, so the two surfaces cannot teach different things. It writes
+   * `checkedOut` into the form model rather than firing the WS command — this
    * editor also creates items, which have no id to check out yet.
    */
   private _renderStateFields() {
@@ -1919,15 +1903,12 @@ export class HVItemEditor extends LitElement {
   /**
    * A date that comes round again — "change the HVAC filter every 3 months".
    *
-   * Two controls for one setting: the date is when it next comes round, and the
-   * repeat is optional beside it. Leaving the repeat empty is a one-off, which
-   * is why the count is a blank rather than a 1 — a household setting a single
-   * date should not have to clear a number to get one.
-   *
-   * The pair is written with the rest of the form, not through
-   * `haventory/reminder/set`: one save, one version bump, one conflict to
-   * resolve. The dedicated commands exist for automations, where there is no
-   * form to carry the other fields.
+   * Two controls for one setting: the date is when it next comes round, the
+   * repeat is optional beside it, and an empty repeat is a one-off — which is
+   * why the count is blank rather than 1. The pair is written with the rest of
+   * the form, not through `haventory/reminder/set`: one save, one version bump,
+   * one conflict to resolve. The dedicated commands exist for automations,
+   * which have no form to carry the other fields.
    */
   private _renderReminderFields() {
     const model = this._model;
@@ -1993,20 +1974,19 @@ export class HVItemEditor extends LitElement {
    * Checking out asks for a due date; checking in just happens.
    *
    * The same `hv-checkout-popover` the detail sheet uses — quick offsets, a
-   * date, a "no due date" way out. On a wide screen it anchors under the
-   * button; on a phone it expands inside the box. Confirming only patches the form model; the item is written
-   * when the form is saved, which is what lets it work while creating an item
-   * that has no id to check out yet.
+   * date, a "no due date" way out — anchored under the button on a wide screen
+   * and expanded inside the box on a phone. Confirming patches the form model
+   * only; the item is written on save, which is what lets it work while
+   * creating an item that has no id to check out yet.
    */
   /**
    * The same quick jumps the check-out popover offers, on the one date it does
-   * not own. An inspection interval is the kind of thing you know in weeks or
-   * months rather than as a calendar square, and typing a date three months out
-   * means doing the arithmetic yourself. Pressing an offset writes the date into
-   * the field above, so the two controls are one value with two ways in.
-   *
-   * The custom row only appears once "+X days" is pressed: it is the escape
-   * hatch for an interval the three presets do not cover, not a fourth preset.
+   * not own. An inspection interval is known in weeks or months rather than as
+   * a calendar square, and typing a date three months out means doing the
+   * arithmetic yourself; pressing an offset writes the date into the field
+   * above, so the two controls are one value with two ways in. The custom row
+   * appears only once "+X days" is pressed — the escape hatch for an interval
+   * the three presets do not cover, not a fourth preset.
    */
   private _renderInspectionOffsets(current: string) {
     return html`
@@ -2175,12 +2155,10 @@ export class HVItemEditor extends LitElement {
   /**
    * Why this file cannot be uploaded, or null when it can.
    *
-   * A courtesy check against the caps `haventory/config` reports, so an
-   * 80 MB video is refused instantly instead of after a minute of upload. The
-   * backend re-derives all of it from the file's own bytes and is the only
-   * thing that decides.
-   *
-   * A cap the config does not report is not checked here at all: an older
+   * A courtesy check against the caps `haventory/config` reports, so an 80 MB
+   * video is refused instantly instead of after a minute of upload; the backend
+   * re-derives all of it from the file's own bytes and is the only thing that
+   * decides. A cap the config does not report is not checked at all — an older
    * backend that never mentioned documents still enforces its own limit, and
    * guessing one would refuse a file the server would have taken.
    */
@@ -2360,11 +2338,10 @@ export class HVItemEditor extends LitElement {
    *
    * Buttons rather than a drag handle, matching the organize dialog's status
    * rows: one reordering idiom across the card, and both work from a keyboard
-   * without a second implementation beside the pointer one.
-   *
-   * The star is the cover in both directions — filled and inert on the photo
-   * that already is one, a button on every other. The list row and the detail
-   * header show position 0, so which photo that is has to be visible here.
+   * without a second implementation beside the pointer one. The star is the
+   * cover in both directions — filled and inert on the photo that already is
+   * one, a button on every other — because the list row and the detail header
+   * show position 0.
    */
   private _renderPhotoControls(attachmentId: string, index: number, total: number) {
     const move = (delta: number) => () =>
@@ -2530,11 +2507,10 @@ export class HVItemEditor extends LitElement {
    *
    * This form is the only surface a desktop gets: the detail sheet that also
    * prints the id opens on a card element of 600px or less, and in the full
-   * view only below the 700px viewport query — while automation YAML is
-   * written on a wide screen. Last in the grid, below the fields and above the
-   * actions: it is a fact about the item, not something to fill in.
-   *
-   * The create form has no id yet and says nothing rather than showing a blank.
+   * view only below the 700px viewport query — while automation YAML is written
+   * on a wide screen. Last in the grid, below the fields and above the actions:
+   * it is a fact about the item, not something to fill in. The create form has
+   * no id yet and says nothing rather than showing a blank.
    */
   private _renderIdRow() {
     const id = this.item?.id;
@@ -2659,17 +2635,13 @@ export class HVItemEditor extends LitElement {
    * The documents already attached, and the picker that adds one.
    *
    * Each row carries its own title field because a filename is what a scanner
-   * or a manufacturer chose — `scan_0142.pdf` says nothing about which appliance
-   * it belongs to, and the list is unreadable without one. An empty title falls
-   * back to the filename rather than blanking the row.
-   *
-   * No `capture` on this input: a document comes from the file system, and
-   * pointing the control at the camera would put a photo of a page where the
-   * PDF should be.
-   *
-   * Each row can be opened from here as well as from the detail sheet's read
-   * view, because that sheet is a phone surface — on a desktop this form is the
-   * only place a manual is reachable at all.
+   * or a manufacturer chose — `scan_0142.pdf` says nothing about which
+   * appliance it belongs to — and an empty title falls back to the filename
+   * rather than blanking the row. No `capture` on this input: a document comes
+   * from the file system, and pointing the control at the camera would put a
+   * photo of a page where the PDF should be. Each row opens from here as well
+   * as from the detail sheet's read view, which is a phone surface — on a
+   * desktop this form is the only place a manual is reachable at all.
    */
   private _renderDocuments() {
     const item = this._current;
@@ -2750,10 +2722,10 @@ export class HVItemEditor extends LitElement {
   /**
    * What the upload queue is doing, under the section it is doing it to.
    *
-   * A queue rendered below both pickers put a phone's photo uploads two
-   * sections away from the grid the user is watching them fill, and reported a
-   * refused document under "Photos". One list per kind keeps each report beside
-   * the control that started it.
+   * One list per kind keeps each report beside the control that started it: a
+   * single queue below both pickers puts a phone's photo uploads two sections
+   * away from the grid they are filling, and reports a refused document under
+   * "Photos".
    */
   private _renderUploadList(kind: AttachmentKind) {
     const entries = this._uploads.filter((u) => u.kind === kind);

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -153,10 +153,9 @@ export class HVItemEditor extends LitElement {
          * The form's small print, at one size. Labels are 11px (the shared
          * hv-label recipe and the photo picker's caption); everything this
          * form declares as a note about a field — hints, sizes, errors, the
-         * upload queue — reads at this one instead of the 11.5/12/12.5px band
-         * they used to spread across. The custom-fields tally is the one piece
-         * of small print here that is not this form's to size: it is the same
-         * facet count the sidebar shows, priced once in the shared sheet.
+         * upload queue — reads at this one. The custom-fields tally is the one
+         * piece of small print here that is not this form's to size: it is the
+         * same facet count the sidebar shows, priced once in the shared sheet.
          */
         --hv-editor-note: 12px;
         background: var(--hv-row-hover);

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -59,8 +59,8 @@ describe('hv-list-row: content', () => {
     expect(q(el, '[data-testid="row-qty"]')?.classList.contains('low')).toBe(true);
   });
 
-  // The stepper used to sit there greyed and check-in was reachable only through
-  // the ⋮ menu, which a wide row hides until the row is hovered.
+  // A greyed stepper leaves check-in reachable only through the ⋮ menu, which a
+  // wide row hides until the row is hovered.
   it('gives a checked-out row the check-in button in the stepper place, at any width', async () => {
     for (const mobile of [false, true]) {
       const el = await mount({ checked_out: true }, { mobile });
@@ -434,8 +434,8 @@ describe('hv-list-row: mobile affordances', () => {
     );
   });
 
-  // Being out used to take the line rather than lead it, so the one row you most
-  // want the shelf of — the borrowed one — was the row that stopped naming it.
+  // Being out leads the line rather than taking it, so the one row you most
+  // want the shelf of — the borrowed one — still names it.
   it('leads a checked-out phone row with the checkout and keeps the location behind it', async () => {
     const el = await mount(
       { checked_out: true, due_date: '2099-07-31', effective_area_id: 'area-workshop', location_path: deepPath },
@@ -483,8 +483,8 @@ describe('hv-list-row: mobile affordances', () => {
     }
   });
 
-  // A passed date used to render exactly like an upcoming one — same wording,
-  // same blue — so the row said nothing about being late.
+  // A passed date drawn like an upcoming one — same wording, same blue — tells
+  // the reader nothing about being late.
   it('says a passed due date is overdue, and colours it that way', async () => {
     const el = await mount({ checked_out: true, due_date: '2000-01-02' }, { mobile: true });
     const secondary = q(el, '[data-testid="row-secondary"]');

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -40,9 +40,8 @@ export function isLowStock(item: Item): boolean {
  * What a row's ⋮ offers, which depends on whether the item is out and whether
  * it has a due date.
  *
- * Shared with the full view's table rows, which used to offer nothing at all —
- * so one list, one set of ids, and the hosts' existing `row-action` handlers
- * answer both surfaces.
+ * Shared with the full view's table rows: one list, one set of ids, and the
+ * hosts' existing `row-action` handlers answer both surfaces.
  */
 export function rowMenuEntries(item: Item): OverflowMenuEntry[] {
   if (item.checked_out) {
@@ -249,7 +248,7 @@ export class HVListRow extends LitElement {
 
          The pill's fill is what separates the area from the path after it: as
          plain text in the same colour and weight, a root location named after
-         its own area printed the word twice with a single space between them and
+         its own area prints the word twice with a single space between them and
          nothing to say which was which. */
       :host([mobile]) .secondary > .area {
         display: flex;
@@ -286,7 +285,7 @@ export class HVListRow extends LitElement {
         color: var(--hv-primary-dark);
       }
       /* A date that has passed is the one thing on this line worth interrupting
-         for — "due Jul 2" in the same blue as "due Aug 24" said nothing — and it
+         for — in the blue an upcoming date takes it reads as neither — and it
          is the same red the table's date cells and the sheet's facts use. The
          line names the date it is talking about, so the colour is left saying
          only that it has gone by. */

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -773,8 +773,8 @@ export class HVLocationTree extends LitElement {
       data-testid="tree-area-head"
       data-area=${group?.id ?? NO_AREA_KEY}
       @keydown=${(e: KeyboardEvent) => {
-        // The head is a treeitem and, where areas are pickable, the target its
-        // own name button used to be — so it answers the keys a button would.
+        // The head is a treeitem and, where areas are pickable, the thing that
+        // gets picked — so it answers the keys a button would.
         if (e.key !== 'Enter' && e.key !== ' ') return;
         e.preventDefault();
         if (pickable) this._emit('select-area', { areaId: group.id });

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -603,9 +603,9 @@ describe('hv-organize-dialog: locations', () => {
     expect(store.state.value.locationsFlatCache).toHaveLength(0);
   });
 
-  // A location row used to be the odd one out: its name did nothing and its
-  // count was a muted number at the far edge, while a category row's count was
-  // the way into the items.
+  // Every row in this dialog opens the items behind it the same way, so a
+  // location row is not the odd one out: a name that does nothing beside a
+  // category row whose count is the way in.
   it('opens the items behind a location from its name or its count', async () => {
     const items = [makeItem({ id: '1', location_id: 'shelf-a' })];
     for (const testid of ['tree-row', 'tree-count']) {
@@ -1150,9 +1150,9 @@ describe('hv-organize-dialog: statuses', () => {
     });
   });
 
-  // One question, one idiom, whichever branch it is: the unused status used to
-  // get a modal and the in-use one an inline disclosure, so the consequential
-  // path carried the lighter ceremony.
+  // One question, one idiom, whichever branch it is: a modal for the unused
+  // status beside an inline disclosure for the in-use one puts the lighter
+  // ceremony on the consequential path.
   it('asks in the same disclosure when nothing carries the status', async () => {
     const { el, sr } = await mount({ tab: 'statuses' });
 
@@ -1167,7 +1167,7 @@ describe('hv-organize-dialog: statuses', () => {
     expect(guard?.querySelector('[data-testid="status-reassign"]')).toBe(null);
     // ...and the action says what it does rather than promising a reassign.
     expect(q(sr, '[data-testid="status-guard-confirm"]')?.textContent?.trim()).toBe('Delete');
-    // The modal it used to raise is gone from the component entirely.
+    // No modal branch anywhere in the component: both go through the disclosure.
     expect(q(sr, '[data-testid="organize-status-confirm"]')).toBe(null);
   });
 
@@ -1596,8 +1596,8 @@ describe('hv-organize-dialog: disclosures come into view', () => {
   });
 
   // On a phone the ⋮ sheet replaces the row's separate buttons, so it is the
-  // only way into edit, merge and delete. DOM-measured at 390px: opened from
-  // the bottom row it stood 216px tall with 16px of it on screen.
+  // only way into edit, merge and delete — and opened from a row near the
+  // bottom it stands almost entirely off screen unless it is scrolled to.
   it('brings the location ⋮ sheet into view', async () => {
     const { el, sr } = await mount({ items, locations, mobile: true });
     const tree = q(sr, '[data-testid="organize-tree"]') as HTMLElement;

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -71,10 +71,9 @@ const MERGE_TARGET_TREE_ID = 'merge-target-tree-holder';
 /**
  * The three batch rewrites.
  *
- * A kind rather than a label, because every line the rewrite prints — the
- * running count, the "nothing to do" and both finished forms — is a different
- * sentence per language, and only English can build them by appending "d" to
- * the verb.
+ * A kind rather than a label: every line a rewrite prints — the running count,
+ * the "nothing to do", both finished forms — is a different sentence per
+ * language, and only English builds them by appending "d" to the verb.
  */
 type RewriteKind = 'merge' | 'rename' | 'remove';
 
@@ -91,13 +90,12 @@ interface RewriteState {
 /**
  * "Organize".
  *
- * One dialog, four tabs: locations, categories, tags and statuses.
- *
- * Locations edit in place with a guarded delete — a location that still holds
- * items or children gets an inline explanation, never a browser confirm.
- * Categories and tags have no rename or merge endpoint, so those are batch
- * rewrites over every affected item, with the same progress and
- * partial-failure treatment bulk actions get.
+ * One dialog, four tabs: locations, categories, tags and statuses. Locations
+ * edit in place with a guarded delete — a location that still holds items or
+ * children gets an inline explanation, never a browser confirm. Categories and
+ * tags have no rename or merge endpoint, so those are batch rewrites over every
+ * affected item, with the progress and partial-failure treatment bulk actions
+ * get.
  */
 @customElement('hv-organize-dialog')
 export class HVOrganizeDialog extends LitElement {
@@ -109,12 +107,11 @@ export class HVOrganizeDialog extends LitElement {
       :host {
         display: block;
         /*
-         * The vertical padding of every row in this dialog, declared once here
-         * so the four tabs cannot drift apart: the value rows below read it,
-         * and it inherits through the shadow boundary into the
-         * hv-location-tree the Locations tab hosts, which reads the same
-         * property with its own fallback. Nothing outside this dialog declares
-         * it, so the full-view sidebar's tree keeps its own spacing.
+         * The vertical padding of every row in this dialog, declared once so
+         * the four tabs cannot drift apart: the value rows below read it, and
+         * it inherits through the shadow boundary into the hv-location-tree the
+         * Locations tab hosts, which reads it with its own fallback. Nothing
+         * outside declares it, so the sidebar's tree keeps its own spacing.
          */
         --hv-organize-row-pad: 8px;
       }
@@ -816,12 +813,12 @@ export class HVOrganizeDialog extends LitElement {
    * scrolling `.body`: what identifies the one currently open, the element to
    * bring into view, and — for the forms — the field that takes focus.
    *
-   * A guard is `role="alert"`, so it announces itself where it stands and takes
-   * no focus: it is a refusal to act, and pulling the caret out of the list
-   * would answer a tap the household did not make. The editors are forms, and a
-   * form opened from a row leaves the keyboard on that row's button unless its
-   * first field claims the caret. The touch layout's ⋮ sheets are neither: a
-   * menu of what the row can do, which needs showing but claims no field.
+   * A guard is `role="alert"`: it announces where it stands and takes no focus,
+   * because it refuses an action and pulling the caret out of the list would
+   * answer a tap the household did not make. A form opened from a row leaves
+   * the keyboard on that row's button unless its first field claims the caret.
+   * The touch layout's ⋮ sheets are neither — a menu needs showing but claims
+   * no field.
    */
   private get _disclosures(): { testid: string; open: string | null; field?: string }[] {
     const value = this._editingValue;
@@ -848,16 +845,14 @@ export class HVOrganizeDialog extends LitElement {
   /**
    * Bring a disclosure into view as it opens.
    *
-   * Every one of them renders below its trigger inside a pane that scrolls, so
-   * one opened from a row near the bottom lands off-screen and the tap reads as
-   * having done nothing — worst on the two guards, which are what stands
-   * between a tap and a batch of items changing.
-   *
-   * `block: 'nearest'` scrolls only as far as it must, so a disclosure already
-   * on screen does not move under the user, and it names no `behavior`, so
-   * there is no motion to gate on a reduced-motion preference. Keyed on which
-   * disclosure is open rather than on the render, so typing inside an open
-   * editor never moves the pane.
+   * Every one renders below its trigger inside a pane that scrolls, so one
+   * opened from a row near the bottom lands off screen and the tap reads as
+   * having done nothing — worst on the two guards, which stand between a tap
+   * and a batch of items changing. `block: 'nearest'` scrolls only as far as it
+   * must and names no `behavior`, so nothing already on screen moves under the
+   * user and there is no motion to gate on a reduced-motion preference. Keyed
+   * on which disclosure is open rather than on the render, so typing inside an
+   * open editor never moves the pane.
    */
   private _revealDisclosures() {
     if (!this.open) {
@@ -1904,11 +1899,11 @@ export class HVOrganizeDialog extends LitElement {
   /**
    * Ask before deleting, in one idiom whichever branch it is.
    *
-   * Both branches open the same inline disclosure. The in-use one carries the
+   * Both branches open the same inline disclosure: the in-use one carries the
    * reassign select — the backend refuses a delete that would strand items, and
-   * picking where they go is what turns that refusal into a completed move —
-   * and the unused one carries the question alone. Splitting them across a
-   * disclosure and a modal gave the consequential path the lighter ceremony.
+   * picking where they go turns that refusal into a completed move — and the
+   * unused one carries the question alone. Split across a disclosure and a
+   * modal, the consequential path takes the lighter ceremony.
    */
   private _askDeleteStatus(slug: string) {
     const count = this._statusCount(slug);

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -1553,7 +1553,7 @@ export class HVOrganizeDialog extends LitElement {
     const merging = this._mergingLocation ? this._findNode(tree, this._mergingLocation) : null;
     const sheeted = this._sheetLocation ? this._findNode(tree, this._sheetLocation) : null;
     // Counted at every depth and against the filter, exactly as the other two
-    // tabs count their values — this was the only tab that stated no total.
+    // tabs count their values, so all three tabs state a total in one idiom.
     const count = countLocations(tree, this._filter);
     return html`
       <div class="toolbar">

--- a/cards/haventory-card/src/components/hv-overflow-menu.test.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.test.ts
@@ -26,9 +26,9 @@ describe('hv-overflow-menu', () => {
     expect(el.shadowRoot?.querySelector('[data-testid="overflow-menu"]')).toBe(null);
   });
 
-  // A long hint used to sit beside the label as a non-shrinking sibling: inside
-  // a 250px menu that left "Organize…" a sliver to render in, and an unbreakable
-  // word simply overflowed across the hint.
+  // A long hint beside its label is a non-shrinking sibling: inside a 250px
+  // menu that leaves "Organize…" a sliver to render in, and an unbreakable word
+  // simply overflows across the hint.
   it('stacks a long hint under its label instead of beside it', async () => {
     const el = await mount([
       { id: 'organize', label: 'Organize…', meta: 'Locations · Tags · Categories' },
@@ -138,10 +138,10 @@ describe('hv-overflow-menu: narrow screens', () => {
 });
 
 // A list filtered down to a single row leaves hv-list's scroller shorter than
-// the open menu (#389). Anchoring the popup inside the row put it inside that
-// scroller's clip, where neither opening direction could fit — opening down and
-// flipping up both left a ~6px sliver. The menu is viewport-fixed instead, so
-// no ancestor's overflow can cut it.
+// the open menu. Anchored inside the row, the popup sits inside that scroller's
+// clip, where neither opening direction fits — down and flipped up both leave a
+// sliver. The menu is viewport-fixed instead, so no ancestor's overflow can cut
+// it.
 describe('hv-overflow-menu: escaping ancestor clips', () => {
 
   it('carries live placement coordinates while open', async () => {

--- a/cards/haventory-card/src/components/hv-overflow-menu.ts
+++ b/cards/haventory-card/src/components/hv-overflow-menu.ts
@@ -169,9 +169,8 @@ export class HVOverflowMenu extends LitElement {
         color: var(--hv-text-tertiary);
       }
 
-      /* A trigger-anchored 250px dropdown is a desktop shape. At 375px it
-         covered most of the list it was supposed to be acting on and "Export
-         current view" wrapped onto two lines, while the rest of the card
+      /* A trigger-anchored 250px dropdown is a desktop shape: at phone width it
+         covers most of the list it is acting on, and the rest of the card
          answers exactly this need with a bottom sheet. The menu becomes one
          here — the inset overrides the measured coordinates.
 

--- a/cards/haventory-card/src/haventory-panel.test.ts
+++ b/cards/haventory-card/src/haventory-panel.test.ts
@@ -376,9 +376,9 @@ describe('haventory-panel: the shared dialog surfaces', () => {
     expect(dialog(sr, 'host-diagnostics').open).toBe(true);
   });
 
-  // The panel used to hold its own `matchMedia` subscription and hand the answer
-  // to the dialogs; it now shares the one the surfaces keep, so the page and the
-  // card agree at a single width without either owning the query.
+  // The panel shares the one `matchMedia` subscription the surfaces keep rather
+  // than holding its own, so the page and the card agree at a single width
+  // without either owning the query.
   it('hands every dialog the phone form on a phone viewport', async () => {
     const restore = stubViewport(true);
     try {

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -75,11 +75,11 @@ export class HostSurfaces {
    * The phone predicate for every dialog here, measured against the viewport.
    *
    * Not the card's width: these are `position: fixed`, so they are laid out
-   * against the window whatever the card measures. The card side used to hand
-   * its own measurement in, which put the organize dialog in its full-bleed
-   * phone page whenever the card sat in a normal dashboard column — on a
-   * desktop monitor, from a card, from the expanded view and unchanged by
-   * expanding, because the measured element was still the card underneath.
+   * against the window whatever the card measures. Handed the card's own
+   * measurement, the organize dialog takes its full-bleed phone page on a
+   * desktop monitor whenever the card sits in a normal dashboard column, and
+   * expanding the card does not change it — the measured element is still the
+   * card underneath.
    */
   private narrowQuery: MediaQueryList | null = null;
   private narrow = false;

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -139,9 +139,8 @@ export const en = {
   // ui/keyboard — the save chord, on a keyboard without a Command key.
   'hv.shortcut.ctrlEnter': 'Ctrl+Enter',
 
-  // Three counted sentences whose components are translated in a later batch;
-  // they land here because `ui/plural` no longer derives an English plural for
-  // anyone, and these were its last three callers outside `src/ui`.
+  // Counted sentences that belong to no one component group. `ui/plural`
+  // derives no English plural, so both forms are written out.
   'hv.bulk.result.failed.one': '{count} failed and was left unchanged.',
   'hv.bulk.result.failed.other': '{count} failed and were left unchanged.',
   'hv.fullView.checkedOutWarning.one': '{count} of them is checked out',
@@ -425,7 +424,7 @@ export const en = {
   // haventory-card-editor — the one field Home Assistant's card editor shows.
   'hv.cardEditor.title': 'Title',
 
-  // Shared, added by the second component batch.
+  // Shared — the verbs and terms more than one component reads.
   'hv.action.set': 'Set',
   'hv.action.done': 'Done',
   'hv.action.rename': 'Rename',

--- a/cards/haventory-card/src/store/columns.test.ts
+++ b/cards/haventory-card/src/store/columns.test.ts
@@ -242,10 +242,10 @@ function nameWidthOf(contentWidth: number): number {
 }
 
 /**
- * What the sidebar panel at 1920 leaves the table's grid, measured on a real
- * instance: HA's docked sidebar takes 256px and the full view's locations rail
- * another 264, which puts the table's box at 1400 and its content box — inside
- * the row's own 20px padding either side — here.
+ * What the sidebar panel at 1920 leaves the table's grid: HA's docked sidebar
+ * takes 256px and the full view's locations rail another 264, which puts the
+ * table's box at 1400 and its content box — inside the row's own 20px padding
+ * either side — here.
  */
 const PANEL_GRID_AT_1920 = 1360;
 

--- a/cards/haventory-card/src/store/sort.test.ts
+++ b/cards/haventory-card/src/store/sort.test.ts
@@ -3,7 +3,7 @@ import type { SortField } from './types';
 
 // Every surface that lets you choose a sort field — the filter panel's select
 // and the full-view table's column headers — opens that field on the direction
-// this table names. It used to be asserted only through the POC search bar.
+// this table names.
 describe('getDefaultOrderFor', () => {
   it('opens a name or a count smallest-first, so A and 0 lead', () => {
     expect(getDefaultOrderFor('name')).toBe('asc');

--- a/cards/haventory-card/src/store/store.revamp.test.ts
+++ b/cards/haventory-card/src/store/store.revamp.test.ts
@@ -1398,7 +1398,7 @@ describe('Store: import reload signalling', () => {
 /**
  * The number under the list has to survive a row nobody in this browser asked
  * for. `total` comes off the last `item/list` reply and the event path patches
- * `items`, so with a filter on, the two used to drift apart and the footer read
+ * `items`, so with a filter on the two can drift apart and the footer read
  * "Showing 1 of 0 matching items".
  */
 describe('Store: the filtered total after an event-inserted row', () => {

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -753,8 +753,8 @@ describe('Store', () => {
     expect(sent[sent.length - 1].filter).toBeDefined();
   });
 
-  // The same asymmetry the other way round: a lone location filter used to
-  // leave the tree bare while the facet lists beside it carried a pair.
+  // The same asymmetry the other way round: a lone location filter must not
+  // leave the tree bare while the facet lists beside it carry a pair.
   it('prices the tree when the only filter is the one it drops', async () => {
     const hass = makeMockHass({
       items: [makeItem({ id: '1', location_id: 'garage' })],
@@ -811,7 +811,7 @@ describe('Store', () => {
     }
   });
 
-  // Issue #440: not every facet refetch is debounced — an item event lands
+  // Not every facet refetch is debounced — an item event lands
   // beside a filter change — so two can be in flight at once, and the response
   // that lands last is not the one that was issued last. The newest request is
   // the only one allowed to assign.

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -890,7 +890,7 @@ function applyMockSort(list: Item[], rawSort: unknown): Item[] {
 const FIXTURE_TS = '2026-01-01T00:00:00.000Z';
 
 /** Counts anonymous fixtures, which the clock cannot number uniquely: two
- * `makeItem()` calls in one millisecond used to share an id. Zero-padded so
+ * `makeItem()` calls in one millisecond would share an id. Zero-padded so
  * lexical order — what the id tie-break compares — follows creation order. */
 let anonymousItems = 0;
 

--- a/cards/haventory-card/src/ui/banners.ts
+++ b/cards/haventory-card/src/ui/banners.ts
@@ -12,11 +12,10 @@ import '../components/hv-banner';
  * The two stacks that say something is wrong: what the connection is doing, and
  * what the last operations came back with.
  *
- * Both were the card's alone. On the expanded view and the sidebar panel — the
- * surfaces that fill the screen, so the card's copy is not behind them — a lost
- * connection, paused live updates and a refused operation all showed nothing at
- * all. They render from here now, so the three surfaces cannot disagree about
- * what a failure looks like or what can be done about it.
+ * All three surfaces render them from here, so they cannot disagree about what
+ * a failure looks like or what can be done about it. The expanded view and the
+ * sidebar panel need their own: each fills the screen, so the card's copy is
+ * not behind them to be read.
  *
  * A rejected *save* is the one failure this stack is not the primary voice for:
  * the sentence inside the open form is, because that is where the user's text

--- a/cards/haventory-card/src/ui/chip.ts
+++ b/cards/haventory-card/src/ui/chip.ts
@@ -285,8 +285,8 @@ export const chip = css`
    * vertical-align: middle puts an inline box on the parent's baseline plus
    * half its x-height, which is the middle of lowercase text and not the middle
    * of the line. Beside a path with capitals and digits in it that leaves the
-   * chip sitting low — measured at 1.4px against 13.5px text, and it does not
-   * shrink as the chip does, because the offset is a property of the text.
+   * chip sitting low, and the offset does not shrink as the chip does, because
+   * it is a property of the text.
    *
    * The elision has to move onto the text with it: text-overflow has no
    * effect on a flex container, so a path left on the row itself would hard-cut

--- a/cards/haventory-card/src/ui/dialog-focus.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.ts
@@ -1,15 +1,11 @@
 /**
  * Initial focus and focus return for the card's modal surfaces.
  *
- * Every dialog here closes on Escape via a `keydown` listener on its own panel.
- * That only fires when focus is already inside the panel, and opening a dialog
- * does not move focus on its own — so a dialog opened from the overflow menu
- * left `document.activeElement` on `<body>` and simply ignored Escape.
- *
- * Focusing the panel fixes three things at once: Escape reaches the handler,
- * screen readers announce the dialog, and because the panel carries
- * `tabindex="-1"` a click on non-focusable content inside it keeps focus in the
- * dialog rather than dropping back to the body.
+ * Every dialog closes on Escape through a `keydown` listener on its own panel,
+ * and opening one moves focus nowhere by itself, so the panel takes focus or
+ * Escape never reaches it. `tabindex="-1"` on the panel also has screen readers
+ * announce the dialog and keeps a click on non-focusable content inside it from
+ * dropping focus back to the body.
  */
 
 /** The genuinely focused element, following `activeElement` through shadow roots. */
@@ -24,17 +20,13 @@ export function deepActiveElement(): HTMLElement | null {
 const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 /**
- * Whether the browser is drawing this element, and would therefore let it take
- * focus.
+ * Whether the browser is drawing this element, and would let it take focus.
  *
- * `visibility: hidden` is how this card holds a control in the layout without
- * offering it — the table's row actions are hidden until their row is hovered
- * or focused. `.focus()` on one of those is a silent no-op, so a trap that
- * ended on it would leave focus on its sentinel and never wrap.
- *
- * `checkVisibility` is the browser's own answer and needs a layout to give it.
- * jsdom performs none and does not implement the method; treating everything
- * as drawn there is exactly what a plain `querySelectorAll` would have said.
+ * `visibility: hidden` holds a control in the layout without offering it — the
+ * table's row actions until their row is hovered — and `.focus()` on one is a
+ * silent no-op, so a trap ending there never wraps. jsdom lays nothing out and
+ * implements no `checkVisibility`; treating everything there as drawn is what a
+ * plain `querySelectorAll` says anyway.
  */
 function isRendered(el: HTMLElement): boolean {
   if (typeof el.checkVisibility !== 'function') return true;
@@ -45,18 +37,14 @@ function isRendered(el: HTMLElement): boolean {
  * Every focusable control under `root`, in tab order, descending into the shadow
  * root of any custom element on the way.
  *
- * `querySelectorAll` stops at the first shadow boundary, so on a surface
- * assembled from `hv-*` components it finds only the controls that surface
- * renders itself. A focus trap built on that list picks a first and a last that
- * sit somewhere in the middle of what can actually be reached, and Tab walks
- * straight out of the trap through everything the query could not see.
- *
- * The walk follows the flattened tree, which is the one the tab order is taken
- * from: a host element renders its shadow root in its place, and its light
- * children appear only where a `<slot>` pulls them in. Walking the light
- * children directly instead would collect content that is written but not
- * rendered — the card passes the expanded view's whole empty state to the table
- * as light DOM, and its buttons exist next to every row it is not showing.
+ * `querySelectorAll` stops at the first shadow boundary, so a trap built on it
+ * takes a first and a last from the middle of what can be reached, and Tab
+ * walks straight out through everything the query could not see. The walk
+ * follows the flattened tree, which is where tab order comes from: a host
+ * renders its shadow root in its place and its light children appear only where
+ * a `<slot>` pulls them in. Walking light children directly collects what is
+ * written but not rendered — the card hands the table the expanded view's whole
+ * empty state, buttons and all, beside every row it is not showing.
  */
 export function deepFocusables(root: ParentNode | null | undefined): HTMLElement[] {
   const found: HTMLElement[] = [];
@@ -98,13 +86,11 @@ export class DialogFocus {
    * panel. Acts only on the open/close transitions, so re-renders never pull
    * focus away from whatever the user is typing in.
    *
-   * `onOpenerGone` is the caller's answer to a close whose opener no longer
-   * exists — a row deleted by the action, a photo removed from under the
-   * lightbox. Focus was on the panel that has just been taken out of the
-   * document, so the browser drops it on `<body>`: outside the surface still on
-   * screen, out of reach of the Escape that would close it, and back at the top
-   * of the page for the next Tab. Only the caller knows where focus belongs
-   * instead, so it acts rather than naming an element.
+   * `onOpenerGone` answers a close whose opener is gone — a row deleted by the
+   * action, a photo removed from under the lightbox. Focus sits on the panel
+   * leaving the document, so the browser drops it on `<body>`: outside the
+   * surface still on screen and out of reach of its Escape. Only the caller
+   * knows where focus belongs instead, so it acts rather than naming an element.
    */
   sync(
     open: boolean,

--- a/cards/haventory-card/src/ui/empty-state.test.ts
+++ b/cards/haventory-card/src/ui/empty-state.test.ts
@@ -17,8 +17,8 @@ function state(patch: { connectionLost?: boolean; loading?: boolean; filters?: P
 
 describe('emptyStateCopy', () => {
   it('always offers a way out', () => {
-    // The expanded view's table used to answer "No items match these filters."
-    // with nothing to press, on the one surface where over-filtering is easiest.
+    // "No items match these filters." with nothing to press is not an answer,
+    // least of all on the surface where over-filtering is easiest.
     for (const kind of ANSWERS) {
       expect(emptyStateCopy(kind).offers.length, kind).toBeGreaterThan(0);
     }

--- a/cards/haventory-card/src/ui/empty-state.ts
+++ b/cards/haventory-card/src/ui/empty-state.ts
@@ -7,15 +7,12 @@ import type { StoreFilters } from '../store/types';
 /**
  * The ways a list of items can have no rows, and what to say about each.
  *
- * The card's list said it properly — a headline, a line of explanation and
- * something to press ("No items match these filters" + Clear all). The expanded
- * view's table, reached from the same card and holding the same items, answered
- * with one bare sentence and no way out: "No items match these filters." with a
- * full stop and nothing to click. That is the surface with a sidebar, an app-bar
- * search and a filter panel — the one where you are most likely to filter
- * yourself down to nothing and least able to see which control did it.
- *
- * Both now render from here, so the wording cannot drift again.
+ * Every empty list gets a headline, a line of explanation and something to
+ * press, and the card's list and the expanded view's table render both from
+ * here so the wording cannot drift apart. The expanded view needs it most: with
+ * a sidebar, an app-bar search and a filter panel, that is where you are most
+ * likely to filter yourself down to nothing and least able to see which control
+ * did it.
  *
  * The card's punctuation convention, of which this is the busiest example:
  * headlines, hints and short empty lines are captions and take no terminal full

--- a/cards/haventory-card/src/ui/item-form.test.ts
+++ b/cards/haventory-card/src/ui/item-form.test.ts
@@ -177,8 +177,8 @@ describe('validateForm', () => {
     expect(validateForm({ ...base(), name: 'A', tags })).toEqual([]);
   });
 
-  // Issue #437: the caps refuse growth past the stored item, never the stored
-  // item itself — so a legacy over-cap item can be saved, including by the
+  // The caps refuse growth past the stored item, never the stored item itself —
+  // so an over-cap item already in the store can be saved, including by the
   // edit that trims some of the excess, and only what an edit adds is capped.
   describe('with a stored item as baseline', () => {
     const legacyDescription = 'd'.repeat(4500);

--- a/cards/haventory-card/src/ui/media.ts
+++ b/cards/haventory-card/src/ui/media.ts
@@ -1,13 +1,11 @@
 /**
  * Signed URLs for item attachments, so an `<img>` can load one.
  *
- * The media view requires authentication and an `<img src>` carries no header,
- * so every URL is signed by core's `auth/sign_path` before it is rendered.
- * Signatures expire; a component that keeps a view open for longer than the
- * lifetime asks again rather than showing a broken image.
- *
- * No component talks to `auth/sign_path` itself: they hold a `MediaUrls` and
- * read a URL out of it synchronously, which is what a Lit template needs.
+ * The media view needs authentication and an `<img src>` carries no header, so
+ * every URL is signed by core's `auth/sign_path` first; signatures expire, and
+ * a view held open past the lifetime asks again rather than breaking the image.
+ * No component signs for itself — each holds a `MediaUrls` and reads a URL out
+ * of it synchronously, which is what a Lit template needs.
  */
 
 import { t } from '../i18n';
@@ -24,32 +22,27 @@ export const MEDIA_URL_TEMPLATE = '/api/haventory/media/{item_id}/{attachment_id
 
 /**
  * Query parameter that versions a media URL by the name the file is served
- * under.
- *
- * The bytes behind an attachment id never change, but the name in the
- * response's `Content-Disposition` does — a retitle rewrites it for that same
- * id — and the backend will only let a client hold the response indefinitely
- * when the URL says which name it was fetched for. Without it a retitled file
- * would keep being saved under its old name for as long as the browser's cache
- * entry lived, which a signature outlasts by half an hour.
- *
- * Pinned to the backend's `MEDIA_NAME_TOKEN_PARAM` by
+ * under. Pinned to the backend's `MEDIA_NAME_TOKEN_PARAM` by
  * `tests/test_frontend_registration.py`.
+ *
+ * The bytes behind an attachment id never change, but a retitle rewrites the
+ * name in `Content-Disposition`, and the backend only allows an indefinite
+ * cache when the URL says which name it was fetched for. A cache entry outlasts
+ * the signature by half an hour, and would keep saving the old name.
  */
 export const MEDIA_NAME_TOKEN_PARAM = 'v';
 
 /**
- * Which form of a picture to ask the backend for.
+ * Which form of a picture to ask the backend for. Pinned to the backend's
+ * `MEDIA_SIZE_PARAM` / `MEDIA_SIZE_THUMB` by
+ * `tests/test_frontend_registration.py`.
  *
  * Only `thumb` exists, and only for a row tile: a 34–72px tile served the
- * original was up to 8 MB of download for a few hundred pixels, which is
- * invisible on Wi-Fi and the difference between usable and not on a phone in a
- * shop. The lightbox and the detail sheet's large picture ask for neither and
- * get the stored file. The backend falls back to the original whenever it
- * cannot make a tile, so this is a request, not a requirement.
- *
- * Pinned to the backend's `MEDIA_SIZE_PARAM` / `MEDIA_SIZE_THUMB` by
- * `tests/test_frontend_registration.py`.
+ * original costs up to 8 MB for a few hundred pixels, invisible on Wi-Fi and
+ * the difference between usable and not on a phone in a shop. The lightbox and
+ * the large picture in the detail sheet ask for neither and get the stored
+ * file. The backend falls back to the original when it cannot make a tile, so
+ * this is a request, not a requirement.
  */
 export const MEDIA_SIZE_PARAM = 'size';
 export type MediaVariant = 'thumb';
@@ -60,8 +53,8 @@ export const MEDIA_VARIANT_THUMB: MediaVariant = 'thumb';
  *
  * A browser caches by full URL, signature included, so a re-signed URL is a
  * fresh download of bytes it already holds. Half an hour outlasts an ordinary
- * session with a list open — no photo is fetched twice — while still being far
- * too short for a URL copied out of the DOM to be a lasting handle.
+ * session with a list open, and is far too short for a URL copied out of the
+ * DOM to be a lasting handle.
  */
 export const SIGNED_URL_TTL_SECONDS = 1800;
 
@@ -113,10 +106,9 @@ interface MediaHost {
 /**
  * Build the unsigned media path for one attachment.
  *
- * A name token makes the URL change when the served filename does, which is
- * what lets the response be cached — see `MEDIA_NAME_TOKEN_PARAM`. Home
- * Assistant signs query parameters together with the path, so the token has to
- * be here before signing rather than appended to a signed URL.
+ * Home Assistant signs query parameters together with the path, so the name
+ * token belongs here rather than appended to a signed URL. What it is for:
+ * `MEDIA_NAME_TOKEN_PARAM`.
  */
 export function mediaPath(
   itemId: string,
@@ -146,11 +138,10 @@ function urlKey(itemId: string, attachmentId: string, variant?: MediaVariant): s
 /**
  * A short stable token for the name one attachment is served under.
  *
- * A hash rather than the name itself: the name is user-supplied text of any
- * length in any script, and this only has to *differ* when the name does. The
- * input is `attachmentTitle`, which is the same precedence the backend builds
- * `Content-Disposition` from, so the token changes exactly when the saved
- * filename would.
+ * A hash, not the name: the name is user-supplied text of any length in any
+ * script and this only has to *differ* when it does. It hashes
+ * `attachmentTitle`, the precedence the backend builds `Content-Disposition`
+ * from, so the token changes exactly when the saved filename would.
  */
 export function attachmentNameToken(attachment: Attachment): string {
   const name = attachmentTitle(attachment);
@@ -247,11 +238,10 @@ interface Entry {
 /**
  * A component's view of the signed URLs it needs.
  *
- * `get` is synchronous because that is what a template can use: it returns the
- * URL when there is a live one, and otherwise starts the signing request and
- * returns null, asking the host to re-render once the answer lands. A signing
- * that failed is remembered on the entry, so the next render is answered from
- * it rather than asking again for a URL that is not coming.
+ * `get` is synchronous because that is what a template can use: it returns a
+ * live URL, or starts the signing request and returns null, asking the host to
+ * re-render once the answer lands. A failed signing is remembered on the entry,
+ * so the next render is answered from it rather than asking again.
  */
 export class MediaUrls {
   private readonly host: MediaHost;
@@ -269,10 +259,9 @@ export class MediaUrls {
   /**
    * Point this at a signer.
    *
-   * Called from the host's `willUpdate`, so a component that has not been given
-   * one yet simply renders no images. A changed signer drops the cache: the old
-   * signatures were issued for a connection that is no longer the one being
-   * rendered.
+   * Called from the host's `willUpdate`, so a component not given one renders
+   * no images. A changed signer drops the cache: the old signatures were issued
+   * for a connection that is no longer the one being rendered.
    */
   configure(sign: SignPath | null): void {
     if (this.sign === sign) return;
@@ -285,14 +274,12 @@ export class MediaUrls {
    *
    * Passing the attachment's `attachmentNameToken` keeps the URL in step with a
    * retitle: a token the held URL was not signed for re-signs rather than
-   * serving a URL whose cached response still carries the old filename. The
-   * entry is keyed on the two ids and the variant, so what `failed` and
-   * `presence` know about these bytes survives the re-sign.
-   *
-   * A `variant` is a different URL and therefore a different signature, so it
-   * gets its own entry. `presence` deliberately does not take one: whether the
-   * file is there is a question about the attachment, not about the size it is
-   * being asked for, and the backend answers 404 for both together.
+   * serving a cached response that still carries the old filename. The entry is
+   * keyed on the two ids and the variant, so what `failed` and `presence` know
+   * about these bytes survives the re-sign, and a `variant` — a different URL
+   * and so a different signature — gets its own entry. `presence` takes none:
+   * whether the file is there is a question about the attachment, not the size
+   * asked for, and the backend answers 404 for both together.
    */
   get(
     itemId: string,
@@ -321,15 +308,12 @@ export class MediaUrls {
    * Whether one attachment's file is really there, starting the check if not
    * yet asked.
    *
-   * Synchronous like `get`, and for the same reason: a template needs an answer
-   * now. A caller that draws a link uses this to decide whether the link can
-   * lead anywhere — metadata outlives its bytes, because a JSON export carries
-   * the references and not the files, so a fresh install can hold a document
-   * whose PDF was never uploaded to it.
-   *
-   * The probe asks for one byte. The media route rejects a missing file with
-   * 404 before it opens anything, so a range that small settles the question
-   * without pulling the document down to answer it.
+   * Synchronous like `get`, and for the same reason. A caller that draws a link
+   * uses it to decide whether the link can lead anywhere: metadata outlives its
+   * bytes, because a JSON export carries the references and not the files. The
+   * probe asks for one byte — the media route rejects a missing file with 404
+   * before it opens anything, so a range that small settles the question
+   * without pulling the document down.
    */
   presence(itemId: string, attachmentId: string): Presence {
     const key = `${itemId}/${attachmentId}`;
@@ -441,13 +425,11 @@ export type PictureState = 'ok' | 'errored' | 'missing';
  * The missing-file state for surfaces that let the browser try the URL first.
  *
  * A row cannot probe up front the way a document list does: a table of two
- * hundred items would ask the backend two hundred extra questions to draw tiles
- * that are almost always fine. It waits for the `<img>` to fail instead and
- * only then asks whether the file is missing or the request merely failed — one
- * probe per broken tile, none at all for a healthy list.
- *
- * Only a 404 turns into `missing`: an inconclusive probe leaves the tile in
- * `errored`, where the caller hides the browser's glyph without claiming the
+ * hundred items would ask two hundred extra questions to draw tiles that are
+ * almost always fine. It waits for the `<img>` to fail and only then asks
+ * whether the file is missing — one probe per broken tile, none for a healthy
+ * list. Only a 404 turns into `missing`; an inconclusive probe leaves the tile
+ * in `errored`, where the caller hides the browser's glyph without claiming the
  * picture is gone.
  */
 export class PictureFallback {
@@ -478,11 +460,10 @@ export class PictureFallback {
   /**
    * One tile's image loaded after all.
    *
-   * The failure a probe could not explain sticks to the attachment, and the
-   * next URL for those same bytes — a re-signed one, half an hour later — is
-   * the first chance to find out it was the request and not the file. Without
-   * this the tile would stay in the state a single dropped connection left it
-   * in, holding a picture the browser is now showing.
+   * A failure the probe could not explain sticks to the attachment, and the
+   * next URL for those same bytes — re-signed, half an hour later — is the
+   * first chance to learn it was the request and not the file. Without this the
+   * tile keeps the state one dropped connection left it in.
    */
   noteLoad(itemId: string, attachmentId: string): void {
     if (!this.errored.delete(`${itemId}/${attachmentId}`)) return;

--- a/cards/haventory-card/src/ui/passed-date-tone.test.ts
+++ b/cards/haventory-card/src/ui/passed-date-tone.test.ts
@@ -7,8 +7,8 @@ import { componentCss } from '../test.utils';
  * One tone for a date that has passed, wherever the card prints a bare one.
  *
  * The three surfaces each draw the same item — a table cell, a phone row's one
- * line, a fact in the detail sheet — and each used to pick its own colour, so
- * the same passed date read as red in one column and amber in the next. Beside
+ * line, a fact in the detail sheet — and one tone across all three keeps the
+ * same passed date from reading red in one column and amber in the next. Beside
  * a word ("Overdue", "Inspection due") a second hue reinforces something the
  * text has already said; on a bare date it *is* the message, and a two-hue
  * vocabulary there claims a ranking of urgency the card never explains.

--- a/cards/haventory-card/src/ui/status.test.ts
+++ b/cards/haventory-card/src/ui/status.test.ts
@@ -165,7 +165,7 @@ describe('ui/status: pricing a slug', () => {
     };
     expect(statusCount(counts, 'ok')).toBe(856);
     expect(statusCount(counts, 'lent_out')).toBe(100);
-    // The one the old derivation reported as 998.
+    // A zero in the map is a zero, not the total minus the slugs beside it.
     expect(statusCount(counts, 'in_transit')).toBe(0);
   });
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -210,22 +210,22 @@ Two questions, two answers, and they are not interchangeable:
   overlay is laid out against the window, so the card's width says nothing about the room it
   has.
 
-Each split bit once. `hv-item-editor` and `hv-filter-panel` are property-driven but are also
-children of `hv-full-view`, which never set the property — so at 375px the expanded view drew
-the editor's three-column desktop grid in 156px + 78px + 78px; `hv-full-view` now reads the
-viewport query and hands the property down. Note what came with it: `hv-filter-panel` in
-`mobile` mode *stages* its edits and drops its own footer, expecting the host to provide one,
-so the expanded view also grew the commit row the card's filter sheet has: a head row above
-the panel — the heading, how many filters are staged, and Clear all — and a footer of Cancel
-and "Show N items". Three controls on one row is one too many for a 375px screen in German,
-which is why the head row exists on both surfaces rather than only on the card's. For the
-same reason the phone toolbar drops its column-picker button and leaves the ⋮ menu's
-Columns entry as the route there.
+The two signals meet in the children of a fixed overlay. `hv-item-editor` and
+`hv-filter-panel` are property-driven but also children of `hv-full-view`, so that surface
+reads the viewport query and hands the property down — left unset, the expanded view draws
+the editor's three-column desktop grid on a phone. What comes with the property:
+`hv-filter-panel` in `mobile` mode *stages* its edits and drops its own footer, expecting the
+host to provide one, so the expanded view carries the commit row the card's filter sheet has —
+a head row above the panel (the heading, how many filters are staged, and Clear all) and a
+footer of Cancel and "Show N items". Three controls on one row is one too many for a 375px
+screen in German, which is why the head row exists on both surfaces rather than only on the
+card's. For the same reason the phone toolbar drops its column-picker button and leaves the ⋮
+menu's Columns entry as the route there.
 
-In the other direction, `HostSurfaces` was fed the card's measurement, so the
-organize dialog took its full-bleed phone page on a desktop monitor whenever the card sat in
-a normal column — and expanding the card changed nothing, because the measured element was
-still the card underneath.
+In the other direction, `HostSurfaces` reads the viewport itself rather than taking the
+card's measurement. Fed the card's width, the organize dialog takes its full-bleed phone page
+on a desktop monitor whenever the card sits in a normal column, and expanding the card does
+not change it — the measured element is still the card underneath.
 
 On a phone viewport the four smaller dialogs — column picker, confirm, import, diagnostics —
 rise from the bottom edge like every other phone surface, through the shared


### PR DESCRIPTION
## Summary

The card's comments kept the trace as well as the rule: pixel readings from one
screen, before-and-after narratives of what a surface did before it rendered from
a shared module, and three issue numbers standing in for a constraint. Every one
of those blocks now keeps the rule it ends on and loses the trace, in production
files, in `docs/frontend_architecture.md` and in the tests. Then the length pass:
the long doc blocks in the dialogs say what they said in fewer lines.

Zero behaviour change and zero test-logic change — no assertion, fixture or test
name moved, and the gate passing unchanged is the assertion. No CSS rules and no
dictionary values were touched; the two comments edited inside `src/i18n/en.ts`
name what their key group is instead of when it was added.

Refs #231 (item 1, FE-SHELLS-C5, FE-DLG-9)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## What changed

**1. The trace sweep.** Measurement figures out, the constraint they were
evidence for kept: `hv-data-table` (`clientWidth 634 against scrollWidth 854`),
`hv-diagnostics-panel` (`scrollWidth 494 against clientWidth 390`), `ui/chip.ts`
(`1.4px against 13.5px text`), `hv-full-view`'s `2px of padding measured 17px
tall`, `hv-overflow-menu`'s 375px dropdown story. History out, present tense in:
`hv-organize-dialog`, `hv-list-row`, `hv-location-tree`, `hv-item-editor`,
`hv-full-view`, `host-surfaces`, `hv-detail-sheet`, `ui/banners.ts`,
`ui/empty-state.ts`. `hv-bulk-bar`'s "as #190's notes settle" now states the rule
it stood for: the backend's message text is not translated.

**2. Not grep-caught, named in the package.** `src/i18n/en.ts`'s "Shared, added
by the second component batch" names its group instead, and the counted-sentence
group beside it does the same. `docs/frontend_architecture.md`'s "Each split bit
once" passage states the two-signals rule without the war story.

**3. The length pass (FE-DLG-9).** Doc blocks of eight lines or more in
`hv-item-editor`, `hv-organize-dialog`, `hv-detail-sheet`, `hv-filter-panel`,
`hv-import-sheet`, `ui/media.ts` and `ui/dialog-focus.ts`: 70 blocks / 731 lines
before, 57 / 561 after. Left long on purpose, because every line is a rule:
`hv-detail-sheet`'s 26-line two-host contract (the in/out property and event
list neither host's bindings state), `hv-item-editor`'s checkout block (the due
date belongs to the checkout, the inspection date does not, and the state is a
button rather than a switch), `hv-organize-dialog`'s merge decomposition (three
moves, and the delete is skipped when one fails).

**4. The tests.** Same greps, same rule, no assertion changes: the comments over
the cases in `hv-card-shell`, `hv-item-editor`, `hv-filter-panel`, `hv-list-row`,
`hv-organize-dialog`, `hv-data-table`, `hv-full-view`, `hv-detail-sheet`,
`hv-overflow-menu`, `hv-import-sheet`, `hv-bulk-bar`, `haventory-panel`,
`ui/empty-state`, `ui/passed-date-tone`, `ui/item-form`, `ui/status`,
`store/store`, `store/store.revamp`, `store/sort`, `store/columns` and
`test.utils.ts`.

## Acceptance: the four greps over `src/`

Run from `cards/haventory-card/src`:

```bash
grep -rnE "measured|scrollWidth [0-9]|clientWidth [0-9]|observed|empirically" --include=*.ts .
grep -rnE "used to|previously|originally|formerly|earlier version|we (had|used|were)|which was |this was " --include=*.ts .
grep -rnE "WP[0-9]|PR #|work package|#[0-9]{2,4}\b" --include=*.ts .
grep -rnE "showed nothing|said nothing|sat there|doing nothing|never (set|forwarded)|now (reads|render|take)|bit once" --include=*.ts .
```

Every remaining hit, with why it stays:

**G1 (32 hits)** — all present-tense mechanism or API doc:
`hv-overflow-menu.ts:175` inset vs coordinates · `hv-card-shell.ts:84` which
signal · `hv-card-shell.test.ts:1823,1826` which element is measured ·
`hv-item-editor.ts:1574,2264` fixed-vs-viewport, cap after re-encode ·
`hv-full-view.ts:125,171,470,1026,1117,2256` unmeasured default, the shell's own
`:host([mobile])`, media query vs card flag, why the shell is measured, the
width seam, the narrow branch · `hv-full-view.test.ts:255` same seam ·
`ui/responsive.ts:98` API doc · `ui/responsive.test.ts:18` case name ·
`ui/tone-contrast.test.ts:10,104,211` compositing and ΔE method ·
`ui/status.ts:113` + `ui/status.test.ts:174` "looks measured" is the constraint ·
`host-surfaces.ts:75,81` viewport predicate · `register.ts:32` first change
observed · `store/store.ts:941,1147,1291`, `store/types.ts:119` "measured
against" = semantics · `test.utils.ts:1049–1051,1197` jsdom lays nothing out ·
`utils/debounce.test.ts:42` the window's start.

**G2 (4 hits)** — `hv-bottom-sheet.test.ts:64` case name ("previously opened
surfaces" is the stacking rule) · `hv-list-row.ts:252` "which was which" is the
constraint · `store/store.ts:115` and `store/types.ts:709` match inside
"ref-**used to**-pic" / "ref-**used to**-o", substring false positives.

**G3 (6 hits)** — `hv-list-row.test.ts:456,457` fixture text `M4 #23` ·
`hv-lightbox.ts:41`, `ui/tokens.ts:28`, `ui/theme.test.ts:58,66` hex colours.

**G4 (4 hits)** — `hv-bottom-sheet.ts:132` never sets the property back ·
`hv-full-view.ts:1985` a captured reference would leave buttons dead ·
`ui/media.test.ts:300` the component never settles · `haventory-card.test.ts:99`
a dashboard that never sets the key. All present-tense mechanism.

## How was this tested?

Both gates, green before each of the three commits.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1304 passed,
  27 skipped · `ruff check .` → All checks passed · `ruff format --check .` → 189
  files already formatted · `mypy` → no issues in 25 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean · `npm run
  typecheck` clean · `npx vitest run` → 67 files, 1906 tests passed · `npm run
  build` → 721.11 kB

phacc not required: nothing under `custom_components/` or `tests/integration/`
changed (the built bundle is git-ignored).

## Counting

| | lines |
|---|---|
| production lines removed | 435 |
| test lines removed | 109 |
| lines added | 451 |

`git diff --stat origin/main`: 41 files changed, 451 insertions(+), 544
deletions(-). Tests plus `test.utils.ts` (21 files): 111 added, 109 removed — a
comment sweep rewrites rather than deletes there. Production is the rest
(non-`*.test.ts` src plus `docs/`): 340 added, 435 removed. The two halves
reconcile with git's totals: 435 + 109 = 544 removed, 340 + 111 = 451 added.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — none: this PR changes no behaviour, and its test edits
  are comments only.
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md`'s
  two-signals passage, restated as the rule.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and
  `docs/data_shapes.md` in sync — none in this PR.
- [x] Essential invariants preserved — untouched.

## Screenshots (card / UI changes)

None: no rendered output changes.

## Follow-ups

- `hv-full-view.test.ts` has a case named `keeps the expand toggle on a narrow
  card, where only "select items" led there` — the name itself narrates history.
  Test names were left alone in this PR on purpose. Not filed: renaming a case
  clears no real-world bar.
- The four greps are a proxy, not a check. Prose archaeology with no trigger word
  is still findable only by reading, which is what a fourth grep was added for in
  the first place. Not filed.

## Handover

1. **Merged / left open** — this PR, for the M3 master to merge once CI is green.
2. **Test this by hand** — nothing. No rendered output, no wording, no behaviour
   changes here; `[German]` and `[phone]` have nothing to look at.
3. **Validate locally** — nothing: pinned by the frontend gate (67 files, 1906
   tests) and the build, both green on a diff that is comments only. The four
   greps above are the acceptance check, and their remaining hits are listed.
4. **Decisions taken against drifted notes** — the C5 table's line numbers are two
   trees stale, so every site was found by phrase; `hv-overflow-menu`'s 375px
   trace was still present and was reworded rather than skipped, and the
   rate-limit narrative in `ui/banners.ts` was already gone with #632. The C5
   tables scoped the greps to non-`*.test.ts`; §6.M3's "test files get the same
   greps" governs, so the sweep covers them and the acceptance list above is over
   all of `src/`.
5. **Follow-ups** — the two above, neither filed.
6. **State left behind** — branch `claude/v0-8-0-m3-comment-sweep`, three commits,
   nothing else. Counting for this PR: 435 production lines removed, 109 test
   lines removed, 451 added.
