### PR TITLE
refactor(store): one optimistic write, one read path, one subscription opener

### DIFF
--- a/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.test.ts
@@ -1,6 +1,6 @@
 import './hv-diagnostics-panel';
 import type { HVDiagnosticsPanel } from './hv-diagnostics-panel';
-import type { DegradedState, HealthResult, StatsCounts } from '../store/types';
+import type { DegradedState, StatsCounts } from '../store/types';
 import { mountComponent, q, settle } from '../test.utils';
 // The clipboard itself is `ui/clipboard`'s own test; what this panel owes is
 // asking the helper and believing its answer, which needs both answers.
@@ -18,15 +18,6 @@ const counts: StatsCounts = {
   no_location_count: 3,
 };
 
-function health(patch: Partial<HealthResult> = {}): HealthResult {
-  return {
-    healthy: true,
-    issues: [],
-    counts,
-    ...patch,
-  };
-}
-
 const NO_DEGRADATION: DegradedState = {
   connectionLost: false,
   reloading: false,
@@ -38,7 +29,6 @@ const NO_DEGRADATION: DegradedState = {
 async function mount(props: Partial<HVDiagnosticsPanel> = {}) {
   const { el } = await mountComponent<HVDiagnosticsPanel>('hv-diagnostics-panel', {
     open: true,
-    health: health(),
     counts,
     version: { integration_version: '0.0.1', schema_version: 4 },
     degraded: { ...NO_DEGRADATION },

--- a/cards/haventory-card/src/components/hv-diagnostics-panel.ts
+++ b/cards/haventory-card/src/components/hv-diagnostics-panel.ts
@@ -10,7 +10,7 @@ import { relativeTime } from '../ui/relative-time';
 import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
 import { copyText } from '../ui/clipboard';
-import type { DegradedState, HealthResult, StatsCounts, VersionInfo } from '../store/types';
+import type { DegradedState, StatsCounts, VersionInfo } from '../store/types';
 
 /**
  * Diagnostics.
@@ -189,7 +189,6 @@ export class HVDiagnosticsPanel extends LitElement {
   @property({ type: Boolean, reflect: true }) open = false;
   /** Phone viewport: rise from the bottom edge instead of centring. */
   @property({ type: Boolean, reflect: true }) mobile = false;
-  @property({ attribute: false }) health: HealthResult | null = null;
   @property({ attribute: false }) counts: StatsCounts | null = null;
   @property({ attribute: false }) version: VersionInfo | null = null;
   @property({ attribute: false }) degraded: DegradedState | null = null;

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -357,7 +357,6 @@ export class HostSurfaces {
         data-testid="host-diagnostics"
         ?open=${this.diagnosticsOpen}
         ?mobile=${mobile}
-        .health=${st?.healthCache ?? null}
         .counts=${st?.statsCounts ?? null}
         .version=${st?.versionInfo ?? null}
         .degraded=${st?.degraded ?? null}

--- a/cards/haventory-card/src/store/store.degraded.test.ts
+++ b/cards/haventory-card/src/store/store.degraded.test.ts
@@ -259,7 +259,7 @@ describe('subscribeRetryDelayMs', () => {
     await store.adjustQuantity('1', 1);
     await store.adjustQuantity('1', 1);
     await store.refreshStats().catch(() => undefined);
-    await store.refreshHealth().catch(() => undefined);
+    await store.refreshVersion().catch(() => undefined);
 
     expect(store.state.value.errorQueue.map((e) => e.code)).toEqual(['connection_lost']);
     expect(store.state.value.degraded.connectionLost).toBe(true);
@@ -454,7 +454,7 @@ describe('Store: a card built while the backend cannot answer', () => {
       // Exactly the loads `init` starts in parallel, so the refusal window
       // closes with it and the recovery that follows is answered normally. The
       // empty-list assertion below is what catches this count going stale.
-      hass.__failNext(8, REFUSED);
+      hass.__failNext(7, REFUSED);
       // The subscribe is refused the same way the commands were: a restarting
       // instance has no `haventory/subscribe` registered yet either.
       hass.__failSubscribeNext(4, REFUSED);

--- a/cards/haventory-card/src/store/store.test.ts
+++ b/cards/haventory-card/src/store/store.test.ts
@@ -296,18 +296,6 @@ describe('Store', () => {
     expect(typeof store.state.value.statsCounts?.items_total).toBe('number');
   });
 
-  it('populates healthCache on init and refreshes on demand', async () => {
-    const hass = makeMockHass({ items: [makeItem({ id: '1', name: 'A' })] });
-    const store = new Store(hass, fast);
-    await store.init();
-
-    expect(store.state.value.healthCache?.counts.items_total).toBe(1);
-
-    await store.createItem({ name: 'B' });
-    await store.refreshHealth();
-    expect(store.state.value.healthCache?.counts.items_total).toBe(2);
-  });
-
   it('deleteLocation removes an empty location and refreshes caches', async () => {
     const hass = makeMockHass({ items: [] });
     const store = new Store(hass, fast);

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -323,6 +323,60 @@ export interface StoreOptions {
   retryBaseMs?: number;
 }
 
+/**
+ * A deferred call that can only ever have one fire outstanding.
+ *
+ * Every waiting the store does is this shape: a burst of events must ask once,
+ * a retry must be droppable, and a disposed store must fire none of them. The
+ * handle is held here rather than beside each caller so `dispose` cannot cancel
+ * three of four and leave the fourth running against a store nobody holds.
+ */
+class Coalesced {
+  private handle: ReturnType<typeof setTimeout> | null = null;
+
+  /** True while a fire is booked — a grace period that must not be restarted. */
+  get pending(): boolean {
+    return this.handle !== null;
+  }
+
+  /** Book `run`, dropping any fire already booked. */
+  schedule(delayMs: number, run: () => void): void {
+    this.cancel();
+    this.handle = setTimeout(() => {
+      this.handle = null;
+      run();
+    }, delayMs);
+  }
+
+  cancel(): void {
+    if (this.handle === null) return;
+    clearTimeout(this.handle);
+    this.handle = null;
+  }
+}
+
+/**
+ * Which request of its kind is the newest.
+ *
+ * Two reads of the same thing can be in flight against different filters, and
+ * the answer that lands last is not the answer to the question asked last — so
+ * each caller claims a turn and drops its answer when the turn has passed.
+ */
+class Latest {
+  private seq = 0;
+
+  /** Take the newest turn; the token reads false once another has taken one. */
+  claim(): () => boolean {
+    const seq = ++this.seq;
+    return () => seq === this.seq;
+  }
+
+  /** End every outstanding turn without starting one. */
+  invalidate(): void {
+    this.seq += 1;
+  }
+}
+
 export class Store {
   private ws: WSClient;
   private stateObs: ReturnType<typeof createObservable<StoreState>>;
@@ -338,37 +392,38 @@ export class Store {
   private areaRegistryUnsub: Unsubscribe | null = null;
   private retryBaseMs: number;
   private consecutiveTransportFailures = 0;
-  private treeRefreshHandle: ReturnType<typeof setTimeout> | null = null;
-  private facetRefreshHandle: ReturnType<typeof setTimeout> | null = null;
-  private areasRefreshHandle: ReturnType<typeof setTimeout> | null = null;
-  private totalRefreshHandle: ReturnType<typeof setTimeout> | null = null;
-  /** Identifies the newest facet-tally request, so a superseded one cannot land. */
-  private distinctRefreshSeq = 0;
-  /** Identifies the newest tree refetch, for the same reason. */
-  private treeRefreshSeq = 0;
-  /** Identifies the newest filtered-total recount, for the same reason. */
-  private totalRefreshSeq = 0;
-  /** Identifies the newest subscribe round, so a superseded one stops reporting. */
-  private subscribeRound = 0;
+  /** The deferred work: every one of these is cancelled by `dispose`. */
+  private readonly treeRefresh = new Coalesced();
+  private readonly facetRefresh = new Coalesced();
+  private readonly areasRefresh = new Coalesced();
+  private readonly totalRefresh = new Coalesced();
+  private readonly subscribeRetry = new Coalesced();
+  private readonly areaRegistryRetry = new Coalesced();
+  /** Counts down the grace period on a closed socket; idle while it is open. */
+  private readonly connectionLostGrace = new Coalesced();
+  /** Which facet-tally request is the newest, so a superseded one cannot land. */
+  private readonly latestFacetTally = new Latest();
+  /** Which tree refetch is the newest, for the same reason. */
+  private readonly latestTree = new Latest();
+  /** Which filtered-total recount is the newest, for the same reason. */
+  private readonly latestTotal = new Latest();
+  /** Which subscribe round is the newest, so a superseded one stops reporting. */
+  private readonly latestSubscribeRound = new Latest();
+  /** Which area-registry watch is the newest, so a superseded one stops reporting. */
+  private readonly latestAreaWatch = new Latest();
   /** Subscribes in the current round that have not resolved or been refused yet. */
   private subscribePending = 0;
   /** First refusal seen in the current round, if any. */
   private subscribeRefusal: { err: unknown } | null = null;
   /** Automatic re-subscribes already spent on the current outage. */
   private subscribeAttempt = 0;
-  private subscribeRetryHandle: ReturnType<typeof setTimeout> | null = null;
   /** Re-opens of the area-registry watch already spent on the current refusal. */
   private areaRegistryAttempt = 0;
-  private areaRegistryRetryHandle: ReturnType<typeof setTimeout> | null = null;
-  /** Identifies the newest area-registry watch, so a superseded one stops reporting. */
-  private areaRegistryGeneration = 0;
   /** Detaches the connection-lifecycle listeners; null while none is attached. */
   private connectionReadyUnsub: Unsubscribe | null = null;
   private connectionLostUnsub: Unsubscribe | null = null;
   /** Detaches the day clock the counts are re-read on; null while none is attached. */
   private dayChangeUnsub: Unsubscribe | null = null;
-  /** Counts down the grace period on a closed socket; null while it is open. */
-  private connectionLostHandle: ReturnType<typeof setTimeout> | null = null;
   /** Last untouched `distinct_values` result, so drafts can be re-merged. */
   private serverDistinct: DistinctValues | null = null;
   /** Whether the last `distinct_values` answer was priced against a filter. */
@@ -480,7 +535,7 @@ export class Store {
     this.connectionReadyUnsub?.();
     this.connectionLostUnsub?.();
     this.connectionReadyUnsub = this.ws.onConnectionReady(() => {
-      this.cancelConnectionLostGrace();
+      this.connectionLostGrace.cancel();
       this.noteSuccess();
       this.scheduleAreasRefresh();
     });
@@ -489,17 +544,12 @@ export class Store {
 
   /** Declare the connection lost unless it comes back inside the grace period. */
   private startConnectionLostGrace() {
-    if (this.connectionLostHandle !== null) return;
-    this.connectionLostHandle = setTimeout(() => {
-      this.connectionLostHandle = null;
-      this.setDegraded({ connectionLost: true });
-    }, CONNECTION_LOST_GRACE_MS);
-  }
-
-  private cancelConnectionLostGrace() {
-    if (this.connectionLostHandle === null) return;
-    clearTimeout(this.connectionLostHandle);
-    this.connectionLostHandle = null;
+    // A second `disconnected` inside the window is the same outage, and
+    // restarting the countdown would postpone the banner indefinitely.
+    if (this.connectionLostGrace.pending) return;
+    this.connectionLostGrace.schedule(CONNECTION_LOST_GRACE_MS, () =>
+      this.setDegraded({ connectionLost: true }),
+    );
   }
 
   /**
@@ -512,7 +562,7 @@ export class Store {
    * and the list is small, so the event only triggers a refetch.
    */
   private watchAreaRegistry(resetRetryBudget = true) {
-    this.cancelAreaRegistryRetry();
+    this.areaRegistryRetry.cancel();
     if (resetRetryBudget) this.areaRegistryAttempt = 0;
     // A re-open spans a window in which the registry could have moved with
     // nothing listening to say so, so the cache is re-read on the way back. The
@@ -520,14 +570,14 @@ export class Store {
     const catchUp = this.areaRegistryAttempt > 0;
     // A refusal can arrive after this watch has been replaced or the store
     // disposed, and HA's own subscribe carries no cancellation of its own.
-    const generation = ++this.areaRegistryGeneration;
+    const current = this.latestAreaWatch.claim();
     if (this.areaRegistryUnsub) this.areaRegistryUnsub();
     this.areaRegistryUnsub = this.ws.subscribeAreaRegistry(() => this.scheduleAreasRefresh(), {
       onOpen: () => {
-        if (catchUp && generation === this.areaRegistryGeneration) this.scheduleAreasRefresh();
+        if (catchUp && current()) this.scheduleAreasRefresh();
       },
       onError: (err) => {
-        if (generation === this.areaRegistryGeneration) this.onAreaRegistryRefused(err);
+        if (current()) this.onAreaRegistryRefused(err);
       },
     });
   }
@@ -545,26 +595,12 @@ export class Store {
     if (this.areaRegistryAttempt >= AREA_REGISTRY_RETRY_ATTEMPTS) return;
     const delay = subscribeRetryDelayMs(err, this.areaRegistryAttempt, this.retryBaseMs);
     this.areaRegistryAttempt += 1;
-    this.cancelAreaRegistryRetry();
-    this.areaRegistryRetryHandle = setTimeout(() => {
-      this.areaRegistryRetryHandle = null;
-      this.watchAreaRegistry(false);
-    }, delay);
-  }
-
-  private cancelAreaRegistryRetry() {
-    if (this.areaRegistryRetryHandle === null) return;
-    clearTimeout(this.areaRegistryRetryHandle);
-    this.areaRegistryRetryHandle = null;
+    this.areaRegistryRetry.schedule(delay, () => this.watchAreaRegistry(false));
   }
 
   /** Coalesce area refetches: editing a handful of areas fires one event each. */
   private scheduleAreasRefresh(delayMs = 250) {
-    if (this.areasRefreshHandle !== null) clearTimeout(this.areasRefreshHandle);
-    this.areasRefreshHandle = setTimeout(() => {
-      this.areasRefreshHandle = null;
-      void this.refreshAreas().catch(() => undefined);
-    }, delayMs);
+    this.areasRefresh.schedule(delayMs, () => void this.refreshAreas().catch(() => undefined));
   }
 
   /** (Re)open the topic subscriptions, starting the retry budget over. */
@@ -581,9 +617,9 @@ export class Store {
    * newest round has been accepted.
    */
   private openSubscriptions(resetRetryBudget: boolean) {
-    this.cancelSubscribeRetry();
+    this.subscribeRetry.cancel();
     if (resetRetryBudget) this.subscribeAttempt = 0;
-    const round = ++this.subscribeRound;
+    const round = this.latestSubscribeRound.claim();
     this.subscribePending = SUBSCRIBE_TOPIC_COUNT;
     this.subscribeRefusal = null;
     const onOpen = () => this.onSubscribeSettled(round, null);
@@ -646,8 +682,8 @@ export class Store {
   }
 
   /** Fold one subscribe outcome into its round, and act once the round is complete. */
-  private onSubscribeSettled(round: number, refusal: { err: unknown } | null) {
-    if (round !== this.subscribeRound) return; // a newer round has taken over
+  private onSubscribeSettled(round: () => boolean, refusal: { err: unknown } | null) {
+    if (!round()) return; // a newer round has taken over
     if (refusal && !this.subscribeRefusal) this.subscribeRefusal = refusal;
     if (this.subscribePending > 0) this.subscribePending -= 1;
     if (this.subscribePending > 0) return;
@@ -718,17 +754,7 @@ export class Store {
       liveUpdatesReason: reason,
       nextLiveRetryAt: Date.now() + delay,
     });
-    this.cancelSubscribeRetry();
-    this.subscribeRetryHandle = setTimeout(() => {
-      this.subscribeRetryHandle = null;
-      this.openSubscriptions(false);
-    }, delay);
-  }
-
-  private cancelSubscribeRetry() {
-    if (this.subscribeRetryHandle === null) return;
-    clearTimeout(this.subscribeRetryHandle);
-    this.subscribeRetryHandle = null;
+    this.subscribeRetry.schedule(delay, () => this.openSubscriptions(false));
   }
 
   /** Tear down the four subscriptions and any pending tree refresh. */
@@ -747,32 +773,21 @@ export class Store {
     // listeners above do.
     this.dayChangeUnsub?.();
     this.dayChangeUnsub = null;
-    this.cancelConnectionLostGrace();
     this.itemsUnsub = this.statsUnsub = this.locationsUnsub = this.statusesUnsub = null;
     this.areaRegistryUnsub = null;
     this.connectionReadyUnsub = null;
     this.connectionLostUnsub = null;
-    // Nothing is listening after this, so a queued re-subscribe must not fire.
-    this.subscribeRound += 1;
-    this.areaRegistryGeneration += 1;
-    this.cancelSubscribeRetry();
-    this.cancelAreaRegistryRetry();
-    if (this.treeRefreshHandle !== null) {
-      clearTimeout(this.treeRefreshHandle);
-      this.treeRefreshHandle = null;
-    }
-    if (this.totalRefreshHandle !== null) {
-      clearTimeout(this.totalRefreshHandle);
-      this.totalRefreshHandle = null;
-    }
-    if (this.facetRefreshHandle !== null) {
-      clearTimeout(this.facetRefreshHandle);
-      this.facetRefreshHandle = null;
-    }
-    if (this.areasRefreshHandle !== null) {
-      clearTimeout(this.areasRefreshHandle);
-      this.areasRefreshHandle = null;
-    }
+    // Nothing is listening after this, so a subscribe still in flight must not
+    // report and nothing already booked may fire.
+    this.latestSubscribeRound.invalidate();
+    this.latestAreaWatch.invalidate();
+    this.connectionLostGrace.cancel();
+    this.subscribeRetry.cancel();
+    this.areaRegistryRetry.cancel();
+    this.treeRefresh.cancel();
+    this.totalRefresh.cancel();
+    this.facetRefresh.cancel();
+    this.areasRefresh.cancel();
     this.stateObs.set({ connected: { items: false, stats: false } });
   }
 
@@ -851,22 +866,18 @@ export class Store {
    * same reason.
    */
   private scheduleTotalRefresh(delayMs = 250) {
-    if (this.totalRefreshHandle !== null) clearTimeout(this.totalRefreshHandle);
-    this.totalRefreshHandle = setTimeout(() => {
-      this.totalRefreshHandle = null;
-      void this.refreshTotal().catch(() => undefined);
-    }, delayMs);
+    this.totalRefresh.schedule(delayMs, () => void this.refreshTotal().catch(() => undefined));
   }
 
   private async refreshTotal(): Promise<void> {
-    const seq = ++this.totalRefreshSeq;
+    const current = this.latestTotal.claim();
     const filters = this.state.value.filters;
     const asked = JSON.stringify(toWireFilter(filters));
     const total = await this.countMatching(filters);
     // A newer recount has taken over, the filter moved under this one — in
     // which case `listItems` has already answered for the new one — or the
     // count failed and left nothing to apply.
-    if (seq !== this.totalRefreshSeq || total === null) return;
+    if (!current() || total === null) return;
     if (JSON.stringify(toWireFilter(this.state.value.filters)) !== asked) return;
     this.stateObs.set({ total });
   }
@@ -876,11 +887,7 @@ export class Store {
    * so a burst of item events (a bulk move, an import) must not fire one per event.
    */
   private scheduleTreeRefresh(delayMs = 250) {
-    if (this.treeRefreshHandle !== null) clearTimeout(this.treeRefreshHandle);
-    this.treeRefreshHandle = setTimeout(() => {
-      this.treeRefreshHandle = null;
-      void this.refreshLocationTree().catch(() => undefined);
-    }, delayMs);
+    this.treeRefresh.schedule(delayMs, () => void this.refreshLocationTree().catch(() => undefined));
   }
 
   /**
@@ -889,11 +896,7 @@ export class Store {
    * every category and tag again.
    */
   private scheduleFacetRefresh(delayMs = 250) {
-    if (this.facetRefreshHandle !== null) clearTimeout(this.facetRefreshHandle);
-    this.facetRefreshHandle = setTimeout(() => {
-      this.facetRefreshHandle = null;
-      void this.refreshDistinctValues().catch(() => undefined);
-    }, delayMs);
+    this.facetRefresh.schedule(delayMs, () => void this.refreshDistinctValues().catch(() => undefined));
   }
 
   private onStatsEvent(evt: AnyEventPayload) {
@@ -947,11 +950,9 @@ export class Store {
   /** Refresh distinct categories/tags with counts (source for autocomplete). */
   async refreshDistinctValues() {
     // Not every caller is debounced — item events land beside filter changes —
-    // so two of these can be in flight against different filters, and run()'s
-    // retries mean the response that lands last is not the one issued last.
-    // The tallies must price the newest filter, so a superseded response is
-    // dropped rather than assigned.
-    const seq = ++this.distinctRefreshSeq;
+    // so two of these can be in flight against different filters, and the
+    // tallies must price the newest one.
+    const current = this.latestFacetTally.claim();
     const counting = this.facetCountFilters();
     // Priced whenever *anything* is narrowing the list, including a filter this
     // measurement then drops. Gating on what survives the drop is what left a
@@ -963,7 +964,7 @@ export class Store {
     const distinct = (await this.run(() =>
       this.ws.distinctValues(filtered ? toWireFilter(counting) : undefined),
     )) as DistinctValues;
-    if (seq !== this.distinctRefreshSeq) return;
+    if (!current()) return;
     this.serverDistinct = distinct;
     this.serverDistinctPriced = filtered;
     // A draft the backend now knows about is no longer a draft.
@@ -1160,21 +1161,21 @@ export class Store {
     // Superseded responses are dropped, the way refreshDistinctValues drops
     // them: the per-location counts ride the tree, so a stale answer would
     // stick an older filter's numbers on the sidebar just the same.
-    const seq = ++this.treeRefreshSeq;
+    const current = this.latestTree.claim();
     const counting = this.locationCountFilters();
     // Same rule as the facet tallies, and the same reason: a lone location
     // filter would otherwise leave this list bare while the two beside it read
     // a pair.
     const filtered = activeFilterCount(this.state.value.filters) > 0;
     const tree = await this.run(() => this.ws.getLocationTree(filtered ? toWireFilter(counting) : undefined));
-    if (seq !== this.treeRefreshSeq) return;
+    if (!current()) return;
     // Sorted once here so every consumer — sidebar, pickers, organize dialog —
     // sees the same order; the API returns nodes in insertion order.
     this.stateObs.set({ locationTreeCache: sortLocationTree((tree ?? []) as LocationTreeNode[]) });
     // The tree covers filed items only, so the whole-inventory match count comes
     // separately; "No location" is then the remainder, with no third query.
     const matchTotal = filtered ? await this.countMatching(counting) : null;
-    if (seq !== this.treeRefreshSeq) return;
+    if (!current()) return;
     this.stateObs.set({ locationMatchTotal: matchTotal });
   }
 
@@ -1335,16 +1336,13 @@ export class Store {
 
   // ---------- Degraded / retry plumbing ----------
   private setDegraded(patch: Partial<DegradedState>) {
-    const next = { ...this.state.value.degraded, ...patch };
     const cur = this.state.value.degraded;
-    const same =
-      cur.connectionLost === next.connectionLost &&
-      cur.reloading === next.reloading &&
-      cur.liveUpdates === next.liveUpdates &&
-      cur.liveUpdatesReason === next.liveUpdatesReason &&
-      cur.nextLiveRetryAt === next.nextLiveRetryAt;
-    if (same) return;
-    this.stateObs.set({ degraded: next });
+    // A patch that names only values already held publishes nothing: every
+    // subscriber re-renders on any notify, and the retry ladder sets the same
+    // state repeatedly while it waits.
+    const keys = Object.keys(patch) as (keyof DegradedState)[];
+    if (keys.every((key) => cur[key] === patch[key])) return;
+    this.stateObs.set({ degraded: { ...cur, ...patch } });
   }
 
   /** Any successful round trip proves the socket is alive. */
@@ -1400,7 +1398,7 @@ export class Store {
   async refreshAll(): Promise<void> {
     this.consecutiveTransportFailures = 0;
     // The calls below re-answer the question the grace period was waiting on.
-    this.cancelConnectionLostGrace();
+    this.connectionLostGrace.cancel();
     this.setDegraded({ ...NO_DEGRADATION });
     await this.reloadAll();
     // Re-establish subscriptions in case one of them was refused earlier.

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -1072,62 +1072,65 @@ export class Store {
   // ---------- Attachments ----------
 
   /**
+   * Take the item a call answered with into the list, and hand it back.
+   *
+   * The caller needs that item too: it is one version on, so a form that goes
+   * on holding the copy it had fails its next save with `conflict`.
+   *
+   * Attachment work is the one family that does not go through `run`. Its
+   * failures belong to the file picker that raised them — shown per file, next
+   * to the file that failed — and the upload's own HTTP errors carry no
+   * backend error code, so counting them would read a rejected file as a lost
+   * connection.
+   */
+  private async applyResult(call: Promise<Item>): Promise<Item> {
+    const updated = await call;
+    this.applyOptimistic(updated);
+    return updated;
+  }
+
+  /**
    * Upload one file and attach it to an item.
    *
    * Its own action rather than part of the item save: an 8 MB POST inside a
-   * form submit makes the save look hung. Errors are thrown rather than pushed
-   * onto the error queue — the picker shows them per file, next to the file
-   * that failed, which a global banner cannot do.
+   * form submit makes the save look hung.
    */
-  async uploadAttachment(
+  uploadAttachment(
     itemId: string,
     file: File,
     kind: AttachmentKind = 'picture',
     expectedVersion?: number,
   ): Promise<Item> {
-    const updated = await this.ws.uploadAttachment(itemId, file, kind, expectedVersion);
-    this.applyOptimistic(updated);
-    return updated;
+    return this.applyResult(this.ws.uploadAttachment(itemId, file, kind, expectedVersion));
   }
 
   /** Rename one attachment for display, leaving its filename and bytes alone. */
-  async updateAttachment(
+  updateAttachment(
     itemId: string,
     attachmentId: string,
     title: string,
     expectedVersion?: number,
   ): Promise<Item> {
-    const updated = await this.ws.updateAttachment(itemId, attachmentId, title, expectedVersion);
-    this.applyOptimistic(updated);
-    return updated;
+    return this.applyResult(
+      this.ws.updateAttachment(itemId, attachmentId, title, expectedVersion),
+    );
   }
 
   /** Renumber one kind's attachments; the first id named becomes position 0. */
-  async reorderAttachments(
+  reorderAttachments(
     itemId: string,
     kind: AttachmentKind,
     attachmentIds: string[],
     expectedVersion?: number,
   ): Promise<Item> {
-    const updated = await this.ws.reorderAttachments(
-      itemId,
-      kind,
-      attachmentIds,
-      expectedVersion,
+    return this.applyResult(
+      this.ws.reorderAttachments(itemId, kind, attachmentIds, expectedVersion),
     );
-    this.applyOptimistic(updated);
-    return updated;
   }
 
   /** Detach one file; the backend deletes the bytes with it. */
-  async removeAttachment(
-    itemId: string,
-    attachmentId: string,
-    expectedVersion?: number,
-  ): Promise<Item> {
-    const updated = await this.ws.removeAttachment(itemId, attachmentId, expectedVersion);
-    this.applyOptimistic(updated);
-    return updated;
+  removeAttachment(itemId: string, attachmentId: string, expectedVersion?: number): Promise<Item> {
+    return this.applyResult(this.ws.removeAttachment(itemId, attachmentId, expectedVersion));
   }
 
   /** Sign one attachment's media path so an `<img>` can load it. */
@@ -1406,6 +1409,33 @@ export class Store {
   }
 
   // ---------- Optimistic writes ----------
+  /**
+   * Show a change on the row, send it, and take the server's copy back — or put
+   * the row the way it was when the call is refused.
+   *
+   * `patch` is what the row looks like while the call is in flight, applied to
+   * the row as it stands so a relative change (a delta, a due date that keeps
+   * the old one) has something to count from. Null where the answer cannot be
+   * guessed, which also means there is nothing to roll back. `details` rides
+   * the error entry: a conflict banner offers the edit again and needs both the
+   * row it was refused for and the changes it was refused with.
+   */
+  private async optimisticWrite(
+    itemId: string,
+    patch: ((before: Item) => Partial<Item> | ItemUpdate) | null,
+    call: () => Promise<Item>,
+    details?: { itemId?: string; changes?: ItemUpdate },
+  ): Promise<void> {
+    const before = patch ? this.state.value.items.find((i) => i.id === itemId) : undefined;
+    if (patch && before) this.applyOptimistic({ ...before, ...patch(before) } as Item);
+    try {
+      this.applyOptimistic(await this.run(call));
+    } catch (err) {
+      this.pushError(err, details);
+      if (before) this.applyOptimistic(before);
+    }
+  }
+
   async createItem(input: ItemCreate) {
     try {
       const created = await this.run(() => this.ws.createItem(input));
@@ -1418,19 +1448,12 @@ export class Store {
   }
 
   async updateItem(itemId: string, changes: ItemUpdate, expectedVersion?: number) {
-    const before = this.state.value.items.find((i) => i.id === itemId);
-    if (before) {
-      const optimistic: Item = { ...before, ...changes } as Item;
-      this.applyOptimistic(optimistic);
-    }
-    try {
-      const updated = await this.run(() => this.ws.updateItem(itemId, changes, expectedVersion));
-      this.applyOptimistic(updated);
-    } catch (err) {
-      // Capture conflict context for actionable retry
-      this.pushError(err, { itemId, changes });
-      if (before) this.applyOptimistic(before);
-    }
+    await this.optimisticWrite(
+      itemId,
+      () => changes,
+      () => this.ws.updateItem(itemId, changes, expectedVersion),
+      { itemId, changes },
+    );
   }
 
   async deleteItem(itemId: string, expectedVersion?: number) {
@@ -1445,51 +1468,37 @@ export class Store {
   }
 
   async adjustQuantity(itemId: string, delta: number, expectedVersion?: number) {
-    const before = this.state.value.items.find((i) => i.id === itemId);
-    if (before) this.applyOptimistic({ ...before, quantity: before.quantity + delta } as Item);
-    try {
-      const updated = await this.run(() => this.ws.adjustQuantity(itemId, delta, expectedVersion));
-      this.applyOptimistic(updated);
-    } catch (err) {
-      this.pushError(err);
-      if (before) this.applyOptimistic(before);
-    }
+    await this.optimisticWrite(
+      itemId,
+      (before) => ({ quantity: before.quantity + delta }),
+      () => this.ws.adjustQuantity(itemId, delta, expectedVersion),
+    );
   }
 
   async setQuantity(itemId: string, quantity: number, expectedVersion?: number) {
-    const before = this.state.value.items.find((i) => i.id === itemId);
-    if (before) this.applyOptimistic({ ...before, quantity } as Item);
-    try {
-      const updated = await this.run(() => this.ws.setQuantity(itemId, quantity, expectedVersion));
-      this.applyOptimistic(updated);
-    } catch (err) {
-      this.pushError(err);
-      if (before) this.applyOptimistic(before);
-    }
+    await this.optimisticWrite(
+      itemId,
+      () => ({ quantity }),
+      () => this.ws.setQuantity(itemId, quantity, expectedVersion),
+    );
   }
 
   async checkOut(itemId: string, dueDate?: string | null, expectedVersion?: number) {
-    const before = this.state.value.items.find((i) => i.id === itemId);
-    if (before) this.applyOptimistic({ ...before, checked_out: true, due_date: dueDate ?? before.due_date } as Item);
-    try {
-      const updated = await this.run(() => this.ws.checkOut(itemId, dueDate, expectedVersion));
-      this.applyOptimistic(updated);
-    } catch (err) {
-      this.pushError(err);
-      if (before) this.applyOptimistic(before);
-    }
+    await this.optimisticWrite(
+      itemId,
+      // No date named means the item keeps the one it has: the command is
+      // "check this out", not "check this out with no due date".
+      (before) => ({ checked_out: true, due_date: dueDate ?? before.due_date }),
+      () => this.ws.checkOut(itemId, dueDate, expectedVersion),
+    );
   }
 
   async markCheckedIn(itemId: string, expectedVersion?: number) {
-    const before = this.state.value.items.find((i) => i.id === itemId);
-    if (before) this.applyOptimistic({ ...before, checked_out: false } as Item);
-    try {
-      const updated = await this.run(() => this.ws.markCheckedIn(itemId, expectedVersion));
-      this.applyOptimistic(updated);
-    } catch (err) {
-      this.pushError(err);
-      if (before) this.applyOptimistic(before);
-    }
+    await this.optimisticWrite(
+      itemId,
+      () => ({ checked_out: false }),
+      () => this.ws.markCheckedIn(itemId, expectedVersion),
+    );
   }
 
   /**
@@ -1501,41 +1510,42 @@ export class Store {
    * series the anchor exists to keep right.
    */
   async bumpReminder(itemId: string, expectedVersion?: number) {
-    try {
-      this.applyOptimistic(await this.run(() => this.ws.bumpReminder(itemId, expectedVersion)));
-    } catch (err) {
-      this.pushError(err);
-    }
+    await this.optimisticWrite(itemId, null, () => this.ws.bumpReminder(itemId, expectedVersion));
   }
 
   async setLowStockThreshold(itemId: string, threshold: number | null, expectedVersion?: number) {
-    const before = this.state.value.items.find((i) => i.id === itemId);
-    if (before) this.applyOptimistic({ ...before, low_stock_threshold: threshold } as Item);
-    try {
-      const updated = await this.run(() => this.ws.setLowStockThreshold(itemId, threshold, expectedVersion));
-      this.applyOptimistic(updated);
-    } catch (err) {
-      this.pushError(err);
-      if (before) this.applyOptimistic(before);
-    }
+    await this.optimisticWrite(
+      itemId,
+      () => ({ low_stock_threshold: threshold }),
+      () => this.ws.setLowStockThreshold(itemId, threshold, expectedVersion),
+    );
   }
 
   async moveItem(itemId: string, locationId: string | null, expectedVersion?: number) {
-    const before = this.state.value.items.find((i) => i.id === itemId);
-    if (before) this.applyOptimistic({ ...before, location_id: locationId } as Item);
-    try {
-      const updated = await this.run(() => this.ws.moveItem(itemId, locationId, expectedVersion));
-      this.applyOptimistic(updated);
-    } catch (err) {
-      this.pushError(err);
-      if (before) this.applyOptimistic(before);
-    }
+    await this.optimisticWrite(
+      itemId,
+      () => ({ location_id: locationId }),
+      () => this.ws.moveItem(itemId, locationId, expectedVersion),
+    );
+  }
+
+  // ---------- Locations ----------
+  /**
+   * Run a location change and re-read both views of the tree.
+   *
+   * The flat list and the nested tree are the same locations shaped for
+   * different surfaces, and every change moves both — the sidebar's counts ride
+   * the tree, the pickers read the flat list. Neither is pushed: the
+   * `locations` topic says a change happened, not what the walk now returns.
+   */
+  private async afterLocationChange<T>(call: Promise<T>): Promise<T> {
+    const result = await call;
+    await Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
+    return result;
   }
 
   async createLocation(name: string, parentId?: string | null, areaId?: string | null): Promise<Location> {
-    const created = await this.ws.createLocation(name, parentId ?? null, areaId ?? undefined);
-    await Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
-    return created;
+    return this.afterLocationChange(this.ws.createLocation(name, parentId ?? null, areaId ?? undefined));
   }
 
   async updateLocation(
@@ -1544,27 +1554,36 @@ export class Store {
     // command takes it, so an edit that also moves the location is one trip.
     changes: { name?: string; areaId?: string | null; newParentId?: string | null },
   ): Promise<Location> {
-    const updated = await this.ws.updateLocation(locationId, changes);
-    await Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
-    return updated;
+    return this.afterLocationChange(this.ws.updateLocation(locationId, changes));
   }
 
   /** Delete an empty location. Rejects with validation_error when it still has children or items. */
   async deleteLocation(locationId: string): Promise<void> {
-    await this.ws.deleteLocation(locationId);
-    await Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
+    await this.afterLocationChange(this.ws.deleteLocation(locationId));
   }
 
   /** Move a whole subtree under a new parent (null = top level). Descendant paths update live. */
   async moveLocationSubtree(locationId: string, newParentId: string | null): Promise<Location> {
-    const moved = await this.ws.moveLocationSubtree(locationId, newParentId);
-    await Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
+    const moved = await this.afterLocationChange(
+      this.ws.moveLocationSubtree(locationId, newParentId),
+    );
     // Denormalized item location_path values changed for the whole subtree.
     await this.listItems(true);
     return moved;
   }
 
   // ---------- Status definitions ----------
+  /**
+   * Run a status change and re-read the vocabulary.
+   *
+   * Display order is part of the list, so the whole list is read back rather
+   * than patched from the one definition the call answered with.
+   */
+  private async afterStatusChange<T>(call: Promise<T>): Promise<T> {
+    const result = await call;
+    await this.refreshStatuses();
+    return result;
+  }
 
   async createStatus(status: {
     slug: string;
@@ -1572,9 +1591,7 @@ export class Store {
     color?: StatusColorValue;
     icon?: string;
   }): Promise<StatusDefinition> {
-    const created = await this.ws.createStatus(status);
-    await this.refreshStatuses();
-    return created;
+    return this.afterStatusChange(this.ws.createStatus(status));
   }
 
   /** Edit presentation. No item moves, so nothing but the vocabulary refreshes. */
@@ -1582,15 +1599,11 @@ export class Store {
     slug: string,
     changes: { label?: string; color?: StatusColorValue; icon?: string },
   ): Promise<StatusDefinition> {
-    const updated = await this.ws.updateStatus(slug, changes);
-    await this.refreshStatuses();
-    return updated;
+    return this.afterStatusChange(this.ws.updateStatus(slug, changes));
   }
 
   async reorderStatuses(slugs: string[]): Promise<StatusDefinition[]> {
-    const ordered = await this.ws.reorderStatuses(slugs);
-    await this.refreshStatuses();
-    return ordered;
+    return this.afterStatusChange(this.ws.reorderStatuses(slugs));
   }
 
   /**
@@ -1605,8 +1618,7 @@ export class Store {
    * broadcast.
    */
   async deleteStatus(slug: string, reassignTo?: string): Promise<number> {
-    const { reassigned } = await this.ws.deleteStatus(slug, reassignTo);
-    await this.refreshStatuses();
+    const { reassigned } = await this.afterStatusChange(this.ws.deleteStatus(slug, reassignTo));
     if (reassigned > 0) await Promise.all([this.listItems(true), this.refreshStats()]);
     return reassigned;
   }

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -11,7 +11,6 @@ import type {
   DistinctValues,
   ExportDocument,
   HassLike,
-  HealthResult,
   ImportPolicy,
   ImportPreview,
   ImportSummary,
@@ -394,7 +393,6 @@ export class Store {
       locationMatchTotal: null,
       locationsFlatCache: null,
       statsCounts: null,
-      healthCache: null,
       versionInfo: null,
       cardTitle: null,
       quickFilters: null,
@@ -431,7 +429,6 @@ export class Store {
     try {
       await Promise.all([
         this.refreshStats(),
-        this.refreshHealth(),
         this.refreshAreas(),
         this.refreshLocationTree(),
         this.refreshLocationsFlat(),
@@ -925,11 +922,6 @@ export class Store {
   async refreshStats() {
     const counts = await this.run(() => this.ws.stats());
     this.stateObs.set({ statsCounts: counts });
-  }
-
-  async refreshHealth() {
-    const health: HealthResult = await this.run(() => this.ws.health());
-    this.stateObs.set({ healthCache: health });
   }
 
   async refreshAreas() {
@@ -1736,7 +1728,6 @@ export class Store {
   async reloadAll(): Promise<void> {
     await Promise.all([
       this.refreshStats(),
-      this.refreshHealth(),
       this.refreshLocationsFlat(),
       this.refreshLocationTree(),
       this.refreshDistinctValues(),

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -917,8 +917,10 @@ export class Store {
   }
 
   // ---------- Data fetchers ----------
-  // Reads go through `run` too: a rate-limited read deserves the same backoff,
-  // and a run of transport failures on any call is what "connection lost" means.
+  // Every command the store sends goes through `run`, reads included: a run of
+  // transport failures on any of them is what "connection lost" means, and one
+  // answer that arrives is what takes that back down. The attachment family is
+  // the exception, and says there why.
   async refreshStats() {
     const counts = await this.run(() => this.ws.stats());
     this.stateObs.set({ statsCounts: counts });
@@ -1195,10 +1197,8 @@ export class Store {
     const key = JSON.stringify({ op: 'list', filter, sort, limit, cursor });
     if (this.inflight.has(key)) return this.inflight.get(key) as Promise<void>;
 
-    const p = this.ws
-      .listItems(filter, sort, limit, cursor)
+    const p = this.run(() => this.ws.listItems(filter, sort, limit, cursor))
       .then((res: ListItemsResult) => {
-        this.noteSuccess();
         const merged = reset ? res.items : mergeUniqueById(this.state.value.items, res.items);
         this.stateObs.set({
           items: merged,
@@ -1209,7 +1209,6 @@ export class Store {
         });
       })
       .catch((err: unknown) => {
-        this.noteFailure(err);
         this.stateObs.set({ loading: false });
         this.pushError(err);
       })
@@ -1228,7 +1227,7 @@ export class Store {
    */
   async countMatching(filters: StoreFilters): Promise<number | null> {
     try {
-      const res = await this.ws.listItems(toWireFilter(filters), filters.sort, 1);
+      const res = await this.run(() => this.ws.listItems(toWireFilter(filters), filters.sort, 1));
       return typeof res.total === 'number' ? res.total : null;
     } catch {
       return null;
@@ -1241,7 +1240,7 @@ export class Store {
    * tag/category merge rewrites need, since selection cannot span unloaded pages.
    */
   async listAllMatching(filter: ItemFilter): Promise<Item[]> {
-    const res = await this.ws.listItems(filter);
+    const res = await this.run(() => this.ws.listItems(filter));
     return res.items;
   }
 
@@ -1538,14 +1537,16 @@ export class Store {
    * the tree, the pickers read the flat list. Neither is pushed: the
    * `locations` topic says a change happened, not what the walk now returns.
    */
-  private async afterLocationChange<T>(call: Promise<T>): Promise<T> {
-    const result = await call;
+  private async afterLocationChange<T>(call: () => Promise<T>): Promise<T> {
+    const result = await this.run(call);
     await Promise.all([this.refreshLocationsFlat(), this.refreshLocationTree()]);
     return result;
   }
 
   async createLocation(name: string, parentId?: string | null, areaId?: string | null): Promise<Location> {
-    return this.afterLocationChange(this.ws.createLocation(name, parentId ?? null, areaId ?? undefined));
+    return this.afterLocationChange(() =>
+      this.ws.createLocation(name, parentId ?? null, areaId ?? undefined),
+    );
   }
 
   async updateLocation(
@@ -1554,17 +1555,17 @@ export class Store {
     // command takes it, so an edit that also moves the location is one trip.
     changes: { name?: string; areaId?: string | null; newParentId?: string | null },
   ): Promise<Location> {
-    return this.afterLocationChange(this.ws.updateLocation(locationId, changes));
+    return this.afterLocationChange(() => this.ws.updateLocation(locationId, changes));
   }
 
   /** Delete an empty location. Rejects with validation_error when it still has children or items. */
   async deleteLocation(locationId: string): Promise<void> {
-    await this.afterLocationChange(this.ws.deleteLocation(locationId));
+    await this.afterLocationChange(() => this.ws.deleteLocation(locationId));
   }
 
   /** Move a whole subtree under a new parent (null = top level). Descendant paths update live. */
   async moveLocationSubtree(locationId: string, newParentId: string | null): Promise<Location> {
-    const moved = await this.afterLocationChange(
+    const moved = await this.afterLocationChange(() =>
       this.ws.moveLocationSubtree(locationId, newParentId),
     );
     // Denormalized item location_path values changed for the whole subtree.
@@ -1579,8 +1580,8 @@ export class Store {
    * Display order is part of the list, so the whole list is read back rather
    * than patched from the one definition the call answered with.
    */
-  private async afterStatusChange<T>(call: Promise<T>): Promise<T> {
-    const result = await call;
+  private async afterStatusChange<T>(call: () => Promise<T>): Promise<T> {
+    const result = await this.run(call);
     await this.refreshStatuses();
     return result;
   }
@@ -1591,7 +1592,7 @@ export class Store {
     color?: StatusColorValue;
     icon?: string;
   }): Promise<StatusDefinition> {
-    return this.afterStatusChange(this.ws.createStatus(status));
+    return this.afterStatusChange(() => this.ws.createStatus(status));
   }
 
   /** Edit presentation. No item moves, so nothing but the vocabulary refreshes. */
@@ -1599,11 +1600,11 @@ export class Store {
     slug: string,
     changes: { label?: string; color?: StatusColorValue; icon?: string },
   ): Promise<StatusDefinition> {
-    return this.afterStatusChange(this.ws.updateStatus(slug, changes));
+    return this.afterStatusChange(() => this.ws.updateStatus(slug, changes));
   }
 
   async reorderStatuses(slugs: string[]): Promise<StatusDefinition[]> {
-    return this.afterStatusChange(this.ws.reorderStatuses(slugs));
+    return this.afterStatusChange(() => this.ws.reorderStatuses(slugs));
   }
 
   /**
@@ -1618,7 +1619,9 @@ export class Store {
    * broadcast.
    */
   async deleteStatus(slug: string, reassignTo?: string): Promise<number> {
-    const { reassigned } = await this.afterStatusChange(this.ws.deleteStatus(slug, reassignTo));
+    const { reassigned } = await this.afterStatusChange(() =>
+      this.ws.deleteStatus(slug, reassignTo),
+    );
     if (reassigned > 0) await Promise.all([this.listItems(true), this.refreshStats()]);
     return reassigned;
   }
@@ -1721,17 +1724,19 @@ export class Store {
    * backup stays self-consistent.
    */
   async exportDocument(scope: 'all' | 'view' = 'all'): Promise<ExportDocument> {
-    return this.ws.exportDocument(scope === 'view' ? toWireFilter(this.state.value.filters) : undefined);
+    return this.run(() =>
+      this.ws.exportDocument(scope === 'view' ? toWireFilter(this.state.value.filters) : undefined),
+    );
   }
 
   /** Validate + classify an import document without mutating state. */
   async previewImport(document: unknown, policy: ImportPolicy): Promise<ImportPreview> {
-    return this.ws.importPreview(document, policy);
+    return this.run(() => this.ws.importPreview(document, policy));
   }
 
   /** Apply an import document, then reload local caches to reflect the new dataset. */
   async executeImport(document: unknown, policy: ImportPolicy): Promise<ImportSummary> {
-    const summary = await this.ws.importExecute(document, policy);
+    const summary = await this.run(() => this.ws.importExecute(document, policy));
     await this.reloadAll();
     return summary;
   }
@@ -1784,8 +1789,7 @@ export class Store {
 
   async refreshItem(itemId: string) {
     try {
-      const latest = await this.ws.getItem(itemId);
-      this.applyOptimistic(latest);
+      this.applyOptimistic(await this.run(() => this.ws.getItem(itemId)));
     } catch (err) {
       this.pushError(err);
     }

--- a/cards/haventory-card/src/store/types.ts
+++ b/cards/haventory-card/src/store/types.ts
@@ -338,20 +338,6 @@ export interface DistinctValues {
   custom_field_keys: string[];
 }
 
-/**
- * Result of haventory/health: the store's counts.
- *
- * `healthy` and `issues` are the backend's index self-check, which now runs in
- * its test suite instead of over a household's store: the pair arrives constant
- * — `true` and empty — on every build, and nothing here reads it. They stay on
- * the type because the backend still sends them.
- */
-export interface HealthResult {
-  healthy: boolean;
-  issues: string[];
-  counts: StatsCounts;
-}
-
 /** Result of haventory/version. */
 export interface VersionInfo {
   integration_version: string;
@@ -730,7 +716,6 @@ export interface StoreState {
   // Optional flat locations cache to enrich UI (e.g., show area per node in selectors)
   locationsFlatCache: Location[] | null;
   statsCounts: StatsCounts | null;
-  healthCache: HealthResult | null;
   versionInfo: VersionInfo | null;
   /** Heading configured in the integration, or null until it has been read. */
   cardTitle: string | null;

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -400,6 +400,58 @@ export class WSClient {
   }
 
   // ---------- Subscriptions ----------
+  /**
+   * Open one subscription, whichever way Home Assistant answers.
+   *
+   * HA hands back either the unsubscribe function or a promise of one,
+   * depending on how far its connection has got, and the promise can still be
+   * refused — which is the only notice that live updates never started, since
+   * no event will arrive to hint at it.
+   *
+   * The closure this returns is the caller's handle in both cases: called
+   * before the promise resolves it records the intent, and the resolution
+   * unsubscribes immediately rather than leaving a subscription nobody holds.
+   */
+  private openSubscription(
+    msg: Record<string, unknown>,
+    onEvent: (event: AnyEventPayload) => void,
+    opts?: { onOpen?: () => void; onError?: (err: unknown) => void },
+  ): Unsubscribe {
+    const unsubOrPromise = subscribeMessage(this.hass, onEvent, msg);
+
+    if (typeof unsubOrPromise === 'function') {
+      opts?.onOpen?.();
+      return unsubOrPromise as unknown as Unsubscribe;
+    }
+
+    let resolvedUnsub: Unsubscribe | null = null;
+    let cancelRequested = false;
+    // The rejection handler is `then`'s second argument rather than a trailing
+    // `catch`, so a throw from `onOpen` cannot be misread as a refused subscribe.
+    Promise.resolve(unsubOrPromise).then(
+      (fn) => {
+        resolvedUnsub = fn as Unsubscribe;
+        if (cancelRequested) {
+          // Nobody is holding this any more, so a throwing unsubscribe has
+          // nothing left to report to.
+          try {
+            resolvedUnsub();
+          } catch {
+            /* ignore */
+          }
+          return;
+        }
+        opts?.onOpen?.();
+      },
+      (err: unknown) => opts?.onError?.(err),
+    );
+
+    return () => {
+      if (resolvedUnsub) resolvedUnsub();
+      else cancelRequested = true;
+    };
+  }
+
   subscribe(
     topic: 'items' | 'locations' | 'stats' | 'statuses',
     cb: (payload: AnyEventPayload) => void,
@@ -433,49 +485,20 @@ export class WSClient {
     if (opts && 'area_id' in opts) msg.area_id = opts.area_id ?? null;
     if (opts && 'include_subtree' in opts) msg.include_subtree = !!opts.include_subtree;
 
-    const unsubOrPromise = subscribeMessage(this.hass, (event) => {
-      // Home Assistant's `subscribeMessage` delivers the *inner* event payload
-      // (the `event` field of the `{id, type:'event', event}` wire frame) to the
-      // callback — NOT the whole envelope. Guard only against a nullish payload.
-      if (!event) return;
-      cb(event as AnyEventPayload);
-    }, msg);
-
-    // Home Assistant may return either an unsubscribe function or a Promise<unsubscribe>.
-    if (typeof unsubOrPromise === 'function') {
-      opts?.onOpen?.();
-      return unsubOrPromise as unknown as Unsubscribe;
-    }
-
-    // Handle Promise<Unsubscribe> with early-cancel support.
-    let resolvedUnsub: Unsubscribe | null = null;
-    let cancelRequested = false;
-    // The rejection handler is `then`'s second argument rather than a trailing
-    // `catch`, so a throw from `onOpen` cannot be misread as a refused subscribe.
-    Promise.resolve(unsubOrPromise).then(
-      (fn) => {
-        resolvedUnsub = fn as Unsubscribe;
-        if (cancelRequested && resolvedUnsub) {
-          try { resolvedUnsub(); } catch { /* ignore */ }
-          return;
-        }
-        opts?.onOpen?.();
+    // A rejected subscribe means no live updates at all, so `onError` is what
+    // lets the card retry, go degraded and offer a manual refresh instead of
+    // quietly showing stale data.
+    return this.openSubscription(
+      msg,
+      (event) => {
+        // Home Assistant's `subscribeMessage` delivers the *inner* event payload
+        // (the `event` field of the `{id, type:'event', event}` wire frame) to the
+        // callback — NOT the whole envelope. Guard only against a nullish payload.
+        if (!event) return;
+        cb(event);
       },
-      (err: unknown) => {
-        // A rejected subscribe means no live updates at all. Report it so the
-        // card can retry, go degraded and offer a manual refresh instead of
-        // quietly showing stale data.
-        opts?.onError?.(err);
-      },
+      opts,
     );
-
-    return () => {
-      if (resolvedUnsub) {
-        resolvedUnsub();
-      } else {
-        cancelRequested = true;
-      }
-    };
   }
 
   /**
@@ -537,36 +560,10 @@ export class WSClient {
     cb: () => void,
     opts?: { onOpen?: () => void; onError?: (err: unknown) => void },
   ): Unsubscribe {
-    const unsubOrPromise = subscribeMessage(this.hass, () => cb(), {
-      type: 'subscribe_events',
-      event_type: 'area_registry_updated',
-    });
-
-    if (typeof unsubOrPromise === 'function') {
-      opts?.onOpen?.();
-      return unsubOrPromise as unknown as Unsubscribe;
-    }
-
-    let resolvedUnsub: Unsubscribe | null = null;
-    let cancelRequested = false;
-    Promise.resolve(unsubOrPromise).then(
-      (fn) => {
-        resolvedUnsub = fn as Unsubscribe;
-        if (cancelRequested) {
-          resolvedUnsub();
-          return;
-        }
-        opts?.onOpen?.();
-      },
-      (err: unknown) => opts?.onError?.(err),
+    return this.openSubscription(
+      { type: 'subscribe_events', event_type: 'area_registry_updated' },
+      () => cb(),
+      opts,
     );
-
-    return () => {
-      if (resolvedUnsub) {
-        resolvedUnsub();
-      } else {
-        cancelRequested = true;
-      }
-    };
   }
 }

--- a/cards/haventory-card/src/store/ws.ts
+++ b/cards/haventory-card/src/store/ws.ts
@@ -9,7 +9,6 @@ import type {
   DistinctValues,
   ExportDocument,
   HassLike,
-  HealthResult,
   ImportPolicy,
   ImportPreview,
   ImportSummary,
@@ -49,10 +48,6 @@ export class WSClient {
 
   stats() {
     return callWS<StatsCounts>(this.hass, { type: 'haventory/stats' });
-  }
-
-  health() {
-    return callWS<HealthResult>(this.hass, { type: 'haventory/health' });
   }
 
   /**

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -40,17 +40,11 @@ export interface MockConfig {
   statuses?: StatusDefinition[];
 }
 
-type HealthPatch = {
-  healthy?: boolean;
-  issues?: string[];
-};
-
 export interface MockHass extends HassLike {
   __emit(topic: AnyEventPayload['topic'], action: string, payload: Record<string, unknown>): void;
   __setConflict(on: boolean): void;
   __setItems(items: Item[]): void;
   __setLocations(locations: Location[]): void;
-  __setHealth(patch: HealthPatch): void;
   /** Reject the next `n` commands with an arbitrary error (transport by default). */
   __failNext(n: number, err?: unknown): void;
   /** Make every subsequent `haventory/subscribe` reject with `err`. */
@@ -102,7 +96,6 @@ export function makeMockHass(initial?: MockConfig): MockHass {
         { slug: 'missing', label: 'Missing', order: 1, color: 'amber', icon: 'alert' },
         { slug: 'needs_repair', label: 'Needs repair', order: 2, color: 'amber', icon: 'wrench' },
       ];
-  let healthOverride: HealthPatch | null = null;
   let failRemaining = 0;
   let failError: unknown = new Error('connection lost');
   let subscribeError: unknown | null = null;
@@ -211,24 +204,6 @@ export function makeMockHass(initial?: MockConfig): MockHass {
             no_location_count: items.filter((i) => i.location_id == null).length,
           };
           return counts as unknown as T;
-        }
-        case 'haventory/health': {
-          const counts: StatsCounts = {
-            items_total: items.length,
-            low_stock_count: items.filter((i) => typeof i.low_stock_threshold === 'number' && i.quantity <= (i.low_stock_threshold as number)).length,
-            checked_out_count: items.filter((i) => i.checked_out).length,
-            overdue_count: items.filter((i) => isMockOverdue(i)).length,
-            checked_out_due_count: items.filter((i) => isMockCheckedOutDue(i)).length,
-            inspection_overdue_count: items.filter((i) => isMockInspectionOverdue(i)).length,
-            inspection_due_count: items.filter((i) => isMockInspectionDue(i)).length,
-            locations_total: locations.length,
-            no_location_count: items.filter((i) => i.location_id == null).length,
-          };
-          return {
-            healthy: healthOverride?.healthy ?? true,
-            issues: healthOverride?.issues ?? [],
-            counts,
-          } as unknown as T;
         }
         case 'haventory/version': {
           return { integration_version: '0.0.1', schema_version: 4 } as unknown as T;
@@ -705,9 +680,6 @@ export function makeMockHass(initial?: MockConfig): MockHass {
     __setConflict(on: boolean) { conflictOnUpdate = on; },
     __setItems(it: Item[]) { items = [...it]; },
     __setLocations(locs: Location[]) { locations = [...locs]; },
-    __setHealth(patch: HealthPatch) {
-      healthOverride = { ...(healthOverride ?? {}), ...patch };
-    },
     __failNext(n: number, err?: unknown) {
       failRemaining = n;
       if (err !== undefined) failError = err;

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -497,7 +497,7 @@ applies optimistic writes with rollback.
 
 **State** (`StoreState`): `items`, `cursor`, `total`, `loading`, `filters`, `selection`,
 `errorQueue`, `areasCache`, `locationTreeCache`, `locationsFlatCache`,
-`statsCounts`, `healthCache`, `versionInfo`, `distinctValuesCache`, `connected`, `degraded`.
+`statsCounts`, `versionInfo`, `distinctValuesCache`, `connected`, `degraded`.
 
 **Notable methods**
 
@@ -681,7 +681,7 @@ Any other key in that record is ignored, so an older or newer payload never brea
 
 ## Data flow
 
-**Startup** — `hass` set → `new Store(hass)` → `init()` warms stats, health, areas, tree,
+**Startup** — `hass` set → `new Store(hass)` → `init()` warms stats, areas, tree,
 flat locations, distinct values and version in parallel → `listItems(true)` → subscribe to
 items / locations / stats, and to HA's `area_registry_updated`.
 
@@ -706,7 +706,7 @@ interactive element carries a testid.
 
 `src/test.utils.ts` provides `makeMockHass()` — an in-memory backend mirroring the WS
 contract, including `items/bulk` with per-op results, a real nested `location/tree` with
-counts, and hooks for the failure paths: `__failNext`, `__failSubscribe`, `__setHealth`,
+counts, and hooks for the failure paths: `__failNext`, `__failSubscribe`,
 `__setItems`, `__setLocations`, plus a `__calls` log. It **throws on an
 unhandled command**, so adding a WS call without extending the mock fails loudly.
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -518,8 +518,10 @@ backend's `ItemFilter`, exported so the count probe and "Export current view" se
 what the list is showing. `include_subtree` is always sent explicitly, because the list
 filter defaults it to `false` server-side while subscriptions default it to `true`.
 
-**Degraded state.** Every WS call goes through `run()`, which classifies failures: a
-*string* error code means a server answered and the command was refused — including the
+**Degraded state.** Every WS call goes through `run()`, which classifies failures — the
+attachment family excepted, because an upload's failures are HTTP and belong to the picker
+that raised them. A *string* error code means a server answered and the command was refused
+— including the
 taxonomy's `unknown_error` catch-all, which is a server-side fault, not a transport one.
 Anything else (Home Assistant's numeric transport codes, a thrown `Error`, no code at all)
 never reached a server; those are reported under the card's own `connection_lost` code with
@@ -587,12 +589,13 @@ recovery, so it is a first-class action rather than a hidden one.
 
 A typed wrapper over `hass.callWS` for each `haventory/*` command, plus `subscribe()`, which
 takes `onError` and `onOpen` callbacks so both a refused and an accepted subscribe are
-observable.
+observable. `openSubscription` is the unwrap `subscribe()` and the area-registry watch
+share: Home Assistant answers with the unsubscribe function or a promise of one, and a
+caller that let go before the promise resolved must not be left holding a live subscription.
 
-It is a deliberate 1:1 mirror of the command catalogue in `backend_api_contract.md`,
-omitting only `haventory/cleanup` and `haventory/unsubscribe` (the latter handled by HA's
-own `subscribeMessage`). A few wrappers have no caller in the card today; they complete the
-mirror and are kept on purpose.
+It carries the commands the card sends and no others, so a wrapper here has a caller. The
+catalogue in `backend_api_contract.md` is the whole surface a client may use; this is the
+part of it HAventory's own card asks for.
 
 Two members are not plain `callWS` wrappers. `uploadAttachment` POSTs the bytes to Home
 Assistant core's `/api/file_upload` through `hass.fetchWithAuth` and only then names the


### PR DESCRIPTION
## Summary

The store said the same thing several times over. This PR says each of them once, and cuts
the one chain nothing was listening to.

- **The six item mutators** were eleven identical lines apiece — apply the guess, send, take
  the server's copy, roll the row back on refusal. `optimisticWrite(itemId, patch, call,
  details?)` is that shape once. `updateItem` folds in with the `{itemId, changes}` its
  conflict banner reads; `bumpReminder` folds in with no patch, which is both what "no
  optimistic update" means and what leaves it nothing to roll back. `createItem` (ensure
  presence, no optimistic apply) and `deleteItem` (remove, then restore) differ in what they
  do to the list and stay as they are.
- **The four attachment wrappers** each awaited, applied and returned the item. `applyResult`
  does it once.
- **The location and status mutators** each called, then awaited the refresh their change
  earns. `afterLocationChange` and `afterStatusChange` name which refresh that is.
- **One read path.** `listItems` carried its own copy of `run()`'s classification, and
  `countMatching`, `listAllMatching`, `refreshItem`, the location/status mutators and the
  import/export calls reached the socket with none — so a success on one of them left a
  "connection lost" banner standing, and a run of transport failures on them counted toward
  nothing. They all go through `run()` now and the comment above the fetchers states the rule
  instead of a claim the code did not keep. The `inflight` de-dupe on the list stays.
- **One subscription opener.** `subscribe()` and `subscribeAreaRegistry()` each implemented
  the function-or-promise unwrap with early cancel; `openSubscription(msg, cb, opts)` is that
  once, keeping the safer of the two variants for both — the `try/catch` around an unsubscribe
  nobody holds any more, which `subscribe` had and the registry watch did not.
- **One timer, one stale-answer guard.** Four debounce slots, three cancel helpers and the
  connection-lost grace period were the same six lines with a different handle; five counters
  were the same "claim a turn, drop the answer once the turn has passed". `Coalesced` and
  `Latest` are each of those once, so `dispose()` cancels a list rather than four hand-written
  `if (handle !== null)` blocks. `setDegraded` compares the keys the patch names instead of
  five fields by name.
- **The dead health chain** (its own commit). `WSClient.health()`, `Store.refreshHealth()`,
  `StoreState.healthCache`, `host-surfaces`' `.health=` binding and `hv-diagnostics-panel`'s
  `health` property were written and never read: the panel's status line derives from
  `connected`/`degraded`, its note renders unconditionally, and `this.health` appears in
  neither its render nor its copy-report. The chain goes, and with it the mock's
  `haventory/health` case, `__setHealth`, `HealthPatch` and `HealthResult`. **The backend
  command, its `backend_api_contract.md` entry and the panel's rendered output are unchanged**
  — the refresh button still re-reads counts through `refreshAll`.

### What deliberately did not move

The attachment family stays off `run()`, and now says why in the code: an upload's failures
are HTTP, carry no backend error code, and belong to the picker that raised them, so counting
them would read a rejected file as a lost connection.

Refs #231 (item 4 — FE-STORE-S3/S4/S5/S8; item 3's card-side health remainder). The issue is
closed by #635.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI
- [x] Refactor (no functional change)

## Counting

| | lines |
|---|---:|
| production removed | 359 |
| test removed | 53 |
| added | 355 (339 production · 3 test · 13 docs) |

`git diff --stat` against `origin/main`: 10 files changed, 355 insertions(+), 422 deletions(-).

## How was this tested?

Both gates green before every commit; no new tests, because nothing new happens — the guards
that already pin this behaviour are the assertion:

- `store.test.ts` — each mutator's optimistic apply and reconcile, `updateItem`'s conflict
  carrying `{itemId, changes}` and its rollback, `deleteItem`'s rollback, `bumpReminder`'s
  no-guess shape and its refusal, the location mutators' refresh pairs.
- `store.subscriptions.test.ts` — the four topics' scope and re-open rounds, the registry
  watch's retry, catch-up and dispose, a promise-returning `subscribeMessage`.
- `store.degraded.test.ts` — the subscribe budget, the grace period, the connection-lost
  counting, and every "stops … once disposed".
- `store.facets.test.ts` / `store.filters.test.ts` / `store.events.test.ts` — the coalesced
  refreshes and the seq guards' stale-response drops.
- `ws.test.ts` — the subscribe unwrap in both of Home Assistant's answer shapes.
- `hv-diagnostics-panel.test.ts` — the panel's rendered output, its refresh event and its
  copy-report, unchanged; `haventory-panel.test.ts` — the panel opening from the ⋮ menu.

Two test edits are mechanical, not rewrites to pass:

- `store.degraded.test.ts` "queues one entry for an outage however many calls fail" called
  `refreshHealth` as the fourth failing call; it calls `refreshVersion` instead — the same
  kind of read, the same count, the same assertions.
- `store.degraded.test.ts` "reads the inventory once the backend starts answering" refuses
  "exactly the loads `init` starts in parallel", which is 7 now that health is not one of
  them. The comment there already names that number as the thing to keep in step.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1304 passed, 27 skipped),
  `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`
  (1903 passed, 71 files), `npm run build` — all green.

phacc (`scripts/test_integration.sh`) not required: nothing under `custom_components/` or
`tests/integration/` is touched. CI's `integration` job runs it anyway.

This is subscription-shaped, so the harder floor applies: `card-smoke.yml` dispatched against
this branch, or the `two_tab` recipe on the master's HA, before merge.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated — none added (no behaviour change); the health cut deletes the case
  that read `healthCache`, and two degraded cases are adjusted mechanically as described.
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md`: `healthCache` and
  `__setHealth` off their lists, `init()`'s warm-up no longer names health, the `run()`
  sentence carries its one exception, the `WSClient` paragraph stops promising wrappers for
  commands nobody calls, and `openSubscription` is named.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
  `docs/data_shapes.md` in sync — no WS schema, error code or field moves. The card stops
  *calling* `haventory/health`; the command and its contract entry are untouched.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

None — no rendered output changes. The diagnostics panel renders byte-identically: the
property that goes was never read by its template.

## Follow-ups

- `store.test.ts` and its five siblings still define `fast` and `flush` per file. Named as a
  follow-up by #635 and deliberately left alone here. Not filed: it is a test-helper tidy, not
  something a household can hit.
- `Store.dispose()` still has no caller in the card (`store.subscriptions.test.ts` says so in
  its own comment). Wiring it up or dropping it is a decision, not a cut. Not filed: nothing
  leaks today, because the element that owns the store outlives it.

## Handover

1. **Merged / left open** — this PR, open for the master to review and merge; it is PR 4 of
   §6.M3 and the last one in that package.
2. **Test this by hand** — nothing this session can do that a person must. `[owner]` The card
   against a real store, if the master's HA cannot be stood up.
3. **Validate locally**
   1. `[browser]` Open the card in two tabs. Create an item in one — the other's list shows
      the row and its footer count moves, without a reload.
   2. `[browser]` Force a `conflict` on `haventory/item/update` (the `routeWebSocket` recipe)
      and edit a row: the row snaps back to its old values and the banner names the conflict,
      with the "view latest" and "re-apply" actions working.
   3. `[browser]` Open the diagnostics panel: the status line, the "since last refresh" tile,
      the three facts and the note read exactly as before, and Refresh still updates the
      counts.
   4. `[browser]` Rename a location: the sidebar tree, its counts and the rows' paths all
      follow, one refetch each.
   5. `[browser]` Upload an oversized photo twice from the item editor: each failure is shown
      by the picker on the file that failed, and no "connection lost" banner appears.
4. **Decisions taken against drifted notes**
   - FE-S4 says a rate-limited read "would start retrying"; #632 removed the limiter and the
     retry loop, so routing the reads through `run()` changes only the connection-lost
     counting and the error normalization, which is what the degraded cases pin.
   - FE-S4 says "route the other direct calls the same way where they should count toward
     `connectionLost`". The attachment family is where they should not: an upload's HTTP
     errors carry no code, so two rejected files in a row would have raised a false "could not
     reach Home Assistant". That exception is in the code and in the doc.
   - FE-S8 names three seq guards; the subscribe round and the area-registry generation are
     the same mechanism, so `Latest` serves all five and `dispose()` invalidates the two that
     outlive it.
   - FE-S5 says the `try/catch` difference between the two unwraps is harmless either way; the
     merged opener keeps the safer one, so the registry watch now swallows a throwing
     unsubscribe it would previously have let escape into a promise nobody awaits.
   - The measurement's FE-S3 line counts predate #632 and #633; the numbers in the counting
     table are from this diff.
5. **Follow-ups** — the two above, neither filed, with reasons.
6. **State left behind** — branch `claude/v0-8-0-m3-store-refactor`, no assets branch, no HA
   touched. Counting for this PR: production removed 359 · test removed 53 · added 355.


---
_Generated by [Claude Code](https://claude.ai/code/session_014oboNMQzmHqX7YoyPmw466)_