### PR TITLE
refactor(card): the discard question asked in one place

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -983,6 +983,53 @@ describe('hv-card-shell: adding an item on a phone', () => {
         discardPrompt().confirmLabel,
       );
     });
+
+    // One asker for every form on this host — the inline expander, the phone add
+    // sheet, the detail sheet's form and the expanded view's — so none of them
+    // can grow a second wording or a second dialog.
+    it('hands the same asker to every surface that hosts a form', async () => {
+      const { sr } = await dirtyAddSheet();
+      const asker = (sr.querySelector('hv-item-editor') as HTMLElement & { confirmDiscard: unknown })
+        .confirmDiscard;
+
+      expect(asker).toBeTypeOf('function');
+      for (const testid of ['card-detail-sheet', 'card-full-view']) {
+        const surface = sr.querySelector(`[data-testid="${testid}"]`) as HTMLElement & {
+          confirmDiscard: unknown;
+        };
+        expect(surface.confirmDiscard, testid).toBe(asker);
+      }
+    });
+  });
+});
+
+// The prompt takes focus out of the form to land it on its accept button, so a
+// "no" that left focus behind on `<body>` stranded a keyboard user in a form
+// they had just chosen to stay in.
+describe('hv-card-shell: declining the question puts focus back in the form', () => {
+  it('refocuses the form the answer kept', async () => {
+    const { el, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Target' })] });
+    const list = sr.querySelector('hv-list') as HTMLElement;
+    const row = list.shadowRoot?.querySelector('hv-list-row') as HTMLElement;
+    (row.shadowRoot?.querySelector('[data-testid="row-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const form = list.shadowRoot?.querySelector('hv-item-editor') as HTMLElement;
+    const name = form.shadowRoot?.querySelector('[data-testid="editor-name"]') as HTMLInputElement;
+    name.value = 'Target EDITED';
+    name.dispatchEvent(new Event('input'));
+    await settle(el);
+
+    (form.shadowRoot?.querySelector('[data-testid="editor-cancel"]') as HTMLButtonElement).click();
+    await settle(el);
+    const guard = sr.querySelector('[data-testid="host-confirm"]') as HTMLElement & { open: boolean };
+    expect(guard.open).toBe(true);
+
+    (guard.shadowRoot?.querySelector('[data-testid="confirm-cancel"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(form.shadowRoot?.activeElement).toBe(name);
+    expect(name.value).toBe('Target EDITED');
   });
 });
 
@@ -1364,7 +1411,7 @@ describe('hv-card-shell: the open editor survives a refetch', () => {
     await settle(el);
     // Typed edits are on the form, so Cancel asks; the pin survives the question
     // and is released by the answer.
-    const guard = editor(sr)?.shadowRoot?.querySelector('[data-testid="editor-discard-confirm"]') as HTMLElement & {
+    const guard = sr.querySelector('[data-testid="host-confirm"]') as HTMLElement & {
       open: boolean;
     };
     expect(guard.open).toBe(true);

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -13,7 +13,6 @@ import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
-import { discardPrompt } from '../ui/discard';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
 import { HostSurfaces } from '../host-surfaces';
@@ -584,12 +583,9 @@ export class HVCardShell extends LitElement {
   private _startEdit(next: string | 'new' | null) {
     if (this._editing === next) return;
     if (this._editing !== null && this._editor?.dirty) {
-      this.surfaces.confirm({
-        ...discardPrompt(),
-        onConfirm: () => {
-          this._editorError = null;
-          this._editing = next;
-        },
+      this.surfaces.confirmDiscard(() => {
+        this._editorError = null;
+        this._editing = next;
       });
       return;
     }
@@ -667,6 +663,7 @@ export class HVCardShell extends LitElement {
       .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
       .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
       .createLocation=${this._createLocationForEditor}
+      .confirmDiscard=${this.surfaces.confirmDiscard}
       ?mobile=${this.mobile}
       .busy=${this._editorBusy}
       .errorMessage=${this._editorError}
@@ -1027,6 +1024,7 @@ export class HVCardShell extends LitElement {
         .columns=${this.surfaces.columns}
         .quickFilters=${this.quickFilters}
         .menuEntries=${this.surfaces.menuEntries()}
+        .confirmDiscard=${this.surfaces.confirmDiscard}
         ?startSelecting=${this._startSelecting}
         @close=${() => {
           this._fullViewOpen = false;
@@ -1125,6 +1123,7 @@ export class HVCardShell extends LitElement {
             .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
             .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
             .createLocation=${this._createLocationForEditor}
+            .confirmDiscard=${this.surfaces.confirmDiscard}
             .busy=${this._editorBusy}
             .errorMessage=${this._editorError}
             @cancel=${() => {

--- a/cards/haventory-card/src/components/hv-detail-sheet.test.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.test.ts
@@ -3,6 +3,7 @@ import { setLanguage } from '../i18n';
 import {
   all,
   componentCss,
+  discardAsker,
   makeAttachment,
   makeItem,
   makeManual,
@@ -18,7 +19,6 @@ vi.mock('../ui/clipboard', async (importOriginal) => ({
   copyText: vi.fn(async () => true),
 }));
 import { copyText } from '../ui/clipboard';
-import { discardPrompt } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, attachmentNameToken } from '../ui/media';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVDetailSheet } from './hv-detail-sheet';
@@ -486,9 +486,14 @@ describe('hv-detail-sheet: edit view', () => {
 // swipe-down or the Back arrow took the typing with them. The sheet answers for
 // the form it hosts — a host outside cannot see into this shadow root.
 describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
+  let host = discardAsker();
+  beforeEach(() => {
+    host = discardAsker();
+  });
+
   /** Open the edit form and type into it. */
   async function dirtySheet() {
-    const el = await mount({ id: '1', name: 'A' });
+    const el = await mount({ id: '1', name: 'A' }, { confirmDiscard: host.ask });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
     await settle(el);
     const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement;
@@ -499,11 +504,6 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     expect(el.dirty).toBe(true);
     return el;
   }
-
-  const guard = (el: HVDetailSheet) =>
-    q(el, '[data-testid="sheet-discard-confirm"]') as HTMLElement & { open: boolean };
-  const press = (el: HVDetailSheet, testid: 'confirm-accept' | 'confirm-cancel') =>
-    (guard(el).shadowRoot?.querySelector(`[data-testid="${testid}"]`) as HTMLButtonElement).click();
 
   /** The three ways out, each landing on the sheet's own cancel path. */
   const dismissals = {
@@ -542,12 +542,12 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     dismissals[how](el);
     await settle(el);
 
-    expect(guard(el).open).toBe(true);
+    expect(host.asked).toBe(1);
     expect(cancels).toBe(0);
     expect(el.open).toBe(true);
     expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
 
-    press(el, 'confirm-accept');
+    host.answer('discard');
     await settle(el);
     expect(cancels).toBe(1);
     expect(el.open).toBe(false);
@@ -558,7 +558,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
   // The grip is hidden in edit mode, so the drag is exercised on the read view:
   // clean there, and it must not start asking about nothing.
   it('dismisses a clean read view on a swipe without a question', async () => {
-    const el = await mount({ id: '1', name: 'A' });
+    const el = await mount({ id: '1', name: 'A' }, { confirmDiscard: host.ask });
     let cancels = 0;
     el.addEventListener('cancel', () => {
       cancels += 1;
@@ -567,7 +567,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     dismissals.swipe(el);
     await settle(el);
 
-    expect(guard(el).open).toBe(false);
+    expect(host.asked).toBe(0);
     expect(cancels).toBe(1);
     expect(el.open).toBe(false);
   });
@@ -577,31 +577,42 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
 
     (q(el, '[data-testid="sheet-back"]') as HTMLButtonElement).click();
     await settle(el);
-    expect(guard(el).open).toBe(true);
+    expect(host.asked).toBe(1);
     expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
 
-    press(el, 'confirm-accept');
+    host.answer('discard');
     await settle(el);
     // Back lands on the read view; the sheet itself stays up.
     expect(el.open).toBe(true);
     expect(q(el, '[data-testid="sheet-qty"]')).toBeTruthy();
   });
 
-  it('asks the same question the form asks itself', async () => {
+  // The form inside asks through the same host, so a dismissal and the form's
+  // own Cancel cannot end up as two different questions.
+  it('hands the form the same asker it uses itself', async () => {
     const el = await dirtySheet();
+    const editor = q(el, '[data-testid="sheet-editor"]') as HTMLElement & {
+      confirmDiscard: unknown;
+    };
+    expect(editor.confirmDiscard).toBe(host.ask);
+  });
+
+  // Declining leaves the sheet exactly where the question found it.
+  it('keeps the form when the question is declined', async () => {
+    const el = await dirtySheet();
+    let cancels = 0;
+    el.addEventListener('cancel', () => {
+      cancels += 1;
+    });
+
     dismissals.scrim(el);
     await settle(el);
+    host.answer('keep');
+    await settle(el);
 
-    const panel = guard(el).shadowRoot as ShadowRoot;
-    expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
-      discardPrompt().heading,
-    );
-    expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
-      discardPrompt().message,
-    );
-    expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
-      discardPrompt().confirmLabel,
-    );
+    expect(cancels).toBe(0);
+    expect(el.open).toBe(true);
+    expect(q(el, '[data-testid="sheet-editor"]')).toBeTruthy();
   });
 
   // Every cancel in the card is composed, so backing out of the date step must
@@ -626,7 +637,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
   });
 
   it('closes a clean form on the scrim without asking', async () => {
-    const el = await mount({ id: '1', name: 'A' });
+    const el = await mount({ id: '1', name: 'A' }, { confirmDiscard: host.ask });
     (q(el, '[data-testid="sheet-edit"]') as HTMLButtonElement).click();
     await settle(el);
     let cancels = 0;
@@ -637,7 +648,7 @@ describe('hv-detail-sheet: a dirty form is asked about before it goes', () => {
     dismissals.scrim(el);
     await settle(el);
 
-    expect(guard(el).open).toBe(false);
+    expect(host.asked).toBe(0);
     expect(cancels).toBe(1);
     expect(el.open).toBe(false);
   });

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -22,13 +22,11 @@ import {
   pictures,
 } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
-import { discardPrompt } from '../ui/discard';
+import type { ConfirmDiscard } from '../ui/discard';
 import { COPIED_MS, copyText } from '../ui/clipboard';
-import { ViewportNarrow } from '../ui/responsive';
 import type { AreaRef, Item, Location, LocationTreeNode, MediaConfig, ScalarValue, StatusDefinition } from '../store/types';
 import './hv-bottom-sheet';
 import './hv-checkout-popover';
-import './hv-confirm';
 import './hv-item-editor';
 import './hv-lightbox';
 import type { HVBottomSheet } from './hv-bottom-sheet';
@@ -453,6 +451,15 @@ export class HVDetailSheet extends LitElement {
   /** Passed straight to the editor: creating a first location from its picker. */
   @property({ attribute: false }) createLocation: ((name: string) => Promise<Location>) | null =
     null;
+  /**
+   * The host's discard question, for this sheet and for the form inside it.
+   *
+   * Both ask it: the form for its own Cancel, this sheet for the Back arrow,
+   * the scrim, a swipe and Escape. The dialog has to outlive the sheet — a
+   * confirmed dismissal takes the sheet down with it — so it belongs to the
+   * host, and null leaves the sheet dismissible without a question.
+   */
+  @property({ attribute: false }) confirmDiscard: ConfirmDiscard | null = null;
   @property({ type: Boolean }) busy = false;
   @property({ type: String }) errorMessage: string | null = null;
 
@@ -470,12 +477,6 @@ export class HVDetailSheet extends LitElement {
   /** Which picture the lightbox was opened on, or null when it is closed. */
   @state() private _lightbox: number | null = null;
   /**
-   * Where the sheet goes once a discard is confirmed, or null while nothing is
-   * being asked. The two answers differ: leaving the form lands on the read
-   * view, dismissing the sheet takes the whole surface down.
-   */
-  @state() private _pendingDiscard: 'read' | 'close' | null = null;
-  /**
    * Whether the id was copied a moment ago. Set only on a copy the browser
    * confirmed — the button is the only feedback there is, so it must not
    * announce a clipboard that still holds something else.
@@ -484,8 +485,6 @@ export class HVDetailSheet extends LitElement {
   private _copiedTimer?: ReturnType<typeof setTimeout>;
 
   private readonly _urls = new MediaUrls(this);
-  /** Window width, for the confirm this sheet raises over itself. */
-  private readonly _viewport = new ViewportNarrow(this);
   /**
    * The item id the sheet is showing. `undefined` until the first update, so
    * that pass settles the view the same way a move to another item does.
@@ -509,7 +508,6 @@ export class HVDetailSheet extends LitElement {
       this._mode = 'read';
       this._checkoutOpen = false;
       this._lightbox = null;
-      this._pendingDiscard = null;
       this._clearCopied();
     }
   }
@@ -587,16 +585,23 @@ export class HVDetailSheet extends LitElement {
    *
    * The sheet answers for the editor it hosts: a host outside cannot see into
    * this shadow root, and the scrim, the swipe and Escape all arrive here
-   * first. `read` is the Back arrow and the form's own cancel — the sheet stays
-   * up on its read view; `close` is a dismissal and takes the sheet with it.
+   * first. `read` is the Back arrow — the sheet stays up on its read view;
+   * `close` is a dismissal and takes the sheet with it. The dialog is the
+   * host's, so a confirmed dismissal is still answerable once this element has
+   * gone.
    */
   private _leaveEdit(to: 'read' | 'close') {
-    if (this.dirty) {
-      this._pendingDiscard = to;
+    const ask = this.confirmDiscard;
+    if (this.dirty && ask) {
+      ask(() => this._applyLeave(to));
       return;
     }
-    if (to === 'read') this._mode = 'read';
-    else this._close();
+    this._applyLeave(to);
+  }
+
+  private _applyLeave(to: 'read' | 'close') {
+    this._mode = 'read';
+    if (to === 'close') this._close();
   }
 
   /**
@@ -995,6 +1000,7 @@ export class HVDetailSheet extends LitElement {
         .tagSuggestions=${this.tagSuggestions}
         .customFieldKeys=${this.customFieldKeys}
         .createLocation=${this.createLocation}
+        .confirmDiscard=${this.confirmDiscard}
         .busy=${this.busy}
         .errorMessage=${this.errorMessage}
         @cancel=${() => {
@@ -1040,31 +1046,7 @@ export class HVDetailSheet extends LitElement {
           e.stopPropagation();
           this._lightbox = null;
         }}
-      ></hv-lightbox>
-
-      <!-- Outside the sheet, and its events stopped here: the host listens for
-           a cancel event on this element to take the sheet down, and an answer
-           of "no, keep my typing" must not read as that. -->
-      <hv-confirm
-        data-testid="sheet-discard-confirm"
-        ?open=${this._pendingDiscard !== null}
-        ?mobile=${this._viewport.narrow}
-        .heading=${discardPrompt().heading}
-        .message=${discardPrompt().message}
-        .confirmLabel=${discardPrompt().confirmLabel}
-        destructive
-        @confirm=${(e: Event) => {
-          e.stopPropagation();
-          const to = this._pendingDiscard;
-          this._pendingDiscard = null;
-          this._mode = 'read';
-          if (to === 'close') this._close();
-        }}
-        @cancel=${(e: Event) => {
-          e.stopPropagation();
-          this._pendingDiscard = null;
-        }}
-      ></hv-confirm>`;
+      ></hv-lightbox>`;
   }
 }
 

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1,7 +1,6 @@
 import './hv-full-view';
-import { componentCss, makeItem, mountHost, q, settle, stubViewport } from '../test.utils';
+import { componentCss, discardAsker, makeItem, mountHost, q, settle, stubViewport } from '../test.utils';
 import { deepActiveElement, deepFocusables } from '../ui/dialog-focus';
-import { discardPrompt } from '../ui/discard';
 import { toIsoDate } from '../ui/relative-time';
 import type { HVFullView } from './hv-full-view';
 import type { Item, Location, StatusDefinition } from '../store/types';
@@ -22,6 +21,11 @@ function loc(id: string, name: string, parentId: string | null = null): Location
   };
 }
 
+/**
+ * Every mount stands a host beside the surface, the way the card and the panel
+ * do: the discard dialog is the host's, and a surface mounted without one would
+ * answer its own question by not asking it.
+ */
 async function mount(
   opts: {
     items?: Item[];
@@ -32,7 +36,8 @@ async function mount(
     narrow?: boolean;
   } = {},
 ) {
-  return mountHost<HVFullView>(
+  const host = discardAsker();
+  const mounted = await mountHost<HVFullView>(
     'hv-full-view',
     {
       items: opts.items ?? [],
@@ -42,12 +47,14 @@ async function mount(
     },
     {
       columns: ['quantity', 'category'],
+      confirmDiscard: host.ask,
       ...(opts.embedded ? { embedded: true } : {}),
       ...(opts.narrow ? { narrow: true } : {}),
       open: true,
     },
     { renders: 2 },
   );
+  return { ...mounted, host };
 }
 
 describe('hv-full-view: phone-width app bar', () => {
@@ -1422,7 +1429,7 @@ describe('hv-full-view: editing', () => {
     });
 
     it('drops the error again when the next edit opens', async () => {
-      const { el, store, sr } = await mount({
+      const { el, store, sr, host } = await mount({
         items: [makeItem({ id: '1', name: 'Old' }), makeItem({ id: '2', name: 'Other' })],
       });
       store['ws'].updateItem = async () => {
@@ -1442,9 +1449,8 @@ describe('hv-full-view: editing', () => {
       await settle(el);
       // The refused save left the typed name in the form, so the switch asks
       // before it takes it away.
-      const guard = q(sr, '[data-testid="full-discard-confirm"]') as HTMLElement & { open: boolean };
-      expect(guard.open).toBe(true);
-      (guard.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement).click();
+      expect(host.asked).toBe(1);
+      host.answer('discard');
       await settle(el);
 
       expect(q(sr, '[data-testid="full-editor"]')?.shadowRoot?.textContent).toContain('Other — editing');
@@ -1492,10 +1498,6 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
     return mounted;
   }
 
-  const guard = (sr: ShadowRoot) =>
-    q(sr, '[data-testid="full-discard-confirm"]') as HTMLElement & { open: boolean };
-  const answer = (sr: ShadowRoot, which: 'confirm-accept' | 'confirm-cancel') =>
-    (guard(sr).shadowRoot?.querySelector(`[data-testid="${which}"]`) as HTMLButtonElement).click();
   const editorName = (sr: ShadowRoot) =>
     (
       (q(sr, '[data-testid="full-editor"]') as HTMLElement | null)?.shadowRoot?.querySelector(
@@ -1526,7 +1528,7 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
   it.each(Object.keys(leave) as (keyof typeof leave)[])(
     '%s asks first and changes nothing until it is answered',
     async (how) => {
-      const { el, sr } = await dirtyEditor(two());
+      const { el, sr, host } = await dirtyEditor(two());
       let closes = 0;
       el.addEventListener('close', () => {
         closes += 1;
@@ -1535,7 +1537,7 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
       leave[how](sr);
       await settle(el);
 
-      expect(guard(sr).open).toBe(true);
+      expect(host.asked).toBe(1);
       expect(closes).toBe(0);
       expect(el.open).toBe(true);
       expect(editorName(sr)).toBe('Typed but unsaved');
@@ -1545,11 +1547,11 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
 
 
   it('opens the other row once the discard is confirmed', async () => {
-    const { el, sr } = await dirtyEditor(two());
+    const { el, sr, host } = await dirtyEditor(two());
 
     leave['row switch'](sr);
     await settle(el);
-    answer(sr, 'confirm-accept');
+    host.answer('discard');
     await settle(el);
 
     expect(q(sr, '[data-testid="full-editor"]')?.shadowRoot?.textContent).toContain('Second — editing');
@@ -1559,7 +1561,7 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
   it.each(['backdrop', 'escape', 'close'] as const)(
     'closes the view once %s is confirmed',
     async (how) => {
-      const { el, sr } = await dirtyEditor(two());
+      const { el, sr, host } = await dirtyEditor(two());
       let closes = 0;
       el.addEventListener('close', () => {
         closes += 1;
@@ -1567,7 +1569,7 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
 
       leave[how](sr);
       await settle(el);
-      answer(sr, 'confirm-accept');
+      host.answer('discard');
       await settle(el);
 
       expect(closes).toBe(1);
@@ -1576,7 +1578,7 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
   );
 
   it('leaves a clean form without a word', async () => {
-    const { el, sr } = await mount({ items: two() });
+    const { el, sr, host } = await mount({ items: two() });
     const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
     (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
     await settle(el);
@@ -1584,14 +1586,14 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
     leave['row switch'](sr);
     await settle(el);
 
-    expect(guard(sr).open).toBe(false);
+    expect(host.asked).toBe(0);
     expect(editorName(sr)).toBe('Second');
   });
 
   // The panel has no backdrop, no Escape and no close button, but it switches
   // rows in the same table.
   it('asks on a row switch in the embedded panel too', async () => {
-    const { el, sr } = await mount({ items: two(), embedded: true });
+    const { el, sr, host } = await mount({ items: two(), embedded: true });
     const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
     (table.shadowRoot?.querySelector('[data-testid="table-edit"]') as HTMLButtonElement).click();
     await settle(el);
@@ -1605,25 +1607,28 @@ describe('hv-full-view: leaving a dirty form always asks', () => {
     leave['row switch'](sr);
     await settle(el);
 
-    expect(guard(sr).open).toBe(true);
+    expect(host.asked).toBe(1);
     expect(editorName(sr)).toBe('Typed but unsaved');
   });
 
-  it('asks the same question the form asks itself', async () => {
-    const { el, sr } = await dirtyEditor(two());
+  // The form inside asks through the same host, so this surface's ways out and
+  // the form's own Cancel cannot become two different questions.
+  it('hands the form the same asker it uses itself', async () => {
+    const { sr, host } = await dirtyEditor(two());
+    const editor = q(sr, '[data-testid="full-editor"]') as HTMLElement & { confirmDiscard: unknown };
+    expect(editor.confirmDiscard).toBe(host.ask);
+  });
+
+  it('keeps the form when the question is declined', async () => {
+    const { el, sr, host } = await dirtyEditor(two());
+
     leave.backdrop(sr);
     await settle(el);
+    host.answer('keep');
+    await settle(el);
 
-    const panel = guard(sr).shadowRoot as ShadowRoot;
-    expect(panel.querySelector('[data-testid="confirm-dialog"]')?.getAttribute('aria-label')).toBe(
-      discardPrompt().heading,
-    );
-    expect(panel.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
-      discardPrompt().message,
-    );
-    expect(panel.querySelector('[data-testid="confirm-accept"]')?.textContent).toContain(
-      discardPrompt().confirmLabel,
-    );
+    expect(el.open).toBe(true);
+    expect(editorName(sr)).toBe('Typed but unsaved');
   });
 });
 
@@ -2505,7 +2510,7 @@ describe('hv-full-view: table row actions', () => {
   });
 
   it('opens the form from the menu, through the same dirty guard as a row click', async () => {
-    const { el, sr } = await mount({
+    const { el, sr, host } = await mount({
       items: [makeItem({ id: '1', name: 'First' }), makeItem({ id: '2', name: 'Second' })],
     });
     const table = q(sr, '[data-testid="full-table"]') as HTMLElement;
@@ -2521,9 +2526,7 @@ describe('hv-full-view: table row actions', () => {
     pick(sr, 'edit', 1);
     await settle(el);
 
-    expect((q(sr, '[data-testid="full-discard-confirm"]') as HTMLElement & { open: boolean }).open).toBe(
-      true,
-    );
+    expect(host.asked).toBe(1);
   });
 });
 

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -26,7 +26,7 @@ import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { editorErrorText } from '../ui/editor-error';
-import { discardPrompt } from '../ui/discard';
+import type { ConfirmDiscard } from '../ui/discard';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
 import { NARROW_QUERY } from '../ui/responsive';
@@ -943,6 +943,15 @@ export class HVFullView extends LitElement {
    * breakpoint: HA sets this whenever the sidebar is collapsed, at any width.
    */
   @property({ type: Boolean }) narrow = false;
+  /**
+   * The host's discard question, for this surface, its form and its sheet.
+   *
+   * This surface leaves an open form for another row, for the create form or by
+   * closing altogether, and the last of those takes the asker down with it — so
+   * the dialog belongs to the host, which is still standing afterwards. Null
+   * leaves the form without a question.
+   */
+  @property({ attribute: false }) confirmDiscard: ConfirmDiscard | null = null;
 
   @state() private _zBase = 0;
   @state() private _filtersOpen = false;
@@ -1051,11 +1060,6 @@ export class HVFullView extends LitElement {
     itemId: string;
     mode: 'check-out' | 'set-due-date';
   } | null = null;
-  /**
-   * Where the surface goes once a discard is confirmed, or null while nothing
-   * is being asked: another row, the create form, or the view closing.
-   */
-  @state() private _pendingDiscard: string | 'new' | 'close' | null = null;
   @state() private _loadingAll = false;
   /** Set while a batch is running so Cancel can stop it between chunks. */
   private _bulkCancelled = false;
@@ -1154,7 +1158,6 @@ export class HVFullView extends LitElement {
         this._editing = null;
         this._detailItemId = null;
         this._editorError = null;
-        this._pendingDiscard = null;
         this._creatingLocation = false;
         this._locationError = null;
         this._selecting = false;
@@ -1261,13 +1264,13 @@ export class HVFullView extends LitElement {
    * the whole surface — asking first if there is typing to lose.
    *
    * The form asks for its own Cancel, ✕ and Escape, but only about closing.
-   * Everything here has somewhere else to be afterwards, so the question is
-   * raised on this side and the destination held until it is answered. Same
-   * wording either way: `ui/discard` owns it.
+   * Everything here has somewhere else to be afterwards, so the destination is
+   * held in the callback until the host's question comes back answered.
    */
   private _leaveEditor(to: string | 'new' | 'close') {
-    if (this._editing !== null && this._editor?.dirty) {
-      this._pendingDiscard = to;
+    const ask = this.confirmDiscard;
+    if (ask && this._editing !== null && this._editor?.dirty) {
+      ask(() => this._applyLeave(to));
       return;
     }
     this._applyLeave(to);
@@ -1335,8 +1338,6 @@ export class HVFullView extends LitElement {
       this._pinnedItem = null;
       this._editing = null;
       this._editorError = null;
-      // Nothing left to discard, so the question — if one was up — is moot.
-      this._pendingDiscard = null;
       return;
     }
     const listed = this.st?.items.find((i) => i.id === editing);
@@ -2470,6 +2471,7 @@ export class HVFullView extends LitElement {
                     .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
                     .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
                     .createLocation=${this._createLocationForEditor}
+                    .confirmDiscard=${this.confirmDiscard}
                     .busy=${this._editorBusy}
                     .errorMessage=${this._editorError}
                     ?mobile=${this._narrow}
@@ -2593,6 +2595,7 @@ export class HVFullView extends LitElement {
               .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
               .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
               .createLocation=${this._createLocationForEditor}
+              .confirmDiscard=${this.confirmDiscard}
               .busy=${this._editorBusy}
               .errorMessage=${this._editorError}
               @cancel=${() => {
@@ -2675,24 +2678,6 @@ export class HVFullView extends LitElement {
             this._pendingBulkCheckout = false;
           }}
         ></hv-checkout-popover>
-
-        <hv-confirm
-          data-testid="full-discard-confirm"
-          ?open=${this._pendingDiscard !== null}
-          ?mobile=${this._narrow}
-          .heading=${discardPrompt().heading}
-          .message=${discardPrompt().message}
-          .confirmLabel=${discardPrompt().confirmLabel}
-          destructive
-          @confirm=${() => {
-            const to = this._pendingDiscard;
-            this._pendingDiscard = null;
-            if (to !== null) this._applyLeave(to);
-          }}
-          @cancel=${() => {
-            this._pendingDiscard = null;
-          }}
-        ></hv-confirm>
     `;
   }
 

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -3,6 +3,7 @@ import './hv-item-editor';
 import {
   all,
   componentCss,
+  discardAsker,
   makeAttachment,
   makeItem,
   makeManual,
@@ -19,7 +20,6 @@ vi.mock('../ui/clipboard', async (importOriginal) => ({
   copyText: vi.fn(async () => true),
 }));
 import { copyText } from '../ui/clipboard';
-import { discardPrompt } from '../ui/discard';
 import { MEDIA_NAME_TOKEN_PARAM, MEDIA_SIZE_PARAM, attachmentNameToken } from '../ui/media';
 import { addDays } from '../ui/relative-time';
 import type { HVItemEditor } from './hv-item-editor';
@@ -1159,7 +1159,8 @@ describe('hv-item-editor: Escape takes back one thing at a time', () => {
   });
 
   it('asks before discarding a form that has been typed into', async () => {
-    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const host = discardAsker();
+    const el = await mount(makeItem({ id: '1', name: 'A' }), { confirmDiscard: host.ask });
     const cancels = onCancel(el);
     await type(el, 'editor-name', 'A longer name');
     expect(el.dirty).toBe(true);
@@ -1167,11 +1168,10 @@ describe('hv-item-editor: Escape takes back one thing at a time', () => {
     esc(el);
     await el.updateComplete;
 
-    const guard = await dialog(el, 'editor-discard-confirm');
-    expect(guard.open).toBe(true);
+    expect(host.asked).toBe(1);
     expect(cancels.count).toBe(0);
 
-    (guard.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement).click();
+    host.answer('discard');
     await el.updateComplete;
     expect(cancels.count).toBe(1);
   });
@@ -1186,49 +1186,49 @@ describe('hv-item-editor: Escape takes back one thing at a time', () => {
 describe('hv-item-editor: every close this form owns asks the same question', () => {
   const paths = ['editor-cancel', 'editor-close'] as const;
 
-  it.each(paths)('%s asks before throwing typed edits away', async (testid) => {
-    const el = await mount(makeItem({ id: '1', name: 'A' }));
+  /** A dirty form with a host standing by to answer for it. */
+  async function dirtyForm() {
+    const host = discardAsker();
+    const el = await mount(makeItem({ id: '1', name: 'A' }), { confirmDiscard: host.ask });
     let cancels = 0;
     el.addEventListener('cancel', () => {
       cancels += 1;
     });
     await type(el, 'editor-name', 'A longer name');
+    return { el, host, cancels: () => cancels };
+  }
+
+  it.each(paths)('%s asks before throwing typed edits away', async (testid) => {
+    const { el, host, cancels } = await dirtyForm();
 
     (q(el, `[data-testid="${testid}"]`) as HTMLButtonElement).click();
     await el.updateComplete;
 
-    const guard = await dialog(el, 'editor-discard-confirm');
-    expect(guard.open).toBe(true);
-    expect(guard.shadowRoot?.querySelector('[data-testid="confirm-message"]')?.textContent).toContain(
-      discardPrompt().message,
-    );
-    expect(cancels).toBe(0);
+    expect(host.asked).toBe(1);
+    expect(cancels()).toBe(0);
 
-    (guard.shadowRoot?.querySelector('[data-testid="confirm-accept"]') as HTMLButtonElement).click();
+    host.answer('discard');
     await el.updateComplete;
-    expect(cancels).toBe(1);
+    expect(cancels()).toBe(1);
   });
 
   it.each(paths)('%s keeps the typing when the question is declined', async (testid) => {
-    const el = await mount(makeItem({ id: '1', name: 'A' }));
-    let cancels = 0;
-    el.addEventListener('cancel', () => {
-      cancels += 1;
-    });
-    await type(el, 'editor-name', 'A longer name');
+    const { el, host, cancels } = await dirtyForm();
 
     (q(el, `[data-testid="${testid}"]`) as HTMLButtonElement).click();
     await el.updateComplete;
-    const guard = await dialog(el, 'editor-discard-confirm');
-    (guard.shadowRoot?.querySelector('[data-testid="confirm-cancel"]') as HTMLButtonElement).click();
+    host.answer('keep');
     await el.updateComplete;
 
-    expect(cancels).toBe(0);
+    expect(cancels()).toBe(0);
     expect((q(el, '[data-testid="editor-name"]') as HTMLInputElement).value).toBe('A longer name');
+    // The question took focus out of the form, so declining it puts focus back.
+    expect(el.shadowRoot?.activeElement).toBe(q(el, '[data-testid="editor-name"]'));
   });
 
   it.each(paths)('%s closes a clean form without asking', async (testid) => {
-    const el = await mount(makeItem({ id: '1', name: 'A' }));
+    const host = discardAsker();
+    const el = await mount(makeItem({ id: '1', name: 'A' }), { confirmDiscard: host.ask });
     let cancels = 0;
     el.addEventListener('cancel', () => {
       cancels += 1;
@@ -1238,39 +1238,25 @@ describe('hv-item-editor: every close this form owns asks the same question', ()
     await el.updateComplete;
 
     expect(cancels).toBe(1);
-    expect((await dialog(el, 'editor-discard-confirm')).open).toBe(false);
+    expect(host.asked).toBe(0);
   });
 
-  // A host with somewhere to go afterwards asks this instead of firing `cancel`
-  // blind: false means the form has taken the question on itself.
-  it('reports whether a host may tear the form down', async () => {
-    const el = await mount(makeItem({ id: '1', name: 'A' }));
-    expect(el.requestClose()).toBe(true);
-
-    await type(el, 'editor-name', 'A longer name');
-    expect(el.requestClose()).toBe(false);
-    await el.updateComplete;
-    expect((await dialog(el, 'editor-discard-confirm')).open).toBe(true);
-  });
-
-  // Both dialogs are fixed to the window, so they take their phone form from the
-  // viewport — the form's own `mobile` is the card element's width and would put
-  // a bottom sheet on a desktop monitor whenever the card sat in a narrow column.
-  it.each(['editor-discard-confirm', 'editor-remove-confirm'] as const)(
-    '%s takes its phone form from the viewport, not the card',
-    async (confirmId) => {
-      for (const narrow of [true, false]) {
-        const restore = stubViewport(narrow);
-        try {
-          const el = await mount(makeItem({ id: '1', name: 'A' }), { mobile: !narrow });
-          expect((await dialog(el, confirmId)).hasAttribute('mobile')).toBe(narrow);
-          el.remove();
-        } finally {
-          restore();
-        }
+  // The remove dialog is fixed to the window, so it takes its phone form from
+  // the viewport — the form's own `mobile` is the card element's width and would
+  // put a bottom sheet on a desktop monitor whenever the card sat in a narrow
+  // column.
+  it('editor-remove-confirm takes its phone form from the viewport, not the card', async () => {
+    for (const narrow of [true, false]) {
+      const restore = stubViewport(narrow);
+      try {
+        const el = await mount(makeItem({ id: '1', name: 'A' }), { mobile: !narrow });
+        expect((await dialog(el, 'editor-remove-confirm')).hasAttribute('mobile')).toBe(narrow);
+        el.remove();
+      } finally {
+        restore();
       }
-    },
-  );
+    }
+  });
 });
 
 // The first minute of a fresh install: an item form whose most important field

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -16,7 +16,7 @@ import {
 import { onDayChange } from '../ui/day-clock';
 import { saveShortcutLabel } from '../ui/keyboard';
 import { counted } from '../ui/plural';
-import { discardPrompt } from '../ui/discard';
+import type { ConfirmDiscard } from '../ui/discard';
 import { COPIED_MS, copyText } from '../ui/clipboard';
 import { ViewportNarrow } from '../ui/responsive';
 import { nextZBase } from '../utils/zindex';
@@ -1172,6 +1172,17 @@ export class HVItemEditor extends LitElement {
   @property({ attribute: false }) createLocation: ((name: string) => Promise<Location>) | null =
     null;
 
+  /**
+   * How this form asks before its own Cancel, ✕ or Escape throws typing away.
+   *
+   * The dialog belongs to the host, not to the form: the same question is asked
+   * when a host switches rows or takes a sheet down, and one asker means one
+   * wording and one prompt on screen however the user left. Null closes without
+   * asking — every host in this card passes one, and a form that could not be
+   * left at all would be worse than one that closes quietly.
+   */
+  @property({ attribute: false }) confirmDiscard: ConfirmDiscard | null = null;
+
   @state() private _model: ItemFormModel = formFromItem(null);
   @state() private _errors: FieldError[] = [];
   @state() private _showErrors = false;
@@ -1215,8 +1226,6 @@ export class HVItemEditor extends LitElement {
   @state() private _dropTarget: AttachmentKind | null = null;
   /** Which photo the lightbox was opened on, or null when it is closed. */
   @state() private _lightbox: number | null = null;
-  /** Escape on a dirty form asks before it throws the typing away. */
-  @state() private _confirmDiscard = false;
   /**
    * Whether the item's id was copied a moment ago. Set only on a copy the
    * browser confirmed — the button is the only feedback there is, so it must
@@ -1287,7 +1296,6 @@ export class HVItemEditor extends LitElement {
       this._uploads = [];
       this._uploaded = null;
       this._confirmRemove = null;
-      this._confirmDiscard = false;
       this._lightbox = null;
       this._locationError = null;
       this._createdLocations = [];
@@ -1344,23 +1352,22 @@ export class HVItemEditor extends LitElement {
   };
 
   /**
-   * Ask the form to close, and say whether the caller may tear it down now.
+   * Every close this form owns: Cancel, the ✕, and Escape with nothing over it.
    *
-   * `false` means the form has raised the discard question itself: the caller
-   * does nothing further and waits for the `cancel` event a confirmed discard
-   * sends, which is the same event Cancel sends on a clean form. A host with
-   * somewhere else to go afterwards — another row, a whole surface closing —
-   * asks its own copy of the question instead, from `ui/discard`.
+   * A clean form goes at once. A dirty one hands the question to the host and
+   * waits: `cancel` is sent only once the answer is yes, and it is the same
+   * event either way, so a host closes the form on one signal however it went.
    */
-  requestClose(): boolean {
-    if (!this.dirty) return true;
-    this._confirmDiscard = true;
-    return false;
-  }
-
-  /** Every close this form owns: Cancel, the ✕, and Escape with nothing over it. */
   private _requestCancel = () => {
-    if (this.requestClose()) this._cancel();
+    const ask = this.confirmDiscard;
+    if (!this.dirty || !ask) {
+      this._cancel();
+      return;
+    }
+    ask(
+      () => this._cancel(),
+      () => this._refocus(),
+    );
   };
 
   /**
@@ -2977,14 +2984,14 @@ export class HVItemEditor extends LitElement {
         }}
       ></hv-lightbox>
 
-      <!-- Outside the form's own keydown scope, and their events stopped here:
-           a host listens for the cancel event on this editor to close it, and a
+      <!-- Outside the form's own keydown scope, and its events stopped here: a
+           host listens for the cancel event on this editor to close it, and a
            dialog saying "no, keep the photo" must not read as "close the
            form".
 
            The mobile flag below is the viewport, not this form's own mobile
-           property: both dialogs are fixed to the window, so the card's width
-           says nothing about the room they have. -->
+           property: the dialog is fixed to the window, so the card's width says
+           nothing about the room it has. -->
       <hv-confirm
         data-testid="editor-remove-confirm"
         ?open=${this._confirmRemove !== null}
@@ -3002,26 +3009,6 @@ export class HVItemEditor extends LitElement {
         @cancel=${(e: Event) => {
           e.stopPropagation();
           this._confirmRemove = null;
-          this._refocus();
-        }}
-      ></hv-confirm>
-
-      <hv-confirm
-        data-testid="editor-discard-confirm"
-        ?open=${this._confirmDiscard}
-        ?mobile=${this._viewport.narrow}
-        .heading=${discardPrompt().heading}
-        .message=${discardPrompt().message}
-        .confirmLabel=${discardPrompt().confirmLabel}
-        destructive
-        @confirm=${(e: Event) => {
-          e.stopPropagation();
-          this._confirmDiscard = false;
-          this._cancel();
-        }}
-        @cancel=${(e: Event) => {
-          e.stopPropagation();
-          this._confirmDiscard = false;
           this._refocus();
         }}
       ></hv-confirm>

--- a/cards/haventory-card/src/haventory-panel.ts
+++ b/cards/haventory-card/src/haventory-panel.ts
@@ -138,6 +138,7 @@ export class HAventoryPanel extends LitElement {
         .quickFilters=${this._quickFilters()}
         .columns=${this.surfaces.columns}
         .menuEntries=${this.surfaces.menuEntries()}
+        .confirmDiscard=${this.surfaces.confirmDiscard}
         @menu-action=${this._onMenuAction}
         @request-delete=${(e: CustomEvent) =>
           this.surfaces.requestDeleteById((e.detail as { itemId: string }).itemId)}

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -6,6 +6,8 @@ import { activeFilterCount, defaultFilters } from './store/store';
 import type { Store } from './store/store';
 import type { ImportPolicy, ImportPreview, ImportSummary } from './store/types';
 import { t, tn } from './i18n';
+import { discardPrompt } from './ui/discard';
+import type { ConfirmDiscard } from './ui/discard';
 import { NARROW_QUERY } from './ui/responsive';
 import type { OrganizeTab } from './components/hv-organize-dialog';
 import type { OverflowMenuEntry } from './components/hv-overflow-menu';
@@ -27,6 +29,8 @@ interface ConfirmSpec {
   confirmLabel?: string;
   destructive?: boolean;
   onConfirm: () => void;
+  /** A declined prompt, for a caller that has to put focus back afterwards. */
+  onCancel?: () => void;
 }
 
 /** The ways a host differs; everything else in these surfaces is identical. */
@@ -174,6 +178,18 @@ export class HostSurfaces {
     this.host.requestUpdate();
   }
 
+  /**
+   * The one place the card asks whether typed edits may be thrown away.
+   *
+   * Every form that can be left with typing in it — the inline expander, the
+   * phone add sheet, the detail sheet's form, the full view's — is handed this
+   * and calls it without knowing which host it is on. A bound field rather than
+   * a method so a host can pass it straight down as a property.
+   */
+  readonly confirmDiscard: ConfirmDiscard = (onConfirm, onCancel) => {
+    this.confirm({ ...discardPrompt(), onConfirm, onCancel });
+  };
+
   /** The delete flow: look the item up, ask, then send version-checked delete. */
   requestDeleteById(itemId: string): void {
     const store = this.getStore();
@@ -310,8 +326,10 @@ export class HostSurfaces {
           this.host.requestUpdate();
         }}
         @cancel=${() => {
+          const declined = this.confirmSpec;
           this.confirmSpec = null;
           this.host.requestUpdate();
+          declined?.onCancel?.();
         }}
       ></hv-confirm>
 

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -2,6 +2,7 @@ import type { CSSResult } from 'lit';
 import { vi } from 'vitest';
 
 import { Store } from './store/store';
+import type { ConfirmDiscard } from './ui/discard';
 import { toIsoDate } from './ui/relative-time';
 import type {
   AnyEventPayload,
@@ -1037,6 +1038,42 @@ export function stubElementWidth(width: number): () => void {
   } as unknown as typeof ResizeObserver;
   return () => {
     globalThis.ResizeObserver = original;
+  };
+}
+
+/** A captured discard question, and the two answers a host can give it. */
+export interface DiscardAsker {
+  /** Hand this to a `confirmDiscard` property. */
+  ask: ConfirmDiscard;
+  /** How many times the surface under test has asked. */
+  readonly asked: number;
+  /** Answer the outstanding question; throws when nothing was asked. */
+  answer(which: 'discard' | 'keep'): void;
+}
+
+/**
+ * The host's discard question, captured instead of drawn.
+ *
+ * The dialog belongs to `HostSurfaces`, so a form or a sheet mounted on its own
+ * has no way to put one on screen — what it owes is asking, waiting, and acting
+ * on the answer, which is what this pins. `hv-card-shell`'s own tests are where
+ * the real prompt and its wording are asserted.
+ */
+export function discardAsker(): DiscardAsker {
+  const pending: { onConfirm: () => void; onCancel?: (() => void) | undefined }[] = [];
+  return {
+    ask: (onConfirm, onCancel) => {
+      pending.push({ onConfirm, onCancel });
+    },
+    get asked() {
+      return pending.length;
+    },
+    answer(which) {
+      const question = pending.pop();
+      if (!question) throw new Error('nothing was asked');
+      if (which === 'discard') question.onConfirm();
+      else question.onCancel?.();
+    },
   };
 }
 

--- a/cards/haventory-card/src/ui/discard.ts
+++ b/cards/haventory-card/src/ui/discard.ts
@@ -14,8 +14,8 @@ import { t } from '../i18n';
  * after — so a constant here would freeze the English strings into every
  * surface that spreads it.
  *
- * Spread into `HostSurfaces.confirm()` alongside an `onConfirm`, or bound field
- * by field onto an `hv-confirm`.
+ * Spread into `HostSurfaces.confirm()` alongside an `onConfirm`; that is the
+ * one caller, and `HostSurfaces.confirmDiscard` is how a form reaches it.
  */
 export function discardPrompt(): {
   heading: string;
@@ -30,3 +30,15 @@ export function discardPrompt(): {
     destructive: true,
   };
 }
+
+/**
+ * Put the discard question to the user and act on the answer.
+ *
+ * Forms take this as a property instead of owning a dialog: the question has to
+ * survive the surface that raised it — a sheet coming down, a row being
+ * switched away from — so it is asked by the element hosting the form, which is
+ * still there afterwards. `onConfirm` runs on a yes. `onCancel` is for a form
+ * that has to put focus back where the question took it from; a caller with
+ * nowhere to put it omits it.
+ */
+export type ConfirmDiscard = (onConfirm: () => void, onCancel?: () => void) => void;

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -639,13 +639,17 @@ Any other key in that record is ignored, so an older or newer payload never brea
   expanded view's 70dvh cap), so Save and Cancel land below the fold on all three. The
   editor solves that once; no host grows a pinned footer of its own. The bar bleeds past
   `.grid`'s side padding so its opaque background reaches the form's edges.
-- **No path discards typed edits without asking.** Cancel, the ✕ and Escape are the form's
-  own, so `hv-item-editor` answers for them itself and hosts do not repeat the check; a host
-  with somewhere to go afterwards — another row, a sheet coming down, the expanded view
-  closing — calls `requestClose()` or asks its own copy. Either way the wording comes from
-  `ui/discard`, so the same decision never reads as two different questions. The phone sheets
-  are part of this: `hv-bottom-sheet` reports a scrim tap or a swipe-down and leaves the
-  closing to its host, which is what lets `hv-detail-sheet` answer for the form inside it.
+- **No path discards typed edits without asking, and one place asks.** Cancel, the ✕ and
+  Escape are the form's own; a row switch, a sheet coming down and the expanded view closing
+  belong to the surface around it. All of them call `confirmDiscard` — a
+  `(onConfirm, onCancel?)` callback (`ui/discard`) handed down from `HostSurfaces`, which is
+  the only thing that names the wording and the only thing that puts a dialog on screen. The
+  question has to outlive its asker (a confirmed dismissal takes the sheet down with it), and
+  a form with no dialog of its own cannot ask twice in two wordings. `hv-item-editor`,
+  `hv-detail-sheet` and `hv-full-view` each take the callback as a property and pass it on to
+  the form they host. The phone sheets are part of this: `hv-bottom-sheet` reports a scrim tap
+  or a swipe-down and leaves the closing to its host, which is what lets `hv-detail-sheet`
+  answer for the form inside it.
 - **An attachment whose file is gone is a state, not an error.** Metadata outlives bytes —
   a JSON export carries the references and not the files, and a backup that took `.storage`
   without the config directory's `haventory/` tree leaves every attachment on every item


### PR DESCRIPTION
## Summary

Four surfaces asked whether typed edits could be thrown away, and three of them owned a private `<hv-confirm>` and a state machine to do it — `hv-item-editor` (`_confirmDiscard`), `hv-detail-sheet` (`_pendingDiscard`) and `hv-full-view` (`_pendingDiscard`). Only `hv-card-shell` went through the host's shared confirm.

The question is now one callback. `ui/discard.ts` exports `ConfirmDiscard = (onConfirm, onCancel?) => void`; `HostSurfaces` builds it once from `discardPrompt()` and its own `hv-confirm`, and the card shell and the panel hand it down as a property. `hv-item-editor`, `hv-detail-sheet` and `hv-full-view` each take it and pass it on to the form they host, so every way out of a dirty form — the form's Cancel, ✕ and Escape; the sheet's Back arrow, scrim, swipe and Escape; the view's row switch, backdrop, Escape and close — reaches one dialog with one wording. `discardPrompt()` now has exactly one production caller.

Two things went with the confirms:

- `hv-item-editor.requestClose()`. It existed so a host could tell the form to ask and learn whether it had; no host called it, and with the callback the form never has to report back.
- `hv-detail-sheet`'s `ViewportNarrow` controller, which measured the window only for the confirm it no longer draws.

One thing came in: `ConfirmSpec` gains an optional `onCancel`. The editor's own Cancel/✕/Escape put focus back on the name field when its dialog was declined, and `hv-confirm` restores nothing on its own — without this the refactor would have left a keyboard user on `<body>` after choosing to stay in the form. FE-DIALOGS-1 (PR 4 of this package) gives `hv-confirm` generic return-focus and can retire it.

Refs #231 (item 2), FE-DIALOGS-6.

## Counting

| | lines |
|---|---:|
| production removed | 133 |
| test removed | 121 |
| added | 326 |

`git diff --stat origin/main`: 13 files changed, 326 insertions(+), 254 deletions(-); of those, `*.test.ts` plus `test.utils.ts` account for +205 / −121.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1304 passed, 27 skipped), `uv run ruff check .`, `uv run ruff format --check .` (189 files), `uv run mypy` (25 source files, no issues)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (71 files, 1905 tests passed), `npm run build`

`scripts/test_integration.sh` not run: no file under `custom_components/` or `tests/integration/` changed (the built bundle is git-ignored).

### What the tests pin now

The three private dialogs are gone, so their `data-testid`s (`editor-discard-confirm`, `sheet-discard-confirm`, `full-discard-confirm`) are gone with them; the question resolves on `host-confirm`. The cases that named them moved rather than being rewritten:

- `test.utils.ts` gains `discardAsker()` — a captured question with `asked` and `answer('discard' | 'keep')` — so a component mounted on its own can be asserted on what it owes: asking, waiting, and acting on the answer.
- `hv-item-editor.test.ts`: every "%s asks / keeps the typing / closes a clean form" case now asserts through the callback. The declined case additionally pins that focus lands back on the name field. The `it.each` over the two confirms for the viewport-derived phone form drops to the one confirm that is left.
- `hv-detail-sheet.test.ts` and `hv-full-view.test.ts`: the scrim/Escape/Back and row-switch/backdrop/Escape/close cases keep every assertion, answered through the asker. Both gain a case pinning that the form inside is handed the *same* asker the surface uses. The full view's `mount` helper now stands a host beside the surface on every mount, as the card and the panel do.
- The two "asks the same question the form asks itself" wording cases in those files are dropped: neither surface names the wording any more, and `hv-card-shell.test.ts`'s "asks the same question every other surface asks" already holds it against `discardPrompt()` on the one dialog.
- `hv-card-shell.test.ts` gains "hands the same asker to every surface that hosts a form" (the inline form, `card-detail-sheet` and `card-full-view` all get one identical function) and "refocuses the form the answer kept", which fails if `onCancel` is dropped anywhere along the chain — checked by removing it.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md`'s "No path discards typed edits without asking" bullet named `requestClose()` and "asks its own copy"; it now states the one-asker rule. No backend contract touched.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — none in this PR.
- [x] Essential invariants preserved.
- [x] No file removed from `custom_components/haventory/`, so `RETIRED_PATHS` is unchanged.
- [x] No dictionary key added or removed (`src/i18n/*.ts`, `strings.json`, `translations/*.json` untouched).

## Screenshots (card / UI changes)

None from this session — it runs offline and drives no Home Assistant. The master's live check at 1920 px and 375 px, light and dark, is the before/after evidence.

## Decisions taken against drifted notes

- FE-DIALOGS-6 says "give the editor a `confirmDiscard: (onConfirm) => void` callback". It is `(onConfirm, onCancel?)`: with `onConfirm` alone, declining the editor's own question drops focus, because the `_refocus()` the private dialog did has nowhere to hang. Same shape otherwise, and the second argument is optional — the sheet and the view pass one argument.
- FE-DIALOGS-6 lists the detail sheet and the full view as passing `surfaces.confirm`. Neither holds a `HostSurfaces`; both are children of an element that does. They take the callback as a property, which is how `createLocation` already reaches the editor through the sheet.
- The measured note reads the editor's discard question as `requestClose`/`_requestCancel`/`_confirmDiscard`. `requestClose()` is removed rather than kept: its boolean answer only meant "I have raised the dialog myself", which is no longer a thing the form can do.

## Follow-ups

- A discard question that is up when the item being edited is deleted by someone else no longer withdraws itself. `hv-full-view` used to clear `_pendingDiscard` in that case; the host's confirm has no withdraw call, and answering the stale question does the same thing it would have done. A second household member deleting the exact row a first is mid-discard on is not worth a withdraw API — named here, not filed.
- The scratch browser harnesses under `.claude/skills/run-haventory/node_modules/.qa/*.mjs` name `editor-discard-confirm`, `sheet-discard-confirm` and `full-discard-confirm`. They are untracked and ungated; the tracked harnesses (`card_views.test.mjs`, `surfaces.mjs`) name none of the three. Whoever regenerates them should reach for `host-confirm`.
- `ConfirmSpec.onCancel` becomes redundant once FE-DIALOGS-1 gives `hv-confirm` return-focus, and the two would then both move focus. Retiring it belongs to that PR.

## Handover

1. **Merged / left open** — this PR, for the M4 master to merge under §5 once its live check is done. Nothing here is left open for the owner.
2. **Test this by hand** — `[phone]` on the sidebar page and in the card: type into a row's form and leave it by every route (Cancel, ✕, the sheet's Back arrow, the scrim, a swipe-down) and check the prompt reads the same each time and rises as a bottom sheet, not a centred dialog.
3. **Validate locally** — the numbered block below.
4. **Decisions taken against drifted notes** — the three above.
5. **Follow-ups** — the three above; none filed, none clears the real-world bar on its own.
6. **State left behind** — branch `claude/v0-8-0-m4-discard-confirm`, no assets branch (no screenshots taken), no Home Assistant touched. Counting for this PR: production −133, tests −121, +326.

### Validate locally

1. `[browser]` **dev HA, 1920 px, card.** Open a row's form, type into the name field, press Escape. Expect: one centred dialog, "Discard changes?"; Cancel leaves the form standing with the typing in it and focus back in the name field; Discard closes the form. Repeat with the form's Cancel button and its ✕ — same dialog, same wording, same place on screen.
2. `[browser]` **1920 px, card, row switch.** With a dirty form open, click another row's edit button. Expect: the same dialog; Discard opens the other row's form, Cancel leaves the first one open and unchanged.
3. `[browser]` **1920 px, expanded view (`/haventory` and the card's expand).** With a dirty form open, try the backdrop, Escape, the close button and another row in turn. Expect the same dialog each time, above the view's scrim, and the destination only after Discard.
4. `[browser]` **375 px, card and `/haventory`.** Tap a row for the detail sheet, tap Edit, type. Then: the Back arrow, the scrim, a swipe-down. Expect the prompt as a bottom sheet each time, above the detail sheet; Discard from Back lands on the read view with the sheet still up; Discard from the scrim or the swipe takes the sheet down. Also open the phone add sheet, type a name, and dismiss it by ✕ and by scrim — same prompt.
5. `[browser]` **375 px, the form's own Delete-a-photo dialog.** Open a form with a photo, press its remove control. Expect the remove prompt to still rise as a bottom sheet — it keeps its own dialog and its viewport-derived phone form, which this PR did not move.
6. `[browser]` **Keyboard, any width.** Reach a dirty form's Cancel by Tab, press Enter, then Escape to decline. Expect focus back in the form's name field, not on the page body.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NhfGrV1Tm1GN4M2xd2egv)_