### PR TITLE
refactor(card): one row chrome for the list row and the table

### DIFF
--- a/cards/haventory-card/src/components/hv-data-table.test.ts
+++ b/cards/haventory-card/src/components/hv-data-table.test.ts
@@ -11,7 +11,7 @@ import {
 import { ACTIONS_COLUMN_WIDTH } from '../store/columns';
 import { MEDIA_NAME_TOKEN_PARAM, MEDIA_SIZE_PARAM, attachmentNameToken } from '../ui/media';
 import { addDays, toIsoDate } from '../ui/relative-time';
-import { rowMenuEntries } from './hv-list-row';
+import { rowMenuEntries } from '../ui/row-chrome';
 import type { HVDataTable } from './hv-data-table';
 import type { OverflowMenuEntry } from './hv-overflow-menu';
 import type { Item, Sort } from '../store/types';

--- a/cards/haventory-card/src/components/hv-data-table.ts
+++ b/cards/haventory-card/src/components/hv-data-table.ts
@@ -15,22 +15,21 @@ import {
   normalizeColumns,
   tableTemplateFor,
 } from '../store/columns';
-import {
-  MEDIA_VARIANT_THUMB,
-  MediaUrls,
-  PictureFallback,
-  ROW_THUMB_SIZE,
-  attachmentNameToken,
-  pictureAlt,
-  pictures,
-} from '../ui/media';
+import { MediaUrls, PictureFallback } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import { getDefaultOrderFor } from '../store/sort';
 import type { AreaRef, StatusDefinition } from '../store/types';
 import type { ColumnKey } from '../store/columns';
-import { isLowStock, rowMenuEntries } from './hv-list-row';
+import {
+  isLowStock,
+  renderNameChips,
+  renderRowThumb,
+  rowChrome,
+  rowKeyAction,
+  rowMenuEntries,
+} from '../ui/row-chrome';
 import './hv-overflow-menu';
-import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
+import { itemStatus, renderStatusChip } from '../ui/status';
 import {
   areaMarkName,
   elideMobilePath,
@@ -54,6 +53,7 @@ export class HVDataTable extends LitElement {
     tokens,
     base,
     chip,
+    rowChrome,
     css`
       :host {
         display: flex;
@@ -180,40 +180,6 @@ export class HVDataTable extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-      }
-      /* The same box the card's list rows draw, so one item is the same size
-         and shape whichever surface it is browsed on. Fixed, so a portrait
-         photo and a landscape one leave the row the same height; and rendered
-         only where there is a picture, so a mostly photo-less inventory does
-         not grow a column of empty squares — and so the name keeps its whole
-         floor on every row that has no photo to spend it on. What the picture
-         costs the name on the rows that do have one, and why the column's floor
-         does not grow to cover it, is on NAME_COLUMN_SIZE. */
-      .thumb {
-        flex: none;
-        width: ${unsafeCSS(ROW_THUMB_SIZE)}px;
-        height: ${unsafeCSS(ROW_THUMB_SIZE)}px;
-        border-radius: 6px;
-        object-fit: cover;
-        background: var(--hv-surface-raised);
-      }
-      /* The tile of a picture whose file the backend no longer has. It keeps the
-         box, because a restore without the media directory leaves every row in
-         this state and a table that dropped them all would hand the width back
-         to the name column row by row. */
-      .thumb.missing {
-        display: inline-grid;
-        place-items: center;
-        box-sizing: border-box;
-        border: 1px dashed var(--hv-divider);
-        color: var(--hv-text-tertiary);
-      }
-      /* Between the failure and the probe's answer. Hidden rather than removed:
-         what an errored <img> draws is the browser's broken-image glyph with the
-         alt text spilling out of a 34px square, which is the whole thing this
-         state exists to keep out of the cell. */
-      .thumb.broken {
-        visibility: hidden;
       }
       /*
        * A phone shows about a quarter of this table — the template's floor is
@@ -489,51 +455,6 @@ export class HVDataTable extends LitElement {
   }
 
   /**
-   * A row's leading thumbnail: the item's first picture, or nothing.
-   *
-   * Asks for the `thumb` variant, so a 36px tile costs a few KB rather than the
-   * whole stored file; the backend serves the original whenever it cannot make
-   * one, so this never decides whether the picture appears. `loading="lazy"`
-   * and `decoding="async"` still matter — a long table would otherwise fetch
-   * and decode every row's tile at once.
-   *
-   * A file the backend no longer has is answered from the failure rather than
-   * probed for up front — see `PictureFallback`.
-   */
-  private _renderThumb(item: Item) {
-    const first = pictures(item.attachments)[0];
-    if (!first) return null;
-    const state = this._thumbs.state(item.id, first.id);
-    if (state === 'missing') {
-      return html`<span
-        class="thumb missing"
-        data-testid="row-thumb-missing"
-        role="img"
-        aria-label=${t('hv.term.fileMissing')}
-        title=${t('hv.term.fileMissing')}
-        >${icon('camera', 18)}</span
-      >`;
-    }
-    const src = this._urls.get(
-      item.id,
-      first.id,
-      attachmentNameToken(first),
-      MEDIA_VARIANT_THUMB,
-    );
-    if (!src) return null;
-    return html`<img
-      class=${state === 'errored' ? 'thumb broken' : 'thumb'}
-      data-testid="row-thumb"
-      src=${src}
-      alt=${pictureAlt(item.name, 0, 1)}
-      loading="lazy"
-      decoding="async"
-      @error=${() => this._thumbs.noteError(item.id, first.id)}
-      @load=${() => this._thumbs.noteLoad(item.id, first.id)}
-    />`;
-  }
-
-  /**
    * `row`, `columnheader` and `cell` are only meaningful under a table, grid or
    * treegrid; with no such ancestor the whole structure is thrown away and a
    * screen reader reads the rows as a run of text. The host is the only element
@@ -607,43 +528,15 @@ export class HVDataTable extends LitElement {
   }
 
   /**
-   * The rows carry `tabindex="0"`, so the keyboard can reach them; without this
-   * there is nothing to do once they are reached, and every item on this
-   * surface is behind a mouse.
-   *
-   * Same keys and same meanings as the card's list row, so the two surfaces do
-   * not teach two vocabularies for the same four actions. Enter follows this
-   * table's own row click: in selection mode a click selects rather than opens,
-   * and the keyboard has to land on whatever the pointer lands on.
-   *
-   * A key pressed on a control inside the row belongs to that control. Without
-   * the guard Enter on Edit would open the editor and then fire the row's own
-   * open on top of it, and Delete anywhere in the action group would ask to
-   * delete the item.
+   * Enter follows this table's own row click: in selection mode a click selects
+   * rather than opens, and the keyboard has to land on whatever the pointer
+   * lands on. The rest of the vocabulary is `rowKeyAction`'s.
    */
   private _onRowKeydown(e: KeyboardEvent, item: Item) {
-    if (e.target !== e.currentTarget) return;
-    switch (e.key) {
-      case 'Enter':
-        e.preventDefault();
-        this._emit(this.selectable ? 'toggle-select' : 'open-item', { itemId: item.id });
-        break;
-      case 'Delete':
-        e.preventDefault();
-        this._emit('request-delete', { itemId: item.id });
-        break;
-      case '+':
-      case '=':
-      case 'Add':
-        e.preventDefault();
-        this._emit('increment', { itemId: item.id });
-        break;
-      case '-':
-      case 'Subtract':
-        e.preventDefault();
-        this._emit('decrement', { itemId: item.id });
-        break;
-    }
+    const action = rowKeyAction(e);
+    if (!action) return;
+    const name = action === 'open-item' && this.selectable ? 'toggle-select' : action;
+    this._emit(name, { itemId: item.id });
   }
 
   private _cell(item: Item, key: ColumnKey) {
@@ -731,18 +624,8 @@ export class HVDataTable extends LitElement {
     const columns = this._columns;
     // The name cell's chip is the flagged-status signal for a table that has no
     // Status column. With the column shown it would put the same word twice on
-    // one row, so the column takes over and the chip stands down. The
-    // checked-out chip below has nothing to stand down for — the Due column
-    // carries a date, not the word — so it names an overdue loan either way,
-    // which is the only thing left saying so once the table is scrolled
-    // sideways or pinned to its name column.
+    // one row, so the column takes over and the chip stands down.
     const statusColumn = columns.includes('status');
-    // Low stands down for Checked out in the same cell, the way a phone row's
-    // one line already picks the most interrupting thing it has to say: both
-    // chips are unshrinkable, and together they take 138px of a 250px track,
-    // which leaves the name too short to tell two items apart. Who has the item
-    // outranks how many are left, and the Qty column still draws a low count in
-    // amber.
     const template = tableTemplateFor(columns, { selectable: this.selectable });
     const loadedIds = this.items.map((i) => i.id);
     const selectedCount = loadedIds.filter((id) => this.selection.has(id)).length;
@@ -813,30 +696,25 @@ export class HVDataTable extends LitElement {
                       >`
                     : null}
                   <span class="name-cell" role="cell">
-                    ${this._renderThumb(item)}
+                    ${renderRowThumb(item, this._urls, this._thumbs)}
                     <span class="name" data-testid="table-name" title=${item.name}>${item.name}</span>
-                    ${isLowStock(item) && !item.checked_out
-                      ? html`<span
-                          class="hv-chip warning"
-                          data-testid="table-low"
-                          aria-label=${t('hv.term.lowStock')}
-                          >${t('hv.term.low')}</span
-                        >`
-                      : null}
-                    ${!statusColumn && itemStatus(item) !== DEFAULT_STATUS
-                      ? renderStatusChip(itemStatus(item), this.statuses, {
-                          testid: 'table-status',
-                        })
-                      : null}
-                    ${item.checked_out
-                      ? html`<span
-                          class="hv-chip ${isOverdue(item.due_date) ? 'error' : 'state'}"
-                          data-testid="table-checked-out"
-                          >${isOverdue(item.due_date)
-                            ? t('hv.term.overdue')
-                            : t('hv.term.checkedOut')}</span
-                        >`
-                      : null}
+                    ${renderNameChips(item, this.statuses, {
+                      prefix: 'table',
+                      // Low stands down for Checked out in this one cell, the
+                      // way a phone row's single line already picks the most
+                      // interrupting thing it has to say: both chips are
+                      // unshrinkable, and together they take 138px of a 250px
+                      // track, which leaves the name too short to tell two items
+                      // apart. Who has the item outranks how many are left, and
+                      // the Qty column still draws a low count in amber.
+                      lowChip: !item.checked_out,
+                      statusChip: !statusColumn,
+                      // The Due column carries the date, so the chip only has to
+                      // name the state — and it is the one thing still saying so
+                      // once the table is scrolled sideways or pinned to its
+                      // name column.
+                      overdueText: 'overdue',
+                    })}
                   </span>
                   ${columns.map((key) => this._cell(item, key))}
                   <span class="actions" role="cell">

--- a/cards/haventory-card/src/components/hv-detail-sheet.ts
+++ b/cards/haventory-card/src/components/hv-detail-sheet.ts
@@ -10,7 +10,7 @@ import { customFieldLabel } from '../ui/field-label';
 import { canBumpReminder, hasReminder, isReminderDue, reminderSummary } from '../ui/reminder';
 import { inferType } from '../ui/item-form';
 import { DEFAULT_STATUS, itemStatus, renderStatusChip } from '../ui/status';
-import { isLowStock } from './hv-list-row';
+import { isLowStock } from '../ui/row-chrome';
 import { areaMarkName, itemPathParts, pathTitle, renderAreaChip } from '../ui/location-path';
 import {
   MediaUrls,

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -266,6 +266,23 @@ describe('hv-list-row: interaction', () => {
     expect(seen).toEqual(['open-item', 'request-delete', 'increment', 'decrement']);
   });
 
+  // Enter on Edit already opens the editor, and an open ⋮ menu holds the
+  // keyboard: the row answering the same press would open the item behind the
+  // menu, and Delete anywhere in that group would ask to delete it.
+  it('leaves a key pressed on a control inside the row to that control', async () => {
+    const el = await mount({ id: 'item-1' });
+    const seen = captured(el, ['open-item', 'request-delete', 'increment', 'decrement']);
+
+    for (const testid of ['row-edit', 'row-menu']) {
+      const control = q(el, `[data-testid="${testid}"]`) as HTMLElement;
+      for (const key of ['Enter', 'Delete', '+', '-']) {
+        control.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, composed: true }));
+      }
+    }
+
+    expect(seen).toEqual([]);
+  });
+
   it('offers edit and row-menu actions, hidden on touch by the mobile attribute', async () => {
     const desktop = await mount({ id: '1' });
     expect(q(desktop, '[data-testid="row-edit"]')).toBeTruthy();

--- a/cards/haventory-card/src/components/hv-list-row.test.ts
+++ b/cards/haventory-card/src/components/hv-list-row.test.ts
@@ -10,7 +10,7 @@ import {
   q,
 } from '../test.utils';
 import { MEDIA_NAME_TOKEN_PARAM, MEDIA_SIZE_PARAM, attachmentNameToken } from '../ui/media';
-import { isLowStock, rowMenuEntries } from './hv-list-row';
+import { rowMenuEntries } from '../ui/row-chrome';
 import { addDays, toIsoDate } from '../ui/relative-time';
 import type { HVListRow } from './hv-list-row';
 import type { Item } from '../store/types';
@@ -25,17 +25,6 @@ function captured(el: HVListRow, names: string[]) {
   for (const name of names) el.addEventListener(name, () => seen.push(name));
   return seen;
 }
-
-describe('isLowStock', () => {
-  it('treats a null threshold as never low', () => {
-    expect(isLowStock(makeItem({ quantity: 0, low_stock_threshold: null }))).toBe(false);
-  });
-
-  it('is low at or below the threshold', () => {
-    expect(isLowStock(makeItem({ quantity: 3, low_stock_threshold: 3 }))).toBe(true);
-    expect(isLowStock(makeItem({ quantity: 4, low_stock_threshold: 3 }))).toBe(false);
-  });
-});
 
 describe('hv-list-row: content', () => {
   it('shows the name over location and category', async () => {

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -13,56 +13,20 @@ import {
 import { icon } from '../ui/icons';
 import { onDayChange } from '../ui/day-clock';
 import { formatDate, isDue, isOverdue } from '../ui/relative-time';
-import { itemStatus, renderStatusChip, statusLabel } from '../ui/status';
+import { itemStatus, statusLabel } from '../ui/status';
 import {
-  MEDIA_VARIANT_THUMB,
-  MediaUrls,
-  PictureFallback,
-  ROW_THUMB_SIZE,
-  ROW_THUMB_SIZE_TOUCH,
-  attachmentNameToken,
-  manuals,
-  pictureAlt,
-  pictures,
-} from '../ui/media';
+  isLowStock,
+  renderNameChips,
+  renderRowThumb,
+  rowChrome,
+  rowKeyAction,
+  rowMenuEntries,
+} from '../ui/row-chrome';
+import { MediaUrls, PictureFallback, ROW_THUMB_SIZE_TOUCH, manuals } from '../ui/media';
 import type { MediaBindings } from '../ui/media';
 import type { TemplateResult } from 'lit';
 import type { AreaRef, Item, StatusDefinition } from '../store/types';
 import './hv-overflow-menu';
-import type { OverflowMenuEntry } from './hv-overflow-menu';
-
-/** True when an item is at or under its low-stock threshold. */
-export function isLowStock(item: Item): boolean {
-  return typeof item.low_stock_threshold === 'number' && item.quantity <= item.low_stock_threshold;
-}
-
-/**
- * What a row's ⋮ offers, which depends on whether the item is out and whether
- * it has a due date.
- *
- * Shared with the full view's table rows: one list, one set of ids, and the
- * hosts' existing `row-action` handlers answer both surfaces.
- */
-export function rowMenuEntries(item: Item): OverflowMenuEntry[] {
-  if (item.checked_out) {
-    return [
-      { id: 'check-in', label: t('hv.action.checkIn'), glyph: 'account' },
-      {
-        id: 'set-due-date',
-        label: item.due_date ? t('hv.row.menu.changeDueDate') : t('hv.row.menu.setDueDate'),
-        glyph: 'calendar',
-      },
-      { divider: true },
-      { id: 'delete', label: t('hv.action.deleteItem'), glyph: 'del' },
-    ];
-  }
-  return [
-    { id: 'check-out', label: t('hv.action.checkOutEllipsis'), glyph: 'account' },
-    { id: 'edit', label: t('hv.action.edit'), glyph: 'pencil' },
-    { divider: true },
-    { id: 'delete', label: t('hv.action.deleteItem'), glyph: 'del' },
-  ];
-}
 
 /**
  * One row of the standard card list.
@@ -78,6 +42,7 @@ export class HVListRow extends LitElement {
     tokens,
     base,
     chip,
+    rowChrome,
     css`
       :host {
         display: block;
@@ -114,40 +79,11 @@ export class HVListRow extends LitElement {
         flex: 1;
         min-width: 0;
       }
-      /* A fixed box, so a portrait photo and a landscape one leave the row the
-         same height and the list keeps a single rhythm. Rows without a picture
-         render nothing here rather than a placeholder: a mostly photo-less
-         inventory would otherwise grow a column of empty squares. */
-      .thumb {
-        flex: none;
-        width: ${unsafeCSS(ROW_THUMB_SIZE)}px;
-        height: ${unsafeCSS(ROW_THUMB_SIZE)}px;
-        border-radius: 6px;
-        object-fit: cover;
-        background: var(--hv-surface-raised);
-      }
+      /* A finger has the width for a larger tile, and one column of rows to
+         spend it on. */
       :host([mobile]) .thumb {
         width: ${unsafeCSS(ROW_THUMB_SIZE_TOUCH)}px;
         height: ${unsafeCSS(ROW_THUMB_SIZE_TOUCH)}px;
-      }
-      /* The tile of a picture whose file the backend no longer has. It keeps
-         the box, because a restore without the media directory leaves every row
-         in this state and a list that dropped them all would reflow entirely.
-         The glyph says a picture belongs here; the title and the label say why
-         it is not being shown. */
-      .thumb.missing {
-        display: inline-grid;
-        place-items: center;
-        box-sizing: border-box;
-        border: 1px dashed var(--hv-divider);
-        color: var(--hv-text-tertiary);
-      }
-      /* Between the failure and the probe's answer. Hidden rather than removed:
-         what an errored <img> draws is the browser's broken-image glyph with the
-         alt text spilling out of a 34px square, which is the whole thing this
-         state exists to keep off the row. */
-      .thumb.broken {
-        visibility: hidden;
       }
       /* A mark, not a chip: that an item has a manual is a fact about it, not
          a state anyone has to act on, so it stays out of the hue vocabulary the
@@ -434,86 +370,15 @@ export class HVListRow extends LitElement {
     this._urls.configure(this.media?.sign ?? null);
   }
 
-  /**
-   * The row's leading thumbnail: the item's first picture, or nothing.
-   *
-   * Asks for the `thumb` variant, so the tile costs a few KB rather than the
-   * whole stored file; the backend serves the original whenever it cannot make
-   * one, so this never decides whether the picture appears. `loading="lazy"`
-   * and `decoding="async"` still matter — a long list would otherwise fetch and
-   * decode everything at once.
-   *
-   * A file the backend no longer has is answered from the failure rather than
-   * probed for up front — see `PictureFallback`.
-   */
-  private _renderThumb() {
-    const first = pictures(this.item.attachments)[0];
-    if (!first) return null;
-    const state = this._thumbs.state(this.item.id, first.id);
-    if (state === 'missing') {
-      return html`<span
-        class="thumb missing"
-        data-testid="row-thumb-missing"
-        role="img"
-        aria-label=${t('hv.term.fileMissing')}
-        title=${t('hv.term.fileMissing')}
-        >${icon('camera', 18)}</span
-      >`;
-    }
-    const src = this._urls.get(
-      this.item.id,
-      first.id,
-      attachmentNameToken(first),
-      MEDIA_VARIANT_THUMB,
-    );
-    if (!src) return null;
-    return html`<img
-      class=${state === 'errored' ? 'thumb broken' : 'thumb'}
-      data-testid="row-thumb"
-      src=${src}
-      alt=${pictureAlt(this.item.name, 0, 1)}
-      loading="lazy"
-      decoding="async"
-      @error=${() => this._thumbs.noteError(this.item.id, first.id)}
-      @load=${() => this._thumbs.noteLoad(this.item.id, first.id)}
-    />`;
-  }
-
   private _emit(name: string, detail: Record<string, unknown> = {}) {
     this.dispatchEvent(
       new CustomEvent(name, { detail: { itemId: this.item.id, ...detail }, bubbles: true, composed: true }),
     );
   }
 
-  /**
-   * A key pressed on a control inside the row belongs to that control: Enter on
-   * Edit opens the editor, and an open ⋮ menu holds the keyboard. Without the
-   * guard the row answers those presses too — opening the item behind the menu,
-   * or asking to delete it.
-   */
   private _onKeydown = (e: KeyboardEvent) => {
-    if (e.target !== e.currentTarget) return;
-    switch (e.key) {
-      case 'Enter':
-        e.preventDefault();
-        this._emit('open-item');
-        break;
-      case 'Delete':
-        e.preventDefault();
-        this._emit('request-delete');
-        break;
-      case '+':
-      case '=':
-      case 'Add':
-        e.preventDefault();
-        this._emit('increment');
-        break;
-      case '-':
-      case 'Subtract':
-        e.preventDefault();
-        this._emit('decrement');
-        break;
-    }
+    const action = rowKeyAction(e);
+    if (action) this._emit(action);
   };
 
   /**
@@ -648,7 +513,7 @@ export class HVListRow extends LitElement {
         @keydown=${this._onKeydown}
         @click=${() => this._emit('open-item')}
       >
-        ${this._renderThumb()}
+        ${renderRowThumb(item, this._urls, this._thumbs)}
         <span class="names">
           <span class="name-line">
             <span class="name" data-testid="row-name" title=${item.name}>${item.name}</span>
@@ -704,24 +569,17 @@ export class HVListRow extends LitElement {
                       >`}
           </span>
         </span>
-        ${!this.mobile && low
-          ? html`<span class="hv-chip warning" data-testid="row-low" aria-label=${t('hv.term.lowStock')}
-              >${t('hv.term.low')}</span
-            >`
-          : null}
-        ${!this.mobile && flagged
-          ? renderStatusChip(status, this.statuses, { testid: 'row-status' })
-          : null}
-        ${!this.mobile && item.checked_out
-          ? html`<span
-              class="hv-chip ${overdue ? 'error' : 'state'}"
-              data-testid="row-checked-out"
-            >
-              ${overdue
-                ? t('hv.term.overdueOn', { date: formatDate(item.due_date) })
-                : t('hv.term.checkedOut')}
-            </span>`
-          : null}
+        ${this.mobile
+          ? // The phone row's one line has said all of this already.
+            null
+          : renderNameChips(item, this.statuses, {
+              prefix: 'row',
+              // Every chip is on offer here: they hang off the row beside the
+              // name rather than sharing a cell with it, so none of them is
+              // taking another's room. Nothing else on the row carries the due
+              // date either, so an overdue loan spells it out.
+              overdueText: 'overdueOn',
+            })}
         ${!this.mobile && inspectionDue
           ? html`<span class="hv-chip warning" data-testid="row-inspection-due">
               ${t('hv.term.inspectionDue')}

--- a/cards/haventory-card/src/components/hv-list-row.ts
+++ b/cards/haventory-card/src/components/hv-list-row.ts
@@ -485,7 +485,14 @@ export class HVListRow extends LitElement {
     );
   }
 
+  /**
+   * A key pressed on a control inside the row belongs to that control: Enter on
+   * Edit opens the editor, and an open ⋮ menu holds the keyboard. Without the
+   * guard the row answers those presses too — opening the item behind the menu,
+   * or asking to delete it.
+   */
   private _onKeydown = (e: KeyboardEvent) => {
+    if (e.target !== e.currentTarget) return;
     switch (e.key) {
       case 'Enter':
         e.preventDefault();

--- a/cards/haventory-card/src/ui/row-chrome.test.ts
+++ b/cards/haventory-card/src/ui/row-chrome.test.ts
@@ -1,0 +1,263 @@
+import { html, render } from 'lit';
+import {
+  isLowStock,
+  renderNameChips,
+  renderRowThumb,
+  rowKeyAction,
+  rowMenuEntries,
+} from './row-chrome';
+import { MEDIA_NAME_TOKEN_PARAM, MEDIA_SIZE_PARAM, MediaUrls, PictureFallback, attachmentNameToken } from './media';
+import { makeAttachment, makeItem } from '../test.utils';
+import type { NameChipOptions } from './row-chrome';
+import type { Item, StatusDefinition } from '../store/types';
+
+/** A host that only has to answer `requestUpdate`, which is all these need. */
+function host() {
+  return { requestUpdate() {} };
+}
+
+function draw(template: unknown) {
+  const box = document.createElement('div');
+  render(html`${template}`, box);
+  return box;
+}
+
+const testids = (box: HTMLElement) =>
+  [...box.querySelectorAll('[data-testid]')].map((el) => el.getAttribute('data-testid'));
+
+/** A keydown as a row receives it: on the row itself, or on a control inside it. */
+function press(key: string, from: 'row' | 'control' = 'row'): KeyboardEvent {
+  const row = document.createElement('div');
+  const inner = document.createElement('button');
+  row.append(inner);
+  const e = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  Object.defineProperty(e, 'currentTarget', { value: row });
+  Object.defineProperty(e, 'target', { value: from === 'row' ? row : inner });
+  return e;
+}
+
+describe('isLowStock', () => {
+  it('treats a null threshold as never low', () => {
+    expect(isLowStock(makeItem({ quantity: 0, low_stock_threshold: null }))).toBe(false);
+  });
+
+  it('is low at or below the threshold', () => {
+    expect(isLowStock(makeItem({ quantity: 3, low_stock_threshold: 3 }))).toBe(true);
+    expect(isLowStock(makeItem({ quantity: 4, low_stock_threshold: 3 }))).toBe(false);
+  });
+});
+
+describe('rowMenuEntries', () => {
+  const ids = (item: Item) =>
+    rowMenuEntries(item)
+      .filter((e): e is Extract<ReturnType<typeof rowMenuEntries>[number], { id: string }> =>
+        'id' in e,
+      )
+      .map((e) => e.id);
+
+  it('offers the way out of a loan for an item that is out', () => {
+    expect(ids(makeItem({ checked_out: true }))).toEqual(['check-in', 'set-due-date', 'delete']);
+  });
+
+  it('offers the way into one for an item on the shelf', () => {
+    expect(ids(makeItem())).toEqual(['check-out', 'edit', 'delete']);
+  });
+
+  // The one entry whose label depends on the item rather than on its state.
+  it('names the due-date entry for what pressing it would do', () => {
+    const labels = (item: Item) =>
+      rowMenuEntries(item)
+        .filter((e): e is Extract<ReturnType<typeof rowMenuEntries>[number], { id: string }> =>
+          'id' in e,
+        )
+        .find((e) => e.id === 'set-due-date')?.label;
+
+    expect(labels(makeItem({ checked_out: true }))).toBe('Set due date…');
+    expect(labels(makeItem({ checked_out: true, due_date: '2099-01-01' }))).toBe('Change due date…');
+  });
+});
+
+describe('rowKeyAction', () => {
+  it('names the four actions a row answers to', () => {
+    expect(rowKeyAction(press('Enter'))).toBe('open-item');
+    expect(rowKeyAction(press('Delete'))).toBe('request-delete');
+    expect(rowKeyAction(press('+'))).toBe('increment');
+    expect(rowKeyAction(press('-'))).toBe('decrement');
+  });
+
+  it('takes the numpad and unshifted spellings of the same two keys', () => {
+    expect(rowKeyAction(press('='))).toBe('increment');
+    expect(rowKeyAction(press('Add'))).toBe('increment');
+    expect(rowKeyAction(press('Subtract'))).toBe('decrement');
+  });
+
+  it('claims a key it acts on, and leaves every other one to the browser', () => {
+    const enter = press('Enter');
+    rowKeyAction(enter);
+    expect(enter.defaultPrevented).toBe(true);
+
+    const tab = press('Tab');
+    expect(rowKeyAction(tab)).toBe(null);
+    expect(tab.defaultPrevented).toBe(false);
+  });
+
+  // Enter on Edit is that button's, and an open ⋮ menu holds the keyboard.
+  it('leaves a key pressed on a control inside the row to that control', () => {
+    for (const key of ['Enter', 'Delete', '+', '-']) {
+      const e = press(key, 'control');
+      expect(rowKeyAction(e), key).toBe(null);
+      expect(e.defaultPrevented, key).toBe(false);
+    }
+  });
+});
+
+describe('renderNameChips', () => {
+  const rowOptions = (patch: Partial<NameChipOptions> = {}): NameChipOptions => ({
+    prefix: 'row',
+    overdueText: 'overdueOn',
+    ...patch,
+  });
+  const tableOptions = (patch: Partial<NameChipOptions> = {}): NameChipOptions => ({
+    prefix: 'table',
+    overdueText: 'overdue',
+    ...patch,
+  });
+  const flagged: StatusDefinition[] = [
+    { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
+    { slug: 'missing', label: 'Missing', order: 1, color: 'amber', icon: 'alert' },
+  ];
+  const everything = {
+    quantity: 1,
+    low_stock_threshold: 5,
+    status: 'missing',
+    checked_out: true,
+  };
+
+  it('says the three things in the order they interrupt in', () => {
+    const box = draw(renderNameChips(makeItem(everything), flagged, rowOptions()));
+    expect(testids(box)).toEqual(['row-low', 'row-status', 'row-checked-out']);
+  });
+
+  // Same chips, same order, the surface's own names — the browser harnesses
+  // locate the two sets separately.
+  it("carries each surface's own test ids", () => {
+    const box = draw(renderNameChips(makeItem(everything), flagged, tableOptions()));
+    expect(testids(box)).toEqual(['table-low', 'table-status', 'table-checked-out']);
+  });
+
+  it('says nothing at all about an item with nothing to report', () => {
+    expect(testids(draw(renderNameChips(makeItem(), flagged, rowOptions())))).toEqual([]);
+  });
+
+  it('drops a chip the surface has no room for', () => {
+    const box = draw(
+      renderNameChips(makeItem(everything), flagged, tableOptions({ lowChip: false, statusChip: false })),
+    );
+    expect(testids(box)).toEqual(['table-checked-out']);
+  });
+
+  // The card's row has nowhere else to put the date; the table's Due column
+  // already carries it.
+  it('spells an overdue loan the way its surface asks for', () => {
+    const overdue = makeItem({ checked_out: true, due_date: '2020-01-01' });
+
+    const withDate = draw(renderNameChips(overdue, flagged, rowOptions()));
+    expect(withDate.querySelector('[data-testid="row-checked-out"]')?.textContent?.trim()).toBe(
+      'Overdue · Jan 1, 2020',
+    );
+
+    const bare = draw(renderNameChips(overdue, flagged, tableOptions()));
+    expect(bare.querySelector('[data-testid="table-checked-out"]')?.textContent?.trim()).toBe(
+      'Overdue',
+    );
+  });
+
+  it('leaves a loan that still has time to run in the calm tone', () => {
+    const box = draw(
+      renderNameChips(makeItem({ checked_out: true, due_date: '2099-01-01' }), flagged, rowOptions()),
+    );
+    const chip = box.querySelector('[data-testid="row-checked-out"]');
+    expect(chip?.classList.contains('state')).toBe(true);
+    expect(chip?.classList.contains('error')).toBe(false);
+    expect(chip?.textContent?.trim()).toBe('Checked out');
+  });
+});
+
+describe('renderRowThumb', () => {
+  const picture = makeAttachment({ id: 'att-1' });
+  const item = makeItem({ id: 'i-1', name: 'Cordless drill', attachments: [picture] });
+
+  /**
+   * The tile once the signing and the presence probe have both landed.
+   *
+   * Each render asks one more question — sign the tile's URL, sign the one the
+   * probe reads, then run the probe — and a component gets those turns from its
+   * host's `requestUpdate`. Here they are taken by hand.
+   */
+  async function settled(urls: MediaUrls, thumbs: PictureFallback) {
+    let box = draw(null);
+    for (let turn = 0; turn < 4; turn += 1) {
+      box = draw(renderRowThumb(item, urls, thumbs));
+      await new Promise((done) => setTimeout(done, 0));
+    }
+    return box;
+  }
+
+  /** Signs immediately, so one turn is enough for the URL to be there. */
+  function signed(fetch?: () => Promise<{ ok: boolean; status: number }>) {
+    const h = host();
+    const urls = new MediaUrls(h, fetch ? { fetch } : {});
+    urls.configure(async (path: string) => `${path}&authSig=test`);
+    return { urls, thumbs: new PictureFallback(h, urls) };
+  }
+
+  it('renders nothing for an item with no picture', () => {
+    const { urls, thumbs } = signed();
+    expect(renderRowThumb(makeItem(), urls, thumbs)).toBe(null);
+  });
+
+  it('renders nothing while there is no signed URL to show', () => {
+    const urls = new MediaUrls(host());
+    expect(renderRowThumb(item, urls, new PictureFallback(host(), urls))).toBe(null);
+  });
+
+  // `size=thumb`: a 34px tile served the stored file is up to 8 MB of download
+  // per row. The parameter is signed with the path, so it has to be on the URL
+  // before signing rather than appended to a signed one.
+  it('asks for the thumb variant of the first picture', async () => {
+    const { urls, thumbs } = signed();
+    renderRowThumb(item, urls, thumbs);
+    await Promise.resolve();
+
+    const img = draw(renderRowThumb(item, urls, thumbs)).querySelector('img');
+    expect(img?.getAttribute('data-testid')).toBe('row-thumb');
+    expect(img?.getAttribute('src')).toBe(
+      `/api/haventory/media/i-1/att-1?${MEDIA_NAME_TOKEN_PARAM}=${attachmentNameToken(picture)}`
+        + `&${MEDIA_SIZE_PARAM}=thumb&authSig=test`,
+    );
+    expect(img?.getAttribute('alt')).toBe('Photo of Cordless drill');
+    expect(img?.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('keeps the box for a picture whose file the backend no longer has', async () => {
+    const { urls, thumbs } = signed(async () => ({ ok: false, status: 404 }));
+    thumbs.noteError('i-1', 'att-1');
+
+    const mark = (await settled(urls, thumbs)).querySelector(
+      '[data-testid="row-thumb-missing"]',
+    );
+    expect(mark?.classList.contains('missing')).toBe(true);
+    expect(mark?.getAttribute('aria-label')).toBe('File missing');
+  });
+
+  // An inconclusive probe is not proof the picture is gone, so the tile stays
+  // an image and only hides the browser's broken-image glyph.
+  it('hides a tile the probe cannot explain rather than marking it missing', async () => {
+    const { urls, thumbs } = signed(async () => ({ ok: false, status: 500 }));
+    thumbs.noteError('i-1', 'att-1');
+
+    const box = await settled(urls, thumbs);
+    expect(box.querySelector('[data-testid="row-thumb-missing"]')).toBe(null);
+    expect(box.querySelector('img')?.classList.contains('broken')).toBe(true);
+  });
+});

--- a/cards/haventory-card/src/ui/row-chrome.ts
+++ b/cards/haventory-card/src/ui/row-chrome.ts
@@ -1,0 +1,252 @@
+import { css, html, unsafeCSS } from 'lit';
+import type { TemplateResult } from 'lit';
+import { t } from '../i18n';
+import { icon } from './icons';
+import { formatDate, isOverdue } from './relative-time';
+import { DEFAULT_STATUS, itemStatus, renderStatusChip } from './status';
+import {
+  MEDIA_VARIANT_THUMB,
+  ROW_THUMB_SIZE,
+  attachmentNameToken,
+  pictureAlt,
+  pictures,
+} from './media';
+import type { MediaUrls, PictureFallback } from './media';
+import type { Item, StatusDefinition } from '../store/types';
+import type { OverflowMenuEntry } from '../components/hv-overflow-menu';
+
+/**
+ * What a row of items is made of, on the card's own `hv-list-row` and on the
+ * full view's `hv-data-table`.
+ *
+ * Both answer the same questions about an item — what it is called, what it is
+ * flagged with, what can be done to it — and have to answer them identically:
+ * one tile for a picture and one mark for a picture whose file is gone, one
+ * order for the low / status / loan chips, one set of keys, one ⋮ list.
+ *
+ * What each surface asks for stays a parameter: the test ids, because the
+ * browser harnesses locate `row-*` and `table-*` separately and one renderer is
+ * what keeps them byte-identical; which chips it has room for; and whether an
+ * overdue loan spells its date. The quantity stepper, the inspection chip, the
+ * tags cell and the card row's phone line stay with their surfaces — those are
+ * the parts that genuinely differ.
+ */
+
+/** True when an item is at or under its low-stock threshold. */
+export function isLowStock(item: Item): boolean {
+  return typeof item.low_stock_threshold === 'number' && item.quantity <= item.low_stock_threshold;
+}
+
+/**
+ * What a row's ⋮ offers, which depends on whether the item is out and whether
+ * it has a due date.
+ *
+ * One list and one set of ids for both surfaces, so the hosts' existing
+ * `row-action` handlers answer either of them.
+ */
+export function rowMenuEntries(item: Item): OverflowMenuEntry[] {
+  if (item.checked_out) {
+    return [
+      { id: 'check-in', label: t('hv.action.checkIn'), glyph: 'account' },
+      {
+        id: 'set-due-date',
+        label: item.due_date ? t('hv.row.menu.changeDueDate') : t('hv.row.menu.setDueDate'),
+        glyph: 'calendar',
+      },
+      { divider: true },
+      { id: 'delete', label: t('hv.action.deleteItem'), glyph: 'del' },
+    ];
+  }
+  return [
+    { id: 'check-out', label: t('hv.action.checkOutEllipsis'), glyph: 'account' },
+    { id: 'edit', label: t('hv.action.edit'), glyph: 'pencil' },
+    { divider: true },
+    { id: 'delete', label: t('hv.action.deleteItem'), glyph: 'del' },
+  ];
+}
+
+/**
+ * The tile a row leads with, at one size on every surface that draws one.
+ *
+ * A fixed box, so a portrait photo and a landscape one leave the row the same
+ * height and a list keeps a single rhythm; and drawn only where there is a
+ * picture, so a mostly photo-less inventory does not grow a column of empty
+ * squares. The table reserves exactly this much inside its name column — what
+ * the tile costs the name there, and why the column's floor does not grow to
+ * cover it, is on `NAME_COLUMN_SIZE`.
+ *
+ * Usage: `static styles = [tokens, base, chip, rowChrome, css\`...\`]`. A
+ * surface that draws the tile at another size overrides the box on its own
+ * rule.
+ */
+export const rowChrome = css`
+  .thumb {
+    flex: none;
+    width: ${unsafeCSS(ROW_THUMB_SIZE)}px;
+    height: ${unsafeCSS(ROW_THUMB_SIZE)}px;
+    border-radius: 6px;
+    object-fit: cover;
+    background: var(--hv-surface-raised);
+  }
+  /* The tile of a picture whose file the backend no longer has. It keeps the
+     box, because a restore without the media directory leaves every row in this
+     state and a list that dropped them all would reflow entirely. The glyph says
+     a picture belongs here; the title and the label say why it is not being
+     shown. */
+  .thumb.missing {
+    display: inline-grid;
+    place-items: center;
+    box-sizing: border-box;
+    border: 1px dashed var(--hv-divider);
+    color: var(--hv-text-tertiary);
+  }
+  /* Between the failure and the probe's answer. Hidden rather than removed:
+     what an errored <img> draws is the browser's broken-image glyph with the alt
+     text spilling out of a 34px square, which is the whole thing this state
+     exists to keep off the row. */
+  .thumb.broken {
+    visibility: hidden;
+  }
+`;
+
+/**
+ * A row's leading thumbnail: the item's first picture, or nothing.
+ *
+ * Asks for the `thumb` variant, so the tile costs a few KB rather than the
+ * whole stored file; the backend serves the original whenever it cannot make
+ * one, so this never decides whether the picture appears. `loading="lazy"` and
+ * `decoding="async"` still matter — a long list would otherwise fetch and decode
+ * everything at once.
+ *
+ * A file the backend no longer has is answered from the failure rather than
+ * probed for up front — see `PictureFallback`.
+ */
+export function renderRowThumb(
+  item: Item,
+  urls: MediaUrls,
+  thumbs: PictureFallback,
+): TemplateResult | null {
+  const first = pictures(item.attachments)[0];
+  if (!first) return null;
+  const state = thumbs.state(item.id, first.id);
+  if (state === 'missing') {
+    return html`<span
+      class="thumb missing"
+      data-testid="row-thumb-missing"
+      role="img"
+      aria-label=${t('hv.term.fileMissing')}
+      title=${t('hv.term.fileMissing')}
+      >${icon('camera', 18)}</span
+    >`;
+  }
+  const src = urls.get(item.id, first.id, attachmentNameToken(first), MEDIA_VARIANT_THUMB);
+  if (!src) return null;
+  return html`<img
+    class=${state === 'errored' ? 'thumb broken' : 'thumb'}
+    data-testid="row-thumb"
+    src=${src}
+    alt=${pictureAlt(item.name, 0, 1)}
+    loading="lazy"
+    decoding="async"
+    @error=${() => thumbs.noteError(item.id, first.id)}
+    @load=${() => thumbs.noteLoad(item.id, first.id)}
+  />`;
+}
+
+/** What a row does with a key, named as the event the surface emits for it. */
+export type RowKeyAction = 'open-item' | 'request-delete' | 'increment' | 'decrement';
+
+/**
+ * The four actions a row answers to, and every spelling each arrives under —
+ * `=` is what an unshifted `+` reports on a US layout, `Add` and `Subtract` are
+ * the numpad's.
+ */
+const ROW_KEYS = new Map<string, RowKeyAction>([
+  ['Enter', 'open-item'],
+  ['Delete', 'request-delete'],
+  ['+', 'increment'],
+  ['=', 'increment'],
+  ['Add', 'increment'],
+  ['-', 'decrement'],
+  ['Subtract', 'decrement'],
+]);
+
+/**
+ * What a keypress on a row means, or null when the row has nothing to do with
+ * it.
+ *
+ * Rows carry `tabindex="0"` so the keyboard can reach them; without these there
+ * is nothing to do once one is reached, and every item on the surface is behind
+ * a mouse.
+ *
+ * A key pressed on a control inside the row belongs to that control: Enter on
+ * Edit opens the editor, and an open ⋮ menu holds the keyboard. One that is
+ * answered is claimed, so the surface underneath does not act on it too;
+ * anything else is left to the browser, or Tab stops leaving the row.
+ */
+export function rowKeyAction(e: KeyboardEvent): RowKeyAction | null {
+  if (e.target !== e.currentTarget) return null;
+  const action = ROW_KEYS.get(e.key);
+  if (!action) return null;
+  e.preventDefault();
+  return action;
+}
+
+/** How a surface names and gates the chips beside an item's name. */
+export interface NameChipOptions {
+  /** Test-id prefix: `row` on the card's list, `table` in the full view. */
+  prefix: string;
+  /**
+   * Whether the low chip is on offer. A surface with one narrow cell for name
+   * and chips together drops it in favour of the loan, which is the more
+   * interrupting of the two.
+   */
+  lowChip?: boolean;
+  /**
+   * Whether the flagged-status chip is on offer. A surface already showing the
+   * status in a column of its own says it once.
+   */
+  statusChip?: boolean;
+  /**
+   * What an overdue loan is called: `overdueOn` spells the date into the chip,
+   * `overdue` leaves it to the column that carries it.
+   */
+  overdueText: 'overdue' | 'overdueOn';
+}
+
+/**
+ * The chips that qualify an item's name: low stock, a flagged status, and who
+ * has the item — in that order, on both surfaces.
+ *
+ * Each is drawn when the item earns it and the surface has room for it. The
+ * order is the order the facts interrupt in, so a row carrying several of them
+ * reads the same way wherever it is browsed.
+ */
+export function renderNameChips(
+  item: Item,
+  statuses: readonly StatusDefinition[] | null | undefined,
+  opts: NameChipOptions,
+): TemplateResult {
+  const status = itemStatus(item);
+  const overdue = isOverdue(item.due_date);
+  return html`${opts.lowChip !== false && isLowStock(item)
+    ? html`<span
+        class="hv-chip warning"
+        data-testid=${`${opts.prefix}-low`}
+        aria-label=${t('hv.term.lowStock')}
+        >${t('hv.term.low')}</span
+      >`
+    : null}${opts.statusChip !== false && status !== DEFAULT_STATUS
+    ? renderStatusChip(status, statuses, { testid: `${opts.prefix}-status` })
+    : null}${item.checked_out
+    ? html`<span
+        class="hv-chip ${overdue ? 'error' : 'state'}"
+        data-testid=${`${opts.prefix}-checked-out`}
+        >${overdue
+          ? opts.overdueText === 'overdueOn'
+            ? t('hv.term.overdueOn', { date: formatDate(item.due_date) })
+            : t('hv.term.overdue')
+          : t('hv.term.checkedOut')}</span
+      >`
+    : null}`;
+}


### PR DESCRIPTION
## Summary

PR 6 of §6.M4 — FE-LISTS-L2 and FE-L6. The card's list row and the full view's table drew the
same row out of two copies: the same thumbnail from the same bytes with the same missing-file
mark, the same four keys, the same low / status / checked-out chips, and the same thumb CSS —
and `hv-data-table` reached into the *component* file `hv-list-row.ts` for two pure helpers.

`cards/haventory-card/src/ui/row-chrome.ts` now holds all of it:

- `renderRowThumb(item, urls, thumbs)` — the tile, the `?size=thumb` URL (#576) and the
  missing-file mark (#606).
- `rowKeyAction(e)` — the four-key table, returning the event name the surface emits. The
  table's `target !== currentTarget` guard is the shared shape.
- `renderNameChips(item, statuses, { prefix, lowChip?, statusChip?, overdueText })` — low,
  flagged status and the loan, in that order.
- `isLowStock` and `rowMenuEntries`, moved out of the component file.
- `rowChrome` — the thumb's CSS, exported once the way `browseRow` is.

Per-surface differences stay parameters, never collapsed: the test-id prefix (`row-*` against
`table-*`, which the browser harnesses locate separately), which chips a surface has room for
(the table stands Low down for Checked out in its one name cell), and whether an overdue loan
spells its date — `hv.term.overdueOn` on the card's row, `hv.term.overdue` in the table, where
the Due column already carries it (#552/#553). `ui/location-path.ts` (#604) was already the
shared path helper and is untouched.

The first commit is a behaviour change and carries its own test and issue: the card's list row
never had the table's guard, so Enter on its Edit button opened the item behind the editor and
Delete pressed inside its open ⋮ menu asked to delete the item that menu describes.

Closes #642
Refs #231

## Commits

| commit | what |
|---|---|
| `ccb2384` | `fix(card): leave a key pressed inside a list row's controls to that control` — closes #642 |
| `fd53fd6` | `refactor(card): one row chrome for the list row and the table` — refs #231, no behaviour change |

## Counting

| | lines |
|---|---:|
| production removed | 321 |
| test removed | 13 |
| added | 598 |

`git diff --stat origin/main`: 7 files, 598 insertions, 334 deletions. The cut is in the
duplication rather than in the total — 320 production lines left the two components and the one
module that replaces them is 252, with the rest of the additions being the new module's own spec
(263 lines) and the call sites. Production nets −5 lines; the two copies net −1.

## Behaviour

- **The refactor commit changes none.** Both surface specs are untouched and green, which is the
  evidence: `hv-list-row.test.ts` and `hv-data-table.test.ts` still pin the thumb, the chips, the
  keys and the ⋮ list per surface, through the shared renderer.
- **The fix commit changes one**, on the card's list row only: a key pressed on a control inside
  the row no longer reaches the row. Pinned by "leaves a key pressed on a control inside the row
  to that control" in `hv-list-row.test.ts`, which is the case the table's spec already had.
- The phone row's area pill (#614) and the one-line rule (#604) are in the mobile branch, which
  this PR does not touch; their tests measure the same.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

Both gates green before each commit.

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1304 passed, 27 skipped;
  `uv run ruff check .` → All checks passed; `uv run ruff format --check .` → 189 files already
  formatted; `uv run mypy` → no issues in 25 source files.
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean, `npm run typecheck` clean,
  `npx vitest run` → 77 files, 1987 passed, `npm run build` → 693.32 kB (from 696.82 kB).

phacc: not required — nothing under `custom_components/` or `tests/integration/` changes (the
built bundle is git-ignored).

New tests, `cards/haventory-card/src/ui/row-chrome.test.ts` (20 cases): `isLowStock`,
`rowMenuEntries` for both check-out states and the due-date entry's two labels; `rowKeyAction`'s
four actions, the numpad and unshifted spellings, what it claims and what it leaves to the
browser, and the guard; `renderNameChips`' order, both surfaces' test ids, both gates, and the
two spellings of an overdue loan; `renderRowThumb`'s `?size=thumb` URL, the no-picture and
no-signature cases, the missing-file mark, and the tile an inconclusive probe leaves hidden
rather than marked missing.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed — none needed: no README-visible behaviour, no WS
  schema, error code or field moved.
- [x] WebSocket API unchanged.
- [x] Essential invariants preserved.
- [x] No file removed from `custom_components/haventory/`, so `RETIRED_PATHS` is unchanged.
- [x] No dictionary edited (`src/i18n/*.ts`, `strings.json`, `translations/*.json`) — the shared
  renderer reads the keys both copies already read.

## Screenshots (card / UI changes)

None from this session — it has no Home Assistant instance. The master's live check at 1920 px
and 375 px, light and dark, is what looks at the rows.

## Follow-ups

- **FE-L6's "chip spacing" was already shared.** `.hv-chip-line`, the chip metrics and the
  elision rules live in `ui/chip.ts` and both row files already read them; the only rule written
  twice was the thumb, which this PR folds. What is left is the two surfaces' own name-line gaps
  (6px on the card's row, 8px in the table's name cell) — collapsing those would move pixels, so
  they stay per surface. Nothing to file.
- **Both surface specs still carry their own thumbnail block.** They cover the same states
  through their own surface, and they are what proves each surface still wires its `MediaUrls` /
  `PictureFallback` pair into the shared renderer. Left alone on purpose rather than merged into
  the module's spec. Not filed.
- **`hv-organize-dialog.ts` imports `describeFailure` from `hv-bulk-bar.ts`** — the last
  cross-component import of a pure helper, the same shape this PR removed for `isLowStock` and
  `rowMenuEntries`. Out of scope here (neither file is in this package). Not filed: it is one
  function and no user can see it.
- **Four visible button labels in `hv-bulk-bar.ts` are English literals** — `Cancel`, `Apply`,
  `Cancel`, `Close`. Filed as #643; `hv.action.cancel` and `hv.action.close` exist already,
  `Apply` needs a new key, so it belongs to the i18n package rather than here.
- Nothing left over from PRs 1–5 of this package that I could find: `ui/dialog-sheet.ts` is gone,
  `item-workspace.ts` and `store-host.ts` are in place, and a sweep of the new modules' exports
  found no dead one — the exports with no production importer are all types satisfied
  structurally at their call sites, which §1.7 of the FE-LISTS measurement already recorded as
  not a cut.

## Handover

**1. Merged / left open.** This PR is for the M4 master to review and squash-merge; nothing here
is left open for the owner.

**2. Test this by hand.** `[phone]` open the card at 375 px and read a row that is low, flagged
and checked out at once — the one line still leads with the loan and keeps the area pill whole;
the wide row at 1920 px draws Low, the status and the loan in that order. `[German]` the same
row in Deutsch: the chips read Wenig / the status label / Überfällig · <date>.

**3. Validate locally.**

1. `[browser]` Dashboard card at 1920 px, an item with a picture, a low quantity, a flagged
   status and an open loan: one 34px tile, then Low, the status chip and the overdue chip with
   its date. Expected: identical to 0.7.1's capture.
2. `[browser]` Same item in the full view's table: the tile at 34px in the name cell, no Low chip
   (the loan takes the cell), the status chip only while the Status column is off, and the
   checked-out chip reading just "Overdue". Expected: identical to 0.7.1's capture.
3. `[browser]` `/haventory` at 375 px: the phone row's single line, its area pill and its
   elision. Expected: unchanged — this PR does not touch that branch.
4. `[browser]` Keyboard on a card row: Tab to the row, Enter opens it, Delete asks to delete,
   `+`/`-` move the quantity. Then Tab on to the row's ⋮, press Enter to open the menu and press
   Delete. Expected: nothing happens behind the menu — no delete prompt. That is #642.
5. `[browser]` Same four keys on a table row, and Enter on the table's Edit button. Expected:
   unchanged from 0.7.1 — the table always had the guard.
6. `[browser]` An item whose picture file is missing from the media directory, on both surfaces.
   Expected: the dashed tile with the camera glyph and the "File missing" title, same box, same
   size, on both.

**4. Decisions taken against drifted notes.**

- FE-L2's table says the card row's Low chip is "shown when `low` (and not checked out — via
  stepper swap)". It is not: the wide card row draws Low and Checked out together, and only the
  table stands Low down. The gate is a parameter (`lowChip`), so both surfaces keep what they
  drew.
- FE-L2 calls the shared keyboard table "identical modulo guard" and its behaviour "none". The
  guard is not free on the card's row — its ⋮ menu bubbles, which the note itself flags — so the
  guard landed as its own commit with its own test and its own issue (#642), and the refactor
  commit changes nothing.
- FE-L6 asks for "the thumb and the name-cell chip spacing" to move into a shared `css` export.
  Only the thumb was written twice; the chip spacing was already `ui/chip.ts`'s. See Follow-ups.

**5. Follow-ups.** Filed: #642 (fixed here), #643 (the bulk bar's four literals). Named and not
filed: the `describeFailure` cross-component import, and the two surface specs' overlapping
thumbnail blocks — reasons above.

**6. State left behind.** Branch `claude/v0-8-0-m4-row-chrome`, two commits, no assets branch
(no screenshots from this session), no `.env` and no Home Assistant instance touched. Counting
for this PR: production removed 321 · test removed 13 · added 598.
