### PR TITLE
feat(card): the built-in statuses in the reader's language

### DIFF
--- a/cards/haventory-card/src/components/hv-filter-panel.test.ts
+++ b/cards/haventory-card/src/components/hv-filter-panel.test.ts
@@ -1,3 +1,4 @@
+import { setLanguage } from '../i18n';
 import './hv-filter-panel';
 import type { HVFilterPanel } from './hv-filter-panel';
 import { defaultFilters } from '../store/store';
@@ -238,6 +239,34 @@ describe('hv-filter-panel: status', () => {
     expect(
       q(el, '[data-testid="filter-status"][data-value="ok"]')!.classList.contains('tone-green'),
     ).toBe(false);
+  });
+
+  // #536: the three the backend seeds are stored in English because they are
+  // data a household owns; the chips are what a household reads, and those
+  // follow the reader. A rename is the household's own word and outranks both.
+  it('names the built-in three in the reader\u2019s language, a renamed one as stored', async () => {
+    setLanguage('de');
+    const seeded = await mount();
+    expect(
+      all(seeded, '[data-testid="filter-status"]').map((c) =>
+        (c.textContent ?? '').replace(/\s+/g, ' ').trim(),
+      ),
+    ).toEqual(['OK', 'Fehlt', 'Reparatur n\u00f6tig']);
+
+    const renamed = await mount(
+      {},
+      {
+        statuses: [
+          { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
+          { slug: 'missing', label: 'Gone walkabout', order: 1, color: 'amber', icon: 'alert' },
+        ],
+      },
+    );
+    expect(
+      all(renamed, '[data-testid="filter-status"]').map((c) =>
+        (c.textContent ?? '').replace(/\s+/g, ' ').trim(),
+      ),
+    ).toEqual(['OK', 'Gone walkabout']);
   });
 
   // A household colour outside the ten has no class to carry it, so the chip

--- a/cards/haventory-card/src/components/hv-organize-dialog.test.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.test.ts
@@ -1766,3 +1766,124 @@ describe('hv-organize-dialog: the language in force', () => {
     expect(q(sr, '[data-testid="new-value-create"]')?.textContent?.trim()).toBe('Erstellen');
   });
 });
