### PR TITLE
fix(card): accessible names and the conflict banner through the catalog

### DIFF
--- a/cards/haventory-card/src/components/hv-bulk-bar.test.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.test.ts
@@ -318,6 +318,26 @@ describe('hv-bulk-bar: the band belongs to the theme', () => {
   });
 });
 
+describe('hv-bulk-bar: the language in force', () => {
+  // Every state of the bar draws its own buttons, and the ones behind a picker
+  // or a running batch are the ones a reader of the source scrolls past.
+  it('names the buttons of all three states in it', async () => {
+    setLanguage('de');
+
+    const picking = await mount();
+    (q(picking, '[data-action="adjust-qty"]') as HTMLButtonElement).click();
+    await picking.updateComplete;
+    expect(q(picking, '[data-testid="bulk-picker-cancel"]')?.textContent?.trim()).toBe('Abbrechen');
+    expect(q(picking, '[data-testid="bulk-picker-apply"]')?.textContent?.trim()).toBe('Anwenden');
+
+    const running = await mount({ progress: { done: 1, total: 4, failed: 0, label: 'Moving' } });
+    expect(q(running, '[data-testid="bulk-cancel"]')?.textContent?.trim()).toBe('Abbrechen');
+
+    const finished = await mount({ result: { label: 'Move', succeeded: 2, failed: [] } });
+    expect(q(finished, '[data-testid="bulk-result-dismiss"]')?.textContent?.trim()).toBe('Schließen');
+  });
+});
+
 describe('hv-bulk-bar: close verbs', () => {
   // A result panel is read and dismissed; "Close" is what every other surface
   // that only dismisses says.

--- a/cards/haventory-card/src/components/hv-bulk-bar.ts
+++ b/cards/haventory-card/src/components/hv-bulk-bar.ts
@@ -362,7 +362,7 @@ export class HVBulkBar extends LitElement {
               }}
             />
             <button class="hv-text-button" data-testid="bulk-picker-cancel" @click=${() => (this._active = null)}>
-              Cancel
+              ${t('hv.action.cancel')}
             </button>
             <button
               class="hv-pill"
@@ -370,7 +370,7 @@ export class HVBulkBar extends LitElement {
               ?disabled=${!Number.isFinite(Number(this._draft)) || this._draft.trim() === '' || Number(this._draft) === 0}
               @click=${() => this._run({ action: 'adjust-qty', delta: Number(this._draft) })}
             >
-              Apply
+              ${t('hv.action.apply')}
             </button>
           </div>
         </div>`;
@@ -401,7 +401,7 @@ export class HVBulkBar extends LitElement {
           data-testid="bulk-cancel"
           @click=${() => this.dispatchEvent(new CustomEvent('cancel-run', { bubbles: true, composed: true }))}
         >
-          Cancel
+          ${t('hv.action.cancel')}
         </button>
       </div>
       <div class="track"><div class="fill" style="width: ${pct}%"></div></div>
@@ -455,7 +455,7 @@ export class HVBulkBar extends LitElement {
           data-testid="bulk-result-dismiss"
           @click=${() => this.dispatchEvent(new CustomEvent('dismiss-result', { bubbles: true, composed: true }))}
         >
-          Close
+          ${t('hv.action.close')}
         </button>
         ${failedCount
           ? html`<button

--- a/cards/haventory-card/src/components/hv-card-shell.test.ts
+++ b/cards/haventory-card/src/components/hv-card-shell.test.ts
@@ -688,6 +688,12 @@ describe('hv-card-shell: list and footer', () => {
   });
 });
 
+/** The treatment the first queued entry is drawn with. */
+const bannerKind = (sr: ShadowRoot) =>
+  (sr.querySelector('[data-testid="banner-entry"]') as HTMLElement).shadowRoot?.querySelector(
+    '[data-testid="banner"]',
+  )?.getAttribute('data-kind');
+
 describe('hv-card-shell: banners', () => {
   it('offers both recovery paths on a conflict', async () => {
     const { el, store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'A' })] });
