### PR TITLE
refactor(card): one item workspace for the shell and the full view

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -405,7 +405,6 @@ export class HVCardShell extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.surfaces.connect();
     this._filterPanelOpen = readPanelPref();
     if (this.store && !this._storeUnsub) {
       // The parent passes a stable `store` object, so a property binding would
@@ -416,7 +415,6 @@ export class HVCardShell extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.surfaces.disconnect();
     this._storeUnsub?.();
     this._storeUnsub = undefined;
   }

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -12,27 +12,22 @@ import { emptyKindFor } from '../ui/empty-state';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
-import { editorErrorText } from '../ui/editor-error';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
 import { HostSurfaces } from '../host-surfaces';
+import { ItemWorkspace } from '../item-workspace';
 import type { Store } from '../store/store';
-import type { Item, Location, StoreFilters, StoreState } from '../store/types';
+import type { StoreFilters, StoreState } from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import './hv-bottom-sheet';
 import './hv-filter-chips';
 import './hv-filter-panel';
 import './hv-list';
-import './hv-item-editor';
-import './hv-detail-sheet';
 import './hv-full-view';
 import type { OrganizeTab } from './hv-organize-dialog';
-import './hv-checkout-popover';
 import './hv-overflow-menu';
 import type { HVFilterPanel } from './hv-filter-panel';
 import type { HVItemEditor } from './hv-item-editor';
-import type { MediaBindings } from '../ui/media';
-import type { ItemCreate, ItemUpdate } from '../store/types';
 
 const SEARCH_DEBOUNCE_MS = 200;
 const FILTER_PANEL_STORAGE_KEY = 'haventory:filter-panel-open:v1';