+
+// The store keeps the built-in three in English because they are data a
+// household owns and edits; the card prints the reader's word for one nobody
+// has renamed. This tab is where the two meet, and the only place the
+// translation could be written back by accident.
+describe('hv-organize-dialog: the statuses tab in German', () => {
+  const ladder = makeItem({ id: 'i1', name: 'Leiter', status: 'missing' });
+
+  it('chips the three the backend seeded in German', async () => {
+    setLanguage('de');
+    const { sr } = await mount({ tab: 'statuses' });
+
+    expect(all(sr, '[data-testid="status-chip"]').map((c) => c.textContent?.trim())).toEqual([
+      'OK',
+      'Fehlt',
+      'Reparatur nötig',
+    ]);
+  });
+
+  it('names each row on the buttons a screen reader reads', async () => {
+    setLanguage('de');
+    const { sr } = await mount({ tab: 'statuses' });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    expect(row?.querySelector('[data-testid="status-edit"]')?.getAttribute('aria-label')).toBe(
+      'Fehlt bearbeiten',
+    );
+    expect(row?.querySelector('[data-testid="status-remove"]')?.getAttribute('aria-label')).toBe(
+      'Fehlt löschen',
+    );
+  });
+
+  it('edits the stored English and shows what it prints as beside it', async () => {
+    setLanguage('de');
+    const { el, sr } = await mount({ tab: 'statuses' });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect((q(sr, '[data-testid="status-label"]') as HTMLInputElement).value).toBe('Missing');
+    expect(q(sr, '[data-testid="status-shown"]')?.textContent?.trim()).toBe('Fehlt');
+  });
+
+  // Rule two, and the reason the box holds English at all: a household that
+  // opened this editor and pressed save would otherwise have renamed all three
+  // for every member, in one language, permanently.
+  it('saves an untouched label back exactly as stored', async () => {
+    setLanguage('de');
+    const { el, sr, hass } = await mount({ tab: 'statuses' });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+    (q(sr, '[data-testid="status-save"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect(hass.__messages.filter((m) => m.type === 'haventory/status/update')).toEqual([
+      expect.objectContaining({ slug: 'missing', label: 'Missing' }),
+    ]);
+  });
+
+  // The stored English is on no screen, so a warning about it would name a word
+  // the reader cannot see; the word they can see is the one that would leave
+  // two chips reading the same thing.
+  it('warns about a collision with the word on the chips, not the one in the store', async () => {
+    setLanguage('de');
+    const { el, sr } = await mount({ tab: 'statuses' });
+
+    (q(sr, '[data-testid="organize-new-status"]') as HTMLButtonElement).click();
+    await settle(el);
+    const input = q(sr, '[data-testid="status-label"]') as HTMLInputElement;
+    input.value = 'Fehlt';
+    input.dispatchEvent(new Event('input'));
+    await settle(el);
+    expect(q(sr, '[data-testid="status-duplicate-hint"]')?.textContent).toContain('Fehlt');
+
+    input.value = 'Missing';
+    input.dispatchEvent(new Event('input'));
+    await settle(el);
+    expect(q(sr, '[data-testid="status-duplicate-hint"]')).toBe(null);
+  });
+
+  it('offers the reassign targets in German', async () => {
+    setLanguage('de');
+    const { el, sr } = await mount({ tab: 'statuses', items: [ladder] });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    (row?.querySelector('[data-testid="status-remove"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    const select = q(sr, '[data-testid="status-reassign"]') as HTMLSelectElement;
+    expect([...select.options].map((o) => o.textContent?.trim())).toEqual([
+      'OK',
+      'Reparatur nötig',
+    ]);
+  });
+
+  // A rename is the household saying what it wants these called, and it holds
+  // for everyone: the box, the chip and the guard all read it back as typed.
+  it('shows a renamed built-in as renamed, and stops offering a translation', async () => {
+    setLanguage('de');
+    const { el, sr } = await mount({
+      tab: 'statuses',
+      statuses: [
+        { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
+        { slug: 'missing', label: 'Verschollen', order: 1, color: 'amber', icon: 'alert' },
+      ],
+    });
+
+    const row = all(sr, '[data-testid="status-row"]').find((r) => r.dataset.value === 'missing');
+    expect(row?.querySelector('[data-testid="status-chip"]')?.textContent?.trim()).toBe(
+      'Verschollen',
+    );
+    (row?.querySelector('[data-testid="status-edit"]') as HTMLButtonElement).click();
+    await settle(el);
+
+    expect((q(sr, '[data-testid="status-label"]') as HTMLInputElement).value).toBe('Verschollen');
+    expect(q(sr, '[data-testid="status-shown"]')).toBe(null);
+  });
+});

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_STATUS,
   STATUS_COLORS,
   STATUS_ICONS,
+  displayLabel,
   hexToneStyle,
   isHexColor,
   knownIcon,
@@ -1822,20 +1823,29 @@ export class HVOrganizeDialog extends LitElement {
    * filter chip and select on the card — only the slug tells them apart, and
    * the slug is what the editor hides. The status being edited is excluded:
    * keeping its own name is not a collision.
+   *
+   * Compared against what each status *displays*, not what it stores: a reader
+   * in German sees "Fehlt" on the chips, and typing that word is the collision
+   * they would have to live with. The stored English behind it is not on any
+   * screen, so a warning about it would name a word nobody can see.
    */
   private get _duplicateLabel(): string | null {
     const typed = this._statusLabel.trim().toLowerCase();
     if (!typed) return null;
     const editing = this._editingStatus;
-    return (
-      this._statusDefs.find((d) => d.slug !== editing && d.label.trim().toLowerCase() === typed)
-        ?.label ?? null
+    const clash = this._statusDefs.find(
+      (d) => d.slug !== editing && displayLabel(d).trim().toLowerCase() === typed,
     );
+    return clash ? displayLabel(clash) : null;
   }
 
   private _startStatusEdit(slug: string | 'new') {
     const existing = slug === 'new' ? undefined : this._statusDefs.find((d) => d.slug === slug);
     this._editingStatus = slug;
+    // The stored label, never the displayed one. The box is what `_saveStatus`
+    // writes: seeded with a translation, a German household that opened this
+    // editor and pressed save would rename the built-in three for everyone,
+    // English readers included, and no language could translate them again.
     this._statusLabel = existing?.label ?? '';
     this._statusColor = existing?.color ?? 'neutral';
     this._statusIcon = existing?.icon ?? 'check';
@@ -1935,12 +1945,15 @@ export class HVOrganizeDialog extends LitElement {
         ${defs.map((d, index) => {
           const isDefault = d.slug === DEFAULT_STATUS;
           const count = this._statusCount(d.slug);
+          // What the chip beside these buttons says, so a screen reader names
+          // the row the same way the screen does.
+          const shown = displayLabel(d);
           return html`
             <div class="value-row status-row" data-testid="status-row" data-value=${d.slug}>
               <span class="move">
                 <button
                   data-testid="status-up"
-                  aria-label=${t('hv.organize.statusMoveUp', { label: d.label })}
+                  aria-label=${t('hv.organize.statusMoveUp', { label: shown })}
                   title=${t('hv.term.moveUp')}
                   ?disabled=${index === 0}
                   @click=${() => this._moveStatus(d.slug, -1)}
@@ -1949,7 +1962,7 @@ export class HVOrganizeDialog extends LitElement {
                 </button>
                 <button
                   data-testid="status-down"
-                  aria-label=${t('hv.organize.statusMoveDown', { label: d.label })}
+                  aria-label=${t('hv.organize.statusMoveDown', { label: shown })}
                   title=${t('hv.term.moveDown')}
                   ?disabled=${index === defs.length - 1}
                   @click=${() => this._moveStatus(d.slug, 1)}
@@ -1970,7 +1983,7 @@ export class HVOrganizeDialog extends LitElement {
                   : null}
                 <button
                   data-testid="status-edit"
-                  aria-label=${t('hv.organize.statusEdit', { label: d.label })}
+                  aria-label=${t('hv.organize.statusEdit', { label: shown })}
                   title=${t('hv.action.edit')}
                   @click=${() => this._startStatusEdit(d.slug)}
                 >
@@ -1982,7 +1995,7 @@ export class HVOrganizeDialog extends LitElement {
                       <button
                         class="danger"
                         data-testid="status-remove"
-                        aria-label=${t('hv.organize.statusDelete', { label: d.label })}
+                        aria-label=${t('hv.organize.statusDelete', { label: shown })}
                         title=${t('hv.action.delete')}
                         @click=${() => this._askDeleteStatus(d.slug)}
                       >
@@ -2016,6 +2029,18 @@ export class HVOrganizeDialog extends LitElement {
     const duplicate = this._duplicateLabel;
     const glyph = knownIcon(this._statusIcon);
     const custom = isHexColor(this._statusColor) ? this._statusColor : null;
+    // A built-in nobody has renamed stores English and prints the reader's
+    // language, so for that reader the box and the chips say different words.
+    // Showing what the box's text prints as is what stops the English in it
+    // reading as a mistake to be corrected — correcting it is exactly the
+    // rename that would take the translation away from everyone. Dropped as
+    // soon as the box stops holding the stored label: from that keystroke on
+    // it is a new name, and the translation no longer describes it.
+    const editing = creating ? undefined : this._statusDefs.find((d) => d.slug === slug);
+    const printsAs =
+      editing && this._statusLabel === editing.label && displayLabel(editing) !== editing.label
+        ? displayLabel(editing)
+        : null;
     return keyed(
       slug,
       html`<div class="expander" data-testid="status-editor" data-field="status-label" ${ref(this._reveal)}>
@@ -2037,6 +2062,9 @@ export class HVOrganizeDialog extends LitElement {
           <span class="status-slug" data-testid="status-slug-preview" title=${derived}
             >${derived}</span
           >
+          ${printsAs === null
+            ? null
+            : html`<span class="hv-chip quiet" data-testid="status-shown">${printsAs}</span>`}
         </label>
         ${duplicate
           ? html`<div class="hint" data-testid="status-duplicate-hint">
@@ -2150,7 +2178,7 @@ export class HVOrganizeDialog extends LitElement {
                   this._reassignTarget = (e.target as HTMLSelectElement).value;
                 }}
               >
-                ${targets.map((d) => html`<option value=${d.slug}>${d.label}</option>`)}
+                ${targets.map((d) => html`<option value=${d.slug}>${displayLabel(d)}</option>`)}
               </select>
             </label>`
           : null}

--- a/cards/haventory-card/src/components/hv-organize-dialog.ts
+++ b/cards/haventory-card/src/components/hv-organize-dialog.ts
@@ -2036,11 +2036,10 @@ export class HVOrganizeDialog extends LitElement {
     // rename that would take the translation away from everyone. Dropped as
     // soon as the box stops holding the stored label: from that keystroke on
     // it is a new name, and the translation no longer describes it.
-    const editing = creating ? undefined : this._statusDefs.find((d) => d.slug === slug);
+    const stored = creating ? undefined : this._statusDefs.find((d) => d.slug === slug);
+    const shown = stored ? displayLabel(stored) : null;
     const printsAs =
-      editing && this._statusLabel === editing.label && displayLabel(editing) !== editing.label
-        ? displayLabel(editing)
-        : null;
+      stored && this._statusLabel === stored.label && shown !== stored.label ? shown : null;
     return keyed(
       slug,
       html`<div class="expander" data-testid="status-editor" data-field="status-label" ${ref(this._reveal)}>

--- a/cards/haventory-card/src/i18n/catalog.test.ts
+++ b/cards/haventory-card/src/i18n/catalog.test.ts
@@ -57,6 +57,7 @@ const IDENTICAL_TO_ENGLISH: Readonly<Record<string, readonly string[]>> = {
   de: [
     // Loan words and international terms German uses unchanged.
     'hv.bottomSheet.label',
+    'hv.status.ok',
     'hv.editor.type.string',
     'hv.surfaces.badge.offline',
     'hv.field.name',

--- a/cards/haventory-card/src/i18n/de.ts
+++ b/cards/haventory-card/src/i18n/de.ts
@@ -404,6 +404,10 @@ export const de: CompleteDictionary = {
   'hv.field.categories': 'Kategorien',
   'hv.field.statuses': 'Status',
 
+  'hv.status.ok': 'OK',
+  'hv.status.missing': 'Fehlt',
+  'hv.status.needs_repair': 'Reparatur nötig',
+
   'hv.store.transportError':
     'Home Assistant war nicht erreichbar – die letzte Aktion ist nicht durchgegangen.',
   'hv.store.unknownError': 'Unbekannter Fehler',

--- a/cards/haventory-card/src/i18n/en.ts
+++ b/cards/haventory-card/src/i18n/en.ts
@@ -452,6 +452,15 @@ export const en = {
   'hv.field.categories': 'Categories',
   'hv.field.statuses': 'Statuses',
 
+  // The three statuses a store is seeded with. A status a household created is
+  // its own words and renders as stored; these three are nobody's words until
+  // somebody renames one, so the card prints them in the reader's language for
+  // as long as each still carries the English the backend wrote. The store
+  // itself never sees these strings — `ui/status.ts` has the rule.
+  'hv.status.ok': 'OK',
+  'hv.status.missing': 'Missing',
+  'hv.status.needs_repair': 'Needs repair',
+
   // store — what the card says when a command does not come back. The
   // backend's own `message` text is not translated; these are the card's.
   'hv.store.transportError': 'Could not reach Home Assistant — the last action did not go through.',

--- a/cards/haventory-card/src/ui/status.test.ts
+++ b/cards/haventory-card/src/ui/status.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'lit';
 import type { StatsCounts, StatusDefinition } from '../store/types';
+import { DICTIONARIES, setLanguage, t } from '../i18n';
+import type { TranslationKey } from '../i18n';
 import {
   BUILT_IN_STATUSES,
   DEFAULT_STATUS,
+  displayLabel,
   isHexColor,
   itemStatus,
   knownIcon,
@@ -15,6 +18,9 @@ import {
   statusList,
   statusTone,
 } from './status';
+
+/** Every language this bundle carries; nothing here is true of German alone. */
+const LANGUAGES = Object.keys(DICTIONARIES);
 
 const CUSTOM: StatusDefinition[] = [
   { slug: 'ok', label: 'Fine', order: 0, color: 'green', icon: 'check' },
@@ -111,6 +117,85 @@ describe('ui/status: rendering a slug', () => {
     expect(knownIcon('not-a-glyph')).toBeNull();
     expect(knownIcon(undefined)).toBeNull();
     expect(knownIcon(null)).toBeNull();
+  });
+});
+
+describe('ui/status: the built-in three in the reader’s language', () => {
+  /** What `haventory/config` answers for a store nobody has touched. */
+  const seeded = (): StatusDefinition[] => BUILT_IN_STATUSES.map((d) => ({ ...d }));
+
+  it('prints a slug still carrying its seeded English in the reader’s language', () => {
+    setLanguage('de');
+    expect(seeded().map((d) => displayLabel(d))).toEqual(['OK', 'Fehlt', 'Reparatur nötig']);
+  });
+
+  it('prints each of them as the catalog’s word for its slug, in every language', () => {
+    // The key is spelled from the slug here and looked up from a table there:
+    // a built-in the table forgets keeps its stored English in every language,
+    // which is the failure #536 is about and nothing else would notice.
+    for (const tag of LANGUAGES) {
+      setLanguage(tag);
+      for (const def of seeded()) {
+        const key = `hv.status.${def.slug}` as TranslationKey;
+        expect([tag, def.slug, displayLabel(def)]).toEqual([tag, def.slug, t(key)]);
+      }
+    }
+  });
+
+  // Rule one. A rename is a household saying what it wants these called; from
+  // then on the stored words are the answer, in every language, or a household
+  // that renamed a status would see it renamed only in the language it typed.
+  it('prints a renamed built-in as stored, in every language', () => {
+    const renamed: StatusDefinition[] = [
+      { slug: 'ok', label: 'Alles gut', order: 0, color: 'green', icon: 'check' },
+      { slug: 'missing', label: 'Verschollen', order: 1, color: 'amber', icon: 'alert' },
+      { slug: 'needs_repair', label: 'Kaputt', order: 2, color: 'amber', icon: 'wrench' },
+    ];
+    for (const tag of LANGUAGES) {
+      setLanguage(tag);
+      expect([tag, renamed.map((d) => displayLabel(d))]).toEqual([
+        tag,
+        ['Alles gut', 'Verschollen', 'Kaputt'],
+      ]);
+    }
+  });
+
+  // A rename to the empty-looking neighbour of the seed is still a rename:
+  // only the exact stored English means "nobody chose this".
+  it('takes any difference from the seed as the household’s own words', () => {
+    setLanguage('de');
+    expect(displayLabel({ slug: 'missing', label: 'missing', order: 1, color: 'amber' })).toBe(
+      'missing',
+    );
+    expect(displayLabel({ slug: 'missing', label: 'Missing ', order: 1, color: 'amber' })).toBe(
+      'Missing ',
+    );
+  });
+
+  // A household's own status carries its own words whatever they are — even a
+  // slug that looks built-in on a store this card has been told nothing about.
+  it('leaves a household’s own status exactly as stored', () => {
+    setLanguage('de');
+    expect(
+      displayLabel({ slug: 'lent_out', label: 'Missing', order: 3, color: 'blue' }),
+    ).toBe('Missing');
+  });
+
+  // Rule three. The stand-in stands in for a fresh store, so a chip drawn
+  // before `haventory/config` answers has to say what the same chip says
+  // after — otherwise every page load rewords three chips a moment in.
+  it('says the same word before and after haventory/config answers, in every language', () => {
+    const wording = (slug: string, defs: StatusDefinition[] | null) => {
+      const host = document.createElement('div');
+      render(renderStatusChip(slug, defs), host);
+      return host.querySelector('.hv-chip-text')?.textContent;
+    };
+    for (const tag of LANGUAGES) {
+      setLanguage(tag);
+      for (const { slug } of BUILT_IN_STATUSES) {
+        expect([tag, slug, wording(slug, null)]).toEqual([tag, slug, wording(slug, seeded())]);
+      }
+    }
   });
 });
 

--- a/cards/haventory-card/src/ui/status.ts
+++ b/cards/haventory-card/src/ui/status.ts
@@ -2,6 +2,8 @@ import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import type { TemplateResult } from 'lit';
 import type { Item, StatsCounts, StatusColor, StatusDefinition } from '../store/types';
+import { t } from '../i18n';
+import type { TranslationKey } from '../i18n';
 import { ICONS, icon } from './icons';
 import type { IconName } from './icons';
 
@@ -15,21 +17,40 @@ import type { IconName } from './icons';
  * therefore takes the definitions the store holds. What stays local is the
  * fallback: the built-in three, which is what an absent `statuses` section has
  * meant since schema v6 and what a backend too old to report them still means.
+ *
+ * One label does not come from the store as stored: a built-in nobody has
+ * renamed is printed in the reader's language. `displayLabel` holds that rule,
+ * and every surface reaches it through `statusLabel` or `renderStatusChip`.
  */
 
 /** What an item carries when nothing set its status. */
 export const DEFAULT_STATUS = 'ok';
 
 /**
- * The built-in vocabulary, matching what the backend seeds. Used only until
+ * The built-in vocabulary, matching what the backend seeds. Used until
  * `haventory/config` answers — after that the store's copy wins, including for
- * these three, because a household may have renamed or recoloured them.
+ * these three, because a household may have renamed or recoloured them — and
+ * its labels stay in use afterwards as the English `displayLabel` measures a
+ * rename against. `tests/test_frontend_registration.py` holds the three to the
+ * backend's own seed, which neither side can read.
  */
 export const BUILT_IN_STATUSES: readonly StatusDefinition[] = [
   { slug: 'ok', label: 'OK', order: 0, color: 'green', icon: 'check' },
   { slug: 'missing', label: 'Missing', order: 1, color: 'amber', icon: 'alert' },
   { slug: 'needs_repair', label: 'Needs repair', order: 2, color: 'amber', icon: 'wrench' },
 ];
+
+/** The key each built-in slug is printed under while nobody has renamed it. */
+const BUILT_IN_LABEL_KEYS: ReadonlyMap<string, TranslationKey> = new Map<string, TranslationKey>([
+  ['ok', 'hv.status.ok'],
+  ['missing', 'hv.status.missing'],
+  ['needs_repair', 'hv.status.needs_repair'],
+]);
+
+/** The English seeded per built-in slug, which is what a rename is measured against. */
+const SEEDED_LABELS: ReadonlyMap<string, string> = new Map(
+  BUILT_IN_STATUSES.map((d) => [d.slug, d.label]),
+);
 
 /**
  * Every colour a status may take: five hues, each in a light and a strong form.
@@ -87,6 +108,31 @@ function definitionOf(
 }
 
 /**
+ * What a definition reads as on screen, which is not always what it stores.
+ *
+ * A status a household created is that household's own words, in whatever
+ * language it typed them, and prints exactly as stored. The three the backend
+ * seeds are nobody's words: while one still carries the English the seed wrote,
+ * the card prints the reader's word for it, so two members of one household
+ * reading different languages each see their own — the same rule Home Assistant
+ * applies to an entity state. The first rename makes the label a choice
+ * somebody took, and from then on it prints as stored in every language.
+ *
+ * The store never sees any of this. A translated chip is a display, not a
+ * rename: nothing here is ever written back, so an export stays language-
+ * neutral and a French household gets French chips the day that dictionary
+ * ships.
+ *
+ * Exported for the one surface that needs the two apart — the organize dialog
+ * edits the stored label and shows this beside it.
+ */
+export function displayLabel(def: StatusDefinition): string {
+  const key = BUILT_IN_LABEL_KEYS.get(def.slug);
+  if (key === undefined || def.label !== SEEDED_LABELS.get(def.slug)) return def.label;
+  return t(key);
+}
+
+/**
  * Display label for a slug.
  *
  * Falls back to the slug itself rather than rendering nothing: an item can
@@ -97,7 +143,8 @@ export function statusLabel(
   slug: string,
   defs: readonly StatusDefinition[] | null | undefined,
 ): string {
-  return definitionOf(slug, defs)?.label ?? slug;
+  const def = definitionOf(slug, defs);
+  return def ? displayLabel(def) : slug;
 }
 
 /**

--- a/docs/data_shapes.md
+++ b/docs/data_shapes.md
@@ -161,7 +161,11 @@ export document:
   characters of lowercase letters, digits and underscores.
 - `label` is the only part a rename touches, so renaming a status rewrites no item and
   raises no `version` question, exactly as a location rename does not touch `location_path`
-  semantics.
+  semantics. The three a store is seeded with — `ok`, `missing`, `needs_repair` — are stored
+  in English and *displayed* by the card in each reader's own language for as long as each
+  still carries that seeded English; renaming one replaces it for everyone, in every
+  language. Nothing writes a translation back, so an export stays language-neutral and its
+  built-ins import as built-ins on any instance.
 - `order` is display order alone; ties break by slug.
 - `color` is one of ten tone tokens — `neutral`, `green`, `blue`, `amber`, `red`, each also in
   a `_strong` form — **or** a `#rrggbb` literal. A token is resolved by the card against the

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -305,6 +305,13 @@ Every string above — and every string in every component — comes out of `src
   `hv.term.*` for the facts more than one surface states, and `hv.field.*` for what an item's
   fields are called — one key per word, read by the column header, the sort option, the editor
   label, the facet tab and the detail sheet's fact row alike.
+- **`hv.status.*` is displayed copy over stored data.** A household owns its status labels
+  and renames them, so they are stored rather than translated — but nobody chose the three a
+  store is seeded with. `ui/status.ts`'s `displayLabel` therefore prints the reader's word for
+  a built-in slug while its stored label is still the seeded English, and the stored label from
+  the first rename on. Every surface reaches it through `statusLabel` or `renderStatusChip`,
+  and nothing writes a translation back: the organize dialog's Statuses tab edits the stored
+  English and shows what it prints as beside the box.
 - **Deliberately untranslated**: `DEFAULT_CARD_TITLE` (a product name, pinned to `const.py`),
   the card-picker entry and `setConfig`'s refusal in `index.ts` (both run before any `hass`
   exists), the diagnostics panel's copy-to-clipboard report (it is read by a maintainer), and

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -39,6 +39,7 @@ from custom_components.haventory.const import (
     STATUS_COLORS,
     STATUS_ICONS,
 )
+from custom_components.haventory.models import seed_status_definitions
 from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL, DATA_PANELS, UrlManager
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -548,6 +549,54 @@ def test_the_card_offers_exactly_the_vocabularies_the_backend_accepts() -> None:
 
     assert declared("STATUS_COLORS") == list(STATUS_COLORS)
     assert declared("STATUS_ICONS") == list(STATUS_ICONS)
+
+
+def test_the_cards_built_in_statuses_are_the_ones_the_backend_seeds() -> None:
+    """``BUILT_IN_STATUSES`` mirrors ``seed_status_definitions()``, label included.
+
+    The card draws that array until ``haventory/config`` answers, so a label
+    that differs reworded three chips for the first moment of every page load.
+    The label carries a second job since #536: a built-in still storing the
+    English the seed wrote is printed in the reader's language, and the card
+    decides that by comparing the stored label against this copy. A seed the
+    card does not know the wording of translates nowhere — every language keeps
+    the English, silently, which is the state that issue was filed about.
+    """
+    source = (REPO_ROOT / "cards" / "haventory-card" / "src" / "ui" / "status.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(
+        r"export const BUILT_IN_STATUSES: readonly StatusDefinition\[\] = \[(.*?)\n\];",
+        source,
+        re.S,
+    )
+    assert match is not None, "BUILT_IN_STATUSES is no longer declared in status.ts"
+
+    def field(entry: str, name: str) -> str:
+        found = re.search(rf"\b{name}:\s*'([^']*)'", entry)
+        assert found is not None, f"{name} is missing from a BUILT_IN_STATUSES entry"
+        return found.group(1)
+
+    def order(entry: str) -> int:
+        found = re.search(r"\border:\s*(\d+)", entry)
+        assert found is not None, "order is missing from a BUILT_IN_STATUSES entry"
+        return int(found.group(1))
+
+    declared = [
+        (
+            field(entry, "slug"),
+            field(entry, "label"),
+            order(entry),
+            field(entry, "color"),
+            field(entry, "icon"),
+        )
+        for entry in re.findall(r"\{([^{}]*)\}", match.group(1))
+    ]
+    seeded = [
+        (d.slug, d.label, d.order, d.color, d.icon) for d in seed_status_definitions().values()
+    ]
+
+    assert declared == seeded
 
 
 def test_the_options_flow_offers_exactly_the_pills_the_card_draws() -> None:


### PR DESCRIPTION
## Summary

The three statuses a store is seeded with are the one piece of copy on the card that is
not copy: `OK` / `Missing` / `Needs repair` are stored data, seeded by the backend, owned
and renameable by the household. A German install has therefore been reading three English
chips on every row, every filter chip, the status facet and the editor's select, until
somebody renamed them in the organize dialog.

Card only, per the owner's decision (§2 item 2 of the V0.8.0 plan). The store stays
language-neutral. `displayLabel` in `ui/status.ts` prints the reader's word for a built-in
slug **while its stored label is still the English the backend seeded**, and the stored
label from the first rename on — the rule Home Assistant applies to an entity state. Three
new keys, `hv.status.ok` / `hv.status.missing` / `hv.status.needs_repair`, in both
dictionaries.

What that holds under, and seeding in the server's language did not: the server language
changing later (the chips follow the reader; nothing stored goes stale), a member whose
profile language differs from the server's (each sees their own), a German export imported
into an English server (an un-renamed store exports the English seeds, so they import as
built-ins — only a deliberate rename travels as a rename), and a language that does not
exist yet (a French household gets French chips the day that dictionary ships).

Every surface that draws a status label already reached `statusLabel` or
`renderStatusChip`, so the rule went into that one helper and moved them all at once:
`hv-list-row`, `hv-data-table`, `hv-detail-sheet`, `ui/row-chrome.ts`'s `renderNameChips`,
`hv-filter-chips` (`hv.chips.status`'s `{label}`), `hv-filter-panel`'s chips,
`hv-full-view`'s facet and `hv-item-editor`'s select. The sweep for label reads that did
**not** go through it found five, all in the organize dialog's Statuses tab; four are
display and now go through the helper:

- the four accessible names on a status row (`Move {label} up/down`, `Edit {label}`,
  `Delete {label}`) — a screen reader was saying a word not on the screen;
- the reassign `<option>`s in the delete guard;
- the duplicate-label warning, which compares against what each status **displays**: a
  reader in German sees "Fehlt" on the chips, so typing that word is the collision they
  would have to live with, and the stored English behind it is on no screen. Without this
  the warning would have gone quiet in German exactly where this PR makes the clash
  reachable.

The fifth is not display and deliberately stays as stored: the edit box is seeded from the
stored label, because the box is what `_saveStatus` writes. Beside it the editor now shows
what that text prints as, so the English in the box does not read as a mistake to be
corrected — correcting it is precisely the rename that would take the translation away from
everybody.

**Search is unaffected.** `_item_matches_q` reads name, description, category, the location
path and the tags — never a status label — so nothing on the backend or in the query path
changes. The backend, `_SEED_STATUSES`, the v5→v6 adopter and the export format are
untouched; no file under `custom_components/` is in this diff.

Closes #536

### The three rules, each its own test

1. **A renamed status shows as stored, in every language.** `ui/status.test.ts` renames all
   three and asserts the stored words come back for every tag in `DICTIONARIES`;
   `hv-filter-panel.test.ts` and `hv-organize-dialog.test.ts` assert the same on the chips a
   German reader actually sees.
2. **The Statuses tab never writes the translation into the store.** Opening the editor on
   `missing` in German shows `Missing` in the box with `Fehlt` beside it, and pressing save
   without touching it sends exactly `{ slug: 'missing', label: 'Missing' }` — so a
   household that opened and closed the editor has renamed nothing for anyone.
3. **The stand-in and the store agree.** A chip rendered before `haventory/config` answers
   and one rendered from a fresh store's definitions say the same word, for every built-in,
   in every language — no chip rewords a few hundred milliseconds into a page load. That
   holds because `BUILT_IN_STATUSES`'s labels are the backend's seed, which nothing checked
   until now: `tests/test_frontend_registration.py` reads the array out of `status.ts` and
   compares it against `seed_status_definitions()`. A drifted label would both reword the
   stand-in and leave that slug in English in *every* language.

Beside those: a built-in whose stored label differs from the seed by so much as trailing
whitespace counts as renamed; a household's own status carrying the word "Missing" under
another slug prints as stored; and every built-in prints as the catalog's word for its slug,
which is what catches a slug the key table forgets.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation / tooling / CI
- [ ] Refactor (no functional change)

## How was this tested?

- [x] Backend: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q` → 1305 passed, 27
      skipped · `uv run ruff check .` → All checks passed · `uv run ruff format --check .`
      → 189 files already formatted · `uv run mypy` → no issues in 25 source files
- [x] Frontend (`cards/haventory-card`): `npx eslint .` clean · `npm run typecheck` clean ·
      `npx vitest run` → 79 files, 2015 tests passed · `npm run build` → 689.41 kB, gzip
      171.36 kB (unchanged to the tenth of a kB: three dictionary entries and a lookup)

**phacc**: not required. No file under `custom_components/` or `tests/integration/` is in
this diff, and §6.M5 runs no phacc. CI's `integration` job ran it anyway and is green.

## Counting

| | lines |
|---|---|
| production removed | 12 |
| test lines removed | 0 |
| lines added | 395 |

`git diff --stat origin/main`: 11 files changed, 395 insertions(+), 12 deletions(-). The
twelve removed are the eight rewritten lines of the organize dialog's status rendering, the
three of `statusLabel`, and one doc line. This is a `feat`, not a cut.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Tests added/updated (happy path + edge/error cases).
- [x] Docs updated where behavior changed.
- [x] WebSocket API changes keep `ws.py`, `docs/backend_api_contract.md`, and
      `docs/data_shapes.md` in sync — no WS change here; `data_shapes.md`'s `label` bullet
      is updated because what that stored field means on screen has moved.
- [x] Essential invariants preserved.

## Screenshots (card / UI changes)

None from this session — it runs offline and never touches a Home Assistant instance. The
master's live check covers both languages; see "Validate locally" below.

## Follow-ups

- `migrations.py`'s `_V6_SEED_STATUSES` writes the same three labels as `models.py`'s
  `_SEED_STATUSES` and nothing holds the two together. A drift there would give a store
  crossing v5 → v6 built-ins that never translate. Small and easy to pin, but it is a
  backend file and this PR touches none; **not filed** — one PR of the collapse package
  already reads both, and a sentence here is the right ceiling until something actually
  edits one of them.
- The duplicate-label warning now compares displayed labels. A household member typing the
  *stored* English of an un-renamed built-in ("Missing") while reading German gets no
  warning, and an English reader would then see two chips both reading "Missing". Reachable
  only by typing a word that is on no screen the typist is looking at; **not filed** — it
  clears no real-world bar, and warning about both spellings would name a word the reader
  cannot see.

## Handover

**1. Merged / left open.** Left open for the master to review and squash-merge. Nothing here
is on the owner-merges list.

**2. Test this by hand.**
- `[German]` The three words themselves — `OK` / `Fehlt` / `Reparatur nötig` — are the
  owner's to accept through #540. They are new values, not rewordings; no existing German
  value was touched.
- `[German]` The organize dialog's status editor in German: the box holds `Missing`, the
  quiet chip beside it holds `Fehlt`. Whether that reads as an explanation or as a puzzle is
  a judgment only a German reader makes, and it is the one screen this design puts two
  languages on at once.
- `[phone]` The status editor's field line now carries a third item (box, slug, printed-as
  chip) and wraps on a narrow width; the row is `flex-wrap`, so it should drop to a second
  line rather than overrun.

**3. Validate locally.**
1. `[HA settings]` Set the Home Assistant profile language to Deutsch on an instance whose
   server language is English, with a fresh store. Expected: the server language is unchanged.
2. `[browser]` Open the card and `/haventory`. Expected: every status chip, the filter
   panel's status row, the sidebar's status facet and the editor's status select read
   `OK` / `Fehlt` / `Reparatur nötig`, and none of them changes wording after the first
   frame — the stand-in and `haventory/config` agree.
3. `[browser]` Organize → Status. Expected: three rows chipped in German; open one for
   editing and the box holds the English (`Missing`), with `Fehlt` beside it.
4. `[browser]` Press save on that editor without typing anything, then reopen it. Expected:
   the box still holds `Missing` and the chip still reads `Fehlt` — the store was not
   renamed.
5. `[browser]` Rename `Fehlt` to `Verschollen` and save. Expected: every chip, the filter
   panel, the facet and the select read `Verschollen`; reopening the editor shows
   `Verschollen` in the box with **no** chip beside it.
6. `[HA settings]` `[browser]` Switch the profile to English and reload. Expected: the
   renamed one still reads `Verschollen`; the two un-renamed ones read `OK` and
   `Needs repair`.
7. `[browser]` Import an export taken before the rename. Expected: the built-ins come back
   translated in a German profile — the export carried the English seeds, so they import as
   built-ins rather than as renames.
8. `[browser]` In German, Organize → Status → new status, type `Fehlt`. Expected: the
   duplicate warning names `Fehlt`. Type `Missing` instead: no warning.

**4. Decisions taken against drifted notes.**
- The package says `tests/test_frontend_registration.py` pins `BUILT_IN_STATUSES` to the
  backend's seeds. It did not — that file pins `STATUS_COLORS`, `STATUS_ICONS`, the media
  params and the quick-filter pills, and nothing held the built-in three to anything. Rule 3
  rests on that equality ("by construction"), and after this PR so does the translation
  rule, so the pin is added here as its own commit.
- The package names one helper, `statusLabel(def)`. The existing `statusLabel(slug, defs)`
  has fifteen call sites and is what every surface already reaches, so the rule went into a
  new `displayLabel(def)` that `statusLabel` calls. The organize dialog is the only caller
  that holds definitions rather than slugs, and it needs the two apart anyway.
- Two files the package does not name were edited: `docs/data_shapes.md`'s `label` bullet
  now says what a seeded label means on screen (it described `label` as stored data a rename
  owns, which is still true and no longer the whole story), and
  `docs/frontend_architecture.md`'s wording section gains the same rule from the card's side.
  Both are one paragraph; leaving them would have left two docs quietly wrong.
- The editor's "translation beside the box" is a bare chip with no sentence around it, so it
  needs no fourth key. The package names three new keys and that is what this PR adds.

**5. Follow-ups.** Above — two, neither filed, each with its reason.

**6. State left behind.** Branch `claude/v0-8-0-m5-status-display`, four commits, pushed. No
assets branch (no screenshots from this session). No HA instance was touched and no `.env`
exists in the worktree. Counting for this session: production removed 12, tests removed 0,
added 395.