### PR TITLE
refactor(store): drop the retry-after reader nobody sends to

### DIFF
--- a/cards/haventory-card/src/store/store.degraded.test.ts
+++ b/cards/haventory-card/src/store/store.degraded.test.ts
@@ -150,27 +150,11 @@ describe('Store: the backend going away and coming back', () => {
 });
 
 describe('subscribeRetryDelayMs', () => {
-  it('prefers the envelope hint over the backoff, in either unit', () => {
-    expect(subscribeRetryDelayMs({ data: { retry_after_ms: 250 } }, 0, 400)).toBe(250);
-    // Seconds, the HTTP Retry-After convention.
-    expect(subscribeRetryDelayMs({ data: { retry_after: 2 } }, 0, 400)).toBe(2000);
-    // The card's own error entries name the bag `context`.
-    expect(subscribeRetryDelayMs({ context: { retry_after_ms: 30 } }, 3, 400)).toBe(30);
-  });
-
-  it('backs off exponentially when the envelope carries no hint', () => {
-    const delays = [0, 1, 2, 3].map((attempt) => subscribeRetryDelayMs({}, attempt, 400));
+  it('backs off exponentially, and never past the ceiling on one wait', () => {
+    const delays = [0, 1, 2, 3].map((attempt) => subscribeRetryDelayMs(attempt, 400));
     expect(delays).toEqual([400, 800, 1600, 3200]);
-  });
-
-  it('clamps a hint that would park live updates for hours', () => {
-    expect(subscribeRetryDelayMs({ data: { retry_after: 86_400 } }, 0, 400)).toBe(30_000);
-  });
-
-  it('ignores a hint that is not a usable number', () => {
-    expect(subscribeRetryDelayMs({ data: { retry_after_ms: 'soon' } }, 0, 400)).toBe(400);
-    expect(subscribeRetryDelayMs({ data: { retry_after: -5 } }, 0, 400)).toBe(400);
-    expect(subscribeRetryDelayMs({ data: { retry_after: Number.NaN } }, 1, 400)).toBe(800);
+    // A base delay a host passed in cannot park live updates for hours.
+    expect(subscribeRetryDelayMs(3, 60_000)).toBe(30_000);
   });
 
   it('declares the connection lost after consecutive transport failures', async () => {

--- a/cards/haventory-card/src/store/store.ts
+++ b/cards/haventory-card/src/store/store.ts
@@ -99,8 +99,8 @@ const CONNECTION_LOST_GRACE_MS = 4_500;
 const SUBSCRIBE_UNAVAILABLE_ATTEMPTS = 7;
 
 /**
- * Ceiling on a single re-subscribe wait. Also clamps a server-sent retry-after
- * hint, so a wrong or hostile value cannot park live updates indefinitely.
+ * Ceiling on a single re-subscribe wait, so a doubling backoff off a large base
+ * delay cannot park live updates for longer than a household would wait.
  */
 const SUBSCRIBE_RETRY_MAX_MS = 30_000;
 
@@ -151,40 +151,12 @@ function errorCode(err: unknown): string {
   return typeof code === 'string' && code ? code : TRANSPORT_ERROR_CODE;
 }
 
-function nonNegativeNumber(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
-}
-
 /**
- * A retry-after hint in milliseconds, or null when the envelope carries none.
- *
- * The error taxonomy defines no retry-after field, so this is read defensively:
- * from `data` (where the contract puts structured context), from `context` (the
- * name the card's own error entries use) and from the top level, accepting
- * either milliseconds or the HTTP convention of seconds. A backend that starts
- * sending one is honoured without a contract change; until then the caller
- * falls back to its own backoff.
+ * How long to wait before re-opening a refused subscription: exponential
+ * backoff off the card's base delay, capped.
  */
-function retryAfterHintMs(err: unknown): number | null {
-  const envelope = err as { data?: unknown; context?: unknown } | undefined;
-  for (const source of [envelope, envelope?.data, envelope?.context]) {
-    if (!source || typeof source !== 'object') continue;
-    const bag = source as Record<string, unknown>;
-    const ms = nonNegativeNumber(bag.retry_after_ms);
-    if (ms !== null) return ms;
-    const seconds = nonNegativeNumber(bag.retry_after);
-    if (seconds !== null) return seconds * 1000;
-  }
-  return null;
-}
-
-/**
- * How long to wait before re-opening a refused subscription: the server's hint
- * when it sends one, otherwise exponential backoff off the card's base delay.
- */
-export function subscribeRetryDelayMs(err: unknown, attempt: number, baseMs: number): number {
-  const delay = retryAfterHintMs(err) ?? baseMs * 2 ** attempt;
-  return Math.min(delay, SUBSCRIBE_RETRY_MAX_MS);
+export function subscribeRetryDelayMs(attempt: number, baseMs: number): number {
+  return Math.min(baseMs * 2 ** attempt, SUBSCRIBE_RETRY_MAX_MS);
 }
 
 /**
@@ -576,8 +548,8 @@ export class Store {
       onOpen: () => {
         if (catchUp && current()) this.scheduleAreasRefresh();
       },
-      onError: (err) => {
-        if (current()) this.onAreaRegistryRefused(err);
+      onError: () => {
+        if (current()) this.onAreaRegistryRefused();
       },
     });
   }
@@ -591,9 +563,9 @@ export class Store {
    * gone, which is not what happened here. Once the budget is spent the card
    * keeps its boot-time snapshot, which is what it did before it listened.
    */
-  private onAreaRegistryRefused(err: unknown) {
+  private onAreaRegistryRefused() {
     if (this.areaRegistryAttempt >= AREA_REGISTRY_RETRY_ATTEMPTS) return;
-    const delay = subscribeRetryDelayMs(err, this.areaRegistryAttempt, this.retryBaseMs);
+    const delay = subscribeRetryDelayMs(this.areaRegistryAttempt, this.retryBaseMs);
     this.areaRegistryAttempt += 1;
     this.areaRegistryRetry.schedule(delay, () => this.watchAreaRegistry(false));
   }
@@ -678,7 +650,7 @@ export class Store {
     if (this.state.value.degraded.liveUpdatesReason === 'unavailable') return;
     this.stateObs.set({ connected: { items: false, stats: false } });
     this.subscribeAttempt = 0;
-    this.scheduleReopen('unavailable', null);
+    this.scheduleReopen('unavailable');
   }
 
   /** Fold one subscribe outcome into its round, and act once the round is complete. */
@@ -742,12 +714,12 @@ export class Store {
       return;
     }
 
-    this.scheduleReopen(reason, err);
+    this.scheduleReopen(reason);
   }
 
   /** Book the next re-subscribe and say so, so the banner can show the wait. */
-  private scheduleReopen(reason: LiveUpdatePause, err: unknown) {
-    const delay = subscribeRetryDelayMs(err, this.subscribeAttempt, this.retryBaseMs);
+  private scheduleReopen(reason: LiveUpdatePause) {
+    const delay = subscribeRetryDelayMs(this.subscribeAttempt, this.retryBaseMs);
     this.subscribeAttempt += 1;
     this.setDegraded({
       liveUpdates: 'retrying',

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -568,10 +568,9 @@ are opened as one **round**, because each
 subscribe is answered on its own and one can be accepted while the next is refused; live
 updates only count as restored once every subscribe in the newest round is accepted, which
 `WSClient.subscribe`'s `onOpen` reports. A round refused with `storage_error` or
-`unknown_command` is re-opened automatically on a bounded budget, waiting the envelope's
-retry-after hint when it carries one (`retry_after_ms`, or `retry_after` in seconds, read
-from `data`, `context` or the top level and clamped to 30 s) and otherwise backing off
-exponentially: both codes say the backend is not there *yet* rather than broken — the first
+`unknown_command` is re-opened automatically on a bounded budget, backing off exponentially
+off the card's base delay and never waiting longer than 30 s for one attempt: both codes say
+the backend is not there *yet* rather than broken — the first
 is what a config entry mid-reload answers, the second is Home Assistant's answer for a
 command type nobody has registered, which is what a restarting instance serves until the
 integration finishes setting up. `degraded.liveUpdates` tracks this as


### PR DESCRIPTION
## Summary

The card's store read a retry-after hint off every refused subscribe: `retryAfterHintMs` looked for `retry_after_ms` (or `retry_after` in seconds) in `data`, `context` and the top level, and `subscribeRetryDelayMs` preferred it over its own backoff. No server has ever sent either field — `grep -rn "retry_after" custom_components/` finds nothing — and the rate limiter, the one refusal that could plausibly have carried a wait, was deleted in #632. The reader is gone, with its `nonNegativeNumber` guard.

What stays is the whole path that still runs: `SUBSCRIBE_RETRY_ATTEMPTS`, `SUBSCRIBE_UNAVAILABLE_ATTEMPTS`, the exponential backoff and the 30 s ceiling on one wait, which serve the `unavailable` re-subscribe (a config entry mid-reload, or Home Assistant answering `unknown_command` while the integration sets up). `subscribeRetryDelayMs` now takes `(attempt, baseMs)`; with nothing left to read off the envelope, `onAreaRegistryRefused` and `scheduleReopen` no longer take an error they only forwarded.

`docs/frontend_architecture.md`'s degraded-state paragraph loses the sentence describing the hint. Nothing in `docs/backend_api_contract.md` or `docs/data_shapes.md` mentions `retry_after` — the taxonomy never defined it — so neither moves.

Refs #230 (item 7 / BE-WS-C2, the card-side half). PR 1 of §6.M5.

## Counting

| | lines |
|---|---|
| production removed | 46 (`store.ts` 42, `frontend_architecture.md` 4) |
| test removed | 20 |
| added | 21 |

`git diff --stat`: 3 files changed, 21 insertions(+), 66 deletions(-).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [x] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1304 passed, 27 skipped), `uv run ruff check .`, `uv run ruff format --check .` (189 files), `uv run mypy` (25 source files, no issues)
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run` (77 files, 1984 tests passed), `npm run build` (692.91 kB, gzip 171.47 kB)

`scripts/test_integration.sh` is not required: the diff touches only `cards/haventory-card/src/` and `docs/`, and §6.M5 asks for no phacc.

The three hint cases in `src/store/store.degraded.test.ts` are deleted with the reader, not rewritten. The surviving backoff case had to take the new signature, and it now also pins the 30 s ceiling — over a base delay a host passes in, which is the only way the ceiling can still be reached now that the wire cannot propose a wait. Without that line the cap the cut keeps would have been left with no test at all.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed (`docs/frontend_architecture.md`; the contract docs never named the field).
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and `docs/data_shapes.md` in sync — no WS change here.
- [x] Essential invariants preserved (case-insensitive search, denormalized `location_path`, optimistic `version`).

## Screenshots (card / UI changes)

None — no rendered output changes. The retry waits a card computes are identical for every input a backend can produce, because no backend produces the input the deleted branch was reading.

## Follow-ups

- With the hint gone, `SUBSCRIBE_RETRY_MAX_MS` is unreachable at the shipped base delay of 400 ms: the subscribe budget spends attempts 0–6, so the largest wait is 25.6 s. The ceiling only bites for a host that passes a larger `retryBaseMs`. It stays because it bounds an option the store exposes, but it is worth knowing it is not on the default path. Not filed — nothing a household can hit.

## Handover

1. **Merged / left open** — this PR; the master merges it once CI is green. Nothing else opened.
2. **Test this by hand** — nothing. No user-visible surface moves.
3. **Validate locally** — nothing: the retry path is pinned by `store.degraded.test.ts` ("re-opens the subscriptions a reload took away", "gives up after a bounded number of unavailable rounds", "backs off exponentially, and never past the ceiling on one wait"). If a session wants the belt-and-braces version, `[dev-ha]` reload the config entry with a card open and watch the "Live updates paused" banner count down and clear itself — unchanged behaviour, same waits.
4. **Decisions taken against drifted notes** — the #230 comment recommends *emitting* the hint from a surviving bucket ("the only thing making the card's backoff better than a guess"); that recommendation assumed cut 7 (one bucket), and C2 (delete) is what shipped, so the hint has no source and the reader goes. The comment's line numbers (`store.ts:121`, `:180-190`) are from `b878bfe` and no longer match; the symbols do.
5. **Follow-ups** — the unreachable ceiling at the default base delay, above. Not filed.
6. **State left behind** — branch `claude/v0-8-0-m5-retry-after`, one commit. No assets branch, no HA instance touched. Counting: production removed 46, tests removed 20, added 21.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SMNHgT4sXFKLrc798D54T1)_