### PR TITLE
refactor(card): the filter chrome, once

### DIFF
--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -86,32 +86,9 @@ describe('hv-card-shell: header', () => {
       makeItem({ id: '2', name: 'Impact Driver', checked_out: true }),
     ];
 
-    it('draws every pill by default', async () => {
-      const { sr } = await mountShell({ items: stocked() });
-      expect(sr.querySelector('[data-testid="badge-total"]')).toBeTruthy();
-      expect(sr.querySelector('[data-testid="badge-low"]')).toBeTruthy();
-      expect(sr.querySelector('[data-testid="badge-out"]')).toBeTruthy();
-    });
-
-    it('draws only the pills the config names', async () => {
-      const { el, sr } = await mountShell({ items: stocked() });
-      el.quickFilters = ['low_stock'];
-      await el.updateComplete;
-
-      expect(sr.querySelector('[data-testid="badge-low"]')).toBeTruthy();
-      expect(sr.querySelector('[data-testid="badge-total"]')).toBe(null);
-      expect(sr.querySelector('[data-testid="badge-out"]')).toBe(null);
-    });
-
-    // Allowed is not the same as shown: the count gate is unchanged.
-    it('still hides an allowed pill whose count is zero', async () => {
-      const { el, sr } = await mountShell({ items: [makeItem({ id: '1' })] });
-      el.quickFilters = ['low_stock', 'checked_out'];
-      await el.updateComplete;
-
-      expect(sr.querySelector('[data-testid="badge-low"]')).toBe(null);
-      expect(sr.querySelector('[data-testid="badge-out"]')).toBe(null);
-    });
+    // Which pills a config leaves is `renderStatBadges`' arithmetic, pinned in
+    // ui/stat-badges.test.ts. What is the card's own is the phone row below and
+    // the config it hands the full view.
 
     // On a phone the wrapper takes a row of its own, so a band with nothing
     // allowed in it would be a blank strip under the title.
@@ -390,28 +367,6 @@ describe('hv-card-shell: overflow menu', () => {
 });
 
 describe('hv-card-shell: search and filters', () => {
-  it('debounces the search before touching the store', async () => {
-    const { store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'Wood Glue' })] });
-    const input = sr.querySelector('[data-testid="search-input"]') as HTMLInputElement;
-
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    try {
-      input.value = 'glue';
-      input.dispatchEvent(new Event('input'));
-      expect(store.state.value.filters.q).toBe('');
-
-      // Still nothing on the last millisecond of the 200 ms window...
-      await vi.advanceTimersByTimeAsync(199);
-      expect(store.state.value.filters.q).toBe('');
-
-      // ...and the store hears it on the next one.
-      await vi.advanceTimersByTimeAsync(1);
-      expect(store.state.value.filters.q).toBe('glue');
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   // The full view and the panel word it this way, and the card searches the same
   // store they do — "matching" claimed a filter that need not be there at all.
   it('offers the whole inventory in the search placeholder, in the full view wording', async () => {

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -1727,6 +1727,26 @@ describe('hv-card-shell: mobile detail sheet', () => {
     expect(store.state.value.items).toHaveLength(0);
     expect(sheet(sr).open).toBe(false);
   });
+
+  // The sheet holds an id, not a copy, so an item deleted from anywhere else —
+  // another client, the expanded view, a service call — leaves it showing an
+  // empty hero rather than closing. Falling off the page looks identical from
+  // the list alone, so the store is asked which happened.
+  it('closes the sheet when the store reports the item gone', async () => {
+    const { el, store, sr } = await mountShell({
+      items: [makeItem({ id: '1', name: 'Doomed' }), makeItem({ id: '2', name: 'Bystander' })],
+      mobile: true,
+    });
+    (firstRow(sr).shadowRoot?.querySelector('[data-testid="list-row"]') as HTMLElement).click();
+    await settle(el);
+    expect(sheet(sr).open).toBe(true);
+
+    await store.deleteItem('1', 1);
+    await settle(el);
+
+    expect(sheet(sr).open).toBe(false);
+    expect(sheet(sr).item).toBe(null);
+  });
 });
 
 describe('hv-card-shell: full view', () => {

--- a/cards/haventory-card/src/components/hv-card-shell.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.ts
@@ -3,25 +3,33 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
 import { icon } from '../ui/icons';
-import { t, tn } from '../i18n';
-import { counted, showingCount } from '../ui/plural';
+import { t } from '../i18n';
+import { showingCount } from '../ui/plural';
 import { ResponsiveController } from '../ui/responsive';
-import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters, soleLocationId } from '../store/store';
 import { emptyKindFor } from '../ui/empty-state';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
-import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
+import {
+  priceStaged,
+  renderFilterChips,
+  renderFilterHead,
+  renderFilterPanel,
+  renderSearch,
+  renderStagedFooter,
+  searchBox,
+  searchDebounce,
+  sheetHead,
+} from '../ui/filter-chrome';
+import { renderStatBadges } from '../ui/stat-badges';
 import { HostSurfaces } from '../host-surfaces';
 import { ItemWorkspace } from '../item-workspace';
 import type { Store } from '../store/store';
 import type { StoreFilters, StoreState } from '../store/types';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import './hv-bottom-sheet';
-import './hv-filter-chips';
-import './hv-filter-panel';
 import './hv-list';
 import './hv-full-view';
 import type { OrganizeTab } from './hv-organize-dialog';
@@ -29,7 +37,6 @@ import './hv-overflow-menu';
 import type { HVFilterPanel } from './hv-filter-panel';
 import type { HVItemEditor } from './hv-item-editor';
 
-const SEARCH_DEBOUNCE_MS = 200;
 const FILTER_PANEL_STORAGE_KEY = 'haventory:filter-panel-open:v1';
 
 /**
@@ -63,6 +70,8 @@ export class HVCardShell extends LitElement {
     base,
     chip,
     bannerStack,
+    searchBox,
+    sheetHead,
     css`
       :host {
         display: block;
@@ -182,24 +191,14 @@ export class HVCardShell extends LitElement {
         gap: 8px;
         padding: 4px 16px 10px;
       }
+      /* The card's own fill and gutter for the box; ui/filter-chrome gives it
+         its shape, and the ink here is what a card surface asks for. */
       .search {
-        flex: 1;
-        min-width: 0;
-        display: flex;
-        align-items: center;
-        gap: 8px;
         background: var(--hv-input-bg);
-        border-radius: var(--hv-radius-chip);
         padding: 8px 14px;
         color: var(--hv-text-secondary);
       }
       .search input {
-        flex: 1;
-        min-width: 0;
-        border: none;
-        background: none;
-        outline: none;
-        font: 400 var(--hv-input-font, 13.5px) var(--hv-font);
         color: var(--hv-text);
       }
       /* The input inside the pill is what actually takes the tap, so the field
@@ -279,17 +278,10 @@ export class HVCardShell extends LitElement {
       .sheet-footer .apply {
         flex: 1;
       }
+      /* Inside the sheet's own 16px gutter; ui/filter-chrome gives the row its
+         shape and the two labels in it their sizes. */
       .sheet-head {
-        display: flex;
-        align-items: center;
-        gap: 10px;
         padding: 6px 16px 10px;
-        border-bottom: 1px solid var(--hv-row-divider);
-      }
-      .sheet-head .heading {
-        font-size: 16px;
-        font-weight: 500;
-        color: var(--hv-text);
       }
       /* The footer's way into the expanded view. Sized to the footer it sits in
          rather than to the card's other text buttons, which is why it is not
@@ -425,11 +417,7 @@ export class HVCardShell extends LitElement {
   }
 
   // ---------- Filters ----------
-  private _emitSearch = debounce((q: string) => this.store?.setFilters({ q }), SEARCH_DEBOUNCE_MS);
-
-  private _setFilters(patch: Partial<StoreFilters>) {
-    this.store?.setFilters(patch);
-  }
+  private _emitSearch = searchDebounce(() => this.store);
 
   private _toggleFilterSurface = () => {
     if (this.mobile) {
@@ -443,11 +431,12 @@ export class HVCardShell extends LitElement {
   };
 
   /** Price a staged (not yet applied) filter so the sheet's button can be honest. */
-  private _priceStaged = debounce((filters: StoreFilters) => {
-    void this.store?.countMatching(filters).then((count) => {
+  private _priceStaged = priceStaged(
+    () => this.store,
+    (count) => {
       this._stagedCount = count;
-    });
-  }, 150);
+    },
+  );
 
   // ---------- Inline editing ----------
   private get _editor(): HVItemEditor | null {
@@ -509,86 +498,19 @@ export class HVCardShell extends LitElement {
 
   // ---------- Render helpers ----------
   private _renderBadges() {
-    const st = this.st;
-    const counts = st?.statsCounts;
-    if (!counts) return null;
-    const f = st?.filters;
-    // A pill shows when the dashboard allows it *and* its count clears the gate
-    // it always had — the config decides what is on offer, the count decides
-    // whether there is anything to say.
-    const allows = (key: QuickFilterKey) => quickFilterAllowed(this.quickFilters, key);
-    const lowStock = allows('low_stock') && counts.low_stock_count > 0;
-    const overdue = allows('overdue') && (counts.overdue_count ?? 0) > 0;
-    const inspection = allows('inspection_due') && (counts.inspection_due_count ?? 0) > 0;
-    const reminder = allows('reminder_due') && (counts.reminder_due_count ?? 0) > 0;
-    const checkedOut = allows('checked_out') && counts.checked_out_count > 0;
+    const badges = renderStatBadges(this.st, this.quickFilters, {
+      prefix: 'badge',
+      chipClass: (tone) => `badge toggle ${tone}`,
+      // The total reports rather than filters, and on a phone the row it would
+      // take is the one the toggles need.
+      total: this.mobile ? undefined : 'badge quiet',
+      setFilters: (patch) => this.store?.setFilters(patch),
+    });
+    if (!badges) return null;
     // On mobile the wrapper takes a row of its own, so an empty one would leave
-    // a blank band under the title rather than nothing at all. The total is not
-    // among them: it does not render on a phone at all.
-    const anyBadge = !this.mobile || lowStock || overdue || inspection || reminder || checkedOut;
-    if (!anyBadge) return null;
-    return html`
-      <div class="badges">
-        ${this.mobile || !allows('total')
-          ? null
-          : html`<span class="hv-chip badge quiet" data-testid="badge-total">${counted(counts.items_total, 'item')}</span>`}
-        ${lowStock
-          ? html`<button
-              class="hv-chip badge toggle warning ${f?.lowStockOnly ? 'on' : ''}"
-              data-testid="badge-low"
-              aria-pressed=${String(!!f?.lowStockOnly)}
-              title=${t('hv.card.badge.lowTitle')}
-              @click=${() => this._setFilters({ lowStockOnly: !f?.lowStockOnly })}
-            >
-              ${t('hv.card.badge.low', { count: counts.low_stock_count })}
-            </button>`
-          : null}
-        ${overdue
-          ? html`<button
-              class="hv-chip badge toggle error ${f?.overdueOnly ? 'on' : ''}"
-              data-testid="badge-overdue"
-              aria-pressed=${String(!!f?.overdueOnly)}
-              title=${t('hv.card.badge.overdueTitle')}
-              @click=${() => this._setFilters({ overdueOnly: !f?.overdueOnly })}
-            >
-              ${t('hv.card.badge.overdue', { count: counts.overdue_count ?? 0 })}
-            </button>`
-          : null}
-        ${inspection
-          ? html`<button
-              class="hv-chip badge toggle warning ${f?.inspectionDueOnly ? 'on' : ''}"
-              data-testid="badge-inspection"
-              aria-pressed=${String(!!f?.inspectionDueOnly)}
-              title=${t('hv.card.badge.inspectionTitle')}
-              @click=${() => this._setFilters({ inspectionDueOnly: !f?.inspectionDueOnly })}
-            >
-              ${t('hv.card.badge.inspection', { count: counts.inspection_due_count ?? 0 })}
-            </button>`
-          : null}
-        ${reminder
-          ? html`<button
-              class="hv-chip badge toggle warning ${f?.reminderDueOnly ? 'on' : ''}"
-              data-testid="badge-reminder"
-              aria-pressed=${String(!!f?.reminderDueOnly)}
-              title=${t('hv.card.badge.reminderTitle')}
-              @click=${() => this._setFilters({ reminderDueOnly: !f?.reminderDueOnly })}
-            >
-              ${t('hv.card.badge.reminder', { count: counts.reminder_due_count ?? 0 })}
-            </button>`
-          : null}
-        ${checkedOut
-          ? html`<button
-              class="hv-chip badge toggle state ${f?.checkedOutOnly ? 'on' : ''}"
-              data-testid="badge-out"
-              aria-pressed=${String(!!f?.checkedOutOnly)}
-              title=${t('hv.card.badge.checkedOutTitle')}
-              @click=${() => this._setFilters({ checkedOutOnly: !f?.checkedOutOnly })}
-            >
-              ${t('hv.card.badge.checkedOut', { count: counts.checked_out_count })}
-            </button>`
-          : null}
-      </div>
-    `;
+    // a blank band under the title rather than nothing at all.
+    if (this.mobile && !badges.any) return null;
+    return html`<div class="badges">${badges.total}${badges.pills}</div>`;
   }
 
   private _onEmptyAction = (e: CustomEvent) => {
@@ -600,32 +522,23 @@ export class HVCardShell extends LitElement {
   };
 
   private _renderFilterPanel(mobile: boolean) {
-    const st = this.st;
-    if (!st) return null;
-    return html`<hv-filter-panel
-      .statuses=${st?.statuses ?? null}
-      .filters=${st.filters}
-      .distinct=${st.distinctValuesCache}
-      .areas=${st.areasCache?.areas ?? []}
-      .locations=${st.locationsFlatCache}
-      .locationTree=${st.locationTreeCache ?? []}
-      .total=${st.total}
-      .grandTotal=${st.statsCounts?.items_total ?? null}
-      .counts=${st.statsCounts}
-      ?mobile=${mobile}
-      @change=${(e: CustomEvent) => this._setFilters(e.detail as Partial<StoreFilters>)}
-      @stage=${(e: CustomEvent) => {
-        const staged = (e.detail as { filters: StoreFilters }).filters;
+    // Nothing to filter before a store is attached, and an empty panel under
+    // the search row would be a control that answers nothing.
+    if (!this.st) return null;
+    return renderFilterPanel(this.st, {
+      mobile,
+      setFilters: (patch) => this.store?.setFilters(patch),
+      clearFilters: () => this.store?.clearFilters(),
+      onStage: (staged) => {
         this._stagedFilters = staged;
         this._priceStaged(staged);
-      }}
-      @apply=${(e: CustomEvent) => {
-        this._setFilters(e.detail as StoreFilters);
+      },
+      onApply: (filters) => {
+        this.store?.setFilters(filters);
         this._filterSheetOpen = false;
         this._stagedFilters = null;
-      }}
-      @clear-filters=${() => this.store?.clearFilters()}
-    ></hv-filter-panel>`;
+      },
+    });
   }
 
   render() {
@@ -635,9 +548,6 @@ export class HVCardShell extends LitElement {
     const stagedFilterCount = activeFilterCount(this._stagedFilters ?? filters);
     const loaded = st?.items.length ?? 0;
     const total = st?.total;
-    // The placeholder counts the whole inventory, not the filtered result: it is
-    // the same sentence the full view and the panel show, so the search box does
-    // not describe the same store two ways depending on which surface opened it.
     const searchTotal = st?.statsCounts?.items_total ?? null;
     const mobile = this.mobile;
     // The filter button reports the surface its own width uses. The desktop
@@ -679,22 +589,15 @@ export class HVCardShell extends LitElement {
       </div>
 
       <div class="search-row">
-        <label class="search">
-          ${icon('magnify', 18)}
-          <span class="hv-sr-only">${t('hv.card.searchItems')}</span>
-          <input
-            type="search"
-            data-testid="search-input"
-            placeholder=${searchTotal === null
-              ? t('hv.card.searchPlaceholder')
-              : tn('hv.card.searchAllPlaceholder', searchTotal)}
-            .value=${this._searchDraft}
-            @input=${(e: Event) => {
-              this._searchDraft = (e.target as HTMLInputElement).value;
-              this._emitSearch(this._searchDraft);
-            }}
-          />
-        </label>
+        ${renderSearch({
+          testid: 'search-input',
+          draft: this._searchDraft,
+          total: searchTotal,
+          onInput: (q) => {
+            this._searchDraft = q;
+            this._emitSearch(q);
+          },
+        })}
         <button
           class="icon-toggle ${filterSurfaceOpen ? 'on' : ''}"
           data-testid="filter-toggle"
@@ -711,15 +614,10 @@ export class HVCardShell extends LitElement {
 
       ${filterCount > 0
         ? html`<div class="chips-row">
-            <hv-filter-chips
-              .statuses=${st?.statuses ?? null}
-              .filters=${filters}
-              .locations=${st?.locationsFlatCache ?? null}
-              .areas=${st?.areasCache?.areas ?? []}
-              @remove-filter=${(e: CustomEvent) =>
-                this._setFilters((e.detail as { patch: Partial<StoreFilters> }).patch)}
-              @clear-filters=${() => this.store?.clearFilters()}
-            ></hv-filter-chips>
+            ${renderFilterChips(st, {
+              setFilters: (patch) => this.store?.setFilters(patch),
+              clearFilters: () => this.store?.clearFilters(),
+            })}
           </div>`
         : null}
       ${mobile
@@ -804,43 +702,27 @@ export class HVCardShell extends LitElement {
               this._filterPanel?.resetDraft();
             }}
           >
-            <div class="sheet-head">
-              <span class="heading">${t('hv.card.filters')}</span>
-              <span style="font-size:12.5px;color:var(--hv-text-secondary)"
-                >${t('hv.card.filtersActive', { count: stagedFilterCount })}</span
-              >
-              <button
-                class="hv-text-button"
-                style="margin-left:auto"
-                data-testid="sheet-clear-all"
-                @click=${() => this._filterPanel?.clearAll()}
-              >
-                ${t('hv.action.clearAll')}
-              </button>
-            </div>
+            ${renderFilterHead({
+              rowClass: 'sheet-head',
+              testids: { clear: 'sheet-clear-all' },
+              staged: stagedFilterCount,
+              onClear: () => this._filterPanel?.clearAll(),
+            })}
             ${this._renderFilterPanel(true)}
-            <div class="sheet-footer" slot="footer">
-              <button
-                class="cancel"
-                data-testid="sheet-cancel"
-                @click=${() => {
-                  this._filterSheetOpen = false;
-                  this._stagedFilters = null;
-                  this._filterPanel?.resetDraft();
-                }}
-              >
-                ${t('hv.action.cancel')}
-              </button>
-              <button
-                class="hv-pill large apply"
-                data-testid="sheet-apply"
-                @click=${() => this._filterPanel?.apply()}
-              >
-                ${this._stagedCount === null
-                  ? t('hv.card.showItems')
-                  : tn('hv.card.showCount', this._stagedCount)}
-              </button>
-            </div>
+            ${renderStagedFooter({
+              prefix: 'sheet',
+              rowClass: 'sheet-footer',
+              slot: 'footer',
+              cancelClass: 'cancel',
+              applyClass: 'hv-pill large apply',
+              stagedCount: this._stagedCount,
+              panel: () => this._filterPanel,
+              onCancel: () => {
+                this._filterSheetOpen = false;
+                this._stagedFilters = null;
+                this._filterPanel?.resetDraft();
+              },
+            })}
           </hv-bottom-sheet>`
         : null}
 
@@ -851,7 +733,7 @@ export class HVCardShell extends LitElement {
             data-testid="add-sheet"
             @cancel=${() => this._workspace.startEdit(null)}
           >
-            <div class="sheet-head">
+            <div class="hv-sheet-head sheet-head">
               <span class="heading">${t('hv.card.newItem')}</span>
               <button
                 class="hv-icon-button"

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1971,62 +1971,13 @@ describe('hv-full-view: app bar filters', () => {
 
   // One vocabulary on both surfaces: the card hands its `quick_filters` config
   // down, and the panel — which has no YAML — takes the default of all of them.
-  describe('the dashboard\'s pill choice', () => {
-    const stocked = () => [
-      makeItem({ id: '1', quantity: 0, low_stock_threshold: 5 }),
-      makeItem({ id: '2', checked_out: true }),
-    ];
-
-    it('draws every pill by default', async () => {
-      const { sr } = await mount({ items: stocked() });
-      expect(q(sr, '[data-testid="full-badge-low"]')).toBeTruthy();
-      expect(q(sr, '[data-testid="full-badge-out"]')).toBeTruthy();
-    });
-
-    it('draws only the pills the config names', async () => {
-      const { el, sr } = await mount({ items: stocked() });
-      el.quickFilters = ['low_stock'];
-      await el.updateComplete;
-
-      expect(q(sr, '[data-testid="full-badge-low"]')).toBeTruthy();
-      expect(q(sr, '[data-testid="full-badge-out"]')).toBe(null);
-    });
-
-    it('still hides an allowed pill whose count is zero', async () => {
-      const { el, sr } = await mount({ items: [makeItem({ id: '1' })] });
-      el.quickFilters = ['low_stock', 'checked_out'];
-      await el.updateComplete;
-
-      expect(q(sr, '[data-testid="full-badge-low"]')).toBe(null);
-      expect(q(sr, '[data-testid="full-badge-out"]')).toBe(null);
-    });
-  });
+  // Which pills a config leaves is `renderStatBadges`' arithmetic, pinned in
+  // ui/stat-badges.test.ts.
 
   // "82 out" reads as "82 out of stock", which is the opposite of what it counts.
   it('spells out what the checked-out pill counts', async () => {
     const { sr } = await mount({ items: flagged });
     expect(q(sr, '[data-testid="full-badge-out"]')?.textContent?.trim()).toBe('2 checked out');
-  });
-
-  it('debounces the app bar search', async () => {
-    const { store, sr } = await mount({ items: [makeItem({ id: '1' })] });
-    const input = q(sr, '[data-testid="full-search"]') as HTMLInputElement;
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    try {
-      input.value = 'glue';
-      input.dispatchEvent(new Event('input'));
-      expect(store.state.value.filters.q).toBe('');
-
-      // Still nothing on the last millisecond of the 200 ms window...
-      await vi.advanceTimersByTimeAsync(199);
-      expect(store.state.value.filters.q).toBe('');
-
-      // ...and the store hears it on the next one.
-      await vi.advanceTimersByTimeAsync(1);
-      expect(store.state.value.filters.q).toBe('glue');
-    } finally {
-      vi.useRealTimers();
-    }
   });
 });
 

--- a/cards/haventory-card/src/components/hv-full-view.test.ts
+++ b/cards/haventory-card/src/components/hv-full-view.test.ts
@@ -1816,6 +1816,38 @@ describe('hv-full-view: phone-width children', () => {
     }
   });
 
+  // Turn the phone sideways with the panel open and the panel drops its own
+  // draft, because it is no longer the surface that stages one. A staged set
+  // held across that flip would leave the head row counting filters the
+  // controls under it no longer carry.
+  it('drops the staged set when the viewport stops being narrow', async () => {
+    // The stub is the restore, and it announces the flip.
+    const viewport = stubViewport(true);
+    try {
+      const { el, sr } = await mount({
+        items: [makeItem({ id: '1', quantity: 0, low_stock_threshold: 5 })],
+      });
+      (q(sr, '[data-testid="full-filters-toggle"]') as HTMLButtonElement).click();
+      await settle(el);
+
+      const count = () => (q(sr, '[data-testid="full-panel-count"]') as HTMLElement).textContent?.trim();
+      const panel = q(sr, '[data-testid="full-filter-panel"]') as HTMLElement;
+      (panel.shadowRoot?.querySelector('[data-testid="filter-low-stock-only"]') as HTMLButtonElement).click();
+      await settle(el);
+      expect(count()).toBe('1 active');
+
+      viewport.announce(false);
+      await settle(el);
+      expect(q(sr, '[data-testid="full-panel-head"]'), 'no phone head row on a desktop width').toBe(null);
+
+      viewport.announce(true);
+      await settle(el);
+      expect(count()).toBe('0 active');
+    } finally {
+      viewport();
+    }
+  });
+
   it('leaves the desktop panel without a head row', async () => {
     const restore = stubViewport(false);
     try {

--- a/cards/haventory-card/src/components/hv-full-view.ts
+++ b/cards/haventory-card/src/components/hv-full-view.ts
@@ -10,7 +10,6 @@ import { icon } from '../ui/icons';
 import { t, tn } from '../i18n';
 import { counted, showingCount } from '../ui/plural';
 import { nextZBase } from '../utils/zindex';
-import { debounce } from '../utils/debounce';
 import { activeFilterCount, defaultFilters, soleLocationId } from '../store/store';
 import { countLocations } from '../store/location-tree';
 import { emptyKindFor, renderEmptyState } from '../ui/empty-state';
@@ -23,11 +22,22 @@ import {
   renderAreaChip,
 } from '../ui/location-path';
 import { DEFAULT_CARD_TITLE } from '../ui/card-title';
-import { quickFilterAllowed } from '../ui/quick-filters';
 import type { QuickFilterKey } from '../ui/quick-filters';
 import type { ConfirmDiscard } from '../ui/discard';
 import { bannerStack, renderDegradedBanners, renderErrorBanners } from '../ui/banners';
 import type { BannerHooks } from '../ui/banners';
+import {
+  priceStaged,
+  renderFilterChips,
+  renderFilterHead,
+  renderFilterPanel,
+  renderSearch,
+  renderStagedFooter,
+  searchBox,
+  searchDebounce,
+  sheetHead,
+} from '../ui/filter-chrome';
+import { renderStatBadges } from '../ui/stat-badges';
 import { ViewportNarrow } from '../ui/responsive';
 import { ItemWorkspace } from '../item-workspace';
 import { statusCount, statusLabel, statusList } from '../ui/status';
@@ -51,15 +61,11 @@ import './hv-bulk-bar';
 import './hv-checkout-popover';
 import './hv-confirm';
 import './hv-data-table';
-import './hv-filter-chips';
-import './hv-filter-panel';
 import './hv-location-tree';
 import './hv-overflow-menu';
 import type { HVItemEditor } from './hv-item-editor';
 import type { HVLocationTree } from './hv-location-tree';
 import type { HVFilterPanel } from './hv-filter-panel';
-
-const SEARCH_DEBOUNCE_MS = 200;
 
 /** The sidebar's collapsible sections, in the order they appear. */
 type SidebarSection = 'locations' | 'status' | 'categories' | 'tags';
@@ -145,6 +151,8 @@ export class HVFullView extends LitElement {
     chip,
     browseRow,
     bannerStack,
+    searchBox,
+    sheetHead,
     css`
       :host {
         display: contents;
@@ -275,32 +283,19 @@ export class HVFullView extends LitElement {
       .appbar .tap:hover {
         background: rgba(255, 255, 255, 0.16);
       }
+      /* The bar's own fill and gutter for the box; ui/filter-chrome gives it
+         its shape, and white ink is what a primary-coloured bar asks for. */
       .appbar .search {
-        flex: 1;
-        /* Without this the field will not shrink below its content width, and
-           a flex item that refuses to shrink pushes everything after it off
-           the end of a narrow bar. */
-        min-width: 0;
         /* A flex-basis is a content-box width by default, so the full-width
            basis it takes on a phone came out 24px wider than the line — its own
            padding — and the bar overflowed its right edge by that much. */
         box-sizing: border-box;
         max-width: 420px;
-        display: flex;
-        align-items: center;
-        gap: 8px;
         background: rgba(255, 255, 255, 0.22);
-        border-radius: var(--hv-radius-chip);
         padding: 7px 14px;
       }
       .appbar .search input {
-        flex: 1;
-        min-width: 0;
-        border: none;
-        background: none;
-        outline: none;
         color: #fff;
-        font: 400 var(--hv-input-font, 13.5px) var(--hv-font);
       }
       .appbar .search input::placeholder {
         color: rgba(255, 255, 255, 0.8);
@@ -776,26 +771,14 @@ export class HVFullView extends LitElement {
            underneath it. */
         overscroll-behavior-y: contain;
       }
-      /* Both only rendered on a phone, where the panel stages its edits. */
+      /* Both only rendered on a phone, where the panel stages its edits. The
+         row's shape and the two labels in it come from ui/filter-chrome; the
+         column around it already has a gutter, so it adds none of its own. */
       .panel-head {
-        display: flex;
         flex: none;
-        align-items: center;
-        gap: 10px;
         padding: 2px 0 8px;
-        border-bottom: 1px solid var(--hv-row-divider);
-      }
-      .panel-head .heading {
-        font-size: 16px;
-        font-weight: 500;
-        color: var(--hv-text);
-      }
-      .panel-head .staged {
-        font-size: 12.5px;
-        color: var(--hv-text-secondary);
       }
       .panel-head .hv-text-button {
-        margin-left: auto;
         flex: none;
       }
       .panel-foot {
@@ -1077,11 +1060,12 @@ export class HVFullView extends LitElement {
   }
 
   /** Price a staged (not yet applied) filter set, so the footer can be honest. */
-  private _priceStaged = debounce((filters: StoreFilters) => {
-    void this.store?.countMatching(filters).then((count) => {
+  private _priceStaged = priceStaged(
+    () => this.store,
+    (count) => {
       this._stagedCount = count;
-    });
-  }, 150);
+    },
+  );
 
   protected willUpdate(changed: Map<string, unknown>) {
     this._workspace.syncPinnedItem();
@@ -1234,11 +1218,7 @@ export class HVFullView extends LitElement {
     list[list.length - 1]?.focus();
   }
 
-  private _emitSearch = debounce((q: string) => this.store?.setFilters({ q }), SEARCH_DEBOUNCE_MS);
-
-  private _setFilters(patch: Partial<StoreFilters>) {
-    this.store?.setFilters(patch);
-  }
+  private _emitSearch = searchDebounce(() => this.store);
 
   /**
    * Show an item: the read sheet on a narrow viewport, the inline form on a
@@ -1454,7 +1434,7 @@ export class HVFullView extends LitElement {
           data-testid="sidebar-tags-mode"
           data-mode=${m}
           title=${m === 'any' ? t('hv.fullView.tagsAnyTitle') : t('hv.fullView.tagsAllTitle')}
-          @click=${() => this._setFilters({ tagsMode: m })}
+          @click=${() => this.store?.setFilters({ tagsMode: m })}
         >
           ${m === 'any' ? t('hv.term.any') : t('hv.term.all')}
         </button>`,
@@ -1519,7 +1499,7 @@ export class HVFullView extends LitElement {
                 tabindex="-1"
                 @click=${() => {
                   this._holdFacetStop('status', facetRowKey('status', s));
-                  this._setFilters({ status: on ? null : s });
+                  this.store?.setFilters({ status: on ? null : s });
                 }}
               >
                 <span class="hv-browse-row-lead ${on ? '' : 'placeholder'}">${icon('check', 15)}</span>
@@ -1671,7 +1651,7 @@ export class HVFullView extends LitElement {
           distinct?.categories ?? [],
           (v) => selectedCategories.has(v),
           (v) =>
-            this._setFilters({
+            this.store?.setFilters({
               categories: selectedCategories.has(v)
                 ? filters.categories.filter((c) => c !== v)
                 : [...filters.categories, v],
@@ -1683,7 +1663,7 @@ export class HVFullView extends LitElement {
           distinct?.tags ?? [],
           (v) => selectedTags.has(v),
           (v) =>
-            this._setFilters({
+            this.store?.setFilters({
               tags: selectedTags.has(v) ? filters.tags.filter((t) => t !== v) : [...filters.tags, v],
             }),
           filters.tags.length > 1 ? this._renderTagsMode(filters.tagsMode) : null,
@@ -1752,13 +1732,13 @@ export class HVFullView extends LitElement {
           .orphanCount=${st?.statsCounts?.no_location_count ?? null}
           .matchingTotalCount=${st?.locationMatchTotal ?? null}
           @select=${(e: CustomEvent) =>
-            this._setFilters({
+            this.store?.setFilters({
               locationIds: this._toggledLocations((e.detail as { locationId: string | null }).locationId),
               orphansOnly: false,
             })}
-          @select-orphans=${() => this._setFilters({ locationIds: [], orphansOnly: true })}
+          @select-orphans=${() => this.store?.setFilters({ locationIds: [], orphansOnly: true })}
           @select-area=${(e: CustomEvent) =>
-            this._setFilters({
+            this.store?.setFilters({
               areaId: (e.detail as { areaId: string }).areaId,
               locationIds: [],
               orphansOnly: false,
@@ -1767,28 +1747,14 @@ export class HVFullView extends LitElement {
     `;
   }
 
-  /**
-   * The phone panel's head row: what the panel is, how much of it is staged,
-   * and the way out of all of it.
-   *
-   * Clear all sits here rather than beside the commit buttons because three
-   * controls do not fit a 375px row in every language: German's
-   * `hv.action.clearAll` broke over two lines and left the button beside it
-   * stacking its count sentence over three. The card's filter sheet has
-   * carried this same head row all along, which is why its footer never had
-   * the problem.
-   */
+  /** The phone panel's head row, which the card's filter sheet has carried all along. */
   private _renderPanelHead(filters: StoreFilters) {
-    const staged = activeFilterCount(this._stagedFilters ?? filters);
-    return html`<div class="panel-head" data-testid="full-panel-head">
-      <span class="heading">${t('hv.card.filters')}</span>
-      <span class="staged" data-testid="full-panel-count">
-        ${t('hv.card.filtersActive', { count: staged })}
-      </span>
-      <button class="hv-text-button" data-testid="full-panel-clear" @click=${() => this._panel()?.clearAll()}>
-        ${t('hv.action.clearAll')}
-      </button>
-    </div>`;
+    return renderFilterHead({
+      rowClass: 'panel-head',
+      testids: { row: 'full-panel-head', count: 'full-panel-count', clear: 'full-panel-clear' },
+      staged: activeFilterCount(this._stagedFilters ?? filters),
+      onClear: () => this._panel()?.clearAll(),
+    });
   }
 
   // Resolved per click, never captured at render time: on the render that first
@@ -1798,35 +1764,26 @@ export class HVFullView extends LitElement {
     return this.renderRoot?.querySelector<HVFilterPanel>('[data-testid="full-filter-panel"]');
   }
 
-  /**
-   * The phone panel's commit row.
-   *
-   * `hv-filter-panel` stages its edits when it is on a phone and drops its own
-   * footer, because its host is expected to provide one — the card's filter
-   * sheet does. This surface had neither, so telling the panel it was on a phone
-   * without this would stage every edit with no way to apply it.
-   */
+  /** The phone panel's commit row, without which its staged edits have no way out. */
   private _renderPanelFoot() {
     const panel = this._panel.bind(this);
-    return html`<div class="panel-foot" data-testid="full-panel-foot">
-      <span class="spacer"></span>
-      <button
-        class="hv-text-button"
-        data-testid="full-panel-cancel"
-        @click=${() => {
-          panel()?.resetDraft();
-          this._filtersOpen = false;
-          this._stagedFilters = null;
-        }}
-      >
-        ${t('hv.action.cancel')}
-      </button>
-      <button class="hv-pill" data-testid="full-panel-apply" @click=${() => panel()?.apply()}>
-        ${this._stagedCount === null
-          ? t('hv.card.showItems')
-          : tn('hv.card.showCount', this._stagedCount)}
-      </button>
-    </div>`;
+    return renderStagedFooter({
+      prefix: 'full-panel',
+      rowClass: 'panel-foot',
+      rowTestid: 'full-panel-foot',
+      cancelClass: 'hv-text-button',
+      applyClass: 'hv-pill',
+      // The row's two controls belong at the far end of it, and one auto margin
+      // is what puts them there.
+      lead: html`<span class="spacer"></span>`,
+      stagedCount: this._stagedCount,
+      panel,
+      onCancel: () => {
+        panel()?.resetDraft();
+        this._filtersOpen = false;
+        this._stagedFilters = null;
+      },
+    });
   }
 
   private _renderEmpty() {
@@ -1885,15 +1842,10 @@ export class HVFullView extends LitElement {
              picker wrapping on its own under the filter button. -->
         <span class="context-actions">
           ${filterCount > 0
-            ? html`<hv-filter-chips
-                .statuses=${this.st?.statuses ?? null}
-                .filters=${filters}
-                .locations=${st?.locationsFlatCache ?? null}
-                .areas=${st?.areasCache?.areas ?? []}
-                @remove-filter=${(e: CustomEvent) =>
-                  this._setFilters((e.detail as { patch: Partial<StoreFilters> }).patch)}
-                @clear-filters=${() => this.store?.clearFilters()}
-              ></hv-filter-chips>`
+            ? renderFilterChips(st, {
+                setFilters: (patch) => this.store?.setFilters(patch),
+                clearFilters: () => this.store?.clearFilters(),
+              })
             : null}
           <button
             class="filters-button ${this._filtersOpen ? 'on' : ''}"
@@ -2058,75 +2010,19 @@ export class HVFullView extends LitElement {
    */
   private _renderAppBar() {
     const st = this.st;
-    const filters = st?.filters ?? defaultFilters();
     const counts = st?.statsCounts;
-    // The dashboard decides what is on offer; the count still decides whether
-    // there is anything to say. Same vocabulary the card's badges read.
-    const allowsPill = (key: QuickFilterKey) => quickFilterAllowed(this.quickFilters, key);
     // The narrow branch dresses these same controls its own way, on its own
     // breakpoint, so the measured steps stand aside for it.
     const steps = this._viewport.narrow ? '' : this._barSteps;
     const addLabelClass = steps.includes('tight') ? 'add-label hv-sr-only' : 'add-label';
-    // One strip, so the pills are what gives when the bar runs out of room —
-    // and no strip at all when nothing is flagged, because an empty one is
-    // still a flex item with a gap in front of it.
-    const pills = [
-      allowsPill('low_stock') && counts && counts.low_stock_count > 0
-        ? html`<button
-            class="hv-chip pill warning ${filters.lowStockOnly ? 'on' : ''}"
-            data-testid="full-badge-low"
-            aria-pressed=${String(filters.lowStockOnly)}
-            title=${t('hv.card.badge.lowTitle')}
-            @click=${() => this._setFilters({ lowStockOnly: !filters.lowStockOnly })}
-          >
-            ${t('hv.card.badge.low', { count: counts.low_stock_count })}
-          </button>`
-        : null,
-      allowsPill('overdue') && counts && (counts.overdue_count ?? 0) > 0
-        ? html`<button
-            class="hv-chip pill error ${filters.overdueOnly ? 'on' : ''}"
-            data-testid="full-badge-overdue"
-            aria-pressed=${String(filters.overdueOnly)}
-            title=${t('hv.card.badge.overdueTitle')}
-            @click=${() => this._setFilters({ overdueOnly: !filters.overdueOnly })}
-          >
-            ${t('hv.card.badge.overdue', { count: counts.overdue_count ?? 0 })}
-          </button>`
-        : null,
-      allowsPill('inspection_due') && counts && (counts.inspection_due_count ?? 0) > 0
-        ? html`<button
-            class="hv-chip pill warning ${filters.inspectionDueOnly ? 'on' : ''}"
-            data-testid="full-badge-inspection"
-            aria-pressed=${String(filters.inspectionDueOnly)}
-            title=${t('hv.card.badge.inspectionTitle')}
-            @click=${() => this._setFilters({ inspectionDueOnly: !filters.inspectionDueOnly })}
-          >
-            ${t('hv.card.badge.inspection', { count: counts.inspection_due_count ?? 0 })}
-          </button>`
-        : null,
-      allowsPill('reminder_due') && counts && (counts.reminder_due_count ?? 0) > 0
-        ? html`<button
-            class="hv-chip pill warning ${filters.reminderDueOnly ? 'on' : ''}"
-            data-testid="full-badge-reminder"
-            aria-pressed=${String(filters.reminderDueOnly)}
-            title=${t('hv.card.badge.reminderTitle')}
-            @click=${() => this._setFilters({ reminderDueOnly: !filters.reminderDueOnly })}
-          >
-            ${t('hv.card.badge.reminder', { count: counts.reminder_due_count ?? 0 })}
-          </button>`
-        : null,
-      allowsPill('checked_out') && counts && counts.checked_out_count > 0
-        ? html`<button
-            class="hv-chip pill ${filters.checkedOutOnly ? 'on' : ''}"
-            data-testid="full-badge-out"
-            aria-pressed=${String(filters.checkedOutOnly)}
-            title=${t('hv.card.badge.checkedOutTitle')}
-            @click=${() => this._setFilters({ checkedOutOnly: !filters.checkedOutOnly })}
-          >
-            ${t('hv.card.badge.checkedOut', { count: counts.checked_out_count })}
-          </button>`
-        : null,
-    ];
+    const badges = renderStatBadges(st, this.quickFilters, {
+      prefix: 'full-badge',
+      // The bar substitutes its own solid fills for the card's pale tints, and
+      // has no blue to spare on a blue bar — so the checked-out pill, which is
+      // the card's one blue badge, takes no hue here.
+      chipClass: (tone) => (tone === 'state' ? 'pill' : `pill ${tone}`),
+      setFilters: (patch) => this.store?.setFilters(patch),
+    });
     return html`
         <div class="appbar ${steps}">
           ${this.embedded
@@ -2140,24 +2036,20 @@ export class HVFullView extends LitElement {
                 ${icon('close', 20)}
               </button>`}
           <h2>${this.heading}</h2>
-          <label class="search">
-            ${icon('magnify', 18)}
-            <span class="hv-sr-only">${t('hv.card.searchItems')}</span>
-            <input
-              type="search"
-              data-testid="full-search"
-              placeholder=${counts
-                ? tn('hv.card.searchAllPlaceholder', counts.items_total)
-                : t('hv.card.searchPlaceholder')}
-              .value=${this._searchDraft}
-              @input=${(e: Event) => {
-                this._searchDraft = (e.target as HTMLInputElement).value;
-                this._emitSearch(this._searchDraft);
-              }}
-            />
-          </label>
-          ${pills.some((pill) => pill !== null)
-            ? html`<div class="pills" data-testid="full-pills">${pills}</div>`
+          ${renderSearch({
+            testid: 'full-search',
+            draft: this._searchDraft,
+            total: counts?.items_total ?? null,
+            onInput: (q) => {
+              this._searchDraft = q;
+              this._emitSearch(q);
+            },
+          })}
+          <!-- One strip, so the pills are what gives when the bar runs out of
+               room — and no strip at all when nothing is flagged, because an
+               empty one is still a flex item with a gap in front of it. -->
+          ${badges?.any
+            ? html`<div class="pills" data-testid="full-pills">${badges.pills}</div>`
             : null}
           <!-- On a phone the bar's first row holds the menu, this button, the
                organize pin and the overflow, and only the heading can shrink.
@@ -2211,7 +2103,6 @@ export class HVFullView extends LitElement {
   private _renderBody() {
     const st = this.st;
     const filters = st?.filters ?? defaultFilters();
-    const counts = st?.statsCounts;
     const loaded = st?.items.length ?? 0;
     const selection = st?.selection ?? new Set<string>();
 
@@ -2231,31 +2122,21 @@ export class HVFullView extends LitElement {
                 ? html`
                   ${this._viewport.narrow ? this._renderPanelHead(filters) : null}
                   <div class="panel-scroll">
-                  <hv-filter-panel
-                    .statuses=${this.st?.statuses ?? null}
-                    data-testid="full-filter-panel"
-                    .filters=${filters}
-                    .distinct=${st?.distinctValuesCache ?? null}
-                    .areas=${st?.areasCache?.areas ?? []}
-                    .locations=${st?.locationsFlatCache ?? null}
-                    .locationTree=${st?.locationTreeCache ?? []}
-                    .total=${st?.total ?? null}
-                    .grandTotal=${counts?.items_total ?? null}
-                    .counts=${counts ?? null}
-                    ?mobile=${this._viewport.narrow}
-                    @change=${(e: CustomEvent) => this._setFilters(e.detail as Partial<StoreFilters>)}
-                    @stage=${(e: CustomEvent) => {
-                      const staged = (e.detail as { filters: StoreFilters }).filters;
+                  ${renderFilterPanel(st, {
+                    testid: 'full-filter-panel',
+                    mobile: this._viewport.narrow,
+                    setFilters: (patch) => this.store?.setFilters(patch),
+                    clearFilters: () => this.store?.clearFilters(),
+                    onStage: (staged) => {
                       this._stagedFilters = staged;
                       this._priceStaged(staged);
-                    }}
-                    @apply=${(e: CustomEvent) => {
-                      this._setFilters(e.detail as StoreFilters);
+                    },
+                    onApply: (applied) => {
+                      this.store?.setFilters(applied);
                       this._filtersOpen = false;
                       this._stagedFilters = null;
-                    }}
-                    @clear-filters=${() => this.store?.clearFilters()}
-                  ></hv-filter-panel>
+                    },
+                  })}
                   </div>
                   ${this._viewport.narrow ? this._renderPanelFoot() : null}
                 `
@@ -2293,7 +2174,7 @@ export class HVFullView extends LitElement {
               ?selectable=${this._selecting}
               ?narrow=${this._viewport.narrow}
               .selection=${selection}
-              @sort-change=${(e: CustomEvent) => this._setFilters({ sort: (e.detail as { sort: Sort }).sort })}
+              @sort-change=${(e: CustomEvent) => this.store?.setFilters({ sort: (e.detail as { sort: Sort }).sort })}
               @near-end=${(e: CustomEvent) =>
                 void this.store?.prefetchIfNeeded((e.detail as { ratio: number }).ratio)}
               @increment=${(e: CustomEvent) => this._workspace.onRowEvent('increment', e.detail)}

--- a/cards/haventory-card/src/test.utils.ts
+++ b/cards/haventory-card/src/test.utils.ts
@@ -989,6 +989,9 @@ export function makeMediaBindings(
   };
 }
 
+/** The restore a {@link stubViewport} hands back, and the flip it can announce. */
+export type ViewportStub = (() => void) & { announce: (matches: boolean) => void };
+
 /**
  * Pin `window.matchMedia` to one answer for the length of a test, and hand back
  * the restore.
@@ -997,22 +1000,38 @@ export function makeMediaBindings(
  * `false` — which reads as "desktop viewport" to the overlays that switch on
  * one, and leaves their phone form untestable. Call the restore in a `finally`
  * so the next test starts from the real implementation.
+ *
+ * `announce` changes the answer and tells the listeners, which is the only way
+ * to reach a host that drops state when the width stops being a phone's.
  */
-export function stubViewport(matches: boolean): () => void {
+export function stubViewport(matches: boolean): ViewportStub {
   const original = window.matchMedia;
+  const listeners: ((e: MediaQueryListEvent) => void)[] = [];
+  let current = matches;
   window.matchMedia = ((media: string) => ({
-    matches,
+    get matches() {
+      return current;
+    },
     media,
     onchange: null,
-    addEventListener: () => {},
-    removeEventListener: () => {},
+    addEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) => listeners.push(fn),
+    removeEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) => {
+      const at = listeners.indexOf(fn);
+      if (at >= 0) listeners.splice(at, 1);
+    },
     addListener: () => {},
     removeListener: () => {},
     dispatchEvent: () => false,
   })) as unknown as typeof window.matchMedia;
-  return () => {
+  const restore = () => {
     window.matchMedia = original;
   };
+  return Object.assign(restore, {
+    announce(next: boolean) {
+      current = next;
+      for (const fn of [...listeners]) fn({ matches: next } as MediaQueryListEvent);
+    },
+  });
 }
 
 /**

--- a/cards/haventory-card/src/ui/filter-chrome.test.ts
+++ b/cards/haventory-card/src/ui/filter-chrome.test.ts
@@ -1,0 +1,221 @@
+import { html, render } from 'lit';
+import {
+  SEARCH_DEBOUNCE_MS,
+  priceStaged,
+  renderFilterHead,
+  renderSearch,
+  renderStagedFooter,
+  searchDebounce,
+} from './filter-chrome';
+import { defaultFilters } from '../store/store';
+import type { Store } from '../store/store';
+import type { StoreFilters } from '../store/types';
+
+/** Just enough store for the two debounced writers to act on. */
+function fakeStore(count: number | null = 7) {
+  const patches: Partial<StoreFilters>[] = [];
+  const priced: StoreFilters[] = [];
+  const store = {
+    setFilters: (patch: Partial<StoreFilters>) => patches.push(patch),
+    countMatching: (filters: StoreFilters) => {
+      priced.push(filters);
+      return Promise.resolve(count);
+    },
+  };
+  return { patches, priced, store: store as unknown as Store };
+}
+
+function draw(template: unknown) {
+  const host = document.createElement('div');
+  render(html`${template}`, host);
+  return host;
+}
+
+describe('searchDebounce', () => {
+  it('waits for the typing to stop before it touches the store', async () => {
+    const { patches, store } = fakeStore();
+    const emit = searchDebounce(() => store);
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      emit('gl');
+      emit('glu');
+      emit('glue');
+      // Still nothing on the last millisecond of the window...
+      await vi.advanceTimersByTimeAsync(SEARCH_DEBOUNCE_MS - 1);
+      expect(patches).toEqual([]);
+
+      // ...and one write, of the last thing typed, on the next one.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(patches).toEqual([{ q: 'glue' }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A host builds its debouncer in a field initializer, which runs before Home
+  // Assistant has handed it anything — a store captured there would be
+  // undefined for the life of the element.
+  it('reads the store per call rather than capturing it', async () => {
+    let attached: Store | undefined;
+    const emit = searchDebounce(() => attached);
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const { patches, store } = fakeStore();
+      emit('glue');
+      attached = store;
+      await vi.advanceTimersByTimeAsync(SEARCH_DEBOUNCE_MS);
+      expect(patches).toEqual([{ q: 'glue' }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('priceStaged', () => {
+  it('counts the staged set once the edits have stopped landing', async () => {
+    const { priced, store } = fakeStore(2);
+    const counts: (number | null)[] = [];
+    const price = priceStaged(() => store, (count) => counts.push(count));
+    const staged = { ...defaultFilters(), lowStockOnly: true };
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      price({ ...defaultFilters() });
+      price(staged);
+      expect(priced).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(priced).toEqual([staged]);
+      expect(counts).toEqual([2]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A store that cannot answer leaves the button on its uncounted wording
+  // rather than claiming a number.
+  it('passes on a count the store could not give', async () => {
+    const { store } = fakeStore(null);
+    const counts: (number | null)[] = [];
+    const price = priceStaged(() => store, (count) => counts.push(count));
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      price(defaultFilters());
+      await vi.advanceTimersByTimeAsync(150);
+      expect(counts).toEqual([null]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('renderSearch', () => {
+  const box = (total: number | null, onInput: (q: string) => void = () => undefined) =>
+    draw(renderSearch({ testid: 'search-input', draft: 'glue', total, onInput }));
+
+  it('offers the whole inventory in the placeholder, and says so once counted', () => {
+    expect((box(null).querySelector('input') as HTMLInputElement).placeholder).toBe('Search items…');
+    expect((box(3).querySelector('input') as HTMLInputElement).placeholder).toBe('Search all 3 items…');
+    expect((box(1).querySelector('input') as HTMLInputElement).placeholder).toBe('Search all 1 item…');
+  });
+
+  it('shows the draft it is handed and reports every keystroke back', () => {
+    const typed: string[] = [];
+    const host = box(3, (q) => typed.push(q));
+    const input = host.querySelector('input') as HTMLInputElement;
+    expect(input.value).toBe('glue');
+    expect(input.dataset.testid).toBe('search-input');
+
+    input.value = 'wood';
+    input.dispatchEvent(new Event('input'));
+    expect(typed).toEqual(['wood']);
+  });
+
+  // The glyph carries no name, so the field has one that is not drawn.
+  it('names the field for a reader who cannot see the magnifier', () => {
+    expect(box(null).querySelector('.hv-sr-only')?.textContent).toBe('Search items');
+  });
+});
+
+describe('renderFilterHead', () => {
+  it('counts the staged set and names each surface the way that surface asked', () => {
+    const cleared: string[] = [];
+    const sheet = draw(
+      renderFilterHead({
+        rowClass: 'sheet-head',
+        testids: { clear: 'sheet-clear-all' },
+        staged: 1,
+        onClear: () => cleared.push('sheet'),
+      }),
+    );
+    const panel = draw(
+      renderFilterHead({
+        rowClass: 'panel-head',
+        testids: { row: 'full-panel-head', count: 'full-panel-count', clear: 'full-panel-clear' },
+        staged: 0,
+        onClear: () => cleared.push('panel'),
+      }),
+    );
+
+    expect([...(sheet.firstElementChild as HTMLElement).classList]).toEqual([
+      'hv-sheet-head',
+      'sheet-head',
+    ]);
+    expect(sheet.querySelector('[data-testid="full-panel-head"]')).toBe(null);
+    expect(sheet.textContent).toContain('1 active');
+    expect(panel.querySelector('[data-testid="full-panel-count"]')?.textContent).toBe('0 active');
+
+    (sheet.querySelector('[data-testid="sheet-clear-all"]') as HTMLButtonElement).click();
+    (panel.querySelector('[data-testid="full-panel-clear"]') as HTMLButtonElement).click();
+    expect(cleared).toEqual(['sheet', 'panel']);
+  });
+});
+
+describe('renderStagedFooter', () => {
+  function foot(stagedCount: number | null, panel: { apply: () => void } | null) {
+    const cancelled: string[] = [];
+    const host = draw(
+      renderStagedFooter({
+        prefix: 'sheet',
+        rowClass: 'sheet-footer',
+        slot: 'footer',
+        cancelClass: 'cancel',
+        applyClass: 'hv-pill large apply',
+        stagedCount,
+        panel: () => panel as never,
+        onCancel: () => cancelled.push('cancel'),
+      }),
+    );
+    return { host, cancelled };
+  }
+
+  it('says what committing would show, and nothing it cannot count', () => {
+    expect(
+      (foot(null, null).host.querySelector('[data-testid="sheet-apply"]') as HTMLElement).textContent?.trim(),
+    ).toBe('Show items');
+    expect(
+      (foot(2, null).host.querySelector('[data-testid="sheet-apply"]') as HTMLElement).textContent?.trim(),
+    ).toBe('Show 2 items');
+  });
+
+  // The panel does not exist on the render that first draws this row, so a
+  // reference captured here would leave the button doing nothing.
+  it('resolves the panel it commits per click', () => {
+    const applied: string[] = [];
+    const { host, cancelled } = foot(2, { apply: () => applied.push('apply') });
+    (host.querySelector('[data-testid="sheet-apply"]') as HTMLButtonElement).click();
+    (host.querySelector('[data-testid="sheet-cancel"]') as HTMLButtonElement).click();
+    expect(applied).toEqual(['apply']);
+    expect(cancelled).toEqual(['cancel']);
+  });
+
+  it('takes the slot and the classes its surface hands it', () => {
+    const row = foot(2, null).host.firstElementChild as HTMLElement;
+    expect(row.getAttribute('slot')).toBe('footer');
+    expect([...row.classList]).toEqual(['sheet-footer']);
+    expect(row.hasAttribute('data-testid')).toBe(false);
+  });
+});

--- a/cards/haventory-card/src/ui/filter-chrome.ts
+++ b/cards/haventory-card/src/ui/filter-chrome.ts
@@ -1,0 +1,285 @@
+import { css, html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import type { TemplateResult } from 'lit';
+import { t, tn } from '../i18n';
+import { icon } from './icons';
+import { debounce } from '../utils/debounce';
+import { defaultFilters } from '../store/store';
+import type { Store } from '../store/store';
+import type { StoreFilters, StoreState } from '../store/types';
+// Registers the elements this file emits. Kept here rather than left to each
+// host, so a surface cannot render the chrome and get two unknown tags.
+import '../components/hv-filter-chips';
+import '../components/hv-filter-panel';
+import type { HVFilterPanel } from '../components/hv-filter-panel';
+
+/**
+ * The controls that decide which items a surface is showing: the search box,
+ * the applied-filter chips, the filter panel, and the head and commit rows a
+ * staged panel needs around it.
+ *
+ * The compact card and the expanded view ask the same questions of the same
+ * store, so the debounce windows, the placeholder's arithmetic and the panel's
+ * four handlers are written once here. What each surface *calls* its controls
+ * is a parameter — `search-input` against `full-search`, `sheet-*` against
+ * `full-panel-*` — because those are what the browser harnesses locate, and one
+ * renderer is what keeps them byte-identical.
+ */
+
+/** How long the search box waits for typing to stop before it filters. */
+export const SEARCH_DEBOUNCE_MS = 200;
+
+/**
+ * How long a staged filter set waits before it is priced. Shorter than the
+ * search window: nothing is fetched, and the number lands on a button the user
+ * is already looking at.
+ */
+const STAGED_PRICE_MS = 150;
+
+/**
+ * Layout for the search pill and the field inside it. Hosts add this to their
+ * styles and paint their own fill and gutter on it.
+ */
+export const searchBox = css`
+  /* Takes the slack in the row it sits in, and can give it back: without the
+     min-width a flex item will not shrink below its content width, and one
+     that refuses to shrink pushes everything after it off the row's end. */
+  .hv-search {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: var(--hv-radius-chip);
+  }
+  /* The pill is what is drawn; the field inside it takes the same slack. */
+  .hv-search input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: none;
+    outline: none;
+    font: 400 var(--hv-input-font, 13.5px) var(--hv-font);
+  }
+`;
+
+/**
+ * Layout for the head row of a sheet or a panel. Hosts add this to their styles
+ * and keep their own padding on it — the card's sheet rows sit inside a 16px
+ * gutter and the expanded view's panel head sits in a column that already has
+ * one.
+ */
+export const sheetHead = css`
+  .hv-sheet-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    border-bottom: 1px solid var(--hv-row-divider);
+  }
+  .hv-sheet-head .heading {
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--hv-text);
+  }
+  .hv-sheet-head .staged {
+    font-size: 12.5px;
+    color: var(--hv-text-secondary);
+  }
+  /* The way out of the whole set sits at the far end of the row, past the two
+     labels that describe it. */
+  .hv-sheet-head .hv-text-button {
+    margin-left: auto;
+  }
+`;
+
+/**
+ * The search box's write into the store, held back until typing stops.
+ *
+ * The store is read per call rather than captured: a host is handed one after
+ * its fields are initialized.
+ */
+export function searchDebounce(getStore: () => Store | undefined): (q: string) => void {
+  return debounce((q: string) => getStore()?.setFilters({ q }), SEARCH_DEBOUNCE_MS);
+}
+
+/**
+ * Price a staged — not yet applied — filter set, so the button that commits it
+ * can say what pressing it will show. Null is a store that could not answer,
+ * which is what leaves the button on its uncounted wording.
+ */
+export function priceStaged(
+  getStore: () => Store | undefined,
+  set: (count: number | null) => void,
+): (filters: StoreFilters) => void {
+  return debounce((filters: StoreFilters) => {
+    void getStore()
+      ?.countMatching(filters)
+      .then(set);
+  }, STAGED_PRICE_MS);
+}
+
+/** What a filter control does to the store it is pointed at. */
+export interface FilterActions {
+  setFilters: (patch: Partial<StoreFilters>) => void;
+  clearFilters: () => void;
+}
+
+export interface SearchOptions {
+  /** `search-input` on the card, `full-search` in the expanded view. */
+  testid: string;
+  /** What the field shows; the host holds it so typing survives a redraw. */
+  draft: string;
+  /**
+   * The whole inventory, for the placeholder — not the filtered result, and
+   * null while there is no count yet. Both surfaces offer the same sentence, so
+   * the box does not describe one store two ways depending on which opened it.
+   */
+  total: number | null;
+  onInput: (q: string) => void;
+}
+
+export function renderSearch(opts: SearchOptions): TemplateResult {
+  return html`<label class="hv-search search">
+    ${icon('magnify', 18)}
+    <span class="hv-sr-only">${t('hv.card.searchItems')}</span>
+    <input
+      type="search"
+      data-testid=${opts.testid}
+      placeholder=${opts.total === null
+        ? t('hv.card.searchPlaceholder')
+        : tn('hv.card.searchAllPlaceholder', opts.total)}
+      .value=${opts.draft}
+      @input=${(e: Event) => opts.onInput((e.target as HTMLInputElement).value)}
+    />
+  </label>`;
+}
+
+/** The applied filters, each with the way to take it back off. */
+export function renderFilterChips(st: StoreState | null, opts: FilterActions): TemplateResult {
+  return html`<hv-filter-chips
+    .statuses=${st?.statuses ?? null}
+    .filters=${st?.filters ?? defaultFilters()}
+    .locations=${st?.locationsFlatCache ?? null}
+    .areas=${st?.areasCache?.areas ?? []}
+    @remove-filter=${(e: CustomEvent) =>
+      opts.setFilters((e.detail as { patch: Partial<StoreFilters> }).patch)}
+    @clear-filters=${opts.clearFilters}
+  ></hv-filter-chips>`;
+}
+
+export interface FilterPanelOptions extends FilterActions {
+  /** The expanded view names its panel; the card finds its own by tag. */
+  testid?: string;
+  /** Stage the edits and commit them on a button, instead of applying live. */
+  mobile: boolean;
+  /** A staged edit landed: the host holds it so its head row can count it. */
+  onStage: (filters: StoreFilters) => void;
+  /** The staged set was committed; the surface holding the panel closes. */
+  onApply: (filters: StoreFilters) => void;
+}
+
+export function renderFilterPanel(st: StoreState | null, opts: FilterPanelOptions): TemplateResult {
+  return html`<hv-filter-panel
+    .statuses=${st?.statuses ?? null}
+    data-testid=${ifDefined(opts.testid)}
+    .filters=${st?.filters ?? defaultFilters()}
+    .distinct=${st?.distinctValuesCache ?? null}
+    .areas=${st?.areasCache?.areas ?? []}
+    .locations=${st?.locationsFlatCache ?? null}
+    .locationTree=${st?.locationTreeCache ?? []}
+    .total=${st?.total ?? null}
+    .grandTotal=${st?.statsCounts?.items_total ?? null}
+    .counts=${st?.statsCounts ?? null}
+    ?mobile=${opts.mobile}
+    @change=${(e: CustomEvent) => opts.setFilters(e.detail as Partial<StoreFilters>)}
+    @stage=${(e: CustomEvent) => opts.onStage((e.detail as { filters: StoreFilters }).filters)}
+    @apply=${(e: CustomEvent) => opts.onApply(e.detail as StoreFilters)}
+    @clear-filters=${opts.clearFilters}
+  ></hv-filter-panel>`;
+}
+
+export interface FilterHeadOptions {
+  /** The row's own class, beside the shared one. */
+  rowClass: string;
+  /** Per-surface test ids; the card's sheet names only its clear button. */
+  testids: { row?: string; count?: string; clear: string };
+  /** How many filters the staged set carries. */
+  staged: number;
+  onClear: () => void;
+}
+
+/**
+ * The head row of a staged filter surface: what it is, how much of it is
+ * staged, and the way out of all of it.
+ *
+ * Clear all sits here rather than beside the commit buttons because three
+ * controls do not fit a 375px row in every language: German's
+ * `hv.action.clearAll` broke over two lines and left the button beside it
+ * stacking its count sentence over three.
+ */
+export function renderFilterHead(opts: FilterHeadOptions): TemplateResult {
+  return html`<div class="hv-sheet-head ${opts.rowClass}" data-testid=${ifDefined(opts.testids.row)}>
+    <span class="heading">${t('hv.card.filters')}</span>
+    <span class="staged" data-testid=${ifDefined(opts.testids.count)}
+      >${t('hv.card.filtersActive', { count: opts.staged })}</span
+    >
+    <button class="hv-text-button" data-testid=${opts.testids.clear} @click=${opts.onClear}>
+      ${t('hv.action.clearAll')}
+    </button>
+  </div>`;
+}
+
+export interface StagedFooterOptions {
+  /** `sheet` on the card, `full-panel` in the expanded view. */
+  prefix: string;
+  /**
+   * The row and its two buttons, as each surface dresses them: the card's
+   * filter sheet commits with a pair of finger-sized buttons at the foot of a
+   * phone screen, the expanded view's panel with a text button and a pill.
+   * `lead` is drawn before them, `slot` is how a bottom sheet takes a footer.
+   */
+  rowClass: string;
+  rowTestid?: string;
+  slot?: string;
+  cancelClass: string;
+  applyClass: string;
+  lead?: TemplateResult;
+  /** The staged set's match count, or null while it is still being counted. */
+  stagedCount: number | null;
+  /**
+   * The panel to commit, resolved per click: on the render that first draws it
+   * the element does not exist yet, so a reference captured here would leave
+   * the button doing nothing.
+   */
+  panel: () => HVFilterPanel | null | undefined;
+  onCancel: () => void;
+}
+
+/**
+ * The commit row a staged panel needs under it.
+ *
+ * `hv-filter-panel` stages its edits when it is on a phone and drops its own
+ * footer, because its host is expected to provide one. Both hosts do, in the
+ * same two words and the same counted sentence.
+ */
+export function renderStagedFooter(opts: StagedFooterOptions): TemplateResult {
+  return html`<div
+    class=${opts.rowClass}
+    data-testid=${ifDefined(opts.rowTestid)}
+    slot=${ifDefined(opts.slot)}
+  >
+    ${opts.lead ?? null}
+    <button class=${opts.cancelClass} data-testid=${`${opts.prefix}-cancel`} @click=${opts.onCancel}>
+      ${t('hv.action.cancel')}
+    </button>
+    <button
+      class=${opts.applyClass}
+      data-testid=${`${opts.prefix}-apply`}
+      @click=${() => opts.panel()?.apply()}
+    >
+      ${opts.stagedCount === null
+        ? t('hv.card.showItems')
+        : tn('hv.card.showCount', opts.stagedCount)}
+    </button>
+  </div>`;
+}

--- a/cards/haventory-card/src/ui/responsive.test.ts
+++ b/cards/haventory-card/src/ui/responsive.test.ts
@@ -125,6 +125,32 @@ describe('ViewportNarrow', () => {
     }
   });
 
+  // The callback is for state that only means something at one width — a staged
+  // filter set counts controls the surface stops drawing. Connecting is not a
+  // change: there is nothing held from a previous answer to drop.
+  it('tells the host when the answer flips, and not when it first reads one', () => {
+    const media = stub(true);
+    try {
+      const flips: boolean[] = [];
+      const c = new ViewportNarrow(makeHost() as never, (narrow) => flips.push(narrow));
+
+      c.hostConnected();
+      expect(c.narrow).toBe(true);
+      expect(flips).toEqual([]);
+
+      media.announce(false);
+      expect(flips).toEqual([false]);
+      media.announce(true);
+      expect(flips).toEqual([false, true]);
+
+      c.hostDisconnected();
+      media.announce(false);
+      expect(flips).toEqual([false, true]);
+    } finally {
+      media.restore();
+    }
+  });
+
   // jsdom answers no media query, and a host that cannot say how wide the window
   // is has no business claiming it is a phone.
   it('stays on the desktop answer when matchMedia is missing', () => {

--- a/cards/haventory-card/src/ui/stat-badges.test.ts
+++ b/cards/haventory-card/src/ui/stat-badges.test.ts
@@ -1,0 +1,176 @@
+import { html, render } from 'lit';
+import { renderStatBadges } from './stat-badges';
+import { defaultFilters } from '../store/store';
+import type { StatBadgeOptions, StatBadgeState } from './stat-badges';
+import type { StatsCounts, StoreFilters } from '../store/types';
+
+const NO_COUNTS: StatsCounts = {
+  items_total: 0,
+  locations_total: 0,
+  no_location_count: 0,
+  low_stock_count: 0,
+  checked_out_count: 0,
+  overdue_count: 0,
+  inspection_due_count: 0,
+  reminder_due_count: 0,
+};
+
+/** What an older backend sends: the required counts and none of the derived ones. */
+const OLDER_BACKEND: StatsCounts = {
+  items_total: 3,
+  locations_total: 0,
+  no_location_count: 0,
+  low_stock_count: 0,
+  checked_out_count: 0,
+};
+
+function state(counts: Partial<StatsCounts>, filters: Partial<StoreFilters> = {}): StatBadgeState {
+  return {
+    statsCounts: { ...NO_COUNTS, ...counts },
+    filters: { ...defaultFilters(), ...filters },
+  };
+}
+
+/** The card's header dressing, which is one of the two the parameters carry. */
+function cardOptions(patch: Partial<StatBadgeOptions> = {}): StatBadgeOptions {
+  return {
+    prefix: 'badge',
+    chipClass: (tone) => `badge toggle ${tone}`,
+    total: 'badge quiet',
+    setFilters: () => undefined,
+    ...patch,
+  };
+}
+
+/** The bar's dressing: no blue on a blue bar, and its own test-id prefix. */
+function barOptions(patch: Partial<StatBadgeOptions> = {}): StatBadgeOptions {
+  return {
+    prefix: 'full-badge',
+    chipClass: (tone) => (tone === 'state' ? 'pill' : `pill ${tone}`),
+    setFilters: () => undefined,
+    ...patch,
+  };
+}
+
+function draw(
+  st: StatBadgeState | null,
+  quickFilters: Parameters<typeof renderStatBadges>[1],
+  opts: StatBadgeOptions,
+) {
+  const badges = renderStatBadges(st, quickFilters, opts);
+  const host = document.createElement('div');
+  render(html`${badges?.total}${badges?.pills}`, host);
+  return { badges, host };
+}
+
+const testids = (host: HTMLElement) =>
+  [...host.querySelectorAll('[data-testid]')].map((el) => el.getAttribute('data-testid'));
+
+describe('renderStatBadges', () => {
+  const stocked = () => state({ items_total: 2, low_stock_count: 1, checked_out_count: 1 });
+
+  it('says nothing at all until the store has counted something', () => {
+    expect(renderStatBadges(null, null, cardOptions())).toBe(null);
+    expect(renderStatBadges({ statsCounts: null, filters: defaultFilters() }, null, cardOptions())).toBe(
+      null,
+    );
+  });
+
+  // The pills are filter toggles, not decoration; a dashboard that never checks
+  // anything out has no use for the checked-out one. The config decides what is
+  // on offer, the count still decides whether there is anything to say.
+  it('draws every pill by default', () => {
+    const { host } = draw(stocked(), null, cardOptions());
+    expect(testids(host)).toEqual(['badge-total', 'badge-low', 'badge-out']);
+  });
+
+  it('draws only the pills the config names', () => {
+    const { host } = draw(stocked(), ['low_stock'], cardOptions());
+    expect(testids(host)).toEqual(['badge-low']);
+  });
+
+  // Allowed is not the same as shown: the count gate is unchanged.
+  it('still hides an allowed pill whose count is zero', () => {
+    // The total is not in this config either, so the row comes out empty — which
+    // is what `any` is for: a surface that gives the badges a row of their own
+    // has to know there is nothing to put in it.
+    const { host, badges } = draw(state({ items_total: 1 }), ['low_stock', 'checked_out'], cardOptions());
+    expect(testids(host)).toEqual([]);
+    expect(badges?.any).toBe(false);
+  });
+
+  // The calendar-derived counts are optional, because an older backend does not
+  // send them; absent has to read as none rather than as a pill saying NaN.
+  it('reads a count an older backend never sent as nothing to report', () => {
+    const { host } = draw({ statsCounts: OLDER_BACKEND, filters: defaultFilters() }, null, cardOptions());
+    expect(testids(host)).toEqual(['badge-total']);
+  });
+
+  it('turns its own filter on when pressed', () => {
+    const patches: Partial<StoreFilters>[] = [];
+    const { host } = draw(stocked(), null, cardOptions({ setFilters: (patch) => patches.push(patch) }));
+    (host.querySelector('[data-testid="badge-low"]') as HTMLButtonElement).click();
+    expect(patches).toEqual([{ lowStockOnly: true }]);
+  });
+
+  it('takes its own filter back off when pressed again', () => {
+    const patches: Partial<StoreFilters>[] = [];
+    const { host } = draw(
+      state({ items_total: 2, low_stock_count: 1 }, { lowStockOnly: true }),
+      null,
+      cardOptions({ setFilters: (patch) => patches.push(patch) }),
+    );
+    (host.querySelector('[data-testid="badge-low"]') as HTMLButtonElement).click();
+    expect(patches).toEqual([{ lowStockOnly: false }]);
+  });
+
+  it('says an applied filter back through aria-pressed and the applied ring', () => {
+    const { host } = draw(
+      state({ items_total: 2, low_stock_count: 1 }, { lowStockOnly: true }),
+      null,
+      cardOptions(),
+    );
+    const low = host.querySelector('[data-testid="badge-low"]') as HTMLButtonElement;
+    expect(low.getAttribute('aria-pressed')).toBe('true');
+    expect(low.classList.contains('on')).toBe(true);
+  });
+
+  // Per-surface test ids and chip classes are what the browser harnesses and
+  // each shadow root's own CSS locate, so one renderer keeps them apart on
+  // purpose rather than by accident.
+  it('names and dresses each surface the way that surface asked', () => {
+    const { host: card } = draw(stocked(), null, cardOptions());
+    const { host: bar } = draw(stocked(), null, barOptions());
+
+    expect(testids(card)).toEqual(['badge-total', 'badge-low', 'badge-out']);
+    expect(testids(bar)).toEqual(['full-badge-low', 'full-badge-out']);
+
+    const cardLow = card.querySelector('[data-testid="badge-low"]') as HTMLElement;
+    const barLow = bar.querySelector('[data-testid="full-badge-low"]') as HTMLElement;
+    expect([...cardLow.classList]).toEqual(['hv-chip', 'badge', 'toggle', 'warning']);
+    expect([...barLow.classList]).toEqual(['hv-chip', 'pill', 'warning']);
+
+    // The card's checked-out badge is its one blue one; the bar paints its own
+    // fills and has no blue to spare on a blue bar.
+    expect([...(card.querySelector('[data-testid="badge-out"]') as HTMLElement).classList]).toContain(
+      'state',
+    );
+    expect([
+      ...(bar.querySelector('[data-testid="full-badge-out"]') as HTMLElement).classList,
+    ]).toEqual(['hv-chip', 'pill']);
+  });
+
+  // The total reports rather than filters, so it is the one chip a surface can
+  // decline — the card's phone row does, and the bar never had one.
+  it('draws the total only for a surface that asked for one, and only when allowed', () => {
+    expect(testids(draw(stocked(), null, cardOptions({ total: undefined })).host)).toEqual([
+      'badge-low',
+      'badge-out',
+    ]);
+    expect(testids(draw(stocked(), ['low_stock'], cardOptions()).host)).toEqual(['badge-low']);
+    expect(testids(draw(stocked(), null, barOptions()).host)).toEqual([
+      'full-badge-low',
+      'full-badge-out',
+    ]);
+  });
+});

--- a/cards/haventory-card/src/ui/stat-badges.ts
+++ b/cards/haventory-card/src/ui/stat-badges.ts
@@ -1,0 +1,171 @@
+import { html } from 'lit';
+import type { TemplateResult } from 'lit';
+import { t } from '../i18n';
+import type { TranslationKey } from '../i18n';
+import { counted } from './plural';
+import { quickFilterAllowed } from './quick-filters';
+import type { QuickFilterKey } from './quick-filters';
+import type { StatsCounts, StoreFilters } from '../store/types';
+
+/**
+ * The counts both of the card's surfaces price, as pressable filters.
+ *
+ * The compact card draws them as badges in its header and the expanded view as
+ * pills on its coloured bar: same five counts, same keys, same gates, two
+ * dressings. Written twice the two copies were free to disagree about which
+ * count a pill reads and when it is drawn at all, so the arithmetic lives here
+ * and what each surface calls its pills is a parameter — the browser harnesses
+ * locate `badge-*` and `full-badge-*`, and one renderer is what keeps them
+ * byte-identical.
+ */
+
+/** The hue a pill carries; what each one means is `ui/chip`'s vocabulary. */
+export type BadgeTone = 'warning' | 'error' | 'state';
+
+type BadgeFilter =
+  | 'lowStockOnly'
+  | 'overdueOnly'
+  | 'inspectionDueOnly'
+  | 'reminderDueOnly'
+  | 'checkedOutOnly';
+
+interface BadgeSpec {
+  /** The dashboard's name for this pill, which decides whether it is on offer. */
+  quick: QuickFilterKey;
+  /** Test-id suffix, after the surface's own prefix. */
+  id: string;
+  tone: BadgeTone;
+  filter: BadgeFilter;
+  count: (counts: StatsCounts) => number;
+  label: TranslationKey;
+  title: TranslationKey;
+}
+
+/**
+ * The five, in the order both surfaces draw them. The optional counts are the
+ * calendar-derived ones an older backend does not send; absent reads as none,
+ * which is the gate below anyway.
+ */
+const BADGES: readonly BadgeSpec[] = [
+  {
+    quick: 'low_stock',
+    id: 'low',
+    tone: 'warning',
+    filter: 'lowStockOnly',
+    count: (counts) => counts.low_stock_count,
+    label: 'hv.card.badge.low',
+    title: 'hv.card.badge.lowTitle',
+  },
+  {
+    quick: 'overdue',
+    id: 'overdue',
+    tone: 'error',
+    filter: 'overdueOnly',
+    count: (counts) => counts.overdue_count ?? 0,
+    label: 'hv.card.badge.overdue',
+    title: 'hv.card.badge.overdueTitle',
+  },
+  {
+    quick: 'inspection_due',
+    id: 'inspection',
+    tone: 'warning',
+    filter: 'inspectionDueOnly',
+    count: (counts) => counts.inspection_due_count ?? 0,
+    label: 'hv.card.badge.inspection',
+    title: 'hv.card.badge.inspectionTitle',
+  },
+  {
+    quick: 'reminder_due',
+    id: 'reminder',
+    tone: 'warning',
+    filter: 'reminderDueOnly',
+    count: (counts) => counts.reminder_due_count ?? 0,
+    label: 'hv.card.badge.reminder',
+    title: 'hv.card.badge.reminderTitle',
+  },
+  {
+    quick: 'checked_out',
+    id: 'out',
+    tone: 'state',
+    filter: 'checkedOutOnly',
+    count: (counts) => counts.checked_out_count,
+    label: 'hv.card.badge.checkedOut',
+    title: 'hv.card.badge.checkedOutTitle',
+  },
+];
+
+/** How a surface names and dresses its pills. */
+export interface StatBadgeOptions {
+  /** `badge` on the card, `full-badge` in the expanded view. */
+  prefix: string;
+  /**
+   * The chip classes a pill of that hue wears, after `hv-chip`. A surface that
+   * paints its own fills answers for the hues it substitutes, and for any it
+   * declines to carry.
+   */
+  chipClass: (tone: BadgeTone) => string;
+  /**
+   * Draw the inventory total as a quiet chip, in the classes named here. It
+   * reports rather than filters, and only the card's header has a row for it.
+   */
+  total?: string;
+  setFilters: (patch: Partial<StoreFilters>) => void;
+}
+
+/** What the badges read out of the store; a whole `StoreState` satisfies it. */
+export interface StatBadgeState {
+  statsCounts: StatsCounts | null;
+  filters: StoreFilters;
+}
+
+/** What a surface has to draw, once the counts and the config have had a say. */
+export interface StatBadges {
+  /** The total chip, when this surface asked for one and the config allows it. */
+  total: TemplateResult | null;
+  /** The five, in order, with a null wherever there is nothing to say. */
+  pills: (TemplateResult | null)[];
+  /** True when any pill has something to say — an empty row is still a band. */
+  any: boolean;
+}
+
+/**
+ * Price the inventory's exceptions, or answer null when there are no counts to
+ * price yet.
+ *
+ * A pill shows when the dashboard allows it *and* its count clears the gate it
+ * always had: the config decides what is on offer, the count decides whether
+ * there is anything to say.
+ */
+export function renderStatBadges(
+  st: StatBadgeState | null,
+  quickFilters: QuickFilterKey[] | null,
+  opts: StatBadgeOptions,
+): StatBadges | null {
+  if (!st?.statsCounts) return null;
+  const counts = st.statsCounts;
+  const filters = st.filters;
+
+  const pills = BADGES.map((spec) => {
+    const count = spec.count(counts);
+    if (!quickFilterAllowed(quickFilters, spec.quick) || count <= 0) return null;
+    const on = filters[spec.filter];
+    return html`<button
+      class="hv-chip ${opts.chipClass(spec.tone)} ${on ? 'on' : ''}"
+      data-testid=${`${opts.prefix}-${spec.id}`}
+      aria-pressed=${String(on)}
+      title=${t(spec.title)}
+      @click=${() => opts.setFilters({ [spec.filter]: !on } as Partial<StoreFilters>)}
+    >
+      ${t(spec.label, { count })}
+    </button>`;
+  });
+
+  const total =
+    opts.total && quickFilterAllowed(quickFilters, 'total')
+      ? html`<span class="hv-chip ${opts.total}" data-testid=${`${opts.prefix}-total`}
+          >${counted(counts.items_total, 'item')}</span
+        >`
+      : null;
+
+  return { total, pills, any: pills.some((pill) => pill !== null) };
+}


### PR DESCRIPTION
## Summary

PR 3 of §6.M4. The compact card and the expanded view ask the same questions of the same store, and each wrote the controls that ask them: two copies of the five stat pills, the search box, the applied-filter chips, the filter panel's four handlers, the staged head row and the commit row under it, and two spellings each of the search window and the staged-count window.

**First commit is test-only.** PR 2's review asked for two pins its merge landed without, and this PR carries them ahead of the chrome work:

- the card's read sheet closes when the store reports its item removed (`ItemWorkspace.syncPinnedItem`'s `wasRemoved` path, which the full view already had a pin for and the card had none);
- the staged-filter drop on a viewport flip, now routed through `ViewportNarrow`'s change callback — the controller case pins the callback (fires with the new answer on a flip, not on connect), and the expanded view's case pins what it is for: after a rotation the head row counts the applied filters again, not a staged set the controls no longer carry. `stubViewport` grows an `announce`, since a flip is the only way to reach a host that drops state when the answer changes.

Both new pins were checked against the production code removed: each fails without it.

**Then the cut.** `ui/stat-badges.ts` holds the pill arithmetic — which counts there are, which the config allows, which have anything to say, what pressing one does — and `ui/filter-chrome.ts` the rest, with the search-box and head-row CSS exported the way `bannerStack` is. Functions, not a base class. `_setFilters` was a private one-liner on both hosts and is now the store call it wrapped.

Per §5, what each surface *calls* its controls stays a parameter, because that is what the browser harnesses and each shadow root's own CSS locate: `badge-*` against `full-badge-*`, `search-input` against `full-search`, `sheet-*` against `full-panel-*`, `.sheet-head` against `full-panel-head`, and the chip classes each surface dresses a hue in.

Refs #231 (item 2, FE-SHELLS-C2 / C8, TESTS-T9)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## Counting

| | lines |
|---|---|
| production removed | 417 |
| test removed | 104 |
| added | 1140 |

`git diff --stat` against `d4f908d`. The two host files are 238 lines lighter (`hv-card-shell` 909 → 791, `hv-full-view` 2412 → 2293); the two new modules are 456. So the duplication goes and the production total rises by about 215 — the shared modules carry the option types and the reasons that two copies of the markup carried implicitly, and about 50 lines of the CSS they hold were moved out of the hosts rather than written. FE-SHELLS-C2 estimated −140; that estimate assumed a 150-line module and no declared option types. Test files add 397 net: 104 lines of duplicated cases leave the host specs and the two new module specs cover the functions directly.

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1304 passed, 27 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all green. Untouched by this PR; run because the gate says so.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (73 files, 1921 tests passed), `npm run build`.

phacc is **not required**: nothing under `custom_components/` or `tests/integration/` is touched.

The check that matters for a cut: the chrome landed with **both host specs passing unchanged** — 1908 tests green before a single test line moved. The test moves came after.

### Tests moved, and what each host kept

The four cases both host specs named for the same behaviour move to the new modules:

- `draws every pill by default`, `draws only the pills the config names`, `still hides an allowed pill whose count is zero` → `ui/stat-badges.test.ts`, against `renderStatBadges`;
- `debounces the search before touching the store` / `debounces the app bar search` → `ui/filter-chrome.test.ts`, against `searchDebounce`.

Each host keeps its badge smoke (`shows the configured heading and the live stat badges` on the card, `holds the quick-filter pills in one strip that scrolls rather than wraps` on the expanded view), and everything that is genuinely the host's stays: the card's phone badge row, the config it hands the full view, its placeholder's choice of the whole-inventory count.

`ui/stat-badges.test.ts` also pins the thing this cut must never break — that the two surfaces come out named and dressed differently on purpose (`badge-low` as `hv-chip badge toggle warning`, `full-badge-low` as `hv-chip pill warning`, and the checked-out pill blue on the card and hueless on the bar).

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — no behaviour changed; no doc moves.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — none.
- [x] Essential invariants preserved.
- No file under `custom_components/haventory/` was removed, so `RETIRED_PATHS` is unchanged.

## Screenshots (card / UI changes)

None from this session — it runs offline and never reaches a Home Assistant instance. §6.M4's live check at 1920 px and 375 px, light and dark, is the master's.

## Decisions taken against drifted notes

1. **The pill CSS is not duplicated, so none was exported.** FE-SHELLS-C8 asks for "the search-box and pill CSS exported the way `bannerStack` is" and marks its own estimate low-confidence, asking for a measurement first. Measured: `.badges` and `.appbar .pills` share three trivial declarations and differ in everything that matters — the card's badges wrap and align right, the bar's pills scroll in one strip and never wrap. `searchBox` and `sheetHead` are exported; the two strips stay where they are.
2. **The checked-out pill's hue is a parameter, not a shared constant.** C2 assumed the chip classes differ only by `badge toggle` against `pill`. They also differ by tone: the card's checked-out badge carries `state` (the blue fill, and `border-color: transparent` with it) and the bar's carries none, because the bar substitutes its own solid fills and has no blue to spare on a blue bar. So `chipClass` is `(tone) => string` rather than a string, and each surface answers for the hues it dresses.
3. **`renderStagedFooter` takes the surfaces' chrome as parameters.** C2 sketched `{prefix, stagedCount, panel}`, which assumes one row. Measured, the two footers share the counted sentence and nothing else: the card's is a pair of finger-sized buttons at the foot of a phone sheet, the expanded view's a text button and a pill in a column that already has a gutter. The row class, the two button classes, the optional row test-id, the slot and the lead spacer are parameters; the `Show N items` / `Show items` decision and the apply/cancel wiring are what is shared, which is the drift that mattered.
4. **`drops the error again when the next edit opens` was left where it is.** §6.M4's PR-3 line says "the four cases both host specs name identically", which reads across from TESTS-T9's list — and T9's fourth is that one. It pins `ItemWorkspace.setEditing`, which is PR 2's module, not this PR's; moving it would mean standing up a workspace harness for another PR's code. C2's own four — the pill trio plus the debounce — are the four this PR moved. See Follow-ups.
5. **The card's filter panel keeps its `if (!st) return null` at the call site.** `renderFilterPanel` renders from defaults when there is no state, which is the expanded view's behaviour; the card declines to draw a panel that could answer nothing. Both surfaces behave exactly as before.

## Follow-ups

- `drops the error again when the next edit opens` is still written twice, in `hv-card-shell.test.ts` and `hv-full-view.test.ts`, for one behaviour that now lives in `ItemWorkspace`. Not filed: a duplicated test clears no real-world bar, and if any later package gives `item-workspace.ts` a spec of its own it is fifteen lines to fold in.
- `hv-full-view`'s `_renderPanelHead` still takes `filters` only to count them; once the staged set is the only thing it reads, the parameter can go. Not filed — it is a two-line tidy inside a file M4 keeps touching.

## Handover

1. **Merged / left open** — this PR, open for the master's review and live check; nothing else.
2. **Test this by hand** — `[phone]` the card's filter sheet at 375 px: head row (Filters · N active · Clear all) on one line, the two footer buttons on one line, in German. `[phone]` the same for `/haventory`'s filter panel. `[German]` the app bar's pill strip at 1280 px with all four counts showing — the strip should scroll, not wrap, and the heading should elide before it does.
3. **Validate locally** — the numbered `[browser]` list below.
4. **Decisions taken against drifted notes** — the five above.
5. **Follow-ups** — the two above, neither filed.
6. **State left behind** — branch `claude/v0-8-0-m4-filter-chrome`, two commits, no assets branch, no HA instance touched, no `.env` written. Counting: production removed 417 · tests removed 104 · added 1140.

### Validate locally

1. `[browser]` Card at 1920 px, light and dark: the header badges read the same words in the same order (total, low, overdue, to inspect, to do, checked out), the total is a quiet chip, pressing `badge-low` applies the filter and rings the badge. Expected: identical to the 0.7.1 capture.
2. `[browser]` Card at 375 px: the badge row takes a line of its own under the title, wraps rather than overflowing, and shows no total. A dashboard config with `quick_filters: [overdue]` and nothing overdue should draw no band at all.
3. `[browser]` Card at 375 px, filter sheet: head row and footer as in item 2 of "Test this by hand"; staging a category leaves the list behind the sheet unmoved and the button reads `Show N items` after about 150 ms; Cancel drops the draft, Clear all clears the sheet only.
4. `[browser]` Expanded view at 1920 px: the app bar's pills are the same five in the same order, the checked-out one is the bar's plain translucent chip (not blue), warning pills amber, overdue red; the search box has its 260 px floor and the strip scrolls when the bar tightens.
5. `[browser]` Expanded view and `/haventory` at 375 px: `full-panel-head` and `full-panel-foot` as before, Clear all at the right edge of the head row, Cancel and the count pill at the right edge of the commit row.
6. `[browser]` Every `data-testid` the harnesses name still resolves: `badge-*`, `full-badge-*`, `search-input`, `full-search`, `sheet-clear-all`, `sheet-cancel`, `sheet-apply`, `full-panel-head`, `full-panel-count`, `full-panel-clear`, `full-panel-cancel`, `full-panel-apply`, `full-pills`, `full-filter-panel`. `card_views.test.mjs` and `surfaces.mjs` are the check.
7. `[browser]` `visual_pass.mjs` light and dark against the pre-merge captures: nothing in the card header, the search row, the filter sheet, the app bar or the phone filter panel should move by a pixel.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NhfGrV1Tm1GN4M2xd2egv)_