### PR TITLE
refactor(card): the widgets written twice

### DIFF
--- a/cards/haventory-card/src/components/hv-checkout-popover.ts
+++ b/cards/haventory-card/src/components/hv-checkout-popover.ts
@@ -4,12 +4,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { tokens, base } from '../ui/tokens';
 import { onEscape } from '../ui/keyboard';
 import { icon } from '../ui/icons';
-import {
-  DEFAULT_CUSTOM_DAYS,
-  quickDayOffsets,
-  addDays,
-  formatDate,
-} from '../ui/relative-time';
+import { DEFAULT_CUSTOM_DAYS, addDays, formatDate } from '../ui/relative-time';
+import { dayOffsets, renderDayOffsets } from '../ui/day-offsets';
 import { nextZBase } from '../utils/zindex';
 import { DialogFocus } from '../ui/dialog-focus';
 import type { Item } from '../store/types';
@@ -41,6 +37,7 @@ export class HVCheckoutPopover extends LitElement {
   static styles = [
     tokens,
     base,
+    dayOffsets,
     css`
       :host {
         display: block;
@@ -93,51 +90,15 @@ export class HVCheckoutPopover extends LitElement {
         display: grid;
         gap: 8px;
       }
-      .offsets {
-        display: flex;
-        gap: 7px;
-        flex-wrap: wrap;
-      }
-      .offset {
-        border: 1px solid var(--hv-divider);
-        background: none;
-        color: var(--hv-chip-text);
-        border-radius: var(--hv-radius-chip);
-        padding: 6px 13px;
-        font: 400 12.5px var(--hv-font);
-      }
+      /* The shape is ui/day-offsets; a thumb's worth of height on top of it is
+         this popover's, and the editor that draws the same chips grows them by
+         its own amount. */
       :host([touch]) .offset {
         min-height: 40px;
         padding: 0 15px;
         font-size: 13.5px;
       }
-      .offset.on {
-        background: var(--hv-primary-dark);
-        border-color: var(--hv-primary-dark);
-        color: #fff;
-        font-weight: 500;
-      }
-      .custom {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        padding: 8px 12px;
-        border: 1px solid var(--hv-divider);
-        border-radius: var(--hv-radius-input);
-        font-size: 13px;
-        color: var(--hv-text-secondary);
-      }
-      .custom input {
-        width: 72px;
-        box-sizing: border-box;
-        border: 1px solid var(--hv-input-border);
-        border-radius: var(--hv-radius-input);
-        background: var(--hv-surface);
-        color: var(--hv-text);
-        padding: 5px 8px;
-        font: 400 13.5px var(--hv-font);
-      }
-      :host([touch]) .custom input {
+      :host([touch]) .day-box input {
         min-height: 44px;
         width: 88px;
         font-size: var(--hv-input-font, 14.5px);
@@ -325,52 +286,26 @@ export class HVCheckoutPopover extends LitElement {
           <div class="sub">${t('hv.checkout.sub')}</div>
         </div>
         <div class="body">
-          <div class="offsets">
-            ${quickDayOffsets().map((offset) => {
-              const value = addDays(offset.days);
-              return html`<button
-                class="offset ${!this._customOpen && this._due === value ? 'on' : ''}"
-                data-testid="checkout-offset"
-                data-days=${offset.days}
-                @click=${() => {
-                  this._customOpen = false;
-                  this._due = value;
-                }}
-              >
-                ${offset.label}
-              </button>`;
-            })}
-            <button
-              class="offset ${this._customOpen ? 'on' : ''}"
-              data-testid="checkout-offset-custom"
-              @click=${() => {
+          ${renderDayOffsets(
+            { current: this._due, customOpen: this._customOpen, customDays: this._customDays },
+            {
+              prefix: 'checkout',
+              onPick: (date) => {
+                this._customOpen = false;
+                this._due = date;
+              },
+              onCustom: (date) => {
                 this._customOpen = true;
-                this._due = addDays(this._customDays);
-              }}
-            >
-              ${t('hv.editor.customDaysOffset')}
-            </button>
-          </div>
-          ${this._customOpen
-            ? html`<label class="custom" data-testid="checkout-custom">
-                <input
-                  type="number"
-                  min="1"
-                  max="3650"
-                  inputmode="numeric"
-                  aria-label=${t('hv.editor.daysFromToday')}
-                  .value=${String(this._customDays)}
-                  @input=${(e: Event) => {
-                    const days = Number((e.target as HTMLInputElement).value);
-                    // An empty or nonsense box means no date yet, not a stale
-                    // one — the confirm button disables itself on a null due.
-                    this._customDays = days;
-                    this._due = Number.isFinite(days) && days >= 1 ? addDays(Math.floor(days)) : null;
-                  }}
-                />
-                <span>${t('hv.editor.daysFromToday')}</span>
-              </label>`
-            : null}
+                this._due = date;
+              },
+              // A cleared box leaves no due date, and the confirm button
+              // disables itself on one.
+              onDays: (days, date) => {
+                this._customDays = days;
+                this._due = date;
+              },
+            },
+          )}
           <label class="date ${this._due ? '' : 'none'}" data-testid="checkout-date">
             ${icon('calendar', 17)}
             <span class="hv-sr-only">${t('hv.editor.dueDate')}</span>

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -22,13 +22,13 @@ import {
   pictures,
 } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
+import { renderDocumentRow, renderLightboxHost, renderPhotoFigure } from '../ui/attachments';
 import type { ConfirmDiscard } from '../ui/discard';
 import { COPIED_MS, copyText } from '../ui/clipboard';
 import type { AreaRef, Item, Location, LocationTreeNode, MediaConfig, ScalarValue, StatusDefinition } from '../store/types';
 import './hv-bottom-sheet';
 import './hv-checkout-popover';
 import './hv-item-editor';
-import './hv-lightbox';
 import type { HVBottomSheet } from './hv-bottom-sheet';
 import type { HVItemEditor } from './hv-item-editor';
 
@@ -643,34 +643,20 @@ export class HVDetailSheet extends LitElement {
     if (!shots.length) return null;
     return html`<div class="gallery" data-testid="sheet-gallery">
       ${shots.map((picture, index) => {
-        if (this._urls.presence(item.id, picture.id) === 'missing') {
-          return html`<figure data-testid="sheet-photo">
-            <span class="missing" data-testid="sheet-photo-missing">
-              ${icon('camera', 24)}
-              <span class="hv-chip warning">${t('hv.term.fileMissing')}</span>
-            </span>
-          </figure>`;
-        }
-        const src = this._urls.get(item.id, picture.id, attachmentNameToken(picture));
-        if (!src) return null;
-        return html`<figure data-testid="sheet-photo">
-          <button
-            data-testid="sheet-photo-open"
-            aria-label=${t('hv.sheet.openPhoto', {
-              photo: pictureAlt(item.name, index, shots.length),
-            })}
-            @click=${() => {
+        const alt = pictureAlt(item.name, index, shots.length);
+        const missing = this._urls.presence(item.id, picture.id) === 'missing';
+        return renderPhotoFigure(
+          {
+            src: missing ? null : this._urls.get(item.id, picture.id, attachmentNameToken(picture)),
+            missing,
+            alt,
+            openLabel: t('hv.sheet.openPhoto', { photo: alt }),
+            onOpen: () => {
               this._lightbox = index;
-            }}
-          >
-            <img
-              src=${src}
-              alt=${pictureAlt(item.name, index, shots.length)}
-              loading="lazy"
-              decoding="async"
-            />
-          </button>
-        </figure>`;
+            },
+          },
+          { testid: 'sheet-photo', glyph: 24 },
+        );
       })}
     </div>`;
   }
@@ -703,27 +689,14 @@ export class HVDetailSheet extends LitElement {
             formatBytes(doc.size),
             t('hv.sheet.documentAdded', { when: relativeTime(doc.uploaded_at) }),
           ].join(' · ');
-          return html`<li class=${missing ? 'missing' : ''} data-testid="sheet-document">
-            <span class="doc-icon">${icon('fileDocument', 20)}</span>
-            <span class="doc-text">
+          return renderDocumentRow(
+            { src, missing },
+            { testid: 'sheet-document', glyph: 20, openText: t('hv.action.open') },
+            html`<span class="doc-text">
               <span class="doc-title" data-testid="sheet-document-title">${title}</span>
               <span class="doc-meta" data-testid="sheet-document-meta">${meta}</span>
-            </span>
-            ${missing
-              ? html`<span class="hv-chip warning" data-testid="sheet-document-missing"
-                  >${t('hv.term.fileMissing')}</span
-                >`
-              : src
-                ? html`<a
-                    class="doc-open"
-                    data-testid="sheet-document-open"
-                    href=${src}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >${icon('openInNew', 15)}${t('hv.action.open')}</a
-                  >`
-                : null}
-          </li>`;
+            </span>`,
+          );
         })}
       </ul>
     </div>`;
@@ -1036,17 +1009,16 @@ export class HVDetailSheet extends LitElement {
         ${item ? (this._mode === 'edit' ? this._renderEdit(item) : this._renderRead(item)) : null}
       </hv-bottom-sheet>
 
-      <hv-lightbox
-        data-testid="sheet-lightbox-host"
-        .item=${item}
-        .media=${this.media}
-        .index=${this._lightbox}
-        .onOpenerGone=${() => this._sheet?.focusPanel()}
-        @close=${(e: Event) => {
-          e.stopPropagation();
+      ${renderLightboxHost({
+        testid: 'sheet-lightbox-host',
+        item,
+        media: this.media,
+        index: this._lightbox,
+        onOpenerGone: () => this._sheet?.focusPanel(),
+        onClose: () => {
           this._lightbox = null;
-        }}
-      ></hv-lightbox>`;
+        },
+      })}`;
   }
 }
 

--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -635,6 +635,11 @@ describe('hv-filter-panel: dates and location', () => {
     expect(chip().getAttribute('aria-controls')).toBe(id);
     const open = el.shadowRoot?.getElementById(id);
     expect(open?.querySelector('hv-location-tree'), 'tree open inside the holder').toBeTruthy();
+    // The tree opens under the chip row, not as another item in it: the row is
+    // a wrapping flex line, and a 230px box joining it would sit beside the
+    // Area select rather than below the group.
+    expect(open?.parentElement?.classList.contains('chips')).toBe(false);
+    expect(open?.previousElementSibling?.classList.contains('chips')).toBe(true);
   });
 
   it('names the picked location on the chip', async () => {

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -511,26 +511,12 @@ export class HVFilterPanel extends LitElement {
       <div class="group">
         <span class="hv-label">${t('hv.filter.where')}</span>
         <div class="chips">
-          ${this._location.render(
-            {
-              triggerClass: `hv-chip toggle chip ${f.locationIds.length ? 'on' : ''}`,
-              testid: 'filter-location',
-              holderId: LOCATION_TREE_ID,
-              trigger: html`${icon('mapMarker', 14)}${label}${icon('chevronDown', 14)}`,
-            },
-            () => html`<hv-location-tree
-              data-testid="filter-location-tree"
-              .nodes=${this.locationTree}
-              .areas=${this.areas}
-              .selectedIds=${f.locationIds}
-              showAll
-              showCounts
-              .totalCount=${this.grandTotal}
-              @select=${(e: CustomEvent) => {
-                this._toggleLocation((e.detail as { locationId: string | null }).locationId);
-              }}
-            ></hv-location-tree>`,
-          )}
+          ${this._location.renderTrigger({
+            triggerClass: `hv-chip toggle chip ${f.locationIds.length ? 'on' : ''}`,
+            testid: 'filter-location',
+            holderId: LOCATION_TREE_ID,
+            trigger: html`${icon('mapMarker', 14)}${label}${icon('chevronDown', 14)}`,
+          })}
           <label class="field select-field ${f.areaId ? 'on' : ''}" data-testid="filter-area">
             <span class="hv-sr-only">${t('hv.filter.area')}</span>
             <select
@@ -551,6 +537,21 @@ export class HVFilterPanel extends LitElement {
             { testid: 'filter-include-subtree' },
           )}
         </div>
+        ${this._location.renderHolder(
+          { holderId: LOCATION_TREE_ID },
+          () => html`<hv-location-tree
+            data-testid="filter-location-tree"
+            .nodes=${this.locationTree}
+            .areas=${this.areas}
+            .selectedIds=${f.locationIds}
+            showAll
+            showCounts
+            .totalCount=${this.grandTotal}
+            @select=${(e: CustomEvent) => {
+              this._toggleLocation((e.detail as { locationId: string | null }).locationId);
+            }}
+          ></hv-location-tree>`,
+        )}
       </div>
     `;
   }

--- a/cards/haventory-card/src/components/hv-filter-panel.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.ts
@@ -6,11 +6,11 @@ import { tokens, base } from '../ui/tokens';
 import { chip, tagLabel } from '../ui/chip';
 import { locationPathParts, pathLabel } from '../ui/location-path';
 import { icon } from '../ui/icons';
+import { LocationPicker } from '../ui/location-picker';
 import { counted } from '../ui/plural';
 import { activeFilterCount, defaultFilters } from '../store/store';
 import { DEFAULT_STATUS, statusCount, statusLabel, statusList, statusTone } from '../ui/status';
 import type { DistinctValues, Location, LocationTreeNode, SortField, StatsCounts, StatusDefinition, StoreFilters } from '../store/types';
-import './hv-location-tree';
 
 /** Sort fields the backend supports, in the order the menu lists them. */
 const SORT_FIELDS: readonly SortField[] = [
@@ -349,7 +349,6 @@ export class HVFilterPanel extends LitElement {
   @property({ attribute: false }) counts: StatsCounts | null = null;
 
   @state() private _draft: StoreFilters | null = null;
-  @state() private _locationOpen = false;
   @state() private _showAllCategories = false;
   @state() private _showAllTags = false;
   @state() private _tagDraft = '';
@@ -358,6 +357,13 @@ export class HVFilterPanel extends LitElement {
     updated: 'after',
     created: 'after',
   };
+
+  /**
+   * The Where chip's tree. A filter narrows by a set, so adding to it means
+   * picking again and the tree stays open; clearing the selection is the one
+   * pick that finishes the job.
+   */
+  private readonly _location = new LocationPicker(this, { keepOpenOnSelect: true });
 
   /** The filter set the controls are bound to. */
   get working(): StoreFilters {
@@ -505,17 +511,26 @@ export class HVFilterPanel extends LitElement {
       <div class="group">
         <span class="hv-label">${t('hv.filter.where')}</span>
         <div class="chips">
-          <button
-            class="hv-chip toggle chip ${f.locationIds.length ? 'on' : ''}"
-            data-testid="filter-location"
-            aria-expanded=${String(this._locationOpen)}
-            aria-controls=${LOCATION_TREE_ID}
-            @click=${() => {
-              this._locationOpen = !this._locationOpen;
-            }}
-          >
-            ${icon('mapMarker', 14)}${label}${icon('chevronDown', 14)}
-          </button>
+          ${this._location.render(
+            {
+              triggerClass: `hv-chip toggle chip ${f.locationIds.length ? 'on' : ''}`,
+              testid: 'filter-location',
+              holderId: LOCATION_TREE_ID,
+              trigger: html`${icon('mapMarker', 14)}${label}${icon('chevronDown', 14)}`,
+            },
+            () => html`<hv-location-tree
+              data-testid="filter-location-tree"
+              .nodes=${this.locationTree}
+              .areas=${this.areas}
+              .selectedIds=${f.locationIds}
+              showAll
+              showCounts
+              .totalCount=${this.grandTotal}
+              @select=${(e: CustomEvent) => {
+                this._toggleLocation((e.detail as { locationId: string | null }).locationId);
+              }}
+            ></hv-location-tree>`,
+          )}
           <label class="field select-field ${f.areaId ? 'on' : ''}" data-testid="filter-area">
             <span class="hv-sr-only">${t('hv.filter.area')}</span>
             <select
@@ -535,26 +550,6 @@ export class HVFilterPanel extends LitElement {
             () => this._patch({ includeSubtree: !f.includeSubtree }),
             { testid: 'filter-include-subtree' },
           )}
-        </div>
-        <div class="tree-holder" id=${LOCATION_TREE_ID} ?hidden=${!this._locationOpen}>
-          ${this._locationOpen
-            ? html`<hv-location-tree
-                data-testid="filter-location-tree"
-                .nodes=${this.locationTree}
-                .areas=${this.areas}
-                .selectedIds=${f.locationIds}
-                showAll
-                showCounts
-                .totalCount=${this.grandTotal}
-                @select=${(e: CustomEvent) => {
-                  const picked = (e.detail as { locationId: string | null }).locationId;
-                  this._toggleLocation(picked);
-                  // Adding to a selection means picking again, so the tree stays
-                  // open; "All items" is the one pick that finishes the job.
-                  if (picked === null) this._locationOpen = false;
-                }}
-              ></hv-location-tree>`
-            : null}
         </div>
       </div>
     `;

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -779,23 +779,22 @@ describe('hv-item-editor: category picker', () => {
     expect(options(el)).toEqual(['Hardware', 'Tools']);
   });
 
-  // In flow the list grew its own grid cell, which grew the row, which
-  // stretched the Location button beside it — the form came apart every time
-  // the suggestions opened. Fixed, not absolute: the expanded view wraps the
-  // whole form in an overflow-y:auto holder that would clip an absolute list.
-  it('floats the list over the form instead of growing the row it sits in', async () => {
+  // The list belongs to the field above it, so it opens under that field and
+  // pushes the form down — the same disclosure the location tree in this form
+  // already is. Placed against the viewport it needed a measurement, two window
+  // listeners and a stacking base, and drifted off its own input whenever the
+  // surface behind it scrolled.
+  it('opens the list in flow under its input, like the location tree', async () => {
     const el = await mount(null);
     await focusCategory(el);
 
     const list = q(el, '[data-testid="editor-category-list"]');
-    expect(list?.classList).toContain('floating');
-    // Placed from a measurement, so it carries its own coordinates and stack.
-    expect(list?.getAttribute('style')).toMatch(/left: -?\d+px/);
-    expect(list?.getAttribute('style')).toMatch(/z-index: \d+/);
+    expect(list?.classList.contains('floating')).toBe(false);
+    expect(list?.getAttribute('style')).toBeNull();
 
     const css = componentCss('hv-item-editor');
-    expect(css).toMatch(/\.list-holder\.floating \{[^}]*position: fixed/);
-    expect(css).toMatch(/\.tree-holder, \.list-holder \{[^}]*margin-top: 6px/);
+    expect(css).not.toMatch(/position: fixed/);
+    expect(css).toMatch(/\.tree-holder,\s*\.list-holder \{[^}]*margin-top: 6px/);
   });
 
   // The combobox always named its listbox, but the listbox left the DOM with

--- a/cards/haventory-card/src/components/hv-item-editor.test.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.test.ts
@@ -1557,6 +1557,30 @@ describe('hv-item-editor: pictures', () => {
     expect(all(el, '[data-testid="editor-photo"]')).toHaveLength(0);
   });
 
+  // The guard hands focus back to the control that raised it, and that control
+  // is the removed tile's own remove button — gone by the time the strip
+  // redraws. Focus lands on the document, out of the form and out of reach of
+  // its Escape, unless the form catches it.
+  it('catches the focus the removed tile took with it', async () => {
+    const media = makeMediaBindings({
+      remove: async (itemId) => makeItem({ id: itemId, version: 9, attachments: [] }),
+    });
+    const el = await mount(
+      makeItem({ id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] }),
+      { media },
+    );
+    await el.updateComplete;
+    // A press moves focus to the control pressed; jsdom's click does not.
+    (q(el, '[data-testid="editor-photo-remove"]') as HTMLButtonElement).focus();
+
+    await removeAttachment(el, 'editor-photo-remove', 'confirm');
+    for (let i = 0; i < 4; i += 1) await el.updateComplete;
+
+    expect(all(el, '[data-testid="editor-photo"]')).toHaveLength(0);
+    expect(document.activeElement).toBe(el);
+    expect(el.shadowRoot?.activeElement).toBe(q(el, '[data-testid="editor-name"]'));
+  });
+
   it('keeps the picture when the guard is dismissed', async () => {
     const media = makeMediaBindings();
     const el = await mount(makeItem({ id: 'i-1', attachments: [makeAttachment({ id: 'att-1' })] }), {

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -37,6 +37,7 @@ import {
   pictures,
 } from '../ui/media';
 import { prepareForUpload } from '../ui/downscale';
+import { renderDocumentRow, renderLightboxHost, renderPhotoFigure } from '../ui/attachments';
 import type { MediaBindings } from '../ui/media';
 import type {
   AreaRef,
@@ -51,7 +52,6 @@ import type {
 } from '../store/types';
 import './hv-chip-input';
 import './hv-confirm';
-import './hv-lightbox';
 import './hv-location-tree';
 import './hv-checkout-popover';
 
@@ -2264,12 +2264,7 @@ export class HVItemEditor extends LitElement {
         @drop=${drop.drop}
       >
         ${shots.map((picture, index) => {
-          // Asked the same way the document rows ask, and for the same reason:
-          // an export carries the references and not the bytes, so a fresh
-          // install genuinely holds pictures whose files were never uploaded to
-          // it. One item's photos are few enough to ask about up front, which
-          // is what keeps the browser from ever being handed a URL it can only
-          // draw its broken-image glyph for.
+          const alt = pictureAlt(item.name, index, shots.length);
           const missing = this._urls.presence(item.id, picture.id) === 'missing';
           // The tile, not the picture: tapping one opens the lightbox, which
           // asks for the stored file itself.
@@ -2281,47 +2276,37 @@ export class HVItemEditor extends LitElement {
                 attachmentNameToken(picture),
                 MEDIA_VARIANT_THUMB,
               );
-          return html`<figure data-testid="editor-photo">
-            ${missing
-              ? html`<span class="placeholder missing" data-testid="editor-photo-missing">
-                  ${icon('camera', 20)}
-                  <span class="hv-chip warning">${t('hv.term.fileMissing')}</span>
-                </span>`
-              : src
-              ? html`<button
-                  class="open"
-                  data-testid="editor-photo-open"
-                  aria-label=${t('hv.editor.viewPhoto', {
-                    photo: pictureAlt(item.name, index, shots.length),
-                  })}
-                  @click=${() => {
-                    this._lightbox = index;
-                  }}
-                >
-                  <img
-                    src=${src}
-                    alt=${pictureAlt(item.name, index, shots.length)}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                </button>`
-              : html`<span class="placeholder" data-testid="editor-photo-placeholder"
-                  >${icon('camera', 20)}</span
-                >`}
-            <button
-              class="remove"
-              data-testid="editor-photo-remove"
-              aria-label=${t('hv.editor.removePhoto', {
-                photo: pictureAlt(item.name, index, shots.length),
-              })}
-              @click=${() => {
-                this._confirmRemove = { id: picture.id, kind: 'picture' };
-              }}
-            >
-              ${icon('close', 15)}
-            </button>
-            ${shots.length > 1 ? this._renderPhotoControls(picture.id, index, shots.length) : null}
-          </figure>`;
+          return renderPhotoFigure(
+            {
+              src,
+              missing,
+              alt,
+              openLabel: t('hv.editor.viewPhoto', { photo: alt }),
+              onOpen: () => {
+                this._lightbox = index;
+              },
+            },
+            {
+              testid: 'editor-photo',
+              glyph: 20,
+              tileClass: 'placeholder',
+              openClass: 'open',
+              pendingTile: true,
+            },
+            html`<button
+                class="remove"
+                data-testid="editor-photo-remove"
+                aria-label=${t('hv.editor.removePhoto', { photo: alt })}
+                @click=${() => {
+                  this._confirmRemove = { id: picture.id, kind: 'picture' };
+                }}
+              >
+                ${icon('close', 15)}
+              </button>
+              ${shots.length > 1
+                ? this._renderPhotoControls(picture.id, index, shots.length)
+                : null}`,
+          );
         })}
         <label class="picker" data-testid="editor-photo-picker">
           ${icon('camera', 20)}
@@ -2519,38 +2504,29 @@ export class HVItemEditor extends LitElement {
         @dragleave=${drop.leave}
         @drop=${drop.drop}
       >
-        ${docs.map((doc) => {
-          const src = this._urls.get(item.id, doc.id, attachmentNameToken(doc));
-          const missing = this._urls.presence(item.id, doc.id) === 'missing';
-          return html`<li data-testid="editor-document">
-            <span class="doc-icon">${icon('fileDocument', 18)}</span>
-            <input
-              class="hv-input doc-title"
-              data-testid="editor-document-title"
-              .value=${doc.title ?? ''}
-              placeholder=${doc.filename}
-              aria-label=${t('hv.editor.titleFor', { filename: doc.filename })}
-              @change=${(e: Event) =>
-                void this._retitle(doc.id, (e.target as HTMLInputElement).value.trim())}
-            />
-            <span class="doc-size">${formatBytes(doc.size)}</span>
-            ${missing
-              ? html`<span class="hv-chip warning" data-testid="editor-document-missing"
-                  >${t('hv.term.fileMissing')}</span
-                >`
-              : src
-                ? html`<a
-                    class="doc-open"
-                    data-testid="editor-document-open"
-                    href=${src}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label=${t('hv.editor.openNamed', { name: attachmentTitle(doc) })}
-                    title=${t('hv.editor.openDocument')}
-                    >${icon('openInNew', 15)}</a
-                  >`
-                : null}
-            <button
+        ${docs.map((doc) =>
+          renderDocumentRow(
+            {
+              src: this._urls.get(item.id, doc.id, attachmentNameToken(doc)),
+              missing: this._urls.presence(item.id, doc.id) === 'missing',
+            },
+            {
+              testid: 'editor-document',
+              glyph: 18,
+              openLabel: t('hv.editor.openNamed', { name: attachmentTitle(doc) }),
+              openTitle: t('hv.editor.openDocument'),
+            },
+            html`<input
+                class="hv-input doc-title"
+                data-testid="editor-document-title"
+                .value=${doc.title ?? ''}
+                placeholder=${doc.filename}
+                aria-label=${t('hv.editor.titleFor', { filename: doc.filename })}
+                @change=${(e: Event) =>
+                  void this._retitle(doc.id, (e.target as HTMLInputElement).value.trim())}
+              />
+              <span class="doc-size">${formatBytes(doc.size)}</span>`,
+            html`<button
               class="doc-remove"
               data-testid="editor-document-remove"
               aria-label=${t('hv.editor.removeNamed', { name: attachmentTitle(doc) })}
@@ -2559,9 +2535,9 @@ export class HVItemEditor extends LitElement {
               }}
             >
               ${icon('close', 15)}
-            </button>
-          </li>`;
-        })}
+            </button>`,
+          ),
+        )}
       </ul>
       <label class="picker doc-picker" data-testid="editor-manual-picker">
         ${icon('fileDocument', 18)}
@@ -2825,17 +2801,16 @@ export class HVItemEditor extends LitElement {
         </div>
       </div>
 
-      <hv-lightbox
-        data-testid="editor-lightbox-host"
-        .item=${this._current}
-        .media=${this.media}
-        .index=${this._lightbox}
-        .onOpenerGone=${() => this._refocus()}
-        @close=${(e: Event) => {
-          e.stopPropagation();
+      ${renderLightboxHost({
+        testid: 'editor-lightbox-host',
+        item: this._current,
+        media: this.media,
+        index: this._lightbox,
+        onOpenerGone: () => this._refocus(),
+        onClose: () => {
           this._lightbox = null;
-        }}
-      ></hv-lightbox>
+        },
+      })}
 
       <!-- Outside the form's own keydown scope, and its events stopped here: a
            host listens for the cancel event on this editor to close it, and a

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -13,6 +13,7 @@ import { counted } from '../ui/plural';
 import type { ConfirmDiscard } from '../ui/discard';
 import { COPIED_MS, copyText } from '../ui/clipboard';
 import { ViewportNarrow } from '../ui/responsive';
+import { LocationPicker } from '../ui/location-picker';
 import { nextZBase } from '../utils/zindex';
 import {
   REMINDER_UNITS,
@@ -1142,7 +1143,6 @@ export class HVItemEditor extends LitElement {
   @state() private _model: ItemFormModel = formFromItem(null);
   @state() private _errors: FieldError[] = [];
   @state() private _showErrors = false;
-  @state() private _locationOpen = false;
   @state() private _moreOpen = false;
   @state() private _categoryOpen = false;
   /** Opened from the arrow: list everything, ignoring what is already typed. */
@@ -1205,6 +1205,8 @@ export class HVItemEditor extends LitElement {
   private readonly _urls = new MediaUrls(this);
   /** Window width, for the two dialogs this form raises over itself. */
   private readonly _viewport = new ViewportNarrow(this);
+  /** The location field: one location, so a pick finishes the job. */
+  private readonly _location = new LocationPicker(this);
   private _uploadSeq = 0;
   /**
    * The item id `_model` was built from. `undefined` until the first update,
@@ -1246,7 +1248,7 @@ export class HVItemEditor extends LitElement {
       this._model = formFromItem(this.item);
       this._errors = [];
       this._showErrors = false;
-      this._locationOpen = false;
+      this._location.close();
       this._moreOpen = false;
       this._checkoutOpen = false;
       this._uploads = [];
@@ -1340,7 +1342,7 @@ export class HVItemEditor extends LitElement {
         this._closeCategory();
       } else if (this._checkoutOpen) {
         this._checkoutOpen = false;
-      } else if (this._locationOpen) {
+      } else if (this._location.open) {
         this._closeLocation();
       } else {
         this._requestCancel();
@@ -1362,7 +1364,7 @@ export class HVItemEditor extends LitElement {
 
   /** Shut the location picker and put focus back on the control that opened it. */
   private _closeLocation() {
-    this._locationOpen = false;
+    this._location.close();
     this._locationError = null;
     this.renderRoot.querySelector<HTMLElement>('[data-testid="editor-location"]')?.focus();
   }
@@ -1441,44 +1443,35 @@ export class HVItemEditor extends LitElement {
     const parts = locationPathParts(loc, locations, this.areas, t('hv.term.noLocation'));
     return html`<div class="cell span2">
       <span class="hv-label">${t('hv.editor.field.location')}</span>
-      <button
-        class="field-button ${this._model.locationId ? '' : 'empty'}"
-        data-testid="editor-location"
-        title=${pathTitle(parts)}
-        aria-expanded=${String(this._locationOpen)}
-        aria-controls=${LOCATION_TREE_ID}
-        @click=${() => {
-          this._locationOpen = !this._locationOpen;
-        }}
-      >
-        ${icon('mapMarker', 15)}${renderAreaChip(areaMarkName(parts.areaName, parts.path))}<span
-          class="value"
-          >${parts.path}</span
-        >${icon('chevronDown', 15)}
-      </button>
-      <div class="tree-holder" id=${LOCATION_TREE_ID} ?hidden=${!this._locationOpen}>
-        ${this._locationOpen
-          ? html`<hv-location-tree
-              data-testid="editor-location-tree"
-              .nodes=${this._knownLocationTree}
-              .areas=${this.areas}
-              .selectedId=${this._model.locationId}
-              showAll
-              allLabel=${t('hv.term.noLocation')}
-              allIcon="close"
-              ?allowCreate=${this.createLocation !== null}
-              @select=${(e: CustomEvent) => {
-                this._patch({ locationId: (e.detail as { locationId: string | null }).locationId });
-                this._locationOpen = false;
-                this._locationError = null;
-              }}
-              @create-location=${(e: CustomEvent) => {
-                e.stopPropagation();
-                void this._createLocation((e.detail as { name: string }).name);
-              }}
-            ></hv-location-tree>`
-          : null}
-      </div>
+      ${this._location.render(
+        {
+          triggerClass: `field-button ${this._model.locationId ? '' : 'empty'}`,
+          testid: 'editor-location',
+          title: pathTitle(parts),
+          holderId: LOCATION_TREE_ID,
+          trigger: html`${icon('mapMarker', 15)}${renderAreaChip(
+            areaMarkName(parts.areaName, parts.path),
+          )}<span class="value">${parts.path}</span>${icon('chevronDown', 15)}`,
+        },
+        () => html`<hv-location-tree
+          data-testid="editor-location-tree"
+          .nodes=${this._knownLocationTree}
+          .areas=${this.areas}
+          .selectedId=${this._model.locationId}
+          showAll
+          allLabel=${t('hv.term.noLocation')}
+          allIcon="close"
+          ?allowCreate=${this.createLocation !== null}
+          @select=${(e: CustomEvent) => {
+            this._patch({ locationId: (e.detail as { locationId: string | null }).locationId });
+            this._locationError = null;
+          }}
+          @create-location=${(e: CustomEvent) => {
+            e.stopPropagation();
+            void this._createLocation((e.detail as { name: string }).name);
+          }}
+        ></hv-location-tree>`,
+      )}
       ${this._locationError
         ? html`<span class="field-error" data-testid="editor-location-error">${this._locationError}</span>`
         : null}
@@ -1500,7 +1493,7 @@ export class HVItemEditor extends LitElement {
       const created = await create(name);
       this._createdLocations = [...this._createdLocations, created];
       this._patch({ locationId: created.id });
-      this._locationOpen = false;
+      this._location.close();
     } catch (err) {
       this._locationError = errorText(err, t('hv.editor.locationCreateFailed'));
     }

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -14,7 +14,6 @@ import type { ConfirmDiscard } from '../ui/discard';
 import { COPIED_MS, copyText } from '../ui/clipboard';
 import { ViewportNarrow } from '../ui/responsive';
 import { LocationPicker } from '../ui/location-picker';
-import { nextZBase } from '../utils/zindex';
 import {
   REMINDER_UNITS,
   customFieldsFrom,
@@ -432,6 +431,10 @@ export class HVItemEditor extends LitElement {
         font-size: var(--hv-editor-note);
         color: var(--hv-error);
       }
+      /* Both disclosures the form opens under a control push the form down
+         rather than covering it: they belong to the field above them, and a
+         layer measured against the viewport drifts off that field the moment
+         the surface behind it scrolls. */
       .tree-holder,
       .list-holder {
         margin-top: 6px;
@@ -441,21 +444,6 @@ export class HVItemEditor extends LitElement {
         max-height: 220px;
         overflow: auto;
         padding: 4px 0;
-      }
-      /* The category list is the one holder that must NOT take part in the
-         layout: in flow it grows its own grid cell, which grows the row and
-         stretches the Location button beside it, so the form comes apart every
-         time the suggestions open. The location tree below is the opposite case
-         and keeps the in-flow rule above — it is meant to push the form open.
-
-         Fixed rather than absolute: the expanded view puts the whole form
-         inside an editor-holder that is max-height 70dvh with overflow-y auto,
-         and an absolute list would be clipped by it. Same technique the
-         checkout popover and the overflow menu use. */
-      .list-holder.floating {
-        position: fixed;
-        margin-top: 0;
-        box-shadow: var(--hv-shadow-menu);
       }
       /* The category field is a text input plus its own dropdown affordance —
          without the arrow the existing values were only findable by guessing. */
@@ -1149,15 +1137,6 @@ export class HVItemEditor extends LitElement {
   @state() private _categoryShowAll = false;
   /** Keyboard cursor into the visible category options; -1 = nothing active. */
   @state() private _categoryIndex = -1;
-  /** Viewport placement of the floating category list, while it is open. */
-  @state() private _categoryBox: {
-    left: number;
-    width: number;
-    edge: number;
-    flip: boolean;
-    room: number;
-  } | null = null;
-  private _categoryZ = 0;
   /** The check-out dialog, and the button it hangs from on a wide screen. */
   @state() private _checkoutOpen = false;
   @state() private _checkoutAnchor: DOMRect | null = null;
@@ -1510,63 +1489,17 @@ export class HVItemEditor extends LitElement {
     return this.categorySuggestions.filter((c) => c.toLowerCase().includes(query));
   }
 
-  /**
-   * Where the floating category list goes, in viewport coordinates.
-   *
-   * Recomputed on every scroll and resize while the list is open: `position:
-   * fixed` is measured against the viewport, and the form it belongs to sits in
-   * a scroll box of its own, so the list would otherwise drift off its input.
-   */
-  private _placeCategory = () => {
-    const combo = this.renderRoot?.querySelector<HTMLElement>('.combo');
-    if (!combo) return;
-    const rect = combo.getBoundingClientRect();
-    const gap = 6;
-    const viewport = window.innerHeight;
-    const roomBelow = viewport - rect.bottom - gap - 8;
-    const roomAbove = rect.top - gap - 8;
-    // Flip up only when below is genuinely too tight and above is roomier.
-    const flip = roomBelow < 120 && roomAbove > roomBelow;
-    this._categoryBox = {
-      left: Math.round(rect.left),
-      width: Math.round(rect.width),
-      edge: flip ? Math.round(viewport - rect.top + gap) : Math.round(rect.bottom + gap),
-      flip,
-      room: Math.max(80, Math.round(flip ? roomAbove : roomBelow)),
-    };
-  };
-
-  private get _categoryStyle(): string {
-    const box = this._categoryBox;
-    if (!box) return '';
-    const edge = box.flip ? `bottom: ${box.edge}px` : `top: ${box.edge}px`;
-    return `${edge}; left: ${box.left}px; width: ${box.width}px; max-height: min(220px, ${box.room}px); z-index: ${this._categoryZ || 9999};`;
-  }
-
   private _openCategory(showAll: boolean) {
     if (!this.categorySuggestions.length) return;
     this._categoryShowAll = showAll;
-    if (!this._categoryOpen) {
-      this._categoryZ = nextZBase();
-      // Capture phase: the scrolling ancestor is a shadow-DOM box of another
-      // component, and a bubbling listener on this element never sees it.
-      window.addEventListener('scroll', this._placeCategory, true);
-      window.addEventListener('resize', this._placeCategory);
-    }
     this._categoryOpen = true;
     this._categoryIndex = -1;
-    this._placeCategory();
   }
 
   private _closeCategory() {
-    if (this._categoryOpen) {
-      window.removeEventListener('scroll', this._placeCategory, true);
-      window.removeEventListener('resize', this._placeCategory);
-    }
     this._categoryOpen = false;
     this._categoryShowAll = false;
     this._categoryIndex = -1;
-    this._categoryBox = null;
   }
 
   /**
@@ -1699,12 +1632,11 @@ export class HVItemEditor extends LitElement {
           : null}
       </div>
       <div
-        class="list-holder floating"
+        class="list-holder"
         role="listbox"
         id=${CATEGORY_LIST_ID}
         data-testid="editor-category-list"
         ?hidden=${!this._categoryOpen}
-        style=${this._categoryStyle}
       >
         ${this._categoryOpen
           ? html`${options.length

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -5,14 +5,8 @@ import { tokens, base } from '../ui/tokens';
 import { chip } from '../ui/chip';
 import { areaMarkName, locationPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import { icon } from '../ui/icons';
-import {
-  DEFAULT_CUSTOM_DAYS,
-  quickDayOffsets,
-  addDays,
-  formatDate,
-  isOverdue,
-  relativeTime,
-} from '../ui/relative-time';
+import { DEFAULT_CUSTOM_DAYS, formatDate, isOverdue, relativeTime } from '../ui/relative-time';
+import { dayOffsets, renderDayOffsets } from '../ui/day-offsets';
 import { onDayChange } from '../ui/day-clock';
 import { saveShortcutLabel } from '../ui/keyboard';
 import { counted } from '../ui/plural';
@@ -144,6 +138,7 @@ export class HVItemEditor extends LitElement {
     tokens,
     base,
     chip,
+    dayOffsets,
     css`
       :host {
         display: block;
@@ -347,54 +342,15 @@ export class HVItemEditor extends LitElement {
         line-height: 1.4;
         color: var(--hv-text-tertiary);
       }
-      /* Same chips, same states as the check-out popover's: one gesture, so it
-         must not look like two. */
-      .offsets {
-        display: flex;
-        gap: 7px;
-        flex-wrap: wrap;
-      }
-      .offset {
-        border: 1px solid var(--hv-divider);
-        background: none;
-        color: var(--hv-chip-text);
-        border-radius: var(--hv-radius-chip);
-        padding: 6px 13px;
-        font: 400 12.5px var(--hv-font);
-        cursor: pointer;
-      }
+      /* The shape is ui/day-offsets; a finger's worth of height on top of it
+         is this form's, and the popover that draws the same chips grows them
+         by its own amount. */
       :host([mobile]) .offset {
         min-height: var(--hv-tap-min, auto);
         padding: 0 15px;
         font-size: 13.5px;
       }
-      .offset.on {
-        background: var(--hv-primary-dark);
-        border-color: var(--hv-primary-dark);
-        color: #fff;
-        font-weight: 500;
-      }
-      .custom-days {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        padding: 8px 12px;
-        border: 1px solid var(--hv-divider);
-        border-radius: var(--hv-radius-input);
-        font-size: 13px;
-        color: var(--hv-text-secondary);
-      }
-      .custom-days input {
-        width: 72px;
-        box-sizing: border-box;
-        border: 1px solid var(--hv-input-border);
-        border-radius: var(--hv-radius-input);
-        background: var(--hv-surface);
-        color: var(--hv-text);
-        padding: 5px 8px;
-        font: 400 13.5px var(--hv-font);
-      }
-      :host([mobile]) .custom-days input {
+      :host([mobile]) .day-box input {
         min-height: 44px;
         width: 88px;
         font-size: var(--hv-input-font, 14.5px);
@@ -1997,57 +1953,28 @@ export class HVItemEditor extends LitElement {
    * the three presets do not cover, not a fourth preset.
    */
   private _renderInspectionOffsets(current: string) {
-    return html`
-      <div class="offsets" data-testid="editor-inspection-offsets">
-        ${quickDayOffsets().map((offset) => {
-          const value = addDays(offset.days);
-          return html`<button
-            class="offset ${!this._inspectionCustomOpen && current === value ? 'on' : ''}"
-            data-testid="editor-inspection-offset"
-            data-days=${offset.days}
-            @click=${() => {
-              this._inspectionCustomOpen = false;
-              this._patch({ inspectionDate: value });
-            }}
-          >
-            ${offset.label}
-          </button>`;
-        })}
-        <button
-          class="offset ${this._inspectionCustomOpen ? 'on' : ''}"
-          data-testid="editor-inspection-offset-custom"
-          @click=${() => {
-            this._inspectionCustomOpen = true;
-            this._patch({ inspectionDate: addDays(this._inspectionCustomDays) });
-          }}
-        >
-          ${t('hv.editor.customDaysOffset')}
-        </button>
-      </div>
-      ${this._inspectionCustomOpen
-        ? html`<label class="custom-days" data-testid="editor-inspection-custom">
-            <input
-              type="number"
-              min="1"
-              max="3650"
-              inputmode="numeric"
-              aria-label=${t('hv.editor.daysFromToday')}
-              .value=${String(this._inspectionCustomDays)}
-              @input=${(e: Event) => {
-                const days = Number((e.target as HTMLInputElement).value);
-                this._inspectionCustomDays = days;
-                // An empty or nonsense box means no date yet rather than a
-                // stale one, so the field clears instead of keeping the last.
-                this._patch({
-                  inspectionDate:
-                    Number.isFinite(days) && days >= 1 ? addDays(Math.floor(days)) : '',
-                });
-              }}
-            />
-            <span>${t('hv.editor.daysFromToday')}</span>
-          </label>`
-        : null}
-    `;
+    return renderDayOffsets(
+      {
+        current,
+        customOpen: this._inspectionCustomOpen,
+        customDays: this._inspectionCustomDays,
+      },
+      {
+        prefix: 'editor-inspection',
+        onPick: (date) => {
+          this._inspectionCustomOpen = false;
+          this._patch({ inspectionDate: date });
+        },
+        onCustom: (date) => {
+          this._inspectionCustomOpen = true;
+          this._patch({ inspectionDate: date });
+        },
+        onDays: (days, date) => {
+          this._inspectionCustomDays = days;
+          this._patch({ inspectionDate: date ?? '' });
+        },
+      },
+    );
   }
 
   private _onCheckoutPressed = (e: Event) => {

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -53,7 +53,6 @@ import type {
 } from '../store/types';
 import './hv-chip-input';
 import './hv-confirm';
-import './hv-location-tree';
 import './hv-checkout-popover';
 
 /**
@@ -1870,13 +1869,10 @@ export class HVItemEditor extends LitElement {
    * creating an item that has no id to check out yet.
    */
   /**
-   * The same quick jumps the check-out popover offers, on the one date it does
-   * not own. An inspection interval is known in weeks or months rather than as
-   * a calendar square, and typing a date three months out means doing the
-   * arithmetic yourself; pressing an offset writes the date into the field
-   * above, so the two controls are one value with two ways in. The custom row
-   * appears only once "+X days" is pressed — the escape hatch for an interval
-   * the three presets do not cover, not a fourth preset.
+   * The quick jumps of `ui/day-offsets`, on the one date the check-out popover
+   * does not own. An inspection interval is known in weeks or months rather
+   * than as a calendar square, and pressing an offset writes the date into the
+   * field above — the two controls are one value with two ways in.
    */
   private _renderInspectionOffsets(current: string) {
     return renderDayOffsets(

--- a/cards/haventory-card/src/components/hv-item-editor.ts
+++ b/cards/haventory-card/src/components/hv-item-editor.ts
@@ -13,6 +13,7 @@ import { counted } from '../ui/plural';
 import type { ConfirmDiscard } from '../ui/discard';
 import { COPIED_MS, copyText } from '../ui/clipboard';
 import { ViewportNarrow } from '../ui/responsive';
+import { focusStranded } from '../ui/dialog-focus';
 import { LocationPicker } from '../ui/location-picker';
 import {
   REMINDER_UNITS,
@@ -2181,6 +2182,12 @@ export class HVItemEditor extends LitElement {
     if (!media || !item) return;
     try {
       this._uploaded = await media.remove(item.id, attachmentId);
+      // The guard handed focus back to the control that raised it, and that
+      // control was this tile's own remove button — still there at the time,
+      // gone the moment the strip redraws without the tile. Nobody else is
+      // watching for that: the guard closed cleanly and the form is still up.
+      await this.updateComplete;
+      if (focusStranded()) this._refocus();
     } catch (err) {
       this._pushUploadError(
         'remove',

--- a/cards/haventory-card/src/components/hv-location-tree.ts
+++ b/cards/haventory-card/src/components/hv-location-tree.ts
@@ -10,6 +10,7 @@ import { icon } from '../ui/icons';
 import type { IconName } from '../ui/icons';
 import { groupRootsByArea, locationMatches } from '../store/location-tree';
 import { renderAreaChip } from '../ui/location-path';
+import { rovingTarget, syncRovingTabindex } from '../ui/roving-list';
 import { counted } from '../ui/plural';
 import type { AreaGroup } from '../store/location-tree';
 import type { AreaRef, LocationTreeNode } from '../store/types';
@@ -384,54 +385,27 @@ export class HVLocationTree extends LitElement {
   }
 
   /**
-   * Leave exactly one node in the tab order, and give that node's own actions
-   * their only way in.
+   * Leave exactly one node in the tab order, its own actions riding with it.
    *
    * Written here rather than in `render` because the walk is the rendered DOM:
    * a template cannot ask which row comes first without rebuilding the walk
    * from the data it was drawn from.
    */
   private _syncRovingTabindex() {
-    const walk = this._walk();
-    if (!walk.length) {
-      this._activeKey = null;
-      return;
-    }
-    const held = walk.find((el) => this._nodeKey(el) === this._activeKey);
-    // The selection is where the tab stop belongs before anyone has moved it:
-    // arriving on the tree and pressing Enter should re-pick what is already
-    // chosen, not jump the household back to its first room.
-    const selected = walk.find((el) => el.getAttribute('aria-selected') === 'true');
-    const active = held ?? selected ?? walk[0];
-    this._activeKey = this._nodeKey(active);
-    for (const el of walk) {
-      const isActive = el === active;
-      el.tabIndex = isActive ? 0 : -1;
-      // A row's merge, edit, delete and overflow buttons have no key of their
-      // own to reach them by, so they ride with their row: Tab from the active
-      // node steps through that node's actions and then leaves the tree.
-      for (const action of el.querySelectorAll<HTMLElement>('.actions button')) {
-        action.tabIndex = isActive ? 0 : -1;
-      }
-    }
+    this._activeKey = syncRovingTabindex(
+      this._walk(),
+      this._activeKey,
+      (el) => this._nodeKey(el),
+      (el) => el.querySelectorAll<HTMLElement>('.actions button'),
+    );
   }
 
   /** Move the tab stop to `el` and take focus with it. */
-  private _activate(el: HTMLElement | undefined) {
-    if (!el) return;
+  private _activate(el: HTMLElement) {
     this._activeKey = this._nodeKey(el);
     el.tabIndex = 0;
     el.focus();
     this.requestUpdate();
-  }
-
-  /** The node one level out from `el` — the nearest earlier, shallower node. */
-  private _parentOf(walk: HTMLElement[], index: number): HTMLElement | undefined {
-    const level = Number(walk[index].getAttribute('aria-level') ?? '1');
-    for (let i = index - 1; i >= 0; i--) {
-      if (Number(walk[i].getAttribute('aria-level') ?? '1') < level) return walk[i];
-    }
-    return undefined;
   }
 
   /** Open or close the node `el` stands for, whichever kind it is. */
@@ -445,43 +419,14 @@ export class HVLocationTree extends LitElement {
   /**
    * The arrow layer the ARIA tree pattern asks for, and the other half of the
    * single tab stop: with one node reachable by Tab, the arrows are the only
-   * way to the rest, and the twisties are out of the tab order because Right
-   * and Left do what they do.
+   * way to the rest.
    */
   private _onTreeKeydown(e: KeyboardEvent) {
-    const keys = ['ArrowDown', 'ArrowUp', 'ArrowRight', 'ArrowLeft', 'Home', 'End'];
-    if (!keys.includes(e.key)) return;
-    const walk = this._walk();
-    const index = walk.findIndex((el) => el.contains(e.target as Node));
-    if (index < 0) return;
-    e.preventDefault();
-    e.stopPropagation();
-
-    const current = walk[index];
-    const expanded = current.getAttribute('aria-expanded');
-    // While a filter is running every node is drawn open whatever the expand
-    // state says, so collapsing one would move nothing on the screen.
-    const filtering = this.filterText.trim().length > 0;
-
-    switch (e.key) {
-      case 'ArrowDown':
-        return this._activate(walk[index + 1]);
-      case 'ArrowUp':
-        return this._activate(walk[index - 1]);
-      case 'Home':
-        return this._activate(walk[0]);
-      case 'End':
-        return this._activate(walk[walk.length - 1]);
-      case 'ArrowRight':
-        // Open what is closed; on what is already open, step into it — the
-        // first child is the next node drawn.
-        if (expanded === 'false') return this._toggleNode(current);
-        if (expanded === 'true') return this._activate(walk[index + 1]);
-        return;
-      case 'ArrowLeft':
-        if (expanded === 'true' && !filtering) return this._toggleNode(current);
-        return this._activate(this._parentOf(walk, index));
-    }
+    const next = rovingTarget(e, this._walk(), {
+      toggle: (el) => this._toggleNode(el),
+      frozen: this.filterText.trim().length > 0,
+    });
+    if (next) this._activate(next);
   }
 
   /** Open the ancestors of `id`, and its area group, so a deep selection is visible. */

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -373,6 +373,13 @@ describe('hv-organize-dialog: locations', () => {
       expect(control().getAttribute('aria-expanded'), picker).toBe('true');
       expect(control().getAttribute('aria-controls'), picker).toBe(id);
       expect(sr.getElementById(id)?.querySelector('hv-location-tree'), `${picker} open`).toBeTruthy();
+      // The tree opens under the control, or under the row holding it — never
+      // as another item inside that row: the merge row is a flex line carrying
+      // the source, the arrow and the target, and a 200px box would join it.
+      const holder = sr.getElementById(id) as HTMLElement;
+      const after =
+        control().parentElement === holder.parentElement ? control() : control().parentElement;
+      expect(holder.previousElementSibling, `${picker} placement`).toBe(after);
     }
   });
 

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -8,6 +8,7 @@ import { ref } from 'lit/directives/ref.js';
 import { tokens, base } from '../ui/tokens';
 import { chip, tagLabel } from '../ui/chip';
 import { Modal, modalChrome } from '../ui/modal';
+import { LocationPicker } from '../ui/location-picker';
 import { icon } from '../ui/icons';
 import type { IconName } from '../ui/icons';
 import { counted } from '../ui/plural';
@@ -46,7 +47,6 @@ import type {
   StoreState,
 } from '../store/types';
 import './hv-confirm';
-import './hv-location-tree';
 
 export type OrganizeTab = 'locations' | 'categories' | 'tags' | 'statuses';
 
@@ -548,6 +548,12 @@ export class HVOrganizeDialog extends LitElement {
         min-height: 46px;
         font-size: 15px;
       }
+      /* The merge target takes what the struck-through source leaves of the row,
+         and stops shrinking before the name it holds is unreadable. */
+      .control.grow {
+        flex: 1;
+        min-width: 180px;
+      }
       .control .value {
         flex: 1;
         min-width: 0;
@@ -702,13 +708,16 @@ export class HVOrganizeDialog extends LitElement {
   @property({ type: String }) tab: OrganizeTab = 'locations';
   @property({ type: Boolean, reflect: true }) mobile = false;
 
+  /** The parent picker and the merge target: one location each, so a pick ends it. */
+  private readonly _parentPicker = new LocationPicker(this);
+  private readonly _mergePicker = new LocationPicker(this);
+
   @state() private _filter = '';
   /** Location being edited, `'new'` for the create row, or null. */
   @state() private _editingLocation: string | 'new' | null = null;
   @state() private _locName = '';
   @state() private _locArea: string | null = null;
   @state() private _locParent: string | null = null;
-  @state() private _locParentOpen = false;
   @state() private _locError: string | null = null;
   /**
    * Whether the open editor's id was copied a moment ago. Set only on a copy the
@@ -721,7 +730,6 @@ export class HVOrganizeDialog extends LitElement {
   /** Location being merged away, with the location it is merging into. */
   @state() private _mergingLocation: string | null = null;
   @state() private _mergeTarget: string | null = null;
-  @state() private _mergeTargetOpen = false;
   /** Location whose actions are open in the touch sheet. */
   @state() private _sheetLocation: string | null = null;
   /** The value row expanded for rename or merge, if any; the kind comes from the active tab. */
@@ -856,7 +864,7 @@ export class HVOrganizeDialog extends LitElement {
     this._newValueError = null;
     this._mergingLocation = null;
     this._mergeTarget = null;
-    this._mergeTargetOpen = false;
+    this._mergePicker.close();
     this._sheetLocation = null;
   }
 
@@ -981,7 +989,7 @@ export class HVOrganizeDialog extends LitElement {
     this._locName = node?.name ?? '';
     this._locArea = node?.area_id ?? null;
     this._locParent = node?.parent_id ?? null;
-    this._locParentOpen = false;
+    this._parentPicker.close();
     this._locError = null;
     this._guard = null;
     this._clearCopied();
@@ -1051,7 +1059,7 @@ export class HVOrganizeDialog extends LitElement {
     this._rewrite = null;
     this._mergingLocation = id;
     this._mergeTarget = null;
-    this._mergeTargetOpen = false;
+    this._mergePicker.close();
   }
 
   /**
@@ -1374,46 +1382,38 @@ export class HVOrganizeDialog extends LitElement {
                 ${t('hv.organize.parentLocationNote')}
               </span>
             </span>
-            <button
-              class="control"
-              data-testid="location-parent"
-              aria-expanded=${String(this._locParentOpen)}
-              aria-controls=${LOC_PARENT_TREE_ID}
-              @click=${() => {
-                this._locParentOpen = !this._locParentOpen;
-              }}
-            >
-              ${icon('mapMarker', 15)}<span class="value">${this._parentLabel(parent, areas)}</span>
-              ${icon('chevronDown', 15)}
-            </button>
-            <div class="tree-holder" id=${LOC_PARENT_TREE_ID} ?hidden=${!this._locParentOpen}>
-              ${this._locParentOpen
-                ? html`<hv-location-tree
-                    data-testid="location-parent-tree"
-                    .nodes=${tree}
-                    .areas=${areas}
-                    .selectedId=${this._locParent}
-                    .selectedAreaId=${this._locParent === null ? this._locArea : null}
-                    .excludeSubtreeOf=${node?.id ?? null}
-                    showAll
-                    allLabel=${t('hv.organize.topLevel')}
-                    areaSelectable
-                    showEmptyAreas
-                    @select=${(e: CustomEvent) => {
-                      this._locParent = (e.detail as { locationId: string | null }).locationId;
-                      this._locParentOpen = false;
-                    }}
-                    @select-area=${(e: CustomEvent) => {
-                      // An area heads the top level rather than sitting in the
-                      // tree, so picking one is both halves of the move: out to
-                      // the top level, and into that area.
-                      this._locParent = null;
-                      this._locArea = (e.detail as { areaId: string }).areaId;
-                      this._locParentOpen = false;
-                    }}
-                  ></hv-location-tree>`
-                : null}
-            </div>
+            ${this._parentPicker.render(
+              {
+                triggerClass: 'control',
+                testid: 'location-parent',
+                holderId: LOC_PARENT_TREE_ID,
+                trigger: html`${icon('mapMarker', 15)}<span class="value"
+                    >${this._parentLabel(parent, areas)}</span
+                  >${icon('chevronDown', 15)}`,
+              },
+              () => html`<hv-location-tree
+                data-testid="location-parent-tree"
+                .nodes=${tree}
+                .areas=${areas}
+                .selectedId=${this._locParent}
+                .selectedAreaId=${this._locParent === null ? this._locArea : null}
+                .excludeSubtreeOf=${node?.id ?? null}
+                showAll
+                allLabel=${t('hv.organize.topLevel')}
+                areaSelectable
+                showEmptyAreas
+                @select=${(e: CustomEvent) => {
+                  this._locParent = (e.detail as { locationId: string | null }).locationId;
+                }}
+                @select-area=${(e: CustomEvent) => {
+                  // An area heads the top level rather than sitting in the tree,
+                  // so picking one is both halves of the move: out to the top
+                  // level, and into that area.
+                  this._locParent = null;
+                  this._locArea = (e.detail as { areaId: string }).areaId;
+                }}
+              ></hv-location-tree>`,
+            )}
           </div>
           ${
             // haventory.item_create and location_create take this string as
@@ -1508,36 +1508,26 @@ export class HVOrganizeDialog extends LitElement {
       <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap">
         <span class="hv-chip" style="text-decoration: line-through">${source.name}</span>
         ${icon('arrowRight', 18)}
-        <button
-          class="control"
-          style="flex:1;min-width:180px"
-          data-testid="merge-target"
-          aria-expanded=${String(this._mergeTargetOpen)}
-          aria-controls=${MERGE_TARGET_TREE_ID}
-          @click=${() => {
-            this._mergeTargetOpen = !this._mergeTargetOpen;
-          }}
-        >
-          ${icon('mapMarker', 15)}<span class="value"
-            >${target?.name ?? t('hv.organize.mergeIntoPlaceholder')}</span
-          >
-          ${icon('chevronDown', 15)}
-        </button>
-      </div>
-      <div class="tree-holder" id=${MERGE_TARGET_TREE_ID} ?hidden=${!this._mergeTargetOpen}>
-        ${this._mergeTargetOpen
-          ? html`<hv-location-tree
-              data-testid="merge-target-tree"
-              .nodes=${tree}
-              .areas=${this.st?.areasCache?.areas ?? []}
-              .selectedId=${this._mergeTarget}
-              .excludeSubtreeOf=${source.id}
-              @select=${(e: CustomEvent) => {
-                this._mergeTarget = (e.detail as { locationId: string | null }).locationId;
-                this._mergeTargetOpen = false;
-              }}
-            ></hv-location-tree>`
-          : null}
+        ${this._mergePicker.render(
+          {
+            triggerClass: 'control grow',
+            testid: 'merge-target',
+            holderId: MERGE_TARGET_TREE_ID,
+            trigger: html`${icon('mapMarker', 15)}<span class="value"
+                >${target?.name ?? t('hv.organize.mergeIntoPlaceholder')}</span
+              >${icon('chevronDown', 15)}`,
+          },
+          () => html`<hv-location-tree
+            data-testid="merge-target-tree"
+            .nodes=${tree}
+            .areas=${this.st?.areasCache?.areas ?? []}
+            .selectedId=${this._mergeTarget}
+            .excludeSubtreeOf=${source.id}
+            @select=${(e: CustomEvent) => {
+              this._mergeTarget = (e.detail as { locationId: string | null }).locationId;
+            }}
+          ></hv-location-tree>`,
+        )}
       </div>
       <span class="note" data-testid="merge-effect">
         ${target

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -1508,27 +1508,28 @@ export class HVOrganizeDialog extends LitElement {
       <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap">
         <span class="hv-chip" style="text-decoration: line-through">${source.name}</span>
         ${icon('arrowRight', 18)}
-        ${this._mergePicker.render(
-          {
-            triggerClass: 'control grow',
-            testid: 'merge-target',
-            holderId: MERGE_TARGET_TREE_ID,
-            trigger: html`${icon('mapMarker', 15)}<span class="value"
-                >${target?.name ?? t('hv.organize.mergeIntoPlaceholder')}</span
-              >${icon('chevronDown', 15)}`,
-          },
-          () => html`<hv-location-tree
-            data-testid="merge-target-tree"
-            .nodes=${tree}
-            .areas=${this.st?.areasCache?.areas ?? []}
-            .selectedId=${this._mergeTarget}
-            .excludeSubtreeOf=${source.id}
-            @select=${(e: CustomEvent) => {
-              this._mergeTarget = (e.detail as { locationId: string | null }).locationId;
-            }}
-          ></hv-location-tree>`,
-        )}
+        ${this._mergePicker.renderTrigger({
+          triggerClass: 'control grow',
+          testid: 'merge-target',
+          holderId: MERGE_TARGET_TREE_ID,
+          trigger: html`${icon('mapMarker', 15)}<span class="value"
+              >${target?.name ?? t('hv.organize.mergeIntoPlaceholder')}</span
+            >${icon('chevronDown', 15)}`,
+        })}
       </div>
+      ${this._mergePicker.renderHolder(
+        { holderId: MERGE_TARGET_TREE_ID },
+        () => html`<hv-location-tree
+          data-testid="merge-target-tree"
+          .nodes=${tree}
+          .areas=${this.st?.areasCache?.areas ?? []}
+          .selectedId=${this._mergeTarget}
+          .excludeSubtreeOf=${source.id}
+          @select=${(e: CustomEvent) => {
+            this._mergeTarget = (e.detail as { locationId: string | null }).locationId;
+          }}
+        ></hv-location-tree>`,
+      )}
       <span class="note" data-testid="merge-effect">
         ${target
           ? t('hv.organize.mergeEffect', {

--- a/cards/haventory-card/src/ui/attachments.test.ts
+++ b/cards/haventory-card/src/ui/attachments.test.ts
@@ -1,0 +1,191 @@
+import { html, render } from 'lit';
+import { renderDocumentRow, renderLightboxHost, renderPhotoFigure } from './attachments';
+import type { DocumentRowStyle, PhotoFigureStyle } from './attachments';
+
+/** The editor's strip: 72px tiles, its own placeholder box, controls on top. */
+const EDITOR_PHOTO: PhotoFigureStyle = {
+  testid: 'editor-photo',
+  glyph: 20,
+  tileClass: 'placeholder',
+  openClass: 'open',
+  pendingTile: true,
+};
+
+/** The sheet's strip: bigger tiles, nothing to hang on them, nothing to manage. */
+const SHEET_PHOTO: PhotoFigureStyle = { testid: 'sheet-photo', glyph: 24 };
+
+const EDITOR_DOC: DocumentRowStyle = {
+  testid: 'editor-document',
+  glyph: 18,
+  openLabel: 'Open Manual',
+  openTitle: 'Open',
+};
+const SHEET_DOC: DocumentRowStyle = { testid: 'sheet-document', glyph: 20, openText: 'Open' };
+
+function draw(content: unknown) {
+  const box = document.createElement('div');
+  render(html`${content}`, box);
+  document.body.append(box);
+  return box;
+}
+
+const q = (box: HTMLElement, testid: string) =>
+  box.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+
+const photo = (patch: Record<string, unknown> = {}) => ({
+  src: '/media/1?sig=x',
+  missing: false,
+  alt: 'Photo 1 of 2 of Drill',
+  openLabel: 'View photo 1 of 2 of Drill',
+  onOpen: () => undefined,
+  ...patch,
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('renderPhotoFigure', () => {
+  it('opens the lightbox from the tile it drew', () => {
+    const opened: true[] = [];
+    const box = draw(renderPhotoFigure(photo({ onOpen: () => opened.push(true) }), EDITOR_PHOTO));
+    const open = q(box, 'editor-photo-open') as HTMLButtonElement;
+    expect(open.className).toBe('open');
+    expect(open.getAttribute('aria-label')).toBe('View photo 1 of 2 of Drill');
+    const img = open.querySelector('img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe('/media/1?sig=x');
+    expect(img.getAttribute('alt')).toBe('Photo 1 of 2 of Drill');
+    expect(img.getAttribute('loading')).toBe('lazy');
+    open.click();
+    expect(opened).toEqual([true]);
+  });
+
+  // An export carries the references and not the bytes, so both surfaces have
+  // to answer a reference the backend cannot resolve — and answer it the same.
+  it('marks a picture whose file the backend does not have, on either surface', () => {
+    for (const style of [EDITOR_PHOTO, SHEET_PHOTO]) {
+      const box = draw(renderPhotoFigure(photo({ src: null, missing: true }), style));
+      const tile = q(box, `${style.testid}-missing`);
+      expect(tile, style.testid).toBeTruthy();
+      expect(tile?.textContent, style.testid).toContain('File missing');
+      expect(tile?.querySelector('.hv-chip.warning'), style.testid).toBeTruthy();
+      expect(tile?.classList.contains('missing'), style.testid).toBe(true);
+      // Never an <img>: a src is what draws the browser's broken-image glyph.
+      expect(box.querySelector('img'), style.testid).toBe(null);
+      expect(q(box, `${style.testid}-open`), style.testid).toBe(null);
+      document.body.innerHTML = '';
+    }
+  });
+
+  it('keeps each strip own dressing on the missing tile', () => {
+    const box = draw(renderPhotoFigure(photo({ src: null, missing: true }), EDITOR_PHOTO));
+    expect(q(box, 'editor-photo-missing')?.className).toBe('placeholder missing');
+    const sheet = draw(renderPhotoFigure(photo({ src: null, missing: true }), SHEET_PHOTO));
+    expect(q(sheet, 'sheet-photo-missing')?.className).toBe('missing');
+  });
+
+  // Signing can fail or still be running. The editor holds the tile's place in
+  // a grid it is also a picker for; the sheet's strip simply has one photo less.
+  it('holds the place for an unsigned picture only where the surface asked', () => {
+    const box = draw(renderPhotoFigure(photo({ src: null }), EDITOR_PHOTO));
+    expect(q(box, 'editor-photo-placeholder')?.className).toBe('placeholder');
+    expect(box.querySelector('img')).toBe(null);
+    expect(renderPhotoFigure(photo({ src: null }), SHEET_PHOTO)).toBe(null);
+  });
+
+  it('hangs the surface controls on the figure, missing or not', () => {
+    const extra = html`<button data-testid="editor-photo-remove">x</button>`;
+    for (const patch of [{}, { src: null, missing: true }]) {
+      const box = draw(renderPhotoFigure(photo(patch), EDITOR_PHOTO, extra));
+      expect(q(box, 'editor-photo-remove')).toBeTruthy();
+      expect(q(box, 'editor-photo')?.querySelector('[data-testid="editor-photo-remove"]')).toBeTruthy();
+      document.body.innerHTML = '';
+    }
+  });
+});
+
+describe('renderDocumentRow', () => {
+  const body = html`<span class="doc-text">Manual</span>`;
+
+  // An anchor to the signed URL, not a button that fetches one: the URL has to
+  // be on the element before the tap or a popup blocker eats the new tab.
+  it('links straight to the signed file', () => {
+    const box = draw(renderDocumentRow({ src: '/media/d?sig=x', missing: false }, SHEET_DOC, body));
+    const link = q(box, 'sheet-document-open') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/media/d?sig=x');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(link.textContent).toContain('Open');
+  });
+
+  it('names the link where the row has no words for it', () => {
+    const box = draw(renderDocumentRow({ src: '/media/d?sig=x', missing: false }, EDITOR_DOC, body));
+    const link = q(box, 'editor-document-open') as HTMLAnchorElement;
+    expect(link.getAttribute('aria-label')).toBe('Open Manual');
+    expect(link.getAttribute('title')).toBe('Open');
+    expect(link.textContent?.trim()).toBe('');
+  });
+
+  it('marks a document whose file the backend does not have, on either surface', () => {
+    for (const style of [EDITOR_DOC, SHEET_DOC]) {
+      const box = draw(renderDocumentRow({ src: '/media/d?sig=x', missing: true }, style, body));
+      expect(q(box, `${style.testid}-missing`)?.textContent, style.testid).toContain('File missing');
+      expect(q(box, `${style.testid}-open`), style.testid).toBe(null);
+      expect(q(box, style.testid)?.classList.contains('missing'), style.testid).toBe(true);
+      document.body.innerHTML = '';
+    }
+  });
+
+  it('offers nothing at all while the URL is unsigned', () => {
+    const box = draw(renderDocumentRow({ src: null, missing: false }, SHEET_DOC, body));
+    expect(q(box, 'sheet-document-open')).toBe(null);
+    expect(q(box, 'sheet-document-missing')).toBe(null);
+    expect(q(box, 'sheet-document')?.textContent).toContain('Manual');
+  });
+
+  it('hangs the surface controls on the end of the row', () => {
+    const tail = html`<button data-testid="editor-document-remove">x</button>`;
+    const box = draw(renderDocumentRow({ src: null, missing: false }, EDITOR_DOC, body, tail));
+    expect(q(box, 'editor-document')?.lastElementChild?.getAttribute('data-testid')).toBe(
+      'editor-document-remove',
+    );
+  });
+});
+
+describe('renderLightboxHost', () => {
+  // A host listening to the surface for "the user is done" must not read a
+  // photo being shut as the surface being shut.
+  it('closes without telling the host of the surface around it', () => {
+    const closed: true[] = [];
+    const outer: Event[] = [];
+    const box = draw(
+      renderLightboxHost({
+        testid: 'sheet-lightbox-host',
+        item: null,
+        media: null,
+        index: 2,
+        onOpenerGone: () => undefined,
+        onClose: () => closed.push(true),
+      }),
+    );
+    box.addEventListener('close', (e) => outer.push(e));
+    const lightbox = q(box, 'sheet-lightbox-host') as HTMLElement;
+    lightbox.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    expect(closed).toEqual([true]);
+    expect(outer).toEqual([]);
+  });
+
+  it('opens at the picture the surface named', () => {
+    const box = draw(
+      renderLightboxHost({
+        testid: 'editor-lightbox-host',
+        item: null,
+        media: null,
+        index: 3,
+        onOpenerGone: () => undefined,
+        onClose: () => undefined,
+      }),
+    );
+    expect((q(box, 'editor-lightbox-host') as unknown as { index: number }).index).toBe(3);
+  });
+});

--- a/cards/haventory-card/src/ui/attachments.ts
+++ b/cards/haventory-card/src/ui/attachments.ts
@@ -1,0 +1,189 @@
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import type { TemplateResult } from 'lit';
+import { t } from '../i18n';
+import { icon } from './icons';
+import type { MediaBindings } from './media';
+import type { Item } from '../store/types';
+import '../components/hv-lightbox';
+
+/**
+ * The photo tile and the document row, as the editor and the detail sheet both
+ * draw them.
+ *
+ * The two surfaces show the same attachments for two different jobs — one
+ * manages them, one reads them — so their strips differ in size, in what sits
+ * beside each entry and in the words on the link. What they must never differ
+ * in is what happens when the backend has no file behind a reference: an export
+ * carries the metadata and not the bytes, so a fresh install genuinely holds
+ * pictures and documents whose files were never uploaded to it, and both
+ * surfaces answer that with the same amber mark rather than handing an `<img>`
+ * or a link a URL that can only 404. That rule, and the branch it hangs on,
+ * are written here once.
+ *
+ * The sizes, the tile classes and the test-ids stay parameters: a browser
+ * harness locates the editor's and the sheet's strips separately, and one
+ * renderer is what keeps them byte-identical.
+ */
+
+/** Two classes into one attribute, without the gap an absent one would leave. */
+const classes = (...parts: (string | undefined)[]) => parts.filter(Boolean).join(' ');
+
+/** What the backend can say about one attachment's file. */
+export interface AttachmentFile {
+  /** The signed URL, or null while it is being signed or when signing failed. */
+  src: string | null;
+  /** The backend has the reference and not the file. */
+  missing: boolean;
+}
+
+/** How a surface dresses its picture strip. */
+export interface PhotoFigureStyle {
+  /** `editor-photo` / `sheet-photo`; the tiles and the button take suffixes. */
+  testid: string;
+  /** The camera glyph's size, which follows the tile size the strip draws. */
+  glyph: number;
+  /** Classes on the tiles drawn in place of a photo. */
+  tileClass?: string;
+  /** Classes on the button that opens the lightbox. */
+  openClass?: string;
+  /**
+   * Draw a tile while there is no URL yet. Without it the figure is left out
+   * of the strip entirely until there is something in it to show.
+   */
+  pendingTile?: boolean;
+}
+
+/** One picture: what it is called, and what opens it. */
+export interface PhotoFigure extends AttachmentFile {
+  /** The image's alt text, which is also what the open button announces. */
+  alt: string;
+  openLabel: string;
+  onOpen: () => void;
+}
+
+/**
+ * One tile of a picture strip, or nothing when there is neither a picture to
+ * show nor a state to report.
+ *
+ * `extra` is whatever the surface hangs on the tile — the editor's remove
+ * button and its reorder row — and it is drawn for every state, including the
+ * missing one: a reference the backend cannot resolve is still the item's to
+ * clear.
+ */
+export function renderPhotoFigure(
+  photo: PhotoFigure,
+  style: PhotoFigureStyle,
+  extra?: unknown,
+): TemplateResult | null {
+  if (!photo.missing && !photo.src && !style.pendingTile) return null;
+  const glyph = icon('camera', style.glyph);
+  const tile = photo.missing
+    ? html`<span
+        class=${classes(style.tileClass, 'missing')}
+        data-testid=${`${style.testid}-missing`}
+      >
+        ${glyph}
+        <span class="hv-chip warning">${t('hv.term.fileMissing')}</span>
+      </span>`
+    : photo.src
+      ? html`<button
+          class=${ifDefined(style.openClass)}
+          data-testid=${`${style.testid}-open`}
+          aria-label=${photo.openLabel}
+          @click=${photo.onOpen}
+        >
+          <img src=${photo.src} alt=${photo.alt} loading="lazy" decoding="async" />
+        </button>`
+      : html`<span class=${ifDefined(style.tileClass)} data-testid=${`${style.testid}-placeholder`}
+          >${glyph}</span
+        >`;
+  return html`<figure data-testid=${style.testid}>${tile}${extra}</figure>`;
+}
+
+/** How a surface dresses its document rows. */
+export interface DocumentRowStyle {
+  /** `editor-document` / `sheet-document`; the chip and the link take suffixes. */
+  testid: string;
+  /** The file glyph's size, which follows the row height the surface draws. */
+  glyph: number;
+  /** What the link says beside its glyph, where the row has the width for words. */
+  openText?: string;
+  /** The link's accessible name and tooltip, where the row's own text is not it. */
+  openLabel?: string;
+  openTitle?: string;
+}
+
+/**
+ * One row of a document list: the file glyph, whatever the surface puts in the
+ * middle, the way in or the reason there is none, and whatever the surface
+ * hangs on the end.
+ *
+ * The link is an anchor to the signed URL rather than a button that fetches
+ * one: the URL has to be on the element before the tap, or a popup blocker
+ * eats the tab a handler would open after awaiting a signature.
+ */
+export function renderDocumentRow(
+  doc: AttachmentFile,
+  style: DocumentRowStyle,
+  body: unknown,
+  tail?: unknown,
+): TemplateResult {
+  return html`<li class=${doc.missing ? 'missing' : ''} data-testid=${style.testid}>
+    <span class="doc-icon">${icon('fileDocument', style.glyph)}</span>
+    ${body}
+    ${doc.missing
+      ? html`<span class="hv-chip warning" data-testid=${`${style.testid}-missing`}
+          >${t('hv.term.fileMissing')}</span
+        >`
+      : doc.src
+        ? html`<a
+            class="doc-open"
+            data-testid=${`${style.testid}-open`}
+            href=${doc.src}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label=${ifDefined(style.openLabel)}
+            title=${ifDefined(style.openTitle)}
+            >${icon('openInNew', 15)}${style.openText}</a
+          >`
+        : null}
+    ${tail}
+  </li>`;
+}
+
+/** Where a surface's lightbox hangs, and what it does when it closes. */
+export interface LightboxHost {
+  /** `editor-lightbox-host` / `sheet-lightbox-host`. */
+  testid: string;
+  item: Item | null;
+  media: MediaBindings | null;
+  /** Which picture to open at, null for closed. */
+  index: number | null;
+  /**
+   * Where focus belongs when the photo that opened it has been removed from
+   * under it. Only the surface still on screen knows.
+   */
+  onOpenerGone: () => void;
+  onClose: () => void;
+}
+
+/**
+ * The lightbox, hung outside the surface that opens it.
+ *
+ * Its `close` is stopped here: a host listening to the surface for "the user is
+ * done" must not read a photo being shut as the surface being shut.
+ */
+export function renderLightboxHost(opts: LightboxHost): TemplateResult {
+  return html`<hv-lightbox
+    data-testid=${opts.testid}
+    .item=${opts.item}
+    .media=${opts.media}
+    .index=${opts.index}
+    .onOpenerGone=${opts.onOpenerGone}
+    @close=${(e: Event) => {
+      e.stopPropagation();
+      opts.onClose();
+    }}
+  ></hv-lightbox>`;
+}

--- a/cards/haventory-card/src/ui/day-offsets.test.ts
+++ b/cards/haventory-card/src/ui/day-offsets.test.ts
@@ -1,0 +1,105 @@
+import { render } from 'lit';
+import { renderDayOffsets } from './day-offsets';
+import { addDays } from './relative-time';
+import type { DayOffsetsOptions, DayOffsetsState } from './day-offsets';
+
+function draw(state: Partial<DayOffsetsState>, opts: Partial<DayOffsetsOptions> = {}) {
+  const picked: string[] = [];
+  const custom: string[] = [];
+  const typed: [number, string | null][] = [];
+  const host = document.createElement('div');
+  render(
+    renderDayOffsets(
+      { current: null, customOpen: false, customDays: 14, ...state },
+      {
+        prefix: 'checkout',
+        onPick: (date) => picked.push(date),
+        onCustom: (date) => custom.push(date),
+        onDays: (days, date) => typed.push([days, date]),
+        ...opts,
+      },
+    ),
+    host,
+  );
+  return { host, picked, custom, typed };
+}
+
+const all = (host: HTMLElement, testid: string) =>
+  [...host.querySelectorAll<HTMLElement>(`[data-testid="${testid}"]`)];
+const q = (host: HTMLElement, testid: string) =>
+  host.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+
+describe('renderDayOffsets', () => {
+  it('offers the three round spans and the way past them', () => {
+    const { host } = draw({});
+    expect(all(host, 'checkout-offset').map((b) => b.dataset.days)).toEqual(['7', '30', '90']);
+    expect(q(host, 'checkout-offset-custom')).not.toBe(null);
+  });
+
+  it('names every control after the surface drawing it', () => {
+    const { host } = draw({}, { prefix: 'editor-inspection' });
+    expect(all(host, 'editor-inspection-offset')).toHaveLength(3);
+    expect(q(host, 'editor-inspection-offsets')).not.toBe(null);
+    expect(q(host, 'editor-inspection-offset-custom')).not.toBe(null);
+    expect(q(host, 'checkout-offset')).toBe(null);
+  });
+
+  it('marks the preset that computes the date the field holds', () => {
+    const { host } = draw({ current: addDays(30) });
+    expect(all(host, 'checkout-offset').map((b) => b.classList.contains('on'))).toEqual([
+      false,
+      true,
+      false,
+    ]);
+  });
+
+  it('hands back the date a preset stands for', () => {
+    const { host, picked } = draw({});
+    (all(host, 'checkout-offset')[2] as HTMLButtonElement).click();
+    expect(picked).toEqual([addDays(90)]);
+  });
+
+  // The custom row is the way out for a span the presets do not cover, so it
+  // takes the on state off them while it owns the date.
+  it('keeps the custom box away until it is asked for, then owns the state', () => {
+    const closed = draw({ current: addDays(7) });
+    expect(q(closed.host, 'checkout-custom')).toBe(null);
+    (q(closed.host, 'checkout-offset-custom') as HTMLButtonElement).click();
+    expect(closed.custom).toEqual([addDays(14)]);
+
+    const open = draw({ current: addDays(7), customOpen: true });
+    expect(q(open.host, 'checkout-custom')).not.toBe(null);
+    expect(all(open.host, 'checkout-offset').some((b) => b.classList.contains('on'))).toBe(false);
+    expect(q(open.host, 'checkout-offset-custom')?.classList.contains('on')).toBe(true);
+  });
+
+  it('computes a date from the count typed into the box', () => {
+    const { host, typed } = draw({ customOpen: true });
+    const input = q(host, 'checkout-custom')?.querySelector('input') as HTMLInputElement;
+    input.value = '3';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(typed).toEqual([[3, addDays(3)]]);
+  });
+
+  // An empty or nonsense box means no date yet rather than the last good one.
+  it('answers a cleared box with no date at all', () => {
+    const { host, typed } = draw({ customOpen: true });
+    const input = q(host, 'checkout-custom')?.querySelector('input') as HTMLInputElement;
+    input.value = '';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.value = '0';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(typed).toEqual([
+      [0, null],
+      [0, null],
+    ]);
+  });
+
+  it('bounds the box so a date is a date and not a century', () => {
+    const { host } = draw({ customOpen: true });
+    const input = q(host, 'checkout-custom')?.querySelector('input') as HTMLInputElement;
+    expect(input.getAttribute('min')).toBe('1');
+    expect(input.getAttribute('max')).toBe('3650');
+    expect(input.getAttribute('inputmode')).toBe('numeric');
+  });
+});

--- a/cards/haventory-card/src/ui/day-offsets.ts
+++ b/cards/haventory-card/src/ui/day-offsets.ts
@@ -1,0 +1,139 @@
+import { css, html } from 'lit';
+import type { TemplateResult } from 'lit';
+import { t } from '../i18n';
+import { addDays, quickDayOffsets } from './relative-time';
+
+/**
+ * The quick jumps a forward date is set by: three presets and a "+X days"
+ * escape hatch.
+ *
+ * The check-out popover dates a borrowing and the editor dates an inspection,
+ * and both are spans a household names in weeks rather than calendar squares.
+ * The two controls looked identical because they are the same gesture, so the
+ * presets, the states, the input's bounds and the rule that an empty box means
+ * no date rather than a stale one are written here once. What each surface
+ * calls its buttons is a parameter — the browser harnesses locate
+ * `checkout-offset` — and one renderer is what keeps them byte-identical.
+ *
+ * The custom row appears only once "+X days" is pressed: it is the way out for
+ * an interval the three presets do not cover, not a fourth preset.
+ */
+
+/**
+ * The row and the custom box. A host adds this to its styles and keeps its own
+ * touch rules on the same class names — the two surfaces grow the chips for a
+ * finger by different amounts, because one is a form and the other a popover.
+ */
+export const dayOffsets = css`
+  .offsets {
+    display: flex;
+    gap: 7px;
+    flex-wrap: wrap;
+  }
+  .offset {
+    border: 1px solid var(--hv-divider);
+    background: none;
+    color: var(--hv-chip-text);
+    border-radius: var(--hv-radius-chip);
+    padding: 6px 13px;
+    font: 400 12.5px var(--hv-font);
+    cursor: pointer;
+  }
+  .offset.on {
+    background: var(--hv-primary-dark);
+    border-color: var(--hv-primary-dark);
+    color: #fff;
+    font-weight: 500;
+  }
+  .day-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border: 1px solid var(--hv-divider);
+    border-radius: var(--hv-radius-input);
+    font-size: 13px;
+    color: var(--hv-text-secondary);
+  }
+  .day-box input {
+    width: 72px;
+    box-sizing: border-box;
+    border: 1px solid var(--hv-input-border);
+    border-radius: var(--hv-radius-input);
+    background: var(--hv-surface);
+    color: var(--hv-text);
+    padding: 5px 8px;
+    font: 400 13.5px var(--hv-font);
+  }
+`;
+
+/** What the control is showing, all of it owned by the host. */
+export interface DayOffsetsState {
+  /** The date the field holds now; a preset reads as on when it computes this. */
+  current: string | null;
+  /** The custom row is showing, which is also what takes the on state off a preset. */
+  customOpen: boolean;
+  /** The count in the custom box. */
+  customDays: number;
+}
+
+/** How a surface names its buttons, and what it does with a date. */
+export interface DayOffsetsOptions {
+  /**
+   * Test-id stem: `checkout` gives `checkout-offset`, `checkout-offset-custom`
+   * and `checkout-custom`.
+   */
+  prefix: string;
+  /** A preset was pressed. The host also closes its custom row. */
+  onPick: (date: string) => void;
+  /** "+X days" was pressed. The host also opens its custom row. */
+  onCustom: (date: string) => void;
+  /**
+   * The custom box was typed in. `date` is null for an empty or nonsense count:
+   * that means no date yet rather than the last good one, so the field clears.
+   */
+  onDays: (days: number, date: string | null) => void;
+}
+
+export function renderDayOffsets(state: DayOffsetsState, opts: DayOffsetsOptions): TemplateResult {
+  const { prefix } = opts;
+  return html`
+    <div class="offsets" data-testid=${`${prefix}-offsets`}>
+      ${quickDayOffsets().map((offset) => {
+        const value = addDays(offset.days);
+        return html`<button
+          class="offset ${!state.customOpen && state.current === value ? 'on' : ''}"
+          data-testid=${`${prefix}-offset`}
+          data-days=${offset.days}
+          @click=${() => opts.onPick(value)}
+        >
+          ${offset.label}
+        </button>`;
+      })}
+      <button
+        class="offset ${state.customOpen ? 'on' : ''}"
+        data-testid=${`${prefix}-offset-custom`}
+        @click=${() => opts.onCustom(addDays(state.customDays))}
+      >
+        ${t('hv.editor.customDaysOffset')}
+      </button>
+    </div>
+    ${state.customOpen
+      ? html`<label class="day-box" data-testid=${`${prefix}-custom`}>
+          <input
+            type="number"
+            min="1"
+            max="3650"
+            inputmode="numeric"
+            aria-label=${t('hv.editor.daysFromToday')}
+            .value=${String(state.customDays)}
+            @input=${(e: Event) => {
+              const days = Number((e.target as HTMLInputElement).value);
+              opts.onDays(days, Number.isFinite(days) && days >= 1 ? addDays(Math.floor(days)) : null);
+            }}
+          />
+          <span>${t('hv.editor.daysFromToday')}</span>
+        </label>`
+      : null}
+  `;
+}

--- a/cards/haventory-card/src/ui/dialog-focus.test.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.test.ts
@@ -1,4 +1,4 @@
-import { DialogFocus, deepActiveElement, deepFocusables } from './dialog-focus';
+import { DialogFocus, deepActiveElement, deepFocusables, focusStranded } from './dialog-focus';
 
 function panel(): HTMLElement {
   const el = document.createElement('div');
@@ -297,5 +297,25 @@ describe('deepFocusables', () => {
   it('survives a surface that has not rendered yet', () => {
     expect(deepFocusables(null)).toEqual([]);
     expect(deepFocusables(undefined)).toEqual([]);
+  });
+});
+
+describe('focusStranded', () => {
+  it('says nothing is stranded while a real control holds focus', () => {
+    const btn = document.createElement('button');
+    document.body.appendChild(btn);
+    btn.focus();
+    expect(focusStranded()).toBe(false);
+    btn.remove();
+  });
+
+  // What the browser does when the element holding focus leaves the document:
+  // it drops focus on the body, out of reach of whatever is still on screen.
+  it('sees focus dropped on the document when its holder goes', () => {
+    const btn = document.createElement('button');
+    document.body.appendChild(btn);
+    btn.focus();
+    btn.remove();
+    expect(focusStranded()).toBe(true);
   });
 });

--- a/cards/haventory-card/src/ui/dialog-focus.ts
+++ b/cards/haventory-card/src/ui/dialog-focus.ts
@@ -17,6 +17,20 @@ export function deepActiveElement(): HTMLElement | null {
   return el;
 }
 
+/**
+ * Whether focus has been left on nothing.
+ *
+ * The browser drops focus on `<body>` when the element holding it leaves the
+ * document, and from there Escape and the arrow keys reach nothing that is
+ * still on screen. Only the surface still standing knows where focus belongs
+ * instead, so this reports rather than acts — and a caller must not yank focus
+ * from a user who had already moved on somewhere else.
+ */
+export function focusStranded(): boolean {
+  const at = deepActiveElement();
+  return !at || at === document.body || !at.isConnected;
+}
+
 const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 /**
@@ -130,7 +144,6 @@ export class DialogFocus {
     // Nothing to return to. Rescue focus only if it really was stranded: a
     // close that happened while the user was already somewhere else must not
     // have focus yanked out from under them.
-    const stranded = deepActiveElement();
-    if (!stranded || stranded === document.body || !stranded.isConnected) onOpenerGone?.();
+    if (focusStranded()) onOpenerGone?.();
   }
 }

--- a/cards/haventory-card/src/ui/location-picker.test.ts
+++ b/cards/haventory-card/src/ui/location-picker.test.ts
@@ -1,0 +1,125 @@
+import { html, render } from 'lit';
+import { LocationPicker } from './location-picker';
+import type { ReactiveControllerHost } from 'lit';
+import type { LocationPickerOptions } from './location-picker';
+
+/**
+ * A host in miniature: it does what a `LitElement` does with a
+ * `requestUpdate` — draw again — and nothing else.
+ */
+function mount(opts: LocationPickerOptions = {}) {
+  const box = document.createElement('div');
+  document.body.append(box);
+  let renders = 0;
+  const host = {
+    requestUpdate: () => draw(),
+    addController: () => undefined,
+    removeController: () => undefined,
+    updateComplete: Promise.resolve(true),
+  } as unknown as ReactiveControllerHost;
+  const picker = new LocationPicker(host, opts);
+  function draw() {
+    renders += 1;
+    render(
+      picker.render(
+        {
+          triggerClass: 'field-button',
+          testid: 'where',
+          title: 'Garage',
+          holderId: 'where-holder',
+          trigger: html`<span class="value">Garage</span>`,
+        },
+        () => html`<span data-testid="tree">tree</span>`,
+      ),
+      box,
+    );
+  }
+  draw();
+  return {
+    picker,
+    box,
+    trigger: () => box.querySelector('[data-testid="where"]') as HTMLButtonElement,
+    holder: () => box.querySelector('#where-holder') as HTMLElement,
+    tree: () => box.querySelector('[data-testid="tree"]'),
+    renders: () => renders,
+  };
+}
+
+/** What the tree sends when a row is picked; `select-area` carries no location. */
+function pick(holder: HTMLElement, detail: Record<string, unknown>, name = 'select') {
+  holder.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }));
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('LocationPicker', () => {
+  it('wears the dressing the host form gave it', () => {
+    const { trigger } = mount();
+    expect(trigger().className).toBe('field-button');
+    expect(trigger().getAttribute('title')).toBe('Garage');
+    expect(trigger().querySelector('.value')?.textContent).toBe('Garage');
+  });
+
+  // aria-expanded on its own says only that something opened; which element it
+  // opened is what aria-controls answers, and it has to resolve in both states.
+  it('names the holder it discloses, open or shut', () => {
+    const { trigger, holder, tree } = mount();
+    expect(trigger().getAttribute('aria-controls')).toBe('where-holder');
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    expect(holder()).toBeTruthy();
+    expect(holder().hasAttribute('hidden')).toBe(true);
+    expect(tree()).toBe(null);
+
+    trigger().click();
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('where-holder');
+    expect(holder().hasAttribute('hidden')).toBe(false);
+    expect(tree()).toBeTruthy();
+  });
+
+  it('opens and shuts from the trigger', () => {
+    const { picker, trigger } = mount();
+    trigger().click();
+    expect(picker.open).toBe(true);
+    trigger().click();
+    expect(picker.open).toBe(false);
+  });
+
+  it('shuts on a pick, which is what the trigger was opened for', () => {
+    const { picker, trigger, holder } = mount();
+    trigger().click();
+    pick(holder(), { locationId: 'garage' });
+    expect(picker.open).toBe(false);
+  });
+
+  // A filter narrows by a set, so adding to it means picking again.
+  it('stays open while a set is being picked, and shuts when it is cleared', () => {
+    const { picker, trigger, holder } = mount({ keepOpenOnSelect: true });
+    trigger().click();
+    pick(holder(), { locationId: 'garage' });
+    expect(picker.open).toBe(true);
+    pick(holder(), { locationId: null });
+    expect(picker.open).toBe(false);
+  });
+
+  // An area heads the top level rather than sitting in it, so picking one is a
+  // pick — and it carries no location, which is the same shape as clearing.
+  it('shuts on an area, whichever way it treats a location', () => {
+    for (const opts of [{}, { keepOpenOnSelect: true }]) {
+      const { picker, trigger, holder } = mount(opts);
+      trigger().click();
+      pick(holder(), { areaId: 'kitchen' }, 'select-area');
+      expect(picker.open).toBe(false);
+      document.body.innerHTML = '';
+    }
+  });
+
+  it('draws nothing again for a close that changes nothing', () => {
+    const { picker, renders } = mount();
+    const before = renders();
+    picker.close();
+    expect(renders()).toBe(before);
+  });
+});

--- a/cards/haventory-card/src/ui/location-picker.ts
+++ b/cards/haventory-card/src/ui/location-picker.ts
@@ -1,0 +1,124 @@
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import type { ReactiveControllerHost, TemplateResult } from 'lit';
+import '../components/hv-location-tree';
+
+/**
+ * The disclosure around `hv-location-tree`: a trigger that says what is picked,
+ * a holder the tree is drawn into while it is open, and the rule that picking
+ * one closes it.
+ *
+ * Four surfaces reach for a location this way — the item editor's field, the
+ * filter panel's Where chip, the organize dialog's parent picker and its merge
+ * target — and each wrote the same button, the same `aria-expanded` /
+ * `aria-controls` pair, the same holder and the same close-on-pick. What
+ * differs stays with the host: the trigger's classes and its contents, and the
+ * tree's own properties, because `.field-button`, `.control` and
+ * `hv-chip toggle` are the host forms' own vocabularies and the tree each
+ * surface wants is a different tree.
+ *
+ * A controller drawing into the host's own template rather than an element of
+ * its own, for those same class rules: they live in the host's stylesheet and
+ * do not reach across a shadow boundary. It also keeps the tree inside the
+ * host's single update, which is what every one of these surfaces' tests waits
+ * on.
+ *
+ * The holder outlives the tree: `aria-controls` pointing at an element that is
+ * not there announces the trigger as controlling nothing, so the box stays and
+ * only its contents come and go.
+ */
+
+/** What a surface settles once, for the life of the picker. */
+export interface LocationPickerOptions {
+  /**
+   * Picking adds to a set rather than finishing the job, so the tree stays open
+   * — the filter panel narrows by several locations at once. Clearing the
+   * selection is still the pick that finishes it, either way round.
+   */
+  keepOpenOnSelect?: boolean;
+}
+
+/** What the trigger and the holder are called and dressed in, per render. */
+export interface LocationPickerChrome {
+  /** The classes the host's stylesheet dresses the trigger in. */
+  triggerClass: string;
+  /** What a harness and the host's own queries locate the trigger by. */
+  testid: string;
+  /** The trigger's tooltip, where the host has more to say than fits on it. */
+  title?: string;
+  /** The trigger's contents: the host's own icons, chips and label. */
+  trigger: unknown;
+  /**
+   * The id `aria-controls` names, and the holder's own. Scoped to the host's
+   * shadow root, so two forms mounted at once do not collide.
+   */
+  holderId: string;
+  /** The holder's classes; every host calls it `tree-holder` and sizes its own. */
+  holderClass?: string;
+}
+
+export class LocationPicker {
+  private readonly _host: ReactiveControllerHost;
+  private readonly _opts: LocationPickerOptions;
+  private _open = false;
+
+  constructor(host: ReactiveControllerHost, opts: LocationPickerOptions = {}) {
+    this._host = host;
+    this._opts = opts;
+  }
+
+  /** Whether the tree is showing, for a host deciding what Escape takes back. */
+  get open(): boolean {
+    return this._open;
+  }
+
+  close(): void {
+    this._set(false);
+  }
+
+  private _set(open: boolean) {
+    if (this._open === open) return;
+    this._open = open;
+    this._host.requestUpdate();
+  }
+
+  /**
+   * A pick closes the tree. An area heads the top level rather than sitting in
+   * it, so picking one is a pick too — and it carries no `locationId`, which is
+   * the same shape as clearing the selection.
+   */
+  private _onSelect = (e: Event) => {
+    const picked = (e as CustomEvent<{ locationId?: string | null }>).detail?.locationId ?? null;
+    if (this._opts.keepOpenOnSelect && picked !== null) return;
+    this.close();
+  };
+
+  /**
+   * `tree` is a function, not a template: a closed picker draws nothing, and
+   * building the nodes for a tree nobody has opened is work every keystroke in
+   * the form around it would pay for.
+   */
+  render(chrome: LocationPickerChrome, tree: () => unknown): TemplateResult {
+    return html`
+      <button
+        class=${chrome.triggerClass}
+        data-testid=${chrome.testid}
+        title=${ifDefined(chrome.title)}
+        aria-expanded=${String(this._open)}
+        aria-controls=${chrome.holderId}
+        @click=${() => this._set(!this._open)}
+      >
+        ${chrome.trigger}
+      </button>
+      <div
+        class=${chrome.holderClass ?? 'tree-holder'}
+        id=${chrome.holderId}
+        ?hidden=${!this._open}
+        @select=${this._onSelect}
+        @select-area=${this._onSelect}
+      >
+        ${this._open ? tree() : null}
+      </div>
+    `;
+  }
+}

--- a/cards/haventory-card/src/ui/location-picker.ts
+++ b/cards/haventory-card/src/ui/location-picker.ts
@@ -38,8 +38,8 @@ export interface LocationPickerOptions {
   keepOpenOnSelect?: boolean;
 }
 
-/** What the trigger and the holder are called and dressed in, per render. */
-export interface LocationPickerChrome {
+/** What the trigger is called and dressed in, per render. */
+export interface LocationPickerTrigger {
   /** The classes the host's stylesheet dresses the trigger in. */
   triggerClass: string;
   /** What a harness and the host's own queries locate the trigger by. */
@@ -52,6 +52,12 @@ export interface LocationPickerChrome {
    * The id `aria-controls` names, and the holder's own. Scoped to the host's
    * shadow root, so two forms mounted at once do not collide.
    */
+  holderId: string;
+}
+
+/** What the holder is called and dressed in, per render. */
+export interface LocationPickerHolder {
+  /** The same id the trigger points at. */
   holderId: string;
   /** The holder's classes; every host calls it `tree-holder` and sizes its own. */
   holderClass?: string;
@@ -93,32 +99,45 @@ export class LocationPicker {
     this.close();
   };
 
+  /** The trigger on its own, for a host that puts the holder somewhere else. */
+  renderTrigger(chrome: LocationPickerTrigger): TemplateResult {
+    return html`<button
+      class=${chrome.triggerClass}
+      data-testid=${chrome.testid}
+      title=${ifDefined(chrome.title)}
+      aria-expanded=${String(this._open)}
+      aria-controls=${chrome.holderId}
+      @click=${() => this._set(!this._open)}
+    >
+      ${chrome.trigger}
+    </button>`;
+  }
+
   /**
-   * `tree` is a function, not a template: a closed picker draws nothing, and
-   * building the nodes for a tree nobody has opened is work every keystroke in
-   * the form around it would pay for.
+   * The holder on its own, for the same host. `tree` is a function, not a
+   * template: a closed picker draws nothing, and building the nodes for a tree
+   * nobody has opened is work every keystroke in the form around it would pay
+   * for.
    */
-  render(chrome: LocationPickerChrome, tree: () => unknown): TemplateResult {
-    return html`
-      <button
-        class=${chrome.triggerClass}
-        data-testid=${chrome.testid}
-        title=${ifDefined(chrome.title)}
-        aria-expanded=${String(this._open)}
-        aria-controls=${chrome.holderId}
-        @click=${() => this._set(!this._open)}
-      >
-        ${chrome.trigger}
-      </button>
-      <div
-        class=${chrome.holderClass ?? 'tree-holder'}
-        id=${chrome.holderId}
-        ?hidden=${!this._open}
-        @select=${this._onSelect}
-        @select-area=${this._onSelect}
-      >
-        ${this._open ? tree() : null}
-      </div>
-    `;
+  renderHolder(holder: LocationPickerHolder, tree: () => unknown): TemplateResult {
+    return html`<div
+      class=${holder.holderClass ?? 'tree-holder'}
+      id=${holder.holderId}
+      ?hidden=${!this._open}
+      @select=${this._onSelect}
+      @select-area=${this._onSelect}
+    >
+      ${this._open ? tree() : null}
+    </div>`;
+  }
+
+  /**
+   * Both, one after the other — the usual case, where the trigger and the box
+   * it opens are siblings in the host's own form. A host whose layout puts them
+   * in different parents — a chip row with the tree under it — draws the two
+   * halves itself.
+   */
+  render(chrome: LocationPickerTrigger & LocationPickerHolder, tree: () => unknown): TemplateResult {
+    return html`${this.renderTrigger(chrome)}${this.renderHolder(chrome, tree)}`;
   }
 }

--- a/cards/haventory-card/src/ui/roving-list.test.ts
+++ b/cards/haventory-card/src/ui/roving-list.test.ts
@@ -16,6 +16,38 @@ function list(values: string[], selected?: string) {
   return [...box.querySelectorAll('button')] as HTMLElement[];
 }
 
+/** One node of a tree in miniature: a depth, a disclosure state, its actions. */
+interface Node {
+  value: string;
+  level?: number;
+  /** Absent for a leaf, which discloses nothing and so says nothing. */
+  expanded?: boolean;
+  selected?: boolean;
+  /** Controls that ride with the row: the tree's rename, merge and delete. */
+  actions?: number;
+}
+
+/** A tree in miniature: rows that carry a level, a state and their own actions. */
+function tree(nodes: Node[]) {
+  const box = document.createElement('div');
+  for (const node of nodes) {
+    const row = document.createElement('div');
+    row.dataset.value = node.value;
+    row.setAttribute('aria-level', String(node.level ?? 1));
+    row.setAttribute('aria-selected', String(node.selected ?? false));
+    if (node.expanded !== undefined) row.setAttribute('aria-expanded', String(node.expanded));
+    const actions = document.createElement('span');
+    actions.className = 'actions';
+    for (let i = 0; i < (node.actions ?? 0); i += 1) actions.append(document.createElement('button'));
+    row.append(actions);
+    box.append(row);
+  }
+  document.body.append(box);
+  return [...box.querySelectorAll<HTMLElement>('[data-value]')];
+}
+
+const actionsOf = (el: HTMLElement) => el.querySelectorAll<HTMLElement>('.actions button');
+
 const keyOf = (el: HTMLElement) => `tags:${el.dataset.value}`;
 const stops = (rows: HTMLElement[]) =>
   rows.filter((r) => r.getAttribute('tabindex') === '0').map((r) => r.dataset.value);
@@ -67,6 +99,102 @@ describe('syncRovingTabindex', () => {
 
   it('holds nothing for an empty list', () => {
     expect(syncRovingTabindex([], 'tags:green', keyOf)).toBe(null);
+  });
+
+  // A tree row is not pressable — it is selected — and means the same thing.
+  it('starts on a selected row however the row says it is selected', () => {
+    const rows = tree([{ value: 'garage' }, { value: 'kitchen', selected: true }]);
+    expect(syncRovingTabindex(rows, null, keyOf)).toBe('tags:kitchen');
+    expect(rows.map((r) => r.getAttribute('tabindex'))).toEqual(['-1', '0']);
+  });
+
+  // A row's own rename, merge and delete buttons have no key to reach them by,
+  // so they ride with their row: Tab from the active one steps through that
+  // row's actions and then leaves the list.
+  it('takes the actions of a row in and out of the tab order with it', () => {
+    const rows = tree([
+      { value: 'garage', actions: 2 },
+      { value: 'kitchen', actions: 2 },
+    ]);
+    syncRovingTabindex(rows, 'tags:kitchen', keyOf, actionsOf);
+    expect([...actionsOf(rows[1])].map((b) => b.getAttribute('tabindex'))).toEqual(['0', '0']);
+    expect([...actionsOf(rows[0])].map((b) => b.getAttribute('tabindex'))).toEqual(['-1', '-1']);
+
+    syncRovingTabindex(rows, 'tags:garage', keyOf, actionsOf);
+    expect([...actionsOf(rows[0])].map((b) => b.getAttribute('tabindex'))).toEqual(['0', '0']);
+    expect([...actionsOf(rows[1])].map((b) => b.getAttribute('tabindex'))).toEqual(['-1', '-1']);
+  });
+});
+
+describe('rovingTarget: rows that open and close', () => {
+  /** Garage open over one child, Kitchen closed over its own, Attic a leaf. */
+  const branch = () =>
+    tree([
+      { value: 'garage', expanded: true },
+      { value: 'shelf', level: 2 },
+      { value: 'kitchen', expanded: false },
+      { value: 'attic' },
+    ]);
+
+  function disclosure(frozen = false) {
+    const toggled: string[] = [];
+    return { toggled, spec: { toggle: (el: HTMLElement) => toggled.push(el.dataset.value!), frozen } };
+  }
+
+  it('opens a closed row with Right, moving nothing', () => {
+    const rows = branch();
+    const { toggled, spec } = disclosure();
+    expect(rovingTarget(press(rows[2], 'ArrowRight'), rows, spec)).toBe(null);
+    expect(toggled).toEqual(['kitchen']);
+  });
+
+  it('steps into an open row with Right — the first child is the next row', () => {
+    const rows = branch();
+    const { toggled, spec } = disclosure();
+    expect(rovingTarget(press(rows[0], 'ArrowRight'), rows, spec)).toBe(rows[1]);
+    expect(toggled).toEqual([]);
+  });
+
+  it('claims Right on a leaf and does nothing with it', () => {
+    const rows = branch();
+    const { toggled, spec } = disclosure();
+    const event = press(rows[3], 'ArrowRight');
+    expect(rovingTarget(event, rows, spec)).toBe(null);
+    expect(event.defaultPrevented).toBe(true);
+    expect(toggled).toEqual([]);
+  });
+
+  it('closes an open row with Left, keeping the stop on it', () => {
+    const rows = branch();
+    const { toggled, spec } = disclosure();
+    expect(rovingTarget(press(rows[0], 'ArrowLeft'), rows, spec)).toBe(null);
+    expect(toggled).toEqual(['garage']);
+  });
+
+  it('steps out to the parent with Left on a row that is not open', () => {
+    const rows = branch();
+    const { toggled, spec } = disclosure();
+    expect(rovingTarget(press(rows[1], 'ArrowLeft'), rows, spec)).toBe(rows[0]);
+    expect(rovingTarget(press(rows[2], 'ArrowLeft'), rows, spec)).toBe(null);
+    expect(toggled).toEqual([]);
+  });
+
+  // A filter draws every node open whatever its own state says, so closing one
+  // would move nothing on the screen.
+  it('steps out rather than closing while the list is drawn open', () => {
+    const rows = branch();
+    const { toggled, spec } = disclosure(true);
+    expect(rovingTarget(press(rows[0], 'ArrowLeft'), rows, spec)).toBe(null);
+    expect(rovingTarget(press(rows[1], 'ArrowLeft'), rows, spec)).toBe(rows[0]);
+    expect(toggled).toEqual([]);
+  });
+
+  it('still walks the list with the keys a flat one answers to', () => {
+    const rows = branch();
+    const { spec } = disclosure();
+    expect(rovingTarget(press(rows[0], 'ArrowDown'), rows, spec)).toBe(rows[1]);
+    expect(rovingTarget(press(rows[3], 'Home'), rows, spec)).toBe(rows[0]);
+    expect(rovingTarget(press(rows[0], 'End'), rows, spec)).toBe(rows[3]);
   });
 });
 

--- a/cards/haventory-card/src/ui/roving-list.ts
+++ b/cards/haventory-card/src/ui/roving-list.ts
@@ -5,8 +5,10 @@
  * tab stop of its own put that vocabulary between the search box and the table:
  * a household with 122 labels made 184 presses of the walk. One row holds
  * `tabindex="0"`, the rest hold `-1`, and Arrow, Home and End move that stop
- * about — the same pattern the locations tree carries, kept here so the three
- * sidebar lists cannot drift apart from each other.
+ * about. The locations tree carries the same pattern one level deeper — its
+ * rows open and close, and Right and Left are what work the twisties, which is
+ * why they are out of the tab order — so it reads from here too, and the four
+ * lists cannot drift apart from each other.
  *
  * The rows are read from the rendered DOM by the caller rather than derived
  * from the data: what is drawn is already exactly what is walkable, and a
@@ -17,8 +19,19 @@
 /** The keys this layer answers to; everything else is the browser's. */
 const MOVE_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End'];
 
-/** Where the stop belongs before anyone has moved it: on what is already picked. */
-const isSelected = (el: HTMLElement) => el.getAttribute('aria-pressed') === 'true';
+/** What a list whose rows open and close adds to them. */
+const DISCLOSURE_KEYS = [...MOVE_KEYS, 'ArrowRight', 'ArrowLeft'];
+
+/**
+ * Where the stop belongs before anyone has moved it: on what is already picked.
+ * A pressable row says so with `aria-pressed` and a row inside a tree with
+ * `aria-selected`; both mean the same thing to whoever arrives on the list.
+ */
+const isSelected = (el: HTMLElement) =>
+  el.getAttribute('aria-pressed') === 'true' || el.getAttribute('aria-selected') === 'true';
+
+/** How deep a row sits, for the step out to its parent. Flat lists are all 1. */
+const levelOf = (el: HTMLElement) => Number(el.getAttribute('aria-level') ?? '1');
 
 /**
  * Leave exactly one row in the tab order, and say which row that is.
@@ -27,32 +40,65 @@ const isSelected = (el: HTMLElement) => el.getAttribute('aria-pressed') === 'tru
  * vocabulary, a cleared filter — hands the stop to the selected row if there is
  * one and to the first row otherwise, so the list is never left without a way
  * in. Null back means the list is empty and there is nothing to hold.
+ *
+ * `riders` names controls that have no key of their own to reach them by and so
+ * travel with their row: the tree's merge, edit and delete buttons are in the
+ * tab order only while their row holds the stop, so Tab from the active row
+ * steps through that row's actions and then leaves the list.
  */
 export function syncRovingTabindex(
   rows: HTMLElement[],
   held: string | null,
   keyOf: (el: HTMLElement) => string,
+  riders?: (el: HTMLElement) => Iterable<HTMLElement>,
 ): string | null {
   if (!rows.length) return null;
   const active = rows.find((el) => keyOf(el) === held) ?? rows.find(isSelected) ?? rows[0];
-  for (const el of rows) el.tabIndex = el === active ? 0 : -1;
+  for (const el of rows) {
+    el.tabIndex = el === active ? 0 : -1;
+    if (riders) for (const rider of riders(el)) rider.tabIndex = el === active ? 0 : -1;
+  }
   return keyOf(active);
 }
 
+/** What a list has to tell this layer before Right and Left mean anything. */
+export interface Disclosure {
+  /** Open or close the node `el` stands for. */
+  toggle: (el: HTMLElement) => void;
+  /**
+   * Every node is drawn open whatever its own state says — a filter is running
+   * — so closing one would move nothing on the screen and Left steps out
+   * instead.
+   */
+  frozen?: boolean;
+}
+
 /**
- * The row a key press moves to, or null when the press is not this list's.
+ * The row a key press moves to, or null when the press moved nothing: it was
+ * not this list's key, or it opened or closed a node rather than travelling.
  *
  * The ends do not wrap: the end of a filter list is an end, and coming back
  * round to the other one reads as the focus having jumped somewhere else. Only
  * a handled key is claimed — Enter and Space stay the row's own, and an
  * unclaimed ArrowDown still scrolls the sidebar.
+ *
+ * With a `disclosure`, Right and Left work the twisties, which is what lets a
+ * tree keep them out of the tab order: Right opens what is closed and steps
+ * into what is open, Left closes what is open and otherwise steps out to the
+ * parent — the nearest earlier row drawn one level shallower.
  */
-export function rovingTarget(e: KeyboardEvent, rows: HTMLElement[]): HTMLElement | null {
-  if (!MOVE_KEYS.includes(e.key)) return null;
+export function rovingTarget(
+  e: KeyboardEvent,
+  rows: HTMLElement[],
+  disclosure?: Disclosure,
+): HTMLElement | null {
+  const keys = disclosure ? DISCLOSURE_KEYS : MOVE_KEYS;
+  if (!keys.includes(e.key)) return null;
   const index = rows.findIndex((el) => el.contains(e.target as Node));
   if (index < 0) return null;
   e.preventDefault();
   e.stopPropagation();
+  const current = rows[index];
   switch (e.key) {
     case 'ArrowDown':
       return rows[Math.min(index + 1, rows.length - 1)];
@@ -62,6 +108,30 @@ export function rovingTarget(e: KeyboardEvent, rows: HTMLElement[]): HTMLElement
       return rows[0];
     case 'End':
       return rows[rows.length - 1];
+    case 'ArrowRight':
+      // Open what is closed; on what is already open, step into it — the first
+      // child is the next row drawn. A leaf has neither and stays put.
+      if (current.getAttribute('aria-expanded') === 'false') {
+        disclosure?.toggle(current);
+        return null;
+      }
+      if (current.getAttribute('aria-expanded') === 'true') return rows[index + 1] ?? null;
+      return null;
+    case 'ArrowLeft':
+      if (current.getAttribute('aria-expanded') === 'true' && !disclosure?.frozen) {
+        disclosure?.toggle(current);
+        return null;
+      }
+      return parentOf(rows, index);
+  }
+  return null;
+}
+
+/** The row one level out from `rows[index]` — the nearest earlier, shallower one. */
+function parentOf(rows: HTMLElement[], index: number): HTMLElement | null {
+  const level = levelOf(rows[index]);
+  for (let i = index - 1; i >= 0; i--) {
+    if (levelOf(rows[i]) < level) return rows[i];
   }
   return null;
 }

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -189,8 +189,9 @@ kept per section in `_facetStop` and reconciled against the rendered rows after 
 render: a held row drawn away — a narrowed vocabulary, a cleared filter — hands the stop to
 the selected row, or to the first one. The section heading, its "+" and the tags any/all
 pair are ordinary tab stops, so a section is still reached, opened and added to without the
-arrows. `ui/roving-list.ts` holds the walk and the key handling; `hv-location-tree` runs the
-same shape for the Locations section behind its own shadow boundary.
+arrows. `ui/roving-list.ts` holds the walk and the key handling, and `hv-location-tree` reads
+the Locations section's from the same module — one level deeper, because a tree's rows also
+open and close.
 
 `hv-filter-panel` answers the same problem by showing less rather than by moving the stop:
 its category and tag groups draw the first `CATEGORY_CHIP_LIMIT` (4) and `TAG_CHIP_LIMIT`
@@ -494,7 +495,10 @@ re-render it — so each container subscribes to `store.state.onChange` itself, 
 | `downscale.ts` | Re-encoding an oversized photo in the browser before it is uploaded: the size and type rules, the capped-edge arithmetic, and the decode/encode seam. Fails open — anything that does not work hands the original file back. |
 | `status.ts` | The item-status vocabulary: the definitions a surface renders from (backend's, or the built-in three until `haventory/config` answers), the label / tone-class / glyph lookups with their fallbacks, the colour and glyph vocabularies the management picker offers, and `renderStatusChip` — one renderer so the mark cannot drift between a table cell and a detail sheet. |
 | `keyboard.ts` | `onEscape()` for the surfaces where Escape means exactly "close", and the platform-correct save-shortcut label. |
-| `roving-list.ts` | A long list of rows as one tab stop: which row holds `tabindex="0"` after a redraw (`syncRovingTabindex`), and which row an Arrow, Home or End press moves to (`rovingTarget`). Used by the sidebar's three facet lists; `hv-location-tree` carries its own copy of the pattern, since a tree also has to open and close nodes. |
+| `roving-list.ts` | A long list of rows as one tab stop: which row holds `tabindex="0"` after a redraw (`syncRovingTabindex`), and which row an Arrow, Home or End press moves to (`rovingTarget`). Used by the sidebar's three facet lists and by `hv-location-tree`, which also passes a `Disclosure` — Right and Left then work the twisties and step out to a parent, which is what keeps the twisties out of the tab order. |
+| `day-offsets.ts` | The quick jumps a forward date is set by: three presets, the "+X days" box, and the rule that an empty box means no date rather than the last one. Drawn by the check-out popover and the editor's inspection field. |
+| `location-picker.ts` | The disclosure around `hv-location-tree`: the trigger, its `aria-expanded` / `aria-controls` pair, the holder, and closing on a pick — with `keepOpenOnSelect` for a surface that picks a set. The trigger's classes and contents and the tree's own properties stay with the host. |
+| `attachments.ts` | The photo figure, the document row and the lightbox host the item editor and the detail sheet share — in particular the one answer both give to a reference whose file the backend does not have. |
 | `plural.ts` | Count agreement for every count string in the card. |
 | `theme.ts` | Whether the card is painted on a light or dark surface, read from HA's own theme variables rather than `prefers-color-scheme`. |
 


### PR DESCRIPTION
## Summary

PR 5 of §6.M4 of `dev/V0_8_0_implementation.md` — FE-DIALOGS-2, -3, -5 and -7a from the
2026-08-22 comment on #231, plus the fold #578's follow-up named.

Five widgets that were written twice now have one definition each:

- **`ui/day-offsets.ts`** (FE-DIALOGS-2) — the three presets, the "+X days" box and the rule
  that an empty box clears the date, drawn once for the check-out popover and the editor's
  inspection field. Test-id stem and touch sizing stay per surface.
- **`ui/location-picker.ts`** (FE-DIALOGS-3) — the trigger, the `aria-expanded` /
  `aria-controls` pair, the holder that outlives the tree in it, the open state and
  close-on-pick, for the editor's location field, the filter panel's Where chip and the
  organize dialog's parent picker and merge target. `keepOpenOnSelect` is the filter panel's
  "adding to a set means picking again" as a flag.
- **`ui/attachments.ts`** (FE-DIALOGS-5) — the photo figure, the document row and the
  lightbox host the editor and the detail sheet share, including the one answer both give to
  a reference whose file the backend does not have (#606).
- **The category list opens in flow** (FE-DIALOGS-7a) — the floating placement, its
  measurement, its two window listeners and its stacking base go; the chevron and the
  show-all it opens stay.
- **`ui/roving-list.ts` grows open/close and parent stepping** — `hv-location-tree`'s own
  `_walk` / `_syncRovingTabindex` / arrow switch fold onto it.

Two behaviour changes ride along, each with its own commit and its own test, per §5: the
category list moving in flow (the owner's §2 item 3 neighbour decision — "keep the control;
stop it floating") and the focus that used to strand on `<body>` after an attachment removal
is confirmed in the editor, which PR 4's report named as belonging here.

Refs #231 #578 #606

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue) — the stranded focus after a
      confirmed attachment removal
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation / tooling / CI — `docs/frontend_architecture.md`'s `ui/` map
- [x] Refactor (no functional change)

## Counting

| | lines |
| --- | ---: |
| production removed | 659 |
| test lines removed | 12 |
| lines added | 1,502 (886 production, 616 test) |

From `git diff --numstat origin/main`. Net production is **+227**, and it is worth saying
where it went rather than rounding it off: the six components lose **638** lines and gain
**309** (net −329), and the four `ui/` modules cost **556**, about a third of that their own
doc blocks. The issue's −125 estimate for the picker assumed an element that also absorbed
`hv-location-tree`'s properties; each of the four pickers passes a different set of them, so
that half of the saving does not exist. The saving that does exist is one definition per
widget, and 128 lines of new module tests that pin the shared rules directly.

## Decisions taken against drifted notes

- **The picker is a controller, not an element** (FE-DLG-3 says "a small element"). Two
  reasons, both in the module's header. Its trigger wears `.field-button`, `hv-chip toggle`
  or `.control` and its holder `.tree-holder` at four different heights — rules that live in
  each host's own stylesheet and do not reach across a shadow boundary, so an element would
  have had to move that CSS or render in light DOM. And an element puts an update boundary
  between the host and the tree, so the tree arrives one microtask after the host's
  `updateComplete` — which is what every one of these surfaces' existing tests awaits; a cut
  whose tests need a second `await` is a cut that rewrote its tests. Written as a controller
  in the `Modal` style, the CSS and the timing are unchanged by construction. This also
  matches PR 3's "functions, not a base class".
- **`hv-bulk-bar` is not an adopter.** The plan lists it, and the #231 comment marks it
  "holder only": it has no trigger, no open state and no close-on-pick — an always-open tree
  in a `.tree-holder` div. Folding it would mean a picker mode with no trigger that is never
  closed, for three lines. Left alone.
- **`.tree-holder` CSS stays per host.** The markup moved; the rule did not, because the four
  holders differ (`max-height` 200/220/220/230, and two carry `margin-top`). Sharing it would
  have meant an override in three hosts and a split of the editor's `.tree-holder,
  .list-holder` rule.

## Behaviour that changed on purpose

1. **The category list opens in flow** under its input, the way the location tree in the same
   form already does, and pushes the form down instead of covering it. Its own commit, its
   own test; the old "floats the list" test is deleted because the behaviour it pinned is
   gone.
2. **Focus is caught after a confirmed attachment removal.** The guard hands focus back to
   the control that raised it — the removed tile's own remove button, still in the document
   when the guard closes and gone a moment later when the strip redraws. The form now puts
   focus back on the name field, the same rescue the lightbox already had. `focusStranded()`
   is the test `DialogFocus` was already making, now named and shared.

Two visual details the folds settle, neither of them a behaviour (the precedent is PR 4's
backdrop alpha): the check-out popover's offset chips gain the editor's `cursor: pointer`,
and the editor's document rows now carry the `missing` class the sheet's do — the editor has
no rule behind it and draws exactly as before.

## How was this tested?

Both gates green before every commit.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1304 passed, 27 skipped),
      `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (25 files, clean)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`
      (76 files, 1968 tests passed), `npm run build`

CI: all 12 checks green, `integration` included.

phacc locally: **not required** — nothing under `custom_components/` or `tests/integration/`
changes, and §6.M4 marks the package "No phacc." CI's `integration` job ran it anyway and is
green.

New and grown tests: `src/ui/day-offsets.test.ts` (8), `src/ui/location-picker.test.ts` (7),
`src/ui/attachments.test.ts` (12), `src/ui/roving-list.test.ts` (+9 for the disclosure and the
riders), `src/ui/dialog-focus.test.ts` (+2 for `focusStranded`), and one case each in the
editor (focus after removal), the filter panel and the organize dialog (where the holder
lands relative to the row its trigger sits in — the one regression this PR nearly shipped and
now pins). No test was rewritten to pass: the only one deleted is the editor's "floats the
list over the form", whose behaviour is gone.

#575's keyboard cases on both roving hosts and #578's one-tab-stop cases are untouched and
are the pin for the roving fold.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — `docs/frontend_architecture.md`'s `ui/` map no
      longer says the tree carries its own copy of the roving pattern, and names the three new
      modules.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
      `docs/data_shapes.md` in sync — no backend change in this PR.
- [x] Essential invariants preserved — card-only refactor; no store, payload or query path
      touched.

## Screenshots (card / UI changes)

None from this session: it has no Home Assistant and never talks to one. The master's live
check and the "Validate locally" block below cover the visible surfaces.

## Follow-ups

- **An orphaned doc block in `hv-item-editor.ts`** — "Checking out asks for a due date;
  checking in just happens…" sits directly above `_renderInspectionOffsets` with no symbol of
  its own, describing the check-out popover instead. Pre-existing on `main`; noticed because
  this PR shortened the block underneath it. Not filed: a comment defect, no user-visible bar.
- **The organize dialog's merge row still carries two inline `style` attributes** — the
  source chip's `text-decoration: line-through` and the row's own
  `display:flex;align-items:center;gap:11px;flex-wrap:wrap`. This PR moved the third
  (`flex:1;min-width:180px` → `.control.grow`) because the picker needs the trigger to carry
  classes and nothing else. Not filed: cosmetic, clears no real-world bar.
- **`hv-checkout-popover` still hand-rolls its own `DialogFocus`, `nextZBase` and scrim**
  rather than taking `ui/modal.ts` — it is anchored to a control rather than centred, which
  is why PR 4 left it out. Not filed: the module would need an anchored mode, and that is a
  package of its own.

## Handover

1. **Merged / left open** — this PR is for the master to review and merge; nothing is left
   open on purpose.
2. **Test this by hand** — `[phone]` the editor's location picker, category list, day offsets
   and photo strip on `/haventory` and in the card: the category list now pushes the form
   down instead of floating over it, which is the one thing a 375 px screen shows differently
   from 0.7.1. `[phone]` the filter panel's Where chip: the tree still opens under the chip
   row, not beside the Area select.
3. **Validate locally** — the numbered list below.
4. **Decisions taken against drifted notes** — the three under "Decisions" above.
5. **Follow-ups** — the three above, none filed.
6. **State left behind** — branch `claude/v0-8-0-m4-shared-widgets`, no assets branch, no HA
   touched. Counting: production removed 659, tests removed 12, added 1,502.

### Validate locally

1. `[browser]` **The editor's category list, at 1920 px and at 375 px, light and dark.**
   Open an item's editor on the card, in the full view and on `/haventory`, focus the
   Category field or press its chevron. Expected: the list opens **under the input, in flow**,
   pushing the fields below it down — no floating layer, and scrolling the surface behind it
   never leaves the list behind. The chevron still shows every category, typing still narrows,
   arrows still walk it, Escape still shuts it before it shuts the form.
2. `[browser]` **The editor's location field on all three hosts.** Press it: the tree opens in
   the box under it, `aria-expanded` flips, picking a location closes it and writes the path
   onto the button. Escape closes the tree first and the form second. Creating the first
   location from an empty tree still files the item in it and closes the tree.
3. `[browser]` **The filter panel's Where chip, desktop panel and phone sheet.** The tree
   opens **under the chip row**, full width, never beside the Area select. Multi-selecting
   leaves it open; "All items" closes it.
4. `[browser]` **The organize dialog's parent picker and merge target.** Parent picker: the
   tree opens under the control inside the location editor; picking a location or an area
   closes it. Merge: the target control keeps the rest of the row beside the struck-through
   source, and its tree opens **under that row**, not inside it.
5. `[browser]` **The check-out popover and the editor's inspection offsets.** Both draw the
   same three chips and the same "+X days" box; pressing a preset marks it, "+X days" takes
   the mark and opens the box, emptying the box clears the date (and disables the popover's
   confirm). At 375 px both grow for a thumb.
6. `[browser]` **The photo strip and the document rows, editor and detail sheet.** Thumbnails
   open the lightbox; a document opens in a new tab. With the media directory moved away,
   every picture draws the dashed "File missing" tile and every document row the amber chip —
   on **both** surfaces, and no broken-image glyph anywhere.
7. `[browser]` **Remove a photo from the editor and press Escape straight after.** Expected:
   the guard closes, the tile goes, and Escape still reaches the form (it asks the discard
   question or closes it) rather than doing nothing — that is the focus rescue.
8. `[browser]` **Keyboard-only through the locations tree**, in the full view's sidebar and in
   the organize dialog: one Tab stop into the tree, ↓↑ walk it, → opens a closed row and steps
   into an open one, ← closes an open row and steps out of a closed one, Home/End reach the
   ends, and Tab from the active row steps through that row's rename/merge/delete before
   leaving the tree. The count from the search box to the first table row is still 31 or
   fewer.