@@ -327,29 +322,33 @@ export class HVCardShell extends LitElement {
   /** The sheet's in-flight filter set, so its header counts what you staged. */
   @state() private _stagedFilters: StoreFilters | null = null;
   @state() private _searchDraft = '';
-  /** Row expanded into the inline editor, or `'new'` for the add-item expander. */
-  @state() private _editing: string | 'new' | null = null;
-  @state() private _editorBusy = false;
-  @state() private _editorError: string | null = null;
   /**
    * Changes whenever anything `_renderEditor` reads has changed identity — see
    * `_syncEditorEpoch`, which is the list of what that is.
    */
   @state() private _editorEpoch = 0;
-  /** Item shown in the mobile detail sheet. */
-  @state() private _detailItemId: string | null = null;
   @state() private _fullViewOpen = false;
   @state() private _startSelecting = false;
-  /** Item whose check-out / due-date step is open, with where to anchor it. */
-  @state() private _checkout: { itemId: string; mode: 'check-out' | 'set-due-date'; anchor: DOMRect | null } | null =
-    null;
+
+  /** The editor, the detail sheet and the check-out step, as the full view has them. */
+  private readonly _workspace = new ItemWorkspace(this, () => this.store, {
+    confirmDiscard: () => this.surfaces.confirmDiscard,
+    editor: () => this._editor,
+    // Touch has no hover: tapping a row opens the detail sheet, which is the
+    // single mobile surface. Desktop expands the row in place instead — and so
+    // does the row menu's Edit, which is a request for the form rather than
+    // for whatever the width would have opened.
+    openItem: (itemId) => {
+      if (this.mobile) this._workspace.openDetail(itemId);
+      else this._workspace.startEdit(itemId);
+    },
+    editItem: (itemId) => this._workspace.startEdit(itemId),
+    requestDelete: (detail) => this.surfaces.requestDeleteById(detail.itemId),
+  });
 
   /** The dialogs both hosts share — confirm, organize, import, diagnostics. */
   readonly surfaces = new HostSurfaces(this, () => this.store, {
-    onItemDeleted: (itemId) => {
-      if (this._editing === itemId) this._editing = null;
-      if (this._detailItemId === itemId) this._detailItemId = null;
-    },
+    onItemDeleted: (itemId) => this._workspace.forgetItem(itemId),
     onBrowse: () => {
       // Organizing is a full-screen job, so the filter it hands back belongs
       // on the full-screen surface too — dropping back to the small card
@@ -359,41 +358,8 @@ export class HVCardShell extends LitElement {
   });
 
   private readonly responsive = new ResponsiveController(this);
-  private _storeUnsub?: () => void;
-  private _media: MediaBindings | null = null;
   /** Identities `_editorEpoch` was last bumped for; see `_syncEditorEpoch`. */
   private _editorInputs: unknown[] = [];
-  /**
-   * The last copy of the row being edited, kept for as long as the form is open.
-   *
-   * A filter change refetches, and the edited row can drop out of the result.
-   * The editor rebuilds its model whenever the item id it was handed changes,
-   * so handing it `null` there would wipe the typed edits just as surely as
-   * unmounting it. `_syncPinnedItem` keeps this at the freshest copy the store
-   * has listed.
-   */
-  private _pinnedItem: Item | null = null;
-
-  /**
-   * Picture access for every surface below, built once per store.
-   *
-   * Rebuilt only when the store is swapped: a fresh object each render would
-   * read as a changed property on every row and re-render the whole list.
-   */
-  private get media(): MediaBindings | null {
-    const store = this.store;
-    if (!store) return null;
-    this._media ??= {
-      sign: (path, expires) => store.signMediaPath(path, expires),
-      upload: (itemId, file, kind) => store.uploadAttachment(itemId, file, kind),
-      remove: (itemId, attachmentId) => store.removeAttachment(itemId, attachmentId),
-      retitle: (itemId, attachmentId, title) =>
-        store.updateAttachment(itemId, attachmentId, title),
-      reorder: (itemId, kind, attachmentIds) =>
-        store.reorderAttachments(itemId, kind, attachmentIds),
-    };
-    return this._media;
-  }
 
   get mobile(): boolean {
     return this.responsive.mobile;
@@ -406,53 +372,16 @@ export class HVCardShell extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     this._filterPanelOpen = readPanelPref();
-    if (this.store && !this._storeUnsub) {
-      // The parent passes a stable `store` object, so a property binding would
-      // never re-render this element — it has to watch the store itself.
-      this._storeUnsub = this.store.state.onChange(() => this.requestUpdate());
-    }
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._storeUnsub?.();
-    this._storeUnsub = undefined;
   }
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has('store') && this.store) {
-      this._media = null;
-      this._storeUnsub?.();
-      this._storeUnsub = this.store.state.onChange(() => this.requestUpdate());
       this._searchDraft = this.store.state.value.filters.q;
     }
     // Reflect the mode so child selectors and :host([mobile]) rules apply.
     this.toggleAttribute('mobile', this.mobile);
-    this._syncPinnedItem();
+    this._workspace.syncPinnedItem();
     this._syncEditorEpoch();
-  }
-
-  /**
-   * Hold on to the row being edited, and close the form when it is really gone.
-   *
-   * Falling off the current page and being deleted look identical from the item
-   * list alone; the store is the only place that knows which happened, so it is
-   * asked rather than guessed at.
-   */
-  private _syncPinnedItem() {
-    const editing = this._editing;
-    if (editing === null || editing === 'new') {
-      this._pinnedItem = null;
-      return;
-    }
-    if (this.store?.wasRemoved(editing)) {
-      this._pinnedItem = null;
-      this._editing = null;
-      this._editorError = null;
-      return;
-    }
-    const listed = this.st?.items.find((i) => i.id === editing);
-    if (listed) this._pinnedItem = listed;
   }
 
   /**
@@ -481,9 +410,9 @@ export class HVCardShell extends LitElement {
       st?.locationsFlatCache,
       st?.locationTreeCache,
       st?.distinctValuesCache,
-      this.media,
-      this._editorBusy,
-      this._editorError,
+      this._workspace.media,
+      this._workspace.editorBusy,
+      this._workspace.editorError,
     ];
     if (next.some((value, i) => value !== this._editorInputs[i])) {
       this._editorInputs = next;
@@ -520,45 +449,6 @@ export class HVCardShell extends LitElement {
     });
   }, 150);
 
-  // ---------- Item actions ----------
-  private _adjust(itemId: string, delta: number) {
-    void this.store?.adjustQuantity(itemId, delta);
-  }
-
-  private _requestDelete(item: Item) {
-    this.surfaces.requestDeleteById(item.id);
-  }
-
-  private _itemById(itemId: string): Item | undefined {
-    return this.st?.items.find((i) => i.id === itemId);
-  }
-
-  /** The item an open editor edits — the listed row, or the pinned copy of it. */
-  private _editorItem(itemId: string | null): Item | null {
-    if (itemId === null) return null;
-    return this._itemById(itemId) ?? (this._pinnedItem?.id === itemId ? this._pinnedItem : null);
-  }
-
-  private _onRowAction(item: Item, detail: { action?: string; anchor?: DOMRect }) {
-    switch (detail.action) {
-      case 'check-out':
-        this._checkout = { itemId: item.id, mode: 'check-out', anchor: detail.anchor ?? null };
-        break;
-      case 'set-due-date':
-        this._checkout = { itemId: item.id, mode: 'set-due-date', anchor: detail.anchor ?? null };
-        break;
-      case 'check-in':
-        void this.store?.markCheckedIn(item.id, item.version);
-        break;
-      case 'edit':
-        this._startEdit(item.id);
-        break;
-      case 'delete':
-        this._requestDelete(item);
-        break;
-    }
-  }
-
   // ---------- Inline editing ----------
   private get _editor(): HVItemEditor | null {
     // Two homes: on a phone the add form is slotted into a sheet in this shadow
@@ -574,141 +464,12 @@ export class HVCardShell extends LitElement {
   }
 
   /**
-   * Open an expander, closing whichever one is open. Only one row edits at a
-   * time; if the open one has unsaved changes the user is asked first, rather
-   * than silently losing them.
+   * The expander, drawn by `hv-list` inside the row order rather than here — so
+   * it takes no arguments: which row it is on is the workspace's `editing`,
+   * which is also what tells the list to call this.
    */
-  private _startEdit(next: string | 'new' | null) {
-    if (this._editing === next) return;
-    if (this._editing !== null && this._editor?.dirty) {
-      this.surfaces.confirmDiscard(() => {
-        this._editorError = null;
-        this._editing = next;
-      });
-      return;
-    }
-    this._editorError = null;
-    this._editing = next;
-  }
-
-  /**
-   * The editor's first-run way out of an empty location picker: a root location
-   * with no area, handed back so the form can file the item in it at once.
-   */
-  private _createLocationForEditor = (name: string): Promise<Location> => {
-    const store = this.store;
-    if (!store) return Promise.reject(new Error(t('hv.card.notConnected')));
-    return store.createLocation(name, null, null);
-  };
-
-  private _onEditorSave = async (e: CustomEvent) => {
-    const detail = e.detail as {
-      itemId: string | null;
-      expectedVersion?: number;
-      changes?: ItemUpdate;
-      create?: ItemCreate;
-    };
-    this._editorBusy = true;
-    this._editorError = null;
-    const errorsBefore = this.st?.errorQueue.length ?? 0;
-    try {
-      if (detail.itemId && detail.changes) {
-        await this.store?.updateItem(detail.itemId, detail.changes, detail.expectedVersion);
-      } else if (detail.create) {
-        await this.store?.createItem(detail.create);
-      }
-    } finally {
-      this._editorBusy = false;
-    }
-    // The store reports failures through its error queue rather than throwing,
-    // so a new entry is how we know the save did not land. Keep the expander
-    // open in that case so the user's edits are still there to retry — and say
-    // why inside it, because the card's banner list is above a form tall enough
-    // to have scrolled it off the screen.
-    const queue = this.st?.errorQueue ?? [];
-    const failed = queue.length > errorsBefore;
-    this._editorError = failed ? editorErrorText(queue[queue.length - 1]) : null;
-    if (!failed) this._editing = null;
-  };
-
-  private _onEditorDelete = (e: CustomEvent) => {
-    const { itemId } = e.detail as { itemId: string };
-    // The pinned copy counts: a row filtered off the page is still deletable
-    // from the form that is still open on it.
-    const item = this._editorItem(itemId);
-    if (!item) return;
-    this._requestDelete(item);
-  };
-
-  /**
-   * `opts.noHeader` is for the mobile add sheet, which draws its own title bar
-   * — the editor's own header leads with an expander chevron that means
-   * nothing once the form is not an expander.
-   */
-  private _renderEditor = (itemId: string | null, opts: { noHeader?: boolean } = {}) => {
-    const st = this.st;
-    return html`<hv-item-editor
-      .statuses=${st?.statuses ?? null}
-      data-testid="inline-editor"
-      .areas=${st?.areasCache?.areas ?? []}
-      .media=${this.media}
-      .mediaConfig=${st?.mediaConfig ?? null}
-      ?noHeader=${opts.noHeader ?? false}
-      .item=${this._editorItem(itemId)}
-      .locations=${st?.locationsFlatCache ?? null}
-      .locationTree=${st?.locationTreeCache ?? []}
-      .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
-      .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
-      .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
-      .createLocation=${this._createLocationForEditor}
-      .confirmDiscard=${this.surfaces.confirmDiscard}
-      ?mobile=${this.mobile}
-      .busy=${this._editorBusy}
-      .errorMessage=${this._editorError}
-      @save=${this._onEditorSave}
-      @delete-item=${this._onEditorDelete}
-      @cancel=${() => {
-        this._editing = null;
-        this._editorError = null;
-      }}
-    ></hv-item-editor>`;
-  };
-
-  private _onRowEvent = (name: string, detail: { itemId: string }) => {
-    const item = this._itemById(detail.itemId);
-    if (!item) return;
-    switch (name) {
-      case 'increment':
-        this._adjust(item.id, +1);
-        break;
-      case 'decrement':
-        if (item.quantity > 0) this._adjust(item.id, -1);
-        break;
-      case 'check-in':
-        void this.store?.markCheckedIn(item.id, item.version);
-        break;
-      case 'reminder-bump':
-        void this.store?.bumpReminder(item.id, item.version);
-        break;
-      case 'request-delete':
-        this._requestDelete(item);
-        break;
-      case 'row-action':
-        this._onRowAction(item, detail as { action?: string; anchor?: DOMRect });
-        break;
-      case 'edit':
-      case 'open-item':
-        // Touch has no hover: tapping a row opens the detail sheet, which is the
-        // single mobile surface. Desktop expands the row in place instead.
-        if (this.mobile) this._detailItemId = item.id;
-        else this._startEdit(item.id);
-        break;
-      default:
-        this.dispatchEvent(
-          new CustomEvent(name, { detail: { itemId: item.id }, bubbles: true, composed: true }),
-        );
-    }
-  };
+  private _renderEditor = () =>
+    this._workspace.renderEditor({ testid: 'inline-editor', mobile: this.mobile });
 
   // ---------- Overflow menu ----------
   /**
@@ -834,7 +595,7 @@ export class HVCardShell extends LitElement {
     const { id } = e.detail as { id: string };
     if (id === 'clear-filters') this.store?.clearFilters();
     else if (id === 'refresh') void this.store?.refreshAll();
-    else if (id === 'add-item') this._startEdit('new');
+    else if (id === 'add-item') this._workspace.startEdit('new');
     else this._runMenuAction(id);
   };
 
@@ -906,7 +667,7 @@ export class HVCardShell extends LitElement {
           data-testid="add-item"
           aria-label=${t('hv.card.addItem')}
           title=${t('hv.card.addItem')}
-          @click=${() => this._startEdit('new')}
+          @click=${() => this._workspace.startEdit('new')}
         >
           ${icon('plus', 16)}${mobile ? null : t('hv.card.addShort')}
         </button>
@@ -971,29 +732,29 @@ export class HVCardShell extends LitElement {
       <hv-list
         .statuses=${st?.statuses ?? null}
         .areas=${st?.areasCache?.areas ?? []}
-        .media=${this.media}
+        .media=${this._workspace.media}
         data-testid="card-list"
         .items=${st?.items ?? []}
         .loading=${st?.loading ?? true}
         .mobile=${mobile}
         .editorTemplate=${this._renderEditor}
         .editorEpoch=${this._editorEpoch}
-        .editingItemId=${this._editing === 'new' ? null : this._editing}
-        .pinnedItem=${this._pinnedItem}
-        .addingNew=${!mobile && this._editing === 'new'}
+        .editingItemId=${this._workspace.editing === 'new' ? null : this._workspace.editing}
+        .pinnedItem=${this._workspace.pinnedItem}
+        .addingNew=${!mobile && this._workspace.editing === 'new'}
         .emptyKind=${emptyKindFor(this.st)}
         .emptyLocationName=${(st?.locationsFlatCache ?? []).find((l) => l.id === soleLocationId(filters))?.name ??
         null}
         @near-end=${(e: CustomEvent) =>
           void this.store?.prefetchIfNeeded((e.detail as { ratio: number }).ratio)}
         @empty-action=${this._onEmptyAction}
-        @increment=${(e: CustomEvent) => this._onRowEvent('increment', e.detail)}
-        @decrement=${(e: CustomEvent) => this._onRowEvent('decrement', e.detail)}
-        @check-in=${(e: CustomEvent) => this._onRowEvent('check-in', e.detail)}
-        @request-delete=${(e: CustomEvent) => this._onRowEvent('request-delete', e.detail)}
-        @edit=${(e: CustomEvent) => this._onRowEvent('edit', e.detail)}
-        @open-item=${(e: CustomEvent) => this._onRowEvent('open-item', e.detail)}
-        @row-action=${(e: CustomEvent) => this._onRowEvent('row-action', e.detail)}
+        @increment=${(e: CustomEvent) => this._workspace.onRowEvent('increment', e.detail)}
+        @decrement=${(e: CustomEvent) => this._workspace.onRowEvent('decrement', e.detail)}
+        @check-in=${(e: CustomEvent) => this._workspace.onRowEvent('check-in', e.detail)}
+        @request-delete=${(e: CustomEvent) => this._workspace.onRowEvent('request-delete', e.detail)}
+        @edit=${(e: CustomEvent) => this._workspace.onRowEvent('edit', e.detail)}
+        @open-item=${(e: CustomEvent) => this._workspace.onRowEvent('open-item', e.detail)}
+        @row-action=${(e: CustomEvent) => this._workspace.onRowEvent('row-action', e.detail)}
       ></hv-list>
 
       ${loaded > 0
@@ -1029,7 +790,7 @@ export class HVCardShell extends LitElement {
           this._startSelecting = false;
         }}
         @menu-action=${this._onMenuSelect}
-        @request-delete=${(e: CustomEvent) => this._onRowEvent('request-delete', e.detail)}
+        @request-delete=${(e: CustomEvent) => this._workspace.onRowEvent('request-delete', e.detail)}
       ></hv-full-view>
       ${mobile
         ? html`<hv-bottom-sheet
@@ -1086,9 +847,9 @@ export class HVCardShell extends LitElement {
       ${mobile
         ? html`<hv-bottom-sheet
             label=${t('hv.card.newItem')}
-            ?open=${this._editing === 'new'}
+            ?open=${this._workspace.editing === 'new'}
             data-testid="add-sheet"
-            @cancel=${() => this._startEdit(null)}
+            @cancel=${() => this._workspace.startEdit(null)}
           >
             <div class="sheet-head">
               <span class="heading">${t('hv.card.newItem')}</span>
@@ -1097,84 +858,19 @@ export class HVCardShell extends LitElement {
                 style="margin-left:auto"
                 data-testid="add-sheet-close"
                 aria-label=${t('hv.action.close')}
-                @click=${() => this._startEdit(null)}
+                @click=${() => this._workspace.startEdit(null)}
               >
                 ${icon('close', 18)}
               </button>
             </div>
-            ${this._editing === 'new' ? this._renderEditor(null, { noHeader: true }) : null}
+            ${this._workspace.editing === 'new'
+              ? this._workspace.renderEditor({ testid: 'inline-editor', mobile, noHeader: true })
+              : null}
           </hv-bottom-sheet>`
         : null}
 
-      ${mobile
-        ? html`<hv-detail-sheet
-            .statuses=${st?.statuses ?? null}
-            .areas=${st?.areasCache?.areas ?? []}
-            .media=${this.media}
-            .mediaConfig=${st?.mediaConfig ?? null}
-            data-testid="card-detail-sheet"
-            ?open=${this._detailItemId !== null}
-            .item=${this._detailItemId ? (this._itemById(this._detailItemId) ?? null) : null}
-            .locations=${st?.locationsFlatCache ?? null}
-            .locationTree=${st?.locationTreeCache ?? []}
-            .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
-            .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
-            .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
-            .createLocation=${this._createLocationForEditor}
-            .confirmDiscard=${this.surfaces.confirmDiscard}
-            .busy=${this._editorBusy}
-            .errorMessage=${this._editorError}
-            @cancel=${() => {
-              this._detailItemId = null;
-              this._editorError = null;
-            }}
-            @increment=${(e: CustomEvent) => this._onRowEvent('increment', e.detail)}
-            @decrement=${(e: CustomEvent) => this._onRowEvent('decrement', e.detail)}
-            @check-in=${(e: CustomEvent) => this._onRowEvent('check-in', e.detail)}
-            @check-out-confirmed=${(e: CustomEvent) => {
-              const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-              const item = this._itemById(itemId);
-              if (item) void this.store?.checkOut(item.id, dueDate, item.version);
-            }}
-            @set-due-date=${(e: CustomEvent) => {
-              const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-              const item = this._itemById(itemId);
-              if (item) void this.store?.updateItem(item.id, { due_date: dueDate }, item.version);
-            }}
-            @reminder-bump=${(e: CustomEvent) => this._onRowEvent('reminder-bump', e.detail)}
-            @request-delete=${(e: CustomEvent) => this._onRowEvent('request-delete', e.detail)}
-            @save=${this._onEditorSave}
-          ></hv-detail-sheet>`
-        : null}
-
-      <!-- Never inline: that presentation is a step drawn inside the body of the
-           surface that opened it, and this is a sibling at the end of the shell
-           with no body around it. The narrow branch reaches its check-out
-           through the detail sheet, which mounts its own. -->
-      <hv-checkout-popover
-        data-testid="card-checkout"
-        ?open=${this._checkout !== null}
-        ?touch=${mobile}
-        .mode=${this._checkout?.mode ?? 'check-out'}
-        .anchor=${this._checkout?.anchor ?? null}
-        .item=${this._checkout ? (this._itemById(this._checkout.itemId) ?? null) : null}
-        @check-out=${(e: CustomEvent) => {
-          const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-          const item = this._itemById(itemId);
-          this._checkout = null;
-          if (item) void this.store?.checkOut(item.id, dueDate, item.version);
-        }}
-        @set-due-date=${(e: CustomEvent) => {
-          const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-          const item = this._itemById(itemId);
-          this._checkout = null;
-          // A due date only exists while an item is out, so this is a plain update.
-          if (item) void this.store?.updateItem(item.id, { due_date: dueDate }, item.version);
-        }}
-        @cancel=${() => {
-          this._checkout = null;
-        }}
-      ></hv-checkout-popover>
+      ${mobile ? this._workspace.renderDetailSheet({ testid: 'card-detail-sheet' }) : null}
+      ${this._workspace.renderCheckoutPopover({ testid: 'card-checkout', mobile })}
 
       ${this.surfaces.renderSurfaces()}
     `;

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -29,7 +29,7 @@ import { editorErrorText } from '../ui/editor-error';
 import type { ConfirmDiscard } from '../ui/discard';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
-import { NARROW_QUERY } from '../ui/responsive';
+import { ViewportNarrow } from '../ui/responsive';
 import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
@@ -939,7 +939,7 @@ export class HVFullView extends LitElement {
   /**
    * Home Assistant's own narrow flag, forwarded by the panel host.
    *
-   * Distinct from `_narrow` below, which is this surface's own phone
+   * Distinct from `_viewport` below, which is this surface's own phone
    * breakpoint: HA sets this whenever the sidebar is collapsed, at any width.
    */
   @property({ type: Boolean }) narrow = false;
@@ -1018,8 +1018,14 @@ export class HVFullView extends LitElement {
    * editor's three-column desktop grid in 156px + 78px + 78px, with "Low-stock
    * at" wrapping over its own field. A media query cannot set a property, so
    * the same breakpoint is read here and handed down.
+   *
+   * The phone panel drops its draft when it stops being on a phone, so a staged
+   * set held from before the rotation would have the head row counting filters
+   * the controls under it no longer carry.
    */
-  @state() private _narrow = false;
+  private readonly _viewport = new ViewportNarrow(this, () => {
+    this._stagedFilters = null;
+  });
   /**
    * Which of the app bar's two steps the room calls for, as the classes that
    * carry them — see `barSteps`.
@@ -1078,18 +1084,12 @@ export class HVFullView extends LitElement {
     if (this.store && !this._storeUnsub) {
       this._storeUnsub = this.store.state.onChange(() => this.requestUpdate());
     }
-    this._narrowQuery ??= window.matchMedia?.(NARROW_QUERY) ?? null;
-    if (this._narrowQuery) {
-      this._narrow = this._narrowQuery.matches;
-      this._narrowQuery.addEventListener('change', this._onNarrowChange);
-    }
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this._storeUnsub?.();
     this._storeUnsub = undefined;
-    this._narrowQuery?.removeEventListener('change', this._onNarrowChange);
     this._barObserver?.disconnect();
     this._barTarget = null;
   }
@@ -1123,15 +1123,6 @@ export class HVFullView extends LitElement {
     const next = barSteps(width);
     if (next !== this._barSteps) this._barSteps = next;
   }
-
-  private _narrowQuery?: MediaQueryList | null;
-  private _onNarrowChange = (e: MediaQueryListEvent) => {
-    this._narrow = e.matches;
-    // The panel drops its draft when it stops being on a phone, so a staged set
-    // held from before the rotation would have the head row counting filters
-    // the controls under it no longer carry.
-    this._stagedFilters = null;
-  };
 
   /** Price a staged (not yet applied) filter set, so the footer can be honest. */
   private _priceStaged = debounce((filters: StoreFilters) => {
@@ -1378,7 +1369,7 @@ export class HVFullView extends LitElement {
    * answers the same tap with the same sheet.
    */
   private _openItem(id: string) {
-    if (this._narrow) {
+    if (this._viewport.narrow) {
       this._detailItemId = id;
       return;
     }
@@ -2094,8 +2085,8 @@ export class HVFullView extends LitElement {
               this._filtersOpen = !this._filtersOpen;
               // The phone panel stages its edits, so its head row and its
               // button both have a number to print from the moment it opens.
-              this._stagedFilters = this._filtersOpen && this._narrow ? filters : null;
-              if (this._filtersOpen && this._narrow) this._priceStaged(filters);
+              this._stagedFilters = this._filtersOpen && this._viewport.narrow ? filters : null;
+              if (this._filtersOpen && this._viewport.narrow) this._priceStaged(filters);
             }}
           >
             ${icon('tune', 16)}${t('hv.card.filters')}
@@ -2105,7 +2096,7 @@ export class HVFullView extends LitElement {
                many for 375px: the picker dropped onto a line of its own under
                the chip. The ⋮ menu offers Columns on both hosts, so nothing is
                lost by leaving it as the only route there at this width. -->
-          ${this._narrow
+          ${this._viewport.narrow
             ? null
             : html`<button
                 class="hv-icon-button"
@@ -2255,7 +2246,7 @@ export class HVFullView extends LitElement {
     const allowsPill = (key: QuickFilterKey) => quickFilterAllowed(this.quickFilters, key);
     // The narrow branch dresses these same controls its own way, on its own
     // breakpoint, so the measured steps stand aside for it.
-    const steps = this._narrow ? '' : this._barSteps;
+    const steps = this._viewport.narrow ? '' : this._barSteps;
     const addLabelClass = steps.includes('tight') ? 'add-label hv-sr-only' : 'add-label';
     // One strip, so the pills are what gives when the bar runs out of room —
     // and no strip at all when nothing is flagged, because an empty one is
@@ -2365,7 +2356,7 @@ export class HVFullView extends LitElement {
             @click=${() => this._leaveEditor('new')}
           >
             ${icon('plus', 16)}<span class=${addLabelClass}
-              >${t(this._narrow ? 'hv.card.addShort' : 'hv.card.addItem')}</span
+              >${t(this._viewport.narrow ? 'hv.card.addShort' : 'hv.card.addItem')}</span
             >
           </button>
           <button
@@ -2419,7 +2410,7 @@ export class HVFullView extends LitElement {
             <div class="panel-holder" id=${FILTER_PANEL_ID} ?hidden=${!this._filtersOpen}>
               ${this._filtersOpen
                 ? html`
-                  ${this._narrow ? this._renderPanelHead(filters) : null}
+                  ${this._viewport.narrow ? this._renderPanelHead(filters) : null}
                   <div class="panel-scroll">
                   <hv-filter-panel
                     .statuses=${this.st?.statuses ?? null}
@@ -2432,7 +2423,7 @@ export class HVFullView extends LitElement {
                     .total=${st?.total ?? null}
                     .grandTotal=${counts?.items_total ?? null}
                     .counts=${counts ?? null}
-                    ?mobile=${this._narrow}
+                    ?mobile=${this._viewport.narrow}
                     @change=${(e: CustomEvent) => this._setFilters(e.detail as Partial<StoreFilters>)}
                     @stage=${(e: CustomEvent) => {
                       const staged = (e.detail as { filters: StoreFilters }).filters;
@@ -2447,7 +2438,7 @@ export class HVFullView extends LitElement {
                     @clear-filters=${() => this.store?.clearFilters()}
                   ></hv-filter-panel>
                   </div>
-                  ${this._narrow ? this._renderPanelFoot() : null}
+                  ${this._viewport.narrow ? this._renderPanelFoot() : null}
                 `
                 : null}
             </div>
@@ -2474,7 +2465,7 @@ export class HVFullView extends LitElement {
                     .confirmDiscard=${this.confirmDiscard}
                     .busy=${this._editorBusy}
                     .errorMessage=${this._editorError}
-                    ?mobile=${this._narrow}
+                    ?mobile=${this._viewport.narrow}
                     @save=${this._onEditorSave}
                     @cancel=${() => {
                       this._editing = null;
@@ -2503,7 +2494,7 @@ export class HVFullView extends LitElement {
               .columns=${this.columns}
               .sort=${filters.sort as Sort}
               ?selectable=${this._selecting}
-              ?narrow=${this._narrow}
+              ?narrow=${this._viewport.narrow}
               .selection=${selection}
               @sort-change=${(e: CustomEvent) => this._setFilters({ sort: (e.detail as { sort: Sort }).sort })}
               @near-end=${(e: CustomEvent) =>
@@ -2563,7 +2554,7 @@ export class HVFullView extends LitElement {
         <hv-confirm
           data-testid="bulk-confirm"
           ?open=${this._pendingDelete}
-          ?mobile=${this._narrow}
+          ?mobile=${this._viewport.narrow}
           .heading=${t('hv.fullView.deleteHeading', {
             items: counted(selection.size, 'item'),
           })}
@@ -2580,7 +2571,7 @@ export class HVFullView extends LitElement {
           }}
         ></hv-confirm>
 
-        ${this._narrow
+        ${this._viewport.narrow
           ? html`<hv-detail-sheet
               data-testid="full-detail-sheet"
               .statuses=${st?.statuses ?? null}
@@ -2639,7 +2630,7 @@ export class HVFullView extends LitElement {
         <hv-checkout-popover
           data-testid="full-checkout"
           ?open=${this._checkout !== null}
-          ?touch=${this._narrow}
+          ?touch=${this._viewport.narrow}
           .mode=${this._checkout?.mode ?? 'check-out'}
           .item=${this._checkout ? (st?.items.find((i) => i.id === this._checkout!.itemId) ?? null) : null}
           @check-out=${(e: CustomEvent) => {
@@ -2667,7 +2658,7 @@ export class HVFullView extends LitElement {
         <hv-checkout-popover
           data-testid="full-bulk-checkout"
           ?open=${this._pendingBulkCheckout}
-          ?touch=${this._narrow}
+          ?touch=${this._viewport.narrow}
           .itemName=${counted(selection.size, 'item')}
           @check-out=${(e: CustomEvent) => {
             const { dueDate } = e.detail as { dueDate: string | null };

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -25,11 +25,11 @@ import {
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
 import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
-import { editorErrorText } from '../ui/editor-error';
 import type { ConfirmDiscard } from '../ui/discard';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
 import { ViewportNarrow } from '../ui/responsive';
+import { ItemWorkspace } from '../item-workspace';
 import { statusCount, statusLabel, statusList } from '../ui/status';
 import type { EmptyOffer } from '../ui/empty-state';
 import type { Store } from '../store/store';
@@ -51,11 +51,8 @@ import './hv-bulk-bar';
 import './hv-checkout-popover';
 import './hv-confirm';
 import './hv-data-table';
-import './hv-detail-sheet';
-import type { MediaBindings } from '../ui/media';
 import './hv-filter-chips';
 import './hv-filter-panel';
-import './hv-item-editor';
 import './hv-location-tree';
 import './hv-overflow-menu';
 import type { HVItemEditor } from './hv-item-editor';
@@ -895,23 +892,20 @@ export class HVFullView extends LitElement {
 
   @property({ attribute: false }) store!: Store;
 
-  private _media: MediaBindings | null = null;
+  /**
+   * The editor, the read sheet and the check-out step, as the card's shell has
+   * them. Delete leaves for the host here: this surface owns no confirmation,
+   * and a row click and the row menu's Edit mean the same thing on it.
+   */
+  private readonly _workspace = new ItemWorkspace(this, () => this.store, {
+    confirmDiscard: () => this.confirmDiscard,
+    editor: () => this._editor,
+    openItem: (itemId) => this._openItem(itemId),
+    editItem: (itemId) => this._openItem(itemId),
+    requestDelete: (detail) =>
+      this.dispatchEvent(new CustomEvent('request-delete', { detail, bubbles: true, composed: true })),
+  });
 
-  /** Picture access for the editor this view hosts; built once per store. */
-  private get media(): MediaBindings | null {
-    const store = this.store;
-    if (!store) return null;
-    this._media ??= {
-      sign: (path, expires) => store.signMediaPath(path, expires),
-      upload: (itemId, file, kind) => store.uploadAttachment(itemId, file, kind),
-      remove: (itemId, attachmentId) => store.removeAttachment(itemId, attachmentId),
-      retitle: (itemId, attachmentId, title) =>
-        store.updateAttachment(itemId, attachmentId, title),
-      reorder: (itemId, kind, attachmentIds) =>
-        store.reorderAttachments(itemId, kind, attachmentIds),
-    };
-    return this._media;
-  }
   @property({ type: Boolean, reflect: true }) open = false;
   @property({ type: String }) heading = DEFAULT_CARD_TITLE;
   @property({ attribute: false }) columns: ColumnKey[] = [];
@@ -956,33 +950,6 @@ export class HVFullView extends LitElement {
   @state() private _zBase = 0;
   @state() private _filtersOpen = false;
   @state() private _searchDraft = '';
-  @state() private _editing: string | 'new' | null = null;
-  /**
-   * The item the read sheet is showing, on a narrow viewport.
-   *
-   * There is no read view at this width otherwise: the table is one, but it is
-   * off the side of a phone, and tapping a row landed straight in the edit form
-   * — a surface the card answers the same tap with a sheet on.
-   */
-  @state() private _detailItemId: string | null = null;
-  @state() private _editorBusy = false;
-  /**
-   * What the open form says about a save the store refused.
-   *
-   * This surface fills the screen, so the card's banner list is not behind it —
-   * without this the user is left with a form that did not close and no account
-   * of why.
-   */
-  @state() private _editorError: string | null = null;
-  /**
-   * The last copy of the row being edited, kept for as long as the form is open.
-   *
-   * Same reason the card's shell keeps one: a filter change refetches, the
-   * edited row can drop out of the result, and the editor rebuilds its model
-   * from whatever item it is handed — so handing it `null` there discards the
-   * typed edits.
-   */
-  @state() private _pinnedItem: Item | null = null;
   @state() private _creatingLocation = false;
   @state() private _locationError: string | null = null;
   /**
@@ -1061,35 +1028,20 @@ export class HVFullView extends LitElement {
   @state() private _pendingDelete = false;
   /** The whole selection's check-out is waiting on one due date. */
   @state() private _pendingBulkCheckout = false;
-  /** The row whose check-out / due-date step is open. */
-  @state() private _checkout: {
-    itemId: string;
-    mode: 'check-out' | 'set-due-date';
-  } | null = null;
   @state() private _loadingAll = false;
   /** Set while a batch is running so Cancel can stop it between chunks. */
   private _bulkCancelled = false;
   /** The ops of the last run, so "Retry failed" can replay just the failures. */
   private _lastOps: { label: string; ops: BulkOperation[] } | null = null;
 
-  private _storeUnsub?: () => void;
   private _prevFocus: HTMLElement | null = null;
 
   private get st(): StoreState | null {
     return this.store?.state.value ?? null;
   }
 
-  connectedCallback(): void {
-    super.connectedCallback();
-    if (this.store && !this._storeUnsub) {
-      this._storeUnsub = this.store.state.onChange(() => this.requestUpdate());
-    }
-  }
-
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._storeUnsub?.();
-    this._storeUnsub = undefined;
     this._barObserver?.disconnect();
     this._barTarget = null;
   }
@@ -1132,11 +1084,7 @@ export class HVFullView extends LitElement {
   }, 150);
 
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has('store') && this.store) {
-      this._storeUnsub?.();
-      this._storeUnsub = this.store.state.onChange(() => this.requestUpdate());
-    }
-    this._syncPinnedItem();
+    this._workspace.syncPinnedItem();
     if (changed.has('open')) {
       if (this.open) {
         this._zBase = nextZBase();
@@ -1146,9 +1094,8 @@ export class HVFullView extends LitElement {
       } else {
         this._filtersOpen = false;
         this._stagedFilters = null;
-        this._editing = null;
-        this._detailItemId = null;
-        this._editorError = null;
+        this._workspace.setEditing(null);
+        this._workspace.closeDetail();
         this._creatingLocation = false;
         this._locationError = null;
         this._selecting = false;
@@ -1252,28 +1199,14 @@ export class HVFullView extends LitElement {
 
   /**
    * Leave the open form — for another row, for the create form, or by closing
-   * the whole surface — asking first if there is typing to lose.
-   *
-   * The form asks for its own Cancel, ✕ and Escape, but only about closing.
-   * Everything here has somewhere else to be afterwards, so the destination is
-   * held in the callback until the host's question comes back answered.
+   * the whole surface. Closing is this surface's own destination: everywhere
+   * else the workspace's question is the whole of it.
    */
   private _leaveEditor(to: string | 'new' | 'close') {
-    const ask = this.confirmDiscard;
-    if (ask && this._editing !== null && this._editor?.dirty) {
-      ask(() => this._applyLeave(to));
-      return;
-    }
-    this._applyLeave(to);
-  }
-
-  private _applyLeave(to: string | 'new' | 'close') {
-    if (to === 'close') {
-      this._close();
-      return;
-    }
-    this._editing = to;
-    this._editorError = null;
+    this._workspace.leave(() => {
+      if (to === 'close') this._close();
+      else this._workspace.setEditing(to);
+    });
   }
 
   // ---------- Focus trap ----------
@@ -1308,58 +1241,6 @@ export class HVFullView extends LitElement {
   }
 
   /**
-   * Hold on to the row being edited, and close the form when it is really gone.
-   *
-   * Falling off the current page and being deleted look identical from the item
-   * list alone; the store is the only place that knows which happened, so it is
-   * asked rather than guessed at.
-   */
-  private _syncPinnedItem() {
-    // The read sheet holds an id too, and a deleted item leaves it showing
-    // nothing at all rather than closing.
-    if (this._detailItemId !== null && this.store?.wasRemoved(this._detailItemId)) {
-      this._detailItemId = null;
-    }
-    const editing = this._editing;
-    if (editing === null || editing === 'new') {
-      this._pinnedItem = null;
-      return;
-    }
-    if (this.store?.wasRemoved(editing)) {
-      this._pinnedItem = null;
-      this._editing = null;
-      this._editorError = null;
-      return;
-    }
-    const listed = this.st?.items.find((i) => i.id === editing);
-    if (listed) this._pinnedItem = listed;
-  }
-
-  /** The item the open editor edits — the listed row, or the pinned copy of it. */
-  private get _editorItem(): Item | null {
-    if (this._editing === null || this._editing === 'new') return null;
-    const id = this._editing;
-    return this.st?.items.find((i) => i.id === id) ?? (this._pinnedItem?.id === id ? this._pinnedItem : null);
-  }
-
-  private _onRowEvent(name: string, detail: { itemId?: string }) {
-    const item = this.st?.items.find((i) => i.id === detail.itemId);
-    if (!item) return;
-    switch (name) {
-      case 'increment':
-        void this.store?.adjustQuantity(item.id, +1);
-        break;
-      case 'decrement':
-        if (item.quantity > 0) void this.store?.adjustQuantity(item.id, -1);
-        break;
-      case 'edit':
-      case 'open-item':
-        this._openItem(item.id);
-        break;
-    }
-  }
-
-  /**
    * Show an item: the read sheet on a narrow viewport, the inline form on a
    * wide one, with Edit one tap deeper inside the sheet.
    *
@@ -1370,73 +1251,11 @@ export class HVFullView extends LitElement {
    */
   private _openItem(id: string) {
     if (this._viewport.narrow) {
-      this._detailItemId = id;
+      this._workspace.openDetail(id);
       return;
     }
     this._leaveEditor(id);
   }
-
-  /**
-   * The table rows' ⋮, answered the way the card's shell answers its own rows'.
-   *
-   * Same ids, same meanings — the entries come from one list — so a household
-   * learns Check out / Check in / due date / Delete once. Delete leaves for the
-   * host, which owns the confirmation and the store call; the Delete key on a
-   * row already went the same way.
-   */
-  private _onRowAction(detail: { itemId?: string; action?: string }) {
-    const item = this.st?.items.find((i) => i.id === detail.itemId);
-    if (!item) return;
-    switch (detail.action) {
-      case 'check-out':
-      case 'set-due-date':
-        this._checkout = { itemId: item.id, mode: detail.action };
-        break;
-      case 'check-in':
-        void this.store?.markCheckedIn(item.id, item.version);
-        break;
-      case 'edit':
-        this._openItem(item.id);
-        break;
-      case 'delete':
-        this.dispatchEvent(
-          new CustomEvent('request-delete', {
-            detail: { itemId: item.id, name: item.name },
-            bubbles: true,
-            composed: true,
-          }),
-        );
-        break;
-    }
-  }
-
-  private _onEditorSave = async (e: CustomEvent) => {
-    const detail = e.detail as {
-      itemId: string | null;
-      expectedVersion?: number;
-      changes?: Parameters<Store['updateItem']>[1];
-      create?: Parameters<Store['createItem']>[0];
-    };
-    this._editorBusy = true;
-    this._editorError = null;
-    const before = this.st?.errorQueue.length ?? 0;
-    try {
-      if (detail.itemId && detail.changes) {
-        await this.store?.updateItem(detail.itemId, detail.changes, detail.expectedVersion);
-      } else if (detail.create) {
-        await this.store?.createItem(detail.create);
-      }
-    } finally {
-      this._editorBusy = false;
-    }
-    // The store reports failures through its error queue rather than throwing,
-    // so a new entry is how we know the save did not land. The form stays open
-    // on the user's edits and names the failure inside itself.
-    const queue = this.st?.errorQueue ?? [];
-    const failed = queue.length > before;
-    this._editorError = failed ? editorErrorText(queue[queue.length - 1]) : null;
-    if (!failed) this._editing = null;
-  };
 
   // ---------- Bulk actions ----------
   private get _selectedItems(): Item[] {
@@ -2442,40 +2261,18 @@ export class HVFullView extends LitElement {
                 `
                 : null}
             </div>
-            ${this._editing !== null
+            ${this._workspace.editing !== null
               ? html`<div class="editor-holder">
-                  ${this._editing !== 'new' && !st?.items.some((i) => i.id === this._editing)
+                  ${this._workspace.editing !== 'new' &&
+                  !st?.items.some((i) => i.id === this._workspace.editing)
                     ? html`<p class="pinned-hint" data-testid="pinned-editor-hint">
                         ${t('hv.list.noLongerMatches')}
                       </p>`
                     : null}
-                  <hv-item-editor
-                    .statuses=${this.st?.statuses ?? null}
-                    data-testid="full-editor"
-                    .areas=${st?.areasCache?.areas ?? []}
-                    .media=${this.media}
-                    .mediaConfig=${st?.mediaConfig ?? null}
-                    .item=${this._editorItem}
-                    .locations=${st?.locationsFlatCache ?? null}
-                    .locationTree=${st?.locationTreeCache ?? []}
-                    .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
-                    .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
-                    .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
-                    .createLocation=${this._createLocationForEditor}
-                    .confirmDiscard=${this.confirmDiscard}
-                    .busy=${this._editorBusy}
-                    .errorMessage=${this._editorError}
-                    ?mobile=${this._viewport.narrow}
-                    @save=${this._onEditorSave}
-                    @cancel=${() => {
-                      this._editing = null;
-                      this._editorError = null;
-                    }}
-                    @delete-item=${(e: CustomEvent) =>
-                      this.dispatchEvent(
-                        new CustomEvent('request-delete', { detail: e.detail, bubbles: true, composed: true }),
-                      )}
-                  ></hv-item-editor>
+                  ${this._workspace.renderEditor({
+                    testid: 'full-editor',
+                    mobile: this._viewport.narrow,
+                  })}
                 </div>`
               : null}
 
@@ -2488,7 +2285,7 @@ export class HVFullView extends LitElement {
             <hv-data-table
               .statuses=${this.st?.statuses ?? null}
               .areas=${st?.areasCache?.areas ?? []}
-              .media=${this.media}
+              .media=${this._workspace.media}
               data-testid="full-table"
               .items=${(st?.items ?? []) as Item[]}
               .columns=${this.columns}
@@ -2499,12 +2296,11 @@ export class HVFullView extends LitElement {
               @sort-change=${(e: CustomEvent) => this._setFilters({ sort: (e.detail as { sort: Sort }).sort })}
               @near-end=${(e: CustomEvent) =>
                 void this.store?.prefetchIfNeeded((e.detail as { ratio: number }).ratio)}
-              @increment=${(e: CustomEvent) => this._onRowEvent('increment', e.detail)}
-              @decrement=${(e: CustomEvent) => this._onRowEvent('decrement', e.detail)}
-              @edit=${(e: CustomEvent) => this._onRowEvent('edit', e.detail)}
-              @open-item=${(e: CustomEvent) => this._onRowEvent('open-item', e.detail)}
-              @row-action=${(e: CustomEvent) =>
-                this._onRowAction(e.detail as { itemId?: string; action?: string })}
+              @increment=${(e: CustomEvent) => this._workspace.onRowEvent('increment', e.detail)}
+              @decrement=${(e: CustomEvent) => this._workspace.onRowEvent('decrement', e.detail)}
+              @edit=${(e: CustomEvent) => this._workspace.onRowEvent('edit', e.detail)}
+              @open-item=${(e: CustomEvent) => this._workspace.onRowEvent('open-item', e.detail)}
+              @row-action=${(e: CustomEvent) => this._workspace.onRowAction(e.detail)}
               @toggle-select=${(e: CustomEvent) =>
                 this.store?.toggleSelected((e.detail as { itemId: string }).itemId)}
               @select-all-loaded=${() => this.store?.selectAllLoaded()}
@@ -2572,89 +2368,18 @@ export class HVFullView extends LitElement {
         ></hv-confirm>
 
         ${this._viewport.narrow
-          ? html`<hv-detail-sheet
-              data-testid="full-detail-sheet"
-              .statuses=${st?.statuses ?? null}
-              .areas=${st?.areasCache?.areas ?? []}
-              .media=${this.media}
-              .mediaConfig=${st?.mediaConfig ?? null}
-              ?open=${this._detailItemId !== null}
-              .item=${this._detailItemId ? (st?.items.find((i) => i.id === this._detailItemId) ?? null) : null}
-              .locations=${st?.locationsFlatCache ?? null}
-              .locationTree=${st?.locationTreeCache ?? []}
-              .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
-              .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((t) => t.value)}
-              .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
-              .createLocation=${this._createLocationForEditor}
-              .confirmDiscard=${this.confirmDiscard}
-              .busy=${this._editorBusy}
-              .errorMessage=${this._editorError}
-              @cancel=${() => {
-                this._detailItemId = null;
-                this._editorError = null;
-              }}
-              @increment=${(e: CustomEvent) => this._onRowEvent('increment', e.detail)}
-              @decrement=${(e: CustomEvent) => this._onRowEvent('decrement', e.detail)}
-              @check-in=${(e: CustomEvent) =>
-                this._onRowAction({ itemId: (e.detail as { itemId: string }).itemId, action: 'check-in' })}
-              @check-out-confirmed=${(e: CustomEvent) => {
-                const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-                const item = st?.items.find((i) => i.id === itemId);
-                if (item) void this.store?.checkOut(item.id, dueDate, item.version);
-              }}
-              @set-due-date=${(e: CustomEvent) => {
-                const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-                const item = st?.items.find((i) => i.id === itemId);
-                if (item) void this.store?.updateItem(item.id, { due_date: dueDate }, item.version);
-              }}
-              @reminder-bump=${(e: CustomEvent) => {
-                const { itemId } = e.detail as { itemId: string };
-                const item = st?.items.find((i) => i.id === itemId);
-                if (item) void this.store?.bumpReminder(item.id, item.version);
-              }}
-              @request-delete=${(e: CustomEvent) =>
-                this.dispatchEvent(
-                  new CustomEvent('request-delete', { detail: e.detail, bubbles: true, composed: true }),
-                )}
-              @save=${this._onEditorSave}
-            ></hv-detail-sheet>`
+          ? this._workspace.renderDetailSheet({ testid: 'full-detail-sheet' })
           : null}
 
-        <!-- Centred and scrimmed at every width, like the bulk popover below.
-             Neither of the other two placements fits this call site: an inline
-             step has to sit inside the body of the surface that opened it, and
-             this is a sibling at the end of the shell with no body around it;
-             an anchored one hangs off the row ⋮, which sits in a column the
-             table scrolls sideways out of view. Finger-sized controls are a
-             separate question and follow the narrow branch on their own. -->
-        <hv-checkout-popover
-          data-testid="full-checkout"
-          ?open=${this._checkout !== null}
-          ?touch=${this._viewport.narrow}
-          .mode=${this._checkout?.mode ?? 'check-out'}
-          .item=${this._checkout ? (st?.items.find((i) => i.id === this._checkout!.itemId) ?? null) : null}
-          @check-out=${(e: CustomEvent) => {
-            const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-            const item = st?.items.find((i) => i.id === itemId);
-            this._checkout = null;
-            if (item) void this.store?.checkOut(item.id, dueDate, item.version);
-          }}
-          @set-due-date=${(e: CustomEvent) => {
-            const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
-            const item = st?.items.find((i) => i.id === itemId);
-            this._checkout = null;
-            // A due date only exists while an item is out, so this is a plain update.
-            if (item) void this.store?.updateItem(item.id, { due_date: dueDate }, item.version);
-          }}
-          @cancel=${() => {
-            this._checkout = null;
-          }}
-        ></hv-checkout-popover>
+        ${this._workspace.renderCheckoutPopover({
+          testid: 'full-checkout',
+          mobile: this._viewport.narrow,
+        })}
 
-        <!-- Centred at every width for the same reason as the one above: it is
-             opened by a bar at the foot of the table with no body of its own to
-             sit in. It anchors to nothing, so it takes the same scrimmed
-             middle-of-the-screen position the bulk confirm does. -->
+        <!-- Centred at every width and scrimmed: it is opened by a bar at the
+             foot of the table with no body of its own to sit in, and it anchors
+             to nothing, so it takes the same middle-of-the-screen position the
+             bulk confirm does. -->
         <hv-checkout-popover
           data-testid="full-bulk-checkout"
           ?open=${this._pendingBulkCheckout}

--- a/cards/haventory-card/src/haventory-panel.ts
+++ b/cards/haventory-card/src/haventory-panel.ts
@@ -97,7 +97,6 @@ export class HAventoryPanel extends LitElement {
         this.requestUpdate();
       });
     }
-    this.surfaces.connect();
     this._syncColorScheme();
   }
 
@@ -107,7 +106,6 @@ export class HAventoryPanel extends LitElement {
       this._storeUnsub();
       this._storeUnsub = undefined;
     }
-    this.surfaces.disconnect();
   }
 
   firstUpdated(): void {

--- a/cards/haventory-card/src/haventory-panel.ts
+++ b/cards/haventory-card/src/haventory-panel.ts
@@ -1,9 +1,6 @@
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
 import { property } from 'lit/decorators.js';
-import { setLanguage } from './i18n';
-import type { HassLike } from './store/types';
-import { Store } from './store/store';
-import { resolveColorScheme } from './ui/theme';
+import { StoreHostElement } from './store-host';
 import { DEFAULT_CARD_TITLE } from './ui/card-title';
 import type { QuickFilterKey } from './ui/quick-filters';
 import { defineCardElement } from './register';
@@ -21,12 +18,12 @@ interface PanelInfo {
  *
  * Home Assistant's custom-panel loader creates this element, sets `hass`,
  * `narrow`, `route` and `panel` on it, and gives it the whole content area.
- * It owns the `Store` (the same lifecycle `haventory-card` has) and a
+ * It owns a `Store` on the lifecycle it shares with `haventory-card`, and a
  * `HostSurfaces` instance (the same one `hv-card-shell` holds on the card
  * side), and hands the inventory itself to `hv-full-view` — embedded rather
  * than modal, since a page has nowhere to close to.
  */
-export class HAventoryPanel extends LitElement {
+export class HAventoryPanel extends StoreHostElement {
   static styles = css`
     :host {
       display: block;
@@ -52,10 +49,6 @@ export class HAventoryPanel extends LitElement {
   /** Set on every navigation. Unread — this panel has no sub-routes. */
   @property({ attribute: false }) route?: unknown;
 
-  private store?: Store;
-  private _storeUnsub?: () => void;
-  private _hass?: HassLike;
-
   /**
    * No `onItemDeleted` hook — the embedded view closes its own editor when the
    * item vanishes. No `onBrowse` — the full view here is the page itself, so
@@ -65,64 +58,6 @@ export class HAventoryPanel extends LitElement {
    * `narrow` — that flag is about the sidebar and flips at a tablet width.
    */
   readonly surfaces = new HostSurfaces(this, () => this.store);
-
-  get hass(): HassLike | undefined {
-    return this._hass;
-  }
-
-  set hass(h: HassLike | undefined) {
-    this._hass = h;
-    // Ahead of the store, for the same reason the card does it there.
-    if (setLanguage(h?.language)) this.requestUpdate();
-    if (h && !this.store) {
-      this.store = new Store(h);
-      this._storeUnsub = this.store.state.onChange(() => {
-        this.requestUpdate();
-      });
-      void this.store.init().catch(() => undefined);
-      // The loader sets `hass` after the element is in the DOM, so the first
-      // render can already be behind us — and a plain field carries no
-      // reactivity of its own. Without this the view holds no store until the
-      // first state change happens to arrive.
-      this.requestUpdate();
-    }
-    // A theme switch arrives as a fresh hass object, so this is the hook for it.
-    this._syncColorScheme();
-  }
-
-  connectedCallback(): void {
-    super.connectedCallback();
-    if (this.store && !this._storeUnsub) {
-      this._storeUnsub = this.store.state.onChange(() => {
-        this.requestUpdate();
-      });
-    }
-    this._syncColorScheme();
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    if (this._storeUnsub) {
-      this._storeUnsub();
-      this._storeUnsub = undefined;
-    }
-  }
-
-  firstUpdated(): void {
-    this._syncColorScheme();
-  }
-
-  /**
-   * Publish the active Home Assistant theme as `color-scheme` on this host, so
-   * the `light-dark()` design tokens and the browser's native controls follow
-   * the frontend rather than the operating system. Inherited, so it covers
-   * every nested component.
-   */
-  private _syncColorScheme(): void {
-    if (!this.isConnected || typeof getComputedStyle !== 'function') return;
-    const scheme = resolveColorScheme(getComputedStyle(this));
-    if (scheme) this.style.colorScheme = scheme;
-  }
 
   render() {
     return html`

--- a/cards/haventory-card/src/host-surfaces.ts
+++ b/cards/haventory-card/src/host-surfaces.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import type { TemplateResult } from 'lit';
+import type { ReactiveControllerHost, TemplateResult } from 'lit';
 import type { ColumnKey } from './store/columns';
 import { loadColumnPrefs, saveColumnPrefs } from './store/columns';
 import { activeFilterCount, defaultFilters } from './store/store';
@@ -8,7 +8,7 @@ import type { ImportPolicy, ImportPreview, ImportSummary } from './store/types';
 import { t, tn } from './i18n';
 import { discardPrompt } from './ui/discard';
 import type { ConfirmDiscard } from './ui/discard';
-import { NARROW_QUERY } from './ui/responsive';
+import { ViewportNarrow } from './ui/responsive';
 import type { OrganizeTab } from './components/hv-organize-dialog';
 import type { OverflowMenuEntry } from './components/hv-overflow-menu';
 import './components/hv-column-picker';
@@ -17,10 +17,11 @@ import './components/hv-organize-dialog';
 import './components/hv-import-sheet';
 import './components/hv-diagnostics-panel';
 
-/** All that these surfaces need from the element hosting them. */
-interface SurfaceHost {
-  requestUpdate(): void;
-}
+/**
+ * All that these surfaces need from the element hosting them: a redraw, and a
+ * lifecycle for the viewport watcher below to hang on.
+ */
+type SurfaceHost = ReactiveControllerHost;
 
 /** What a confirmation prompt needs to say and do. */
 interface ConfirmSpec {
@@ -85,12 +86,7 @@ export class HostSurfaces {
    * expanding the card does not change it — the measured element is still the
    * card underneath.
    */
-  private narrowQuery: MediaQueryList | null = null;
-  private narrow = false;
-  private readonly onNarrowChange = (e: MediaQueryListEvent) => {
-    this.narrow = e.matches;
-    this.host.requestUpdate();
-  };
+  private readonly viewport: ViewportNarrow;
   private pickerOpen = false;
   private confirmSpec: ConfirmSpec | null = null;
   private organizeOpen = false;
@@ -106,27 +102,7 @@ export class HostSurfaces {
     this.host = host;
     this.getStore = getStore;
     this.hooks = hooks;
-  }
-
-  /**
-   * Start watching the viewport. Hosts call this from `connectedCallback`, and
-   * `disconnect()` from the matching teardown — an instance is a plain object
-   * rather than a reactive controller, so it has no lifecycle of its own, and a
-   * listener left behind would keep waking a detached element.
-   *
-   * `matchMedia` is missing in jsdom unless a test provides one; without it the
-   * dialogs take their desktop form, which is the honest default for a host
-   * that cannot say how wide it is.
-   */
-  connect(): void {
-    this.narrowQuery ??= window.matchMedia?.(NARROW_QUERY) ?? null;
-    if (!this.narrowQuery) return;
-    this.narrow = this.narrowQuery.matches;
-    this.narrowQuery.addEventListener('change', this.onNarrowChange);
-  }
-
-  disconnect(): void {
-    this.narrowQuery?.removeEventListener('change', this.onNarrowChange);
+    this.viewport = new ViewportNarrow(host);
   }
 
   /**
@@ -297,7 +273,7 @@ export class HostSurfaces {
   /** Every dialog these surfaces own. Render once, after the host's main UI. */
   renderSurfaces(): TemplateResult {
     const st = this.getStore()?.state.value ?? null;
-    const mobile = this.narrow;
+    const mobile = this.viewport.narrow;
     return html`
       <hv-column-picker
         data-testid="host-columns"

--- a/cards/haventory-card/src/index.ts
+++ b/cards/haventory-card/src/index.ts
@@ -1,9 +1,6 @@
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
 import { registerCustomCard } from './ha-contract';
-import { setLanguage } from './i18n';
-import type { HassLike } from './store/types';
-import { Store } from './store/store';
-import { resolveColorScheme } from './ui/theme';
+import { StoreHostElement } from './store-host';
 import { DEFAULT_CARD_TITLE } from './ui/card-title';
 import { normalizeQuickFilters } from './ui/quick-filters';
 import type { QuickFilterKey } from './ui/quick-filters';
@@ -15,7 +12,7 @@ import './components/hv-card-shell';
 import './haventory-panel';
 import './haventory-card-editor';
 
-export class HAventoryCard extends LitElement {
+export class HAventoryCard extends StoreHostElement {
   static styles = css`
     :host {
       display: block;
@@ -26,10 +23,6 @@ export class HAventoryCard extends LitElement {
   `;
 
   private config?: { title?: string; quickFilters?: QuickFilterKey[] | null };
-
-  private store?: Store;
-  private _storeUnsub?: () => void;
-  private _hass?: HassLike;
 
   /**
    * What the card picker writes into a new dashboard entry.
@@ -89,64 +82,6 @@ export class HAventoryCard extends LitElement {
     min_rows: number;
   } {
     return { columns: 12, rows: 8, min_columns: 6, min_rows: 4 };
-  }
-
-  get hass(): HassLike | undefined {
-    return this._hass;
-  }
-
-  set hass(h: HassLike | undefined) {
-    this._hass = h;
-    // Ahead of the store, so the first render of every surface it feeds is
-    // already in the user's language rather than flashing English first.
-    if (setLanguage(h?.language)) this.requestUpdate();
-    if (h && !this.store) {
-      this.store = new Store(h);
-      this._storeUnsub = this.store.state.onChange(() => {
-        this.requestUpdate();
-      });
-      void this.store.init().catch(() => undefined);
-    }
-    // A theme switch arrives as a fresh hass object, so this is the hook for it.
-    this._syncColorScheme();
-  }
-
-  connectedCallback(): void {
-    super.connectedCallback();
-    // If hass was already set before connectedCallback ran, ensure subscription exists
-    if (this.store && !this._storeUnsub) {
-      this._storeUnsub = this.store.state.onChange(() => {
-        this.requestUpdate();
-      });
-    }
-    this._syncColorScheme();
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    if (this._storeUnsub) {
-      this._storeUnsub();
-      this._storeUnsub = undefined;
-    }
-  }
-
-  firstUpdated(): void {
-    this._syncColorScheme();
-  }
-
-  /**
-   * Publish the active Home Assistant theme as `color-scheme` on this host.
-   *
-   * `light-dark()` in the design tokens resolves against it, and the browser
-   * uses it to paint native controls, so both follow HA rather than the OS.
-   * The value is inherited, so setting it here covers every nested component.
-   * When the theme has not painted yet we leave the property alone and the OS
-   * preference keeps deciding.
-   */
-  private _syncColorScheme(): void {
-    if (!this.isConnected || typeof getComputedStyle !== 'function') return;
-    const scheme = resolveColorScheme(getComputedStyle(this));
-    if (scheme) this.style.colorScheme = scheme;
   }
 
   /**

--- a/cards/haventory-card/src/item-workspace.ts
+++ b/cards/haventory-card/src/item-workspace.ts
@@ -1,0 +1,494 @@
+import { html } from 'lit';
+import type { ReactiveController, ReactiveControllerHost, TemplateResult } from 'lit';
+import { t } from './i18n';
+import { editorErrorText } from './ui/editor-error';
+import type { ConfirmDiscard } from './ui/discard';
+import type { MediaBindings } from './ui/media';
+import type { Store } from './store/store';
+import type { Item, ItemCreate, ItemUpdate, Location, StoreState } from './store/types';
+import type { HVItemEditor } from './components/hv-item-editor';
+import './components/hv-checkout-popover';
+import './components/hv-detail-sheet';
+import './components/hv-item-editor';
+
+/**
+ * All that this workspace needs from the element hosting it: a redraw, a
+ * lifecycle for the store subscription, and somewhere to raise a row event the
+ * table below it does not answer.
+ */
+type WorkspaceHost = ReactiveControllerHost & EventTarget;
+
+/** Where an editor, a read sheet or a check-out step is being drawn. */
+interface SurfaceOptions {
+  /** The per-surface `data-testid`; the browser harnesses locate these. */
+  testid: string;
+  /** Finger-sized controls and the one-column form. */
+  mobile: boolean;
+}
+
+/** The ways a host differs; everything else in this workspace is identical. */
+export interface WorkspaceHooks {
+  /**
+   * The host's discard question. The card's shells raise it through their
+   * `HostSurfaces`, the expanded view through the property its host sets, and
+   * `null` leaves a form without one.
+   */
+  confirmDiscard: () => ConfirmDiscard | null;
+  /**
+   * The open form, wherever this host renders it — the dirty check has to find
+   * it across whichever shadow root it landed in.
+   */
+  editor: () => HVItemEditor | null;
+  /**
+   * A row was opened: tapped, or Enter on it. The expanded view answers this
+   * and the menu entry below identically; the card does not, because a tap on
+   * a phone opens the read sheet and the menu entry opens the form.
+   */
+  openItem: (itemId: string) => void;
+  /** The row menu's Edit entry. */
+  editItem: (itemId: string) => void;
+  /**
+   * A delete was asked for, from a row menu, the open form or the read sheet.
+   * The card confirms it in its own `HostSurfaces`; the expanded view has none,
+   * so it hands the request to whichever element is hosting it.
+   */
+  requestDelete: (detail: { itemId: string; name?: string }) => void;
+}
+
+/**
+ * Everything both of the card's shells do to one item.
+ *
+ * The compact card and the expanded view are two sizes of the same workspace:
+ * each opens the edit form, holds on to the row it is open on, saves it, shows
+ * one item in a read sheet at phone width, and runs a check-out step from a
+ * row. Written twice, the two copies were free to drift on when typing is
+ * asked about, what a refused save leaves on screen and which events a row may
+ * raise — so the state, the store calls and the three templates live here,
+ * held by the host rather than repeated in it. The same arrangement
+ * `HostSurfaces` uses for the dialogs.
+ *
+ * The templates take the surface's own `data-testid` and phone flag as
+ * parameters: `inline-editor` / `full-editor` / `sheet-editor` and their
+ * neighbours are what the browser harnesses locate, and one renderer is what
+ * keeps them from drifting apart in anything else.
+ */
+export class ItemWorkspace implements ReactiveController {
+  /** Row expanded into the editor, or `'new'` for the create form. */
+  editing: string | 'new' | null = null;
+  /** True while a save is in flight; the form greys itself out. */
+  editorBusy = false;
+  /**
+   * What the open form says about a save the store refused.
+   *
+   * The store reports failures through its error queue rather than throwing,
+   * and the form can be tall enough to have scrolled the host's banner list off
+   * the screen — so the account of what happened goes inside the form, beside
+   * the text it kept.
+   */
+  editorError: string | null = null;
+  /**
+   * The last copy of the row being edited, kept for as long as the form is
+   * open.
+   *
+   * A filter change refetches, and the edited row can drop out of the result.
+   * The editor rebuilds its model whenever the item it was handed changes, so
+   * handing it `null` there would wipe the typed edits just as surely as
+   * unmounting it. `syncPinnedItem` keeps this at the freshest listed copy.
+   */
+  pinnedItem: Item | null = null;
+  /** Item shown in the read sheet, which is the phone's read surface. */
+  detailItemId: string | null = null;
+  /** Item whose check-out / due-date step is open, with where to anchor it. */
+  checkout: { itemId: string; mode: 'check-out' | 'set-due-date'; anchor: DOMRect | null } | null =
+    null;
+
+  private readonly host: WorkspaceHost;
+  private readonly getStore: () => Store | undefined;
+  private readonly hooks: WorkspaceHooks;
+  private storeUnsub?: () => void;
+  private subscribedTo?: Store;
+  private mediaFor?: Store;
+  private mediaBindings: MediaBindings | null = null;
+
+  constructor(host: WorkspaceHost, getStore: () => Store | undefined, hooks: WorkspaceHooks) {
+    this.host = host;
+    this.getStore = getStore;
+    this.hooks = hooks;
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    this.subscribe();
+  }
+
+  hostDisconnected(): void {
+    this.storeUnsub?.();
+    this.storeUnsub = undefined;
+    this.subscribedTo = undefined;
+  }
+
+  /** A store handed in after the first render still has to be watched. */
+  hostUpdate(): void {
+    this.subscribe();
+  }
+
+  /**
+   * Both hosts are passed a stable `store` object, so a property binding would
+   * never re-render them — the workspace watches the store itself.
+   */
+  private subscribe(): void {
+    const store = this.getStore();
+    if (!store || store === this.subscribedTo) return;
+    this.storeUnsub?.();
+    this.subscribedTo = store;
+    this.storeUnsub = store.state.onChange(() => this.host.requestUpdate());
+  }
+
+  private get st(): StoreState | null {
+    return this.getStore()?.state.value ?? null;
+  }
+
+  private itemById(itemId: string | undefined): Item | undefined {
+    return this.st?.items.find((i) => i.id === itemId);
+  }
+
+  /**
+   * Picture access for every surface below, built once per store.
+   *
+   * A fresh object each render would read as a changed property on every row
+   * and re-render the whole list, so it is rebuilt only when the store is
+   * swapped.
+   */
+  get media(): MediaBindings | null {
+    const store = this.getStore();
+    if (!store) return null;
+    if (this.mediaFor !== store) {
+      this.mediaFor = store;
+      this.mediaBindings = {
+        sign: (path, expires) => store.signMediaPath(path, expires),
+        upload: (itemId, file, kind) => store.uploadAttachment(itemId, file, kind),
+        remove: (itemId, attachmentId) => store.removeAttachment(itemId, attachmentId),
+        retitle: (itemId, attachmentId, title) => store.updateAttachment(itemId, attachmentId, title),
+        reorder: (itemId, kind, attachmentIds) => store.reorderAttachments(itemId, kind, attachmentIds),
+      };
+    }
+    return this.mediaBindings;
+  }
+
+  /** The item the open form edits — the listed row, or the pinned copy of it. */
+  get editorItem(): Item | null {
+    const id = this.editing;
+    if (id === null || id === 'new') return null;
+    return this.itemById(id) ?? (this.pinnedItem?.id === id ? this.pinnedItem : null);
+  }
+
+  /**
+   * Hold on to the row being edited, and close what is open on it when it is
+   * really gone.
+   *
+   * Falling off the current page and being deleted look identical from the item
+   * list alone; the store is the only place that knows which happened, so it is
+   * asked rather than guessed at.
+   */
+  syncPinnedItem(): void {
+    // The read sheet holds an id too, and a deleted item leaves it showing
+    // nothing at all rather than closing.
+    if (this.detailItemId !== null && this.getStore()?.wasRemoved(this.detailItemId)) {
+      this.detailItemId = null;
+    }
+    const editing = this.editing;
+    if (editing === null || editing === 'new') {
+      this.pinnedItem = null;
+      return;
+    }
+    if (this.getStore()?.wasRemoved(editing)) {
+      this.pinnedItem = null;
+      this.editing = null;
+      this.editorError = null;
+      return;
+    }
+    const listed = this.itemById(editing);
+    if (listed) this.pinnedItem = listed;
+  }
+
+  /**
+   * Open a form, closing whichever one is open. Only one row edits at a time;
+   * if the open one has unsaved changes the user is asked first, rather than
+   * silently losing them.
+   */
+  startEdit(next: string | 'new' | null): void {
+    if (this.editing === next) return;
+    this.leave(() => this.setEditing(next));
+  }
+
+  /**
+   * Leave the open form — for another row, for the create form, or by taking
+   * the whole surface down — asking first if there is typing to lose.
+   *
+   * The form asks for its own Cancel, ✕ and Escape, but only about closing.
+   * Everything here has somewhere else to be afterwards, so the destination is
+   * held in the callback until the host's question comes back answered.
+   */
+  leave(go: () => void): void {
+    const ask = this.hooks.confirmDiscard();
+    if (ask && this.editing !== null && this.hooks.editor()?.dirty) {
+      ask(go);
+      return;
+    }
+    go();
+  }
+
+  /** Show `next` in the form, dropping what the last save said. */
+  setEditing(next: string | 'new' | null): void {
+    this.editing = next;
+    this.editorError = null;
+    this.host.requestUpdate();
+  }
+
+  /** Open the read sheet on an item. */
+  openDetail(itemId: string): void {
+    this.detailItemId = itemId;
+    this.host.requestUpdate();
+  }
+
+  /** Close the read sheet, dropping what the last save said inside it. */
+  closeDetail(): void {
+    this.detailItemId = null;
+    this.editorError = null;
+    this.host.requestUpdate();
+  }
+
+  /**
+   * A delete has been confirmed and sent. Close whatever is still pointing at
+   * the item, ahead of the store broadcasting its disappearance.
+   */
+  forgetItem(itemId: string): void {
+    if (this.editing === itemId) this.editing = null;
+    if (this.detailItemId === itemId) this.detailItemId = null;
+    this.host.requestUpdate();
+  }
+
+  /**
+   * The editor's first-run way out of an empty location picker: a root location
+   * with no area, handed back so the form can file the item in it at once.
+   */
+  readonly createLocationForEditor = (name: string): Promise<Location> => {
+    const store = this.getStore();
+    if (!store) return Promise.reject(new Error(t('hv.card.notConnected')));
+    return store.createLocation(name, null, null);
+  };
+
+  readonly onEditorSave = async (e: CustomEvent): Promise<void> => {
+    const detail = e.detail as {
+      itemId: string | null;
+      expectedVersion?: number;
+      changes?: ItemUpdate;
+      create?: ItemCreate;
+    };
+    this.editorBusy = true;
+    this.editorError = null;
+    this.host.requestUpdate();
+    const before = this.st?.errorQueue.length ?? 0;
+    try {
+      if (detail.itemId && detail.changes) {
+        await this.getStore()?.updateItem(detail.itemId, detail.changes, detail.expectedVersion);
+      } else if (detail.create) {
+        await this.getStore()?.createItem(detail.create);
+      }
+    } finally {
+      this.editorBusy = false;
+    }
+    // The store reports failures through its error queue rather than throwing,
+    // so a new entry is how we know the save did not land. Keep the form open
+    // in that case so the user's edits are still there to retry.
+    const queue = this.st?.errorQueue ?? [];
+    const failed = queue.length > before;
+    this.editorError = failed ? editorErrorText(queue[queue.length - 1]) : null;
+    if (!failed) this.editing = null;
+    this.host.requestUpdate();
+  };
+
+  /**
+   * What a row's ⋮ entry means. The ids and their meanings come from one list,
+   * so a household learns Check out / Check in / due date / Edit / Delete once
+   * however it reached them.
+   */
+  onRowAction(detail: { itemId?: string; action?: string; anchor?: DOMRect }): void {
+    const item = this.itemById(detail.itemId);
+    if (!item) return;
+    switch (detail.action) {
+      case 'check-out':
+      case 'set-due-date':
+        this.checkout = { itemId: item.id, mode: detail.action, anchor: detail.anchor ?? null };
+        this.host.requestUpdate();
+        break;
+      case 'check-in':
+        void this.getStore()?.markCheckedIn(item.id, item.version);
+        break;
+      case 'edit':
+        this.hooks.editItem(item.id);
+        break;
+      case 'delete':
+        this.hooks.requestDelete({ itemId: item.id, name: item.name });
+        break;
+    }
+  }
+
+  /**
+   * Everything a row, a table row or the read sheet can raise about one item.
+   * A name this does not know is re-raised on the host, which is where a
+   * surface above it can still answer.
+   */
+  onRowEvent(name: string, detail: { itemId?: string }): void {
+    const item = this.itemById(detail.itemId);
+    if (!item) return;
+    const store = this.getStore();
+    switch (name) {
+      case 'increment':
+        void store?.adjustQuantity(item.id, +1);
+        break;
+      case 'decrement':
+        if (item.quantity > 0) void store?.adjustQuantity(item.id, -1);
+        break;
+      case 'check-in':
+        void store?.markCheckedIn(item.id, item.version);
+        break;
+      case 'reminder-bump':
+        void store?.bumpReminder(item.id, item.version);
+        break;
+      case 'request-delete':
+        this.hooks.requestDelete({ itemId: item.id });
+        break;
+      case 'row-action':
+        this.onRowAction(detail as { itemId?: string; action?: string; anchor?: DOMRect });
+        break;
+      case 'edit':
+      case 'open-item':
+        this.hooks.openItem(item.id);
+        break;
+      default:
+        this.host.dispatchEvent(
+          new CustomEvent(name, { detail: { itemId: item.id }, bubbles: true, composed: true }),
+        );
+    }
+  }
+
+  /**
+   * The edit form.
+   *
+   * `noHeader` is for the phone add sheet, which draws its own title bar — the
+   * editor's own header leads with an expander chevron that means nothing once
+   * the form is not an expander.
+   */
+  renderEditor(opts: SurfaceOptions & { noHeader?: boolean }): TemplateResult {
+    const st = this.st;
+    return html`<hv-item-editor
+      .statuses=${st?.statuses ?? null}
+      data-testid=${opts.testid}
+      .areas=${st?.areasCache?.areas ?? []}
+      .media=${this.media}
+      .mediaConfig=${st?.mediaConfig ?? null}
+      ?noHeader=${opts.noHeader ?? false}
+      .item=${this.editorItem}
+      .locations=${st?.locationsFlatCache ?? null}
+      .locationTree=${st?.locationTreeCache ?? []}
+      .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
+      .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((tag) => tag.value)}
+      .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
+      .createLocation=${this.createLocationForEditor}
+      .confirmDiscard=${this.hooks.confirmDiscard()}
+      ?mobile=${opts.mobile}
+      .busy=${this.editorBusy}
+      .errorMessage=${this.editorError}
+      @save=${this.onEditorSave}
+      @delete-item=${(e: CustomEvent) =>
+        this.hooks.requestDelete(e.detail as { itemId: string; name?: string })}
+      @cancel=${() => this.setEditing(null)}
+    ></hv-item-editor>`;
+  }
+
+  /**
+   * The read sheet: one item, at phone width, with Edit one tap deeper inside
+   * it. The sheet reads the viewport itself, so it takes no phone flag from
+   * here — only its host decides whether to draw it at all.
+   */
+  renderDetailSheet(opts: Pick<SurfaceOptions, 'testid'>): TemplateResult {
+    const st = this.st;
+    return html`<hv-detail-sheet
+      .statuses=${st?.statuses ?? null}
+      data-testid=${opts.testid}
+      .areas=${st?.areasCache?.areas ?? []}
+      .media=${this.media}
+      .mediaConfig=${st?.mediaConfig ?? null}
+      ?open=${this.detailItemId !== null}
+      .item=${this.detailItemId ? (this.itemById(this.detailItemId) ?? null) : null}
+      .locations=${st?.locationsFlatCache ?? null}
+      .locationTree=${st?.locationTreeCache ?? []}
+      .categorySuggestions=${(st?.distinctValuesCache?.categories ?? []).map((c) => c.value)}
+      .tagSuggestions=${(st?.distinctValuesCache?.tags ?? []).map((tag) => tag.value)}
+      .customFieldKeys=${st?.distinctValuesCache?.custom_field_keys ?? []}
+      .createLocation=${this.createLocationForEditor}
+      .confirmDiscard=${this.hooks.confirmDiscard()}
+      .busy=${this.editorBusy}
+      .errorMessage=${this.editorError}
+      @cancel=${() => this.closeDetail()}
+      @increment=${(e: CustomEvent) => this.onRowEvent('increment', e.detail)}
+      @decrement=${(e: CustomEvent) => this.onRowEvent('decrement', e.detail)}
+      @check-in=${(e: CustomEvent) => this.onRowEvent('check-in', e.detail)}
+      @reminder-bump=${(e: CustomEvent) => this.onRowEvent('reminder-bump', e.detail)}
+      @request-delete=${(e: CustomEvent) => this.onRowEvent('request-delete', e.detail)}
+      @check-out-confirmed=${(e: CustomEvent) => this.onCheckOut(e)}
+      @set-due-date=${(e: CustomEvent) => this.onSetDueDate(e)}
+      @save=${this.onEditorSave}
+    ></hv-detail-sheet>`;
+  }
+
+  /**
+   * The check-out step for one row.
+   *
+   * Never inline: that presentation is a step drawn inside the body of the
+   * surface that opened it, and this is a sibling at the end of a shell with no
+   * body around it. It hangs off the row that opened it wherever the row hands
+   * a rectangle over, which the card's do and the table's do not — the table's
+   * ⋮ sits in a column that scrolls sideways out of view, so there the step is
+   * centred and scrimmed instead. The card's phone branch reaches its check-out
+   * through the read sheet, which mounts its own.
+   */
+  renderCheckoutPopover(opts: SurfaceOptions): TemplateResult {
+    return html`<hv-checkout-popover
+      data-testid=${opts.testid}
+      ?open=${this.checkout !== null}
+      ?touch=${opts.mobile}
+      .mode=${this.checkout?.mode ?? 'check-out'}
+      .anchor=${this.checkout?.anchor ?? null}
+      .item=${this.checkout ? (this.itemById(this.checkout.itemId) ?? null) : null}
+      @check-out=${(e: CustomEvent) => {
+        this.checkout = null;
+        this.host.requestUpdate();
+        this.onCheckOut(e);
+      }}
+      @set-due-date=${(e: CustomEvent) => {
+        this.checkout = null;
+        this.host.requestUpdate();
+        this.onSetDueDate(e);
+      }}
+      @cancel=${() => {
+        this.checkout = null;
+        this.host.requestUpdate();
+      }}
+    ></hv-checkout-popover>`;
+  }
+
+  private onCheckOut(e: CustomEvent): void {
+    const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
+    const item = this.itemById(itemId);
+    if (item) void this.getStore()?.checkOut(item.id, dueDate, item.version);
+  }
+
+  /** A due date only exists while an item is out, so this is a plain update. */
+  private onSetDueDate(e: CustomEvent): void {
+    const { itemId, dueDate } = e.detail as { itemId: string; dueDate: string | null };
+    const item = this.itemById(itemId);
+    if (item) void this.getStore()?.updateItem(item.id, { due_date: dueDate }, item.version);
+  }
+}

--- a/cards/haventory-card/src/store-host.ts
+++ b/cards/haventory-card/src/store-host.ts
@@ -1,0 +1,83 @@
+import { LitElement } from 'lit';
+import { setLanguage } from './i18n';
+import { Store } from './store/store';
+import { resolveColorScheme } from './ui/theme';
+import type { HassLike } from './store/types';
+
+/**
+ * What the two elements Home Assistant instantiates itself share.
+ *
+ * The Lovelace card and the sidebar panel are each handed a `hass` object and
+ * nothing else, and each owns a `Store` built from it. The lifecycle around
+ * that store is the same on both: build it once, watch it for as long as the
+ * element is in the DOM, set the language ahead of it, and publish the active
+ * theme. What differs is what they render and what configuration they read.
+ */
+export abstract class StoreHostElement extends LitElement {
+  protected store?: Store;
+  private _storeUnsub?: () => void;
+  private _hass?: HassLike;
+
+  get hass(): HassLike | undefined {
+    return this._hass;
+  }
+
+  set hass(h: HassLike | undefined) {
+    this._hass = h;
+    // Ahead of the store, so the first render of every surface it feeds is
+    // already in the user's language rather than flashing English first.
+    if (setLanguage(h?.language)) this.requestUpdate();
+    if (h && !this.store) {
+      this.store = new Store(h);
+      this._storeUnsub = this.store.state.onChange(() => {
+        this.requestUpdate();
+      });
+      void this.store.init().catch(() => undefined);
+      // The element can already have rendered by the time `hass` arrives, and
+      // a plain field carries no reactivity of its own — without this the
+      // surface below holds no store until the first state change happens to
+      // arrive.
+      this.requestUpdate();
+    }
+    // A theme switch arrives as a fresh hass object, so this is the hook for it.
+    this._syncColorScheme();
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    // `hass` can have been set before this element was in the DOM.
+    if (this.store && !this._storeUnsub) {
+      this._storeUnsub = this.store.state.onChange(() => {
+        this.requestUpdate();
+      });
+    }
+    this._syncColorScheme();
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._storeUnsub) {
+      this._storeUnsub();
+      this._storeUnsub = undefined;
+    }
+  }
+
+  protected firstUpdated(): void {
+    this._syncColorScheme();
+  }
+
+  /**
+   * Publish the active Home Assistant theme as `color-scheme` on this host.
+   *
+   * `light-dark()` in the design tokens resolves against it, and the browser
+   * uses it to paint native controls, so both follow HA rather than the OS.
+   * The value is inherited, so setting it here covers every nested component.
+   * When the theme has not painted yet we leave the property alone and the OS
+   * preference keeps deciding.
+   */
+  private _syncColorScheme(): void {
+    if (!this.isConnected || typeof getComputedStyle !== 'function') return;
+    const scheme = resolveColorScheme(getComputedStyle(this));
+    if (scheme) this.style.colorScheme = scheme;
+  }
+}

--- a/cards/haventory-card/src/ui/responsive.ts
+++ b/cards/haventory-card/src/ui/responsive.ts
@@ -39,11 +39,17 @@ export const NARROW_QUERY = '(max-width: 700px)';
  */
 export class ViewportNarrow implements ReactiveController {
   private readonly host: ReactiveControllerHost;
+  private readonly notify?: (narrow: boolean) => void;
   private query: MediaQueryList | null = null;
   private matches = false;
 
-  constructor(host: ReactiveControllerHost) {
+  /**
+   * `onChange` is for a host holding state that only means something at one
+   * width — it is dropped when the answer flips. The redraw happens either way.
+   */
+  constructor(host: ReactiveControllerHost, onChange?: (narrow: boolean) => void) {
     this.host = host;
+    this.notify = onChange;
     host.addController(this);
   }
 
@@ -65,6 +71,7 @@ export class ViewportNarrow implements ReactiveController {
 
   private readonly onChange = (e: MediaQueryListEvent) => {
     this.matches = e.matches;
+    this.notify?.(this.matches);
     this.host.requestUpdate();
   };
 }

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -46,8 +46,14 @@ It also publishes the active HA theme as `color-scheme` on the host, which every
 component inherits.
 
 `src/haventory-panel.ts` defines `haventory-panel` — the same bundle's second element,
-which HA's custom-panel loader instantiates for the sidebar page. It mirrors the card's
-store lifecycle and renders `<hv-full-view embedded open>`.
+which HA's custom-panel loader instantiates for the sidebar page. It renders
+`<hv-full-view embedded open>`.
+
+Both take that store lifecycle from `StoreHostElement` (`src/store-host.ts`), which they
+extend: the `hass` setter that sets the language before anything renders and builds the
+store from the first object, the subscription that survives a disconnect and comes back
+with the element, and the `color-scheme` publish. What each one adds is what it renders
+and what configuration it reads.
 
 `src/haventory-card-editor.ts` defines `haventory-card-editor` — the bundle's third
 HA-facing element, which `getConfigElement` creates by tag. It renders one field for
@@ -83,9 +89,22 @@ the delete/discard confirmation, the organize dialog, the import sheet, the diag
 panel with its refresh state, and the shared ⋮ menu-entry builder. On the card side the
 instance lives in `hv-card-shell`; on the panel it lives in the panel element directly.
 Host differences enter as constructor hooks (`onItemDeleted`, `onBrowse`). The phone form of
-those dialogs is not one of them: the instance watches the viewport itself (`NARROW_QUERY`,
-started and stopped from each host's connected/disconnected callbacks) and hands the same
-answer to all five, so the card and the panel cannot disagree about what a phone is.
+those dialogs is not one of them: the instance watches the viewport itself (a
+`ViewportNarrow` controller on the host, so it needs no lifecycle calls of its own) and
+hands the same answer to all five, so the card and the panel cannot disagree about what a
+phone is.
+
+`hv-card-shell` and `hv-full-view` hold an `ItemWorkspace` (`src/item-workspace.ts`) on the
+same terms — host, `getStore`, hooks. It is everything the two shells do to one item: which
+row the form is open on, the copy of that row pinned while a refetch is in flight, the save
+and what a refused one leaves on screen, the read sheet's item, the check-out step, and one
+dispatch table for every event a row can raise. It renders the editor, the read sheet and
+the check-out popover, each taking its surface's own `data-testid` and phone flag as
+parameters. The hooks are the three things that genuinely differ: where a row tap goes
+(the card sends a phone tap to the read sheet and the row menu's Edit to the form; the
+expanded view sends both to the same place), who answers a delete (the card's
+`HostSurfaces`; the expanded view's host, over an event), and which shadow root the open
+form is in.
 
 ---
 
@@ -114,7 +133,8 @@ Home Assistant theme variable bound without a line in `HA_THEME_VARS`.
 haventory-card                     Lovelace element; store owner
 └── hv-card-shell                  container: header, search, filters, list, footer;
     │                              holds the HostSurfaces instance (the four dialogs
-    │                              below it render through that)
+    │                              below it render through that) and the ItemWorkspace
+    │                              (the editor, the read sheet and the check-out step)
     ├── hv-overflow-menu           the ⋮ menu (also used by the app bar and rows)
     ├── hv-filter-chips            removable chips for every active filter
     ├── hv-filter-panel            the complete filter set; desktop panel / mobile sheet
@@ -446,8 +466,8 @@ threading each one back through the root element as a re-dispatched event is mor
 than it is worth.
 
 Because the shell receives a stable `store` object, a property binding would never
-re-render it — so each container subscribes to `store.state.onChange` itself in
-`connectedCallback` and unsubscribes on disconnect.
+re-render it — so each container subscribes to `store.state.onChange` itself, through the
+`ItemWorkspace` it holds, for as long as it is in the DOM.
 
 ---
 
@@ -458,7 +478,7 @@ re-render it — so each container subscribes to `store.state.onChange` itself i
 | `tokens.ts` | Every design token as a `--hv-*` custom property, bound to the HA theme variable first with the mock hex as fallback, plus dark-mode and reduced-motion overrides. `base` adds the pill/icon-button/chip/input primitives. Composed as `static styles = [tokens, base, css\`…\`]`. |
 | `icons.ts` | ~30 MDI glyphs as inline path data, rendered as `<svg fill="currentColor">`. See the deviation note below. |
 | `brand-icon.ts` | The HAventory mark as one path, published to HA's icon registry (`window.customIcons`) under the `haventory:` prefix so the sidebar entry can name it. The backend's `PANEL_ICON` is the matching string. |
-| `responsive.ts` | The two phone predicates: `ResponsiveController` (a Lit reactive controller driving mobile mode from the card's own measured width, ≤600px) and `NARROW_QUERY`, the viewport query every fixed overlay switches on. |
+| `responsive.ts` | The two phone predicates, both as Lit reactive controllers: `ResponsiveController` drives mobile mode from the card's own measured width (≤600px), and `ViewportNarrow` follows `NARROW_QUERY`, the viewport query every fixed overlay switches on. |
 | `dialog-sheet.ts` | The bottom-sheet presentation the host dialogs share under `mobile`, as one `css` block added to each of their `static styles`. |
 | `relative-time.ts` | "2 h ago" / "Jul 31" formatting, overdue checks, and the `+N days` arithmetic the check-out chips use. |
 | `day-clock.ts` | `onDayChange(cb)`: one shared timer to the next local midnight, so everything that renders a date re-renders when the day turns. See "The day turning over". |


### PR DESCRIPTION
## Summary

PR 2 of §6.M4 of the V0.8.0 plan: FE-SHELLS-C1 (one item workspace), FE-SHELLS-C3 (one
viewport watcher), FE-SHELLS-C4 (one store/theme lifecycle) and FE-LISTS-L3 (one row-action
dispatch table). Subtraction only — no behaviour change, no test rewritten, no dictionary
touched.

Three cuts, one commit each:

1. **One viewport watcher.** `HostSurfaces` and `hv-full-view` each re-implemented the
   `NARROW_QUERY` watcher that `ViewportNarrow` already is, which is why both hosts had to
   call `surfaces.connect()` / `surfaces.disconnect()` by hand. Both take the controller
   now, and the four call sites go with them. `ViewportNarrow` gains an optional change
   callback — the full view drops its staged filter set when the answer flips, which is
   state that only means something at one width.
2. **One item workspace** (`src/item-workspace.ts`). The compact card and the expanded view
   each held the same thing: `editing` / `editorBusy` / `editorError` / `pinnedItem` /
   `checkout` / `detailItemId`, `syncPinnedItem`, `editorItem`, `onEditorSave`,
   `createLocationForEditor`, `media`, the store subscription, and a row dispatch table
   switching on the same ids. One class in the `HostSurfaces` style — host, `getStore`,
   hooks — with three templates (`renderEditor`, `renderDetailSheet`,
   `renderCheckoutPopover`) parameterised by the surface's own `data-testid` and phone flag.
   Each host keeps its three overrides: where a row tap goes, who answers a delete, and
   which shadow root the open form is in. The discard question is held once by the
   workspace instead of being bound per template, which is what PR 1 (#637) made possible.
3. **One store and theme lifecycle** (`src/store-host.ts`). `haventory-card` and
   `haventory-panel` are the two elements Home Assistant instantiates itself, and each
   carried the same five members. They now extend `StoreHostElement`.

Per-surface test ids and classes stayed parameters, not casualties: `inline-editor`,
`full-editor`, `sheet-editor`, `card-detail-sheet` / `full-detail-sheet`, `card-checkout` /
`full-checkout`, `pinned-editor-hint` and `add-sheet` are byte-identical to `main`, and
every one of the 1905 card tests passes **unchanged** — including the phone edit bar
(#573), the sheet pill (#586) and the panel's phone rows (#604, #614).

Refs #231

## Counting

| | lines |
|---|---|
| production removed | 882 |
| test removed | 0 |
| added | 720 production (+29 doc lines, 9 removed) |

`git diff --numstat origin/main`; net −162 lines of `src/`, with every doc comment on the
moved code carried over rather than dropped.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1304 passed, 27
      skipped; `uv run ruff check .` → All checks passed!; `uv run ruff format --check .` →
      189 files already formatted; `uv run mypy` → Success: no issues found in 25 source
      files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
      `npx vitest run` → 71 files / 1905 tests passed, `npm run build` ok,
      `npm audit --audit-level=high` → 0 vulnerabilities

phacc (`scripts/test_integration.sh`): **not required** — nothing under
`custom_components/` or `tests/integration/` changes. The only file this touches in the
integration tree is the git-ignored `www/haventory-card.js` the card build writes.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated — none: a cut changes no behaviour, so both host suites stay
      exactly as they are and are the pin. 1905 tests pass untouched.
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md` described the
      split these cuts removed (a `HostSurfaces` started and stopped by hand, a panel that
      mirrored the card's store lifecycle, and no account of who holds the editor state).
- [x] WebSocket API unchanged.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

None: nothing on screen moves. The templates are byte-identical to `main` apart from the
`data-testid` becoming a parameter that resolves to the same string.

---

## Handover

**1. Merged / left open.** This PR only; it merges on the master's review once CI is green.
Nothing here is left open for the owner.

**2. Test this by hand.** `[phone]` the card's row ⋮ at 375 px: its Edit entry opens the
inline form while a tap on the row body opens the read sheet, and that asymmetry is
preserved here on purpose — a phone reader is the only one who can say whether the ⋮ is
reachable there at all. `[phone]` the add sheet's own title bar, and the editor's action
row on one line.

**3. Validate locally.** `[browser]` on the dev HA, at 1920 px and 375 px, light and dark,
on the card, the expanded view and `/haventory`:

1. Open the editor from a desktop row, type, then open another row — the discard question
   appears once and confirming opens the other row. Expected: identical on the card, the
   expanded view and the panel.
2. At 375 px: tap a row on the card → the read sheet opens, not the form; tap a row in the
   expanded view → the read sheet opens; Edit inside the sheet opens the form.
3. Add item from the card header at 375 px → the add sheet draws its own title bar and the
   form has no header chevron; ✕ and the scrim both close it, asking first if you typed.
4. Check out from a card row's ⋮ → the popover anchors to the row. Check out from a table
   row's ⋮ → the popover is centred and scrimmed. Set a due date on an item already out
   from both.
5. Delete from inside the open form and from a row ⋮ on all three surfaces → one
   confirmation each, and the form closes.
6. Switch the HA theme with the card and `/haventory` open → both follow, which is the
   shared `color-scheme` publish.
7. `card_views.test.mjs` and `surfaces.mjs` → every `data-testid` they name still resolves.

**4. Decisions taken against drifted notes.**

- C1 asks for templates parameterised by `{testid, mobile, anchor?}`; the anchor needs no
  parameter, because it rides in the workspace's `checkout` state, handed over by whichever
  row opened the step. The card's rows supply a rectangle, the table's do not, and both
  hosts already behaved that way.
- C1's "est. −150 test LOC once one module test covers the shared half" was not taken.
  Leaving both host suites untouched is the strongest available evidence that the cut
  changed nothing, and the per-surface pins §5 names live in them. Moving the paired cases
  is cheaper once PR 3 has moved the filter chrome's four.
- Two asymmetries the shared copy settles, both in the expanded view's favour: the card's
  read sheet now closes when the item it shows is deleted from somewhere else (a delete
  raised on the card itself still closes it through `onItemDeleted`), and the picture
  bindings now follow a store swap on both surfaces (the shell already dropped its cache;
  the full view kept the old store's).
- `hv-full-view` keeps its `confirmDiscard` property, because that is its host's way in.
  What the workspace holds is the single use of it, so the form and the read sheet cannot
  be handed two different askers.
- The row menu's Edit and a tap on a row body stay two hooks rather than one: they mean the
  same thing on the expanded view and different things on the card. Collapsing them would
  have changed behaviour at 375 px.
- FE-SHELLS-C7 (`forceMobile` is a test-only production property) is named in C3's note as
  "fold into C3's PR" but is not in the package's PR list, so it was left alone.

**5. Follow-ups.** None filed. One observation for the browser pass: the card's row ⋮ Edit
opens the inline expander at every width, which is the one id the card and the expanded
view answer differently. Whether that ⋮ is reachable at 375 px at all is a browser question
(`hv-list-row`'s `:host([mobile]) .hover-actions`) and worth a look during M4's live checks
before anyone files it.

**6. State left behind.** Branch `claude/v0-8-0-m4-item-workspace`, four commits, nothing
stashed and no assets branch. Two new modules for later PRs in this package to build on:
`src/item-workspace.ts` (PR 5's day offsets and attachments have one editor host to teach)
and `src/store-host.ts`. No `.env` written, no Home Assistant touched. Counting for this
PR: 882 production lines removed, 0 test lines removed, 720 added.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NhfGrV1Tm1GN4M2xd2egv)_