@@ -705,6 +711,53 @@ describe('hv-card-shell: banners', () => {
     (sr.querySelector('[data-testid="banner-dismiss"]') as HTMLButtonElement).click();
     await settle(el);
     expect(sr.querySelector('[data-testid="banner-entry"]')).toBe(null);
+  });
+
+  // "version conflict: expected 4, actual 5" is the backend's own English, and
+  // it stayed English on a German screen beside a translated heading. The
+  // numbers name a row of a store nobody can see, so the frame is all of it —
+  // the same call the form makes in `ui/editor-error`.
+  it('frames a refused save in words rather than in version numbers', async () => {
+    const { el, store, sr } = await mountShell({ items: [makeItem({ id: '1', name: 'A' })] });
+    store['pushError'](
+      { code: 'conflict', message: 'version conflict: expected 4, actual 5' },
+      { itemId: '1', changes: { name: 'B' } },
+    );
+    await settle(el);
+
+    const banner = (sr.querySelector('[data-testid="banner-entry"]') as HTMLElement).shadowRoot;
+    expect(banner?.textContent).toContain('Someone else changed this item');
+    expect(banner?.querySelector('[data-testid="banner-message"]')?.textContent).toBe('');
+    expect(bannerKind(sr)).toBe('warning');
+    expect(sr.querySelector('[data-testid="banner-view-latest"]')).toBeTruthy();
+  });
+
+  // The row's own ± is the other half: a delta cannot be re-applied against a
+  // version somebody else has moved, so the store files the entry without an
+  // item — and the banner used to fall through to the raw message with no
+  // heading at all, which was the one place a household read the numbers with
+  // nothing around them.
+  it('frames a refused quantity the same way, with no way back offered', async () => {
+    const { el, store, sr } = await mountShell({
+      items: [makeItem({ id: '1', name: 'A', quantity: 3 })],
+    });
+    store['ws'].adjustQuantity = async () => {
+      throw { code: 'conflict', message: 'version conflict: expected 4, actual 5' };
+    };
+
+    await store.adjustQuantity('1', 1);
+    await settle(el);
+
+    const entry = sr.querySelector('[data-testid="banner-entry"]') as HTMLElement;
+    expect(entry.dataset.code).toBe('conflict');
+    expect(entry.shadowRoot?.textContent).toContain('Someone else changed this item');
+    expect(entry.shadowRoot?.querySelector('[data-testid="banner-message"]')?.textContent).toBe('');
+    // Down to the tone: one event, one treatment, whether or not the row it
+    // happened on can be named.
+    expect(bannerKind(sr)).toBe('warning');
+    expect(sr.querySelector('[data-testid="banner-view-latest"]')).toBe(null);
+    // The queue still carries the backend's sentence; only the banner drops it.
+    expect(store.state.value.errorQueue[0].message).toBe('version conflict: expected 4, actual 5');
   });
 
   it('re-applies the rejected change against the newer server version', async () => {

--- a/cards/haventory-card/src/components/hv-chip-input.test.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.test.ts
@@ -1,3 +1,4 @@
+import { setLanguage } from '../i18n';
 import './hv-chip-input';
 import type { HVChipInput } from './hv-chip-input';
 import { all, mountComponent, q } from '../test.utils';
@@ -41,6 +42,14 @@ describe('hv-chip-input', () => {
     expect(token.querySelector('.hv-tag-mark')?.getAttribute('aria-hidden')).toBe('true');
     // The remove button is named for the value, not for what is printed on the chip.
     expect(q(el, '[data-testid="chip-remove"]')?.getAttribute('aria-label')).toBe('Remove battery');
+  });
+
+  // The name is spoken and never drawn, which is how it stayed English while
+  // every label around it moved.
+  it('names the remove button in the language in force', async () => {
+    setLanguage('de');
+    const el = await mount({ values: ['werkzeug'] });
+    expect(q(el, '[data-testid="chip-remove"]')?.getAttribute('aria-label')).toBe('werkzeug entfernen');
   });
 
   // A tag someone writes with a # of their own would otherwise read as ##ok.

--- a/cards/haventory-card/src/components/hv-chip-input.ts
+++ b/cards/haventory-card/src/components/hv-chip-input.ts
@@ -139,7 +139,7 @@ export class HVChipInput extends LitElement {
               class="hv-icon-button chip-remove"
               data-testid="chip-remove"
               data-value=${tag}
-              aria-label=${`Remove ${tag}`}
+              aria-label=${t('hv.action.removeTag', { tag })}
               @click=${() => this._remove(tag)}
             >
               ${icon('close', 12)}

--- a/cards/haventory-card/src/components/hv-filter-chips.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { setLanguage } from '../i18n';
 import './hv-filter-chips';
 import { chipsFor, clearedValueFor } from './hv-filter-chips';
 import { defaultFilters } from '../store/store';
@@ -360,6 +361,15 @@ describe('hv-filter-chips', () => {
     const el = await mount({ filters: { ...defaultFilters(), overdueOnly: true } });
     const chip = el.shadowRoot?.querySelector('[data-testid="filter-chip"]') as HTMLElement;
     expect(chip.getAttribute('aria-label')).toBe('Clear filter Overdue');
+  });
+
+  // A name nobody sees is a name nobody proofreads: this one was English on a
+  // row of German chips until a screen reader said so.
+  it('says that name in the language in force', async () => {
+    setLanguage('de');
+    const el = await mount({ filters: { ...defaultFilters(), overdueOnly: true } });
+    const chip = el.shadowRoot?.querySelector('[data-testid="filter-chip"]') as HTMLElement;
+    expect(chip.getAttribute('aria-label')).toBe('Filter Überfällig zurücksetzen');
   });
 
   // A search term, a list of tags or a nested location path has no length this

--- a/cards/haventory-card/src/components/hv-filter-chips.ts
+++ b/cards/haventory-card/src/components/hv-filter-chips.ts
@@ -266,7 +266,7 @@ export class HVFilterChips extends LitElement {
             data-testid="filter-chip"
             data-key=${entry.key}
             title=${entry.label}
-            aria-label=${`Clear filter ${entry.label}`}
+            aria-label=${t('hv.action.clearFilter', { label: entry.label })}
             @click=${() =>
               this.dispatchEvent(
                 new CustomEvent('remove-filter', {

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -153,6 +153,7 @@ export const de: CompleteDictionary = {
   'hv.action.close': 'Schließen',
   'hv.action.edit': 'Bearbeiten',
   'hv.action.create': 'Erstellen',
+  'hv.action.apply': 'Anwenden',
   'hv.action.confirm': 'Bestätigen',
   'hv.action.delete': 'Löschen',
   'hv.action.remove': 'Entfernen',

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -160,6 +160,8 @@ export const de: CompleteDictionary = {
   'hv.action.open': 'Öffnen',
   'hv.action.repeat': 'Wiederholen',
   'hv.action.clearAll': 'Alle zurücksetzen',
+  'hv.action.clearFilter': 'Filter {label} zurücksetzen',
+  'hv.action.removeTag': '{tag} entfernen',
   'hv.action.deleteItem': 'Gegenstand löschen',
   'hv.action.editItem': 'Gegenstand bearbeiten',
   'hv.action.checkIn': 'Zurückgeben',

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -174,6 +174,7 @@ export const en = {
   'hv.action.close': 'Close',
   'hv.action.edit': 'Edit',
   'hv.action.create': 'Create',
+  'hv.action.apply': 'Apply',
   'hv.action.confirm': 'Confirm',
   'hv.action.delete': 'Delete',
   'hv.action.remove': 'Remove',

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -181,6 +181,10 @@ export const en = {
   'hv.action.open': 'Open',
   'hv.action.repeat': 'Retry',
   'hv.action.clearAll': 'Clear all',
+  // The × on a chip, spoken rather than drawn: the chip's own text is beside
+  // it on screen, and an accessible name has to carry it instead.
+  'hv.action.clearFilter': 'Clear filter {label}',
+  'hv.action.removeTag': 'Remove {tag}',
   'hv.action.deleteItem': 'Delete item',
   'hv.action.editItem': 'Edit item',
   'hv.action.checkIn': 'Check in',

--- a/cards/haventory-card/src/i18n/literals.test.ts
+++ b/cards/haventory-card/src/i18n/literals.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Copy written into a template instead of read through `t()`.
+ *
+ * Such a string is English in every language, and no other test sees it: the
+ * catalog tests check the keys that exist, never the words that never became
+ * one. An accessible name is the easiest of them to miss — it is drawn
+ * nowhere, so only a screen reader ever says it out loud.
+ */
+
+const SRC = join(__dirname, '..');
+
+/** Every source the card ships. A test file may write whatever it asserts on. */
+function sourceFiles(dir: string = SRC): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (!entry.name.endsWith('.ts') || entry.name.endsWith('.test.ts')) return [];
+    if (entry.name.startsWith('test.')) return [];
+    return [path];
+  });
+}
+
+const relative = (path: string) => path.slice(SRC.length + 1).replace(/\\/g, '/');
+const sources = sourceFiles().map((path) => [relative(path), readFileSync(path, 'utf8')] as const);
+
+function offenders(pattern: RegExp): string[] {
+  return sources.flatMap(([name, source]) =>
+    [...source.matchAll(pattern)].map((match) => `${name}: ${match[0].trim()}`),
+  );
+}
+
+describe('the card says nothing in English by hand', () => {
+  it('builds no accessible name out of a sentence', () => {
+    // A template literal opening with a capital letter is copy; `t(...)`, a
+    // property and an interpolated value all open with something else.
+    expect(offenders(/aria-label=\$\{`[A-Z][^`]*`/g)).toEqual([]);
+  });
+});

--- a/cards/haventory-card/src/i18n/literals.test.ts
+++ b/cards/haventory-card/src/i18n/literals.test.ts
@@ -26,9 +26,10 @@ function sourceFiles(dir: string = SRC): string[] {
 const relative = (path: string) => path.slice(SRC.length + 1).replace(/\\/g, '/');
 const sources = sourceFiles().map((path) => [relative(path), readFileSync(path, 'utf8')] as const);
 
+/** Where each match is, and the text that gives it away. */
 function offenders(pattern: RegExp): string[] {
   return sources.flatMap(([name, source]) =>
-    [...source.matchAll(pattern)].map((match) => `${name}: ${match[0].trim()}`),
+    [...source.matchAll(pattern)].map((match) => `${name}: ${(match[1] ?? match[0]).trim()}`),
   );
 }
 
@@ -37,5 +38,12 @@ describe('the card says nothing in English by hand', () => {
     // A template literal opening with a capital letter is copy; `t(...)`, a
     // property and an interpolated value all open with something else.
     expect(offenders(/aria-label=\$\{`[A-Z][^`]*`/g)).toEqual([]);
+  });
+
+  it('draws no label on a control that is only a word', () => {
+    // A line of a template holding one capitalised word between two tags is
+    // that control's whole copy, written out; a label read through `t()` is an
+    // interpolation and never bare text.
+    expect(offenders(/>\s*\n\s*([A-Z][A-Za-z]*)\s*\n\s*</g)).toEqual([]);
   });
 });

--- a/cards/haventory-card/src/ui/banners.ts
+++ b/cards/haventory-card/src/ui/banners.ts
@@ -113,15 +113,24 @@ export function renderErrorBanners(st: StoreState | null, hooks: BannerHooks): T
   return html`
     <div class="banners" data-testid="banners">
       ${errors.map((e) => {
-        const conflict = e.kind === 'conflict' && e.itemId;
+        const conflict = e.kind === 'conflict';
+        // A conflict's own message names version numbers, which say nothing to
+        // a household in any language — the heading is the whole account, the
+        // way `ui/editor-error` frames the same event inside the form. The
+        // queue keeps the backend's sentence either way.
+        //
+        // The two ways out need the item the write was refused for. A quantity
+        // delta cannot be re-applied against a version somebody else moved, so
+        // the store files that one with no item and it gets the sentence alone.
+        const recoverable = conflict && e.itemId;
         return html`<hv-banner
           kind=${conflict ? 'warning' : 'error'}
           .heading=${conflict ? t('hv.banner.conflict.heading') : null}
-          .message=${e.message}
+          .message=${conflict ? '' : e.message}
           data-testid="banner-entry"
           data-code=${e.code}
         >
-          ${conflict
+          ${recoverable
             ? html`<span slot="below">
                 <button
                   class="hv-pill outline"


### PR DESCRIPTION
## Summary

Three fixes, one per commit, all in the card's copy layer.

1. **The two accessible names that were English literals** (#615). The × on a filter chip
   built `` `Clear filter ${entry.label}` `` and the × on a tag chip built `` `Remove ${tag}` ``,
   so a German household using a screen reader heard "Clear filter Küche" among controls that
   otherwise speak German. Two keys beside `hv.action.clearAll` in both dictionaries —
   `hv.action.clearFilter` (`Clear filter {label}` / `Filter {label} zurücksetzen`) and
   `hv.action.removeTag` (`Remove {tag}` / `{tag} entfernen`) — read through `t()`.
2. **The four bulk-bar labels that were English literals** (#643, riding along per M4's
   handover on #236). The quantity picker's *Cancel* and *Apply*, the progress band's *Cancel*
   and the result panel's *Close* were written into the template. `hv.action.cancel` and
   `hv.action.close` already existed; `hv.action.apply` is re-added with readers this time
   (English `Apply`, German `Anwenden` — the value M3 deleted when nothing read it), and the
   unused-key test from #646 now holds it.
3. **The conflict banner's raw detail** (#540's 2026-08-22 comment). Both faces printed the
   backend's `version conflict: expected 4, actual 5`. Above the editor it sat beside the
   translated heading; on a row's quantity ± it *was* the whole banner, because the heading
   was gated on `e.kind === 'conflict' && e.itemId` and a delta cannot be re-applied against
   a newer version, so the store files that entry without an item. A `conflict` now renders
   `hv.banner.conflict.heading` alone in both cases — the way `ui/editor-error.ts` already
   frames it inside the form. *View latest* / *Re-apply* stay gated on the item, as before.

**One more thing 3 changes, deliberately.** A conflict with no item used to be drawn as an
`error` (red) because the same expression decided the tone; it is now the `warning` the
save-path conflict has always had. One event, one treatment, whether or not the row it
happened on can be named — asserted on both faces.

**The seam for 3.** The store's `ErrorEntry` keeps carrying the backend's message: it is the
data, and `errorCode`'s contract is read off it (the test asserts the queue still holds the
sentence). What is dropped is dropped in `ui/banners.ts`, where the banner is composed —
the same place that already decides the kind, the heading and which actions the entry earns.
The form and the banner say the same thing but not in the same shape (one sentence against a
heading plus two buttons), so a shared "text for an entry" helper would have to return both
halves for one caller and neither for the other; each presenter deciding for itself is the
smaller seam. `ui/editor-error.ts` is untouched.

**Dictionaries.** Three new keys, English and German, per §6.M5's "M5 edits the dictionaries"
rule. No existing German value is reworded — that is M7's, off #540's read. `Remove {tag}` is
deliberately *not* folded onto `hv.organize.removeValue` ("Remove {value}"), whose German is
the same string: the organize dialog's button drops a value from every item that carries it,
the chip's × drops a tag from the draft in front of you. Different actions, so different keys —
the same rule #542 applied, which does not fold on the German matching.

**The two sweeps** live in `src/i18n/literals.test.ts` — one file for "user-facing text is
never a literal", the way `ha-contract.test.ts` and `unused-keys.test.ts` each sweep the tree
for their own rule. The bare-word grep was run against `main` first: it returned exactly the
four labels the issue names and nothing else, so it needed no narrowing.

Closes #615
Closes #643
Refs #540

## Counting

| | Lines |
|---|---|
| Production lines removed | 9 |
| Test lines removed | 0 |
| Lines added | 167 |

`git diff --stat origin/main...HEAD`: 11 files changed, 167 insertions(+), 9 deletions(-).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` (1304 passed, 27 skipped),
      `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all clean.
- [x] Frontend (`cards/haventory-card`): `npx eslint .`, `npm run typecheck`, `npx vitest run`
      (79 files, 2001 tests passed), `npm run build` — all clean. Both halves were green before
      each of the three commits.

phacc (`scripts/test_integration.sh`) is not required: nothing under `custom_components/`
(other than the git-ignored built bundle) or `tests/integration/` is touched.

New tests, per commit:

- `src/i18n/literals.test.ts` — an `aria-label` built from a template literal opening with a
  capital letter (red on `main` with exactly the two call sites #615 names); a template line
  that is one capitalised word between two tags (red on `main` with exactly the four #643
  names).
- `hv-filter-chips` and `hv-chip-input` — the chip's × is named in the language in force.
- `hv-bulk-bar` — the picker, the running band and the result panel name their buttons in the
  language in force.
- `hv-card-shell` — a refused save shows the heading with an empty message and keeps both ways
  out; a refused quantity (driven through `store.adjustQuantity` against a `ws` that throws
  `conflict`, so the missing item is the store's own doing) shows the same heading in the same
  tone, offers no way back, and leaves the backend's sentence in the queue.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + at least one edge/error case).
- [x] Docs updated where behavior changed — none needed: no user-facing behaviour outside the
      card's own copy, and `docs/frontend_architecture.md`'s line on conflicts ("a rejected
      save … renders as a banner with *View latest* / *Re-apply*") still describes the save
      path exactly.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md` and
      `docs/data_shapes.md` in sync — no API change; the wire and the stored payload are
      untouched.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

None from this session — it runs offline and drives no Home Assistant. The German screens are
the master's live check (§6.M5) and the owner's read through #540.

## Follow-ups

- The `>`-word sweep only catches a *single* capitalised word on its own line. A two-word
  English label written into a template ("Add item") would pass it. Not filed: no such line
  exists today, and the sweep that would catch it needs a vocabulary rather than a shape, which
  is a different kind of test.
- `hv-organize-dialog.ts` renders `aria-label=${c.replace(/_/g, ' ')}` for a colour swatch and
  `aria-label=${name}` for a status name — values, not sentences, so neither is copy and
  neither sweep flags them. Left alone.

## Handover

1. **Merged / left open** — this PR is PR 3 of §6.M5; the master merges it after its review.
   Nothing here is left for the owner.
2. **Test this by hand** — `[German]` the two chip × names and the four bulk-bar buttons read
   as German on a real screen (the aria ones need a screen reader, not devtools, to be judged);
   `[German]` the conflict banner's single sentence is the whole account a household needs.
3. **Validate locally** —
   1. `[dev-ha]` `[browser]` Profile language Deutsch, open the card, apply a category filter,
      inspect the chip's ×: `aria-label` reads `Filter <label> zurücksetzen`. Expected: no
      English.
   2. `[browser]` Open the item editor, add a tag, inspect the chip's ×: `aria-label` reads
      `<tag> entfernen`.
   3. `[browser]` Full view, select two rows, open the quantity action: the buttons read
      *Abbrechen* and *Anwenden*; run a bulk move and read the band (*Abbrechen*) and the
      result panel (*Schließen*).
   4. `[browser]` Force a conflict (the `routeWebSocket` recipe): the banner above the editor
      reads *Jemand anderes hat diesen Gegenstand geändert.* and nothing else; *Aktuellen Stand
      ansehen* and *Meine Änderung erneut anwenden* are still there.
   5. `[browser]` Force the same on a row's ± (a conflict on `item/adjust_quantity`): the same
      sentence in the same amber banner, no buttons, no version numbers.
4. **Decisions taken against drifted notes** — the package names #615 and #540 for this PR;
   #643 was filed after the plan was written and rides along here per M4's handover on #236,
   since it is the same defect in the same file family and the same three-key edit.
   `hv.action.apply` is re-added rather than a new name invented, so the German that M3 deleted
   comes back unchanged. The banner's tone for an item-less conflict moves from red to amber,
   which the plan does not mention but follows from the heading being the same.
5. **Follow-ups** — the two above, neither filed.
6. **State left behind** — branch `claude/v0-8-0-m5-a11y-banner`, no assets branch, no HA
   touched. Counting for this PR: production removed 9 · tests removed 0 · added 167.
